### PR TITLE
docs: typos and links

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -274,7 +274,7 @@ You can also pass an object to the collection's `graphQL` property, which allows
 
 ## TypeScript
 
-You can import types from Payload to help make writing your Collection configs easier and type-safe. There are two main types that represent the Collection Config, `CollectionConfig` and `SanitizeCollectionConfig`.
+You can import types from Payload to help make writing your Collection configs easier and type-safe. There are two main types that represent the Collection Config, `CollectionConfig` and `SanitizedCollectionConfig`.
 
 The `CollectionConfig` type represents a raw Collection Config in its full form, where only the bare minimum properties are marked as required. The `SanitizedCollectionConfig` type represents a Collection Config after it has been fully sanitized. Generally, this is only used internally by Payload.
 

--- a/docs/database/migrations.mdx
+++ b/docs/database/migrations.mdx
@@ -183,13 +183,13 @@ Depending on which Database Adapter you use, your migration workflow might diffe
 
 In relational databases, migrations will be **required** for non-development database environments. But with MongoDB, you might only need to run migrations once in a while (or never even need them).
 
-#### MongoDB
+#### MongoDB#mongodb-migrations
 
 In MongoDB, you'll only ever really need to run migrations for times where you change your database shape, and you have lots of existing data that you'd like to transform from Shape A to Shape B.
 
 In this case, you can create a migration by running `pnpm payload migrate:create`, and then write the logic that you need to perform to migrate your documents to their new shape. You can then either run your migrations in CI before you build / deploy, or you can run them locally, against your production database, by using your production database connection string on your local computer and running the `pnpm payload migrate` command.
 
-#### Postgres
+#### Postgres#postgres-migrations
 
 In relational databases like Postgres, migrations are a bit more important, because each time you add a new field or a new collection, you'll need to update the shape of your database to match your Payload Config (otherwise you'll see errors upon trying to read / write your data).
 

--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -16,8 +16,8 @@ This plugin sets up multi-tenancy for your application from within your [Admin P
   If you need help, check out our [Community
   Help](https://payloadcms.com/community-help). If you think you've found a bug,
   please [open a new
-  issue](https://github.com/payloadcms/payload/issues/new?assignees=&labels=plugin%3A%multi-tenant&template=bug_report.md&title=plugin-multi-tenant%3A)
-  with as much detail as possible.
+  issue](https://github.com/payloadcms/payload/issues/new/choose) with as much
+  detail as possible.
 </Banner>
 
 ## Core features
@@ -35,7 +35,7 @@ This plugin sets up multi-tenancy for your application from within your [Admin P
 By default this plugin cleans up documents when a tenant is deleted. You should ensure you have
 strong access control on your tenants collection to prevent deletions by unauthorized users.
 
-You can disabled this behavior by setting `cleanupAfterTenantDelete` to `false` in the plugin options.
+You can disable this behavior by setting `cleanupAfterTenantDelete` to `false` in the plugin options.
 
 </Banner>
 


### PR DESCRIPTION
- update SantizeCollection to SanitizedCollection in TypeScript section

- fix new issue link in Multi-Tenant plugin section

- correct You can disabled to disable in Core Features

- fix duplicate section links for MongoDB and Postgres in Migrations section