### PR TITLE
fix(templates): only generate slug from title on demand

### DIFF
--- a/templates/website/src/fields/slug/SlugComponent.tsx
+++ b/templates/website/src/fields/slug/SlugComponent.tsx
@@ -29,8 +29,6 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
 
   const { dispatchFields, getDataByPath } = useForm()
 
-  // The value of the checkbox
-  // We're using separate useFormFields to minimise re-renders
   const isLocked = useFormFields(([fields]) => {
     return fields[checkboxFieldPath]?.value as string
   })
@@ -65,29 +63,24 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
     [isLocked, checkboxFieldPath, dispatchFields],
   )
 
-  const readOnly = readOnlyFromProps || isLocked
-
   return (
     <div className="field-type slug-field-component">
       <div className="label-wrapper">
         <FieldLabel htmlFor={`field-${path}`} label={label} />
-
         {!isLocked && (
           <Button className="lock-button" buttonStyle="none" onClick={handleGenerate}>
             Generate
           </Button>
         )}
-
         <Button className="lock-button" buttonStyle="none" onClick={handleLock}>
           {isLocked ? 'Unlock' : 'Lock'}
         </Button>
       </div>
-
       <TextInput
         value={value}
         onChange={setValue}
         path={path || field.name}
-        readOnly={Boolean(readOnly)}
+        readOnly={Boolean(readOnlyFromProps || isLocked)}
       />
     </div>
   )

--- a/templates/website/src/fields/slug/formatSlug.ts
+++ b/templates/website/src/fields/slug/formatSlug.ts
@@ -1,8 +1,8 @@
 import type { FieldHook } from 'payload'
 
-export const formatSlug = (val: string): string =>
+export const formatSlug = (val: string): string | undefined =>
   val
-    .replace(/ /g, '-')
+    ?.replace(/ /g, '-')
     .replace(/[^\w-]+/g, '')
     .toLowerCase()
 
@@ -13,10 +13,10 @@ export const formatSlugHook =
       return formatSlug(value)
     }
 
-    if (operation === 'create' || !data?.slug) {
-      const fallbackData = data?.[fallback] || data?.[fallback]
+    if (operation === 'create' || data?.slug === undefined) {
+      const fallbackData = data?.[fallback]
 
-      if (fallbackData && typeof fallbackData === 'string') {
+      if (typeof fallbackData === 'string') {
         return formatSlug(fallbackData)
       }
     }

--- a/templates/website/src/fields/slug/index.scss
+++ b/templates/website/src/fields/slug/index.scss
@@ -3,6 +3,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: calc(var(--base) / 2);
   }
 
   .lock-button {

--- a/templates/with-vercel-website/src/fields/slug/SlugComponent.tsx
+++ b/templates/with-vercel-website/src/fields/slug/SlugComponent.tsx
@@ -29,8 +29,6 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
 
   const { dispatchFields, getDataByPath } = useForm()
 
-  // The value of the checkbox
-  // We're using separate useFormFields to minimise re-renders
   const isLocked = useFormFields(([fields]) => {
     return fields[checkboxFieldPath]?.value as string
   })
@@ -65,29 +63,24 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
     [isLocked, checkboxFieldPath, dispatchFields],
   )
 
-  const readOnly = readOnlyFromProps || isLocked
-
   return (
     <div className="field-type slug-field-component">
       <div className="label-wrapper">
         <FieldLabel htmlFor={`field-${path}`} label={label} />
-
         {!isLocked && (
           <Button className="lock-button" buttonStyle="none" onClick={handleGenerate}>
             Generate
           </Button>
         )}
-
         <Button className="lock-button" buttonStyle="none" onClick={handleLock}>
           {isLocked ? 'Unlock' : 'Lock'}
         </Button>
       </div>
-
       <TextInput
         value={value}
         onChange={setValue}
         path={path || field.name}
-        readOnly={Boolean(readOnly)}
+        readOnly={Boolean(readOnlyFromProps || isLocked)}
       />
     </div>
   )

--- a/templates/with-vercel-website/src/fields/slug/formatSlug.ts
+++ b/templates/with-vercel-website/src/fields/slug/formatSlug.ts
@@ -1,8 +1,8 @@
 import type { FieldHook } from 'payload'
 
-export const formatSlug = (val: string): string =>
+export const formatSlug = (val: string): string | undefined =>
   val
-    .replace(/ /g, '-')
+    ?.replace(/ /g, '-')
     .replace(/[^\w-]+/g, '')
     .toLowerCase()
 
@@ -13,10 +13,10 @@ export const formatSlugHook =
       return formatSlug(value)
     }
 
-    if (operation === 'create' || !data?.slug) {
-      const fallbackData = data?.[fallback] || data?.[fallback]
+    if (operation === 'create' || data?.slug === undefined) {
+      const fallbackData = data?.[fallback]
 
-      if (fallbackData && typeof fallbackData === 'string') {
+      if (typeof fallbackData === 'string') {
         return formatSlug(fallbackData)
       }
     }

--- a/templates/with-vercel-website/src/fields/slug/index.scss
+++ b/templates/with-vercel-website/src/fields/slug/index.scss
@@ -3,6 +3,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: calc(var(--base) / 2);
   }
 
   .lock-button {


### PR DESCRIPTION
Currently, the slug field is generated from the title field indefinitely, even after the document has been created and the initial slug has been assigned. This should only occur on create, however, as it currently does, or when the user explicitly requests it.

Given that slugs often determine the URL structure of the webpage that the document corresponds to, they should rarely change after being published, and when they do, would require HTTP redirects, etc. to do right in a production environment.

But this is also a problem with Live Preview which relies on a constant iframe src. If your Live Preview URL includes the slug as a route param, which is often the case, then changing the slug will result in a broken connection as the queried document can no longer be found. The current workaround is to save the document and refresh the page.

Now, the slug is only generated on initial create, or when the user explicitly clicks the new "generate" button above the slug field. In the future we can evaluate supporting dynamic Live Preview URLs.

Regenerating this URL on every change would put additional load on the client as it would have to reestablish connection every time it changes, but it should be supported still. See #13055.

Discord discussion here: https://discord.com/channels/967097582721572934/1102950643259424828/1387737976892686346

Related: #10536

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211027926448078