### PR TITLE
fix(next): remove error handling from next auth functions

### DIFF
--- a/packages/next/src/auth/login.ts
+++ b/packages/next/src/auth/login.ts
@@ -2,8 +2,7 @@
 
 import type { CollectionSlug } from 'payload'
 
-import { cookies as getCookies } from 'next/headers.js'
-import { generatePayloadCookie, getPayload } from 'payload'
+import { getPayload } from 'payload'
 
 import { setPayloadAuthCookie } from '../utilities/setPayloadAuthCookie.js'
 
@@ -31,6 +30,7 @@ export async function login({ collection, config, email, password, username }: L
   const payload = await getPayload({ config })
 
   const authConfig = payload.collections[collection]?.config.auth
+
   if (!authConfig) {
     throw new Error(`No auth config found for collection: ${collection}`)
   }
@@ -61,27 +61,22 @@ export async function login({ collection, config, email, password, username }: L
     loginData = { email, password }
   }
 
-  try {
-    const result = await payload.login({
-      collection,
-      data: loginData,
+  const result = await payload.login({
+    collection,
+    data: loginData,
+  })
+
+  if (result.token) {
+    await setPayloadAuthCookie({
+      authConfig,
+      cookiePrefix: payload.config.cookiePrefix,
+      token: result.token,
     })
-
-    if (result.token) {
-      await setPayloadAuthCookie({
-        authConfig,
-        cookiePrefix: payload.config.cookiePrefix,
-        token: result.token,
-      })
-    }
-
-    if ('removeTokenFromResponses' in config && config.removeTokenFromResponses) {
-      delete result.token
-    }
-
-    return result
-  } catch (e) {
-    console.error('Login error:', e)
-    throw new Error(`${e}`)
   }
+
+  if ('removeTokenFromResponses' in config && config.removeTokenFromResponses) {
+    delete result.token
+  }
+
+  return result
 }

--- a/packages/next/src/auth/logout.ts
+++ b/packages/next/src/auth/logout.ts
@@ -6,24 +6,19 @@ import { getPayload } from 'payload'
 import { getExistingAuthToken } from '../utilities/getExistingAuthToken.js'
 
 export async function logout({ config }: { config: any }) {
-  try {
-    const payload = await getPayload({ config })
-    const headers = await nextHeaders()
-    const result = await payload.auth({ headers })
+  const payload = await getPayload({ config })
+  const headers = await nextHeaders()
+  const result = await payload.auth({ headers })
 
-    if (!result.user) {
-      return { message: 'User already logged out', success: true }
-    }
+  if (!result.user) {
+    return { message: 'User already logged out', success: true }
+  }
 
-    const existingCookie = await getExistingAuthToken(payload.config.cookiePrefix)
+  const existingCookie = await getExistingAuthToken(payload.config.cookiePrefix)
 
-    if (existingCookie) {
-      const cookies = await getCookies()
-      cookies.delete(existingCookie.name)
-      return { message: 'User logged out successfully', success: true }
-    }
-  } catch (e) {
-    console.error('Logout error:', e)
-    throw new Error(`${e}`)
+  if (existingCookie) {
+    const cookies = await getCookies()
+    cookies.delete(existingCookie.name)
+    return { message: 'User logged out successfully', success: true }
   }
 }

--- a/packages/next/src/auth/refresh.ts
+++ b/packages/next/src/auth/refresh.ts
@@ -9,34 +9,30 @@ import { getExistingAuthToken } from '../utilities/getExistingAuthToken.js'
 import { setPayloadAuthCookie } from '../utilities/setPayloadAuthCookie.js'
 
 export async function refresh({ collection, config }: { collection: CollectionSlug; config: any }) {
-  try {
-    const payload = await getPayload({ config })
-    const authConfig = payload.collections[collection]?.config.auth
+  const payload = await getPayload({ config })
+  const authConfig = payload.collections[collection]?.config.auth
 
-    if (!authConfig) {
-      throw new Error(`No auth config found for collection: ${collection}`)
-    }
-
-    const { user } = await payload.auth({ headers: await nextHeaders() })
-    if (!user) {
-      throw new Error('User not authenticated')
-    }
-
-    const existingCookie = await getExistingAuthToken(payload.config.cookiePrefix)
-
-    if (!existingCookie) {
-      return { message: 'No valid token found', success: false }
-    }
-
-    await setPayloadAuthCookie({
-      authConfig,
-      cookiePrefix: payload.config.cookiePrefix,
-      token: existingCookie.value,
-    })
-
-    return { message: 'Token refreshed successfully', success: true }
-  } catch (e) {
-    console.error('Refresh error:', e)
-    throw new Error(`${e}`)
+  if (!authConfig) {
+    throw new Error(`No auth config found for collection: ${collection}`)
   }
+
+  const { user } = await payload.auth({ headers: await nextHeaders() })
+
+  if (!user) {
+    throw new Error('User not authenticated')
+  }
+
+  const existingCookie = await getExistingAuthToken(payload.config.cookiePrefix)
+
+  if (!existingCookie) {
+    return { message: 'No valid token found', success: false }
+  }
+
+  await setPayloadAuthCookie({
+    authConfig,
+    cookiePrefix: payload.config.cookiePrefix,
+    token: existingCookie.value,
+  })
+
+  return { message: 'Token refreshed successfully', success: true }
 }


### PR DESCRIPTION
The `@payloadcms/next/auth` functions are unnecessarily wrapped with `try...catch` blocks that propagate the original error as a plain string. This makes it impossible for the end user's error handling to differentiate between error types.

These functions also throw errors regardless, and therefore must be wrapped with proper error handling anyway. Especially after removing the internal logging in #12881, these blocks do not serve any purpose.

This PR also removes unused imports.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210628212784055