### PR TITLE
docs: fix import statements for `plugin-nested-docs`

### DIFF
--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -180,8 +180,8 @@ and `createBreadcrumbField` methods. They will merge your customizations overtop
 
 ```ts
 import type { CollectionConfig } from 'payload'
-import { createParentField } from '@payloadcms/plugin-nested-docs/fields'
-import { createBreadcrumbsField } from '@payloadcms/plugin-nested-docs/fields'
+import { createParentField } from '@payloadcms/plugin-nested-docs'
+import { createBreadcrumbsField } from '@payloadcms/plugin-nested-docs'
 
 const examplePageConfig: CollectionConfig = {
   slug: 'pages',


### PR DESCRIPTION
The module `@payloadcms/plugin-nested-docs/fields` does not seem to exist (anymore). Instead `createParentField` and `createBreadcrumbsField` are exported by `@payloadcms/plugin-nested-docs`

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
