### PR TITLE
fix: thread req into interal folder payload operations

### DIFF
--- a/packages/next/src/views/BrowseByFolder/buildView.tsx
+++ b/packages/next/src/views/BrowseByFolder/buildView.tsx
@@ -76,9 +76,8 @@ export const buildBrowseByFolderView = async (
 
   const { breadcrumbs, documents, subfolders } = await getFolderData({
     folderID,
-    payload: initPageResult.req.payload,
+    req: initPageResult.req,
     search: query?.search as string,
-    user: initPageResult.req.user,
   })
 
   const resolvedFolderID = breadcrumbs[breadcrumbs.length - 1]?.id

--- a/packages/next/src/views/CollectionFolders/buildView.tsx
+++ b/packages/next/src/views/CollectionFolders/buildView.tsx
@@ -112,9 +112,8 @@ export const buildCollectionFolderView = async (
     const { breadcrumbs, documents, subfolders } = await getFolderData({
       collectionSlug,
       folderID,
-      payload: initPageResult.req.payload,
+      req: initPageResult.req,
       search: query?.search as string,
-      user: initPageResult.req.user,
     })
 
     const resolvedFolderID = breadcrumbs[breadcrumbs.length - 1]?.id

--- a/packages/payload/src/folders/endpoints/populateFolderData.ts
+++ b/packages/payload/src/folders/endpoints/populateFolderData.ts
@@ -33,9 +33,8 @@ export const populateFolderDataEndpoint: Endpoint = {
     const data = await getFolderData({
       collectionSlug: req.searchParams?.get('collectionSlug') || undefined,
       folderID: req.searchParams?.get('folderID') || undefined,
-      payload: req.payload,
+      req,
       search: req.searchParams?.get('search') || undefined,
-      user: req.user,
     })
 
     return Response.json(data)

--- a/packages/payload/src/folders/utils/getFolderBreadcrumbs.ts
+++ b/packages/payload/src/folders/utils/getFolderBreadcrumbs.ts
@@ -1,12 +1,10 @@
-import type { User } from '../../index.js'
-import type { Document, Payload } from '../../types/index.js'
+import type { Document, PayloadRequest } from '../../types/index.js'
 import type { FolderBreadcrumb } from '../types.js'
 
 type GetFolderBreadcrumbsArgs = {
   breadcrumbs?: FolderBreadcrumb[]
   folderID?: number | string
-  payload: Payload
-  user?: User
+  req: PayloadRequest
 }
 /**
  * Builds breadcrumbs up from child folder
@@ -15,9 +13,9 @@ type GetFolderBreadcrumbsArgs = {
 export const getFolderBreadcrumbs = async ({
   breadcrumbs = [],
   folderID,
-  payload,
-  user,
+  req,
 }: GetFolderBreadcrumbsArgs): Promise<FolderBreadcrumb[] | null> => {
+  const { payload, user } = req
   const folderFieldName: string = payload.config.folders.fieldName
   if (folderID) {
     const folderQuery = await payload.find({
@@ -25,6 +23,7 @@ export const getFolderBreadcrumbs = async ({
       depth: 0,
       limit: 1,
       overrideAccess: false,
+      req,
       select: {
         name: true,
         [folderFieldName]: true,
@@ -52,8 +51,7 @@ export const getFolderBreadcrumbs = async ({
             typeof folder[folderFieldName] === 'string'
               ? folder[folderFieldName]
               : folder[folderFieldName].id,
-          payload,
-          user,
+          req,
         })
       }
     }

--- a/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
+++ b/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
@@ -1,7 +1,6 @@
-import type { User } from '../../auth/types.js'
 import type { PaginatedDocs } from '../../database/types.js'
 import type { CollectionSlug } from '../../index.js'
-import type { Document, Payload } from '../../types/index.js'
+import type { Document, PayloadRequest } from '../../types/index.js'
 import type { FolderOrDocument } from '../types.js'
 
 import { formatFolderOrDocumentItem } from './formatFolderOrDocumentItem.js'
@@ -13,15 +12,14 @@ type QueryDocumentsAndFoldersResults = {
 type QueryDocumentsAndFoldersArgs = {
   collectionSlug?: CollectionSlug
   parentFolderID: number | string
-  payload: Payload
-  user?: User
+  req: PayloadRequest
 }
 export async function queryDocumentsAndFoldersFromJoin({
   collectionSlug,
   parentFolderID,
-  payload,
-  user,
+  req,
 }: QueryDocumentsAndFoldersArgs): Promise<QueryDocumentsAndFoldersResults> {
+  const { payload, user } = req
   const folderCollectionSlugs: string[] = payload.config.collections.reduce<string[]>(
     (acc, collection) => {
       if (collection?.folders) {
@@ -50,6 +48,7 @@ export async function queryDocumentsAndFoldersFromJoin({
     },
     limit: 1,
     overrideAccess: false,
+    req,
     user,
     where: {
       id: {

--- a/packages/payload/src/folders/utils/getOrphanedDocs.ts
+++ b/packages/payload/src/folders/utils/getOrphanedDocs.ts
@@ -1,20 +1,19 @@
-import type { CollectionSlug, Payload, User, Where } from '../../index.js'
+import type { CollectionSlug, PayloadRequest, Where } from '../../index.js'
 import type { FolderOrDocument } from '../types.js'
 
 import { formatFolderOrDocumentItem } from './formatFolderOrDocumentItem.js'
 
 type Args = {
   collectionSlug: CollectionSlug
-  payload: Payload
+  req: PayloadRequest
   search?: string
-  user?: User
 }
 export async function getOrphanedDocs({
   collectionSlug,
-  payload,
+  req,
   search,
-  user,
 }: Args): Promise<FolderOrDocument[]> {
+  const { payload, user } = req
   let whereConstraints: Where = {
     or: [
       {
@@ -42,6 +41,7 @@ export async function getOrphanedDocs({
     collection: collectionSlug,
     limit: 0,
     overrideAccess: false,
+    req,
     sort: payload.collections[collectionSlug].config.admin.useAsTitle,
     user,
     where: whereConstraints,


### PR DESCRIPTION
Instead of threading `payload` and `req` through to `getFolderData()`, instead we should thread the `req` so we can pass that into payload operations that get called internally.