### PR TITLE
fix(plugin-import-export): omit CSV columns when toCSV returns undefined

### DIFF
--- a/packages/plugin-import-export/src/export/flattenObject.ts
+++ b/packages/plugin-import-export/src/export/flattenObject.ts
@@ -28,13 +28,16 @@ export const flattenObject = ({
           } else {
             if (toCSVFunctions?.[newKey]) {
               const columnName = `${newKey}_${index}`
-              row[columnName] = toCSVFunctions[newKey]({
+              const result = toCSVFunctions[newKey]({
                 columnName,
                 doc,
                 row,
                 siblingDoc,
                 value: item,
               })
+              if (typeof result !== 'undefined') {
+                row[columnName] = result
+              }
             } else {
               row[`${newKey}_${index}`] = item
             }
@@ -44,23 +47,29 @@ export const flattenObject = ({
         if (!toCSVFunctions?.[newKey]) {
           flatten(value, newKey)
         } else {
-          row[newKey] = toCSVFunctions[newKey]({
+          const result = toCSVFunctions[newKey]({
             columnName: newKey,
             doc,
             row,
             siblingDoc,
             value,
           })
+          if (typeof result !== 'undefined') {
+            row[newKey] = result
+          }
         }
       } else {
         if (toCSVFunctions?.[newKey]) {
-          row[newKey] = toCSVFunctions[newKey]({
+          const result = toCSVFunctions[newKey]({
             columnName: newKey,
             doc,
             row,
             siblingDoc,
             value,
           })
+          if (typeof result !== 'undefined') {
+            row[newKey] = result
+          }
         } else {
           row[newKey] = value
         }

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -437,6 +437,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].customRelationship_id).toBeDefined()
       expect(data[0].customRelationship_email).toBeDefined()
       expect(data[0].customRelationship_createdAt).toBeUndefined()
+      expect(data[0].customRelationship).toBeUndefined()
     })
 
     it('should create a JSON file for collection', async () => {

--- a/test/plugin-import-export/payload-types.ts
+++ b/test/plugin-import-export/payload-types.ts
@@ -674,9 +674,7 @@ export interface TaskCreateCollectionExport {
     userCollection?: string | null;
     exportsCollection?: string | null;
   };
-  output: {
-    success?: boolean | null;
-  };
+  output?: unknown;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?

Ensure fields using a custom `toCSV` function that return `undefined` are excluded from the exported CSV.

### Why?

Previously, when a `toCSV` function returned `undefined`, the field key would still be added to the export row. This caused the column to appear in the CSV output with an empty string value (`""`), leading to unexpected results and failed assertions in tests expecting the field to be truly omitted.

### How?

Updated the `flattenObject` utility to:
- Check if the value returned by a `toCSV` function is `undefined`
- Only assign the value to the export row if it is explicitly defined
- Applied this logic in all relevant paths (arrays, objects, primitives)

This change ensures that fields are only included in the CSV when a meaningful value is returned.