### PR TITLE
feat: create the importmap file if missing and the location can be found

### DIFF
--- a/packages/payload/src/bin/generateImportMap/index.ts
+++ b/packages/payload/src/bin/generateImportMap/index.ts
@@ -58,7 +58,7 @@ export async function generateImportMap(
 
   const baseDir = config.admin.importMap.baseDir ?? process.cwd()
 
-  const importMapFilePath = resolveImportMapFilePath({
+  const importMapFilePath = await resolveImportMapFilePath({
     adminRoute: config.routes.admin,
     importMapFile: config?.admin?.importMap?.importMapFile,
     rootDir,

--- a/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
@@ -17,7 +17,11 @@ export function resolveImportMapFilePath({
 
   if (importMapFile?.length) {
     if (!fs.existsSync(importMapFile)) {
-      throw new Error(`Could not find the import map file at ${importMapFile}`)
+      try {
+        fs.writeFileSync(importMapFile, '', { flag: 'wx' })
+      } catch (err) {
+        throw new Error(`Could not find the import map file at ${importMapFile}`, err)
+      }
     }
     importMapFilePath = importMapFile
   } else {
@@ -25,9 +29,17 @@ export function resolveImportMapFilePath({
     const srcAppLocation = path.resolve(rootDir, `src/app/(payload)${adminRoute}/`)
 
     if (fs.existsSync(appLocation)) {
-      importMapFilePath = path.resolve(appLocation, 'importMap.js')
+      const importMapJsPath = path.resolve(appLocation, 'importMap.js')
+      if (!fs.existsSync(importMapJsPath)) {
+        fs.writeFileSync(importMapJsPath, '', { flag: 'wx' })
+      }
+      importMapFilePath = importMapJsPath
     } else if (fs.existsSync(srcAppLocation)) {
-      importMapFilePath = path.resolve(srcAppLocation, 'importMap.js')
+      const importMapJsPath = path.resolve(srcAppLocation, 'importMap.js')
+      if (!fs.existsSync(importMapJsPath)) {
+        fs.writeFileSync(importMapJsPath, '', { flag: 'wx' })
+      }
+      importMapFilePath = importMapJsPath
     } else {
       throw new Error(
         `Could not find Payload import map folder. Looked in ${appLocation} and ${srcAppLocation}`,

--- a/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
@@ -29,7 +29,9 @@ export async function resolveImportMapFilePath({
       try {
         await fs.writeFile(importMapFile, '', { flag: 'wx' })
       } catch (err) {
-        throw new Error(`Could not find the import map file at ${importMapFile}`, err)
+        throw new Error(
+          `Could not find the import map file at ${importMapFile}${err?.message ? `: ${err.message}` : ''}`,
+        )
       }
     }
     importMapFilePath = importMapFile

--- a/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
@@ -29,17 +29,15 @@ export function resolveImportMapFilePath({
     const srcAppLocation = path.resolve(rootDir, `src/app/(payload)${adminRoute}/`)
 
     if (fs.existsSync(appLocation)) {
-      const importMapJsPath = path.resolve(appLocation, 'importMap.js')
-      if (!fs.existsSync(importMapJsPath)) {
-        fs.writeFileSync(importMapJsPath, '', { flag: 'wx' })
+      importMapFilePath = path.resolve(appLocation, 'importMap.js')
+      if (!fs.existsSync(importMapFilePath)) {
+        fs.writeFileSync(importMapFilePath, '', { flag: 'wx' })
       }
-      importMapFilePath = importMapJsPath
     } else if (fs.existsSync(srcAppLocation)) {
-      const importMapJsPath = path.resolve(srcAppLocation, 'importMap.js')
-      if (!fs.existsSync(importMapJsPath)) {
-        fs.writeFileSync(importMapJsPath, '', { flag: 'wx' })
+      importMapFilePath = path.resolve(srcAppLocation, 'importMap.js')
+      if (!fs.existsSync(importMapFilePath)) {
+        fs.writeFileSync(importMapFilePath, '', { flag: 'wx' })
       }
-      importMapFilePath = importMapJsPath
     } else {
       throw new Error(
         `Could not find Payload import map folder. Looked in ${appLocation} and ${srcAppLocation}`,

--- a/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
@@ -30,7 +30,7 @@ export async function resolveImportMapFilePath({
         await fs.writeFile(importMapFile, '', { flag: 'wx' })
       } catch (err) {
         throw new Error(
-          `Could not find the import map file at ${importMapFile}${err?.message ? `: ${err.message}` : ''}`,
+          `Could not find the import map file at ${importMapFile}${err instanceof Error && err?.message ? `: ${err.message}` : ''}`,
         )
       }
     }

--- a/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
@@ -1,10 +1,19 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import path from 'path'
+
+async function pathOrFileExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path)
+    return true
+  } catch {
+    return false
+  }
+}
 
 /**
  * Returns the path to the import map file. If the import map file is not found, it throws an error.
  */
-export function resolveImportMapFilePath({
+export async function resolveImportMapFilePath({
   adminRoute = '/admin',
   importMapFile,
   rootDir,
@@ -16,9 +25,9 @@ export function resolveImportMapFilePath({
   let importMapFilePath: string | undefined = undefined
 
   if (importMapFile?.length) {
-    if (!fs.existsSync(importMapFile)) {
+    if (!(await pathOrFileExists(importMapFile))) {
       try {
-        fs.writeFileSync(importMapFile, '', { flag: 'wx' })
+        await fs.writeFile(importMapFile, '', { flag: 'wx' })
       } catch (err) {
         throw new Error(`Could not find the import map file at ${importMapFile}`, err)
       }
@@ -28,15 +37,15 @@ export function resolveImportMapFilePath({
     const appLocation = path.resolve(rootDir, `app/(payload)${adminRoute}/`)
     const srcAppLocation = path.resolve(rootDir, `src/app/(payload)${adminRoute}/`)
 
-    if (fs.existsSync(appLocation)) {
+    if (appLocation && (await pathOrFileExists(appLocation))) {
       importMapFilePath = path.resolve(appLocation, 'importMap.js')
-      if (!fs.existsSync(importMapFilePath)) {
-        fs.writeFileSync(importMapFilePath, '', { flag: 'wx' })
+      if (!(await pathOrFileExists(importMapFilePath))) {
+        await fs.writeFile(importMapFilePath, '', { flag: 'wx' })
       }
-    } else if (fs.existsSync(srcAppLocation)) {
+    } else if (srcAppLocation && (await pathOrFileExists(srcAppLocation))) {
       importMapFilePath = path.resolve(srcAppLocation, 'importMap.js')
-      if (!fs.existsSync(importMapFilePath)) {
-        fs.writeFileSync(importMapFilePath, '', { flag: 'wx' })
+      if (!(await pathOrFileExists(importMapFilePath))) {
+        await fs.writeFile(importMapFilePath, '', { flag: 'wx' })
       }
     } else {
       throw new Error(


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12639
Currently, if an `importmap.js` file is not found — it throws an error.

This change allows the file to be created if the directory can be found. If you specify your own `importmap` location in the config, it will attempt to create when missing and throw an error if it cannot.
