### PR TITLE
fix(ui): usePreventLeave should not show alert for exceptions

### DIFF
--- a/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
@@ -135,7 +135,7 @@ export const usePreventLeave = ({
           }
         }
       } catch (err) {
-        alert(err)
+        console.log(err)
       }
     }
 

--- a/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
@@ -135,7 +135,7 @@ export const usePreventLeave = ({
           }
         }
       } catch (err) {
-        console.log(err)
+        console.log('An unexpected exception was thrown in LeaveWithoutSaving:usePreventLeave', err)
       }
     }
 

--- a/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
@@ -82,21 +82,25 @@ export const usePreventLeave = ({
   // check when page is about to be changed
   useEffect(() => {
     function isAnchorOfCurrentUrl(currentUrl: string, newUrl: string) {
-      const currentUrlObj = new URL(currentUrl)
-      const newUrlObj = new URL(newUrl)
-      // Compare hostname, pathname, and search parameters
-      if (
-        currentUrlObj.hostname === newUrlObj.hostname &&
-        currentUrlObj.pathname === newUrlObj.pathname &&
-        currentUrlObj.search === newUrlObj.search
-      ) {
-        // Check if the new URL is just an anchor of the current URL page
-        const currentHash = currentUrlObj.hash
-        const newHash = newUrlObj.hash
-        return (
-          currentHash !== newHash &&
-          currentUrlObj.href.replace(currentHash, '') === newUrlObj.href.replace(newHash, '')
-        )
+      try {
+        const currentUrlObj = new URL(currentUrl)
+        const newUrlObj = new URL(newUrl)
+        // Compare hostname, pathname, and search parameters
+        if (
+          currentUrlObj.hostname === newUrlObj.hostname &&
+          currentUrlObj.pathname === newUrlObj.pathname &&
+          currentUrlObj.search === newUrlObj.search
+        ) {
+          // Check if the new URL is just an anchor of the current URL page
+          const currentHash = currentUrlObj.hash
+          const newHash = newUrlObj.hash
+          return (
+            currentHash !== newHash &&
+            currentUrlObj.href.replace(currentHash, '') === newUrlObj.href.replace(newHash, '')
+          )
+        }
+      } catch (err) {
+        console.log('Unexpected exception thrown in LeaveWithoutSaving:isAnchorOfCurrentUrl', err)
       }
       return false
     }
@@ -135,7 +139,7 @@ export const usePreventLeave = ({
           }
         }
       } catch (err) {
-        console.log('An unexpected exception was thrown in LeaveWithoutSaving:usePreventLeave', err)
+        console.log('Unexpected exception thrown in LeaveWithoutSaving:usePreventLeave', err)
       }
     }
 


### PR DESCRIPTION
When using 3rd party custom components in an edit form there exists a possibility that a non-navigational click event will propagate through to payload. 

In this case the `findClosestAnchor` function in `usePreventLeave` may find an anchor without href, resulting in the `newUrlObj = new URL(newUrl)` in `isAnchorOfCurrentUrl` throwing the exception:

> TypeError: URL constructor:  is not a valid URL.

As a result a native alert is shown to the user, with no real explanation as to what is going on. This is not a good experience. 

I suggest moving it to a console log which is less "in your face" for users who do not know what to do about it anyway.

I discovered this while using a data grid component with a context menu. Clicking on menu items (which are `<a>` tags without href in this component) triggers the error.

(Another on-liner fix would ofc be to not attempt to create an URL object if there is no href `if (anchor?.href) {`, but I opted for this version since using `alert()` in production code is not a preferred practice anyway)

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
