### PR TITLE
docs: remove group from list of default field validations

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -350,7 +350,6 @@ import {
   code,
   date,
   email,
-  group,
   json,
   number,
   point,


### PR DESCRIPTION
### What?

Removes group from the list of default field validations in the docs

### Why?

It doesn't exist in the code: https://github.com/payloadcms/payload/blob/886c07e918d492c295e82e2ee3aa421f2df26f92/packages/payload/src/fields/validations.ts