### PR TITLE
fix(ui): oversized column selector pills

### DIFF
--- a/packages/ui/src/elements/ColumnSelector/index.tsx
+++ b/packages/ui/src/elements/ColumnSelector/index.tsx
@@ -76,6 +76,7 @@ export const ColumnSelector: React.FC<Props> = ({ collectionSlug }) => {
             onClick={() => {
               void toggleColumn(accessor)
             }}
+            size="small"
           >
             {col.CustomLabel ?? <FieldLabel label={label as StaticLabel} unstyled />}
           </Pill>


### PR DESCRIPTION
#10030 adjusted the default `Pill` component size but forgot to set the column selector pill sizes to small

## Before

![Screenshot 2025-05-27 at 14 34 31@2x](https://github.com/user-attachments/assets/0f7d44e7-343a-4542-9bc5-830f4bd2bd96)

## After

![Screenshot 2025-05-27 at 14 34 25@2x](https://github.com/user-attachments/assets/33f65fb7-130a-405b-820f-e31259b4f950)
