### PR TITLE
fix: delete subfolders hook with relational databases

### DIFF
--- a/packages/payload/src/folders/createFolderCollection.ts
+++ b/packages/payload/src/folders/createFolderCollection.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from '../collections/config/types.js'
 
 import { populateFolderDataEndpoint } from './endpoints/populateFolderData.js'
-import { deleteSubfoldersAfterDelete } from './hooks/deleteSubfoldersAfterDelete.js'
+import { deleteSubfoldersBeforeDelete } from './hooks/deleteSubfoldersAfterDelete.js'
 import { dissasociateAfterDelete } from './hooks/dissasociateAfterDelete.js'
 import { reparentChildFolder } from './hooks/reparentChildFolder.js'
 
@@ -61,8 +61,8 @@ export const createFolderCollection = ({
         collectionSlugs,
         folderFieldName,
       }),
-      deleteSubfoldersAfterDelete({ folderFieldName, folderSlug: slug }),
     ],
+    beforeDelete: [deleteSubfoldersBeforeDelete({ folderFieldName, folderSlug: slug })],
   },
   labels: {
     plural: 'Folders',

--- a/packages/payload/src/folders/hooks/deleteSubfoldersAfterDelete.ts
+++ b/packages/payload/src/folders/hooks/deleteSubfoldersAfterDelete.ts
@@ -1,13 +1,13 @@
-import type { CollectionAfterDeleteHook } from '../../index.js'
+import type { CollectionBeforeDeleteHook } from '../../index.js'
 
 type Args = {
   folderFieldName: string
   folderSlug: string
 }
-export const deleteSubfoldersAfterDelete = ({
+export const deleteSubfoldersBeforeDelete = ({
   folderFieldName,
   folderSlug,
-}: Args): CollectionAfterDeleteHook => {
+}: Args): CollectionBeforeDeleteHook => {
   return async ({ id, req }) => {
     await req.payload.delete({
       collection: folderSlug,


### PR DESCRIPTION
* Adds integration tests for folder view hooks
* Fixes deleting subfolders with Postgres / SQLite by changing `afterDelete` to `beforeDelete`.