### PR TITLE
fix(ui): adjusts margin spacing on upload actions

### DIFF
--- a/packages/ui/src/elements/Upload/index.scss
+++ b/packages/ui/src/elements/Upload/index.scss
@@ -60,9 +60,8 @@
       flex-wrap: wrap;
     }
 
-    &__previewSizes,
-    &__edit {
-      margin-top: calc(var(--base) * 1.2);
+    &__upload-actions {
+      margin-top: calc(var(--base) * 0.5);
     }
 
     &__previewDrawer {


### PR DESCRIPTION
### What?

Previously margin was being added to the actual buttons inside the `upload-actions` container which caused inconsistencies with the folder button when folders are enabled on the collection. 

### How?

Now, we've moved the margin spacing to the `upload-actions` container itself instead of on the specific buttons inside it.

#### Before
![Screenshot 2025-06-05 at 9 39 14 AM](https://github.com/user-attachments/assets/d43257b4-91dd-40ea-82ef-3a803c5177dc)

#### After
![Screenshot 2025-06-05 at 9 38 43 AM](https://github.com/user-attachments/assets/0bdd1d23-81d2-4cbb-bae6-82bacbc8c8a0)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210547303951844