### PR TITLE
fix(ui): vertically align table headers to the middle

### DIFF
--- a/packages/ui/src/elements/Table/index.scss
+++ b/packages/ui/src/elements/Table/index.scss
@@ -16,6 +16,7 @@
       th {
         font-weight: normal;
         text-align: left;
+        vertical-align: middle;
         [dir='rtl'] & {
           text-align: right;
         }


### PR DESCRIPTION
This fixes a small ui bug where the items in the table header were not vertically aligned when they don't contain the SortColumn component. The SortColumn component handles vertical alignment with a nested flexbox. The PR adds vertical-align: middle directly to the th element so that the text in the header is vertically aligned even when there isn't a nested flexbox

Before:
<img width="719" alt="Screenshot 2025-06-05 at 10 24 19 AM" src="https://github.com/user-attachments/assets/3962517e-3b22-452a-af04-8397549c4ed9" />

After:
<img width="719" alt="Screenshot 2025-06-05 at 10 30 39 AM" src="https://github.com/user-attachments/assets/0c5a0847-8ee2-4439-981e-f3538908e920" />
