### PR TITLE
fix(richtext-lexical): text state css not applied if 2+ text state groups present

### DIFF
--- a/packages/richtext-lexical/src/features/textState/textState.ts
+++ b/packages/richtext-lexical/src/features/textState/textState.ts
@@ -70,6 +70,7 @@ export function StatePlugin() {
 
             const css = stateEntry.stateValues[stateValue]?.css
             if (css) {
+              // merge existing styles with the new ones
               Object.assign(mergedStyles, css)
             }
           })

--- a/packages/richtext-lexical/src/features/textState/textState.ts
+++ b/packages/richtext-lexical/src/features/textState/textState.ts
@@ -77,9 +77,7 @@ export function StatePlugin() {
 
           // wipe previous inline styles once, then set the merged ones
           dom.style.cssText = ''
-          for (const [prop, val] of Object.entries(mergedStyles)) {
-            dom.style.setProperty(prop, val)
-          }
+          Object.assign(dom.style, mergedStyles)
         }
       })
     })

--- a/packages/richtext-lexical/src/features/textState/textState.ts
+++ b/packages/richtext-lexical/src/features/textState/textState.ts
@@ -53,24 +53,32 @@ export function StatePlugin() {
           if (!node || !dom) {
             continue
           }
-          // stateKey could be color for example
-          stateMap.forEach((stateEntry, _stateKey) => {
-            // stateValue could be bg-red for example
+
+          const mergedStyles: Record<string, string> = Object.create(null)
+          // Examples:
+          // stateKey: 'color'
+          // stateValue: 'bg-red'
+          stateMap.forEach((stateEntry, stateKey) => {
             const stateValue = $getState(node, stateEntry.stateConfig)
             if (!stateValue) {
-              delete dom.dataset[_stateKey]
-              dom.style.cssText = ''
+              // clear the previous dataset value for this key
+              delete dom.dataset[stateKey]
               return
-            }
-            dom.dataset[_stateKey] = stateValue
+            } // skip - nothing else to do
+
+            dom.dataset[stateKey] = stateValue
+
             const css = stateEntry.stateValues[stateValue]?.css
-            if (!css) {
-              return
+            if (css) {
+              Object.assign(mergedStyles, css)
             }
-            Object.entries(css).forEach(([key, value]) => {
-              dom.style.setProperty(key, value)
-            })
           })
+
+          // wipe previous inline styles once, then set the merged ones
+          dom.style.cssText = ''
+          for (const [prop, val] of Object.entries(mergedStyles)) {
+            dom.style.setProperty(prop, val)
+          }
         }
       })
     })

--- a/test/lexical/collections/_LexicalFullyFeatured/index.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/index.ts
@@ -31,7 +31,8 @@ export const LexicalFullyFeatured: CollectionConfig = {
           EXPERIMENTAL_TableFeature(),
           TextStateFeature({
             state: {
-              color: { ...defaultColors.background, ...defaultColors.text },
+              color: { ...defaultColors.text },
+              backgroundColor: { ...defaultColors.background },
             },
           }),
           BlocksFeature({


### PR DESCRIPTION
Fixes #12723 

## Problem

With two or more state groups, a falsy state entry would run `dom.style.cssText = ''`, wiping all inline styles - including valid styles just set by earlier groups. This caused earlier groups to lack css styling.

## Solution

**1. Collect first, apply once**

During the stateMap.forEach loop, gather each active group's styles into a shared `mergedStyles` object.

Inactive groups still clear their own `data-*` attribute but leave styles untouched.

**2. Single reset + single write**

After the loop, perform one cssText reset, instead of one cssText in each iteration. Then apply each state group's css all at once, after the blank reset

Result: every state group can coexist without overwriting styles from the others

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210495300843718