### PR TITLE
docs(examples): fix typo on authentication overview page

### DIFF
--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -178,7 +178,7 @@ All auth-related operations are available via Payload's REST, Local, and GraphQL
 
 ## Strategies
 
-Out of the box Payload ships with a three powerful Authentication strategies:
+Out of the box Payload ships with three powerful Authentication strategies:
 
 - [HTTP-Only Cookies](./cookies)
 - [JSON Web Tokens (JWT)](./jwt)


### PR DESCRIPTION
This is teeny tiny – the sentence "Out of the box Payload ships with a three powerful Authentication strategies:" has an unnecessary "a" on the Authentication overview page. This PR removes it.
