### PR TITLE
fix(richtext-lexical): prevent runtime error if using TextStateFeature without props

### DIFF
--- a/packages/richtext-lexical/src/features/textState/feature.server.ts
+++ b/packages/richtext-lexical/src/features/textState/feature.server.ts
@@ -69,7 +69,7 @@ export const TextStateFeature = createServerFeature<
     return {
       ClientFeature: '@payloadcms/richtext-lexical/client#TextStateFeatureClient',
       clientFeatureProps: {
-        state: props.state,
+        state: props?.state,
       },
     }
   },


### PR DESCRIPTION
TextStateFeature wasn't intended to be used without props, but it still shouldn't throw a runtime error if used that way. Perhaps some users are experimenting until they decide on the props.

Fixes #12518
