### PR TITLE
test: fix seeding script with postgres

### DIFF
--- a/test/versions/seed.ts
+++ b/test/versions/seed.ts
@@ -300,11 +300,17 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     depth: 0,
   })
 
+  const pointGeoJSON: any = {
+    type: 'Point',
+    coordinates: [1, 3],
+  }
+
   await _payload.db.updateOne({
     collection: diffCollectionSlug,
     id: diffDoc.id,
     data: {
       ...diffDoc,
+      point: pointGeoJSON,
       createdAt: new Date(new Date(diffDoc.createdAt).getTime() - 2 * 60 * 10000).toISOString(),
       updatedAt: new Date(new Date(diffDoc.updatedAt).getTime() - 2 * 60 * 10000).toISOString(),
     },
@@ -390,7 +396,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
           },
         ],
       },
-      point: [1, 3],
+      point: pointGeoJSON,
       radio: 'option2',
       relationship: draft2.id,
       relationshipHasMany: [manyDraftsID, draft2.id],


### PR DESCRIPTION
Fixes versions seeding script with postgres. When using `payload.db.updateOne` directly, you need to manually transform a point field value to GeoJSON. 