### PR TITLE
fix(ui): bulk upload losing state when adding additional files

### DIFF
--- a/packages/ui/src/elements/BulkUpload/FileSidebar/index.scss
+++ b/packages/ui/src/elements/BulkUpload/FileSidebar/index.scss
@@ -83,12 +83,13 @@
         background-color: var(--theme-elevation-100);
       }
 
-      .thumbnail {
-        width: base(1.2);
-        height: base(1.2);
+      .file-selections__thumbnail,
+      .file-selections__thumbnail-shimmer {
+        width: calc(var(--base) * 1.2);
+        height: calc(var(--base) * 1.2);
+        border-radius: var(--style-radius-s);
         flex-shrink: 0;
         object-fit: cover;
-        border-radius: var(--style-radius-s);
       }
 
       p {

--- a/packages/ui/src/elements/BulkUpload/FileSidebar/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FileSidebar/index.tsx
@@ -14,12 +14,13 @@ import { Drawer } from '../../Drawer/index.js'
 import { ErrorPill } from '../../ErrorPill/index.js'
 import { Pill } from '../../Pill/index.js'
 import { ShimmerEffect } from '../../ShimmerEffect/index.js'
+import { createThumbnail } from '../../Thumbnail/createThumbnail.js'
 import { Thumbnail } from '../../Thumbnail/index.js'
 import { Actions } from '../ActionsBar/index.js'
-import './index.scss'
 import { AddFilesView } from '../AddFilesView/index.js'
 import { useFormsManager } from '../FormsManager/index.js'
 import { useBulkUpload } from '../index.js'
+import './index.scss'
 
 const addMoreFilesDrawerSlug = 'bulk-upload-drawer--add-more-files'
 
@@ -33,7 +34,6 @@ export function FileSidebar() {
     isInitializing,
     removeFile,
     setActiveIndex,
-    thumbnailUrls,
     totalErrorCount,
   } = useFormsManager()
   const { initialFiles, maxFiles } = useBulkUpload()
@@ -139,7 +139,7 @@ export function FileSidebar() {
                   />
                 ))
               : null}
-            {forms.map(({ errorCount, formState }, index) => {
+            {forms.map(({ errorCount, formID, formState }, index) => {
               const currentFile = (formState?.file?.value as File) || ({} as File)
 
               return (
@@ -151,17 +151,14 @@ export function FileSidebar() {
                   ]
                     .filter(Boolean)
                     .join(' ')}
-                  key={index}
+                  key={formID}
                 >
                   <button
                     className={`${baseClass}__fileRow`}
                     onClick={() => setActiveIndex(index)}
                     type="button"
                   >
-                    <Thumbnail
-                      className={`${baseClass}__thumbnail`}
-                      fileSrc={isImage(currentFile.type) ? thumbnailUrls[index] : null}
-                    />
+                    <SidebarThumbnail file={currentFile} formID={formID} />
                     <div className={`${baseClass}__fileDetails`}>
                       <p className={`${baseClass}__fileName`} title={currentFile.name}>
                         {currentFile.name || t('upload:noFile')}
@@ -198,5 +195,57 @@ export function FileSidebar() {
         </AnimateHeight>
       </div>
     </div>
+  )
+}
+
+function SidebarThumbnail({ file, formID }: { file: File; formID: string }) {
+  const [thumbnailURL, setThumbnailURL] = React.useState<null | string>(null)
+  const [isLoading, setIsLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    let isCancelled = false
+
+    async function generateThumbnail() {
+      setIsLoading(true)
+      setThumbnailURL(null)
+
+      try {
+        if (isImage(file.type)) {
+          await new Promise((resolve) => setTimeout(resolve, 4000))
+          const url = await createThumbnail(file)
+          if (!isCancelled) {
+            setThumbnailURL(url)
+          }
+        } else {
+          setThumbnailURL(null)
+        }
+      } catch (_) {
+        if (!isCancelled) {
+          setThumbnailURL(null)
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void generateThumbnail()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [file])
+
+  if (isLoading) {
+    return <ShimmerEffect className={`${baseClass}__thumbnail-shimmer`} disableInlineStyles />
+  }
+
+  return (
+    <Thumbnail
+      className={`${baseClass}__thumbnail`}
+      fileSrc={thumbnailURL}
+      key={`${formID}-${thumbnailURL || 'placeholder'}`}
+    />
   )
 }

--- a/packages/ui/src/elements/BulkUpload/FileSidebar/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FileSidebar/index.tsx
@@ -211,7 +211,6 @@ function SidebarThumbnail({ file, formID }: { file: File; formID: string }) {
 
       try {
         if (isImage(file.type)) {
-          await new Promise((resolve) => setTimeout(resolve, 4000))
           const url = await createThumbnail(file)
           if (!isCancelled) {
             setThumbnailURL(url)

--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -264,6 +264,16 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
 
   const addFiles = React.useCallback(
     async (files: FileList) => {
+      if (forms.length) {
+        // save the state of the current form before adding new files
+        dispatch({
+          type: 'UPDATE_FORM',
+          errorCount: forms[activeIndex].errorCount,
+          formState: getFormDataRef.current(),
+          index: activeIndex,
+        })
+      }
+
       toggleLoadingOverlay({ isLoading: true, key: 'addingDocs' })
       if (!hasInitializedState) {
         await initializeSharedFormState()
@@ -271,7 +281,7 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
       dispatch({ type: 'ADD_FORMS', files, initialState: initialStateRef.current })
       toggleLoadingOverlay({ isLoading: false, key: 'addingDocs' })
     },
-    [initializeSharedFormState, hasInitializedState, toggleLoadingOverlay],
+    [initializeSharedFormState, hasInitializedState, toggleLoadingOverlay, activeIndex, forms],
   )
 
   const removeThumbnails = React.useCallback((indexes: number[]) => {

--- a/packages/ui/src/elements/BulkUpload/FormsManager/reducer.ts
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/reducer.ts
@@ -4,6 +4,7 @@ export type State = {
   activeIndex: number
   forms: {
     errorCount: number
+    formID: string
     formState: FormState
     uploadEdits?: UploadEdits
   }[]
@@ -49,6 +50,7 @@ export function formsManagementReducer(state: State, action: Action): State {
       for (let i = 0; i < action.files.length; i++) {
         newForms[i] = {
           errorCount: 0,
+          formID: crypto.randomUUID(),
           formState: {
             ...(action.initialState || {}),
             file: {

--- a/packages/ui/src/elements/ShimmerEffect/index.tsx
+++ b/packages/ui/src/elements/ShimmerEffect/index.tsx
@@ -6,21 +6,29 @@ import './index.scss'
 
 export type ShimmerEffectProps = {
   readonly animationDelay?: string
+  readonly className?: string
+  readonly disableInlineStyles?: boolean
   readonly height?: number | string
   readonly width?: number | string
 }
 
 export const ShimmerEffect: React.FC<ShimmerEffectProps> = ({
   animationDelay = '0ms',
+  className,
+  disableInlineStyles = false,
   height = '60px',
   width = '100%',
 }) => {
   return (
     <div
-      className="shimmer-effect"
+      className={['shimmer-effect', className].filter(Boolean).join(' ')}
       style={{
-        height: typeof height === 'number' ? `${height}px` : height,
-        width: typeof width === 'number' ? `${width}px` : width,
+        height: disableInlineStyles
+          ? undefined
+          : typeof height === 'number'
+            ? `${height}px`
+            : height,
+        width: disableInlineStyles ? undefined : typeof width === 'number' ? `${width}px` : width,
       }}
     >
       <div

--- a/packages/ui/src/elements/ShimmerEffect/index.tsx
+++ b/packages/ui/src/elements/ShimmerEffect/index.tsx
@@ -23,12 +23,8 @@ export const ShimmerEffect: React.FC<ShimmerEffectProps> = ({
     <div
       className={['shimmer-effect', className].filter(Boolean).join(' ')}
       style={{
-        height: disableInlineStyles
-          ? undefined
-          : typeof height === 'number'
-            ? `${height}px`
-            : height,
-        width: disableInlineStyles ? undefined : typeof width === 'number' ? `${width}px` : width,
+        height: !disableInlineStyles && (typeof height === 'number' ? `${height}px` : height),
+        width: !disableInlineStyles && (typeof width === 'number' ? `${width}px` : width),
       }}
     >
       <div

--- a/packages/ui/src/elements/Thumbnail/createThumbnail.ts
+++ b/packages/ui/src/elements/Thumbnail/createThumbnail.ts
@@ -27,12 +27,16 @@ export const createThumbnail = (file: File): Promise<string> => {
       const canvas = new OffscreenCanvas(drawWidth, drawHeight) // Create an OffscreenCanvas
       const ctx = canvas.getContext('2d')
 
+      // Determine output format based on input file type
+      const outputFormat = file.type === 'image/png' ? 'image/png' : 'image/jpeg'
+      const quality = file.type === 'image/png' ? undefined : 0.8 // PNG doesn't use quality, use higher quality for JPEG
+
       // Draw the image onto the OffscreenCanvas with calculated dimensions
       ctx.drawImage(img, 0, 0, drawWidth, drawHeight)
 
       // Convert the OffscreenCanvas to a Blob and free up memory
       canvas
-        .convertToBlob({ type: 'image/jpeg', quality: 0.25 })
+        .convertToBlob({ type: outputFormat, ...(quality && { quality }) })
         .then((blob) => {
           URL.revokeObjectURL(img.src) // Release the Object URL
           const reader = new FileReader()

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -1145,6 +1145,34 @@ describe('Uploads', () => {
         .first()
       await expect(errorCount).toHaveText('1')
     })
+
+    test('should preserve state when adding additional files to an existing bulk upload', async () => {
+      await page.goto(uploadsTwo.list)
+      await page.locator('.list-header__title-actions button', { hasText: 'Bulk Upload' }).click()
+
+      await page.setInputFiles('.dropzone input[type="file"]', path.resolve(dirname, './image.png'))
+
+      await page.locator('#field-prefix').fill('should-preserve')
+
+      // add another file
+      await page
+        .locator('.file-selections__header__actions button', { hasText: 'Add File' })
+        .click()
+      await page.setInputFiles('.dropzone input[type="file"]', path.resolve(dirname, './small.png'))
+
+      const originalFileRow = page
+        .locator('.file-selections__filesContainer .file-selections__fileRowContainer')
+        .nth(1)
+
+      // ensure the original file thumbnail is visible (not using default placeholder svg)
+      await expect(originalFileRow.locator('.thumbnail img')).toBeVisible()
+
+      // navigate to the first file added
+      await originalFileRow.locator('button.file-selections__fileRow').click()
+
+      // ensure the prefix field is still filled with the original value
+      await expect(page.locator('#field-prefix')).toHaveValue('should-preserve')
+    })
   })
 
   describe('remote url fetching', () => {


### PR DESCRIPTION
Fixes #12945 

Fixes an issue where adding additional upload files would clear the state of the originally uploaded files.