### PR TITLE
fix(ui): date format of useAsTitle lost after changing value

### DIFF
--- a/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
@@ -30,14 +30,8 @@ export const SetDocumentTitle: React.FC<{
 
   const title = formatDocTitle({
     collectionConfig,
-    data: { id: '' },
+    data: { id: '', [useAsTitle]: field?.value || '' },
     dateFormat: dateFormatFromConfig,
-    fallback:
-      typeof field === 'string'
-        ? field
-        : typeof field === 'number'
-          ? String(field)
-          : (field?.value as string) || fallback,
     globalConfig,
     i18n,
   })

--- a/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
@@ -32,6 +32,7 @@ export const SetDocumentTitle: React.FC<{
     collectionConfig,
     data: { id: '', [useAsTitle]: field?.value || '' },
     dateFormat: dateFormatFromConfig,
+    fallback,
     globalConfig,
     i18n,
   })

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -85,6 +85,19 @@ describe('Date', () => {
     await expect(page.locator('.doc-header__title.render-title')).toContainText('August')
   })
 
+  test('should retain date format in useAsTitle after modifying value', async () => {
+    await page.goto(url.list)
+    await page.locator('.row-1 .cell-default a').click()
+    await expect(page.locator('.doc-header__title.render-title')).toContainText('August')
+
+    const dateField = page.locator('#field-default input')
+    await expect(dateField).toBeVisible()
+    await dateField.fill('02/07/2023')
+
+    await expect(dateField).toHaveValue('02/07/2023')
+    await expect(page.locator('.doc-header__title.render-title')).toContainText('February')
+  })
+
   test('should clear date', async () => {
     await page.goto(url.create)
     const dateField = page.locator('#field-default input')

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,15 +21,8 @@
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "sourceMap": true,
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
-    "types": [
-      "node",
-      "jest"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["node", "jest"],
     "incremental": true,
     "isolatedModules": true,
     "plugins": [
@@ -38,72 +31,36 @@
       }
     ],
     "paths": {
-      "@payload-config": [
-        "./test/fields/config.ts"
-      ],
-      "@payloadcms/admin-bar": [
-        "./packages/admin-bar/src"
-      ],
-      "@payloadcms/live-preview": [
-        "./packages/live-preview/src"
-      ],
-      "@payloadcms/live-preview-react": [
-        "./packages/live-preview-react/src/index.ts"
-      ],
-      "@payloadcms/live-preview-vue": [
-        "./packages/live-preview-vue/src/index.ts"
-      ],
-      "@payloadcms/ui": [
-        "./packages/ui/src/exports/client/index.ts"
-      ],
-      "@payloadcms/ui/shared": [
-        "./packages/ui/src/exports/shared/index.ts"
-      ],
-      "@payloadcms/ui/rsc": [
-        "./packages/ui/src/exports/rsc/index.ts"
-      ],
-      "@payloadcms/ui/scss": [
-        "./packages/ui/src/scss.scss"
-      ],
-      "@payloadcms/ui/scss/app.scss": [
-        "./packages/ui/src/scss/app.scss"
-      ],
-      "@payloadcms/next/*": [
-        "./packages/next/src/exports/*.ts"
-      ],
+      "@payload-config": ["./test/_community/config.ts"],
+      "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
+      "@payloadcms/live-preview": ["./packages/live-preview/src"],
+      "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
+      "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],
+      "@payloadcms/ui": ["./packages/ui/src/exports/client/index.ts"],
+      "@payloadcms/ui/shared": ["./packages/ui/src/exports/shared/index.ts"],
+      "@payloadcms/ui/rsc": ["./packages/ui/src/exports/rsc/index.ts"],
+      "@payloadcms/ui/scss": ["./packages/ui/src/scss.scss"],
+      "@payloadcms/ui/scss/app.scss": ["./packages/ui/src/scss/app.scss"],
+      "@payloadcms/next/*": ["./packages/next/src/exports/*.ts"],
       "@payloadcms/richtext-lexical/client": [
         "./packages/richtext-lexical/src/exports/client/index.ts"
       ],
-      "@payloadcms/richtext-lexical/rsc": [
-        "./packages/richtext-lexical/src/exports/server/rsc.ts"
-      ],
-      "@payloadcms/richtext-slate/rsc": [
-        "./packages/richtext-slate/src/exports/server/rsc.ts"
-      ],
+      "@payloadcms/richtext-lexical/rsc": ["./packages/richtext-lexical/src/exports/server/rsc.ts"],
+      "@payloadcms/richtext-slate/rsc": ["./packages/richtext-slate/src/exports/server/rsc.ts"],
       "@payloadcms/richtext-slate/client": [
         "./packages/richtext-slate/src/exports/client/index.ts"
       ],
-      "@payloadcms/plugin-seo/client": [
-        "./packages/plugin-seo/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-sentry/client": [
-        "./packages/plugin-sentry/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-stripe/client": [
-        "./packages/plugin-stripe/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-search/client": [
-        "./packages/plugin-search/src/exports/client.ts"
-      ],
+      "@payloadcms/plugin-seo/client": ["./packages/plugin-seo/src/exports/client.ts"],
+      "@payloadcms/plugin-sentry/client": ["./packages/plugin-sentry/src/exports/client.ts"],
+      "@payloadcms/plugin-stripe/client": ["./packages/plugin-stripe/src/exports/client.ts"],
+      "@payloadcms/plugin-search/client": ["./packages/plugin-search/src/exports/client.ts"],
       "@payloadcms/plugin-form-builder/client": [
         "./packages/plugin-form-builder/src/exports/client.ts"
       ],
       "@payloadcms/plugin-import-export/rsc": [
         "./packages/plugin-import-export/src/exports/rsc.ts"
       ],
-      "@payloadcms/plugin-multi-tenant/rsc": [
-        "./packages/plugin-multi-tenant/src/exports/rsc.ts"
-      ],
+      "@payloadcms/plugin-multi-tenant/rsc": ["./packages/plugin-multi-tenant/src/exports/rsc.ts"],
       "@payloadcms/plugin-multi-tenant/utilities": [
         "./packages/plugin-multi-tenant/src/exports/utilities.ts"
       ],
@@ -113,42 +70,25 @@
       "@payloadcms/plugin-multi-tenant/client": [
         "./packages/plugin-multi-tenant/src/exports/client.ts"
       ],
-      "@payloadcms/plugin-multi-tenant": [
-        "./packages/plugin-multi-tenant/src/index.ts"
-      ],
+      "@payloadcms/plugin-multi-tenant": ["./packages/plugin-multi-tenant/src/index.ts"],
       "@payloadcms/plugin-multi-tenant/translations/languages/all": [
         "./packages/plugin-multi-tenant/src/translations/index.ts"
       ],
       "@payloadcms/plugin-multi-tenant/translations/languages/*": [
         "./packages/plugin-multi-tenant/src/translations/languages/*.ts"
       ],
-      "@payloadcms/next": [
-        "./packages/next/src/exports/*"
-      ],
-      "@payloadcms/storage-azure/client": [
-        "./packages/storage-azure/src/exports/client.ts"
-      ],
-      "@payloadcms/storage-s3/client": [
-        "./packages/storage-s3/src/exports/client.ts"
-      ],
+      "@payloadcms/next": ["./packages/next/src/exports/*"],
+      "@payloadcms/storage-azure/client": ["./packages/storage-azure/src/exports/client.ts"],
+      "@payloadcms/storage-s3/client": ["./packages/storage-s3/src/exports/client.ts"],
       "@payloadcms/storage-vercel-blob/client": [
         "./packages/storage-vercel-blob/src/exports/client.ts"
       ],
-      "@payloadcms/storage-gcs/client": [
-        "./packages/storage-gcs/src/exports/client.ts"
-      ],
+      "@payloadcms/storage-gcs/client": ["./packages/storage-gcs/src/exports/client.ts"],
       "@payloadcms/storage-uploadthing/client": [
         "./packages/storage-uploadthing/src/exports/client.ts"
       ]
     }
   },
-  "include": [
-    "${configDir}/src"
-  ],
-  "exclude": [
-    "${configDir}/dist",
-    "${configDir}/build",
-    "${configDir}/temp",
-    "**/*.spec.ts"
-  ]
+  "include": ["${configDir}/src"],
+  "exclude": ["${configDir}/dist", "${configDir}/build", "${configDir}/temp", "**/*.spec.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,8 +21,15 @@
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "sourceMap": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["node", "jest"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": true,
     "isolatedModules": true,
     "plugins": [
@@ -31,36 +38,72 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/_community/config.ts"],
-      "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
-      "@payloadcms/live-preview": ["./packages/live-preview/src"],
-      "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
-      "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],
-      "@payloadcms/ui": ["./packages/ui/src/exports/client/index.ts"],
-      "@payloadcms/ui/shared": ["./packages/ui/src/exports/shared/index.ts"],
-      "@payloadcms/ui/rsc": ["./packages/ui/src/exports/rsc/index.ts"],
-      "@payloadcms/ui/scss": ["./packages/ui/src/scss.scss"],
-      "@payloadcms/ui/scss/app.scss": ["./packages/ui/src/scss/app.scss"],
-      "@payloadcms/next/*": ["./packages/next/src/exports/*.ts"],
+      "@payload-config": [
+        "./test/fields/config.ts"
+      ],
+      "@payloadcms/admin-bar": [
+        "./packages/admin-bar/src"
+      ],
+      "@payloadcms/live-preview": [
+        "./packages/live-preview/src"
+      ],
+      "@payloadcms/live-preview-react": [
+        "./packages/live-preview-react/src/index.ts"
+      ],
+      "@payloadcms/live-preview-vue": [
+        "./packages/live-preview-vue/src/index.ts"
+      ],
+      "@payloadcms/ui": [
+        "./packages/ui/src/exports/client/index.ts"
+      ],
+      "@payloadcms/ui/shared": [
+        "./packages/ui/src/exports/shared/index.ts"
+      ],
+      "@payloadcms/ui/rsc": [
+        "./packages/ui/src/exports/rsc/index.ts"
+      ],
+      "@payloadcms/ui/scss": [
+        "./packages/ui/src/scss.scss"
+      ],
+      "@payloadcms/ui/scss/app.scss": [
+        "./packages/ui/src/scss/app.scss"
+      ],
+      "@payloadcms/next/*": [
+        "./packages/next/src/exports/*.ts"
+      ],
       "@payloadcms/richtext-lexical/client": [
         "./packages/richtext-lexical/src/exports/client/index.ts"
       ],
-      "@payloadcms/richtext-lexical/rsc": ["./packages/richtext-lexical/src/exports/server/rsc.ts"],
-      "@payloadcms/richtext-slate/rsc": ["./packages/richtext-slate/src/exports/server/rsc.ts"],
+      "@payloadcms/richtext-lexical/rsc": [
+        "./packages/richtext-lexical/src/exports/server/rsc.ts"
+      ],
+      "@payloadcms/richtext-slate/rsc": [
+        "./packages/richtext-slate/src/exports/server/rsc.ts"
+      ],
       "@payloadcms/richtext-slate/client": [
         "./packages/richtext-slate/src/exports/client/index.ts"
       ],
-      "@payloadcms/plugin-seo/client": ["./packages/plugin-seo/src/exports/client.ts"],
-      "@payloadcms/plugin-sentry/client": ["./packages/plugin-sentry/src/exports/client.ts"],
-      "@payloadcms/plugin-stripe/client": ["./packages/plugin-stripe/src/exports/client.ts"],
-      "@payloadcms/plugin-search/client": ["./packages/plugin-search/src/exports/client.ts"],
+      "@payloadcms/plugin-seo/client": [
+        "./packages/plugin-seo/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-sentry/client": [
+        "./packages/plugin-sentry/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-stripe/client": [
+        "./packages/plugin-stripe/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-search/client": [
+        "./packages/plugin-search/src/exports/client.ts"
+      ],
       "@payloadcms/plugin-form-builder/client": [
         "./packages/plugin-form-builder/src/exports/client.ts"
       ],
       "@payloadcms/plugin-import-export/rsc": [
         "./packages/plugin-import-export/src/exports/rsc.ts"
       ],
-      "@payloadcms/plugin-multi-tenant/rsc": ["./packages/plugin-multi-tenant/src/exports/rsc.ts"],
+      "@payloadcms/plugin-multi-tenant/rsc": [
+        "./packages/plugin-multi-tenant/src/exports/rsc.ts"
+      ],
       "@payloadcms/plugin-multi-tenant/utilities": [
         "./packages/plugin-multi-tenant/src/exports/utilities.ts"
       ],
@@ -70,25 +113,42 @@
       "@payloadcms/plugin-multi-tenant/client": [
         "./packages/plugin-multi-tenant/src/exports/client.ts"
       ],
-      "@payloadcms/plugin-multi-tenant": ["./packages/plugin-multi-tenant/src/index.ts"],
+      "@payloadcms/plugin-multi-tenant": [
+        "./packages/plugin-multi-tenant/src/index.ts"
+      ],
       "@payloadcms/plugin-multi-tenant/translations/languages/all": [
         "./packages/plugin-multi-tenant/src/translations/index.ts"
       ],
       "@payloadcms/plugin-multi-tenant/translations/languages/*": [
         "./packages/plugin-multi-tenant/src/translations/languages/*.ts"
       ],
-      "@payloadcms/next": ["./packages/next/src/exports/*"],
-      "@payloadcms/storage-azure/client": ["./packages/storage-azure/src/exports/client.ts"],
-      "@payloadcms/storage-s3/client": ["./packages/storage-s3/src/exports/client.ts"],
+      "@payloadcms/next": [
+        "./packages/next/src/exports/*"
+      ],
+      "@payloadcms/storage-azure/client": [
+        "./packages/storage-azure/src/exports/client.ts"
+      ],
+      "@payloadcms/storage-s3/client": [
+        "./packages/storage-s3/src/exports/client.ts"
+      ],
       "@payloadcms/storage-vercel-blob/client": [
         "./packages/storage-vercel-blob/src/exports/client.ts"
       ],
-      "@payloadcms/storage-gcs/client": ["./packages/storage-gcs/src/exports/client.ts"],
+      "@payloadcms/storage-gcs/client": [
+        "./packages/storage-gcs/src/exports/client.ts"
+      ],
       "@payloadcms/storage-uploadthing/client": [
         "./packages/storage-uploadthing/src/exports/client.ts"
       ]
     }
   },
-  "include": ["${configDir}/src"],
-  "exclude": ["${configDir}/dist", "${configDir}/build", "${configDir}/temp", "**/*.spec.ts"]
+  "include": [
+    "${configDir}/src"
+  ],
+  "exclude": [
+    "${configDir}/dist",
+    "${configDir}/build",
+    "${configDir}/temp",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
When a collection's `admin.useAsTitle` property points to a date field, the date format is lost after making a change to the field's value.

Before:

https://github.com/user-attachments/assets/10e61517-3245-4645-be4c-33017bfc860c

After:

https://github.com/user-attachments/assets/d3d62d2e-364e-48a2-91c1-2ce4b0962fe5

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210632330039313