### PR TITLE
fix(ui): render DateTime label as <label> instead of <span>

### DIFF
--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -167,7 +167,9 @@ const DateTimeFieldComponent: DateFieldClientComponent = (props) => {
     >
       <RenderCustomComponent
         CustomComponent={Label}
-        Fallback={<FieldLabel label={label} localized={localized} required={required} />}
+        Fallback={
+          <FieldLabel label={label} localized={localized} path={path} required={required} />
+        }
       />
       <div className={`${fieldBaseClass}__wrap`} id={`field-${path.replace(/\./g, '__')}`}>
         <RenderCustomComponent


### PR DESCRIPTION
## What / Why
Date & Time fields were rendering their field label as a `<span>` while every other field type uses a proper `<label>` with a matching `htmlFor`.

Because the element was a span it broke styles and made 'field-label' have different styles from the rest of 'field-label's.

**Root cause:** DateTimeField failed to pass its `path` (or an explicit `htmlFor`) to `FieldLabel`. When `FieldLabel` receives no `htmlFor`, it intentionally downgrades to a `<span>`.

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/edecfce7-0326-4f3e-af76-d7b37158343a)
*DateTime label rendered as `<span>`, causing style inconsistencies*

### After  
![image](https://github.com/user-attachments/assets/d9fb06c2-1ca0-4f8d-803d-15c6c6355d1e)
*DateTime label now rendered as proper `<label>` element*

## Changes introduced
- `packages/ui/src/fields/DateTime/index.tsx`
  - Added `path={path}` prop to `FieldLabel` component

## Behavior after the fix
- Date-time labels are now real `<label>` elements with `for="field-…"`
- Visual alignment now matches every other field type  

## How to test manually
1. Run `pnpm dev fields`
2. Inspect the DateTime field markup – label is now `<label>` 
3. Observe that vertical spacing matches other types of fields