### PR TITLE
fix: error when saving global with versioning enabled

### DIFF
--- a/packages/payload/src/versions/getLatestGlobalVersion.ts
+++ b/packages/payload/src/versions/getLatestGlobalVersion.ts
@@ -1,5 +1,6 @@
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { Document, Payload, PayloadRequest, Where } from '../types/index.js'
+import type { TypeWithVersion } from './types.js'
 
 type Args = {
   config: SanitizedGlobalConfig
@@ -20,7 +21,7 @@ export const getLatestGlobalVersion = async ({
   req,
   where,
 }: Args): Promise<{ global: Document; globalExists: boolean }> => {
-  let latestVersion
+  let latestVersion: TypeWithVersion<Document> | undefined
 
   const whereQuery = published
     ? { 'version._status': { equals: 'published' } }
@@ -52,9 +53,6 @@ export const getLatestGlobalVersion = async ({
       global,
       globalExists,
     }
-  }
-  if (!('createdAt' in latestVersion.version) || !('updatedAt' in latestVersion.version)) {
-    throw new Error('Could not find createdAt or updatedAt in latestVersion.version')
   }
 
   if (!latestVersion.version.createdAt) {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1540,6 +1540,30 @@ describe('Versions', () => {
         expect(globalLocalVersionID).toBeDefined()
       })
 
+      it('ensure global can be published after saving draft', async () => {
+        const draftVersion = await payload.updateGlobal({
+          slug: 'max-versions',
+          draft: true,
+          data: {
+            title: 'Draft',
+            _status: 'draft',
+          },
+        })
+        expect(draftVersion.title).toStrictEqual('Draft')
+        expect(draftVersion._status).toStrictEqual('draft')
+
+        const publishedVersion = await payload.updateGlobal({
+          slug: 'max-versions',
+          draft: false,
+          data: {
+            title: 'Published',
+            _status: 'published',
+          },
+        })
+        expect(publishedVersion.title).toStrictEqual('Published')
+        expect(publishedVersion._status).toStrictEqual('published')
+      })
+
       it('should have different createdAt in a new version while the same version.createdAt', async () => {
         const doc = await payload.updateGlobal({
           slug: autoSaveGlobalSlug,


### PR DESCRIPTION
When saving a global with versioning enabled as draft, and then publishing it, the following error may appear: `[16:50:35] ERROR: Could not find createdAt or updatedAt in latestVersion.version`

This is due to an incorrect check to appease typescript strict mode. We shouldn't throw if `version.updatedAt` doesn't exist - the purpose of this logic is to add that property if it doesn't exist

