### PR TITLE
fix(ui): prevent form validation after draft submit error

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -59,6 +59,11 @@ export const Form: React.FC<FormProps> = (props) => {
   const { id, collectionSlug, docConfig, docPermissions, getDocPreferences, globalSlug } =
     useDocumentInfo()
 
+  const validateDrafts =
+    docConfig?.versions?.drafts && typeof docConfig?.versions?.drafts === 'object'
+      ? (docConfig.versions.drafts.validate ?? false)
+      : false
+
   const {
     action,
     beforeSubmit,
@@ -98,7 +103,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const { startRouteTransition } = useRouteTransition()
   const { getUploadHandler } = useUploadHandlers()
 
-  const { config } = useConfig()
+  const { config, getEntityConfig } = useConfig()
 
   const [disabled, setDisabled] = useState(disabledFromProps || false)
   const [isMounted, setIsMounted] = useState(false)
@@ -393,7 +398,7 @@ export const Form: React.FC<FormProps> = (props) => {
 
           // When there was an error submitting a draft,
           // set the form state to unsubmitted, to not trigger visible form validation on changes after the failed submit.
-          if (overridesFromArgs['_status'] === 'draft') {
+          if (!validateDrafts && overridesFromArgs['_status'] === 'draft') {
             setSubmitted(false)
           }
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -436,6 +436,12 @@ export const Form: React.FC<FormProps> = (props) => {
               errorToast(<FieldErrorsToast errorMessage={err.message || t('error:unknown')} />)
             })
 
+            // When there's no field-related errors, don't consider the form as submitted,
+            // to not trigger visible validation.
+            if (!fieldErrors.length && nonFieldErrors.length) {
+              setSubmitted(false)
+            }
+
             return
           }
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -391,6 +391,12 @@ export const Form: React.FC<FormProps> = (props) => {
           setProcessing(false)
           setSubmitted(true)
 
+          // When there was an error submitting a draft,
+          // set the form state to unsubmitted, to not trigger visible form validation on changes after the failed submit.
+          if (overridesFromArgs['_status'] === 'draft') {
+            setSubmitted(false)
+          }
+
           contextRef.current = { ...contextRef.current } // triggers rerender of all components that subscribe to form
           if (json.message) {
             errorToast(json.message)
@@ -435,12 +441,6 @@ export const Form: React.FC<FormProps> = (props) => {
             nonFieldErrors.forEach((err) => {
               errorToast(<FieldErrorsToast errorMessage={err.message || t('error:unknown')} />)
             })
-
-            // When there's no field-related errors, don't consider the form as submitted,
-            // to not trigger visible validation.
-            if (!fieldErrors.length && nonFieldErrors.length) {
-              setSubmitted(false)
-            }
 
             return
           }

--- a/test/versions/collections/DraftsWithChangeHook.ts
+++ b/test/versions/collections/DraftsWithChangeHook.ts
@@ -1,0 +1,48 @@
+import type { CollectionConfig } from 'payload'
+
+import { APIError } from 'payload'
+
+import { draftWithChangeHookCollectionSlug } from '../slugs.js'
+
+const DraftWithChangeHookPosts: CollectionConfig = {
+  slug: draftWithChangeHookCollectionSlug,
+  admin: {
+    defaultColumns: ['title', 'description', 'createdAt', '_status'],
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Title',
+      localized: true,
+      required: true,
+      unique: true,
+      hooks: {
+        beforeChange: [
+          (args) => {
+            if (args?.data?.title?.includes('Invalid')) {
+              throw new APIError('beforeChange hook threw APIError 422', 422)
+            }
+          },
+        ],
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      label: 'Description',
+      required: true,
+    },
+  ],
+  versions: {
+    drafts: {
+      schedulePublish: {
+        timeFormat: 'HH:mm',
+      },
+    },
+    maxPerDoc: 0,
+  },
+}
+
+export default DraftWithChangeHookPosts

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -10,6 +10,7 @@ import CustomIDs from './collections/CustomIDs.js'
 import { Diff } from './collections/Diff/index.js'
 import DisablePublish from './collections/DisablePublish.js'
 import DraftPosts from './collections/Drafts.js'
+import DraftWithChangeHook from './collections/DraftsWithChangeHook.js'
 import DraftWithMax from './collections/DraftsWithMax.js'
 import DraftsWithValidate from './collections/DraftsWithValidate.js'
 import ErrorOnUnpublish from './collections/ErrorOnUnpublish.js'
@@ -44,6 +45,7 @@ export default buildConfigWithDefaults({
     AutosaveWithDraftValidate,
     DraftPosts,
     DraftWithMax,
+    DraftWithChangeHook,
     DraftsWithValidate,
     ErrorOnUnpublish,
     LocalizedPosts,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1145,6 +1145,10 @@ describe('Versions', () => {
       await titleField.fill('')
       await saveDocAndAssert(page, '#action-save-draft', 'error')
 
+      const parentFieldType = page.locator('.field-type:has(#field-title)')
+      await expect(parentFieldType.locator('.tooltip--show')).toBeVisible()
+      await expect(parentFieldType).toHaveClass(/error/)
+
       await titleField.fill('New title')
 
       await saveDocAndAssert(page, '#action-save-draft')

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -74,6 +74,7 @@ export interface Config {
     'autosave-with-validate-posts': AutosaveWithValidatePost;
     'draft-posts': DraftPost;
     'draft-with-max-posts': DraftWithMaxPost;
+    'draft-posts-with-change-hook': DraftPostsWithChangeHook;
     'draft-with-validate-posts': DraftWithValidatePost;
     'error-on-unpublish': ErrorOnUnpublish;
     'localized-posts': LocalizedPost;
@@ -98,6 +99,7 @@ export interface Config {
     'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'draft-posts': DraftPostsSelect<false> | DraftPostsSelect<true>;
     'draft-with-max-posts': DraftWithMaxPostsSelect<false> | DraftWithMaxPostsSelect<true>;
+    'draft-posts-with-change-hook': DraftPostsWithChangeHookSelect<false> | DraftPostsWithChangeHookSelect<true>;
     'draft-with-validate-posts': DraftWithValidatePostsSelect<false> | DraftWithValidatePostsSelect<true>;
     'error-on-unpublish': ErrorOnUnpublishSelect<false> | ErrorOnUnpublishSelect<true>;
     'localized-posts': LocalizedPostsSelect<false> | LocalizedPostsSelect<true>;
@@ -280,6 +282,18 @@ export interface DraftWithMaxPost {
       }[]
     | null;
   relation?: (string | null) | DraftWithMaxPost;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "draft-posts-with-change-hook".
+ */
+export interface DraftPostsWithChangeHook {
+  id: string;
+  title: string;
+  description: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -675,6 +689,10 @@ export interface PayloadLockedDocument {
         value: string | DraftWithMaxPost;
       } | null)
     | ({
+        relationTo: 'draft-posts-with-change-hook';
+        value: string | DraftPostsWithChangeHook;
+      } | null)
+    | ({
         relationTo: 'draft-with-validate-posts';
         value: string | DraftWithValidatePost;
       } | null)
@@ -861,6 +879,17 @@ export interface DraftWithMaxPostsSelect<T extends boolean = true> {
             };
       };
   relation?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "draft-posts-with-change-hook_select".
+ */
+export interface DraftPostsWithChangeHookSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1303,6 +1332,10 @@ export interface TaskSchedulePublish {
       | ({
           relationTo: 'draft-posts';
           value: string | DraftPost;
+        } | null)
+      | ({
+          relationTo: 'draft-posts-with-change-hook';
+          value: string | DraftPostsWithChangeHook;
         } | null);
     global?: 'draft-global' | null;
     user?: (string | null) | User;

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -11,6 +11,8 @@ export const draftCollectionSlug = 'draft-posts'
 export const draftWithValidateCollectionSlug = 'draft-with-validate-posts'
 export const draftWithMaxCollectionSlug = 'draft-with-max-posts'
 
+export const draftWithChangeHookCollectionSlug = 'draft-posts-with-change-hook'
+
 export const postCollectionSlug = 'posts'
 
 export const diffCollectionSlug = 'diff'
@@ -29,6 +31,7 @@ export const textCollectionSlug = 'text'
 export const collectionSlugs = [
   autosaveCollectionSlug,
   draftCollectionSlug,
+  draftWithChangeHookCollectionSlug,
   postCollectionSlug,
   diffCollectionSlug,
   mediaCollectionSlug,


### PR DESCRIPTION
Follow-up to #12893.

### What?

Removes cases where submitting a document as a draft in a collection with versioning enabled would cause publishing validation errors to be displayed on further document form changes. An example case is when saving the draft failed due to a `beforeChange` hook throwing an `APIError`.

### How

The behavior change is that the form state is marked as un-submitted post a submit failure as a draft. The form not being considered as submitted results in `packages/ui/src/views/Edit/index.tsx` to use `skipValidation: true`.


