### PR TITLE
docs: document how to expose the jobs collection in Admin UI

### DIFF
--- a/docs/jobs-queue/overview.mdx
+++ b/docs/jobs-queue/overview.mdx
@@ -68,3 +68,26 @@ Here's a quick overview:
 - Workflows are groupings of specific tasks which should be run in-order, and can be retried from a specific point of failure
 - A Job is an instance of a single task or workflow which will be executed
 - A Queue is a way to segment your jobs into different "groups" - for example, some to run nightly, and others to run every 10 minutes
+
+### Visualizing Jobs in the Admin UI
+
+By default, the internal `payload-jobs` collection is hidden from the Payload Admin Panel. To make this collection visible for debugging or inspection purposes, you can override its configuration using `jobsCollectionOverrides`.
+
+```ts
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  // ... other config
+  jobs: {
+    // ... other job settings
+    jobsCollectionOverrides: ({ defaultJobsCollection }) => {
+      if (!defaultJobsCollection.admin) {
+        defaultJobsCollection.admin = {}
+      }
+
+      defaultJobsCollection.admin.hidden = false
+      return defaultJobsCollection
+    },
+  },
+})
+```


### PR DESCRIPTION
### What?

Adds documentation to demonstrate how to make the internal `payload-jobs` collection visible in the Admin Panel using the `jobsCollectionOverrides` option.

### Why?

By default, the jobs collection is hidden from the UI. However, for debugging or monitoring purposes—especially during development—some teams may want direct access to view and inspect job entries.

### How?

A code snippet is added under the **"Jobs Queue > Overview"** page showing how to override the collection config to set `admin.hidden = false`.

---

**Before:**

No mention of how to expose the `payload-jobs` collection in the documentation.

**After:**

Clear section and code example on how to enable visibility for the jobs collection.

---

Supersedes: [#12321](https://github.com/payloadcms/payload/pull/12321)  
Related Discord thread: [Payload Jobs UI](https://discord.com/channels/967097582721572934/1367918548428652635)
