### PR TITLE
fix(richtext-lexical, ui): opening relationship field with appearance: "drawer" inside rich text inline block

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -768,7 +768,11 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
               }}
               onMenuOpen={() => {
                 if (appearance === 'drawer') {
-                  openListDrawer()
+                  // TODO: This timeout is only necessary for inline blocks in the lexical editor
+                  // and when the devtools are closed. Temporary solution, we can probably do better.
+                  setTimeout(() => {
+                    openListDrawer()
+                  }, 50)
                 } else if (appearance === 'select') {
                   setMenuIsOpen(true)
                   if (!hasLoadedFirstPageRef.current) {


### PR DESCRIPTION
To reproduce this bug, insert the following feature into the richtext editor:


```ts
BlocksFeature({
  inlineBlocks: [
    {
      slug: 'inline-media',
      fields: [
        {
          name: 'media',
          type: 'relationship',
          relationTo: ['media'],
          admin: {
            appearance: 'drawer',
          },
        },
      ],
    },
  ],
}),
```

Then try opening the relationship field drawer. The inline block drawer will close.

Note: Interestingly, at least in Chrome, this only happens with DevTools closed. It worked fine with DevTools open. It probably has to do with capturing events like focus.
The current solution is a 50ms delay. I couldn't test it with CPU throttle because it disappears when I close the devtools. If you encounter this bug, please open an issue so we can increase the delay or, better yet, find a more elegant solution.