### PR TITLE
fix: orderable has incorrect sort results depending on capitalization

### DIFF
--- a/packages/payload/src/config/orderable/fractional-indexing.js
+++ b/packages/payload/src/config/orderable/fractional-indexing.js
@@ -13,7 +13,7 @@
 
 // This is based on https://observablehq.com/@dgreensp/implementing-fractional-indexing
 
-export const BASE_62_DIGITS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+export const BASE_36_DIGITS = '0123456789abcdefghijklmnopqrstuvwxyz'
 
 // `a` may be empty string, `b` is null or non-empty string.
 // `a < b` lexicographically if `b` is non-null.
@@ -215,7 +215,7 @@ function decrementInteger(x, digits) {
  * @param {string=} digits
  * @return {string}
  */
-export function generateKeyBetween(a, b, digits = BASE_62_DIGITS) {
+export function generateKeyBetween(a, b, digits = BASE_36_DIGITS) {
   if (a != null) {
     validateOrderKey(a, digits)
   }
@@ -283,7 +283,7 @@ export function generateKeyBetween(a, b, digits = BASE_62_DIGITS) {
  * @param {string} digits
  * @return {string[]}
  */
-export function generateNKeysBetween(a, b, n, digits = BASE_62_DIGITS) {
+export function generateNKeysBetween(a, b, n, digits = BASE_36_DIGITS) {
   if (n === 0) {
     return []
   }


### PR DESCRIPTION
### What?
The results when querying orderable collections can be incorrect due to how the underlying database handles sorting when capitalized letters are introduced.

### Why?
The original fractional indexing logic uses base 62 characters to maximize the amount of data per character. This optimization saves a few characters of text in the database but fails to return accurate results when mixing uppercase and lowercase characters. 

### How?
Instead we can use base 36 values instead (0-9,a-z) so that all databases handle the sort consistently without needing to introduce collation or other alternate solutions.

Fixes #12397