### PR TITLE
fix: parseCookies ignore invalid encoded values

### DIFF
--- a/packages/payload/src/utilities/parseCookies.ts
+++ b/packages/payload/src/utilities/parseCookies.ts
@@ -14,8 +14,8 @@ export const parseCookies = (headers: Request['headers']): Map<string, string> =
       try {
         const decodedValue = decodeURI(encodedValue)
         list.set(key, decodedValue)
-      } catch (e) {
-        throw new APIError(`Error decoding cookie value for key ${key}: ${e.message}`)
+      } catch {
+        // ignore invalid encoded values
       }
     })
   }


### PR DESCRIPTION
this has been already reported here:
https://github.com/payloadcms/payload/issues/10591

`parseCookies.ts` tries to decode cookie's values using `decodeURI()` and throws an Error when it fails

Since it does that on all cookies set on the current domain, there's no control on which cookie get evaluated; for instance ads networks, analytics providers, external fonts, etc... all set cookies with different encodings.

### Taking in consideration:

- HTTP specs doesn't define a standard way for cookie value encoding but simply provide recommendations:
[RFC6265](https://httpwg.org/specs/rfc6265.html#sane-set-cookie)
> To maximize compatibility with user agents, servers that wish to store arbitrary data in a cookie-value SHOULD encode that data, for example, using Base64

- NextJS does a pretty similar parsing and ignore invalid encoded values
https://github.com/vercel/edge-runtime/blob/main/packages/cookies/src/serialize.ts
`function parseCookie(cookie: string)`
```typescript
try {
      map.set(key, decodeURIComponent(value ?? 'true'))
    } catch {
      // ignore invalid encoded values
    }
```

### With the current implementation:
- it's impossible to login because `parseCookies.ts` get called and if fails to parse throws and error
- requests to `/api/users/me` fail for the same reason

### Fix
the pull request address these issues by simply ignoring decoding errors:
CURRENT:
```typescript
 try {
        const decodedValue = decodeURI(encodedValue)
        list.set(key, decodedValue)
      } catch (e) {
        throw new APIError(`Error decoding cookie value for key ${key}: ${e.message}`)
      }
```
AFTER THIS PULL REQUEST
```typescript
      try {
        const decodedValue = decodeURI(encodedValue)
        list.set(key, decodedValue)
      } catch {
        // ignore invalid encoded values
      }
```