### PR TITLE
fix(translations): reformats `bnBD` and `bnIN` translation imports to camelCase

### DIFF
--- a/packages/translations/src/exports/all.ts
+++ b/packages/translations/src/exports/all.ts
@@ -3,8 +3,8 @@ import type { SupportedLanguages } from '../types.js'
 import { ar } from '../languages/ar.js'
 import { az } from '../languages/az.js'
 import { bg } from '../languages/bg.js'
-import { bnBD } from '../languages/bn-BD.js'
-import { bnIN } from '../languages/bn-IN.js'
+import { bnBd } from '../languages/bnBd.js'
+import { bnIn } from '../languages/bnIn.js'
 import { ca } from '../languages/ca.js'
 import { cs } from '../languages/cs.js'
 import { da } from '../languages/da.js'
@@ -46,8 +46,8 @@ export const translations = {
   ar,
   az,
   bg,
-  'bn-BD': bnBD,
-  'bn-IN': bnIN,
+  'bn-BD': bnBd,
+  'bn-IN': bnIn,
   ca,
   cs,
   da,

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -1,6 +1,6 @@
-import type { Language } from '../types.js'
+import type { DefaultTranslationsObject, Language } from '../types.js'
 
-export const bnBDTranslations = {
+export const bnBdTranslations: DefaultTranslationsObject = {
   authentication: {
     account: 'অ্যাকাউন্ট',
     accountOfCurrentUser: 'বর্তমান ব্যবহারকারীর অ্যাকাউন্ট',
@@ -554,7 +554,7 @@ export const bnBDTranslations = {
   },
 }
 
-export const bnBD: Language = {
+export const bnBd: Language = {
   dateFNSKey: 'bn-BD',
-  translations: bnBDTranslations,
+  translations: bnBdTranslations,
 }

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -1,6 +1,6 @@
-import type { Language } from '../types.js'
+import type { DefaultTranslationsObject, Language } from '../types.js'
 
-export const bnINTranslations = {
+export const bnInTranslations: DefaultTranslationsObject = {
   authentication: {
     account: 'অ্যাকাউন্ট',
     accountOfCurrentUser: 'বর্তমান ব্যবহারকারীর অ্যাকাউন্ট',
@@ -554,7 +554,7 @@ export const bnINTranslations = {
   },
 }
 
-export const bnIN: Language = {
+export const bnIn: Language = {
   dateFNSKey: 'bn-IN',
-  translations: bnINTranslations,
+  translations: bnInTranslations,
 }

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -1,4 +1,5 @@
 import type { DefaultTranslationsObject, Language } from '../types.js'
+
 export const esTranslations: DefaultTranslationsObject = {
   authentication: {
     account: 'Cuenta',

--- a/packages/translations/src/utilities/languages.ts
+++ b/packages/translations/src/utilities/languages.ts
@@ -6,6 +6,8 @@ export const acceptedLanguages = [
   'ar',
   'az',
   'bg',
+  'bn-BD',
+  'bn-IN',
   'ca',
   'cs',
   'da',


### PR DESCRIPTION
### What?

This PR updates the import names for the Bengali (Bangladesh) and Bengali (India) translations to follow the camelCase convention used for other hyphenated locales:

- `bnBD → bnBd`

- `bnIN → bnIn`

This aligns with the existing pattern already used for translations like `zhTw.`

Locale keys in the `translations` map (`'bn-BD'`, `'bn-IN'`) remain unchanged.