### PR TITLE
fix: browseByFolder route should be optional

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -851,7 +851,7 @@ export type Config = {
        *
        * @default '/browse-by-folder'
        */
-      browseByFolder: `/${string}`
+      browseByFolder?: `/${string}`
       /** The route for the create first user page.
        *
        * @default '/create-first-user'


### PR DESCRIPTION
[Reported here](https://github.com/payloadcms/payload/pull/10030#issuecomment-2901667256)

`routes.browseByFolder` should be optional.
