### PR TITLE
docs: fixed beforeHook documentation to reflect actual behaviour

### DIFF
--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -121,7 +121,7 @@ The following arguments are provided to the `beforeValidate` hook:
 
 ### beforeChange
 
-Immediately following validation, `beforeChange` hooks will run within `create` and `update` operations. At this stage, you can be confident that the data that will be saved to the document is valid in accordance to your field validations. You can optionally modify the shape of data to be saved.
+Immediately before validation, beforeChange hooks will run during create and update operations. At this stage, the data should be treated as unvalidated user input. There is no guarantee that required fields exist or that fields are in the correct format. As such, using this data for side effects requires manual validation. You can optionally modify the shape of the data to be saved.
 
 ```ts
 import type { CollectionBeforeChangeHook } from 'payload'


### PR DESCRIPTION
There are various open issues relating to the beforeChange hook as well as statements from payload team about its behaviour that conflict with the docs - this brings the docs in line with the expected behaviour of the hook

Current expected behaviour:

https://github.com/payloadcms/payload/issues/9714#issuecomment-2710872473

beforeChange open issues:

https://github.com/payloadcms/payload/issues/12065
https://github.com/payloadcms/payload/issues/11169
https://github.com/payloadcms/payload/issues/9714

We should probably acknowledge, as part of this documentation change for discussion, that while this update reflects the current behavior, it raises questions about the efficacy of the hook and whether this is truly the desired behavior. 

I suspect users want the behaviour as documented today, not the modified version, but have not realised the true implementation detail through error or external abuse yet. It is hard to detect problems that arise from this when using the admin UI as it obscures them with the validation errors while not making it obvious that the hook still ran.

I would suggest that having the data passed into this hook as strongly typed instead of Partial<collection> does not aid developers in understanding how this hook works.

The short version: **I think there is a requirement for a hook that runs before the database write but with valid data, and i think people believe this is that hook.**