### PR TITLE
refactor: use parseCookies method from Next.js

### DIFF
--- a/packages/payload/src/auth/cookies.spec.ts
+++ b/packages/payload/src/auth/cookies.spec.ts
@@ -1,0 +1,24 @@
+import { parseCookies } from './cookies.js'
+
+describe('parseCookies', () => {
+  it('parses cookie attributes without values', () => {
+    const fakeHeaders = new Map()
+    fakeHeaders.set('Cookie', 'my_value=true; Secure; HttpOnly')
+
+    const parsed = parseCookies(fakeHeaders as unknown as Request['headers'])
+
+    expect(parsed.get('my_value')).toBe('true')
+    expect(parsed.get('Secure')).toBe('true')
+    expect(parsed.get('HttpOnly')).toBe('true')
+    expect(parsed.size).toBe(3)
+  })
+  it('strips whitespace', () => {
+    const fakeHeaders = new Map()
+    fakeHeaders.set('Cookie', 'my_value=true; ')
+
+    const parsed = parseCookies(fakeHeaders as unknown as Request['headers'])
+
+    expect(parsed.get('my_value')).toBe('true')
+    expect(parsed.size).toBe(1)
+  })
+})

--- a/packages/payload/src/auth/cookies.spec.ts
+++ b/packages/payload/src/auth/cookies.spec.ts
@@ -31,4 +31,12 @@ describe('parseCookies', () => {
     expect(parsed.get('my_value')).toBe('true')
     expect(parsed.size).toBe(1)
   })
+
+  it('ensure empty map is returned if there are no cookies', () => {
+    const fakeHeaders = new Map()
+
+    const parsed = parseCookies(fakeHeaders as unknown as Request['headers'])
+
+    expect(parsed.size).toBe(0)
+  })
 })

--- a/packages/payload/src/auth/cookies.spec.ts
+++ b/packages/payload/src/auth/cookies.spec.ts
@@ -21,4 +21,14 @@ describe('parseCookies', () => {
     expect(parsed.get('my_value')).toBe('true')
     expect(parsed.size).toBe(1)
   })
+
+  it('ensure invalid cookies are ignored', () => {
+    const fakeHeaders = new Map()
+    fakeHeaders.set('Cookie', 'my_value=true; invalid_cookie=%E0%A4%A')
+
+    const parsed = parseCookies(fakeHeaders as unknown as Request['headers'])
+
+    expect(parsed.get('my_value')).toBe('true')
+    expect(parsed.size).toBe(1)
+  })
 })

--- a/packages/payload/src/auth/cookies.ts
+++ b/packages/payload/src/auth/cookies.ts
@@ -203,6 +203,10 @@ export function parseCookies(headers: Request['headers']) {
 
   const cookie = headers.get('Cookie')
 
+  if (!cookie) {
+    return map
+  }
+
   for (const pair of cookie.split(/; */)) {
     if (!pair) {
       continue

--- a/packages/payload/src/auth/cookies.ts
+++ b/packages/payload/src/auth/cookies.ts
@@ -185,24 +185,46 @@ export const generateExpiredPayloadCookie = <T extends Omit<GeneratePayloadCooki
   })
 }
 
-export const parseCookies = (headers: Request['headers']): Map<string, string> => {
-  const cookieMap = new Map<string, string>()
+export function parseCookies(headers: Request['headers']) {
+  // Taken from https://github.com/vercel/edge-runtime/blob/main/packages/cookies/src/serialize.ts
+
+  /*
+  The MIT License (MIT)
+
+  Copyright (c) 2024 Vercel, Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  */
+  const map = new Map<string, string>()
+
   const cookie = headers.get('Cookie')
 
-  if (cookie) {
-    cookie.split(';').forEach((cookie) => {
-      const parts = cookie.split('=')
-      const key = parts.shift()?.trim()
-      const encodedValue = parts.join('=')
+  for (const pair of cookie.split(/; */)) {
+    if (!pair) {
+      continue
+    }
 
-      try {
-        const decodedValue = decodeURI(encodedValue)
-        cookieMap.set(key, decodedValue)
-      } catch (ignore) {
-        return null
-      }
-    })
+    const splitAt = pair.indexOf('=')
+
+    // If the attribute doesn't have a value, set it to 'true'.
+    if (splitAt === -1) {
+      map.set(pair, 'true')
+      continue
+    }
+
+    // Otherwise split it into key and value and trim the whitespace on the
+    // value.
+    const [key, value] = [pair.slice(0, splitAt), pair.slice(splitAt + 1)]
+    try {
+      map.set(key, decodeURIComponent(value ?? 'true'))
+    } catch {
+      // ignore invalid encoded values
+    }
   }
 
-  return cookieMap
+  return map
 }


### PR DESCRIPTION
Following up on https://github.com/payloadcms/payload/pull/12515, we could instead use the same `parseCookies` method that Next.js uses. This handles a few edge-cases differently:
- correctly strips whitespace
- parses attributes without explicit values

I think it's a good idea to match the behavior of Next.js as close as possible here. [This](https://github.com/vercel/edge-runtime/pull/374) is a good example of how the Next.js behavior behaves differently.

## Example

Input: `'my_value=true; Secure; HttpOnly'`

Previous Output:
```
Map(3) {
  'my_value' => 'true',
  'Secure' => '',
  'HttpOnly' => '',
}
```

New Output:
```
Map(3) {
  'my_value' => 'true',
  'Secure' => 'true',
  'HttpOnly' => 'true'
}
```