### PR TITLE
chore: migrate to TypeScript strict in Payload package - #4/4

### DIFF
--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -161,8 +161,10 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       countVersions,
       create,
       createGlobal,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createGlobalVersion,
       createJSONQuery,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createVersion,
       defaultIDType: payloadIDType,
       deleteMany,

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -161,10 +161,8 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       countVersions,
       create,
       createGlobal,
-      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createGlobalVersion,
       createJSONQuery,
-      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createVersion,
       defaultIDType: payloadIDType,
       deleteMany,

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -74,7 +74,7 @@
     "build": "rimraf .dist && rimraf tsconfig.tsbuildinfo && pnpm copyfiles && pnpm build:types && pnpm build:swc && pnpm build:esbuild",
     "build:esbuild": "echo skipping esbuild",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
-    "build:types": "concurrently --group \"tsc --emitDeclarationOnly --outDir dist\" \"tsc-strict\"",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "clean": "rimraf -g {dist,*.tsbuildinfo}",
     "clean:cache": "rimraf node_modules/.cache",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
@@ -124,15 +124,13 @@
     "@types/pluralize": "0.0.33",
     "@types/uuid": "10.0.0",
     "@types/ws": "^8.5.10",
-    "concurrently": "9.1.2",
     "copyfiles": "2.4.1",
     "cross-env": "7.0.3",
     "esbuild": "0.25.5",
     "graphql-http": "^1.22.0",
     "react-datepicker": "7.6.0",
     "rimraf": "6.0.1",
-    "sharp": "0.32.6",
-    "typescript-strict-plugin": "2.4.4"
+    "sharp": "0.32.6"
   },
   "peerDependencies": {
     "graphql": "^16.8.1"

--- a/packages/payload/src/auth/crypto.ts
+++ b/packages/payload/src/auth/crypto.ts
@@ -5,7 +5,9 @@ const algorithm = 'aes-256-ctr'
 
 export function encrypt(text: string): string {
   const iv = crypto.randomBytes(16)
-  const cipher = crypto.createCipheriv(algorithm, this.secret, iv)
+  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+  const secret = this.secret
+  const cipher = crypto.createCipheriv(algorithm, secret, iv)
 
   const encrypted = Buffer.concat([cipher.update(text), cipher.final()])
 
@@ -19,7 +21,9 @@ export function decrypt(hash: string): string {
   const iv = hash.slice(0, 32)
   const content = hash.slice(32)
 
-  const decipher = crypto.createDecipheriv(algorithm, this.secret, Buffer.from(iv, 'hex'))
+  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+  const secret = this.secret
+  const decipher = crypto.createDecipheriv(algorithm, secret, Buffer.from(iv, 'hex'))
 
   const decrypted = Buffer.concat([decipher.update(Buffer.from(content, 'hex')), decipher.final()])
 

--- a/packages/payload/src/auth/crypto.ts
+++ b/packages/payload/src/auth/crypto.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import crypto from 'crypto'
 
 const algorithm = 'aes-256-ctr'

--- a/packages/payload/src/auth/operations/unlock.ts
+++ b/packages/payload/src/auth/operations/unlock.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type {
@@ -94,7 +93,7 @@ export const unlockOperation = async <TSlug extends CollectionSlug>(
       where: whereConstraint,
     })
 
-    let result
+    let result: boolean | null = null
 
     if (user) {
       await resetLoginAttempts({
@@ -112,7 +111,7 @@ export const unlockOperation = async <TSlug extends CollectionSlug>(
       await commitTransaction(req)
     }
 
-    return result
+    return result!
   } catch (error: unknown) {
     await killTransaction(req)
     throw error

--- a/packages/payload/src/auth/strategies/local/authenticate.ts
+++ b/packages/payload/src/auth/strategies/local/authenticate.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import crypto from 'crypto'
+// @ts-expect-error - no types available
 import scmp from 'scmp'
 
 import type { TypeWithID } from '../../../collections/config/types.js'

--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -69,7 +69,7 @@ export const bin = async () => {
   }
 
   const userBinScript = Array.isArray(config.bin)
-    ? config.bin.find(({ key }) => key === script)
+    ? config.bin.find(({ key }: { key: string }) => key === script)
     : false
 
   if (userBinScript) {

--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { ParsedArgs } from 'minimist'
 
 import type { SanitizedConfig } from '../config/types.js'

--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -97,7 +97,8 @@ export const migrate = async ({ config, parsedArgs }: Args): Promise<void> => {
           skipEmpty,
         })
       } catch (err) {
-        throw new Error(`Error creating migration: ${err.message}`)
+        const error = err instanceof Error ? err.message : 'Unknown error'
+        throw new Error(`Error creating migration: ${error}`)
       }
       break
     case 'migrate:down':

--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { I18nClient, TFunction } from '@payloadcms/translations'
 
 import type { StaticDescription } from '../../admin/types.js'

--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import type { I18nClient } from '@payloadcms/translations'
+import type { I18nClient, TFunction } from '@payloadcms/translations'
 
 import type { StaticDescription } from '../../admin/types.js'
 import type { ImportMap } from '../../bin/generateImportMap/index.js'
@@ -139,7 +139,7 @@ export const createClientCollectionConfig = ({
                   clientCollection.admin.description = collection.admin.description
                 }
               } else if (typeof collection.admin.description === 'function') {
-                const description = collection.admin.description({ t: i18n.t })
+                const description = collection.admin.description({ t: i18n.t as TFunction })
                 if (description) {
                   clientCollection.admin.description = description
                 }
@@ -215,11 +215,11 @@ export const createClientCollectionConfig = ({
         clientCollection.labels = {
           plural:
             typeof collection.labels.plural === 'function'
-              ? collection.labels.plural({ i18n, t: i18n.t })
+              ? collection.labels.plural({ i18n, t: i18n.t as TFunction })
               : collection.labels.plural,
           singular:
             typeof collection.labels.singular === 'function'
-              ? collection.labels.singular({ i18n, t: i18n.t })
+              ? collection.labels.singular({ i18n, t: i18n.t as TFunction })
               : collection.labels.singular,
         }
         break

--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -159,7 +159,8 @@ export const createClientCollectionConfig = ({
               }
               break
             default:
-              clientCollection.admin[adminKey] = collection.admin[adminKey]
+              ;(clientCollection as any).admin[adminKey] =
+                collection.admin[adminKey as keyof SanitizedCollectionConfig['admin']]
           }
         }
         break
@@ -241,13 +242,14 @@ export const createClientCollectionConfig = ({
               return sanitizedSize
             })
           } else {
-            clientCollection.upload[uploadKey] = collection.upload[uploadKey]
+            ;(clientCollection.upload as any)[uploadKey] =
+              collection.upload[uploadKey as keyof SanitizedUploadConfig]
           }
         }
         break
 
       default:
-        clientCollection[key] = collection[key]
+        ;(clientCollection as any)[key] = collection[key as keyof SanitizedCollectionConfig]
     }
   }
 

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -47,7 +47,7 @@ const batchAndLoadDocs =
     *
     **/
 
-    const batchByFindArgs = {}
+    const batchByFindArgs: Record<string, string[]> = {}
 
     for (const key of keys) {
       const [

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { BatchLoadFn } from 'dataloader'
 
 import DataLoader from 'dataloader'

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -22,7 +22,7 @@ import { isValidID } from '../utilities/isValidID.js'
 
 const batchAndLoadDocs =
   (req: PayloadRequest): BatchLoadFn<string, TypeWithID> =>
-  async (keys: string[]): Promise<TypeWithID[]> => {
+  async (keys: readonly string[]): Promise<TypeWithID[]> => {
     const { payload } = req
 
     // Create docs array of same length as keys, using null as value

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -271,7 +271,7 @@ export const deleteOperation = async <
       } catch (error) {
         errors.push({
           id: doc.id,
-          message: error.message,
+          message: error instanceof Error ? error.message : 'Unknown error',
         })
       }
       return null

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { AccessResult } from '../../config/types.js'

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -1,3 +1,4 @@
+import type { AccessResult } from '../../config/types.js'
 // @ts-strict-ignore
 import type { PaginatedDocs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../../types/index.js'
@@ -54,7 +55,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
     // Access
     // /////////////////////////////////////
 
-    let accessResults
+    let accessResults!: AccessResult
 
     if (!overrideAccess) {
       accessResults = await executeAccess({ req }, collectionConfig.access.readVersions)

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -1,5 +1,4 @@
 import type { AccessResult } from '../../config/types.js'
-// @ts-strict-ignore
 import type { PaginatedDocs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import { status as httpStatus } from 'http-status'

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -263,6 +263,7 @@ export const updateOperation = async <
       args,
       collection: collectionConfig,
       operation: 'update',
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       result,
     })
 
@@ -270,6 +271,7 @@ export const updateOperation = async <
       await commitTransaction(req)
     }
 
+    // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
     return result
   } catch (error: unknown) {
     await killTransaction(args.req)

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -236,7 +236,7 @@ export const updateOperation = async <
       } catch (error) {
         errors.push({
           id,
-          message: error.message,
+          message: error instanceof Error ? error.message : 'Unknown error',
         })
       }
       return null

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { I18nClient } from '@payloadcms/translations'
 import type { DeepPartial } from 'ts-essentials'
 

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -203,7 +203,7 @@ export const createClientConfig = ({
         }
         break
       default:
-        clientConfig[key] = config[key]
+        ;(clientConfig as any)[key] = config[key as keyof SanitizedConfig]
     }
   }
   return clientConfig as ClientConfig

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { AcceptedLanguages } from '@payloadcms/translations'
 
 import { en } from '@payloadcms/translations/languages/en'

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -315,7 +315,7 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
         if (hooks && config?.jobs?.runHooks !== true) {
           for (const hook of Object.keys(hooks)) {
             const defaultAmount = hook === 'afterRead' || hook === 'beforeChange' ? 1 : 0
-            if (hooks[hook]?.length > defaultAmount) {
+            if (hooks[hook as keyof typeof hooks]!.length > defaultAmount) {
               // eslint-disable-next-line no-console
               console.warn(
                 `The jobsCollectionOverrides function is returning a collection with an additional ${hook} hook defined. These hooks will not run unless the jobs.runHooks option is set to true. Setting this option to true will negatively impact performance.`,

--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -82,7 +82,7 @@ export async function validateQueryPaths({
         }
       } else if (!Array.isArray(constraint)) {
         for (const operator in constraint) {
-          const val = constraint[operator]
+          const val = constraint[operator as keyof typeof constraint]
           if (validOperatorSet.has(operator as Operator)) {
             promises.push(
               validateSearchParam({

--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
 import type { FlattenedField } from '../../fields/config/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -109,8 +109,8 @@ export async function validateSearchParam({
         if (field.virtual === true) {
           errors.push({ path })
         } else {
-          constraint[`${field.virtual}`] = constraint[path]
-          delete constraint[path]
+          constraint[`${field.virtual}` as keyof WhereField] = constraint[path as keyof WhereField]
+          delete constraint[path as keyof WhereField]
         }
       }
 
@@ -155,7 +155,7 @@ export async function validateSearchParam({
         const entitySlug = collectionSlug || globalConfig!.slug
         const segments = fieldPath.split('.')
 
-        let fieldAccess
+        let fieldAccess: any
 
         if (versionFields) {
           fieldAccess = policies[entityType]![entitySlug]!

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
 import type { FlattenedField } from '../../fields/config/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -33,7 +33,9 @@ const sanitizeJoinFieldQuery = async ({
 }) => {
   const { joinPath } = join
 
-  if (joinsQuery[joinPath] === false) {
+  // TODO: fix any's in joinsQuery[joinPath]
+
+  if ((joinsQuery as any)[joinPath] === false) {
     return
   }
 
@@ -44,15 +46,15 @@ const sanitizeJoinFieldQuery = async ({
     : true
 
   if (accessResult === false) {
-    joinsQuery[joinPath] = false
+    ;(joinsQuery as any)[joinPath] = false
     return
   }
 
-  if (!joinsQuery[joinPath]) {
-    joinsQuery[joinPath] = {}
+  if (!(joinsQuery as any)[joinPath]) {
+    ;(joinsQuery as any)[joinPath] = {}
   }
 
-  const joinQuery = joinsQuery[joinPath]
+  const joinQuery = (joinsQuery as any)[joinPath]
 
   if (!joinQuery.where) {
     joinQuery.where = {}

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedCollectionConfig, SanitizedJoin } from '../collections/config/types.js'
 import type { JoinQuery, PayloadRequest } from '../types/index.js'
 

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -213,7 +213,8 @@ export const createClientField = ({
               break
 
             default:
-              clientField.admin[adminKey] = incomingField.admin[adminKey]
+              ;(clientField.admin as any)[adminKey] =
+                incomingField.admin[adminKey as keyof typeof incomingField.admin]
           }
         }
 
@@ -238,7 +239,7 @@ export const createClientField = ({
         break
 
       default:
-        clientField[key] = incomingField[key]
+        ;(clientField as any)[key] = incomingField[key as keyof Field]
     }
   }
 
@@ -387,7 +388,7 @@ export const createClientField = ({
               continue
             }
 
-            const tabProp = tab[key]
+            const tabProp = tab[key as keyof typeof tab]
 
             if (key === 'fields') {
               clientTab.fields = createClientFields({
@@ -401,6 +402,7 @@ export const createClientField = ({
               (key === 'label' || key === 'description') &&
               typeof tabProp === 'function'
             ) {
+              // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
               clientTab[key] = tabProp({ t: i18n.t })
             } else if (key === 'admin') {
               clientTab.admin = {} as AdminClient
@@ -426,11 +428,12 @@ export const createClientField = ({
                     break
 
                   default:
-                    clientField.admin![adminKey] = tab.admin[adminKey]
+                    ;(clientTab.admin as any)[adminKey] =
+                      tab.admin[adminKey as keyof typeof tab.admin]
                 }
               }
             } else {
-              clientTab[key] = tabProp
+              ;(clientTab as any)[key] = tabProp
             }
           }
           field.tabs[i] = clientTab

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 /* eslint-disable perfectionist/sort-switch-case */
 // Keep perfectionist/sort-switch-case disabled - it incorrectly messes up the ordering of the switch cases, causing it to break
-import type { I18nClient } from '@payloadcms/translations'
+import type { I18nClient, TFunction } from '@payloadcms/translations'
 
 import type {
   AdminClient,
@@ -145,12 +145,12 @@ export const createClientBlocks = ({
 
       if (block.labels.singular) {
         if (typeof block.labels.singular === 'function') {
-          clientBlock.labels.singular = block.labels.singular({ i18n, t: i18n.t })
+          clientBlock.labels.singular = block.labels.singular({ i18n, t: i18n.t as TFunction })
         } else {
           clientBlock.labels.singular = block.labels.singular
         }
         if (typeof block.labels.plural === 'function') {
-          clientBlock.labels.plural = block.labels.plural({ i18n, t: i18n.t })
+          clientBlock.labels.plural = block.labels.plural({ i18n, t: i18n.t as TFunction })
         } else {
           clientBlock.labels.plural = block.labels.plural
         }
@@ -251,12 +251,12 @@ export const createClientField = ({
 
         if (incomingField.labels.singular) {
           if (typeof incomingField.labels.singular === 'function') {
-            field.labels.singular = incomingField.labels.singular({ i18n, t: i18n.t })
+            field.labels.singular = incomingField.labels.singular({ i18n, t: i18n.t as TFunction })
           } else {
             field.labels.singular = incomingField.labels.singular
           }
           if (typeof incomingField.labels.plural === 'function') {
-            field.labels.plural = incomingField.labels.plural({ i18n, t: i18n.t })
+            field.labels.plural = incomingField.labels.plural({ i18n, t: i18n.t as TFunction })
           } else {
             field.labels.plural = incomingField.labels.plural
           }
@@ -292,12 +292,12 @@ export const createClientField = ({
 
         if (incomingField.labels.singular) {
           if (typeof incomingField.labels.singular === 'function') {
-            field.labels.singular = incomingField.labels.singular({ i18n, t: i18n.t })
+            field.labels.singular = incomingField.labels.singular({ i18n, t: i18n.t as TFunction })
           } else {
             field.labels.singular = incomingField.labels.singular
           }
           if (typeof incomingField.labels.plural === 'function') {
-            field.labels.plural = incomingField.labels.plural({ i18n, t: i18n.t })
+            field.labels.plural = incomingField.labels.plural({ i18n, t: i18n.t as TFunction })
           } else {
             field.labels.plural = incomingField.labels.plural
           }
@@ -350,7 +350,7 @@ export const createClientField = ({
             }
 
             field.options[i] = {
-              label: option.label({ i18n, t: i18n.t }),
+              label: option.label({ i18n, t: i18n.t as TFunction }),
               value: option.value,
             }
           }
@@ -414,7 +414,10 @@ export const createClientField = ({
                   case 'description':
                     if ('description' in tab.admin) {
                       if (typeof tab.admin?.description === 'function') {
-                        clientTab.admin.description = tab.admin.description({ i18n, t: i18n.t })
+                        clientTab.admin.description = tab.admin.description({
+                          i18n,
+                          t: i18n.t as TFunction,
+                        })
                       } else {
                         clientTab.admin.description = tab.admin.description
                       }

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { deepMergeSimple } from '@payloadcms/translations/utilities'
 import { v4 as uuid } from 'uuid'
 

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -233,9 +233,10 @@ export const sanitizeFields = async ({
       }
 
       if (typeof field.validate === 'undefined') {
-        const defaultValidate = validations[field.type]
+        const defaultValidate = validations[field.type as keyof typeof validations]
         if (defaultValidate) {
-          field.validate = (val, options) => defaultValidate(val, { ...field, ...options })
+          field.validate = (val: any, options: any) =>
+            defaultValidate(val, { ...field, ...options })
         } else {
           field.validate = (): true => true
         }

--- a/packages/payload/src/fields/hooks/afterRead/index.ts
+++ b/packages/payload/src/fields/hooks/afterRead/index.ts
@@ -56,8 +56,8 @@ export async function afterRead<T extends JsonObject>(args: Args<T>): Promise<T>
     showHiddenFields,
   } = args
 
-  const fieldPromises = []
-  const populationPromises = []
+  const fieldPromises: Promise<void>[] = []
+  const populationPromises: Promise<void>[] = []
 
   let depth =
     incomingDepth || incomingDepth === 0

--- a/packages/payload/src/fields/hooks/afterRead/index.ts
+++ b/packages/payload/src/fields/hooks/afterRead/index.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
 import type { RequestContext } from '../../../index.js'

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { PayloadRequest, PopulateType } from '../../../types/index.js'
 import type { JoinField, RelationshipField, UploadField } from '../../config/types.js'
 

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -47,7 +47,8 @@ const populate = async ({
     relation = Array.isArray(field.relationTo) ? (data.relationTo as string) : field.relationTo
   }
 
-  const relatedCollection = req.payload.collections[relation]
+  const relatedCollection =
+    req.payload.collections[relation as keyof typeof req.payload.collections]
 
   if (relatedCollection) {
     let id: unknown
@@ -173,7 +174,7 @@ export const relationshipPopulationPromise = async ({
     ) {
       Object.keys(siblingDoc[field.name]).forEach((localeKey) => {
         if (Array.isArray(siblingDoc[field.name][localeKey])) {
-          siblingDoc[field.name][localeKey].forEach((relatedDoc, index) => {
+          siblingDoc[field.name][localeKey].forEach((_relatedDoc: any, index: number) => {
             const rowPromise = async () => {
               await populate({
                 currentDepth,
@@ -203,7 +204,7 @@ export const relationshipPopulationPromise = async ({
       ;(Array.isArray(siblingDoc[field.name])
         ? siblingDoc[field.name]
         : siblingDoc[field.name].docs
-      ).forEach((relatedDoc, index) => {
+      ).forEach((relatedDoc: any, index: number) => {
         const rowPromise = async () => {
           if (relatedDoc) {
             await populate({

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -168,7 +168,7 @@ export const promise = async ({
         try {
           JSON.parse(siblingData[field.name] as string)
         } catch (e) {
-          jsonError = e
+          jsonError = e as object
         }
       }
 

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { ValidationFieldError } from '../../../errors/index.js'

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -214,7 +214,7 @@ export const promise = async ({
     // Push merge locale action if applicable
     if (localization && fieldShouldBeLocalized({ field, parentIsLocalized })) {
       mergeLocaleActions.push(() => {
-        const localeData = {}
+        const localeData: Record<string, unknown> = {}
 
         for (const locale of localization.localeCodes) {
           const fieldValue =

--- a/packages/payload/src/fields/setDefaultBeforeDuplicate.ts
+++ b/packages/payload/src/fields/setDefaultBeforeDuplicate.ts
@@ -2,7 +2,7 @@
 // default beforeDuplicate hook for required and unique fields
 import { type FieldAffectingData, type FieldHook, fieldShouldBeLocalized } from './config/types.js'
 
-const isStringValue = (value) => typeof value === 'string' && value.trim() !== ''
+const isStringValue = (value: unknown) => typeof value === 'string' && value.trim() !== ''
 const unique: FieldHook = ({ value }) => (isStringValue(value) ? `${value} - Copy` : undefined)
 const localizedUnique: FieldHook = ({ req, value }) =>
   isStringValue(value) ? `${value} - ${req?.t('general:copy') ?? 'Copy'}` : undefined

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -5,6 +5,7 @@ import ObjectIdImport from 'bson-objectid'
 const ObjectId = (ObjectIdImport.default ||
   ObjectIdImport) as unknown as typeof ObjectIdImport.default
 
+import type { TFunction } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 
 import type { RichTextAdapter } from '../admin/types.js'
@@ -444,7 +445,7 @@ const validateArrayLength = (
     maxRows?: number
     minRows?: number
     required?: boolean
-    t: (key: string, options?: { [key: string]: number | string }) => string
+    t: TFunction
   },
 ) => {
   const { maxRows, minRows, required, t } = options

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -32,6 +32,7 @@ import type {
   TextField,
   UploadField,
   Validate,
+  ValueWithRelation,
 } from './config/types.js'
 
 import { isNumber } from '../utilities/isNumber.js'
@@ -317,7 +318,7 @@ export const json: JSONFieldValidation = (
   value,
   { jsonError, jsonSchema, req: { t }, required },
 ) => {
-  const isNotEmpty = (value) => {
+  const isNotEmpty = (value: null | string | undefined) => {
     if (value === undefined || value === null) {
       return false
     }
@@ -401,7 +402,7 @@ export const date: DateFieldValidation = (
   // We need to also check for the timezone data based on this field's config
   // We cannot do this inside the timezone field validation as it's visually hidden
   const hasRequiredTimezone = timezone && required
-  const selectedTimezone: string = siblingData?.[`${name}_tz`]
+  const selectedTimezone: string = siblingData?.[`${name}_tz` as keyof typeof siblingData]
   // Always resolve to true if the field is not required, as timezone may be optional too then
   const validTimezone = hasRequiredTimezone ? Boolean(selectedTimezone) : true
 
@@ -440,7 +441,7 @@ export const richText: RichTextFieldValidation = async (value, options) => {
 }
 
 const validateArrayLength = (
-  value,
+  value: unknown,
   options: {
     maxRows?: number
     minRows?: number
@@ -450,7 +451,7 @@ const validateArrayLength = (
 ) => {
   const { maxRows, minRows, required, t } = options
 
-  const arrayLength = Array.isArray(value) ? value.length : value || 0
+  const arrayLength = Array.isArray(value) ? value.length : (value as number) || 0
 
   if (!required && arrayLength === 0) {
     return true
@@ -818,7 +819,7 @@ export const relationship: RelationshipFieldValidation = async (value, options) 
 
     const invalidRelationships = values.filter((val) => {
       let collectionSlug: string
-      let requestedID
+      let requestedID: number | string | undefined | ValueWithRelation
 
       if (typeof relationTo === 'string') {
         collectionSlug = relationTo
@@ -841,7 +842,7 @@ export const relationship: RelationshipFieldValidation = async (value, options) 
       const idType =
         payload.collections[collectionSlug!]?.customIDType || payload?.db?.defaultIDType || 'text'
 
-      return !isValidID(requestedID, idType)
+      return !isValidID(requestedID as number | string, idType)
     })
 
     if (invalidRelationships.length > 0) {

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -374,7 +374,7 @@ export const json: JSONFieldValidation = (
         return ajv.errorsText()
       }
     } catch (error) {
-      return error.message
+      return error instanceof Error ? error.message : 'Unknown error'
     }
   }
   return true

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import Ajv from 'ajv'
 import ObjectIdImport from 'bson-objectid'
 

--- a/packages/payload/src/globals/config/client.ts
+++ b/packages/payload/src/globals/config/client.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { I18nClient, TFunction } from '@payloadcms/translations'
 
 import type { ImportMap } from '../../bin/generateImportMap/index.js'

--- a/packages/payload/src/globals/config/client.ts
+++ b/packages/payload/src/globals/config/client.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import type { I18nClient } from '@payloadcms/translations'
+import type { I18nClient, TFunction } from '@payloadcms/translations'
 
 import type { ImportMap } from '../../bin/generateImportMap/index.js'
 import type {
@@ -103,7 +103,9 @@ export const createClientGlobalConfig = ({
         break
       case 'label':
         clientGlobal.label =
-          typeof global.label === 'function' ? global.label({ i18n, t: i18n.t }) : global.label
+          typeof global.label === 'function'
+            ? global.label({ i18n, t: i18n.t as TFunction })
+            : global.label
         break
       default: {
         clientGlobal[key] = global[key]

--- a/packages/payload/src/globals/config/client.ts
+++ b/packages/payload/src/globals/config/client.ts
@@ -89,7 +89,8 @@ export const createClientGlobalConfig = ({
               clientGlobal.admin.preview = true
               break
             default:
-              clientGlobal.admin[adminKey] = global.admin[adminKey]
+              ;(clientGlobal.admin as any)[adminKey] =
+                global.admin[adminKey as keyof typeof global.admin]
           }
         }
         break
@@ -108,7 +109,7 @@ export const createClientGlobalConfig = ({
             : global.label
         break
       default: {
-        clientGlobal[key] = global[key]
+        ;(clientGlobal as any)[key] = global[key as keyof typeof global]
         break
       }
     }

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -267,13 +267,13 @@ export class BasePayload {
     return auth(this, options)
   }
 
-  authStrategies: AuthStrategy[]
+  authStrategies!: AuthStrategy[]
 
   blocks: Record<BlockSlug, FlattenedBlock> = {}
 
   collections: Record<CollectionSlug, Collection> = {}
 
-  config: SanitizedConfig
+  config!: SanitizedConfig
   /**
    * @description Performs count operation
    * @param options
@@ -323,7 +323,7 @@ export class BasePayload {
   }
 
   crons: Cron[] = []
-  db: DatabaseAdapter
+  db!: DatabaseAdapter
 
   decrypt = decrypt
 
@@ -346,14 +346,14 @@ export class BasePayload {
     return duplicate<TSlug, TSelect>(this, options)
   }
 
-  email: InitializedEmailAdapter
+  email!: InitializedEmailAdapter
 
   // TODO: re-implement or remove?
   // errorHandler: ErrorHandler
 
   encrypt = encrypt
 
-  extensions: (args: {
+  extensions!: (args: {
     args: OperationArgs<any>
     req: graphQLRequest<unknown, unknown>
     result: ExecutionResult
@@ -453,13 +453,13 @@ export class BasePayload {
 
   getAPIURL = (): string => `${this.config.serverURL}${this.config.routes.api}`
 
-  globals: Globals
+  globals!: Globals
 
-  importMap: ImportMap
+  importMap!: ImportMap
 
   jobs = getJobsLocalAPI(this)
 
-  logger: Logger
+  logger!: Logger
 
   login = async <TSlug extends CollectionSlug>(
     options: LoginOptions<TSlug>,
@@ -499,13 +499,13 @@ export class BasePayload {
     return restoreVersion<TSlug>(this, options)
   }
 
-  schema: GraphQLSchema
+  schema!: GraphQLSchema
 
-  secret: string
+  secret!: string
 
-  sendEmail: InitializedEmailAdapter['sendEmail']
+  sendEmail!: InitializedEmailAdapter['sendEmail']
 
-  types: {
+  types!: {
     arrayTypes: any
     blockInputTypes: any
     blockTypes: any
@@ -529,7 +529,7 @@ export class BasePayload {
     return update<TSlug, TSelect>(this, options)
   }
 
-  validationRules: (args: OperationArgs<any>) => ValidationRule[]
+  validationRules!: (args: OperationArgs<any>) => ValidationRule[]
 
   verifyEmail = async <TSlug extends CollectionSlug>(
     options: VerifyEmailOptions<TSlug>,

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -653,10 +653,13 @@ export class BasePayload {
       }
     }
 
-    this.blocks = this.config.blocks!.reduce((blocks, block) => {
-      blocks[block.slug] = block
-      return blocks
-    }, {})
+    this.blocks = this.config.blocks!.reduce(
+      (blocks, block) => {
+        blocks[block.slug] = block
+        return blocks
+      },
+      {} as Record<string, FlattenedBlock>,
+    )
 
     // Generate types on startup
     if (process.env.NODE_ENV !== 'production' && this.config.typescript.autoGenerate !== false) {
@@ -837,10 +840,10 @@ let cached: {
   promise: null | Promise<Payload>
   reload: boolean | Promise<void>
   ws: null | WebSocket
-} = global._payload
+} = (global as any)._payload
 
 if (!cached) {
-  cached = global._payload = { payload: null, promise: null, reload: false, ws: null }
+  cached = (global as any)._payload = { payload: null, promise: null, reload: false, ws: null }
 }
 
 export const reload = async (
@@ -852,18 +855,24 @@ export const reload = async (
 
   payload.config = config
 
-  payload.collections = config.collections.reduce((collections, collection) => {
-    collections[collection.slug] = {
-      config: collection,
-      customIDType: payload.collections[collection.slug]?.customIDType,
-    }
-    return collections
-  }, {})
+  payload.collections = config.collections.reduce(
+    (collections, collection) => {
+      collections[collection.slug] = {
+        config: collection,
+        customIDType: payload.collections[collection.slug]?.customIDType,
+      }
+      return collections
+    },
+    {} as Record<string, any>,
+  )
 
-  payload.blocks = config.blocks!.reduce((blocks, block) => {
-    blocks[block.slug] = block
-    return blocks
-  }, {})
+  payload.blocks = config.blocks!.reduce(
+    (blocks, block) => {
+      blocks[block.slug] = block
+      return blocks
+    },
+    {} as Record<string, FlattenedBlock>,
+  )
 
   payload.globals = {
     config: config.globals,
@@ -894,12 +903,12 @@ export const reload = async (
     await payload.db.connect({ hotReload: true })
   }
 
-  global._payload_clientConfigs = {} as Record<keyof SupportedLanguages, ClientConfig>
-  global._payload_schemaMap = null
-  global._payload_clientSchemaMap = null
-  global._payload_doNotCacheClientConfig = true // This will help refreshing the client config cache more reliably. If you remove this, please test HMR + client config refreshing (do new fields appear in the document?)
-  global._payload_doNotCacheSchemaMap = true
-  global._payload_doNotCacheClientSchemaMap = true
+  ;(global as any)._payload_clientConfigs = {} as Record<keyof SupportedLanguages, ClientConfig>
+  ;(global as any)._payload_schemaMap = null
+  ;(global as any)._payload_clientSchemaMap = null
+  ;(global as any)._payload_doNotCacheClientConfig = true // This will help refreshing the client config cache more reliably. If you remove this, please test HMR + client config refreshing (do new fields appear in the document?)
+  ;(global as any)._payload_doNotCacheSchemaMap = true
+  ;(global as any)._payload_doNotCacheClientSchemaMap = true
 }
 
 export const getPayload = async (

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -977,7 +977,7 @@ export const getPayload = async (
   } catch (e) {
     cached.promise = null
     // add identifier to error object, so that our error logger in routeError.ts does not attempt to re-initialize getPayload
-    e.payloadInitError = true
+    ;(e as { payloadInitError?: boolean }).payloadInitError = true
     throw e
   }
 

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-strict-ignore
 import type { ExecutionResult, GraphQLSchema, ValidationRule } from 'graphql'
 import type { Request as graphQLRequest, OperationArgs } from 'graphql-http'
 import type { Logger } from 'pino'

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { PayloadRequest, Sort, Where } from '../../../types/index.js'
 import type { WorkflowJSON } from '../../config/types/workflowJSONTypes.js'
 import type {

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -207,7 +207,7 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
     ? []
     : undefined
 
-  const runSingleJob = async (job) => {
+  const runSingleJob = async (job: BaseJob) => {
     if (!job.workflowSlug && !job.taskSlug) {
       throw new Error('Job must have either a workflowSlug or a taskSlug')
     }
@@ -330,13 +330,16 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
     }
   }
 
-  const resultsObject: RunJobsResult['jobStatus'] = resultsArray.reduce((acc, cur) => {
-    if (cur !== null) {
-      // Check if there's a valid result to include
-      acc[cur.id] = cur.result
-    }
-    return acc
-  }, {})
+  const resultsObject: RunJobsResult['jobStatus'] = resultsArray.reduce(
+    (acc, cur) => {
+      if (cur !== null) {
+        // Check if there's a valid result to include
+        acc[cur.id] = cur.result
+      }
+      return acc
+    },
+    {} as Record<string, RunJobResult>,
+  )
 
   let remainingJobsFromQueried = 0
   for (const jobID in resultsObject) {

--- a/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type { WorkflowJSON, WorkflowStep } from '../../../config/types/workflowJSONTypes.js'
 import type {

--- a/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
@@ -79,7 +79,8 @@ export const runJSONJob = async ({
         }
       }),
     )
-  } catch (err) {
+  } catch (_err) {
+    const err = _err as Error
     const errorResult = handleWorkflowError({
       error: err,
       job,

--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import ObjectIdImport from 'bson-objectid'
 
 import type { PayloadRequest } from '../../../../types/index.js'

--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -313,7 +313,7 @@ export const getRunTaskFunction = <TIsInline extends boolean>(
         })
       } catch (err) {
         await handleTaskFailed({
-          error: err,
+          error: err as Error | undefined,
           executedAt,
           input: input!,
           job,

--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -188,7 +188,7 @@ export const getRunTaskFunction = <TIsInline extends boolean>(
 
       let inlineRunner: TaskHandler<TaskType> = null!
       if (isInline) {
-        inlineRunner = task
+        inlineRunner = task as TaskHandler<TaskType>
       }
 
       let taskConfig!: TaskConfig<string>
@@ -386,7 +386,7 @@ export const getRunTaskFunction = <TIsInline extends boolean>(
   } else {
     const tasks: RunTaskFunctions = {}
     for (const task of req?.payload?.config?.jobs?.tasks ?? []) {
-      tasks[task.slug] = runTask(task.slug)
+      tasks[task.slug] = runTask(task.slug) as RunTaskFunction<string>
     }
     return tasks as TIsInline extends true ? RunInlineTaskFunction : RunTaskFunctions
   }

--- a/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type { BaseJob } from '../../../config/types/workflowTypes.js'
 

--- a/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
@@ -30,7 +30,7 @@ export function getUpdateJobFunction(job: BaseJob, req: PayloadRequest): UpdateJ
           }
         }
       } else {
-        job[key] = updatedJob[key]
+        ;(job as any)[key] = updatedJob[key as keyof BaseJob]
       }
     }
 

--- a/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { pathToFileURL } from 'url'
 
 export async function importHandlerPath<T>(path: string): Promise<T> {

--- a/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
@@ -15,7 +15,7 @@ export async function importHandlerPath<T>(path: string): Promise<T> {
         : await eval(`import('${pathToFileURL(runnerPath!).href}')`)
   } catch (e) {
     throw new Error(
-      `Error importing job queue handler module for path ${path}. This is an advanced feature that may require a sophisticated build pipeline, especially when using it in production or within Next.js, e.g. by calling opening the /api/payload-jobs/run endpoint. You will have to transpile the handler files separately and ensure they are available in the same location when the job is run. If you're using an endpoint to execute your jobs, it's recommended to define your handlers as functions directly in your Payload Config, or use import paths handlers outside of Next.js. Import Error: \n${e.message}`,
+      `Error importing job queue handler module for path ${path}. This is an advanced feature that may require a sophisticated build pipeline, especially when using it in production or within Next.js, e.g. by calling opening the /api/payload-jobs/run endpoint. You will have to transpile the handler files separately and ensure they are available in the same location when the job is run. If you're using an endpoint to execute your jobs, it's recommended to define your handlers as functions directly in your Payload Config, or use import paths handlers outside of Next.js. Import Error: \n${e instanceof Error ? e.message : 'Unknown error'}`,
     )
   }
 

--- a/packages/payload/src/queues/operations/runJobs/runJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/index.ts
@@ -1,3 +1,4 @@
+import type { APIError } from '../../../../errors/APIError.js'
 // @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type {
@@ -48,7 +49,8 @@ export const runJob = async ({
       req,
       tasks: getRunTaskFunction(state, job, workflowConfig, req, false, updateJob),
     })
-  } catch (err) {
+  } catch (_err) {
+    const err = _err as APIError
     const { hasFinalError } = handleWorkflowError({
       error: err,
       job,

--- a/packages/payload/src/queues/operations/runJobs/runJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/index.ts
@@ -1,5 +1,4 @@
 import type { APIError } from '../../../../errors/APIError.js'
-// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type {
   BaseJob,

--- a/packages/payload/src/uploads/cropImage.ts
+++ b/packages/payload/src/uploads/cropImage.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SharpOptions } from 'sharp'
 
 import type { SanitizedConfig } from '../config/types.js'

--- a/packages/payload/src/uploads/cropImage.ts
+++ b/packages/payload/src/uploads/cropImage.ts
@@ -8,8 +8,8 @@ import type { UploadEdits } from './types.js'
 
 import { optionallyAppendMetadata } from './optionallyAppendMetadata.js'
 
-export const percentToPixel = (value, dimension) => {
-  return Math.floor((parseFloat(value) / 100) * dimension)
+const percentToPixel = (value: number, dimension: number) => {
+  return Math.floor((value / 100) * dimension)
 }
 
 type CropImageArgs = {

--- a/packages/payload/src/uploads/endpoints/getFile.ts
+++ b/packages/payload/src/uploads/endpoints/getFile.ts
@@ -61,7 +61,7 @@ export const getFileHandler: PayloadHandler = async (req) => {
   try {
     stats = await fsPromises.stat(filePath)
   } catch (err) {
-    if (err.code === 'ENOENT') {
+    if ((err as { code?: string }).code === 'ENOENT') {
       req.payload.logger.error(
         `File ${filename} for collection ${collection.config.slug} is missing on the disk. Expected path: ${filePath}`,
       )

--- a/packages/payload/src/uploads/endpoints/getFile.ts
+++ b/packages/payload/src/uploads/endpoints/getFile.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { Stats } from 'fs'
 
 import { fileTypeFromFile } from 'file-type'

--- a/packages/payload/src/uploads/endpoints/getFileFromURL.ts
+++ b/packages/payload/src/uploads/endpoints/getFileFromURL.ts
@@ -76,7 +76,10 @@ export const getFileFromURLHandler: PayloadHandler = async (req) => {
         'Content-Type': response.headers.get('content-type') || 'application/octet-stream',
       },
     })
-  } catch (error) {
-    throw new APIError(`Error fetching file: ${error.message}`, 500)
+  } catch (err) {
+    throw new APIError(
+      `Error fetching file: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      500,
+    )
   }
 }

--- a/packages/payload/src/uploads/endpoints/getFileFromURL.ts
+++ b/packages/payload/src/uploads/endpoints/getFileFromURL.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { PayloadHandler } from '../../config/types.js'
 
 import executeAccess from '../../auth/executeAccess.js'

--- a/packages/payload/src/uploads/fetchAPI-multipart/fileFactory.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/fileFactory.ts
@@ -31,6 +31,7 @@ const moveFromTemp: MoveFile = (filePath, options, fileUploadOptions) => (resolv
  */
 const moveFromBuffer: MoveFile = (filePath, options, fileUploadOptions) => (resolve, reject) => {
   debugLog(fileUploadOptions, `Moving uploaded buffer to ${filePath}`)
+  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
   saveBufferToFile(options.buffer, filePath, promiseCallback(resolve, reject))
 }
 

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -16,6 +16,12 @@ import { buildFields, debugLog, isFunc, parseFileName } from './utilities.js'
 
 const waitFlushProperty = Symbol('wait flush property symbol')
 
+declare global {
+  interface Request {
+    [waitFlushProperty]?: Promise<any>[]
+  }
+}
+
 type ProcessMultipart = (args: {
   options: FetchAPIFileUploadOptions
   request: Request
@@ -39,7 +45,7 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
     files: undefined!,
   }
 
-  const headersObject = {}
+  const headersObject: Record<string, string> = {}
   request.headers.forEach((value, name) => {
     headersObject[name] = value
   })

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { Readable } from 'stream'
 
 import Busboy from 'busboy'

--- a/packages/payload/src/uploads/fetchAPI-multipart/processNested.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processNested.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { isSafeFromPollution } from './utilities.js'
 
-export const processNested = function (data) {
+export const processNested = function (data: Record<string, any>) {
   if (!data || data.length < 1) {
     return Object.create(null)
   }

--- a/packages/payload/src/uploads/fetchAPI-multipart/processNested.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processNested.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { isSafeFromPollution } from './utilities.js'
 
 export const processNested = function (data: Record<string, any>) {

--- a/packages/payload/src/uploads/fetchAPI-multipart/utilities.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/utilities.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import fs from 'fs'
 import path from 'path'
 import { Readable } from 'stream'

--- a/packages/payload/src/uploads/fetchAPI-multipart/utilities.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/utilities.ts
@@ -132,8 +132,7 @@ export const checkAndMakeDir: CheckAndMakeDir = (fileUploadOptions, filePath) =>
  * Delete a file.
  */
 type DeleteFile = (filePath: string, callback: (args: any) => void) => void
-export const deleteFile: DeleteFile = (filePath, callback: (args) => void) =>
-  fs.unlink(filePath, callback)
+export const deleteFile: DeleteFile = (filePath, callback) => fs.unlink(filePath, callback)
 
 /**
  * Copy file via streams
@@ -188,7 +187,11 @@ export const moveFile: MoveFile = (src, dst, callback) =>
  * @param {Buffer} buffer - buffer to save to a file.
  * @param {string} filePath - path to a file.
  */
-export const saveBufferToFile = (buffer, filePath, callback) => {
+export const saveBufferToFile = (
+  buffer: Buffer,
+  filePath: string,
+  callback: (err?: Error) => void,
+) => {
   if (!Buffer.isBuffer(buffer)) {
     return callback(new Error('buffer variable should be type of Buffer!'))
   }
@@ -220,7 +223,7 @@ export const saveBufferToFile = (buffer, filePath, callback) => {
  * @param fileName {String} - file name to decode.
  * @returns {String}
  */
-const uriDecodeFileName = (opts, fileName) => {
+const uriDecodeFileName = (opts: FetchAPIFileUploadOptions, fileName: string) => {
   if (!opts || !opts.uriDecodeFileNames) {
     return fileName
   }

--- a/packages/payload/src/uploads/fetchAPI-stream-file/index.ts
+++ b/packages/payload/src/uploads/fetchAPI-stream-file/index.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import fs from 'fs'
 
-export function iteratorToStream(iterator) {
+export function iteratorToStream(iterator: AsyncIterator<Uint8Array>) {
   return new ReadableStream({
     async pull(controller) {
       const { done, value } = await iterator.next()

--- a/packages/payload/src/uploads/fetchAPI-stream-file/index.ts
+++ b/packages/payload/src/uploads/fetchAPI-stream-file/index.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import fs from 'fs'
 
 export function iteratorToStream(iterator: AsyncIterator<Uint8Array>) {

--- a/packages/payload/src/uploads/tempFile.ts
+++ b/packages/payload/src/uploads/tempFile.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import fs from 'fs/promises'
 import os from 'node:os'
 import path from 'node:path'

--- a/packages/payload/src/uploads/tempFile.ts
+++ b/packages/payload/src/uploads/tempFile.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { v4 as uuid } from 'uuid'
 
-async function runTask(temporaryPath: string, callback) {
+async function runTask(temporaryPath: string, callback: (temporaryPath: string) => Promise<any>) {
   try {
     return await callback(temporaryPath)
   } finally {
@@ -17,7 +17,10 @@ type Options = {
   name?: string
 }
 
-export const temporaryFileTask = async (callback, options: Options = {}) => {
+export const temporaryFileTask = async (
+  callback: (temporaryPath: string) => Promise<any>,
+  options: Options = {},
+) => {
   const filePath = await temporaryFile(options)
   return runTask(filePath, callback)
 }

--- a/packages/payload/src/utilities/addLocalesToRequest.ts
+++ b/packages/payload/src/utilities/addLocalesToRequest.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedConfig } from '../config/types.js'
 import type { PayloadRequest } from '../types/index.js'
 

--- a/packages/payload/src/utilities/addLocalesToRequest.ts
+++ b/packages/payload/src/utilities/addLocalesToRequest.ts
@@ -16,8 +16,8 @@ export function addLocalesToRequestFromData(req: PayloadRequest): void {
   if (data) {
     const localeOnReq = req.locale
     const fallbackLocaleOnReq = req.fallbackLocale
-    let localeFromData
-    let fallbackLocaleFromData
+    let localeFromData!: string
+    let fallbackLocaleFromData!: string
 
     if (!localeOnReq && data?.locale && typeof data.locale === 'string') {
       localeFromData = data.locale

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { JSONSchema4, JSONSchema4TypeName } from 'json-schema'
 
 import pluralize from 'pluralize'

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -18,7 +18,7 @@ import { generateJobsJSONSchemas } from '../queues/config/generateJobsJSONSchema
 import { toWords } from './formatLabels.js'
 import { getCollectionIDFieldTypes } from './getCollectionIDFieldTypes.js'
 
-const fieldIsRequired = (field: FlattenedField) => {
+const fieldIsRequired = (field: FlattenedField): boolean => {
   const isConditional = Boolean(field?.admin && field?.admin?.condition)
   if (isConditional) {
     return false
@@ -50,13 +50,16 @@ function buildOptionEnums(options: Option[]): string[] {
 function generateEntitySchemas(
   entities: (SanitizedCollectionConfig | SanitizedGlobalConfig)[],
 ): JSONSchema4 {
-  const properties = [...entities].reduce((acc, { slug }) => {
-    acc[slug] = {
-      $ref: `#/definitions/${slug}`,
-    }
+  const properties = [...entities].reduce(
+    (acc, { slug }) => {
+      acc[slug] = {
+        $ref: `#/definitions/${slug}`,
+      }
 
-    return acc
-  }, {})
+      return acc
+    },
+    {} as Record<string, JSONSchema4>,
+  )
 
   return {
     type: 'object',
@@ -69,13 +72,16 @@ function generateEntitySchemas(
 function generateEntitySelectSchemas(
   entities: (SanitizedCollectionConfig | SanitizedGlobalConfig)[],
 ): JSONSchema4 {
-  const properties = [...entities].reduce((acc, { slug }) => {
-    acc[slug] = {
-      $ref: `#/definitions/${slug}_select`,
-    }
+  const properties = [...entities].reduce(
+    (acc, { slug }) => {
+      acc[slug] = {
+        $ref: `#/definitions/${slug}_select`,
+      }
 
-    return acc
-  }, {})
+      return acc
+    },
+    {} as Record<string, JSONSchema4>,
+  )
 
   return {
     type: 'object',
@@ -97,7 +103,7 @@ function generateCollectionJoinsSchemas(collections: SanitizedCollectionConfig[]
 
       for (const collectionSlug in joins) {
         for (const join of joins[collectionSlug]!) {
-          schema.properties[join.joinPath] = {
+          ;(schema.properties as any)[join.joinPath] = {
             type: 'string',
             enum: [collectionSlug],
           }
@@ -106,7 +112,7 @@ function generateCollectionJoinsSchemas(collections: SanitizedCollectionConfig[]
       }
 
       for (const join of polymorphicJoins) {
-        schema.properties[join.joinPath] = {
+        ;(schema.properties as any)[join.joinPath] = {
           type: 'string',
           enum: join.field.collection,
         }
@@ -1079,14 +1085,17 @@ export function timezonesToJSONSchema(
 }
 
 function generateAuthOperationSchemas(collections: SanitizedCollectionConfig[]): JSONSchema4 {
-  const properties = collections.reduce((acc, collection) => {
-    if (collection.auth) {
-      acc[collection.slug] = {
-        $ref: `#/definitions/auth/${collection.slug}`,
+  const properties = collections.reduce(
+    (acc, collection) => {
+      if (collection.auth) {
+        acc[collection.slug] = {
+          $ref: `#/definitions/auth/${collection.slug}`,
+        }
       }
-    }
-    return acc
-  }, {})
+      return acc
+    },
+    {} as Record<string, JSONSchema4>,
+  )
 
   return {
     type: 'object',
@@ -1157,7 +1166,7 @@ export function configToJSONSchema(
 
       return acc
     },
-    {},
+    {} as Record<string, JSONSchema4>,
   )
 
   const timezoneDefinitions = timezonesToJSONSchema(config.admin.timezones.supportedTimezones)
@@ -1169,7 +1178,7 @@ export function configToJSONSchema(
         acc.auth[authCollection.slug] = authCollectionToOperationsJSONSchema(authCollection)
         return acc
       },
-      { auth: {} },
+      { auth: {} as Record<string, JSONSchema4> },
     )
 
   const jobsSchemas = config.jobs

--- a/packages/payload/src/utilities/deepCopyObject.ts
+++ b/packages/payload/src/utilities/deepCopyObject.ts
@@ -1,4 +1,4 @@
-// @ts-strict-ignore
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { JsonValue } from '../types/index.js'
 
 /*
@@ -21,7 +21,7 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 IN THE SOFTWARE.
 */
 
-function copyBuffer(cur) {
+function copyBuffer(cur: any) {
   if (cur instanceof Buffer) {
     return Buffer.from(cur)
   }
@@ -30,23 +30,23 @@ function copyBuffer(cur) {
 }
 
 const constructorHandlers = new Map()
-constructorHandlers.set(Date, (o) => new Date(o))
-constructorHandlers.set(Map, (o, fn) => new Map(cloneArray<any>(Array.from(o), fn)))
-constructorHandlers.set(Set, (o, fn) => new Set(cloneArray(Array.from(o), fn)))
+constructorHandlers.set(Date, (o: any) => new Date(o))
+constructorHandlers.set(Map, (o: any, fn: any) => new Map(cloneArray<any>(Array.from(o), fn)))
+constructorHandlers.set(Set, (o: any, fn: any) => new Set(cloneArray(Array.from(o), fn)))
 constructorHandlers.set(RegExp, (regex: RegExp) => new RegExp(regex.source, regex.flags))
 
 let handler: ((o: any, fn: any) => any) | null = null
 
-function cloneArray<T extends object>(a: T, fn): T {
+function cloneArray<T extends object>(a: T, fn: (o: any) => any): T {
   const keys = Object.keys(a)
-  const a2 = new Array(keys.length)
+  const a2 = new Array(keys.length) as T
   for (let i = 0; i < keys.length; i++) {
-    const k = keys[i]!
-    const cur = a[k]
+    const k = keys[i] as keyof typeof a
+    const cur = a[k] as any
     if (typeof cur !== 'object' || cur === null) {
       a2[k] = cur
     } else if (cur instanceof RegExp) {
-      a2[k] = new RegExp(cur.source, cur.flags)
+      a2[k] = new RegExp(cur.source, cur.flags) as any
     } else if (cur.constructor !== Object && (handler = constructorHandlers.get(cur.constructor))) {
       a2[k] = handler(cur, fn)
     } else if (ArrayBuffer.isView(cur)) {
@@ -55,7 +55,7 @@ function cloneArray<T extends object>(a: T, fn): T {
       a2[k] = fn(cur)
     }
   }
-  return a2 as T
+  return a2
 }
 
 export const deepCopyObject = <T>(o: T): T => {
@@ -72,25 +72,25 @@ export const deepCopyObject = <T>(o: T): T => {
   if (o.constructor !== Object && (handler = constructorHandlers.get(o.constructor))) {
     return handler(o, deepCopyObject)
   }
-  const o2 = {}
+  const o2 = {} as T
   for (const k in o) {
     if (Object.hasOwnProperty.call(o, k) === false) {
       continue
     }
     const cur = o[k]
     if (typeof cur !== 'object' || cur === null) {
-      o2[k as string] = cur
+      o2[k] = cur
     } else if (cur instanceof RegExp) {
-      o2[k as string] = new RegExp(cur.source, cur.flags)
+      o2[k] = new RegExp(cur.source, cur.flags) as any
     } else if (cur.constructor !== Object && (handler = constructorHandlers.get(cur.constructor))) {
-      o2[k as string] = handler(cur, deepCopyObject)
+      o2[k] = handler(cur, deepCopyObject)
     } else if (ArrayBuffer.isView(cur)) {
-      o2[k as string] = copyBuffer(cur)
+      o2[k] = copyBuffer(cur)
     } else {
-      o2[k as string] = deepCopyObject(cur)
+      o2[k] = deepCopyObject(cur)
     }
   }
-  return o2 as T
+  return o2
 }
 
 /*

--- a/packages/payload/src/utilities/fieldSchemaToJSON.ts
+++ b/packages/payload/src/utilities/fieldSchemaToJSON.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { ClientConfig } from '../config/client.js'
 import type { ClientField } from '../fields/config/client.js'
 

--- a/packages/payload/src/utilities/fieldSchemaToJSON.ts
+++ b/packages/payload/src/utilities/fieldSchemaToJSON.ts
@@ -43,7 +43,7 @@ export const fieldSchemaToJSON = (fields: ClientField[], config: ClientConfig): 
           type: field.type,
           blocks: (field.blockReferences ?? field.blocks).reduce((acc, _block) => {
             const block = typeof _block === 'string' ? config.blocksMap[_block]! : _block
-            acc[block.slug] = {
+            ;(acc as any)[block.slug] = {
               fields: fieldSchemaToJSON(
                 [
                   ...block.fields,

--- a/packages/payload/src/utilities/flattenTopLevelFields.ts
+++ b/packages/payload/src/utilities/flattenTopLevelFields.ts
@@ -127,7 +127,7 @@ export function flattenTopLevelFields<TField extends ClientField | Field>(
     } else if (field.type === 'tabs' && 'tabs' in field) {
       return [
         ...acc,
-        ...field.tabs.reduce<FlattenedField<TField>[]>((tabFields, tab: TabType<TField>) => {
+        ...field.tabs.reduce<FlattenedField<TField>[]>((tabFields, tab) => {
           if (tabHasName(tab)) {
             if (moveSubFieldsToTop) {
               const translatedLabel =

--- a/packages/payload/src/utilities/flattenTopLevelFields.ts
+++ b/packages/payload/src/utilities/flattenTopLevelFields.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { I18nClient } from '@payloadcms/translations'
 
 import { getTranslation } from '@payloadcms/translations'

--- a/packages/payload/src/utilities/formatErrors.ts
+++ b/packages/payload/src/utilities/formatErrors.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { ErrorResult } from '../config/types.js'
 import type { APIError } from '../errors/APIError.js'
 

--- a/packages/payload/src/utilities/formatErrors.ts
+++ b/packages/payload/src/utilities/formatErrors.ts
@@ -33,8 +33,8 @@ export const formatErrors = (incoming: { [key: string]: unknown } | APIError): E
         errors: Object.keys(incoming.errors).reduce(
           (acc, key) => {
             acc.push({
-              field: incoming.errors![key].path,
-              message: incoming.errors![key].message,
+              field: (incoming.errors as any)[key].path,
+              message: (incoming.errors as any)[key].message,
             })
             return acc
           },

--- a/packages/payload/src/utilities/getCollectionIDFieldTypes.ts
+++ b/packages/payload/src/utilities/getCollectionIDFieldTypes.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedConfig } from '../config/types.js'
 
 /**

--- a/packages/payload/src/utilities/getCollectionIDFieldTypes.ts
+++ b/packages/payload/src/utilities/getCollectionIDFieldTypes.ts
@@ -13,17 +13,20 @@ export function getCollectionIDFieldTypes({
   config: SanitizedConfig
   defaultIDType: 'number' | 'text'
 }): { [key: string]: 'number' | 'string' } {
-  return config.collections.reduce((acc, collection) => {
-    const customCollectionIdField = collection.fields.find(
-      (field) => 'name' in field && field.name === 'id',
-    )
+  return config.collections.reduce(
+    (acc, collection) => {
+      const customCollectionIdField = collection.fields.find(
+        (field) => 'name' in field && field.name === 'id',
+      )
 
-    acc[collection.slug] = defaultIDType === 'text' ? 'string' : 'number'
+      acc[collection.slug] = defaultIDType === 'text' ? 'string' : 'number'
 
-    if (customCollectionIdField) {
-      acc[collection.slug] = customCollectionIdField.type === 'number' ? 'number' : 'string'
-    }
+      if (customCollectionIdField) {
+        acc[collection.slug] = customCollectionIdField.type === 'number' ? 'number' : 'string'
+      }
 
-    return acc
-  }, {})
+      return acc
+    },
+    {} as Record<string, 'number' | 'string'>,
+  )
 }

--- a/packages/payload/src/utilities/getDataByPath.ts
+++ b/packages/payload/src/utilities/getDataByPath.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { FormState } from '../admin/types.js'
 
 import { unflatten } from './unflatten.js'

--- a/packages/payload/src/utilities/getDataByPath.ts
+++ b/packages/payload/src/utilities/getDataByPath.ts
@@ -7,7 +7,7 @@ export const getDataByPath = <T = unknown>(fields: FormState, path: string): T =
   const pathPrefixToRemove = path.substring(0, path.lastIndexOf('.') + 1)
   const name = path.split('.').pop()
 
-  const data = {}
+  const data: Record<string, any> = {}
   Object.keys(fields).forEach((key) => {
     if (!fields[key]?.disableFormData && (key.indexOf(`${path}.`) === 0 || key === path)) {
       data[key.replace(pathPrefixToRemove, '')] = fields[key]?.value

--- a/packages/payload/src/utilities/getEntityPolicies.ts
+++ b/packages/payload/src/utilities/getEntityPolicies.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { CollectionPermission, FieldsPermissions, GlobalPermission } from '../auth/types.js'
 import type { SanitizedCollectionConfig, TypeWithID } from '../collections/config/types.js'
 import type { Access } from '../config/types.js'

--- a/packages/payload/src/utilities/getFieldPermissions.ts
+++ b/packages/payload/src/utilities/getFieldPermissions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // @ts-strict-ignore
 import type { SanitizedFieldPermissions } from '../auth/types.js'
 import type { ClientField, Field } from '../fields/config/types.js'
@@ -31,26 +32,28 @@ export const getFieldPermissions = ({
 } => ({
   operation:
     permissions === true ||
-    permissions?.[operation] === true ||
-    permissions?.[parentName] === true ||
+    permissions?.[operation as keyof typeof permissions] === true ||
+    permissions?.[parentName as keyof typeof permissions] === true ||
     ('name' in field &&
       typeof permissions === 'object' &&
-      permissions?.[field.name] &&
-      (permissions[field.name] === true ||
-        (operation in permissions[field.name] && permissions[field.name][operation]))),
+      permissions?.[field.name as keyof typeof permissions] &&
+      (permissions[field.name as keyof typeof permissions] === true ||
+        (operation in (permissions as any)[field.name] &&
+          (permissions as any)[field.name][operation]))),
+
   permissions:
     permissions === undefined || permissions === null || permissions === true
       ? true
       : 'name' in field
-        ? permissions?.[field.name]
+        ? (permissions as any)[field.name]
         : permissions,
   read:
     permissions === true ||
     permissions?.read === true ||
-    permissions?.[parentName] === true ||
+    permissions?.[parentName as keyof typeof permissions] === true ||
     ('name' in field &&
       typeof permissions === 'object' &&
-      permissions?.[field.name] &&
-      (permissions[field.name] === true ||
-        ('read' in permissions[field.name] && permissions[field.name].read))),
+      permissions?.[field.name as keyof typeof permissions] &&
+      ((permissions as any)[field.name] === true ||
+        ('read' in (permissions as any)[field.name] && (permissions as any)[field.name].read))),
 })

--- a/packages/payload/src/utilities/getFieldPermissions.ts
+++ b/packages/payload/src/utilities/getFieldPermissions.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// @ts-strict-ignore
 import type { SanitizedFieldPermissions } from '../auth/types.js'
 import type { ClientField, Field } from '../fields/config/types.js'
 import type { Operation } from '../types/index.js'

--- a/packages/payload/src/utilities/getObjectDotNotation.ts
+++ b/packages/payload/src/utilities/getObjectDotNotation.ts
@@ -7,6 +7,6 @@ export const getObjectDotNotation = <T>(
   if (!path || !obj) {
     return defaultValue!
   }
-  const result = path.split('.').reduce((o, i) => o?.[i], obj)
+  const result = path.split('.').reduce((o, i) => o?.[i] as Record<string, unknown>, obj)
   return result === undefined ? defaultValue! : (result as T)
 }

--- a/packages/payload/src/utilities/getObjectDotNotation.ts
+++ b/packages/payload/src/utilities/getObjectDotNotation.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 export const getObjectDotNotation = <T>(
   obj: Record<string, unknown>,
   path: string,

--- a/packages/payload/src/utilities/getSiblingData.ts
+++ b/packages/payload/src/utilities/getSiblingData.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { Data, FormState } from '../admin/types.js'
 
 import { reduceFieldsToValues } from './reduceFieldsToValues.js'

--- a/packages/payload/src/utilities/getSiblingData.ts
+++ b/packages/payload/src/utilities/getSiblingData.ts
@@ -13,7 +13,7 @@ export const getSiblingData = (fields: FormState, path: string): Data => {
     return reduceFieldsToValues(fields, true)
   }
 
-  const siblingFields = {}
+  const siblingFields: Record<string, any> = {}
 
   // Determine if the last segment of the path is an array-based row
   const pathSegments = path.split('.')

--- a/packages/payload/src/utilities/getUniqueListBy.ts
+++ b/packages/payload/src/utilities/getUniqueListBy.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 export function getUniqueListBy<T>(arr: T[], key: string): T[] {
-  return [...new Map(arr.map((item) => [item[key], item])).values()]
+  return [...new Map(arr.map((item) => [item[key as keyof T], item])).values()]
 }

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -4,6 +4,7 @@ import { match } from 'path-to-regexp'
 
 import type { Collection } from '../collections/config/types.js'
 import type { Endpoint, PayloadHandler, SanitizedConfig } from '../config/types.js'
+import type { APIError } from '../errors/APIError.js'
 import type { GlobalConfig } from '../globals/config/types.js'
 import type { PayloadRequest } from '../types/index.js'
 
@@ -232,7 +233,8 @@ export const handleEndpoints = async ({
       status: response.status,
       statusText: response.statusText,
     })
-  } catch (err) {
+  } catch (_err) {
+    const err = _err as APIError
     return routeError({
       collection,
       config: incomingConfig,

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 import { match } from 'path-to-regexp'
 

--- a/packages/payload/src/utilities/logError.ts
+++ b/packages/payload/src/utilities/logError.ts
@@ -11,9 +11,10 @@ export const logError = ({ err, payload }: { err: unknown; payload: Payload }): 
     typeof err === 'object' &&
     'name' in err &&
     typeof err.name === 'string' &&
-    typeof payload.config.loggingLevels[err.name] !== 'undefined'
+    typeof payload.config.loggingLevels[err.name as keyof typeof payload.config.loggingLevels] !==
+      'undefined'
   ) {
-    level = payload.config.loggingLevels[err.name]
+    level = payload.config.loggingLevels[err.name as keyof typeof payload.config.loggingLevels]
   }
 
   if (level) {

--- a/packages/payload/src/utilities/logError.ts
+++ b/packages/payload/src/utilities/logError.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type pino from 'pino'
 
 import type { Payload } from '../types/index.js'

--- a/packages/payload/src/utilities/reduceFieldsToValues.ts
+++ b/packages/payload/src/utilities/reduceFieldsToValues.ts
@@ -14,7 +14,7 @@ export const reduceFieldsToValues = (
   unflatten?: boolean,
   ignoreDisableFormData?: boolean,
 ): Data => {
-  let data = {}
+  let data: Record<string, any> = {}
 
   if (!fields) {
     return data

--- a/packages/payload/src/utilities/reduceFieldsToValues.ts
+++ b/packages/payload/src/utilities/reduceFieldsToValues.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { Data, FormState } from '../admin/types.js'
 
 import { unflatten as flatleyUnflatten } from './unflatten.js'

--- a/packages/payload/src/utilities/sanitizeJoinParams.ts
+++ b/packages/payload/src/utilities/sanitizeJoinParams.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { JoinQuery } from '../types/index.js'
 
 import { isNumber } from './isNumber.js'

--- a/packages/payload/src/utilities/sanitizeJoinParams.ts
+++ b/packages/payload/src/utilities/sanitizeJoinParams.ts
@@ -19,8 +19,9 @@ export type JoinParams =
  * Convert request JoinQuery object from strings to numbers
  * @param joins
  */
-export const sanitizeJoinParams = (joins: JoinParams = {}): JoinQuery => {
-  const joinQuery = {}
+export const sanitizeJoinParams = (_joins: JoinParams = {}): JoinQuery => {
+  const joinQuery: Record<string, any> = {}
+  const joins = _joins as Record<string, any>
 
   Object.keys(joins).forEach((schemaPath) => {
     if (joins[schemaPath] === 'false' || joins[schemaPath] === false) {

--- a/packages/payload/src/utilities/sanitizePermissions.ts
+++ b/packages/payload/src/utilities/sanitizePermissions.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { MarkOptional } from 'ts-essentials'
 
 import type {

--- a/packages/payload/src/utilities/sanitizePermissions.ts
+++ b/packages/payload/src/utilities/sanitizePermissions.ts
@@ -36,8 +36,9 @@ function checkAndSanitizeFieldsPermssions(data: FieldsPermissions): boolean {
  * If nested fields or blocks are present, the function will recursively check those as well.
  */
 function checkAndSanitizePermissions(
-  data: CollectionPermission | FieldPermissions | GlobalPermission,
+  _data: CollectionPermission | FieldPermissions | GlobalPermission,
 ): boolean {
+  const data = _data as Record<string, any>
   /**
    * Check blocks permissions
    */

--- a/packages/payload/src/utilities/sanitizePopulateParam.ts
+++ b/packages/payload/src/utilities/sanitizePopulateParam.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { PopulateType } from '../types/index.js'
 
 import { sanitizeSelectParam } from './sanitizeSelectParam.js'

--- a/packages/payload/src/utilities/sanitizePopulateParam.ts
+++ b/packages/payload/src/utilities/sanitizePopulateParam.ts
@@ -12,7 +12,9 @@ export const sanitizePopulateParam = (unsanitizedPopulate: unknown): PopulateTyp
   }
 
   for (const k in unsanitizedPopulate) {
-    unsanitizedPopulate[k] = sanitizeSelectParam(unsanitizedPopulate[k])
+    ;(unsanitizedPopulate as Record<string, any>)[k] = sanitizeSelectParam(
+      unsanitizedPopulate[k as keyof typeof unsanitizedPopulate],
+    )
   }
 
   return unsanitizedPopulate as PopulateType

--- a/packages/payload/src/utilities/sanitizeSelectParam.ts
+++ b/packages/payload/src/utilities/sanitizeSelectParam.ts
@@ -6,11 +6,12 @@ import type { SelectType } from '../types/index.js'
  */
 export const sanitizeSelectParam = (unsanitizedSelect: unknown): SelectType | undefined => {
   if (unsanitizedSelect && typeof unsanitizedSelect === 'object') {
-    for (const k in unsanitizedSelect) {
+    for (const _k in unsanitizedSelect) {
+      const k = _k as keyof typeof unsanitizedSelect
       if (unsanitizedSelect[k] === 'true') {
-        unsanitizedSelect[k] = true
+        ;(unsanitizedSelect as Record<string, any>)[k] = true
       } else if (unsanitizedSelect[k] === 'false') {
-        unsanitizedSelect[k] = false
+        ;(unsanitizedSelect as Record<string, any>)[k] = false
       } else if (typeof unsanitizedSelect[k] === 'object') {
         sanitizeSelectParam(unsanitizedSelect[k])
       }

--- a/packages/payload/src/utilities/sanitizeSelectParam.ts
+++ b/packages/payload/src/utilities/sanitizeSelectParam.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SelectType } from '../types/index.js'
 
 /**

--- a/packages/payload/src/utilities/telemetry/conf/envPaths.ts
+++ b/packages/payload/src/utilities/telemetry/conf/envPaths.ts
@@ -21,7 +21,7 @@ const homedir = os.homedir()
 const tmpdir = os.tmpdir()
 const { env } = process
 
-const macos = (name) => {
+const macos = (name: string) => {
   const library = path.join(homedir, 'Library')
 
   return {
@@ -33,7 +33,7 @@ const macos = (name) => {
   }
 }
 
-const windows = (name) => {
+const windows = (name: string) => {
   const appData = env.APPDATA || path.join(homedir, 'AppData', 'Roaming')
   const localAppData = env.LOCALAPPDATA || path.join(homedir, 'AppData', 'Local')
 
@@ -48,7 +48,7 @@ const windows = (name) => {
 }
 
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-const linux = (name) => {
+const linux = (name: string) => {
   const username = path.basename(homedir)
 
   return {
@@ -61,7 +61,7 @@ const linux = (name) => {
   }
 }
 
-export function envPaths(name, { suffix = 'nodejs' } = {}) {
+export function envPaths(name: string, { suffix = 'nodejs' } = {}) {
   if (typeof name !== 'string') {
     throw new TypeError(`Expected a string, got ${typeof name}`)
   }

--- a/packages/payload/src/utilities/timestamp.ts
+++ b/packages/payload/src/utilities/timestamp.ts
@@ -1,5 +1,4 @@
-// @ts-strict-ignore
-export const timestamp = (label) => {
+export const timestamp = (label: string) => {
   if (!process.env.PAYLOAD_TIME) {
     process.env.PAYLOAD_TIME = String(new Date().getTime())
   }

--- a/packages/payload/src/utilities/traverseFields.ts
+++ b/packages/payload/src/utilities/traverseFields.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { Config, SanitizedConfig } from '../config/types.js'
 import type { ArrayField, Block, BlocksField, Field, TabAsField } from '../fields/config/types.js'
 
@@ -199,12 +198,15 @@ export const traverseFields = ({
         }
 
         if ('name' in tab && tab.name) {
-          if (!ref[tab.name] || typeof ref[tab.name] !== 'object') {
+          if (
+            !ref[tab.name as keyof typeof ref] ||
+            typeof ref[tab.name as keyof typeof ref] !== 'object'
+          ) {
             if (fillEmpty) {
               if (tab.localized) {
-                ref[tab.name] = { en: {} }
+                ;(ref as Record<string, any>)[tab.name] = { en: {} }
               } else {
-                ref[tab.name] = {}
+                ;(ref as Record<string, any>)[tab.name] = {}
               }
             } else {
               continue
@@ -235,11 +237,14 @@ export const traverseFields = ({
             )
           }
 
-          tabRef = tabRef[tab.name]
+          tabRef = tabRef[tab.name as keyof typeof tabRef]
 
           if (tab.localized) {
             for (const key in tabRef as Record<string, unknown>) {
-              if (tabRef[key] && typeof tabRef[key] === 'object') {
+              if (
+                tabRef[key as keyof typeof tabRef] &&
+                typeof tabRef[key as keyof typeof tabRef] === 'object'
+              ) {
                 traverseFields({
                   callback,
                   callbackStack,
@@ -250,7 +255,7 @@ export const traverseFields = ({
                   leavesFirst,
                   parentIsLocalized: true,
                   parentRef: currentParentRef,
-                  ref: tabRef[key],
+                  ref: tabRef[key as keyof typeof tabRef],
                 })
               }
             }
@@ -307,30 +312,26 @@ export const traverseFields = ({
     if (field.type !== 'tab' && (fieldHasSubFields(field) || field.type === 'blocks')) {
       if ('name' in field && field.name) {
         currentParentRef = currentRef
-        if (!ref[field.name]) {
+        if (!ref[field.name as keyof typeof ref]) {
           if (fillEmpty) {
             if (field.type === 'group') {
               if (fieldShouldBeLocalized({ field, parentIsLocalized: parentIsLocalized! })) {
-                ref[field.name] = {
-                  en: {},
-                }
+                ;(ref as Record<string, any>)[field.name] = { en: {} }
               } else {
-                ref[field.name] = {}
+                ;(ref as Record<string, any>)[field.name] = {}
               }
             } else if (field.type === 'array' || field.type === 'blocks') {
               if (fieldShouldBeLocalized({ field, parentIsLocalized: parentIsLocalized! })) {
-                ref[field.name] = {
-                  en: [],
-                }
+                ;(ref as Record<string, any>)[field.name] = { en: [] }
               } else {
-                ref[field.name] = []
+                ;(ref as Record<string, any>)[field.name] = []
               }
             }
           } else {
             return
           }
         }
-        currentRef = ref[field.name]
+        currentRef = ref[field.name as keyof typeof ref]
       }
 
       if (
@@ -341,7 +342,7 @@ export const traverseFields = ({
       ) {
         if (fieldAffectsData(field)) {
           for (const key in currentRef as Record<string, unknown>) {
-            if (currentRef[key]) {
+            if (currentRef[key as keyof typeof currentRef]) {
               traverseFields({
                 callback,
                 callbackStack,
@@ -352,7 +353,7 @@ export const traverseFields = ({
                 leavesFirst,
                 parentIsLocalized: true,
                 parentRef: currentParentRef,
-                ref: currentRef[key],
+                ref: currentRef[key as keyof typeof currentRef],
               })
             }
           }
@@ -385,7 +386,7 @@ export const traverseFields = ({
           }
 
           for (const key in currentRef as Record<string, unknown>) {
-            const localeData = currentRef[key]
+            const localeData = currentRef[key as keyof typeof currentRef]
             if (!Array.isArray(localeData)) {
               continue
             }

--- a/packages/payload/src/utilities/unflatten.ts
+++ b/packages/payload/src/utilities/unflatten.ts
@@ -1,4 +1,4 @@
-// @ts-strict-ignore
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /*
  * Copyright (c) 2014, Hugh Kennedy
  * All rights reserved.
@@ -16,7 +16,7 @@
  * Reference: https://www.npmjs.com/package/is-buffer
  * All rights reserved.
  */
-function isBuffer(obj) {
+function isBuffer(obj: any) {
   return (
     obj != null &&
     obj.constructor != null &&
@@ -32,7 +32,7 @@ interface Opts {
   recursive?: boolean
 }
 
-export const unflatten = (target, opts?: Opts) => {
+export const unflatten = (target: any, opts?: Opts) => {
   opts = opts || {}
 
   const delimiter = opts.delimiter || '.'
@@ -47,7 +47,7 @@ export const unflatten = (target, opts?: Opts) => {
   }
 
   // safely ensure that the key is an integer.
-  const getkey = (key) => {
+  const getkey = (key: any) => {
     const parsedKey = Number(key)
     return isNaN(parsedKey) || key.indexOf('.') !== -1 || opts.object ? key : parsedKey
   }
@@ -58,7 +58,7 @@ export const unflatten = (target, opts?: Opts) => {
     const split = key.split(delimiter)
     let key1 = getkey(split.shift())
     let key2 = getkey(split[0])
-    let recipient = result
+    let recipient = result as Record<string, any>
 
     while (key2 !== undefined) {
       if (key1 === '__proto__') {

--- a/packages/payload/src/utilities/wait.ts
+++ b/packages/payload/src/utilities/wait.ts
@@ -1,5 +1,4 @@
-// @ts-strict-ignore
-export async function wait(ms) {
+export async function wait(ms: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)
   })

--- a/packages/payload/src/versions/baseFields.ts
+++ b/packages/payload/src/versions/baseFields.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
-import type { CheckboxField, Field } from '../fields/config/types.js'
+import type { CheckboxField, Field, Option } from '../fields/config/types.js'
 
-export const statuses = [
+export const statuses: Option[] = [
   {
     label: ({ t }) => t('version:draft'),
     value: 'draft',

--- a/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
+++ b/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
@@ -67,7 +67,7 @@ export const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
     })
   }
 
-  let versionAccessResult
+  let versionAccessResult: undefined | Where
 
   if (hasWhereAccessResult(accessResult)) {
     versionAccessResult = appendVersionToQueryKey(accessResult)
@@ -82,7 +82,7 @@ export const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
     req,
     select: getQueryDraftsSelect({ select }),
     sort: '-updatedAt',
-    where: combineQueries(queryToBuild, versionAccessResult),
+    where: combineQueries(queryToBuild, versionAccessResult!),
   }
 
   let versionDocs
@@ -102,12 +102,13 @@ export const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
 
   // Patch globalType onto version doc
   if (entityType === 'global' && 'globalType' in doc) {
+    // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
     draft.version.globalType = doc.globalType
   }
 
   // handle when .version wasn't selected due to projection
   if (!draft.version) {
-    draft.version = {}
+    draft.version = {} as T
   }
 
   // Disregard all other draft content at this point,

--- a/packages/payload/src/versions/getLatestGlobalVersion.ts
+++ b/packages/payload/src/versions/getLatestGlobalVersion.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { Document, Payload, PayloadRequest, Where } from '../types/index.js'
 
@@ -53,6 +52,9 @@ export const getLatestGlobalVersion = async ({
       global,
       globalExists,
     }
+  }
+  if (!('createdAt' in latestVersion.version) || !('updatedAt' in latestVersion.version)) {
+    throw new Error('Could not find createdAt or updatedAt in latestVersion.version')
   }
 
   if (!latestVersion.version.createdAt) {

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -36,7 +36,7 @@ export const saveVersion = async ({
   select,
   snapshot,
 }: Args): Promise<TypeWithID> => {
-  let result
+  let result: TypeWithID | undefined
   let createNewVersion = true
   const now = new Date().toISOString()
   const versionData = deepCopyObjectSimple(doc)
@@ -87,7 +87,7 @@ export const saveVersion = async ({
       const [latestVersion] = docs
 
       // overwrite the latest version if it's set to autosave
-      if (latestVersion?.autosave === true) {
+      if (latestVersion && 'autosave' in latestVersion && latestVersion.autosave === true) {
         createNewVersion = false
 
         const data: Record<string, unknown> = {
@@ -199,10 +199,10 @@ export const saveVersion = async ({
     })
   }
 
-  let createdVersion = result.version
+  let createdVersion = (result as any).version
 
   createdVersion = sanitizeInternalFields(createdVersion)
-  createdVersion.id = result.parent
+  createdVersion.id = (result as any).parent
 
   return createdVersion
 }

--- a/packages/payload/tsconfig.json
+++ b/packages/payload/tsconfig.json
@@ -10,11 +10,11 @@
     "strictBindCallApply": true,
     "strictBuiltinIteratorReturn": true,
     "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
 
-    "strictPropertyInitialization": false, // 13 errors in 1 file
     "noImplicitAny": false, // 277 errors in 55 files
     "noImplicitThis": false, // 2 errors in 1 file
-    "useUnknownInCatchVariables": true, // 18 errors in 13 files
+    "useUnknownInCatchVariables": false, // 18 errors in 13 files
   },
   "references": [{ "path": "../translations" }]
 }

--- a/packages/payload/tsconfig.json
+++ b/packages/payload/tsconfig.json
@@ -1,20 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    /* TODO: remove the following lines */
-    // "strict": false,
-    "strictNullChecks": true,
-
-
-    "alwaysStrict": true,
-    "strictBindCallApply": true,
-    "strictBuiltinIteratorReturn": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "useUnknownInCatchVariables": true,
-    "noImplicitThis": true,
-
-    "noImplicitAny": false, // 277 errors in 55 files
-  },
   "references": [{ "path": "../translations" }]
 }

--- a/packages/payload/tsconfig.json
+++ b/packages/payload/tsconfig.json
@@ -11,10 +11,10 @@
     "strictBuiltinIteratorReturn": true,
     "strictFunctionTypes": true,
     "strictPropertyInitialization": true,
+    "useUnknownInCatchVariables": true,
 
     "noImplicitAny": false, // 277 errors in 55 files
     "noImplicitThis": false, // 2 errors in 1 file
-    "useUnknownInCatchVariables": false, // 18 errors in 13 files
   },
   "references": [{ "path": "../translations" }]
 }

--- a/packages/payload/tsconfig.json
+++ b/packages/payload/tsconfig.json
@@ -2,16 +2,19 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* TODO: remove the following lines */
-    "strict": false,
+    // "strict": false,
     "strictNullChecks": true,
-    "plugins": [
-      {
-        "name": "typescript-strict-plugin"
-      },
-      {
-        "name": "tsc-strict"
-      }
-    ],
+
+
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
+    "strictBuiltinIteratorReturn": true,
+    "strictFunctionTypes": true,
+
+    "strictPropertyInitialization": false, // 13 errors in 1 file
+    "noImplicitAny": false, // 277 errors in 55 files
+    "noImplicitThis": false, // 2 errors in 1 file
+    "useUnknownInCatchVariables": true, // 18 errors in 13 files
   },
   "references": [{ "path": "../translations" }]
 }

--- a/packages/payload/tsconfig.json
+++ b/packages/payload/tsconfig.json
@@ -12,9 +12,9 @@
     "strictFunctionTypes": true,
     "strictPropertyInitialization": true,
     "useUnknownInCatchVariables": true,
+    "noImplicitThis": true,
 
     "noImplicitAny": false, // 277 errors in 55 files
-    "noImplicitThis": false, // 2 errors in 1 file
   },
   "references": [{ "path": "../translations" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,9 +913,6 @@ importers:
       '@types/ws':
         specifier: ^8.5.10
         version: 8.5.13
-      concurrently:
-        specifier: 9.1.2
-        version: 9.1.2
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -937,9 +934,6 @@ importers:
       sharp:
         specifier: 0.32.6
         version: 0.32.6
-      typescript-strict-plugin:
-        specifier: 2.4.4
-        version: 2.4.4
 
   packages/payload-cloud:
     dependencies:
@@ -6271,17 +6265,9 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
-  cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
-
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
-
-  cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
 
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
@@ -6296,10 +6282,6 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  clone@1.0.4:
-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
-    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -6380,11 +6362,6 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  concurrently@9.1.2:
-    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -6552,9 +6529,6 @@ packages:
   default-browser@5.2.1:
     resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
     engines: {node: '>=18'}
-
-  defaults@1.0.4:
-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   defaults@3.0.0:
     resolution: {integrity: sha512-RsqXDEAALjfRTro+IFNKpcPCt0/Cy2FqHSIlnomiJp9YGadpQnrtbRpSgN2+np21qHcIKiva4fiOQGjS9/qR/A==}
@@ -7109,10 +7083,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  execa@4.1.0:
-    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
-    engines: {node: '>=10'}
-
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -7382,10 +7352,6 @@ packages:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
     engines: {node: '>=12'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -7605,10 +7571,6 @@ packages:
     resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
     engines: {node: '>= 14'}
 
-  human-signals@1.1.1:
-    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
-    engines: {node: '>=8.12.0'}
-
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -7784,10 +7746,6 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
-  is-interactive@1.0.0:
-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
-    engines: {node: '>=8'}
-
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
@@ -7850,10 +7808,6 @@ packages:
   is-typed-array@1.1.13:
     resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
-
-  is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
 
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
@@ -8239,10 +8193,6 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
-  log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -8782,10 +8732,6 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
-
-  ora@5.4.1:
-    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
-    engines: {node: '>=10'}
 
   os-homedir@1.0.2:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
@@ -9333,10 +9279,6 @@ packages:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
 
-  restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
-
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -9624,10 +9566,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shell-quote@1.8.2:
-    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
-    engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
@@ -10093,10 +10031,6 @@ packages:
     resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
     engines: {node: '>=14'}
 
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-
   treeify@1.1.0:
     resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
     engines: {node: '>=0.6'}
@@ -10231,10 +10165,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: 5.7.3
-
-  typescript-strict-plugin@2.4.4:
-    resolution: {integrity: sha512-OXcWHQk+pW9gqEL/Mb1eTgj/Yiqk1oHBERr9v4VInPOYN++p+cXejmQK/h/VlUPGD++FXQ8pgiqVMyEtxU4T6A==}
-    hasBin: true
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -10417,9 +10347,6 @@ packages:
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
     engines: {node: '>=10.13.0'}
-
-  wcwidth@1.0.1:
-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -16100,15 +16027,9 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
-  cli-cursor@3.1.0:
-    dependencies:
-      restore-cursor: 3.1.0
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
-
-  cli-spinners@2.9.2: {}
 
   cli-truncate@4.0.0:
     dependencies:
@@ -16128,8 +16049,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  clone@1.0.4: {}
 
   clsx@2.1.1: {}
 
@@ -16194,16 +16113,6 @@ snapshots:
   compute-scroll-into-view@1.0.20: {}
 
   concat-map@0.0.1: {}
-
-  concurrently@9.1.2:
-    dependencies:
-      chalk: 4.1.2
-      lodash: 4.17.21
-      rxjs: 7.8.1
-      shell-quote: 1.8.2
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.7.2
 
   confbox@0.1.8: {}
 
@@ -16358,10 +16267,6 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.0
-
-  defaults@1.0.4:
-    dependencies:
-      clone: 1.0.4
 
   defaults@3.0.0: {}
 
@@ -17056,18 +16961,6 @@ snapshots:
 
   events@3.3.0: {}
 
-  execa@4.1.0:
-    dependencies:
-      cross-spawn: 7.0.5
-      get-stream: 5.2.0
-      human-signals: 1.1.1
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.5
@@ -17362,10 +17255,6 @@ snapshots:
 
   get-stdin@9.0.0: {}
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.2
-
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -17630,8 +17519,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  human-signals@1.1.1: {}
-
   human-signals@2.1.0: {}
 
   human-signals@5.0.0: {}
@@ -17775,8 +17662,6 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
-  is-interactive@1.0.0: {}
-
   is-negative-zero@2.0.3: {}
 
   is-number-object@1.0.7:
@@ -17823,8 +17708,6 @@ snapshots:
   is-typed-array@1.1.13:
     dependencies:
       which-typed-array: 1.1.15
-
-  is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
 
@@ -18418,11 +18301,6 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash@4.17.21: {}
-
-  log-symbols@4.1.0:
-    dependencies:
-      chalk: 4.1.2
-      is-unicode-supported: 0.1.0
 
   log-update@6.1.0:
     dependencies:
@@ -19105,18 +18983,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ora@5.4.1:
-    dependencies:
-      bl: 4.1.0
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.9.2
-      is-interactive: 1.0.0
-      is-unicode-supported: 0.1.0
-      log-symbols: 4.1.0
-      strip-ansi: 6.0.1
-      wcwidth: 1.0.1
-
   os-homedir@1.0.2: {}
 
   os-tmpdir@1.0.2: {}
@@ -19705,11 +19571,6 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
-  restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -19989,8 +19850,6 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shell-quote@1.8.2: {}
 
   shelljs@0.8.5:
     dependencies:
@@ -20504,8 +20363,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tree-kill@1.2.2: {}
-
   treeify@1.1.0: {}
 
   truncate-utf8-bytes@1.0.2:
@@ -20627,14 +20484,6 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript-strict-plugin@2.4.4:
-    dependencies:
-      chalk: 3.0.0
-      execa: 4.1.0
-      minimatch: 9.0.5
-      ora: 5.4.1
-      yargs: 16.2.0
 
   typescript@5.7.3: {}
 
@@ -20801,10 +20650,6 @@ snapshots:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
-
-  wcwidth@1.0.1:
-    dependencies:
-      defaults: 1.0.4
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
Important: An intentional effort is being made during migration to not modify runtime behavior. This implies that there will be several assertions, non-null assertions, and @ts-expect-error. This philosophy applies only to migrating old code to TypeScript strict, not to writing new code. For a more detailed justification for this reasoning, see #11840 (comment).

In this PR, instead of following the approach of migrating a subset of files, I'm migrating all files by disabling specific rules. The first commits are named after the rule being disabled.

With this PR, the migration of the payload package is complete 🚀
