### PR TITLE
fix: ensure redirect route is correctly formatted for "Copy to locale"

### DIFF
--- a/packages/ui/src/elements/CopyLocaleData/index.tsx
+++ b/packages/ui/src/elements/CopyLocaleData/index.tsx
@@ -3,6 +3,7 @@
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
 import { useRouter } from 'next/navigation.js'
+import { formatAdminURL } from 'payload/shared'
 import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
@@ -82,7 +83,11 @@ export const CopyLocaleData: React.FC = () => {
 
         startRouteTransition(() =>
           router.push(
-            `${serverURL}${admin}/${collectionSlug ? `collections/${collectionSlug}/${id}` : `globals/${globalSlug}`}?locale=${to}`,
+            formatAdminURL({
+              adminRoute: admin,
+              path: `/${collectionSlug ? `collections/${collectionSlug}/${id}` : `globals/${globalSlug}`}`,
+              serverURL,
+            }) + `?locale=${to}`,
           ),
         )
 


### PR DESCRIPTION
### What?
When you set admin route as "/" and enable localization, once you create a document in one locale and try to copy to another locale, it will redirect to ```http://collections/{sampleCollectionSlug}/{documentID}?locale={toLocale}```, which doesn't work because it does not include the serverURL.
### Why?
It used to redirect to ``${serverURL}${admin}/${collectionSlug ? `collections/${collectionSlug}/${id}` : `globals/${globalSlug}`}?locale=${to}``, but when admin is '/', and serverURL is not defined in payload config, it then redirect incorrectly
### How?
I replaced the target url with `formatAdminURL` function in `payload/shared` to make it handle admin path appropriately


Fixes #12558


