### PR TITLE
docs: fix formatting in custom components > edit view paragraph

### DIFF
--- a/docs/custom-components/edit-view.mdx
+++ b/docs/custom-components/edit-view.mdx
@@ -340,12 +340,12 @@ export const EditMenuItems = (props: EditViewMenuItemClientProps) => {
 ```
 
 <Banner type="info">
-  **Styling:** Use Payload&apos;s built-in <code>PopupList.Button</code> to
-  ensure your menu items automatically match the default dropdown styles. If you
-  want a different look, you can customize the appearance by passing your own{' '}
-  <code>className</code> to <code>PopupList.Button</code>, or use a completely
-  custom button built with a standard HTML <code>&lt;button&gt;</code> element
-  or any other component that fits your design preferences.
+  **Styling:** Use Payload's built-in `PopupList.Button` to ensure your menu
+  items automatically match the default dropdown styles. If you want a different
+  look, you can customize the appearance by passing your own `className` to
+  `PopupList.Button`, or use a completely custom button built with a standard
+  HTML `button` element or any other component that fits your design
+  preferences.
 </Banner>
 
 ### SaveDraftButton


### PR DESCRIPTION
Fixes bad formatting on docs page: https://payloadcms.com/docs/custom-components/edit-view
![Screenshot 2025-06-05 at 5 35 43 PM](https://github.com/user-attachments/assets/49eb813e-344f-49db-9d06-84ad1f2e1553)
