### PR TITLE
chore: add eslint rule to ignore default exports in test suite configs

### DIFF
--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -247,8 +247,6 @@ export const rootEslintConfig = [
       payload: payloadPlugin,
     },
     rules: {
-      ...baseRules,
-      ...typescriptRules,
       'no-restricted-exports': 'off',
     },
     files: ['*.config.ts', 'config.ts'],

--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -29,6 +29,12 @@ export const testEslintConfig = [
     },
   },
   {
+    files: ['**/*.config.ts', '**/config.ts'],
+    rules: {
+      'no-restricted-exports': 'off',
+    },
+  },
+  {
     files: ['**/*.int.spec.ts', '**/int.spec.ts'],
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',


### PR DESCRIPTION
Adds eslint rule `no-restricted-exports` with value `off` for payload config files inside our `test` suite since we have to export with default from those