### PR TITLE
chore: migrate to TypeScript strict in Payload package - Part 2/N

### DIFF
--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { GenericLanguages, I18n } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 
@@ -197,6 +196,7 @@ type RichTextAdapterBase<
   AdapterProps = any,
   ExtraFieldProperties = {},
 > = {
+  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
   generateImportMap?: Config['admin']['importMap']['generators'][0]
   generateSchemaMap?: (args: {
     config: SanitizedConfig

--- a/packages/payload/src/admin/forms/Diff.ts
+++ b/packages/payload/src/admin/forms/Diff.ts
@@ -1,5 +1,3 @@
-// @ts-strict-ignore
-
 import type { I18nClient } from '@payloadcms/translations'
 
 import type { ClientField, Field, FieldTypes, Tab } from '../../fields/config/types.js'
@@ -7,7 +5,6 @@ import type {
   ClientFieldWithOptionalType,
   PayloadRequest,
   SanitizedFieldPermissions,
-  TypedLocale,
 } from '../../index.js'
 
 export type VersionTab = {
@@ -27,7 +24,7 @@ export type BaseVersionField = {
 
 export type VersionField = {
   field?: BaseVersionField
-  fieldByLocale?: Record<TypedLocale, BaseVersionField>
+  fieldByLocale?: Record<string, BaseVersionField>
 }
 
 /**

--- a/packages/payload/src/auth/cookies.ts
+++ b/packages/payload/src/auth/cookies.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from './../collections/config/types.js'
 
 type CookieOptions = {
@@ -197,7 +196,7 @@ export const parseCookies = (headers: Request['headers']): Map<string, string> =
 
       try {
         const decodedValue = decodeURI(encodedValue)
-        cookieMap.set(key, decodedValue)
+        cookieMap.set(key!, decodedValue)
       } catch (ignore) {
         return null
       }

--- a/packages/payload/src/auth/crypto.ts
+++ b/packages/payload/src/auth/crypto.ts
@@ -1,11 +1,12 @@
-// @ts-strict-ignore
 import crypto from 'crypto'
 
 const algorithm = 'aes-256-ctr'
 
 export function encrypt(text: string): string {
   const iv = crypto.randomBytes(16)
-  const cipher = crypto.createCipheriv(algorithm, this.secret, iv)
+  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+  const secret = this.secret
+  const cipher = crypto.createCipheriv(algorithm, secret, iv)
 
   const encrypted = Buffer.concat([cipher.update(text), cipher.final()])
 
@@ -19,7 +20,9 @@ export function decrypt(hash: string): string {
   const iv = hash.slice(0, 32)
   const content = hash.slice(32)
 
-  const decipher = crypto.createDecipheriv(algorithm, this.secret, Buffer.from(iv, 'hex'))
+  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+  const secret = this.secret
+  const decipher = crypto.createDecipheriv(algorithm, secret, Buffer.from(iv, 'hex'))
 
   const decrypted = Buffer.concat([decipher.update(Buffer.from(content, 'hex')), decipher.final()])
 

--- a/packages/payload/src/auth/endpoints/forgotPassword.ts
+++ b/packages/payload/src/auth/endpoints/forgotPassword.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
@@ -25,7 +24,7 @@ export const forgotPasswordHandler: PayloadHandler = async (req) => {
     collection,
     data: authData,
     disableEmail: Boolean(req.data?.disableEmail),
-    expiration: typeof req.data.expiration === 'number' ? req.data.expiration : undefined,
+    expiration: typeof req.data?.expiration === 'number' ? req.data.expiration : undefined,
     req,
   })
 

--- a/packages/payload/src/auth/endpoints/login.ts
+++ b/packages/payload/src/auth/endpoints/login.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
@@ -35,7 +34,7 @@ export const loginHandler: PayloadHandler = async (req) => {
   const cookie = generatePayloadCookie({
     collectionAuthConfig: collection.config.auth,
     cookiePrefix: req.payload.config.cookiePrefix,
-    token: result.token,
+    token: result.token!,
   })
 
   if (collection.config.auth.removeTokenFromResponses) {

--- a/packages/payload/src/auth/endpoints/me.ts
+++ b/packages/payload/src/auth/endpoints/me.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
@@ -14,7 +13,7 @@ export const meHandler: PayloadHandler = async (req) => {
 
   const result = await meOperation({
     collection,
-    currentToken,
+    currentToken: currentToken!,
     req,
   })
 

--- a/packages/payload/src/auth/endpoints/refresh.ts
+++ b/packages/payload/src/auth/endpoints/refresh.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
@@ -30,6 +29,7 @@ export const refreshHandler: PayloadHandler = async (req) => {
     })
 
     if (collection.config.auth.removeTokenFromResponses) {
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       delete result.refreshedToken
     }
 

--- a/packages/payload/src/auth/endpoints/registerFirstUser.ts
+++ b/packages/payload/src/auth/endpoints/registerFirstUser.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
@@ -34,7 +33,7 @@ export const registerFirstUserHandler: PayloadHandler = async (req) => {
   const cookie = generatePayloadCookie({
     collectionAuthConfig: collection.config.auth,
     cookiePrefix: req.payload.config.cookiePrefix,
-    token: result.token,
+    token: result.token!,
   })
 
   return Response.json(

--- a/packages/payload/src/auth/endpoints/resetPassword.ts
+++ b/packages/payload/src/auth/endpoints/resetPassword.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
@@ -26,7 +25,7 @@ export const resetPasswordHandler: PayloadHandler = async (req) => {
   const cookie = generatePayloadCookie({
     collectionAuthConfig: collection.config.auth,
     cookiePrefix: req.payload.config.cookiePrefix,
-    token: result.token,
+    token: result.token!,
   })
 
   if (collection.config.auth.removeTokenFromResponses) {

--- a/packages/payload/src/auth/extractJWT.ts
+++ b/packages/payload/src/auth/extractJWT.ts
@@ -50,7 +50,7 @@ export const extractJWT = (args: Omit<AuthStrategyFunctionArgs, 'strategyName'>)
   const extractionOrder = payload.config.auth.jwtOrder
 
   for (const extractionStrategy of extractionOrder) {
-    const result = extractionMethods[extractionStrategy]({ headers, payload })
+    const result = extractionMethods[extractionStrategy]!({ headers, payload })
 
     if (result) {
       return result

--- a/packages/payload/src/auth/getAccessResults.ts
+++ b/packages/payload/src/auth/getAccessResults.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { AllOperations, PayloadRequest } from '../types/index.js'
 import type { Permissions, SanitizedPermissions } from './types.js'
 
@@ -53,7 +52,7 @@ export async function getAccessResults({
         operations: collectionOperations,
         req,
       })
-      results.collections[collection.slug] = collectionPolicy
+      results.collections![collection.slug] = collectionPolicy
     }),
   )
 
@@ -72,7 +71,7 @@ export async function getAccessResults({
         operations: globalOperations,
         req,
       })
-      results.globals[global.slug] = globalPolicy
+      results.globals![global.slug] = globalPolicy
     }),
   )
 

--- a/packages/payload/src/auth/getFieldsToSign.ts
+++ b/packages/payload/src/auth/getFieldsToSign.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { CollectionConfig } from '../collections/config/types.js'
 import type { Field, TabAsField } from '../fields/config/types.js'
 import type { PayloadRequest } from '../types/index.js'
@@ -126,7 +125,7 @@ export const getFieldsToSign = (args: {
   }
 
   traverseFields({
-    data: user,
+    data: user!,
     fields: collectionConfig.fields,
     result,
   })

--- a/packages/payload/src/auth/getLoginOptions.ts
+++ b/packages/payload/src/auth/getLoginOptions.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { Auth } from './types.js'
 
 export const getLoginOptions = (
@@ -8,7 +7,7 @@ export const getLoginOptions = (
   canLoginWithUsername: boolean
 } => {
   return {
-    canLoginWithEmail: !loginWithUsername || loginWithUsername.allowEmailLogin,
+    canLoginWithEmail: !loginWithUsername || loginWithUsername.allowEmailLogin!,
     canLoginWithUsername: Boolean(loginWithUsername),
   }
 }

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import crypto from 'crypto'
 import { status as httpStatus } from 'http-status'
 import { URL } from 'url'
@@ -153,7 +152,7 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
     })
 
     if (!disableEmail && user.email) {
-      const protocol = new URL(req.url).protocol // includes the final :
+      const protocol = new URL(req.url!).protocol // includes the final :
       const serverURL =
         config.serverURL !== null && config.serverURL !== ''
           ? config.serverURL

--- a/packages/payload/src/auth/operations/local/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/local/forgotPassword.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { CollectionSlug, Payload, RequestContext } from '../../../index.js'
 import type { PayloadRequest } from '../../../types/index.js'
 import type { Result } from '../forgotPassword.js'
@@ -40,7 +39,7 @@ async function localForgotPassword<T extends CollectionSlug>(
     disableEmail,
     expiration,
     req: await createLocalReq(options, payload),
-  })
+  }) as Promise<Result>
 }
 
 export const forgotPassword = localForgotPassword

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -251,7 +251,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
 
     const fieldsToSign = getFieldsToSign({
       collectionConfig,
-      email: sanitizedEmail,
+      email: sanitizedEmail!,
       user,
     })
 


### PR DESCRIPTION
Important: An intentional effort is being made during migration to not modify runtime behavior except in very rare exceptions. This implies that there will be several assertions, non-null assertions, and `@ts-expect-error`. This philosophy applies only to migrating old code to TypeScript strict, not to writing new code. For a more detailed justification for this reasoning, [read this comment](https://github.com/payloadcms/payload/pull/11840#discussion_r2021975897).