### PR TITLE
fix: uses valid fractional index for test

### DIFF
--- a/test/sort/int.spec.ts
+++ b/test/sort/int.spec.ts
@@ -630,7 +630,7 @@ describe('Sort', () => {
       })
 
       // TODO: this test is currently not working, come back to fix in a separate PR, issue: 12907
-      it.skip('should not break with existing base 62 digits', async () => {
+      it('should not break with existing base 62 digits', async () => {
         const collection = orderableSlug
         // create seed docs with aa, aA, AA
         const aa = await payload.create({
@@ -738,12 +738,12 @@ describe('Sort', () => {
       })
 
       // TODO: this test is currently not working, come back to fix in a separate PR, issue: 12907
-      it.skip('should set order by default', () => {
+      it('should set order by default', () => {
         expect(orderable1._orderable_orderableJoinField1_order).toBeDefined()
       })
 
       // TODO: this test is currently not working, come back to fix in a separate PR, issue: 12907
-      it.skip('should allow setting the order with the local API', async () => {
+      it('should allow setting the order with the local API', async () => {
         // create two orderableJoinSlug docs
         orderable2 = await payload.update({
           collection: orderableSlug,
@@ -766,7 +766,7 @@ describe('Sort', () => {
         expect(orderable4._orderable_orderableJoinField1_order).toBe('e2')
       })
       // TODO: this test is currently not working, come back to fix in a separate PR, issue: 12907
-      it.skip('should sort join docs in the correct', async () => {
+      it('should sort join docs in the correct', async () => {
         related = await payload.findByID({
           collection: orderableJoinSlug,
           id: related.id,

--- a/test/sort/int.spec.ts
+++ b/test/sort/int.spec.ts
@@ -646,11 +646,11 @@ describe('Sort', () => {
             _order: 'aA',
           },
         })
-        const AA = await payload.create({
+        const a0 = await payload.create({
           collection,
           data: {
-            title: 'Base62 AA',
-            _order: 'AA',
+            title: 'Base62 a0',
+            _order: 'a0',
           },
         })
 
@@ -689,7 +689,7 @@ describe('Sort', () => {
         expect(docs[0]?.id).toStrictEqual(aa.id)
         expect(docs[1]?.id).toStrictEqual(aA.id)
         expect(docs[2]?.id).toStrictEqual(orderableDoc.id)
-        expect(docs[3]?.id).toStrictEqual(AA.id)
+        expect(docs[3]?.id).toStrictEqual(a0.id)
       })
     })
 

--- a/test/sort/int.spec.ts
+++ b/test/sort/int.spec.ts
@@ -686,6 +686,11 @@ describe('Sort', () => {
           },
         })
 
+        console.log({
+          actual: docs.map((doc) => doc.id),
+          expected: [aa.id, aA.id, orderableDoc.id, a0.id],
+        })
+
         expect(docs[0]?.id).toStrictEqual(aa.id)
         expect(docs[1]?.id).toStrictEqual(aA.id)
         expect(docs[2]?.id).toStrictEqual(orderableDoc.id)


### PR DESCRIPTION
The test was previously using `AA` which is an invalid fractional index. This replaces AA with the smallest possible value `a0`.
