### PR TITLE
fix(ui): improve collection description layout and spacing

### DIFF
--- a/packages/ui/src/elements/DocumentFields/index.scss
+++ b/packages/ui/src/elements/DocumentFields/index.scss
@@ -45,6 +45,12 @@
       flex-grow: 1;
     }
 
+    &__header {
+      padding: calc(var(--base) * 1) var(--gutter-h);
+      border-bottom: 1px solid var(--theme-elevation-100);
+      border-right: 1px solid var(--theme-elevation-100);
+    }
+
     &__edit {
       padding-top: calc(var(--base) * 1.5);
       padding-bottom: var(--spacing-view-bottom);
@@ -145,6 +151,10 @@
       &__main {
         width: 100%;
         min-height: initial;
+      }
+
+      &__header {
+        padding: calc(var(--base) * 0.75) var(--gutter-h);
       }
 
       &__sidebar-wrap {

--- a/packages/ui/src/elements/DocumentFields/index.tsx
+++ b/packages/ui/src/elements/DocumentFields/index.tsx
@@ -64,12 +64,12 @@ export const DocumentFields: React.FC<Args> = ({
         .join(' ')}
     >
       <div className={`${baseClass}__main`}>
+        {Description ? (
+          <header className={`${baseClass}__header`}>
+            <div className={`${baseClass}__sub-header`}>{Description}</div>
+          </header>
+        ) : null}
         <Gutter className={`${baseClass}__edit`}>
-          {Description ? (
-            <header className={`${baseClass}__header`}>
-              <div className={`${baseClass}__sub-header`}>{Description}</div>
-            </header>
-          ) : null}
           {BeforeFields}
           <RenderFields
             className={`${baseClass}__fields`}

--- a/packages/ui/src/elements/ListHeader/index.scss
+++ b/packages/ui/src/elements/ListHeader/index.scss
@@ -5,6 +5,7 @@
     display: flex;
     align-items: flex-end;
     flex-wrap: wrap;
+    gap: calc(var(--base) * 0.5);
 
     &__content {
       display: grid;
@@ -43,6 +44,12 @@
 
     .btn {
       margin: 0;
+    }
+  }
+
+  @include mid-break {
+    .list-header {
+      gap: calc(var(--base) * 0.25);
     }
   }
 }


### PR DESCRIPTION
## What / Why
Collection descriptions had poor visual separation and spacing issues:
- In list view: description was too close to the collection heading
- In edit view: description appeared mixed with form fields, making it look like a regular field instead of a description section

This made descriptions less readable and visually confusing.

## Changes introduced
- `packages/ui/src/elements/DocumentFields/index.tsx`
  - Moved description header outside of Gutter component to create proper visual separation
- `packages/ui/src/elements/DocumentFields/index.scss`
  - Added `&__header` styles with padding and borders to create a distinct section
  - Added responsive padding adjustments for mid-break screens
- `packages/ui/src/elements/ListHeader/index.scss`
  - Added gap to `.list-header` to improve spacing between title and description
  - Added responsive gap adjustment for smaller screens

## Behavior after the fix
- **List view**: Collection descriptions now have proper spacing from the heading
- **Edit view**: Descriptions appear in a visually distinct header section, separated from form fields
- **Responsive**: Appropriate spacing adjustments on smaller screens

## How to test manually
1. Run `pnpm dev admin` to see admin test collections with descriptions
2. OR run `pnpm dev` and add a collection description inside `test/_community/collections/Posts/index.ts`
3. **List view**: Observe improved spacing between title and description
4. **Edit view**: Notice description appears in a bordered header section, separate from form fields
5. Test on different screen sizes to verify responsive behavior

## Screenshots
### List View - Before/After
![List view - pnpm dev admin](https://github.com/user-attachments/assets/41de9e56-67aa-4155-95ba-36d8d9712a5c)
![List view - pnpm dev](https://github.com/user-attachments/assets/77af166b-1819-40c2-9d27-52605716e192)

### Edit View - Before/After  
![Edit view - pnpm dev admin](https://github.com/user-attachments/assets/86602108-d75c-40b0-9b99-88d3017a5bf7)
![Edit view - pnpm dev](https://github.com/user-attachments/assets/ab5a26e9-552d-4bd3-b3dd-9c5ec8ad4aed)