### PR TITLE
fix(next): folder redirects not working

### DIFF
--- a/packages/next/src/views/BrowseByFolder/buildView.tsx
+++ b/packages/next/src/views/BrowseByFolder/buildView.tsx
@@ -88,7 +88,7 @@ export const buildBrowseByFolderView = async (
     ((resolvedFolderID && folderID && folderID !== resolvedFolderID) ||
       (folderID && !resolvedFolderID))
   ) {
-    return redirect(
+    redirect(
       formatAdminURL({
         adminRoute,
         path: config.admin.routes.browseByFolder,

--- a/packages/next/src/views/BrowseByFolder/index.tsx
+++ b/packages/next/src/views/BrowseByFolder/index.tsx
@@ -11,6 +11,9 @@ export const BrowseByFolder: React.FC<BuildFolderViewArgs> = async (args) => {
     const { View } = await buildBrowseByFolderView(args)
     return View
   } catch (error) {
+    if (error?.message === 'NEXT_REDIRECT') {
+      throw error
+    }
     if (error.message === 'not-found') {
       notFound()
     } else {

--- a/packages/next/src/views/CollectionFolders/buildView.tsx
+++ b/packages/next/src/views/CollectionFolders/buildView.tsx
@@ -124,7 +124,7 @@ export const buildCollectionFolderView = async (
       ((resolvedFolderID && folderID && folderID !== resolvedFolderID) ||
         (folderID && !resolvedFolderID))
     ) {
-      return redirect(
+      redirect(
         formatAdminURL({
           adminRoute,
           path: `/collections/${collectionSlug}/${config.folders.slug}`,

--- a/packages/next/src/views/CollectionFolders/index.tsx
+++ b/packages/next/src/views/CollectionFolders/index.tsx
@@ -11,6 +11,9 @@ export const CollectionFolderView: React.FC<BuildCollectionFolderViewStateArgs> 
     const { View } = await buildCollectionFolderView(args)
     return View
   } catch (error) {
+    if (error?.message === 'NEXT_REDIRECT') {
+      throw error
+    }
     if (error.message === 'not-found') {
       notFound()
     } else {


### PR DESCRIPTION
Fixes an issue where redirects were not being caught properly and therefore not working.

`/admin/collections/:collectionSlug/:foldersSlug/some-bad-id`
should redirect to 
`/admin/collections/:collectionSlug/:foldersSlug`