### PR TITLE
fix(db-postgres): `in` query with `null`

### DIFF
--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -374,7 +374,7 @@ export function parseParams({
                   Array.isArray(queryValue) &&
                   queryValue.some((v) => v === null)
                 ) {
-                  orConditions.push(adapter.operators.isNull(resolvedColumn))
+                  orConditions.push(isNull(resolvedColumn))
                   resolvedQueryValue = queryValue.filter((v) => v !== null)
                 }
                 let constraint = adapter.operators[queryOperator](

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -367,7 +367,25 @@ export function parseParams({
                   break
                 }
 
-                constraints.push(adapter.operators[queryOperator](resolvedColumn, queryValue))
+                const orConditions: SQL<unknown>[] = []
+                let resolvedQueryValue = queryValue
+                if (
+                  operator === 'in' &&
+                  Array.isArray(queryValue) &&
+                  queryValue.some((v) => v === null)
+                ) {
+                  orConditions.push(adapter.operators.isNull(resolvedColumn))
+                  resolvedQueryValue = queryValue.filter((v) => v !== null)
+                }
+                let constraint = adapter.operators[queryOperator](
+                  resolvedColumn,
+                  resolvedQueryValue,
+                )
+                if (orConditions.length) {
+                  orConditions.push(constraint)
+                  constraint = or(...orConditions)
+                }
+                constraints.push(constraint)
               }
             }
           }

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2621,6 +2621,7 @@ describe('database', () => {
   })
 
   it('should support in with null', async () => {
+    await payload.delete({ collection: 'posts', where: {} })
     const post_1 = await payload.create({
       collection: 'posts',
       data: { title: 'a', text: 'text-1' },

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2619,4 +2619,33 @@ describe('database', () => {
     expect(res.testBlocks[0]?.text).toBe('text')
     expect(res.testBlocksLocalized[0]?.text).toBe('text-localized')
   })
+
+  it('should support in with null', async () => {
+    const post_1 = await payload.create({
+      collection: 'posts',
+      data: { title: 'a', text: 'text-1' },
+    })
+    const post_2 = await payload.create({
+      collection: 'posts',
+      data: { title: 'a', text: 'text-2' },
+    })
+    const post_3 = await payload.create({
+      collection: 'posts',
+      data: { title: 'a', text: 'text-3' },
+    })
+    const post_null = await payload.create({
+      collection: 'posts',
+      data: { title: 'a', text: null },
+    })
+
+    global.d = true
+    const { docs } = await payload.find({
+      collection: 'posts',
+      where: { text: { in: ['text-1', 'text-3', null] } },
+    })
+    expect(docs).toHaveLength(3)
+    expect(docs[0].id).toBe(post_null.id)
+    expect(docs[1].id).toBe(post_3.id)
+    expect(docs[2].id).toBe(post_1.id)
+  })
 })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2638,7 +2638,6 @@ describe('database', () => {
       data: { title: 'a', text: null },
     })
 
-    global.d = true
     const { docs } = await payload.find({
       collection: 'posts',
       where: { text: { in: ['text-1', 'text-3', null] } },


### PR DESCRIPTION
Previously, this was possible in MongoDB but not in Postgres/SQLite (having `null` in an `in` query)
```
const { docs } = await payload.find({
  collection: 'posts',
  where: { text: { in: ['text-1', 'text-3', null] } },
})
```
This PR fixes that behavior