### PR TITLE
fix(plugin-import-export): download button in collection edit view

### DIFF
--- a/packages/plugin-import-export/src/getExportCollection.ts
+++ b/packages/plugin-import-export/src/getExportCollection.ts
@@ -29,6 +29,11 @@ export const getExportCollection = ({
       update: () => false,
     },
     admin: {
+      components: {
+        edit: {
+          SaveButton: '@payloadcms/plugin-import-export/rsc#ExportSaveButton',
+        },
+      },
       group: false,
       useAsTitle: 'name',
     },

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -1,4 +1,4 @@
-import type { Config, JobsConfig } from 'payload'
+import type { Config } from 'payload'
 
 import { deepMergeSimple } from 'payload'
 

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -48,12 +48,6 @@ export const importExportPlugin =
       if (!components.listMenuItems) {
         components.listMenuItems = []
       }
-      if (!components.edit) {
-        components.edit = {}
-      }
-      if (!components.edit.SaveButton) {
-        components.edit.SaveButton = '@payloadcms/plugin-import-export/rsc#ExportSaveButton'
-      }
       components.listMenuItems.push({
         clientProps: {
           exportCollectionSlug: exportCollection.slug,


### PR DESCRIPTION
The custom save button showing on export enabled collections in the edit view. Instead it was meant to only appear in the export collection. This makes it so it only appears in the export drawer.
