### PR TITLE
examples: fix broken navigation to post in localization example

### DIFF
--- a/examples/localization/src/components/Card/index.tsx
+++ b/examples/localization/src/components/Card/index.tsx
@@ -2,6 +2,7 @@
 import { cn } from '@/utilities/ui'
 import useClickableCard from '@/utilities/useClickableCard'
 import Link from 'next/link'
+import { useLocale } from 'next-intl';
 import React, { Fragment } from 'react'
 
 import type { Post } from '@/payload-types'
@@ -16,6 +17,7 @@ export const Card: React.FC<{
   showCategories?: boolean
   title?: string
 }> = (props) => {
+  const locale = useLocale();
   const { card, link } = useClickableCard({})
   const { className, doc, relationTo, showCategories, title: titleFromProps } = props
 
@@ -25,7 +27,7 @@ export const Card: React.FC<{
   const hasCategories = categories && Array.isArray(categories) && categories.length > 0
   const titleToUse = titleFromProps || title
   const sanitizedDescription = description?.replace(/\s/g, ' ') // replace non-breaking space with white space
-  const href = `/${relationTo}/${slug}`
+  const href = `/${locale}/${relationTo}/${slug}`
 
   return (
     <article


### PR DESCRIPTION
This pull request updates the `Card` component in the localization example to support localized URLs. The most significant changes include importing a new hook for locale management and modifying the URL generation logic to include the locale.

Localization updates:

* [`examples/localization/src/components/Card/index.tsx`](diffhunk://#diff-619212c47638e7ff51284c62740ba188c87f008d481442b7f4951e2c150a2415R5): Imported `useLocale` from `next-intl` to manage locale-based functionality.
* [`examples/localization/src/components/Card/index.tsx`](diffhunk://#diff-619212c47638e7ff51284c62740ba188c87f008d481442b7f4951e2c150a2415R20): Added a `locale` constant using the `useLocale` hook to retrieve the current locale.
* [`examples/localization/src/components/Card/index.tsx`](diffhunk://#diff-619212c47638e7ff51284c62740ba188c87f008d481442b7f4951e2c150a2415L28-R30): Updated the `href` generation logic to include the locale in the URL structure, ensuring localized navigation.