### PR TITLE
fix(next): live preview popup triggers leave without saving modal

### DIFF
--- a/packages/next/src/views/LivePreview/Toolbar/Controls/index.tsx
+++ b/packages/next/src/views/LivePreview/Toolbar/Controls/index.tsx
@@ -114,6 +114,7 @@ export const ToolbarControls: React.FC<EditViewProps> = () => {
           e.preventDefault()
           setPreviewWindowType('popup')
         }}
+        target="_blank"
         type="button"
       >
         <LinkIcon />


### PR DESCRIPTION
Partially closes #12121.

When you edit a document in Live Preview using the default iframe window, then attempt to open the window as a popup, the `LeaveWithoutSaving` modal will appear.

This is because the `usePreventLeave` hook watches for anchor tags that might cause a page navigation, and rightfully warns the user before they navigate away and lose their changes. The reason the popup button triggers this hook is because it uses an anchor tag with an href for accessibility, which fires events that are caught and processed by the hook. 

The fix is to add the `target="_blank"` attribute here so that the hook understands that these events do not navigate the user away from the page and can be ignored.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210643905956946