### PR TITLE
fix: folders.collectionOverrides should be excluded from the client config

### DIFF
--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -144,6 +144,21 @@ export const createClientConfig = ({
           importMap,
         })
         break
+      case 'folders':
+        if (config.folders) {
+          clientConfig.folders = {}
+          if (config.folders.debug) {
+            clientConfig.folders.debug = config.folders.debug
+          }
+          if (config.folders.fieldName) {
+            clientConfig.folders.fieldName = config.folders.fieldName
+          }
+          if (config.folders.slug) {
+            clientConfig.folders.slug = config.folders.slug
+          }
+        }
+        break
+
       case 'globals':
         ;(clientConfig.globals as ClientGlobalConfig[]) = createClientGlobalConfigs({
           defaultIDType: config.db.defaultIDType,
@@ -152,7 +167,6 @@ export const createClientConfig = ({
           importMap,
         })
         break
-
       case 'localization':
         if (typeof config.localization === 'object' && config.localization) {
           clientConfig.localization = {}

--- a/test/folders/config.ts
+++ b/test/folders/config.ts
@@ -18,6 +18,11 @@ export default buildConfigWithDefaults({
   },
   folders: {
     // debug: true,
+    collectionOverrides: [
+      ({ collection }) => {
+        return collection
+      },
+    ],
   },
   collections: [Posts, Media, Drafts, Autosave],
   globals: [


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12631

Adding `folders.collectionOverrides` was being set on the client config - it should be omitted.