### PR TITLE
fix: adds routeParams to the req on views

### DIFF
--- a/packages/next/src/utilities/initPage/index.ts
+++ b/packages/next/src/utilities/initPage/index.ts
@@ -16,6 +16,7 @@ export const initPage = async ({
   config: configPromise,
   importMap,
   route,
+  routeParams = {},
   searchParams,
   useLayoutReq,
 }: Args): Promise<InitPageResult> => {
@@ -38,6 +39,7 @@ export const initPage = async ({
           depth: 10,
           ignoreQueryPrefix: true,
         }),
+        routeParams,
       },
       urlSuffix: `${route}${searchParams ? queryString : ''}`,
     },

--- a/packages/next/src/utilities/initPage/types.ts
+++ b/packages/next/src/utilities/initPage/types.ts
@@ -17,6 +17,12 @@ export type Args = {
    */
   route: string
   /**
+   * The route parameters of the current route
+   *
+   * @example `{ collection: 'posts', id: "post-id" }`.
+   */
+  routeParams?: { [key: string]: string }
+  /**
    * The search parameters of the current route provided to all pages in Next.js.
    */
   searchParams: { [key: string]: string | string[] | undefined }

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -276,7 +276,7 @@ export const getRouteData = ({
           // Collection Folder Views
           // --> /collections/:collectionSlug/:folderCollectionSlug
           // --> /collections/:collectionSlug/:folderCollectionSlug/:folderID
-          initPageOptions.routeParams.folderSlug = segmentThree
+          initPageOptions.routeParams.folderCollection = segmentThree
           initPageOptions.routeParams.folderID = segmentFour
 
           ViewToRender = {

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -295,6 +295,7 @@ export const getRouteData = ({
           // --> /collections/:collectionSlug/:id/versions
           // --> /collections/:collectionSlug/:id/versions/:versionID
           initPageOptions.routeParams.id = segmentThree
+          initPageOptions.routeParams.versionID = segmentFive
 
           ViewToRender = {
             Component: DocumentView,
@@ -320,6 +321,7 @@ export const getRouteData = ({
         // --> /globals/:globalSlug/versions/:versionID
         // --> /globals/:globalSlug/api
         initPageOptions.routeParams.global = matchedGlobal.slug
+        initPageOptions.routeParams.versionID = segmentFour
 
         ViewToRender = {
           Component: DocumentView,

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -103,6 +103,7 @@ export const getRouteData = ({
     config,
     importMap,
     route: currentRoute,
+    routeParams: {},
     searchParams,
   }
 
@@ -212,6 +213,8 @@ export const getRouteData = ({
         `/${segmentOne}` === config.admin.routes.browseByFolder
       ) {
         // --> /browse-by-folder/:folderID
+        initPageOptions.routeParams.folderID = folderID
+
         ViewToRender = {
           Component: oneSegmentViews.browseByFolder,
         }
@@ -221,6 +224,7 @@ export const getRouteData = ({
         folderID = segmentTwo
       } else if (isCollection && matchedCollection) {
         // --> /collections/:collectionSlug
+        initPageOptions.routeParams.collection = matchedCollection.slug
 
         ViewToRender = {
           Component: ListView,
@@ -234,6 +238,7 @@ export const getRouteData = ({
         )
       } else if (isGlobal && matchedGlobal) {
         // --> /globals/:globalSlug
+        initPageOptions.routeParams.global = matchedGlobal.slug
 
         ViewToRender = {
           Component: DocumentView,
@@ -256,6 +261,8 @@ export const getRouteData = ({
     default:
       if (segmentTwo === 'verify') {
         // --> /:collectionSlug/verify/:token
+        initPageOptions.routeParams.collection = segmentOne
+
         ViewToRender = {
           Component: Verify,
         }
@@ -264,10 +271,14 @@ export const getRouteData = ({
         templateType = 'minimal'
         viewType = 'verify'
       } else if (isCollection && matchedCollection) {
+        initPageOptions.routeParams.collection = matchedCollection.slug
         if (config.folders && segmentThree === config.folders.slug && matchedCollection.folders) {
           // Collection Folder Views
           // --> /collections/:collectionSlug/:folderCollectionSlug
           // --> /collections/:collectionSlug/:folderCollectionSlug/:folderID
+          initPageOptions.routeParams.folderSlug = segmentThree
+          initPageOptions.routeParams.folderID = segmentFour
+
           ViewToRender = {
             Component: CollectionFolderView,
           }
@@ -283,6 +294,8 @@ export const getRouteData = ({
           // --> /collections/:collectionSlug/:id/preview
           // --> /collections/:collectionSlug/:id/versions
           // --> /collections/:collectionSlug/:id/versions/:versionID
+          initPageOptions.routeParams.id = segmentThree
+
           ViewToRender = {
             Component: DocumentView,
           }
@@ -306,6 +319,7 @@ export const getRouteData = ({
         // --> /globals/:globalSlug/preview
         // --> /globals/:globalSlug/versions/:versionID
         // --> /globals/:globalSlug/api
+        initPageOptions.routeParams.global = matchedGlobal.slug
 
         ViewToRender = {
           Component: DocumentView,


### PR DESCRIPTION
Prior to this change, `routeParams` were not added to the req on views. Noticed when attempting to access them inside of a `baseListFilter`.

I would have preferred to make the keys `collectionSlug` instead of `collection` but I decided it should align with what these functions are using: 
- https://github.com/payloadcms/payload/blob/main/packages/payload/src/utilities/getRequestEntity.ts
- https://github.com/payloadcms/payload/blob/main/packages/payload/src/utilities/handleEndpoints.ts
