### PR TITLE
fix: infinite loop in findUp utility when a result is not found

### DIFF
--- a/packages/payload/src/utilities/findUp.ts
+++ b/packages/payload/src/utilities/findUp.ts
@@ -30,7 +30,7 @@ export function findUpSync({
           break
         }
       }
-      if (!found) {
+      if (!found && dir !== root) {
         dir = path.dirname(dir) // Move up one directory level.
         continue
       }
@@ -77,7 +77,7 @@ export async function findUp({
           break
         }
       }
-      if (!found) {
+      if (!found && dir !== root) {
         dir = path.dirname(dir) // Move up one directory level.
         continue
       }


### PR DESCRIPTION
### What?
Fixes an infinite loop that may occur when invoking the findUp() utility to search for a file by name and no result is found.

### Why?
If triggered, the infinite loop will hang the entire application. For example, this occurs when trying to boot Payload from a Cloudflare Worker, as reported in #12327 

### How?
By checking whether it has reached the root directory before analysing the parent folder