### PR TITLE
docs: add Content-Type header for JWT authentication

### DIFF
--- a/docs/authentication/jwt.mdx
+++ b/docs/authentication/jwt.mdx
@@ -23,6 +23,9 @@ Example:
 ```ts
 const user = await fetch('http://localhost:3000/api/users/login', {
   method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
   body: JSON.stringify({
     email: 'dev@payloadcms.com',
     password: 'password',


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

-->

### What?
Fix docs fragment about JWT strategy authentication

### Why?
The example in docs doesn't work out of the box
<img width="535" alt="image" src="https://github.com/user-attachments/assets/ae62b89e-25bd-4d50-b64f-f0edb4f40ca7" />

Solution is to set `Content-Type: application/json`
<img width="819" alt="image" src="https://github.com/user-attachments/assets/4e645576-071d-436d-a5e2-eaa9e218f855" />




