### PR TITLE
fix(richtext-lexical): support inline block types in strict mode for JSXConvertersFunction type

### DIFF
--- a/packages/richtext-lexical/src/features/converters/lexicalToJSX/Component/index.tsx
+++ b/packages/richtext-lexical/src/features/converters/lexicalToJSX/Component/index.tsx
@@ -16,7 +16,7 @@ export type JSXConvertersFunction<
   T extends { [key: string]: any; type?: string } =
     | DefaultNodeTypes
     | SerializedBlockNode<{ blockName?: null | string }>
-    | SerializedInlineBlockNode<{ blockName?: null | string; blockType: string }>,
+    | SerializedInlineBlockNode<{ blockName?: null | string }>,
 > = (args: { defaultConverters: JSXConverters<DefaultNodeTypes> }) => JSXConverters<T>
 
 type RichTextProps = {


### PR DESCRIPTION
Same as https://github.com/payloadcms/payload/pull/10398 but for inline blocks.

> Reproduction steps:
> 1. Set `strict: true` in `templates/website/tsconfig.json`
> 2. You will find a ts error in `templates/website/src/components/RichText/index.tsx`.
> 
> This is because the blockType property of blocks is generated by Payload as a literal (e.g. "mediaBlock") and cannot be assigned to a string.
> 
> To test this PR, you can make the change to `JSXConvertersFunction` in node_modules of the website template
