### PR TITLE
fix(ui): should select document after creation from relationship field

### DIFF
--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
@@ -25,11 +25,7 @@ $lexical-contenteditable-bottom-padding: 8px;
     }
   }
 
-  .rich-text-lexical--show-gutter
-    > .rich-text-lexical__wrap
-    > .editor-container
-    > .editor-scroller
-    > .editor {
+  .rich-text-lexical > .rich-text-lexical__wrap > .editor-container > .editor-scroller > .editor {
     > .ContentEditable__root {
       padding-left: 3rem;
     }
@@ -46,7 +42,7 @@ $lexical-contenteditable-bottom-padding: 8px;
   }
 
   html[data-theme='light'] {
-    .rich-text-lexical.rich-text-lexical--show-gutter {
+    .rich-text-lexical {
       &.error:not(:hover) {
         > .rich-text-lexical__wrap
           > .editor-container
@@ -70,7 +66,7 @@ $lexical-contenteditable-bottom-padding: 8px;
   }
 
   html[data-theme='dark'] {
-    .rich-text-lexical.rich-text-lexical--show-gutter {
+    .rich-text-lexical {
       &.error {
         > .rich-text-lexical__wrap
           > .editor-container
@@ -78,6 +74,21 @@ $lexical-contenteditable-bottom-padding: 8px;
           > .editor
           > .ContentEditable__root::before {
           border-left: 2px solid var(--theme-error-500);
+        }
+      }
+    }
+  }
+
+  @include small-break {
+    .rich-text-lexical {
+      &.error {
+        > .rich-text-lexical__wrap
+          > .editor-container
+          > .editor-scroller
+          > .editor
+          > .ContentEditable__root::before {
+          top: 0;
+          height: 100%;
         }
       }
     }

--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
@@ -25,7 +25,11 @@ $lexical-contenteditable-bottom-padding: 8px;
     }
   }
 
-  .rich-text-lexical > .rich-text-lexical__wrap > .editor-container > .editor-scroller > .editor {
+  .rich-text-lexical--show-gutter
+    > .rich-text-lexical__wrap
+    > .editor-container
+    > .editor-scroller
+    > .editor {
     > .ContentEditable__root {
       padding-left: 3rem;
     }
@@ -42,7 +46,7 @@ $lexical-contenteditable-bottom-padding: 8px;
   }
 
   html[data-theme='light'] {
-    .rich-text-lexical {
+    .rich-text-lexical.rich-text-lexical--show-gutter {
       &.error:not(:hover) {
         > .rich-text-lexical__wrap
           > .editor-container
@@ -66,7 +70,7 @@ $lexical-contenteditable-bottom-padding: 8px;
   }
 
   html[data-theme='dark'] {
-    .rich-text-lexical {
+    .rich-text-lexical.rich-text-lexical--show-gutter {
       &.error {
         > .rich-text-lexical__wrap
           > .editor-container
@@ -74,21 +78,6 @@ $lexical-contenteditable-bottom-padding: 8px;
           > .editor
           > .ContentEditable__root::before {
           border-left: 2px solid var(--theme-error-500);
-        }
-      }
-    }
-  }
-
-  @include small-break {
-    .rich-text-lexical {
-      &.error {
-        > .rich-text-lexical__wrap
-          > .editor-container
-          > .editor-scroller
-          > .editor
-          > .ContentEditable__root::before {
-          top: 0;
-          height: 100%;
         }
       }
     }

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -52,7 +52,13 @@ export const AddNewRelation: React.FC<Props> = ({
 
   const onSave: DocumentDrawerContextType['onSave'] = useCallback(
     ({ doc, operation }) => {
-      if (operation === 'create') {
+      // if autosave is enabled, the operation will be 'update'
+      const isAutosaveEnabled =
+        typeof collectionConfig?.versions?.drafts === 'object'
+          ? collectionConfig.versions.drafts.autosave
+          : false
+
+      if (operation === 'create' || (operation === 'update' && isAutosaveEnabled)) {
         // ensure the value is not already in the array
         let isNewValue = false
         if (!value) {

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -95,18 +95,18 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   // Store fields in ref so the autosave func
   // can always retrieve the most to date copies
   // after the timeout has executed
-   
+  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
   fieldRef.current = fields
 
   // Store modified in ref so the autosave func
   // can bail out if modified becomes false while
   // timing out during autosave
-   
+  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
   modifiedRef.current = modified
 
   // Store locale in ref so the autosave func
   // can always retrieve the most to date locale
-   
+  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
   localeRef.current = locale
 
   const { queueTask } = useQueues()

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -23,6 +23,7 @@ import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { formatTimeToNow } from '../../utilities/formatDocTitle/formatDateTitle.js'
 import { reduceFieldsToValuesWithValidation } from '../../utilities/reduceFieldsToValuesWithValidation.js'
+import { useDocumentDrawerContext } from '../DocumentDrawer/Provider.js'
 import { LeaveWithoutSaving } from '../LeaveWithoutSaving/index.js'
 import './index.scss'
 
@@ -55,6 +56,8 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     setUnpublishedVersionCount,
     updateSavedDocumentData,
   } = useDocumentInfo()
+
+  const { onSave: onSaveFromDocumentDrawer } = useDocumentDrawerContext()
 
   const { reportUpdate } = useDocumentEvents()
   const { dispatchFields, isValid, setBackgroundProcessing, setIsValid, setSubmitted } = useForm()
@@ -92,18 +95,18 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   // Store fields in ref so the autosave func
   // can always retrieve the most to date copies
   // after the timeout has executed
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
+   
   fieldRef.current = fields
 
   // Store modified in ref so the autosave func
   // can bail out if modified becomes false while
   // timing out during autosave
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
+   
   modifiedRef.current = modified
 
   // Store locale in ref so the autosave func
   // can always retrieve the most to date locale
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
+   
   localeRef.current = locale
 
   const { queueTask } = useQueues()
@@ -183,6 +186,8 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
                 // We need to log the time in order to figure out if we need to trigger the state off later
                 endTimestamp = newDate.getTime()
 
+                const json = await res.json()
+
                 if (res.status === 200) {
                   setLastUpdateTime(newDate.getTime())
 
@@ -192,13 +197,20 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
                     updatedAt: newDate.toISOString(),
                   })
 
+                  // if onSaveFromDocumentDrawer is defined, call it
+                  if (typeof onSaveFromDocumentDrawer === 'function') {
+                    void onSaveFromDocumentDrawer({
+                      ...json,
+                      operation: 'update',
+                    })
+                  }
+
                   if (!mostRecentVersionIsAutosaved) {
                     incrementVersionCount()
                     setMostRecentVersionIsAutosaved(true)
                     setUnpublishedVersionCount((prev) => prev + 1)
                   }
                 }
-                const json = await res.json()
 
                 if (versionsConfig?.drafts && versionsConfig?.drafts?.validate && json?.errors) {
                   if (Array.isArray(json.errors)) {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -175,6 +175,36 @@ describe('Versions', () => {
       }).toPass({ timeout: 10000, intervals: [100] })
     })
 
+    test('autosave relationships - should select doc after creating from relationship field', async () => {
+      await page.goto(postURL.create)
+      const autosaveRelationField = page.locator('#field-relationToAutosaves')
+      await expect(autosaveRelationField).toBeVisible()
+      const addNewButton = autosaveRelationField.locator(
+        '.relationship-add-new__add-button.doc-drawer__toggler',
+      )
+      await addNewButton.click()
+      const titleField = page.locator('#field-title')
+      const descriptionField = page.locator('#field-description')
+      await titleField.fill('test')
+      await descriptionField.fill('test')
+
+      const createdDate = await page.textContent(
+        'li:has(p:has-text("Created:")) .doc-controls__value',
+      )
+
+      // wait for modified date and created date to be different
+      await expect(async () => {
+        const modifiedDateLocator = page.locator(
+          'li:has(p:has-text("Last Modified:")) .doc-controls__value',
+        )
+        await expect(modifiedDateLocator).not.toHaveText(createdDate ?? '')
+      }).toPass({ timeout: POLL_TOPASS_TIMEOUT, intervals: [100] })
+
+      const closeDrawer = page.locator('.doc-drawer__header-close')
+      await closeDrawer.click()
+      const fieldValue = autosaveRelationField.locator('.value-container')
+      await expect(fieldValue).toContainText('test')
+    })
     test('should show collection versions view level action in collection versions view', async () => {
       await page.goto(url.list)
       await page.locator('tbody tr .cell-title a').first().click()


### PR DESCRIPTION
### What?
After creating a new document from a relationship field, this doc should automatically become the selected document for that relationship field. This is the expected and current behavior. However, when the relationship ties to a collection with autosave enabled, this does not happen. 

### Why?
This is expected behavior and should still happen when the relationship is using an autosave enabled collection.

### How?
1. The logic in `addNewRelation` contained an `if` statement that checked for `operation === 'create'` - however when autosave is enabled, the `create` operation runs on the first data update and subsequently it is a `update` operation.
2. The `onSave` from the document drawer provider was not being run as part of the autosave workflow.

#### Reported by client.