### PR TITLE
fix(live-preview): correct type inference

### DIFF
--- a/packages/live-preview-react/src/useLivePreview.ts
+++ b/packages/live-preview-react/src/useLivePreview.ts
@@ -2,18 +2,27 @@
 import { ready, subscribe, unsubscribe } from '@payloadcms/live-preview'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-// To prevent the flicker of missing data on initial load,
-// you can pass in the initial page data from the server
-// To prevent the flicker of stale data while the post message is being sent,
-// you can conditionally render loading UI based on the `isLoading` state
-
-export const useLivePreview = <T extends Record<string, unknown>>(props: {
+/**
+ * This is a React hook to implement {@link https://payloadcms.com/docs/live-preview/overview Payload Live Preview}.
+ *
+ * @link https://payloadcms.com/docs/live-preview/frontend
+ */
+// NOTE: cannot use Record<string, unknown> here bc generated interfaces will not satisfy the type constraint
+export const useLivePreview = <T extends Record<string, any>>(props: {
   apiRoute?: string
   depth?: number
+  /**
+   * To prevent the flicker of missing data on initial load,
+   * you can pass in the initial page data from the server.
+   */
   initialData: T
   serverURL: string
 }): {
   data: T
+  /**
+   * To prevent the flicker of stale data while the post message is being sent,
+   * you can conditionally render loading UI based on the `isLoading` state.
+   */
   isLoading: boolean
 } => {
   const { apiRoute, depth, initialData, serverURL } = props

--- a/packages/live-preview-vue/src/index.ts
+++ b/packages/live-preview-vue/src/index.ts
@@ -4,17 +4,25 @@ import { ready, subscribe, unsubscribe } from '@payloadcms/live-preview'
 import { onMounted, onUnmounted, ref } from 'vue'
 
 /**
- * Vue composable to implement Payload CMS Live Preview.
+ * This is a Vue composable to implement {@link https://payloadcms.com/docs/live-preview/overview Payload Live Preview}.
  *
- * {@link https://payloadcms.com/docs/live-preview/frontend View the documentation}
+ * @link https://payloadcms.com/docs/live-preview/frontend
  */
-export const useLivePreview = <T extends Record<string, unknown>>(props: {
+export const useLivePreview = <T extends Record<string, any>>(props: {
   apiRoute?: string
   depth?: number
+  /**
+   * To prevent the flicker of missing data on initial load,
+   * you can pass in the initial page data from the server.
+   */
   initialData: T
   serverURL: string
 }): {
   data: Ref<T>
+  /**
+   * To prevent the flicker of stale data while the post message is being sent,
+   * you can conditionally render loading UI based on the `isLoading` state.
+   */
   isLoading: Ref<boolean>
 } => {
   const { apiRoute, depth, initialData, serverURL } = props


### PR DESCRIPTION
Type inferences broke as a result of migrating to ts strict mode in #12298. This leads to compile-time errors that may prevent build.

Here is an example:

```ts
export interface Page {
  id: string;
  slug: string;
  title: string;
  // ...
}

/** 
* Type 'Page' does not satisfy the constraint 'Record<string, unknown>'.
* Index signature for type 'string' is missing in type 'Page'.
*/
const { data } = useLivePreview<Page>({
  depth: 2,
  initialData: initialPage,
  serverURL: PAYLOAD_SERVER_URL,
})
```

The problem is that Payload generated type _interfaces_ do not satisfy the `Record<string, unknown>` type. This is because interfaces are a possible target for declaration merging, so their properties are not fully known. More details on this [here](https://github.com/microsoft/TypeScript/issues/42825).

This PR also cleans up the JSDocs.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210524295135085