### PR TITLE
fix(richtext-lexical): consistent html converter inline padding

### DIFF
--- a/packages/richtext-lexical/src/features/blockquote/server/index.ts
+++ b/packages/richtext-lexical/src/features/blockquote/server/index.ts
@@ -53,7 +53,7 @@ export const BlockquoteFeature = createServerFeature({
               })
               const style = [
                 node.format ? `text-align: ${node.format};` : '',
-                node.indent > 0 ? `padding-inline-start: ${node.indent * 40}px;` : '',
+                node.indent > 0 ? `padding-inline-start: ${Number(node.indent) * 2}rem;` : '',
               ]
                 .filter(Boolean)
                 .join(' ')

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/shared/findConverterForNode.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/shared/findConverterForNode.ts
@@ -83,7 +83,7 @@ export function findConverterForNode<
 
   if (!disableIndent && (!Array.isArray(disableIndent) || !disableIndent?.includes(node.type))) {
     if ('indent' in node && node.indent && node.type !== 'listitem') {
-      style['padding-inline-start'] = `${Number(node.indent) * 2}em`
+      style['padding-inline-start'] = `${Number(node.indent) * 2}rem`
     }
   }
 

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/converter/converters/paragraph.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/converter/converters/paragraph.ts
@@ -31,7 +31,7 @@ export const ParagraphHTMLConverter: HTMLConverter<SerializedParagraphNode> = {
     })
     const style = [
       node.format ? `text-align: ${node.format};` : '',
-      node.indent > 0 ? `padding-inline-start: ${node.indent * 40}px;` : '',
+      node.indent > 0 ? `padding-inline-start: ${Number(node.indent) * 2}rem;` : '',
     ]
       .filter(Boolean)
       .join(' ')

--- a/packages/richtext-lexical/src/features/heading/server/index.ts
+++ b/packages/richtext-lexical/src/features/heading/server/index.ts
@@ -71,7 +71,7 @@ export const HeadingFeature = createServerFeature<
                 })
                 const style = [
                   node.format ? `text-align: ${node.format};` : '',
-                  node.indent > 0 ? `padding-inline-start: ${node.indent * 40}px;` : '',
+                  node.indent > 0 ? `padding-inline-start: ${Number(node.indent) * 2}rem;` : '',
                 ]
                   .filter(Boolean)
                   .join(' ')


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12847

- Uses rem instead of em for inline padding, for indent consistency between nodes with different font sizes
- Use rem instead of px in deprecated html converters for consistency

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210564720112211