### PR TITLE
fix: auto inject req.user into query preset constraints

### DIFF
--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -71,6 +71,10 @@ export const getConstraints = (config: Config): Field => ({
                     }
                   }
 
+                  if (data?.access?.[operation]?.constraint === 'specificUsers') {
+                    return [...(data?.access?.[operation]?.users || []), req.user.id]
+                  }
+
                   return data?.access?.[operation]?.users
                 },
               ],

--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -65,13 +65,11 @@ export const getConstraints = (config: Config): Field => ({
             hooks: {
               beforeChange: [
                 ({ data, req }) => {
-                  if (data?.access?.[operation]?.constraint === 'onlyMe') {
-                    if (req.user) {
-                      return [req.user.id]
-                    }
+                  if (data?.access?.[operation]?.constraint === 'onlyMe' && req.user) {
+                    return [req.user.id]
                   }
 
-                  if (data?.access?.[operation]?.constraint === 'specificUsers') {
+                  if (data?.access?.[operation]?.constraint === 'specificUsers' && req.user) {
                     return [...(data?.access?.[operation]?.users || []), req.user.id]
                   }
 

--- a/packages/payload/src/query-presets/preventLockout.ts
+++ b/packages/payload/src/query-presets/preventLockout.ts
@@ -72,7 +72,7 @@ export const preventLockout: Validate = async (
       canUpdate = true
     } catch (_err) {
       if (!canRead || !canUpdate) {
-        throw new APIError('Cannot remove yourself from this preset.', 403, {}, true)
+        throw new APIError('This action will lock you out of this preset.', 403, {}, true)
       }
     } finally {
       if (transaction) {


### PR DESCRIPTION
In #12322 we prevented against accidental query preset lockout by throwing a validation error when the user is going to change the preset in a way that removes their own access to it. This, however, puts the responsibility on the user to make the corrections and is an unnecessary step.

For example, the API currently forbids leaving yourself out of the `users` array when specifying the `specificUsers` constraint, but when you encounter this error, have to update the field manually and try again.

To improve the experience, we now automatically inject the requesting user onto the `users` array when this constraint is selected. This will guarantee they have access and prevent an accidental lockout while also avoiding the API error feedback loop.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210524295135119