### PR TITLE
fix(plugin-import-export): incorrect config extension of jobs

### DIFF
--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -9,7 +9,7 @@ import { flattenObject } from './flattenObject.js'
 import { getFilename } from './getFilename.js'
 import { getSelect } from './getSelect.js'
 
-type Export = {
+export type Export = {
   collectionSlug: string
   /**
    * If true, enables debug logging

--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -1,11 +1,11 @@
-import type { Config, TaskHandler, User } from 'payload'
+import type { Config, TaskConfig, User } from 'payload'
 
 import type { CreateExportArgs } from './createExport.js'
 
 import { createExport } from './createExport.js'
 import { getFields } from './getFields.js'
 
-export const getCreateCollectionExportTask = (config: Config): TaskHandler<any, string> => {
+export const getCreateCollectionExportTask = (config: Config): TaskConfig<any> => {
   const inputSchema = getFields(config).concat(
     {
       name: 'user',
@@ -22,7 +22,6 @@ export const getCreateCollectionExportTask = (config: Config): TaskHandler<any, 
   )
 
   return {
-    // @ts-expect-error plugin tasks cannot have predefined type slug
     slug: 'createCollectionExport',
     handler: async ({ input, req }: CreateExportArgs) => {
       let user: undefined | User

--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -1,11 +1,16 @@
 import type { Config, TaskConfig, User } from 'payload'
 
-import type { CreateExportArgs } from './createExport.js'
+import type { CreateExportArgs, Export } from './createExport.js'
 
 import { createExport } from './createExport.js'
 import { getFields } from './getFields.js'
 
-export const getCreateCollectionExportTask = (config: Config): TaskConfig<any> => {
+export const getCreateCollectionExportTask = (
+  config: Config,
+): TaskConfig<{
+  input: Export
+  output: { success: boolean }
+}> => {
   const inputSchema = getFields(config).concat(
     {
       name: 'user',
@@ -40,7 +45,9 @@ export const getCreateCollectionExportTask = (config: Config): TaskConfig<any> =
       await createExport({ input, req, user })
 
       return {
-        success: true,
+        output: {
+          success: true,
+        },
       }
     },
     inputSchema,

--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -9,7 +9,7 @@ export const getCreateCollectionExportTask = (
   config: Config,
 ): TaskConfig<{
   input: Export
-  output: { success: boolean }
+  output: object
 }> => {
   const inputSchema = getFields(config).concat(
     {
@@ -45,17 +45,9 @@ export const getCreateCollectionExportTask = (
       await createExport({ input, req, user })
 
       return {
-        output: {
-          success: true,
-        },
+        output: {},
       }
     },
     inputSchema,
-    outputSchema: [
-      {
-        name: 'success',
-        type: 'checkbox',
-      },
-    ],
   }
 }

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -28,11 +28,13 @@ export const importExportPlugin =
     )
 
     // inject the createExport job into the config
-    config.jobs =
-      config.jobs ||
-      ({
-        tasks: [getCreateCollectionExportTask(config)],
-      } as unknown as JobsConfig) // cannot type jobs config inside of plugins
+    config.jobs = config.jobs || { tasks: [] }
+
+    if (!config.jobs.tasks) {
+      config.jobs.tasks = []
+    }
+
+    config.jobs.tasks.push(getCreateCollectionExportTask(config))
 
     let collectionsToUpdate = config.collections
 

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -28,13 +28,7 @@ export const importExportPlugin =
     )
 
     // inject the createExport job into the config
-    config.jobs = config.jobs || { tasks: [] }
-
-    if (!config.jobs.tasks) {
-      config.jobs.tasks = []
-    }
-
-    config.jobs.tasks.push(getCreateCollectionExportTask(config))
+    ;((config.jobs ??= {}).tasks ??= []).push(getCreateCollectionExportTask(config))
 
     let collectionsToUpdate = config.collections
 


### PR DESCRIPTION
### What?
In a project that has `jobs` configured and the import/export plugin will error on start:

`payload-jobs validation failed: taskSlug: createCollectionExport is not a valid enum value for path taskSlug.`

### Why?

The plugin was not properly extending the jobs configuration.

### How?

Properly extend existing config.jobs to add the `createCollectionExport` task.

Fixes #

