### PR TITLE
chore(examples): remove unused imports from custom server example

### DIFF
--- a/examples/custom-server/src/payload.config.ts
+++ b/examples/custom-server/src/payload.config.ts
@@ -1,7 +1,6 @@
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import path from 'path'
-import express from 'express'
 import { buildConfig } from 'payload'
 import { fileURLToPath } from 'url'
 

--- a/examples/custom-server/src/server.ts
+++ b/examples/custom-server/src/server.ts
@@ -1,5 +1,4 @@
 import express from 'express'
-import type { Request, Response } from 'express'
 import { parse } from 'url'
 import next from 'next'
 


### PR DESCRIPTION
Removed `express` imports that were not being utilized.