### PR TITLE
docs: fix typo(with be -> will be) in Authentication page

### DIFF
--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -71,7 +71,7 @@ export const Admins: CollectionConfig = {
 </Banner>
 
 <Banner type="warning">
-  **Note:** Auth-enabled Collections with be automatically injected with the
+  **Note:** Auth-enabled Collections will be automatically injected with the
   `hash`, `salt`, and `email` fields. [More
   details](../fields/overview#field-names).
 </Banner>


### PR DESCRIPTION
Correct sentence will be: "Auth-enabled Collections will be automatically injected with the ..." instead of "Auth-enabled Collections with be automatically injected with the ..."