### PR TITLE
fix(live-preview): foreign postMessage events reset client-side state

### DIFF
--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -67,5 +67,9 @@ export const handleMessage = async <T extends Record<string, any>>(args: {
     return mergedData
   }
 
-  return initialData
+  if (!_payloadLivePreview.previousData) {
+    _payloadLivePreview.previousData = initialData
+  }
+
+  return _payloadLivePreview.previousData as T
 }


### PR DESCRIPTION
Fixes #10654. Needed for #12860.

If the admin panel broadcasts foreign postMessage events, i.e. those without the `payload-live-preview` signature, client-side live preview subscriptions will reset back to initial state.

This is because we dispatch two postMessage events in the admin panel, one for client-side live preview to catch (`payload-live-preview`), and the other for server-side live preview (`payload-document-event`). This was not previously noticeable because both events would only get called simultaneously on initial render, where initial state is already the expected result.

Now that Live Preview can be freely toggled on and off, both events are frequently dispatched and very obviously disregard the current working state.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210628466702818