### PR TITLE
fix: sanitize duplicate blocks

### DIFF
--- a/packages/payload/src/fields/config/sanitize.spec.ts
+++ b/packages/payload/src/fields/config/sanitize.spec.ts
@@ -9,7 +9,12 @@ import type {
   TextField,
 } from './types.js'
 
-import { InvalidFieldName, InvalidFieldRelationship, MissingFieldType } from '../../errors/index.js'
+import {
+  DuplicateFieldName,
+  InvalidFieldName,
+  InvalidFieldRelationship,
+  MissingFieldType,
+} from '../../errors/index.js'
 import { sanitizeFields } from './sanitize.js'
 import { CollectionConfig } from '../../index.js'
 
@@ -53,6 +58,68 @@ describe('sanitizeFields', () => {
         validRelationships: [],
       })
     }).rejects.toThrow(InvalidFieldName)
+  })
+
+  it('should throw on duplicate field name', async () => {
+    const fields: Field[] = [
+      {
+        name: 'someField',
+        type: 'text',
+        label: 'someField',
+      },
+      {
+        name: 'someField',
+        type: 'text',
+        label: 'someField',
+      },
+    ]
+
+    await expect(async () => {
+      await sanitizeFields({
+        config,
+        collectionConfig,
+        fields,
+        validRelationships: [],
+      })
+    }).rejects.toThrow(DuplicateFieldName)
+  })
+
+  it('should throw on duplicate block slug', async () => {
+    const fields: Field[] = [
+      {
+        name: 'blocks',
+        type: 'blocks',
+        blocks: [
+          {
+            slug: 'block',
+            fields: [
+              {
+                name: 'blockField',
+                type: 'text',
+              },
+            ],
+          },
+          {
+            slug: 'block',
+            fields: [
+              {
+                name: 'blockField',
+                type: 'text',
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    await expect(async () => {
+      await sanitizeFields({
+        config,
+        collectionConfig,
+        fields,
+        validRelationships: [],
+      })
+    }).rejects.toThrow(DuplicateFieldName)
   })
 
   describe('auto-labeling', () => {

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -242,6 +242,7 @@ export const sanitizeFields = async ({
       if (!field.hooks) {
         field.hooks = {}
       }
+
       if (!field.access) {
         field.access = {}
       }
@@ -289,13 +290,25 @@ export const sanitizeFields = async ({
         throw new Error('You cannot have both blockReferences and blocks in the same blocks field')
       }
 
+      const blockNames: string[] = []
+
       for (const block of field.blockReferences ?? field.blocks) {
+        const blockName = typeof block === 'string' ? block : block.slug
+
+        if (blockNames.includes(blockName)) {
+          throw new DuplicateFieldName(blockName)
+        }
+
+        blockNames.push(blockName)
+
         if (typeof block === 'string') {
           continue
         }
+
         if (block._sanitized === true) {
           continue
         }
+
         block._sanitized = true
         block.fields = block.fields.concat(baseBlockFields)
         block.labels = !block.labels ? formatLabels(block.slug) : block.labels

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -290,16 +290,16 @@ export const sanitizeFields = async ({
         throw new Error('You cannot have both blockReferences and blocks in the same blocks field')
       }
 
-      const blockNames: string[] = []
+      const blockSlugs: string[] = []
 
       for (const block of field.blockReferences ?? field.blocks) {
-        const blockName = typeof block === 'string' ? block : block.slug
+        const blockSlug = typeof block === 'string' ? block : block.slug
 
-        if (blockNames.includes(blockName)) {
-          throw new DuplicateFieldName(blockName)
+        if (blockSlugs.includes(blockSlug)) {
+          throw new DuplicateFieldName(blockSlug)
         }
 
-        blockNames.push(blockName)
+        blockSlugs.push(blockSlug)
 
         if (typeof block === 'string') {
           continue


### PR DESCRIPTION
Although we sanitize against duplicate field names, this does not prevent against duplicate block slugs which causes runtime errors.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210524295135093