### PR TITLE
fix(plugin-form-builder): export DateField type

### DIFF
--- a/packages/plugin-form-builder/src/exports/types.ts
+++ b/packages/plugin-form-builder/src/exports/types.ts
@@ -3,6 +3,7 @@ export type {
   BlockConfig,
   CheckboxField,
   CountryField,
+  DateField,
   Email,
   EmailField,
   FieldConfig,


### PR DESCRIPTION
Just forgot to export the DateField type along with other field types from the plugin