### PR TITLE
fix(plugin-redirects): add missing optional chaining

### DIFF
--- a/packages/plugin-redirects/src/types.ts
+++ b/packages/plugin-redirects/src/types.ts
@@ -4,7 +4,7 @@ import type { redirectTypes } from './redirectTypes.js'
 export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 
 export type RedirectsPluginConfig = {
-  collections: string[]
+  collections?: string[]
   overrides?: { fields?: FieldsOverride } & Partial<Omit<CollectionConfig, 'fields'>>
   redirectTypeFieldOverride?: Partial<SelectField>
   redirectTypes?: (typeof redirectTypes)[number][]

--- a/packages/plugin-redirects/src/types.ts
+++ b/packages/plugin-redirects/src/types.ts
@@ -4,7 +4,7 @@ import type { redirectTypes } from './redirectTypes.js'
 export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 
 export type RedirectsPluginConfig = {
-  collections?: string[]
+  collections: string[]
   overrides?: { fields?: FieldsOverride } & Partial<Omit<CollectionConfig, 'fields'>>
   redirectTypeFieldOverride?: Partial<SelectField>
   redirectTypes?: (typeof redirectTypes)[number][]

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -139,7 +139,7 @@ export const AddNewRelation: React.FC<Props> = ({
   }, [isDrawerOpen, relatedToMany])
 
   const label = t('fields:addNewLabel', {
-    label: getTranslation(relatedCollections[0].labels.singular, i18n),
+    label: getTranslation(relatedCollections[0]?.labels.singular, i18n),
   })
 
   if (show) {


### PR DESCRIPTION
### What?
Updates the redirects plugin types to make collections a required type

### Why?
Currently not including the collections object when importing the plugin causes an error to occur when going to the page in the UI, also it cannot generate types. Likely due to it unable to make a reference to a collection.

### How?
Makes collections required

Fixes #12709 
