### PR TITLE
fix(ui): cloudfront removing X-HTTP-Method-Override header

### DIFF
--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -738,7 +738,7 @@ Payload supports a method override feature that allows you to send GET requests 
 
 ### How to Use
 
-To use this feature, include the `X-HTTP-Method-Override` header set to `GET` in your POST request. The parameters should be sent in the body of the request with the `Content-Type` set to `application/x-www-form-urlencoded`.
+To use this feature, include the `X-Payload-HTTP-Method-Override` header set to `GET` in your POST request. The parameters should be sent in the body of the request with the `Content-Type` set to `application/x-www-form-urlencoded`.
 
 ### Example
 
@@ -753,7 +753,7 @@ const res = await fetch(`${api}/${collectionSlug}`, {
   headers: {
     'Accept-Language': i18n.language,
     'Content-Type': 'application/x-www-form-urlencoded',
-    'X-HTTP-Method-Override': 'GET',
+    'X-Payload-HTTP-Method-Override': 'GET',
   },
   body: qs.stringify({
     depth: 1,

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -81,7 +81,8 @@ export const handleEndpoints = async ({
   // packages/ui/src/fields/Relationship/index.tsx
   if (
     request.method.toLowerCase() === 'post' &&
-    request.headers.get('X-HTTP-Method-Override') === 'GET'
+    (request.headers.get('X-Payload-HTTP-Method-Override') === 'GET' ||
+      request.headers.get('X-HTTP-Method-Override') === 'GET')
   ) {
     const search = await request.text()
 

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
@@ -138,7 +138,7 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType, schedulePub
         headers: {
           'Accept-Language': i18n.language,
           'Content-Type': 'application/x-www-form-urlencoded',
-          'X-HTTP-Method-Override': 'GET',
+          'X-Payload-HTTP-Method-Override': 'GET',
         },
       })
       .then((res) => res.json())

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -282,7 +282,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
               headers: {
                 'Accept-Language': i18n.language,
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'X-HTTP-Method-Override': 'GET',
+                'X-Payload-HTTP-Method-Override': 'GET',
               },
               method: 'POST',
             })
@@ -429,7 +429,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
             headers: {
               'Accept-Language': i18n.language,
               'Content-Type': 'application/x-www-form-urlencoded',
-              'X-HTTP-Method-Override': 'GET',
+              'X-Payload-HTTP-Method-Override': 'GET',
             },
             method: 'POST',
           })

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -218,7 +218,7 @@ export function UploadInput(props: UploadInputProps) {
         headers: {
           'Accept-Language': i18n.language,
           'Content-Type': 'application/x-www-form-urlencoded',
-          'X-HTTP-Method-Override': 'GET',
+          'X-Payload-HTTP-Method-Override': 'GET',
         },
         method: 'POST',
       })


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10606
Fixes https://github.com/payloadcms/payload/issues/12272

Removes the need for this workaround https://github.com/payloadcms/payload/discussions/7248#discussioncomment-11688273

Some cloud providers look for and remove the `X-HTTP-Method-Override` header, i.e. CloudFront https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html

We still need the functionality that this header provides, this PR just adjusts the header naming so it does not get removed. 

This is not a breaking change since the backend still looks for the previous `X-HTTP-Method-Override` and the new `X-Payload-HTTP-Method-Override`