### PR TITLE
fix: ensure job autoruns are not triggered if jobs collection not enabled

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -51,6 +51,7 @@ import type {
   TypedUser,
 } from '../index.js'
 import type { QueryPreset, QueryPresetConstraints } from '../query-presets/types.js'
+import type { SanitizedJobsConfig } from '../queues/config/types/index.js'
 import type { PayloadRequest, Where } from '../types/index.js'
 import type { PayloadLogger } from '../utilities/logger.js'
 
@@ -1250,7 +1251,7 @@ export type SanitizedConfig = {
   endpoints: Endpoint[]
   globals: SanitizedGlobalConfig[]
   i18n: Required<I18nOptions>
-  jobs: JobsConfig // Redefine here, as the DeepRequired<Config> can break its type
+  jobs: SanitizedJobsConfig
   localization: false | SanitizedLocalizationConfig
   paths: {
     config: string
@@ -1275,6 +1276,7 @@ export type SanitizedConfig = {
   | 'endpoint'
   | 'globals'
   | 'i18n'
+  | 'jobs'
   | 'localization'
   | 'upload'
 >

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -772,7 +772,7 @@ export class BasePayload {
       throw error
     }
 
-    if (this.config.jobs.autoRun && !isNextBuild()) {
+    if (this.config.jobs.enabled && this.config.jobs.autoRun && !isNextBuild()) {
       const DEFAULT_CRON = '* * * * *'
       const DEFAULT_LIMIT = 10
 

--- a/packages/payload/src/queues/config/index.ts
+++ b/packages/payload/src/queues/config/index.ts
@@ -8,7 +8,7 @@ import { getJobTaskStatus } from '../utilities/getJobTaskStatus.js'
 
 export const jobsCollectionSlug = 'payload-jobs'
 
-export const getDefaultJobsCollection: (config: Config) => CollectionConfig | null = (config) => {
+export const getDefaultJobsCollection: (config: Config) => CollectionConfig = (config) => {
   const workflowSlugs: Set<string> = new Set()
   const taskSlugs: Set<string> = new Set(['inline'])
 

--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -42,6 +42,13 @@ export type RunJobAccessArgs = {
 
 export type RunJobAccess = (args: RunJobAccessArgs) => boolean | Promise<boolean>
 
+export type SanitizedJobsConfig = {
+  /**
+   * If set to `true`, the job system is enabled and a payload-jobs collection exists.
+   * This property is automatically set during sanitization.
+   */
+  enabled?: boolean
+} & JobsConfig
 export type JobsConfig = {
   /**
    * Specify access control to determine who can interact with jobs.

--- a/packages/payload/src/queues/restEndpointRun.ts
+++ b/packages/payload/src/queues/restEndpointRun.ts
@@ -3,18 +3,7 @@ import type { Endpoint, SanitizedConfig } from '../config/types.js'
 import { runJobs, type RunJobsArgs } from './operations/runJobs/index.js'
 
 const configHasJobs = (config: SanitizedConfig): boolean => {
-  if (!config.jobs) {
-    return false
-  }
-
-  if (config.jobs.tasks?.length > 0) {
-    return true
-  }
-  if (config.jobs.workflows?.length > 0) {
-    return true
-  }
-
-  return false
+  return Boolean(config.jobs?.tasks?.length || config.jobs?.workflows?.length)
 }
 
 export const runJobsEndpoint: Endpoint = {
@@ -28,7 +17,9 @@ export const runJobsEndpoint: Endpoint = {
       )
     }
 
-    const hasAccess = await req.payload.config.jobs.access.run({ req })
+    const accessFn = req.payload.config.jobs?.access?.run ?? (() => true)
+
+    const hasAccess = await accessFn({ req })
 
     if (!hasAccess) {
       return Response.json(


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12776

- Adds a new `jobs.config.enabled` property to the sanitized config, which can be used to easily check if the jobs system is enabled (i.e., if the payload-jobs collection was added during sanitization). This is then checked before Payload sets up job autoruns.
- Fixes some type issues that occurred due to still deep-requiring the jobs config - we forgot to omit it from the `DeepRequired(Config)` call. The deep-required jobs config was then incorrectly merged with the sanitized jobs config, resulting in a SanitizedConfig where all jobs config properties were marked as required, even though they may be undefined.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210546736100115