### PR TITLE
fix(plugin-nested-docs): check error name that is changed at compile time

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -6,7 +6,7 @@ import type {
   ValidationError,
 } from 'payload'
 
-import { APIError } from 'payload'
+import { APIError, ValidationErrorName } from 'payload'
 
 import type { NestedDocsPluginConfig } from '../types.js'
 
@@ -96,7 +96,7 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
         req.payload.logger.error(err)
 
         if (
-          (err as ValidationError)?.name === 'ValidationError' &&
+          (err as ValidationError)?.name === ValidationErrorName &&
           (err as ValidationError)?.data?.errors?.length
         ) {
           throw new APIError(


### PR DESCRIPTION
Since `ValidationErrorName` [gets dynamically reassigned during compilation](https://github.com/payloadcms/payload/blob/main/packages/payload/src/errors/ValidationError.ts#L11), we must reference the variable rather than use a static string to compare against