### PR TITLE
feat: adds calling of before and after operation hooks to resetPassword

### DIFF
--- a/packages/payload/src/auth/operations/local/resetPassword.ts
+++ b/packages/payload/src/auth/operations/local/resetPassword.ts
@@ -17,9 +17,9 @@ export type Options<T extends CollectionSlug> = {
   req?: Partial<PayloadRequest>
 }
 
-async function localResetPassword<T extends CollectionSlug>(
+async function localResetPassword<TSlug extends CollectionSlug>(
   payload: Payload,
-  options: Options<T>,
+  options: Options<TSlug>,
 ): Promise<Result> {
   const { collection: collectionSlug, data, overrideAccess } = options
 
@@ -33,7 +33,7 @@ async function localResetPassword<T extends CollectionSlug>(
     )
   }
 
-  const result = await resetPasswordOperation({
+  const result = await resetPasswordOperation<TSlug>({
     collection,
     data,
     overrideAccess,

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -82,6 +82,7 @@ export type HookOperationType =
   | 'login'
   | 'read'
   | 'refresh'
+  | 'resetPassword'
   | 'update'
 
 type CreateOrUpdateOperation = Extract<HookOperationType, 'create' | 'update'>

--- a/packages/payload/src/collections/operations/utils.ts
+++ b/packages/payload/src/collections/operations/utils.ts
@@ -1,13 +1,10 @@
 import type { forgotPasswordOperation } from '../../auth/operations/forgotPassword.js'
 import type { loginOperation } from '../../auth/operations/login.js'
 import type { refreshOperation } from '../../auth/operations/refresh.js'
+import type { resetPasswordOperation } from '../../auth/operations/resetPassword.js'
 import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest } from '../../types/index.js'
-import type {
-  AfterOperationHook,
-  SanitizedCollectionConfig,
-  SelectFromCollectionSlug,
-} from '../config/types.js'
+import type { SanitizedCollectionConfig, SelectFromCollectionSlug } from '../config/types.js'
 import type { countOperation } from './count.js'
 import type { countVersionsOperation } from './countVersions.js'
 import type { createOperation } from './create.js'
@@ -36,6 +33,7 @@ export type AfterOperationMap<TOperationGeneric extends CollectionSlug> = {
   forgotPassword: typeof forgotPasswordOperation
   login: typeof loginOperation<TOperationGeneric>
   refresh: typeof refreshOperation
+  resetPassword: typeof resetPasswordOperation<TOperationGeneric>
   update: typeof updateOperation<TOperationGeneric, SelectFromCollectionSlug<TOperationGeneric>>
   updateByID: typeof updateByIDOperation<
     TOperationGeneric,
@@ -97,6 +95,11 @@ export type AfterOperationArg<TOperationGeneric extends CollectionSlug> = {
       args: Parameters<AfterOperationMap<TOperationGeneric>['refresh']>[0]
       operation: 'refresh'
       result: Awaited<ReturnType<AfterOperationMap<TOperationGeneric>['refresh']>>
+    }
+  | {
+      args: Parameters<AfterOperationMap<TOperationGeneric>['resetPassword']>[0]
+      operation: 'resetPassword'
+      result: Awaited<ReturnType<AfterOperationMap<TOperationGeneric>['resetPassword']>>
     }
   | {
       args: Parameters<AfterOperationMap<TOperationGeneric>['update']>[0]


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12111

Invokes the before and after operation hooks inside the resetPassword operation.