### PR TITLE
feat(ui): enable search for nested fields on wherebuilder

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -121,6 +121,11 @@ export const Condition: React.FC<Props> = (props) => {
           <div className={`${baseClass}__field`}>
             <ReactSelect
               disabled={disabled}
+              filterOption={(candidate, inputValue) =>
+                ((candidate.data?.plainLabel as string) ?? candidate.label)
+                  .toLowerCase()
+                  .includes(inputValue.toLowerCase())
+              }
               isClearable={false}
               onChange={handleFieldChange}
               options={reducedFields.filter((field) => !field.field.admin.disableListFilter)}

--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -121,8 +121,8 @@ export const Condition: React.FC<Props> = (props) => {
           <div className={`${baseClass}__field`}>
             <ReactSelect
               disabled={disabled}
-              filterOption={(candidate, inputValue) =>
-                ((candidate.data?.plainLabel as string) ?? candidate.label)
+              filterOption={(option, inputValue) =>
+                ((option?.data?.plainTextLabel as string) || option.label)
                   .toLowerCase()
                   .includes(inputValue.toLowerCase())
               }

--- a/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
+++ b/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
@@ -9,6 +9,7 @@ import type { ReducedField } from './types.js'
 
 import { createNestedClientFieldPath } from '../../forms/Form/createNestedClientFieldPath.js'
 import { combineFieldLabel } from '../../utilities/combineFieldLabel.js'
+import { extractTextFromReactNode } from '../../utilities/extractTextFromReactNode.js'
 import fieldTypes from './field-types.js'
 
 type ReduceFieldOptionsArgs = {
@@ -152,10 +153,15 @@ export const reduceFields = ({
           })
         : localizedLabel
 
+      // React elements in filter options are not searchable in React Select
+      // Extract plain text to make them filterable in dropdowns
+      const textFromLabel = extractTextFromReactNode(formattedLabel)
+
       const fieldPath = pathPrefix ? createNestedClientFieldPath(pathPrefix, field) : field.name
 
       const formattedField: ReducedField = {
         label: formattedLabel,
+        plainLabel: textFromLabel,
         value: fieldPath,
         ...fieldTypes[field.type],
         field,

--- a/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
+++ b/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
@@ -161,7 +161,7 @@ export const reduceFields = ({
 
       const formattedField: ReducedField = {
         label: formattedLabel,
-        plainLabel: textFromLabel,
+        plainTextLabel: textFromLabel,
         value: fieldPath,
         ...fieldTypes[field.type],
         field,

--- a/packages/ui/src/elements/WhereBuilder/types.ts
+++ b/packages/ui/src/elements/WhereBuilder/types.ts
@@ -21,7 +21,7 @@ export type ReducedField = {
     label: string
     value: Operator
   }[]
-  plainLabel?: string
+  plainTextLabel?: string
   value: string
 }
 

--- a/packages/ui/src/elements/WhereBuilder/types.ts
+++ b/packages/ui/src/elements/WhereBuilder/types.ts
@@ -21,6 +21,7 @@ export type ReducedField = {
     label: string
     value: Operator
   }[]
+  plainLabel?: string
   value: string
 }
 

--- a/packages/ui/src/utilities/extractTextFromReactNode.ts
+++ b/packages/ui/src/utilities/extractTextFromReactNode.ts
@@ -1,0 +1,41 @@
+import React from 'react'
+
+/**
+ * Extracts plain text content from a React node by recursively traversing its structure.
+ *
+ * For server components and static analysis.
+ */
+export const extractTextFromReactNode = (node: React.ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return ''
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return node.toString()
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(extractTextFromReactNode).join('')
+  }
+
+  if (React.isValidElement(node)) {
+    const textParts: string[] = []
+
+    for (const [key, value] of Object.entries(node.props)) {
+      // Only recurse into props that might contain React content
+      if (
+        key === 'children' ||
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        React.isValidElement(value) ||
+        Array.isArray(value)
+      ) {
+        textParts.push(extractTextFromReactNode(value))
+      }
+    }
+
+    return textParts.join('')
+  }
+
+  return ''
+}

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -121,6 +121,24 @@ describe('List View', () => {
     await expect(page.locator(tableRowLocator)).toHaveCount(2)
   })
 
+  test('should search for nested fields in field dropdown', async () => {
+    await page.goto(postsUrl.list)
+
+    await openListFilters(page, {})
+
+    const whereBuilder = page.locator('.where-builder')
+    await whereBuilder.locator('.where-builder__add-first-filter').click()
+    const conditionField = whereBuilder.locator('.condition__field')
+    await conditionField.click()
+    await conditionField.locator('input.rs__input').fill('Tab 1 > Title')
+
+    await expect(
+      conditionField.locator('.rs__menu-list').locator('div', {
+        hasText: exactText('Tab 1 > Title'),
+      }),
+    ).toBeVisible()
+  })
+
   const tableRowLocator = 'table > tbody > tr'
 
   describe('list view descriptions', () => {
@@ -413,7 +431,7 @@ describe('List View', () => {
       await expect(whereBuilder.locator('.condition__value input')).toHaveValue('')
     })
 
-    // eslint-disable-next-line playwright/expect-expect
+     
     test('should remove condition from URL when value is cleared', async () => {
       await page.goto(postsUrl.list)
 


### PR DESCRIPTION
## What
A follow-up to the https://github.com/payloadcms/payload/pull/11986 and https://github.com/payloadcms/payload/pull/12419

## Why
https://github.com/payloadcms/payload/pull/11986 was reverted after it flooded the console with errors https://github.com/payloadcms/payload/pull/12421

## How
Adapting the approach by @jacobsfletch in https://github.com/payloadcms/payload/pull/12419 and fine-tuning it to a workable solution

## Code setup
`test/_community/collection/Posts/index.ts`
```
{
      type: "collapsible",
      label: "Meta",
      fields: [
        {
          name: 'media',
          type: 'relationship',
          relationTo: 'media',
          label: 'Sequoia',
          filterOptions: () => {
            return {
              id: { in: ['68406b7ae1ac559e808d3a35'] },
            }
          }
        },
        {
          name: 'media2',
          type: 'relationship',
          relationTo: 'media',
          label: 'Yosemite',
          filterOptions: () => {
            return {
              id: { in: ['68406b55e1ac559e808d39da'] },
            }
          }
        },
      ],
    },
```

## Demo
The same as in https://github.com/payloadcms/payload/pull/11986