### PR TITLE
docs: improve module augmentation docs for request context

### DIFF
--- a/docs/hooks/context.mdx
+++ b/docs/hooks/context.mdx
@@ -128,20 +128,18 @@ const MyCollection: CollectionConfig = {
 
 ## TypeScript
 
-The default TypeScript interface for `context` is `{ [key: string]: unknown }`. If you prefer a more strict typing in your project or when authoring plugins for others, you can override this using the `declare` syntax.
+The default TypeScript interface for `context` is `{ [key: string]: unknown }`. If you prefer a more strict typing in your project or when authoring plugins for others, you can override this using the `declare module` syntax.
 
-This is known as "type augmentation", a TypeScript feature which allows us to add types to existing types. Simply put this in any `.ts` or `.d.ts` file:
+This is known as [module augmentation / declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation), a TypeScript feature which allows us to add properties to existing types. Simply put this in any `.ts` or `.d.ts` file:
 
 ```ts
-import { RequestContext as OriginalRequestContext } from 'payload'
-
 declare module 'payload' {
-  // Create a new interface that merges your additional fields with the original one
-  export interface RequestContext extends OriginalRequestContext {
+  // Augment the RequestContext interface to include your custom properties
+  export interface RequestContext {
     myObject?: string
     // ...
   }
 }
 ```
 
-This will add the property `myObject` with a type of string to every context object. Make sure to follow this example correctly, as type augmentation can mess up your types if you do it wrong.
+This will add the property `myObject` with a type of string to every context object. Make sure to follow this example correctly, as module augmentation can mess up your types if you do it wrong.


### PR DESCRIPTION
The original documentation was unnecessarily complex - you don't need to import the original interface and extend from it in order to add additional properties to it via module augmentation.