### PR TITLE
templates: do not expose users in example custom routes

### DIFF
--- a/examples/astro/payload/src/app/my-route/route.ts
+++ b/examples/astro/payload/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/examples/remix/payload/src/app/my-route/route.ts
+++ b/examples/remix/payload/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/templates/_template/src/app/my-route/route.ts
+++ b/templates/_template/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/templates/blank/src/app/my-route/route.ts
+++ b/templates/blank/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/templates/plugin/dev/app/my-route/route.ts
+++ b/templates/plugin/dev/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/templates/with-payload-cloud/src/app/my-route/route.ts
+++ b/templates/with-payload-cloud/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/templates/with-postgres/src/app/my-route/route.ts
+++ b/templates/with-postgres/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/templates/with-vercel-mongodb/src/app/my-route/route.ts
+++ b/templates/with-vercel-mongodb/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }

--- a/templates/with-vercel-postgres/src/app/my-route/route.ts
+++ b/templates/with-vercel-postgres/src/app/my-route/route.ts
@@ -1,14 +1,12 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
   const payload = await getPayload({
     config: configPromise,
   })
 
-  const data = await payload.find({
-    collection: 'users',
+  return Response.json({
+    message: 'This is an example of a custom route.',
   })
-
-  return Response.json(data)
 }


### PR DESCRIPTION
Follow up to #12404.

Templates include a custom route for demonstration purposes that shows how to get Payload and use it. It was intended that these routes are either removed or modified for every new project, however, we can't guarantee this. This means that they should not expose any sensitive data, such as the users list.

Instead, we can return a simple message from these routes indicating they are custom. This will ensure that even if they are kept as-is and deployed, no sensitive data is leaked. Payload is still instantiated, but we simply don't use it.

This PR also types the first argument to further help users get started building custom routes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210524294758027