### PR TITLE
fix(plugin-multi-tenant): add missing translation for Assigned Tenant field

### DIFF
--- a/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
@@ -59,7 +59,7 @@ export const tenantField = ({
   },
   index: true,
   // @ts-expect-error translations are not typed for this plugin
-  label: ({ t }) => t('plugin-multi-tenant:fields:tenantFieldLabel'),
+  label: ({ t }) => t('plugin-multi-tenant:field-assignedTentant-label'),
   relationTo: tenantsCollectionSlug,
   unique,
 })

--- a/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
@@ -58,7 +58,8 @@ export const tenantField = ({
     ],
   },
   index: true,
-  label: 'Assigned Tenant',
+  // @ts-expect-error translations are not typed for this plugin
+  label: ({ t }) => t('plugin-multi-tenant:fields:tenantFieldLabel'),
   relationTo: tenantsCollectionSlug,
   unique,
 })

--- a/packages/plugin-multi-tenant/src/translations/languages/ar.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ar.ts
@@ -5,9 +5,7 @@ export const arTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'أنت على وشك تغيير الملكية من <0>{{fromTenant}}</0> إلى <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'تأكيد تغيير {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'المستأجر المعين',
-    },
+    'field-assignedTentant-label': 'المستأجر المعين',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ar.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ar.ts
@@ -5,6 +5,9 @@ export const arTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'أنت على وشك تغيير الملكية من <0>{{fromTenant}}</0> إلى <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'تأكيد تغيير {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'المستأجر المعين',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/az.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/az.ts
@@ -5,9 +5,7 @@ export const azTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Siz <0>{{fromTenant}}</0> mülkiyyətini <0>{{toTenant}}</0> mülkiyyətinə dəyişdirəcəksiniz.',
     'confirm-tenant-switch--heading': '{{tenantLabel}} dəyişikliyini təsdiqləyin',
-    fields: {
-      tenantFieldLabel: 'Təyin edilmiş Kirayəçi',
-    },
+    'field-assignedTentant-label': 'Təyin edilmiş İcarəçi',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/az.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/az.ts
@@ -5,6 +5,9 @@ export const azTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Siz <0>{{fromTenant}}</0> mülkiyyətini <0>{{toTenant}}</0> mülkiyyətinə dəyişdirəcəksiniz.',
     'confirm-tenant-switch--heading': '{{tenantLabel}} dəyişikliyini təsdiqləyin',
+    fields: {
+      tenantFieldLabel: 'Təyin edilmiş Kirayəçi',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/bg.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/bg.ts
@@ -5,9 +5,7 @@ export const bgTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Предстои да промените собствеността от <0>{{fromTenant}}</0> на <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Потвърдете промяната на {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Назначен наемател',
-    },
+    'field-assignedTentant-label': 'Назначен наемател',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/bg.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/bg.ts
@@ -5,6 +5,9 @@ export const bgTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Предстои да промените собствеността от <0>{{fromTenant}}</0> на <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Потвърдете промяната на {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Назначен наемател',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ca.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ca.ts
@@ -5,6 +5,9 @@ export const caTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Estàs a punt de canviar la propietat de <0>{{fromTenant}}</0> a <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirmeu el canvi de {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Inquilí Assignat',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ca.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ca.ts
@@ -5,9 +5,7 @@ export const caTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Estàs a punt de canviar la propietat de <0>{{fromTenant}}</0> a <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirmeu el canvi de {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Inquilí Assignat',
-    },
+    'field-assignedTentant-label': 'Llogater Assignat',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/cs.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/cs.ts
@@ -5,6 +5,9 @@ export const csTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Chystáte se změnit vlastnictví z <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrďte změnu {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Přidělený nájemce',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/cs.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/cs.ts
@@ -5,9 +5,7 @@ export const csTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Chystáte se změnit vlastnictví z <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrďte změnu {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Přidělený nájemce',
-    },
+    'field-assignedTentant-label': 'Přiřazený nájemce',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/da.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/da.ts
@@ -5,9 +5,7 @@ export const daTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Du er ved at ændre ejerskab fra <0>{{fromTenant}}</0> til <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bekræft {{tenantLabel}} ændring',
-    fields: {
-      tenantFieldLabel: 'Tildelt Lejer',
-    },
+    'field-assignedTentant-label': 'Tildelt Lejer',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/da.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/da.ts
@@ -5,6 +5,9 @@ export const daTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Du er ved at ændre ejerskab fra <0>{{fromTenant}}</0> til <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bekræft {{tenantLabel}} ændring',
+    fields: {
+      tenantFieldLabel: 'Tildelt Lejer',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/de.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/de.ts
@@ -5,6 +5,9 @@ export const deTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Sie sind dabei, den Besitz von <0>{{fromTenant}}</0> auf <0>{{toTenant}}</0> zu übertragen.',
     'confirm-tenant-switch--heading': 'Bestätigen Sie die Änderung von {{tenantLabel}}.',
+    fields: {
+      tenantFieldLabel: 'Zugewiesener Mieter',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/de.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/de.ts
@@ -5,9 +5,7 @@ export const deTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Sie sind dabei, den Besitz von <0>{{fromTenant}}</0> auf <0>{{toTenant}}</0> zu übertragen.',
     'confirm-tenant-switch--heading': 'Bestätigen Sie die Änderung von {{tenantLabel}}.',
-    fields: {
-      tenantFieldLabel: 'Zugewiesener Mieter',
-    },
+    'field-assignedTentant-label': 'Zugewiesener Mieter',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/de.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/de.ts
@@ -5,7 +5,7 @@ export const deTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Sie sind dabei, den Besitz von <0>{{fromTenant}}</0> auf <0>{{toTenant}}</0> zu übertragen.',
     'confirm-tenant-switch--heading': 'Bestätigen Sie die Änderung von {{tenantLabel}}.',
-    'field-assignedTentant-label': 'Zugewiesener Mieter',
+    'field-assignedTentant-label': 'Zugewiesener Mandant',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/en.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/en.ts
@@ -5,6 +5,9 @@ export const enTranslations = {
     'confirm-tenant-switch--body':
       'You are about to change ownership from <0>{{fromTenant}}</0> to <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirm {{tenantLabel}} change',
+    fields: {
+      tenantFieldLabel: 'Assigned Tenant',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/en.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/en.ts
@@ -5,9 +5,7 @@ export const enTranslations = {
     'confirm-tenant-switch--body':
       'You are about to change ownership from <0>{{fromTenant}}</0> to <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirm {{tenantLabel}} change',
-    fields: {
-      tenantFieldLabel: 'Assigned Tenant',
-    },
+    'field-assignedTentant-label': 'Assigned Tenant',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/es.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/es.ts
@@ -5,9 +5,7 @@ export const esTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Está a punto de cambiar la propiedad de <0>{{fromTenant}}</0> a <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirme el cambio de {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Inquilino Asignado',
-    },
+    'field-assignedTentant-label': 'Inquilino Asignado',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/es.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/es.ts
@@ -5,6 +5,9 @@ export const esTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Está a punto de cambiar la propiedad de <0>{{fromTenant}}</0> a <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirme el cambio de {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Inquilino Asignado',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/et.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/et.ts
@@ -5,6 +5,9 @@ export const etTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Te olete tegemas omandiõiguse muudatust <0>{{fromTenant}}</0>lt <0>{{toTenant}}</0>le.',
     'confirm-tenant-switch--heading': 'Kinnita {{tenantLabel}} muutus',
+    fields: {
+      tenantFieldLabel: 'Määratud üürnik',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/et.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/et.ts
@@ -5,9 +5,7 @@ export const etTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Te olete tegemas omandiõiguse muudatust <0>{{fromTenant}}</0>lt <0>{{toTenant}}</0>le.',
     'confirm-tenant-switch--heading': 'Kinnita {{tenantLabel}} muutus',
-    fields: {
-      tenantFieldLabel: 'Määratud üürnik',
-    },
+    'field-assignedTentant-label': 'Määratud üürnik',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/fa.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/fa.ts
@@ -5,6 +5,9 @@ export const faTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'شما در حال تغییر مالکیت از <0>{{fromTenant}}</0> به <0>{{toTenant}}</0> هستید',
     'confirm-tenant-switch--heading': 'تایید تغییر {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'مستاجر اختصاص یافته',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/fa.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/fa.ts
@@ -5,9 +5,7 @@ export const faTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'شما در حال تغییر مالکیت از <0>{{fromTenant}}</0> به <0>{{toTenant}}</0> هستید',
     'confirm-tenant-switch--heading': 'تایید تغییر {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'مستاجر اختصاص یافته',
-    },
+    'field-assignedTentant-label': 'مستاجر اختصاص یافته',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/fr.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/fr.ts
@@ -5,9 +5,7 @@ export const frTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Vous êtes sur le point de changer la propriété de <0>{{fromTenant}}</0> à <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirmer le changement de {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Locataire Assigné',
-    },
+    'field-assignedTentant-label': 'Locataire Attribué',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/fr.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/fr.ts
@@ -5,6 +5,9 @@ export const frTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Vous êtes sur le point de changer la propriété de <0>{{fromTenant}}</0> à <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirmer le changement de {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Locataire Assigné',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/he.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/he.ts
@@ -5,9 +5,7 @@ export const heTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'אתה עומד לשנות בעלות מ- <0>{{fromTenant}}</0> ל- <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'אשר שינוי {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'שוכר מוקצה',
-    },
+    'field-assignedTentant-label': 'דייר מוקצה',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/he.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/he.ts
@@ -5,6 +5,9 @@ export const heTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'אתה עומד לשנות בעלות מ- <0>{{fromTenant}}</0> ל- <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'אשר שינוי {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'שוכר מוקצה',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/hr.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/hr.ts
@@ -5,6 +5,9 @@ export const hrTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Upravo ćete promijeniti vlasništvo sa <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrdi promjenu {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Dodijeljeni najmoprimac',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/hr.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/hr.ts
@@ -5,9 +5,7 @@ export const hrTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Upravo ćete promijeniti vlasništvo sa <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrdi promjenu {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Dodijeljeni najmoprimac',
-    },
+    'field-assignedTentant-label': 'Dodijeljeni stanar',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/hu.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/hu.ts
@@ -5,6 +5,9 @@ export const huTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Ön azon van, hogy megváltoztassa a tulajdonjogot <0>{{fromTenant}}</0>-ről <0>{{toTenant}}</0>-re.',
     'confirm-tenant-switch--heading': 'Erősítse meg a(z) {{tenantLabel}} változtatást',
+    fields: {
+      tenantFieldLabel: 'Kijelölt Bérlő',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/hu.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/hu.ts
@@ -5,9 +5,7 @@ export const huTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Ön azon van, hogy megváltoztassa a tulajdonjogot <0>{{fromTenant}}</0>-ről <0>{{toTenant}}</0>-re.',
     'confirm-tenant-switch--heading': 'Erősítse meg a(z) {{tenantLabel}} változtatást',
-    fields: {
-      tenantFieldLabel: 'Kijelölt Bérlő',
-    },
+    'field-assignedTentant-label': 'Kijelölt Bérlő',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/hy.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/hy.ts
@@ -5,6 +5,9 @@ export const hyTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Դուք պատրաստ եք փոխել գերեցդիմատնին ընկերությունը <0>{{fromTenant}}</0>-ից <0>{{toTenant}}</0>-ին',
     'confirm-tenant-switch--heading': 'Հաստատեք {{tenantLabel}} փոփոխությունը',
+    fields: {
+      tenantFieldLabel: 'Հանձնարարված վարձակալ',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/hy.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/hy.ts
@@ -5,9 +5,7 @@ export const hyTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Դուք պատրաստ եք փոխել գերեցդիմատնին ընկերությունը <0>{{fromTenant}}</0>-ից <0>{{toTenant}}</0>-ին',
     'confirm-tenant-switch--heading': 'Հաստատեք {{tenantLabel}} փոփոխությունը',
-    fields: {
-      tenantFieldLabel: 'Հանձնարարված վարձակալ',
-    },
+    'field-assignedTentant-label': 'Հանձնարարված վարձակալ',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/it.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/it.ts
@@ -5,9 +5,7 @@ export const itTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Stai per cambiare proprietà da <0>{{fromTenant}}</0> a <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Conferma il cambiamento di {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Inquilino Assegnato',
-    },
+    'field-assignedTentant-label': 'Inquilino Assegnato',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/it.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/it.ts
@@ -5,6 +5,9 @@ export const itTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Stai per cambiare proprietà da <0>{{fromTenant}}</0> a <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Conferma il cambiamento di {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Inquilino Assegnato',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ja.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ja.ts
@@ -5,9 +5,7 @@ export const jaTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'あなたは所有権を<0>{{fromTenant}}</0>から<0>{{toTenant}}</0>へ変更しようとしています',
     'confirm-tenant-switch--heading': '{{tenantLabel}}の変更を確認してください',
-    fields: {
-      tenantFieldLabel: '割り当てられたテナント',
-    },
+    'field-assignedTentant-label': '割り当てられたテナント',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ja.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ja.ts
@@ -5,6 +5,9 @@ export const jaTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'あなたは所有権を<0>{{fromTenant}}</0>から<0>{{toTenant}}</0>へ変更しようとしています',
     'confirm-tenant-switch--heading': '{{tenantLabel}}の変更を確認してください',
+    fields: {
+      tenantFieldLabel: '割り当てられたテナント',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ko.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ko.ts
@@ -5,6 +5,9 @@ export const koTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       '<0>{{fromTenant}}</0>에서 <0>{{toTenant}}</0>으로 소유권을 변경하려고 합니다.',
     'confirm-tenant-switch--heading': '{{tenantLabel}} 변경을 확인하세요',
+    fields: {
+      tenantFieldLabel: '할당된 임차인',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ko.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ko.ts
@@ -5,9 +5,7 @@ export const koTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       '<0>{{fromTenant}}</0>에서 <0>{{toTenant}}</0>으로 소유권을 변경하려고 합니다.',
     'confirm-tenant-switch--heading': '{{tenantLabel}} 변경을 확인하세요',
-    fields: {
-      tenantFieldLabel: '할당된 임차인',
-    },
+    'field-assignedTentant-label': '지정된 세입자',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/lt.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/lt.ts
@@ -5,9 +5,7 @@ export const ltTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Jūs ketinate pakeisti nuosavybės teisę iš <0>{{fromTenant}}</0> į <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Patvirtinkite {{tenantLabel}} pakeitimą',
-    fields: {
-      tenantFieldLabel: 'Paskirtas nuomininkas',
-    },
+    'field-assignedTentant-label': 'Paskirtas nuomininkas',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/lt.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/lt.ts
@@ -5,6 +5,9 @@ export const ltTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Jūs ketinate pakeisti nuosavybės teisę iš <0>{{fromTenant}}</0> į <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Patvirtinkite {{tenantLabel}} pakeitimą',
+    fields: {
+      tenantFieldLabel: 'Paskirtas nuomininkas',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/lv.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/lv.ts
@@ -5,9 +5,7 @@ export const lvTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Jūs gatavojaties mainīt īpašumtiesības no <0>{{fromTenant}}</0> uz <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Apstipriniet {{tenantLabel}} izmaiņu',
-    fields: {
-      tenantFieldLabel: 'Piešķirts īrnieks',
-    },
+    'field-assignedTentant-label': 'Piešķirts īrnieks',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/lv.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/lv.ts
@@ -1,0 +1,17 @@
+import type { PluginDefaultTranslationsObject, PluginLanguage } from '../types.js'
+
+export const lvTranslations: PluginDefaultTranslationsObject = {
+  'plugin-multi-tenant': {
+    'confirm-tenant-switch--body':
+      'Jūs gatavojaties mainīt īpašumtiesības no <0>{{fromTenant}}</0> uz <0>{{toTenant}}</0>',
+    'confirm-tenant-switch--heading': 'Apstipriniet {{tenantLabel}} izmaiņu',
+    fields: {
+      tenantFieldLabel: 'Piešķirts īrnieks',
+    },
+  },
+}
+
+export const lv: PluginLanguage = {
+  dateFNSKey: 'lv',
+  translations: lvTranslations,
+}

--- a/packages/plugin-multi-tenant/src/translations/languages/my.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/my.ts
@@ -5,6 +5,9 @@ export const myTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Anda akan mengubah pemilikan dari <0>{{fromTenant}}</0> ke <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Sahkan perubahan {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'ထိုးထားသော အငှားရှင်',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/my.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/my.ts
@@ -5,9 +5,7 @@ export const myTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Anda akan mengubah pemilikan dari <0>{{fromTenant}}</0> ke <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Sahkan perubahan {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'ထိုးထားသော အငှားရှင်',
-    },
+    'field-assignedTentant-label': 'ခွဲစိုက်ထားသော အငှားယူသူ',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/nb.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/nb.ts
@@ -5,9 +5,7 @@ export const nbTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Du er i ferd med å endre eierskap fra <0>{{fromTenant}}</0> til <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bekreft {{tenantLabel}} endring',
-    fields: {
-      tenantFieldLabel: 'Tildelt Leietaker',
-    },
+    'field-assignedTentant-label': 'Tildelt leietaker',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/nb.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/nb.ts
@@ -5,6 +5,9 @@ export const nbTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Du er i ferd med å endre eierskap fra <0>{{fromTenant}}</0> til <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bekreft {{tenantLabel}} endring',
+    fields: {
+      tenantFieldLabel: 'Tildelt Leietaker',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/nl.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/nl.ts
@@ -5,6 +5,9 @@ export const nlTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'U staat op het punt het eigendom te wijzigen van <0>{{fromTenant}}</0> naar <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bevestig wijziging van {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Toegewezen Huurder',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/nl.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/nl.ts
@@ -5,9 +5,7 @@ export const nlTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'U staat op het punt het eigendom te wijzigen van <0>{{fromTenant}}</0> naar <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bevestig wijziging van {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Toegewezen Huurder',
-    },
+    'field-assignedTentant-label': 'Toegewezen Huurder',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/pl.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/pl.ts
@@ -5,9 +5,7 @@ export const plTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Za chwilę nastąpi zmiana właściciela z <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potwierdź zmianę {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Przypisany Najemca',
-    },
+    'field-assignedTentant-label': 'Przypisany Najemca',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/pl.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/pl.ts
@@ -5,6 +5,9 @@ export const plTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Za chwilę nastąpi zmiana właściciela z <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potwierdź zmianę {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Przypisany Najemca',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/pt.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/pt.ts
@@ -5,6 +5,9 @@ export const ptTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Você está prestes a alterar a propriedade de <0>{{fromTenant}}</0> para <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirme a alteração de {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Inquilino Atribuído',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/pt.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/pt.ts
@@ -5,9 +5,7 @@ export const ptTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Você está prestes a alterar a propriedade de <0>{{fromTenant}}</0> para <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirme a alteração de {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Inquilino Atribuído',
-    },
+    'field-assignedTentant-label': 'Inquilino Atribuído',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ro.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ro.ts
@@ -5,9 +5,7 @@ export const roTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Sunteți pe punctul de a schimba proprietatea de la <0>{{fromTenant}}</0> la <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirmați schimbarea {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Locatar Alocat',
-    },
+    'field-assignedTentant-label': 'Locatar Atribuit',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ro.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ro.ts
@@ -5,6 +5,9 @@ export const roTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Sunteți pe punctul de a schimba proprietatea de la <0>{{fromTenant}}</0> la <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Confirmați schimbarea {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Locatar Alocat',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/rs.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/rs.ts
@@ -5,9 +5,7 @@ export const rsTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Upravo ćete promeniti vlasništvo sa <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrdi promena {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Dodeljeni stanar',
-    },
+    'field-assignedTentant-label': 'Dodeljen stanar',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/rs.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/rs.ts
@@ -5,6 +5,9 @@ export const rsTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Upravo ćete promeniti vlasništvo sa <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrdi promena {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Dodeljeni stanar',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/rsLatin.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/rsLatin.ts
@@ -5,6 +5,9 @@ export const rsLatinTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Uskoro ćete promeniti vlasništvo sa <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrdite promenu {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Dodeljeni stanar',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/rsLatin.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/rsLatin.ts
@@ -5,9 +5,7 @@ export const rsLatinTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Uskoro ćete promeniti vlasništvo sa <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrdite promenu {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Dodeljeni stanar',
-    },
+    'field-assignedTentant-label': 'Dodeljen stanar',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ru.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ru.ts
@@ -5,6 +5,9 @@ export const ruTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Вы собираетесь изменить владельца с <0>{{fromTenant}}</0> на <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Подтвердите изменение {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Назначенный арендатор',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/ru.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/ru.ts
@@ -5,9 +5,7 @@ export const ruTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Вы собираетесь изменить владельца с <0>{{fromTenant}}</0> на <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Подтвердите изменение {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Назначенный арендатор',
-    },
+    'field-assignedTentant-label': 'Назначенный Арендатор',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/sk.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/sk.ts
@@ -5,9 +5,7 @@ export const skTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Chystáte sa zmeniť vlastníctvo z <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrďte zmenu {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Pridelený nájomca',
-    },
+    'field-assignedTentant-label': 'Pridelený nájomca',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/sk.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/sk.ts
@@ -5,6 +5,9 @@ export const skTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Chystáte sa zmeniť vlastníctvo z <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potvrďte zmenu {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Pridelený nájomca',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/sl.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/sl.ts
@@ -5,9 +5,7 @@ export const slTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Ravno ste pred spremembo lastništva iz <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potrdi spremembo {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Dodeljen najemnik',
-    },
+    'field-assignedTentant-label': 'Dodeljen najemnik',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/sl.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/sl.ts
@@ -5,6 +5,9 @@ export const slTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Ravno ste pred spremembo lastništva iz <0>{{fromTenant}}</0> na <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Potrdi spremembo {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Dodeljen najemnik',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/sv.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/sv.ts
@@ -5,6 +5,9 @@ export const svTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Du är på väg att ändra ägare från <0>{{fromTenant}}</0> till <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bekräfta ändring av {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Tilldelad Hyresgäst',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/sv.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/sv.ts
@@ -5,9 +5,7 @@ export const svTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Du är på väg att ändra ägare från <0>{{fromTenant}}</0> till <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Bekräfta ändring av {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Tilldelad Hyresgäst',
-    },
+    'field-assignedTentant-label': 'Tilldelad hyresgäst',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/th.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/th.ts
@@ -5,6 +5,9 @@ export const thTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'คุณกำลังจะเปลี่ยนความเป็นเจ้าของจาก <0>{{fromTenant}}</0> เป็น <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'ยืนยันการเปลี่ยนแปลง {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'ผู้เช่าที่ได้รับการมอบหมาย',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/th.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/th.ts
@@ -5,9 +5,7 @@ export const thTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'คุณกำลังจะเปลี่ยนความเป็นเจ้าของจาก <0>{{fromTenant}}</0> เป็น <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'ยืนยันการเปลี่ยนแปลง {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'ผู้เช่าที่ได้รับการมอบหมาย',
-    },
+    'field-assignedTentant-label': 'ผู้เช่าที่ได้รับการกำหนด',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/tr.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/tr.ts
@@ -5,9 +5,7 @@ export const trTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       "Sahipliği <0>{{fromTenant}}</0>'den <0>{{toTenant}}</0>'e değiştirmek üzeresiniz.",
     'confirm-tenant-switch--heading': '{{tenantLabel}} değişikliğini onayla',
-    fields: {
-      tenantFieldLabel: 'Atanan Kiracı',
-    },
+    'field-assignedTentant-label': 'Atanan Kiracı',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/tr.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/tr.ts
@@ -5,6 +5,9 @@ export const trTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       "Sahipliği <0>{{fromTenant}}</0>'den <0>{{toTenant}}</0>'e değiştirmek üzeresiniz.",
     'confirm-tenant-switch--heading': '{{tenantLabel}} değişikliğini onayla',
+    fields: {
+      tenantFieldLabel: 'Atanan Kiracı',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/uk.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/uk.ts
@@ -5,6 +5,9 @@ export const ukTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Ви збираєтесь змінити власність з <0>{{fromTenant}}</0> на <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Підтвердіть зміну {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Призначений орендар',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/uk.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/uk.ts
@@ -5,9 +5,7 @@ export const ukTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Ви збираєтесь змінити власність з <0>{{fromTenant}}</0> на <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Підтвердіть зміну {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Призначений орендар',
-    },
+    'field-assignedTentant-label': 'Призначений орендар',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/vi.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/vi.ts
@@ -5,6 +5,9 @@ export const viTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Bạn đang chuẩn bị chuyển quyền sở hữu từ <0>{{fromTenant}}</0> sang <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Xác nhận thay đổi {{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: 'Người thuê được giao',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/vi.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/vi.ts
@@ -5,9 +5,7 @@ export const viTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       'Bạn đang chuẩn bị chuyển quyền sở hữu từ <0>{{fromTenant}}</0> sang <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': 'Xác nhận thay đổi {{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: 'Người thuê được giao',
-    },
+    'field-assignedTentant-label': 'Người thuê đã được chỉ định',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/zh.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/zh.ts
@@ -4,6 +4,9 @@ export const zhTranslations: PluginDefaultTranslationsObject = {
   'plugin-multi-tenant': {
     'confirm-tenant-switch--body': '您即将将所有权从<0>{{fromTenant}}</0>更改为<0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': '确认更改{{tenantLabel}}',
+    fields: {
+      tenantFieldLabel: '指定租户',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/zh.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/zh.ts
@@ -4,9 +4,7 @@ export const zhTranslations: PluginDefaultTranslationsObject = {
   'plugin-multi-tenant': {
     'confirm-tenant-switch--body': '您即将将所有权从<0>{{fromTenant}}</0>更改为<0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': '确认更改{{tenantLabel}}',
-    fields: {
-      tenantFieldLabel: '指定租户',
-    },
+    'field-assignedTentant-label': '指定租户',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/zhTw.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/zhTw.ts
@@ -5,9 +5,7 @@ export const zhTwTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       '您即將將所有權從 <0>{{fromTenant}}</0> 轉移至 <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': '確認{{tenantLabel}}更改',
-    fields: {
-      tenantFieldLabel: '指定租戶',
-    },
+    'field-assignedTentant-label': '指定的租戶',
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/languages/zhTw.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/zhTw.ts
@@ -5,6 +5,9 @@ export const zhTwTranslations: PluginDefaultTranslationsObject = {
     'confirm-tenant-switch--body':
       '您即將將所有權從 <0>{{fromTenant}}</0> 轉移至 <0>{{toTenant}}</0>',
     'confirm-tenant-switch--heading': '確認{{tenantLabel}}更改',
+    fields: {
+      tenantFieldLabel: '指定租戶',
+    },
   },
 }
 

--- a/packages/plugin-multi-tenant/src/translations/types.ts
+++ b/packages/plugin-multi-tenant/src/translations/types.ts
@@ -6,9 +6,7 @@ export type PluginLanguage = Language<{
   'plugin-multi-tenant': {
     'confirm-tenant-switch--body': string
     'confirm-tenant-switch--heading': string
-    fields: {
-      tenantFieldLabel: string
-    }
+    'field-assignedTentant-label': string
   }
 }>
 

--- a/packages/plugin-multi-tenant/src/translations/types.ts
+++ b/packages/plugin-multi-tenant/src/translations/types.ts
@@ -6,6 +6,9 @@ export type PluginLanguage = Language<{
   'plugin-multi-tenant': {
     'confirm-tenant-switch--body': string
     'confirm-tenant-switch--heading': string
+    fields: {
+      tenantFieldLabel: string
+    }
   }
 }>
 


### PR DESCRIPTION
Previously the "Assigned Tenant" field didn't have a translated label