### PR TITLE
fix: richTextField supports beforeInput/afterInput, but these were missing from types.ts

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1268,6 +1268,8 @@ export type RichTextField<
 > = {
   admin?: {
     components?: {
+      afterInput?: CustomComponent[]
+      beforeInput?: CustomComponent[]
       Error?: CustomComponent
       Label?: CustomComponent
     } & Admin['components']


### PR DESCRIPTION
Add `afterInput` and `beforeInput` to `admin.components` of RichTextField type. These props are supported but missing from types.