### PR TITLE
fix(db-mongodb): exists query on checkbox fields

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -417,7 +417,7 @@ export const sanitizeQueryValue = ({
       return buildExistsQuery(
         formattedValue,
         path,
-        !['relationship', 'upload'].includes(field.type),
+        !['checkbox', 'relationship', 'upload'].includes(field.type),
       )
     }
   }

--- a/test/fields/collections/Checkbox/index.ts
+++ b/test/fields/collections/Checkbox/index.ts
@@ -10,6 +10,10 @@ const CheckboxFields: CollectionConfig = {
       type: 'checkbox',
       required: true,
     },
+    {
+      name: 'checkboxNotRequired',
+      type: 'checkbox',
+    },
   ],
 }
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -30,6 +30,7 @@ import { clearAndSeedEverything } from './seed.js'
 import {
   arrayFieldsSlug,
   blockFieldsSlug,
+  checkboxFieldsSlug,
   collapsibleFieldsSlug,
   groupFieldsSlug,
   relationshipFieldsSlug,
@@ -1346,6 +1347,58 @@ describe('Fields', () => {
       expect(doc.point).toEqual(point)
       expect(doc.localized).toEqual(localized)
       expect(doc.group).toMatchObject(group)
+    })
+  })
+
+  describe('checkbox', () => {
+    beforeEach(async () => {
+      await payload.delete({
+        collection: checkboxFieldsSlug,
+        where: {
+          id: {
+            exists: true,
+          },
+        },
+      })
+    })
+
+    it('should query checkbox fields with exists operator', async () => {
+      const existsTrueDoc = await payload.create({
+        collection: checkboxFieldsSlug,
+        data: {
+          checkbox: true,
+          checkboxNotRequired: false,
+        },
+      })
+
+      const existsFalseDoc = await payload.create({
+        collection: checkboxFieldsSlug,
+        data: {
+          checkbox: true,
+        },
+      })
+
+      const existsFalse = await payload.find({
+        collection: checkboxFieldsSlug,
+        where: {
+          checkboxNotRequired: {
+            exists: false,
+          },
+        },
+      })
+      expect(existsFalse.totalDocs).toBe(1)
+      expect(existsFalse.docs[0]?.id).toEqual(existsFalseDoc.id)
+
+      const existsTrue = await payload.find({
+        collection: checkboxFieldsSlug,
+        where: {
+          checkboxNotRequired: {
+            exists: true,
+          },
+        },
+      })
+      expect(existsTrue.totalDocs).toBe(1)
+      expect(existsTrue.docs[0]?.id).toEqual(existsTrueDoc.id)
     })
   })
 

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -730,6 +730,7 @@ export interface TextField {
 export interface CheckboxField {
   id: string;
   checkbox: boolean;
+  checkboxNotRequired?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -2318,6 +2319,7 @@ export interface LocalizedTabsBlockSelect<T extends boolean = true> {
  */
 export interface CheckboxFieldsSelect<T extends boolean = true> {
   checkbox?: T;
+  checkboxNotRequired?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12466

Fixes an issue where querying on checkbox fields with the `exists` operator throws an `Cast to Boolean failed for value "" (type string) at path` error.