### PR TITLE
fix(richtext-slate): add 'li' string literal to RichTextElement type

### DIFF
--- a/docs/rich-text/slate.mdx
+++ b/docs/rich-text/slate.mdx
@@ -81,6 +81,7 @@ The default `elements` available in Payload are:
 - `link`
 - `ol`
 - `ul`
+- `li`
 - `textAlign`
 - `indent`
 - [`relationship`](#relationship-element)

--- a/packages/richtext-slate/src/types.ts
+++ b/packages/richtext-slate/src/types.ts
@@ -41,6 +41,7 @@ export type RichTextElement =
   | 'h5'
   | 'h6'
   | 'indent'
+  | 'li'
   | 'link'
   | 'ol'
   | 'relationship'


### PR DESCRIPTION
Fixes #12160
