### PR TITLE
fix(ui): clear miliseconds in date fields unless theyre explicitly provided in the display format

### DIFF
--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -65,6 +65,13 @@ const DatePicker: React.FC<Props> = (props) => {
       const tzOffset = incomingDate.getTimezoneOffset() / 60
       newDate.setHours(12 - tzOffset, 0)
     }
+
+    if (newDate instanceof Date && !dateFormat.includes('SSS')) {
+      // Unless the dateFormat includes milliseconds, set milliseconds to 0
+      // This is to ensure that the timestamp is consistent with the displayFormat
+      newDate.setMilliseconds(0)
+    }
+
     if (typeof onChangeFromProps === 'function') {
       onChangeFromProps(newDate)
     }

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -25,6 +25,16 @@ const DateFields: CollectionConfig = {
       },
     },
     {
+      name: 'timeOnlyWithMiliseconds',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'timeOnly',
+          displayFormat: 'h:mm.ss.SSS aa',
+        },
+      },
+    },
+    {
       name: 'timeOnlyWithCustomFormat',
       type: 'date',
       admin: {

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -903,6 +903,7 @@ export interface DateField {
   id: string;
   default: string;
   timeOnly?: string | null;
+  timeOnlyWithMiliseconds?: string | null;
   timeOnlyWithCustomFormat?: string | null;
   dayOnly?: string | null;
   dayAndTime?: string | null;
@@ -2486,6 +2487,7 @@ export interface CustomRowIdSelect<T extends boolean = true> {
 export interface DateFieldsSelect<T extends boolean = true> {
   default?: T;
   timeOnly?: T;
+  timeOnlyWithMiliseconds?: T;
   timeOnlyWithCustomFormat?: T;
   dayOnly?: T;
   dayAndTime?: T;


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12532

Normally we clear any values when picking a date such that your hour, minutes and seconds are normalised to 0 unless specified. Equally when you specify a time we will normalise seconds so that only minutes are relevant as configured.

Miliseconds were never removed from the actual date value and whatever milisecond the editor was in was that value that was being added. There's this [abandoned issue](https://github.com/Hacker0x01/react-datepicker/issues/1991) from the UI library `react-datepicker` as it's not something configurable.

This fixes that problem by making sure that miliseconds are always 0 unless the `displayFormat` includes `SSS` as an intention to show and customise them.

This also caused [issues with scheduled jobs](https://github.com/payloadcms/payload/issues/12566) if things were slightly out of order or not being scheduled in the expected time interval.