### PR TITLE
fix(ui): align caret on error tooltip for checkbox field

### DIFF
--- a/packages/ui/src/fields/Checkbox/index.tsx
+++ b/packages/ui/src/fields/Checkbox/index.tsx
@@ -101,7 +101,7 @@ const CheckboxFieldComponent: CheckboxFieldClientComponent = (props) => {
     >
       <RenderCustomComponent
         CustomComponent={Error}
-        Fallback={<FieldError path={path} showError={showError} />}
+        Fallback={<FieldError alignCaret="left" path={path} showError={showError} />}
       />
       <CheckboxInput
         AfterInput={AfterInput}

--- a/packages/ui/src/fields/Checkbox/index.tsx
+++ b/packages/ui/src/fields/Checkbox/index.tsx
@@ -5,6 +5,7 @@ import type {
   CheckboxFieldValidation,
 } from 'payload'
 
+import { rtlLanguages } from '@payloadcms/translations'
 import React, { useCallback, useMemo } from 'react'
 
 import type { CheckboxInputProps } from './Input.js'
@@ -16,6 +17,7 @@ import { useForm } from '../../forms/Form/context.js'
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useTranslation } from '../../providers/Translation/index.js'
 import { generateFieldID } from '../../utilities/generateFieldID.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
@@ -47,6 +49,11 @@ const CheckboxFieldComponent: CheckboxFieldClientComponent = (props) => {
   const { uuid } = useForm()
 
   const editDepth = useEditDepth()
+
+  const {
+    i18n: { language },
+  } = useTranslation()
+  const isRTL = (rtlLanguages as readonly string[]).includes(language)
 
   const memoizedValidate: CheckboxFieldValidation = useCallback(
     (value, options) => {
@@ -101,7 +108,9 @@ const CheckboxFieldComponent: CheckboxFieldClientComponent = (props) => {
     >
       <RenderCustomComponent
         CustomComponent={Error}
-        Fallback={<FieldError alignCaret="left" path={path} showError={showError} />}
+        Fallback={
+          <FieldError alignCaret={isRTL ? 'right' : 'left'} path={path} showError={showError} />
+        }
       />
       <CheckboxInput
         AfterInput={AfterInput}


### PR DESCRIPTION
### What?
Aligns the caret on the error message tooltip to the left when using a checkbox field.

### Why?
All field error message tooltips have a right-aligned caret - when using a checkbox field, this results in the caret pointing to open space (see screenshots).

### How?
Left aligns the tooltip caret just for the checkbox field.

**Before:**
![Screenshot 2025-06-24 at 2 45 38 PM](https://github.com/user-attachments/assets/923f6a06-1f24-468d-88d8-12e3f0f0d27f)

**After:**
![Screenshot 2025-06-24 at 2 46 47 PM](https://github.com/user-attachments/assets/a2ebbe6a-2095-4295-9e94-320a1b943a6d)


#### Reported by client
