### PR TITLE
fix(ui): set gap to 0 in sort column buttons to remove unneeded spacing

### DIFF
--- a/packages/ui/src/elements/SortColumn/index.scss
+++ b/packages/ui/src/elements/SortColumn/index.scss
@@ -25,7 +25,7 @@
     &__buttons {
       display: flex;
       align-items: center;
-      gap: calc(var(--base) / 4);
+      gap: 0;
     }
 
     &__button {


### PR DESCRIPTION
### What

This PR adjusts the `gap` between buttons in the `SortColumn` component. The previous spacing (`calc(var(--base) / 4)`) caused too much visual separation between the sort buttons. It has been replaced with `gap: 0` to tighten their alignment.

#### Before:
![Screenshot 2025-05-21 at 1 33 17 PM](https://github.com/user-attachments/assets/a5f759fc-647a-46e3-8dac-e3e100fc7b98)

#### After:
![Screenshot 2025-05-21 at 1 34 04 PM](https://github.com/user-attachments/assets/29572620-bd62-4e3e-80b7-d32ed4c81911)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210547304672275