### PR TITLE
fix(db-*): `migrate:reset` executes in a wrong order

### DIFF
--- a/packages/drizzle/src/migrateReset.ts
+++ b/packages/drizzle/src/migrateReset.ts
@@ -28,6 +28,8 @@ export async function migrateReset(this: DrizzleAdapter): Promise<void> {
 
   const req = await createLocalReq({}, payload)
 
+  existingMigrations.reverse()
+
   // Rollback all migrations in order
   for (const migration of existingMigrations) {
     const migrationFile = migrationFiles.find((m) => m.name === migration.name)

--- a/packages/payload/src/database/migrations/migrateReset.ts
+++ b/packages/payload/src/database/migrations/migrateReset.ts
@@ -21,6 +21,8 @@ export async function migrateReset(this: BaseDatabaseAdapter): Promise<void> {
 
   const req = await createLocalReq({}, payload)
 
+  migrationFiles.reverse()
+
   // Rollback all migrations in order
   for (const migration of migrationFiles) {
     // Create or update migration in database

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -577,6 +577,27 @@ describe('database', () => {
     })
   })
 
+  it('should run migrate:reset', async () => {
+    // known drizzle issue: https://github.com/payloadcms/payload/issues/4597
+    // eslint-disable-next-line jest/no-conditional-in-test
+    if (!isMongoose(payload)) {
+      return
+    }
+    let error
+    try {
+      await payload.db.migrateReset()
+    } catch (e) {
+      error = e
+    }
+
+    const migrations = await payload.find({
+      collection: 'payload-migrations',
+    })
+
+    expect(error).toBeUndefined()
+    expect(migrations.docs).toHaveLength(0)
+  })
+
   describe('predefined migrations', () => {
     it('mongoose - should execute migrateVersionsV1_V2', async () => {
       // eslint-disable-next-line jest/no-conditional-in-test


### PR DESCRIPTION
fixes https://github.com/payloadcms/payload/issues/12442