### PR TITLE
docs: building without a db connection

### DIFF
--- a/docs/production/building-without-a-db-connection.mdx
+++ b/docs/production/building-without-a-db-connection.mdx
@@ -14,6 +14,12 @@ The important note is that Payload by itself does not have this requirement, But
 
 Solutions:
 
+## Using the experimental-build-mode Next.js build flag
+
+You can run Next.js build using the `pnpx next build --experimental-build mode compile` command to only compile the code without static generation, which does not require a DB connection. In that case, your pages will be rendered dynamically, but after that, you can still generate static pages using the `pnpx next build --experimental-build mode generate` command when you have a DB connection.
+
+[Next.js documentation](https://nextjs.org/docs/pages/api-reference/cli/next#next-build-options)
+
 ## Opting-out of SSG
 
 You can opt out of SSG by adding this all the route segment files:
@@ -22,11 +28,5 @@ You can opt out of SSG by adding this all the route segment files:
 export const dynamic = 'force-dynamic'
 ```
 
-Note that it will disable static optimization and your site will be slower.
+**Note that it will disable static optimization and your site will be slower**.
 More on [Next.js documentation](https://nextjs.org/docs/app/deep-dive/caching#opting-out-2)
-
-## Using the experimental-build-mode Next.js build flag
-
-You can run Next.js build using the `pnpx next build --experimental-build mode compile` command to only compile the code without static generation, which does not require a DB connection. In that case, your pages will be rendered dynamically, but after that, you can still generate static pages using the `pnpx next build --experimental-build mode generate` command when you have a DB connection.
-
-[Next.js documentation](https://nextjs.org/docs/pages/api-reference/cli/next#next-build-options)

--- a/docs/production/building-without-a-db-connection.mdx
+++ b/docs/production/building-without-a-db-connection.mdx
@@ -1,0 +1,32 @@
+---
+title: Building without a DB connection
+label: Building without a DB connection
+order: 10
+desc: You don't want to have a DB connection while building your Docker container? Learn how to prevent that!
+keywords: deployment, production, config, configuration, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
+---
+
+# Building without a DB connection
+
+One of the most common problems when building a site for production, especially with Docker - is the DB connection requirement.
+
+The important note is that Payload by itself does not have this requirement, But [Next.js' SSG ](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation) does if any of your route segments have SSG enabled (which is default, unless you opted out or used a [Dynamic API](https://nextjs.org/docs/app/deep-dive/caching#dynamic-apis)) and use the Payload Local API.
+
+Solutions:
+
+## Opting-out of SSG
+
+You can opt out of SSG by adding this all the route segment files:
+
+```ts
+export const dynamic = 'force-dynamic'
+```
+
+Note that it will disable static optimization and your site will be slower.
+More on [Next.js documentation](https://nextjs.org/docs/app/deep-dive/caching#opting-out-2)
+
+## Using the experimental-build-mode Next.js build flag
+
+You can run Next.js build using the `pnpx next build --experimental-build mode compile` command to only compile the code without static generation, which does not require a DB connection. In that case, your pages will be rendered dynamically, but after that, you can still generate static pages using the `pnpx next build --experimental-build mode generate` command when you have a DB connection.
+
+[Next.js documentation](https://nextjs.org/docs/pages/api-reference/cli/next#next-build-options)

--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -150,7 +150,7 @@ Follow the docs to configure any one of these storage providers. For local devel
 ## Docker
 
 This is an example of a multi-stage docker build of Payload for production. Ensure you are setting your environment
-variables on deployment, like `PAYLOAD_SECRET`, `PAYLOAD_CONFIG_PATH`, and `DATABASE_URI` if needed.
+variables on deployment, like `PAYLOAD_SECRET`, `PAYLOAD_CONFIG_PATH`, and `DATABASE_URI` if needed. If you don't want to have a DB connection and your build requires that, learn [here](./building-without-a-db-connection) how to prevent that.
 
 In your Next.js config, set the `output` property `standalone`.
 


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/12605

Adds documentation for one of the most common problems - building a site without a database connection (and why Payload may even need that).