### PR TITLE
fix: filtering joins in `where` by ID

### DIFF
--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -355,11 +355,7 @@ export const getTableColumnFromPath = ({
           throw new APIError('Not supported')
         }
 
-        let newCollectionPath = pathSegments.slice(1).join('.')
-        // where: { relatedPosts: { equals: 1}} -> { 'relatedPosts.id': { equals: 1}}
-        if (!newCollectionPath) {
-          newCollectionPath = 'id'
-        }
+        const newCollectionPath = pathSegments.slice(1).join('.')
 
         if (field.hasMany) {
           const relationTableName = `${adapter.tableNameMap.get(toSnakeCase(field.collection))}${adapter.relationshipsSuffix}`

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -104,6 +104,12 @@ export async function validateSearchParam({
         return
       }
 
+      // where: { relatedPosts: { equals: 1}} -> { 'relatedPosts.id': { equals: 1}}
+      if (field.type === 'join' && path === incomingPath) {
+        constraint[`${path}.id` as keyof WhereField] = constraint[path as keyof WhereField]
+        delete constraint[path as keyof WhereField]
+      }
+
       if ('virtual' in field && field.virtual) {
         if (field.virtual === true) {
           errors.push({ path })

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -1619,6 +1619,31 @@ describe('Joins Field', () => {
     expect(found.docs[0].id).toBe(category.id)
   })
 
+  it('should support where querying by a join field as ID', async () => {
+    const category = await payload.create({ collection: 'categories', data: {} })
+    const post = await payload.create({
+      collection: 'posts',
+      data: { category: category.id, title: 'my-title' },
+    })
+    const found_1 = await payload.find({
+      collection: 'categories',
+      where: { 'relatedPosts.id': { equals: post.id } },
+      overrideAccess: true,
+    })
+
+    expect(found_1.docs).toHaveLength(1)
+    expect(found_1.docs[0].id).toBe(category.id)
+
+    const found_2 = await payload.find({
+      collection: 'categories',
+      where: { relatedPosts: { equals: post.id } },
+      overrideAccess: true,
+    })
+
+    expect(found_2.docs).toHaveLength(1)
+    expect(found_2.docs[0].id).toBe(category.id)
+  })
+
   it('should support where querying by a join field with hasMany relationship', async () => {
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12768

Example:
```
const found_1 = await payload.find({
  collection: 'categories',
  where: { 'relatedPosts.id': { equals: post.id } },
})
```
or
```
const found_2 = await payload.find({
  collection: 'categories',
  where: { relatedPosts: { equals: post.id } },
})
```