### PR TITLE
docs: update rich text to HTML conversion documentation

### DIFF
--- a/docs/rich-text/converting-html.mdx
+++ b/docs/rich-text/converting-html.mdx
@@ -6,14 +6,14 @@ desc: Converting between lexical richtext and HTML
 keywords: lexical, richtext, html
 ---
 
-## Converting Rich Text to HTML
+## Rich Text to HTML
 
 There are two main approaches to convert your Lexical-based rich text to HTML:
 
 1. **Generate HTML on-demand (Recommended)**: Convert JSON to HTML wherever you need it, on-demand.
 2. **Generate HTML within your Collection**: Create a new field that automatically converts your saved JSON content to HTML. This is not recommended because it adds overhead to the Payload API and may not work well with live preview.
 
-### Generating HTML on-demand (Recommended)
+### On-demand (Recommended)
 
 To convert JSON to HTML on-demand, use the `convertLexicalToHTML` function from `@payloadcms/richtext-lexical/html`. Here's an example of how to use it in a React component in your frontend:
 
@@ -32,7 +32,7 @@ export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
 }
 ```
 
-### Converting Lexical Blocks
+#### Lexical Blocks
 
 If your rich text includes Lexical blocks, you need to provide a way to convert them to HTML. For example:
 
@@ -84,9 +84,81 @@ export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
 }
 ```
 
-### Outputting HTML from the Collection
+#### Dynamic Population (Advanced)
 
-To automatically generate HTML from the saved richText field in your Collection, use the `lexicalHTMLField()` helper. This approach converts the JSON to HTML using an `afterRead` hook. For instance:
+By default, `convertLexicalToHTML` expects fully populated data (e.g. uploads, links, etc.). If you need to dynamically fetch and populate those nodes, use the async variant, `convertLexicalToHTMLAsync`, from `@payloadcms/richtext-lexical/html-async`. You must provide a `populate` function:
+
+```tsx
+'use client'
+
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
+import { getRestPopulateFn } from '@payloadcms/richtext-lexical/client'
+import { convertLexicalToHTMLAsync } from '@payloadcms/richtext-lexical/html-async'
+import React, { useEffect, useState } from 'react'
+
+export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
+  const [html, setHTML] = useState<null | string>(null)
+  useEffect(() => {
+    async function convert() {
+      const html = await convertLexicalToHTMLAsync({
+        data,
+        populate: getRestPopulateFn({
+          apiURL: `http://localhost:3000/api`,
+        }),
+      })
+      setHTML(html)
+    }
+
+    void convert()
+  }, [data])
+
+  return html && <div dangerouslySetInnerHTML={{ __html: html }} />
+}
+```
+
+Using the REST populate function will send a separate request for each node. If you need to populate a large number of nodes, this may be slow. For improved performance on the server, you can use the `getPayloadPopulateFn` function:
+
+```tsx
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
+import { getPayloadPopulateFn } from '@payloadcms/richtext-lexical'
+import { convertLexicalToHTMLAsync } from '@payloadcms/richtext-lexical/html-async'
+import { getPayload } from 'payload'
+import React from 'react'
+
+import config from '../../config.js'
+
+export const MyRSCComponent = async ({
+  data,
+}: {
+  data: SerializedEditorState
+}) => {
+  const payload = await getPayload({
+    config,
+  })
+
+  const html = await convertLexicalToHTMLAsync({
+    data,
+    populate: await getPayloadPopulateFn({
+      currentDepth: 0,
+      depth: 1,
+      payload,
+    }),
+  })
+
+  return html && <div dangerouslySetInnerHTML={{ __html: html }} />
+}
+```
+
+### HTML field
+
+The `lexicalHTMLField()` helper converts JSON to HTML and saves it in a field that is updated every time you read it via an `afterRead` hook. It's generally not recommended for two reasons:
+
+1. It creates a column with duplicate content in another format.
+2. In [live preview](/docs/live-preview/overview), it makes it not "live".
+
+Consider using the [on-demand HTML converter above](/docs/rich-text/converting-html#on-demand-recommended) or the [JSX converter](/docs/rich-text/converting-jsx) unless you have a good reason.
 
 ```ts
 import type { HTMLConvertersFunction } from '@payloadcms/richtext-lexical/html'
@@ -154,74 +226,7 @@ const Pages: CollectionConfig = {
 }
 ```
 
-### Generating HTML in Your Frontend with Dynamic Population (Advanced)
-
-By default, `convertLexicalToHTML` expects fully populated data (e.g. uploads, links, etc.). If you need to dynamically fetch and populate those nodes, use the async variant, `convertLexicalToHTMLAsync`, from `@payloadcms/richtext-lexical/html-async`. You must provide a `populate` function:
-
-```tsx
-'use client'
-
-import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
-
-import { getRestPopulateFn } from '@payloadcms/richtext-lexical/client'
-import { convertLexicalToHTMLAsync } from '@payloadcms/richtext-lexical/html-async'
-import React, { useEffect, useState } from 'react'
-
-export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
-  const [html, setHTML] = useState<null | string>(null)
-  useEffect(() => {
-    async function convert() {
-      const html = await convertLexicalToHTMLAsync({
-        data,
-        populate: getRestPopulateFn({
-          apiURL: `http://localhost:3000/api`,
-        }),
-      })
-      setHTML(html)
-    }
-
-    void convert()
-  }, [data])
-
-  return html && <div dangerouslySetInnerHTML={{ __html: html }} />
-}
-```
-
-Using the REST populate function will send a separate request for each node. If you need to populate a large number of nodes, this may be slow. For improved performance on the server, you can use the `getPayloadPopulateFn` function:
-
-```tsx
-import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
-
-import { getPayloadPopulateFn } from '@payloadcms/richtext-lexical'
-import { convertLexicalToHTMLAsync } from '@payloadcms/richtext-lexical/html-async'
-import { getPayload } from 'payload'
-import React from 'react'
-
-import config from '../../config.js'
-
-export const MyRSCComponent = async ({
-  data,
-}: {
-  data: SerializedEditorState
-}) => {
-  const payload = await getPayload({
-    config,
-  })
-
-  const html = await convertLexicalToHTMLAsync({
-    data,
-    populate: await getPayloadPopulateFn({
-      currentDepth: 0,
-      depth: 1,
-      payload,
-    }),
-  })
-
-  return html && <div dangerouslySetInnerHTML={{ __html: html }} />
-}
-```
-
-## Converting HTML to Richtext
+## HTML to Richtext
 
 If you need to convert raw HTML into a Lexical editor state, use `convertHTMLToLexical` from `@payloadcms/richtext-lexical`, along with the [editorConfigFactory to retrieve the editor config](/docs/rich-text/converters#retrieving-the-editor-config):
 

--- a/docs/rich-text/converting-html.mdx
+++ b/docs/rich-text/converting-html.mdx
@@ -156,7 +156,7 @@ export const MyRSCComponent = async ({
 The `lexicalHTMLField()` helper converts JSON to HTML and saves it in a field that is updated every time you read it via an `afterRead` hook. It's generally not recommended for two reasons:
 
 1. It creates a column with duplicate content in another format.
-2. In [live preview](/docs/live-preview/overview), it makes it not "live".
+2. In [client-side live preview](/docs/live-preview/client), it makes it not "live".
 
 Consider using the [on-demand HTML converter above](/docs/rich-text/converting-html#on-demand-recommended) or the [JSX converter](/docs/rich-text/converting-jsx) unless you have a good reason.
 

--- a/docs/rich-text/converting-html.mdx
+++ b/docs/rich-text/converting-html.mdx
@@ -13,7 +13,7 @@ There are two main approaches to convert your Lexical-based rich text to HTML:
 1. **Generate HTML on-demand (Recommended)**: Convert JSON to HTML wherever you need it, on-demand.
 2. **Generate HTML within your Collection**: Create a new field that automatically converts your saved JSON content to HTML. This is not recommended because it adds overhead to the Payload API and may not work well with live preview.
 
-### On-demand (Recommended)
+### On-demand
 
 To convert JSON to HTML on-demand, use the `convertLexicalToHTML` function from `@payloadcms/richtext-lexical/html`. Here's an example of how to use it in a React component in your frontend:
 
@@ -27,58 +27,6 @@ import React from 'react'
 
 export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
   const html = convertLexicalToHTML({ data })
-
-  return <div dangerouslySetInnerHTML={{ __html: html }} />
-}
-```
-
-#### Lexical Blocks
-
-If your rich text includes Lexical blocks, you need to provide a way to convert them to HTML. For example:
-
-```tsx
-'use client'
-
-import type { MyInlineBlock, MyTextBlock } from '@/payload-types'
-import type {
-  DefaultNodeTypes,
-  SerializedBlockNode,
-  SerializedInlineBlockNode,
-} from '@payloadcms/richtext-lexical'
-import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
-
-import {
-  convertLexicalToHTML,
-  type HTMLConvertersFunction,
-} from '@payloadcms/richtext-lexical/html'
-import React from 'react'
-
-type NodeTypes =
-  | DefaultNodeTypes
-  | SerializedBlockNode<MyTextBlock>
-  | SerializedInlineBlockNode<MyInlineBlock>
-
-const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
-  defaultConverters,
-}) => ({
-  ...defaultConverters,
-  blocks: {
-    // Each key should match your block's slug
-    myTextBlock: ({ node, providedCSSString }) =>
-      `<div style="background-color: red;${providedCSSString}">${node.fields.text}</div>`,
-  },
-  inlineBlocks: {
-    // Each key should match your inline block's slug
-    myInlineBlock: ({ node, providedStyleTag }) =>
-      `<span${providedStyleTag}>${node.fields.text}</span$>`,
-  },
-})
-
-export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
-  const html = convertLexicalToHTML({
-    converters: htmlConverters,
-    data,
-  })
 
   return <div dangerouslySetInnerHTML={{ __html: html }} />
 }
@@ -223,6 +171,58 @@ const Pages: CollectionConfig = {
       >,
     }),
   ],
+}
+```
+
+## Blocks to HTML
+
+If your rich text includes Lexical blocks, you need to provide a way to convert them to HTML. For example:
+
+```tsx
+'use client'
+
+import type { MyInlineBlock, MyTextBlock } from '@/payload-types'
+import type {
+  DefaultNodeTypes,
+  SerializedBlockNode,
+  SerializedInlineBlockNode,
+} from '@payloadcms/richtext-lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
+import {
+  convertLexicalToHTML,
+  type HTMLConvertersFunction,
+} from '@payloadcms/richtext-lexical/html'
+import React from 'react'
+
+type NodeTypes =
+  | DefaultNodeTypes
+  | SerializedBlockNode<MyTextBlock>
+  | SerializedInlineBlockNode<MyInlineBlock>
+
+const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
+  defaultConverters,
+}) => ({
+  ...defaultConverters,
+  blocks: {
+    // Each key should match your block's slug
+    myTextBlock: ({ node, providedCSSString }) =>
+      `<div style="background-color: red;${providedCSSString}">${node.fields.text}</div>`,
+  },
+  inlineBlocks: {
+    // Each key should match your inline block's slug
+    myInlineBlock: ({ node, providedStyleTag }) =>
+      `<span${providedStyleTag}>${node.fields.text}</span$>`,
+  },
+})
+
+export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
+  const html = convertLexicalToHTML({
+    converters: htmlConverters,
+    data,
+  })
+
+  return <div dangerouslySetInnerHTML={{ __html: html }} />
 }
 ```
 

--- a/docs/rich-text/converting-jsx.mdx
+++ b/docs/rich-text/converting-jsx.mdx
@@ -6,7 +6,7 @@ desc: Converting between lexical richtext and JSX
 keywords: lexical, richtext, jsx
 ---
 
-## Converting Richtext to JSX
+## Richtext to JSX
 
 To convert richtext to JSX, import the `RichText` component from `@payloadcms/richtext-lexical/react` and pass the richtext content to it:
 
@@ -28,7 +28,7 @@ The `RichText` component includes built-in converters for common Lexical nodes. 
   populated data to work correctly.
 </Banner>
 
-### Converting Internal Links
+### Internal Links
 
 By default, Payload doesn't know how to convert **internal** links to JSX, as it doesn't know what the corresponding URL of the internal link is. You'll notice that you get a "found internal link, but internalDocToHref is not provided" error in the console when you try to render content with internal links.
 
@@ -81,7 +81,7 @@ export const MyComponent: React.FC<{
 }
 ```
 
-### Converting Lexical Blocks
+### Lexical Blocks
 
 If your rich text includes custom Blocks or Inline Blocks, you must supply custom converters that match each block's slug. This converter is not included by default, as Payload doesn't know how to render your custom blocks.
 
@@ -133,7 +133,7 @@ export const MyComponent: React.FC<{
 }
 ```
 
-### Overriding Default JSX Converters
+### Overriding Converters
 
 You can override any of the default JSX converters by passing passing your custom converter, keyed to the node type, to the `converters` prop / the converters function.
 

--- a/docs/rich-text/converting-markdown.mdx
+++ b/docs/rich-text/converting-markdown.mdx
@@ -6,7 +6,7 @@ desc: Converting between lexical richtext and Markdown / MDX
 keywords: lexical, richtext, markdown, md, mdx
 ---
 
-## Converting Richtext to Markdown
+## Richtext to Markdown
 
 If you have access to the Payload Config and the [lexical editor config](/docs/rich-text/converters#retrieving-the-editor-config), you can convert the lexical editor state to Markdown with the following:
 
@@ -91,7 +91,7 @@ const Pages: CollectionConfig = {
 }
 ```
 
-## Converting Markdown to Richtext
+## Markdown to Richtext
 
 If you have access to the Payload Config and the [lexical editor config](/docs/rich-text/converters#retrieving-the-editor-config), you can convert Markdown to the lexical editor state with the following:
 

--- a/docs/rich-text/converting-plaintext.mdx
+++ b/docs/rich-text/converting-plaintext.mdx
@@ -6,7 +6,7 @@ desc: Converting between lexical richtext and plaintext
 keywords: lexical, richtext, plaintext, text
 ---
 
-## Converting Richtext to Plaintext
+## Richtext to Plaintext
 
 Here's how you can convert richtext data to plaintext using `@payloadcms/richtext-lexical/plaintext`.
 


### PR DESCRIPTION
Fixes #8168, #8277

The fact that `lexicalHTMLField` doesn't work with live preview was already clarified at the beginning of the page. I mentioned it again in the dedicated section because it seems there was still confusion.

Also, I reordered and hierarchized the headings correctly. The introduction said there were two ways to convert to HTML, but there were four headings with the same level. I also made the headings a little shorter to make the table of contents easier to parse.