### PR TITLE
fix(db-mongodb): Do not add fallback sort if user sent a sort order

### DIFF
--- a/packages/db-mongodb/src/queries/buildSortParam.ts
+++ b/packages/db-mongodb/src/queries/buildSortParam.ts
@@ -158,7 +158,7 @@ export const buildSortParam = ({
     fallbackSort = '-createdAt'
   }
 
-  if (!(sort.includes(fallbackSort) || sort.includes(fallbackSort.replace('-', '')))) {
+  if (!sort?.length  && (!(sort.includes(fallbackSort) || sort.includes(fallbackSort.replace('-', ''))))) {
     sort.push(fallbackSort)
   }
 


### PR DESCRIPTION
the current code pushes -createdAt sort even if user sent a sort order , which makes it dual sort and causes performance issue, only visible in large database, if user sent a sort do not add any other sort, fixes this https://github.com/payloadcms/payload/issues/12690

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
