### PR TITLE
fix(db-sqlite): sqlite unique validation messages

### DIFF
--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -385,8 +385,9 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
     if (error.code === '23505' || error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
       let fieldName: null | string = null
       // We need to try and find the right constraint for the field but if we can't we fallback to a generic message
-      if (adapter.fieldConstraints?.[tableName] && error.code === '23505') {
-        if (adapter.fieldConstraints[tableName]?.[error.constraint]) {
+      if (error.code === '23505') {
+        // For PostgreSQL, we can try to extract the field name from the error constraint
+        if (adapter.fieldConstraints?.[tableName]?.[error.constraint]) {
           fieldName = adapter.fieldConstraints[tableName]?.[error.constraint]
         } else {
           const replacement = `${tableName}_`
@@ -399,27 +400,36 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
             }
           }
         }
-      } else if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
-        // For SQLite, we can try to extract the field name from the error message
-        const regex = /UNIQUE constraint failed: ([^.]+)\.([^.]+)/
 
-        const match: string = error.message.match(regex)
+        if (!fieldName) {
+          // Last case scenario we extract the key and value from the detail on the error
+          const detail = error.detail
+          const regex = /Key \(([^)]+)\)=\(([^)]+)\)/
+          const match: string[] = detail.match(regex)
 
-        if (match?.[2] && adapter.fieldConstraints[tableName]) {
-          fieldName = adapter.fieldConstraints[tableName][`${match[2]}_idx`]
+          if (match && match[1]) {
+            const key = match[1]
+
+            fieldName = key
+          }
         }
-      }
+      } else if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        /**
+         * For SQLite, we can try to extract the field name from the error message
+         * The message typically looks like:
+         * "UNIQUE constraint failed: table_name.field_name"
+         */
+        const regex = /UNIQUE constraint failed: ([^.]+)\.([^.]+)/
+        const match: string[] = error.message.match(regex)
 
-      if (!fieldName && error.detail) {
-        // Last case scenario we extract the key and value from the detail on the error
-        const detail = error.detail
-        const regex = /Key \(([^)]+)\)=\(([^)]+)\)/
-        const match = detail.match(regex)
+        if (match && match[2]) {
+          if (adapter.fieldConstraints[tableName]) {
+            fieldName = adapter.fieldConstraints[tableName][`${match[2]}_idx`]
+          }
 
-        if (match) {
-          const key = match[1]
-
-          fieldName = key
+          if (!fieldName) {
+            fieldName = match[2]
+          }
         }
       }
 

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -403,10 +403,10 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         // For SQLite, we can try to extract the field name from the error message
         const regex = /UNIQUE constraint failed: ([^.]+)\.([^.]+)/
 
-        const match = error.message.match(regex)
+        const match: string = error.message.match(regex)
 
-        if (match) {
-          fieldName = match[2] // The second group is the field name
+        if (match?.[2] && adapter.fieldConstraints[tableName]) {
+          fieldName = adapter.fieldConstraints[tableName][`${match[2]}_idx`]
         }
       }
 

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -13,7 +13,6 @@ export const PostsCollection: CollectionConfig = {
     {
       name: 'title',
       type: 'text',
-      unique: true,
     },
     {
       name: 'content',

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -13,6 +13,7 @@ export const PostsCollection: CollectionConfig = {
     {
       name: 'title',
       type: 'text',
+      unique: true,
     },
     {
       name: 'content',

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -746,6 +746,16 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      slug: 'unique-fields',
+      fields: [
+        {
+          name: 'slug',
+          type: 'text',
+          unique: true,
+        },
+      ],
+    },
   ],
   globals: [
     {

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -750,7 +750,7 @@ export default buildConfigWithDefaults({
       slug: 'unique-fields',
       fields: [
         {
-          name: 'slug',
+          name: 'slugField',
           type: 'text',
           unique: true,
         },

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2651,7 +2651,7 @@ describe('database', () => {
     await payload.create({
       collection: 'unique-fields',
       data: {
-        slug: 'unique-text',
+        slugField: 'unique-text',
       },
     })
 
@@ -2659,12 +2659,11 @@ describe('database', () => {
       await payload.create({
         collection: 'unique-fields',
         data: {
-          slug: 'unique-text',
+          slugField: 'unique-text',
         },
       })
     } catch (e) {
-      console.log(e)
-      expect((e as ValidationError).message).toEqual('The following field is invalid: slug')
+      expect((e as ValidationError).message).toEqual('The following field is invalid: slugField')
     }
   })
 })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1,7 +1,7 @@
 import type { MongooseAdapter } from '@payloadcms/db-mongodb'
 import type { PostgresAdapter } from '@payloadcms/db-postgres/types'
 import type { NextRESTClient } from 'helpers/NextRESTClient.js'
-import type { Payload, PayloadRequest, TypeWithID } from 'payload'
+import type { Payload, PayloadRequest, TypeWithID, ValidationError } from 'payload'
 
 import {
   migrateRelationshipsV2_V3,
@@ -2645,5 +2645,26 @@ describe('database', () => {
     expect(docs[0].id).toBe(post_null.id)
     expect(docs[1].id).toBe(post_3.id)
     expect(docs[2].id).toBe(post_1.id)
+  })
+
+  it('should throw specific unique contraint errors', async () => {
+    await payload.create({
+      collection: 'unique-fields',
+      data: {
+        slug: 'unique-text',
+      },
+    })
+
+    try {
+      await payload.create({
+        collection: 'unique-fields',
+        data: {
+          slug: 'unique-text',
+        },
+      })
+    } catch (e) {
+      console.log(e)
+      expect((e as ValidationError).message).toEqual('The following field is invalid: slug')
+    }
   })
 })


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12628

When using sqlite, the error from the db is a bit different than Postgres.

This PR allows us to extract the fieldName when using sqlite for the unique constraint error.

#### Postgres error response
![CleanShot 2025-06-09 at 21 33 57@2x](https://github.com/user-attachments/assets/5812145f-d1d0-4d65-a479-00a863054fa0)


#### Sqlite error response
![CleanShot 2025-06-09 at 09 19 47](https://github.com/user-attachments/assets/af284f15-6570-4bab-9199-8a7fd16536be)
