### PR TITLE
templates: fix pnpm 10 ignored build scripts warning

### DIFF
--- a/templates/_template/package.json
+++ b/templates/_template/package.json
@@ -55,7 +55,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -54,7 +54,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }

--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -108,7 +108,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   },
   "registry": "https://registry.npmjs.org/"

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -86,7 +86,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }

--- a/templates/with-payload-cloud/package.json
+++ b/templates/with-payload-cloud/package.json
@@ -43,7 +43,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }

--- a/templates/with-postgres/package.json
+++ b/templates/with-postgres/package.json
@@ -56,7 +56,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }

--- a/templates/with-vercel-mongodb/package.json
+++ b/templates/with-vercel-mongodb/package.json
@@ -55,7 +55,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }

--- a/templates/with-vercel-postgres/package.json
+++ b/templates/with-vercel-postgres/package.json
@@ -56,7 +56,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }

--- a/templates/with-vercel-website/package.json
+++ b/templates/with-vercel-website/package.json
@@ -88,7 +88,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp"
+      "sharp",
+      "esbuild",
+      "unrs-resolver"
     ]
   }
 }


### PR DESCRIPTION
When using pnpm 10 to install any of our templates, the following warning is thrown:

![Screenshot 2025-06-29 at 13 23 28@2x](https://github.com/user-attachments/assets/450630f1-0455-48a0-96e9-516110b6146c)

> Warning: Ignored build scripts: esbuild, unrs-resolver. Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.

This PR fixes this by adding those packages to `onlyBuiltDependencies`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210668927737253