### PR TITLE
fix(plugin-import-export): csv export for polymorphic relationship fields

### DIFF
--- a/packages/plugin-import-export/src/export/flattenObject.ts
+++ b/packages/plugin-import-export/src/export/flattenObject.ts
@@ -30,6 +30,7 @@ export const flattenObject = ({
               const columnName = `${newKey}_${index}`
               const result = toCSVFunctions[newKey]({
                 columnName,
+                data: row,
                 doc,
                 row,
                 siblingDoc,
@@ -49,6 +50,7 @@ export const flattenObject = ({
         } else {
           const result = toCSVFunctions[newKey]({
             columnName: newKey,
+            data: row,
             doc,
             row,
             siblingDoc,
@@ -62,6 +64,7 @@ export const flattenObject = ({
         if (toCSVFunctions?.[newKey]) {
           const result = toCSVFunctions[newKey]({
             columnName: newKey,
+            data: row,
             doc,
             row,
             siblingDoc,

--- a/packages/plugin-import-export/src/types.ts
+++ b/packages/plugin-import-export/src/types.ts
@@ -36,6 +36,11 @@ export type ToCSVFunction = (args: {
    */
   columnName: string
   /**
+   * Alias for `row`, the object that accumulates CSV output.
+   * Use this to write additional fields into the exported row.
+   */
+  data: Record<string, unknown>
+  /**
    * The top level document
    */
   doc: Document

--- a/test/plugin-import-export/collections/Pages.ts
+++ b/test/plugin-import-export/collections/Pages.ts
@@ -33,7 +33,7 @@ export const Pages: CollectionConfig = {
       custom: {
         'plugin-import-export': {
           toCSV: ({ value, columnName, row, siblingDoc }) => {
-            return value + ' toCSV'
+            return String(value) + ' toCSV'
           },
         },
       },
@@ -85,7 +85,7 @@ export const Pages: CollectionConfig = {
           custom: {
             'plugin-import-export': {
               toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
-                return value + ' toCSV'
+                return String(value) + ' toCSV'
               },
             },
           },
@@ -106,7 +106,7 @@ export const Pages: CollectionConfig = {
               custom: {
                 'plugin-import-export': {
                   toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
-                    return value + ' toCSV'
+                    return String(value) + ' toCSV'
                   },
                 },
               },
@@ -123,7 +123,7 @@ export const Pages: CollectionConfig = {
               custom: {
                 'plugin-import-export': {
                   toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
-                    return value + ' toCSV'
+                    return String(value) + ' toCSV'
                   },
                 },
               },
@@ -202,6 +202,18 @@ export const Pages: CollectionConfig = {
       name: 'excerpt',
       label: 'Excerpt',
       type: 'text',
+    },
+    {
+      name: 'hasOnePolymorphic',
+      type: 'relationship',
+      relationTo: ['users', 'posts'],
+      hasMany: false,
+    },
+    {
+      name: 'hasManyPolymorphic',
+      type: 'relationship',
+      relationTo: ['users', 'posts'],
+      hasMany: true,
     },
   ],
 }

--- a/test/plugin-import-export/collections/Posts.ts
+++ b/test/plugin-import-export/collections/Posts.ts
@@ -1,0 +1,21 @@
+import type { CollectionConfig } from 'payload'
+
+import { postsSlug } from '../shared.js'
+
+export const Posts: CollectionConfig = {
+  slug: postsSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      name: 'title',
+      label: { en: 'Title', es: 'Título', de: 'Titel' },
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/test/plugin-import-export/config.ts
+++ b/test/plugin-import-export/config.ts
@@ -8,6 +8,7 @@ import { es } from '@payloadcms/translations/languages/es'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Pages } from './collections/Pages.js'
+import { Posts } from './collections/Posts.js'
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 export default buildConfigWithDefaults({
@@ -16,7 +17,7 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Pages],
+  collections: [Users, Pages, Posts],
   localization: {
     defaultLocale: 'en',
     fallback: true,

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -541,6 +541,40 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toStrictEqual('Jobs 0')
     })
 
+    it('should export polymorphic relationship fields to CSV', async () => {
+      const doc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          fields: ['id', 'hasOnePolymorphic', 'hasManyPolymorphic'],
+          format: 'csv',
+          where: {
+            title: { contains: 'Polymorphic' },
+          },
+        },
+      })
+
+      const exportDoc = await payload.findByID({
+        collection: 'exports',
+        id: doc.id,
+      })
+
+      expect(exportDoc.filename).toBeDefined()
+      const expectedPath = path.join(dirname, './uploads', exportDoc.filename as string)
+      const data = await readCSV(expectedPath)
+
+      // hasOnePolymorphic
+      expect(data[0].hasOnePolymorphic_id).toBeDefined()
+      expect(data[0].hasOnePolymorphic_relationTo).toBe('posts')
+
+      // hasManyPolymorphic
+      expect(data[0].hasManyPolymorphic_0_value_id).toBeDefined()
+      expect(data[0].hasManyPolymorphic_0_relationTo).toBe('users')
+      expect(data[0].hasManyPolymorphic_1_value_id).toBeDefined()
+      expect(data[0].hasManyPolymorphic_1_relationTo).toBe('posts')
+    })
+
     // disabled so we don't always run a massive test
     it.skip('should create a file from a large set of collection documents', async () => {
       const allPromises = []

--- a/test/plugin-import-export/payload-types.ts
+++ b/test/plugin-import-export/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     users: User;
     pages: Page;
+    posts: Post;
     exports: Export;
     'exports-tasks': ExportsTask;
     'payload-jobs': PayloadJob;
@@ -80,6 +81,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     pages: PagesSelect<false> | PagesSelect<true>;
+    posts: PostsSelect<false> | PostsSelect<true>;
     exports: ExportsSelect<false> | ExportsSelect<true>;
     'exports-tasks': ExportsTasksSelect<false> | ExportsTasksSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
@@ -212,6 +214,38 @@ export interface Page {
   hasManyNumber?: number[] | null;
   relationship?: (string | null) | User;
   excerpt?: string | null;
+  hasOnePolymorphic?:
+    | ({
+        relationTo: 'users';
+        value: string | User;
+      } | null)
+    | ({
+        relationTo: 'posts';
+        value: string | Post;
+      } | null);
+  hasManyPolymorphic?:
+    | (
+        | {
+            relationTo: 'users';
+            value: string | User;
+          }
+        | {
+            relationTo: 'posts';
+            value: string | Post;
+          }
+      )[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts".
+ */
+export interface Post {
+  id: string;
+  title: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -396,6 +430,10 @@ export interface PayloadLockedDocument {
         value: string | Page;
       } | null)
     | ({
+        relationTo: 'posts';
+        value: string | Post;
+      } | null)
+    | ({
         relationTo: 'exports';
         value: string | Export;
       } | null)
@@ -525,6 +563,18 @@ export interface PagesSelect<T extends boolean = true> {
   hasManyNumber?: T;
   relationship?: T;
   excerpt?: T;
+  hasOnePolymorphic?: T;
+  hasManyPolymorphic?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts_select".
+ */
+export interface PostsSelect<T extends boolean = true> {
+  title?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/test/plugin-import-export/seed/index.ts
+++ b/test/plugin-import-export/seed/index.ts
@@ -14,6 +14,17 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         name: 'name value',
       },
     })
+    // Seed posts
+    const posts = []
+    for (let i = 0; i < 2; i++) {
+      const post = await payload.create({
+        collection: 'posts',
+        data: {
+          title: `Post ${i}`,
+        },
+      })
+      posts.push(post)
+    }
     // create pages
     for (let i = 0; i < 5; i++) {
       await payload.create({
@@ -144,6 +155,29 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         collection: 'pages',
         data: {
           title: `Jobs ${i}`,
+        },
+      })
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await payload.create({
+        collection: 'pages',
+        data: {
+          title: `Polymorphic ${i}`,
+          hasOnePolymorphic: {
+            relationTo: 'posts',
+            value: posts[0]?.id ?? '',
+          },
+          hasManyPolymorphic: [
+            {
+              relationTo: 'users',
+              value: user.id,
+            },
+            {
+              relationTo: 'posts',
+              value: posts[1]?.id ?? '',
+            },
+          ],
         },
       })
     }

--- a/test/plugin-import-export/shared.ts
+++ b/test/plugin-import-export/shared.ts
@@ -1,1 +1,3 @@
 export const pagesSlug = 'pages'
+
+export const postsSlug = 'posts'


### PR DESCRIPTION
### What?

Fixes CSV export support for polymorphic relationship and upload fields.

### Why?

Polymorphic fields in Payload use a `{ relationTo, value }` structure. The previous implementation incorrectly accessed `.id` directly on the top-level object, which caused issues depending on query depth or data shape. This led to missing or invalid values in exported CSVs.

### How?

- Updated getCustomFieldFunctions to safely access relationTo and value.id from polymorphic fields

- Ensured `hasMany` polymorphic fields export each related ID and relationTo as separate CSV columns