### PR TITLE
perf(ui): do not re-animate drawer on re-render, reduce useEffects

### DIFF
--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Modal, useModal } from '@faceless-ui/modal'
-import React, { createContext, use, useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import React, { createContext, use, useCallback, useLayoutEffect, useState } from 'react'
 
 import type { Props, TogglerProps } from './types.js'
 

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Modal, useModal } from '@faceless-ui/modal'
-import React, { createContext, use, useCallback, useEffect, useState } from 'react'
+import React, { createContext, use, useCallback, useEffect, useLayoutEffect, useState } from 'react'
 
 import type { Props, TogglerProps } from './types.js'
 
@@ -58,14 +58,18 @@ export const Drawer: React.FC<Props> = ({
   const { closeModal, modalState } = useModal()
   const drawerDepth = useDrawerDepth()
 
-  const [isOpen, setIsOpen] = useState(false)
-  const [animateIn, setAnimateIn] = useState(false)
+  const [isOpen, setIsOpen] = useState(modalState[slug]?.isOpen || false)
+  const [animateIn, setAnimateIn] = useState(modalState[slug]?.isOpen || false)
+
+  const openFromContext = modalState[slug]?.isOpen
 
   useEffect(() => {
-    setIsOpen(modalState[slug]?.isOpen)
-  }, [slug, modalState])
+    setIsOpen(openFromContext)
+    // By depending on openFromContext instead of [slug, modalState] we avoid
+    // running the effect when some other, unrelated modal in the same context changes.
+  }, [openFromContext])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setAnimateIn(isOpen)
   }, [isOpen])
 

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -58,16 +58,9 @@ export const Drawer: React.FC<Props> = ({
   const { closeModal, modalState } = useModal()
   const drawerDepth = useDrawerDepth()
 
-  const [isOpen, setIsOpen] = useState(modalState[slug]?.isOpen || false)
-  const [animateIn, setAnimateIn] = useState(modalState[slug]?.isOpen || false)
+  const isOpen = !!modalState[slug]?.isOpen
 
-  const openFromContext = modalState[slug]?.isOpen
-
-  useEffect(() => {
-    setIsOpen(openFromContext)
-    // By depending on openFromContext instead of [slug, modalState] we avoid
-    // running the effect when some other, unrelated modal in the same context changes.
-  }, [openFromContext])
+  const [animateIn, setAnimateIn] = useState(isOpen)
 
   useLayoutEffect(() => {
     setAnimateIn(isOpen)


### PR DESCRIPTION
Previously, every time the drawer re-rendered a new entry animation may be triggered. This PR fixes this by setting the open state to `modalState[slug]?.isOpen` instead of `false`.

Additionally, I was able to simplify this component while maintaining functionality. Got rid of one `useEffect` and one `useState` call. The remaining useEffect also runs less often (previously, it ran every time `modalState` changed => it re-ran if _any_ modal opened or closed, not just the current one)