### PR TITLE
fix(ui): don't enable validation after document was submitted

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -103,6 +103,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const [disabled, setDisabled] = useState(disabledFromProps || false)
   const [isMounted, setIsMounted] = useState(false)
   const [modified, setModified] = useState(false)
+  const [skipValidationOnLastSubmit, setSkipValidationOnLastSubmit] = useState(false)
 
   /**
    * Tracks wether the form state passes validation.
@@ -213,6 +214,11 @@ export const Form: React.FC<FormProps> = (props) => {
         }
         return
       }
+
+      // Remember the submit's `skipValidation` option,
+      // so that Form knows how to retain the same validation behavior for
+      // `onChange` after the submit.
+      setSkipValidationOnLastSubmit(skipValidation)
 
       // create new toast promise which will resolve manually later
       let errorToast, successToast

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -50,7 +50,11 @@ export type FormProps = {
   isDocumentForm?: boolean
   isInitializing?: boolean
   log?: boolean
-  onChange?: ((args: { formState: FormState; submitted?: boolean }) => Promise<FormState>)[]
+  onChange?: ((args: {
+    formState: FormState
+    skipValidationOnLastSubmit?: boolean
+    submitted?: boolean
+  }) => Promise<FormState>)[]
   onSubmit?: (fields: FormState, data: Data) => void
   onSuccess?: (json: unknown) => Promise<FormState | void> | void
   redirect?: string

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -330,7 +330,7 @@ export function DefaultEditView({
   )
 
   const onChange: FormProps['onChange'][0] = useCallback(
-    async ({ formState: prevFormState }) => {
+    async ({ formState: prevFormState, skipValidationOnLastSubmit, submitted }) => {
       const controller = handleAbortRef(abortOnChangeRef)
 
       const currentTime = Date.now()
@@ -352,7 +352,10 @@ export function DefaultEditView({
         formState: prevFormState,
         globalSlug,
         operation,
-        skipValidation: true,
+        // Only run validation on change once the form has been submitted,
+        // but only if the submit action didn't skip validation
+        // (saving drafts skips validation, publish changes does not).
+        skipValidation: submitted ? skipValidationOnLastSubmit : true,
         // Performance optimization: Setting it to false ensure that only fields that have explicit requireRender set in the form state will be rendered (e.g. new array rows).
         // We only want to render ALL fields on initial render, not in onChange.
         renderAllFields: false,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -330,7 +330,7 @@ export function DefaultEditView({
   )
 
   const onChange: FormProps['onChange'][0] = useCallback(
-    async ({ formState: prevFormState, submitted }) => {
+    async ({ formState: prevFormState }) => {
       const controller = handleAbortRef(abortOnChangeRef)
 
       const currentTime = Date.now()
@@ -352,7 +352,7 @@ export function DefaultEditView({
         formState: prevFormState,
         globalSlug,
         operation,
-        skipValidation: !submitted,
+        skipValidation: true,
         // Performance optimization: Setting it to false ensure that only fields that have explicit requireRender set in the form state will be rendered (e.g. new array rows).
         // We only want to render ALL fields on initial render, not in onChange.
         renderAllFields: false,


### PR DESCRIPTION
### What?

Don't enable validation after a document was submitted.

### Why?

When a user is editing a draft, the validation should always be skipped. Saving should e.g. be possible even if a required field is not filled yet, since a draft is just work in progress. Only the published document needs to fulfill the
validation rules.

So far, saving a document (draft) enabled the validation. 

This meant that there was circumstances in which the UI suggested to the user that
a draft needed to fulfill all publishing validation, e.g. in the following situation:
- A collection has versioning enabled.
- Saving a draft failed (e.g. a `beforeChange` hook threw an
  `APIError`).

Demo of old behavior:

![2025-06-10 18 06 44](https://github.com/user-attachments/assets/9e6616b9-5e12-49f3-8fd9-cd212f642499)

Demo of new behavior:

![2025-06-18 09 57 37](https://github.com/user-attachments/assets/0679c816-7428-42cc-8ea2-3943cb99a3e6)

### How to test

E.g. change `test/versions/collections` to:

```ts
import type { CollectionConfig } from 'payload'

import { APIError } from 'payload'
import { lexicalEditor } from '@payloadcms/richtext-lexical'

import {
  postCollectionSlug,
} from '../slugs.js'

const Posts: CollectionConfig = {
  slug: postCollectionSlug,
  admin: {
    useAsTitle: 'title',
  },
  fields: [
    {
      name: 'title',
      type: 'text',
      required: true,
    },
    {
      name: 'content',
      type: 'richText',
      required: true,
      editor: lexicalEditor({
        features: ({ defaultFeatures }) => [...defaultFeatures],
      }),
      hooks: {
        beforeChange: [
          (args) => {
            console.log(args)

            if (args?.data?.title?.includes('b')) {
              throw new APIError('forbidden character b', 422)
            }
          },
        ],
      },
    },
  ],
  versions: {
    drafts: true,
    maxPerDoc: 0 /* unlimited */,
  },
}

export default Posts
```