### PR TITLE
feat: better select type

### DIFF
--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -233,7 +233,10 @@ export type TransformDataWithSelect<
               : // select 'id' always
                 K extends 'id'
                 ? K
-                : never]: Data[K]
+                : never]: Extract<Data[K], TypeWithID> extends never // if the select field is not to-one relation
+              ? Data[K] // TODO handle to many relations
+              : // drop foreign keys from to-one relations
+                Exclude<Data[K], Extract<Data[K], TypeWithID>['id']>
           }
         : // Handle exclude mode
           {

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -238,9 +238,23 @@ export type TransformDataWithSelect<
                 ? Data[K] // do nothing
                 : // drop foreign keys from to-many relations
                   Extract<Data[K], Array<unknown>> extends Array<infer U>
-                  ?
-                      | Array<Exclude<U, Extract<U, TypeWithID>['id']>>
-                      | Exclude<Data[K], Array<unknown>>
+                  ? Extract<U, DataFromCollectionSlug<CollectionSlug>> extends never // if the select field is object but not a collection (e.g., a group)
+                    ?
+                        | Array<
+                            Exclude<
+                              // transform nested object that are not collections
+                              K extends keyof Select
+                                ? Select[K] extends object
+                                  ? TransformDataWithSelect<U, Select[K]>
+                                  : U
+                                : U,
+                              Extract<U, TypeWithID>['id']
+                            >
+                          >
+                        | Exclude<Data[K], Array<unknown>>
+                    :
+                        | Array<Exclude<U, Extract<U, TypeWithID>['id']>>
+                        | Exclude<Data[K], Array<unknown>>
                   : never
               : // drop foreign keys from to-one relations
                 Exclude<Data[K], Extract<Data[K], TypeWithID>['id']>

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -213,7 +213,7 @@ export type TransformDataWithSelect<
     ? Data
     : // START Handle types when they aren't generated
       // For example in any package in this repository outside of tests / plugins
-      // This stil gives us autocomplete when using include select mode, i.e select: {title :true} returns type {title: any, id: string | number}
+      // This still gives us autocomplete when using include select mode, i.e select: {title :true} returns type {title: any, id: string | number}
       string extends keyof Omit<Data, 'id'>
       ? Select extends SelectIncludeType
         ? {

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -234,7 +234,14 @@ export type TransformDataWithSelect<
                 K extends 'id'
                 ? K
                 : never]: Extract<Data[K], TypeWithID> extends never // if the select field is not to-one relation
-              ? Data[K] // TODO handle to many relations
+              ? Extract<Data[K], Array<unknown>> extends never // if the select field is not to-many relation
+                ? Data[K] // do nothing
+                : // drop foreign keys from to-many relations
+                  Extract<Data[K], Array<unknown>> extends Array<infer U>
+                  ?
+                      | Array<Exclude<U, Extract<U, TypeWithID>['id']>>
+                      | Exclude<Data[K], Array<unknown>>
+                  : never
               : // drop foreign keys from to-one relations
                 Exclude<Data[K], Extract<Data[K], TypeWithID>['id']>
           }

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -177,6 +177,10 @@ describe('Select', () => {
           number: post.number,
           text: post.text,
         })
+
+        // this will fail if types are not the same
+        const _enforce_1: Equal<(typeof res)['number'], null | number | undefined> = true
+        const _enforce_2: Equal<(typeof res)['text'], null | string | undefined> = true
       })
 
       it('should select relationships', async () => {

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -194,6 +194,10 @@ describe('Select', () => {
           hasManyUpload: post.hasManyUpload,
         })
 
+        // this will fail if types are not the same
+        const _enforce_1: Equal<(typeof res_1)['hasManyUpload'], Array<Upload> | null | undefined> =
+          true
+
         const res_2 = await payload.findByID({
           collection: 'posts',
           id: postId,

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -1,3 +1,5 @@
+import type { Equal } from 'drizzle-orm'
+
 import { randomUUID } from 'crypto'
 import path from 'path'
 import { deepCopyObject, type Payload } from 'payload'
@@ -13,6 +15,8 @@ import type {
   Page,
   Point,
   Post,
+  Rel,
+  Upload,
   VersionedPost,
 } from './payload-types.js'
 
@@ -203,6 +207,9 @@ describe('Select', () => {
           id: postId,
           hasOne: post.hasOne,
         })
+
+        // this will fail if types are not the same
+        const _enforce_2: Equal<(typeof res_2)['hasOne'], null | Rel | undefined> = true
 
         const res_3 = await payload.findByID({
           collection: 'posts',


### PR DESCRIPTION
### What?

Add type support for return value when select is used. Instead of returning the `string | Relation` in to-one relations and `(string | Relation)[]` not proper type is returned - `Relation` or `Relation[]` for cases when the relation is explicitly selected.

NOTE1: string can be replaced with number, depends on the IDs you use in your app
NOTE2: Relation is a collection type

### Why?

Because it is frustrating working with union types when you know that in runtime you will have this typing

### How?

I have expanded `TransformDataWithSelect` type.

Type checking is done using a type utils `Equal` that resolves to `true` if types are same and `false` otherwise. We type a variable with this and assign `true` to a variable. If type resolves to `false` you get an error.

Should I add type checks in every test case?

### Future works?

1. We should add same support for `depth`.
2. Add support for nested selects?
