### PR TITLE
fix(plugin-redirects): make 'from' field unique to prevent errors in redirect logic

### DIFF
--- a/packages/plugin-redirects/src/index.ts
+++ b/packages/plugin-redirects/src/index.ts
@@ -28,6 +28,7 @@ export const redirectsPlugin =
         index: true,
         label: 'From URL',
         required: true,
+        unique: true,
       },
       {
         name: 'to',


### PR DESCRIPTION
### What?
This PR updates the `from` field in `plugin-redirects` to add `unique: true`.

### Why?
If you create multiple redirects with the same `from` URL — the application won't know which one to follow, which causes errors and unpredictable behavior. 

### How?
Adds `unique: true` to the plugin injected `from` field.

### Migration Required
This change will require a migration. Projects already using this plugin will need to:
- Ensure there are no duplicate `from` values in their existing redirects collection.
- Remove or modify any duplicate entries before applying this update.

Fixes #12959