### PR TITLE
test: guard against null values in custom toCSV functions

### DIFF
--- a/test/plugin-import-export/collections/Pages.ts
+++ b/test/plugin-import-export/collections/Pages.ts
@@ -33,7 +33,7 @@ export const Pages: CollectionConfig = {
       custom: {
         'plugin-import-export': {
           toCSV: ({ value, columnName, row, siblingDoc }) => {
-            return value + ' toCSV'
+            return String(value) + ' toCSV'
           },
         },
       },
@@ -44,9 +44,11 @@ export const Pages: CollectionConfig = {
       relationTo: 'users',
       custom: {
         'plugin-import-export': {
-          toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
-            row[`${columnName}_id`] = value.id
-            row[`${columnName}_email`] = value.email
+          toCSV: ({ value, columnName, row }) => {
+            if (value && typeof value === 'object' && 'id' in value && 'email' in value) {
+              row[`${columnName}_id`] = (value as { id: number | string }).id
+              row[`${columnName}_email`] = (value as { email: string }).email
+            }
           },
         },
       },
@@ -85,7 +87,7 @@ export const Pages: CollectionConfig = {
           custom: {
             'plugin-import-export': {
               toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
-                return value + ' toCSV'
+                return String(value) + ' toCSV'
               },
             },
           },
@@ -106,7 +108,7 @@ export const Pages: CollectionConfig = {
               custom: {
                 'plugin-import-export': {
                   toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
-                    return value + ' toCSV'
+                    return String(value) + ' toCSV'
                   },
                 },
               },
@@ -123,7 +125,7 @@ export const Pages: CollectionConfig = {
               custom: {
                 'plugin-import-export': {
                   toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
-                    return value + ' toCSV'
+                    return String(value) + ' toCSV'
                   },
                 },
               },


### PR DESCRIPTION
### What?

Fixes a crash when exporting documents to CSV if a custom `toCSV` function tries to access properties on a `null` value.

### Why?

In some cases (especially with Postgres), fields like relationships may be explicitly `null` if unset. Custom `toCSV` functions that assume the value is always defined would throw a `TypeError` when attempting to access nested properties like `value.id`.

### How?

Added a null check in the custom `toCSV` implementation for `customRelationship`, ensuring the field is an object before accessing its properties.

This prevents the export from failing and makes custom field transforms more resilient to missing or optional values.
