### PR TITLE
fix(ui): prevent error if rows is undefined in mergeServerFormState

### DIFF
--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -50,7 +50,7 @@ export const mergeServerFormState = ({
       newState[path].rows = [...(currentState[path]?.rows || [])] // shallow copy to avoid mutating the original array
 
       incomingField.rows.forEach((row) => {
-        const indexInCurrentState = currentState[path].rows.findIndex(
+        const indexInCurrentState = currentState[path].rows?.findIndex(
           (existingRow) => existingRow.id === row.id,
         )
 


### PR DESCRIPTION
### What? 
Adds optional chaining when accessing `rows` in  `mergeServerFormState` to prevent error crashing the UI.

### Why? 
When an array field is populated in a `beforeChange` hook and was previously empty, it crashes `mergeServerFormState.ts` on this line because no `rows` exist: 

```ts 
const indexInCurrentState = currentState[path].rows.findIndex
``` 

The line after this checks `if (indexInCurrentState > -1)` so returning undefined here will not affect the subsequent code.

### How? 
Added optional chaining  to the access of `rows`, which prevents the error being thrown.

Fixes #12944 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210660738684837