### PR TITLE
fix(ui): remember `skipValidation` across form submits

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -104,6 +104,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const [disabled, setDisabled] = useState(disabledFromProps || false)
   const [isMounted, setIsMounted] = useState(false)
   const [modified, setModified] = useState(false)
+  const [skipValidationOnLastSubmit, setSkipValidationOnLastSubmit] = useState(false)
 
   /**
    * Tracks wether the form state passes validation.
@@ -214,6 +215,11 @@ export const Form: React.FC<FormProps> = (props) => {
         }
         return
       }
+
+      // Remember the submit's `skipValidation` option,
+      // so that Form knows how to retain the same validation behavior for
+      // `onChange` after the submit.
+      setSkipValidationOnLastSubmit(skipValidation)
 
       // create new toast promise which will resolve manually later
       let errorToast, successToast

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -50,7 +50,11 @@ export type FormProps = {
   isDocumentForm?: boolean
   isInitializing?: boolean
   log?: boolean
-  onChange?: ((args: { formState: FormState; submitted?: boolean }) => Promise<FormState>)[]
+  onChange?: ((args: {
+    formState: FormState
+    skipValidationOnLastSubmit?: boolean
+    submitted?: boolean
+  }) => Promise<FormState>)[]
   onSubmit?: (fields: FormState, data: Data) => void
   onSuccess?: (json: unknown) => Promise<FormState | void> | void
   redirect?: string

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -335,7 +335,7 @@ export function DefaultEditView({
   )
 
   const onChange: FormProps['onChange'][0] = useCallback(
-    async ({ formState: prevFormState, submitted }) => {
+    async ({ formState: prevFormState, skipValidationOnLastSubmit, submitted }) => {
       const controller = handleAbortRef(abortOnChangeRef)
 
       const currentTime = Date.now()
@@ -357,7 +357,10 @@ export function DefaultEditView({
         formState: prevFormState,
         globalSlug,
         operation,
-        skipValidation: !submitted,
+        // Only run validation on change once the form has been submitted,
+        // but only if the submit action didn't skip validation
+        // (saving drafts skips validation, publish changes does not).
+        skipValidation: submitted ? skipValidationOnLastSubmit : true,
         // Performance optimization: Setting it to false ensure that only fields that have explicit requireRender set in the form state will be rendered (e.g. new array rows).
         // We only want to render ALL fields on initial render, not in onChange.
         renderAllFields: false,


### PR DESCRIPTION
This is a replacement PR for #12748.

### What?

The change allows the UI to retain the validation mode of the last submit action:

- When a user presses "Publish changes", validation is enabled. If validation fails (and blocks the publish), publishig validation stays enabled as the user keeps interacting with the form.
- When a user presses "Save draft", validation is disabled. When the user keeps interacting with the form, the validation remains disabled.

Demo of this PR's behavior:

https://github.com/user-attachments/assets/8881c260-2983-4778-b09c-2a528a647129

### Why?

Before this change, situations could be provoked in which after failing to submit a draft, the publishing validation was suddenly running, which was confusing for users. For precise reproduction steps of such behavior, see #12748.

Exemplary demo of unexpected old behavior in certain circumstances:

![2025-06-10 18 06 44](https://github.com/user-attachments/assets/9e6616b9-5e12-49f3-8fd9-cd212f642499)

### How?

There's new form state, `skipValidationOnLastSubmit`, which is updated with the `skipValidation` boolean value of form submit. This state is passed on to the edit view's `onChange` handler, allowing it to know the right `skipValidation` value to use for consistency with the last submit.

