### PR TITLE
fix: disable graphql introspection queries when disableIntrospectionInProduction is true

### DIFF
--- a/docs/graphql/overview.mdx
+++ b/docs/graphql/overview.mdx
@@ -16,14 +16,15 @@ The labels you provide for your Collections and Globals are used to name the Gra
 
 At the top of your Payload Config you can define all the options to manage GraphQL.
 
-| Option                          | Description                                                                                                                     |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `mutations`                     | Any custom Mutations to be added in addition to what Payload provides. [More](/docs/graphql/extending)                          |
-| `queries`                       | Any custom Queries to be added in addition to what Payload provides. [More](/docs/graphql/extending)                            |
-| `maxComplexity`                 | A number used to set the maximum allowed complexity allowed by requests [More](/docs/graphql/overview#query-complexity-limits)  |
-| `disablePlaygroundInProduction` | A boolean that if false will enable the GraphQL playground, defaults to true. [More](/docs/graphql/overview#graphql-playground) |
-| `disable`                       | A boolean that if true will disable the GraphQL entirely, defaults to false.                                                    |
-| `validationRules`               | A function that takes the ExecutionArgs and returns an array of ValidationRules.                                                |
+| Option                             | Description                                                                                                                                                |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mutations`                        | Any custom Mutations to be added in addition to what Payload provides. [More](/docs/graphql/extending)                                                     |
+| `queries`                          | Any custom Queries to be added in addition to what Payload provides. [More](/docs/graphql/extending)                                                       |
+| `maxComplexity`                    | A number used to set the maximum allowed complexity allowed by requests [More](/docs/graphql/overview#query-complexity-limits)                             |
+| `disablePlaygroundInProduction`    | A boolean that if false will enable the GraphQL playground in production environments, defaults to true. [More](/docs/graphql/overview#graphql-playground) |
+| `disableIntrospectionInProduction` | A boolean that if false will enable the GraphQL introspection in production environments, defaults to true.                                                |
+| `disable`                          | A boolean that if true will disable the GraphQL entirely, defaults to false.                                                                               |
+| `validationRules`                  | A function that takes the ExecutionArgs and returns an array of ValidationRules.                                                                           |
 
 ## Collections
 

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -113,6 +113,7 @@ export function configToSchema(config: SanitizedConfig): {
       variables: args.variableValues,
       // onComplete: (complexity) => { console.log('Query Complexity:', complexity); },
     }),
+    ...(config.graphQL.disablePlaygroundInProduction ? [NoProductionIntrospection] : []),
     ...(typeof config?.graphQL?.validationRules === 'function'
       ? config.graphQL.validationRules(args)
       : []),
@@ -123,3 +124,18 @@ export function configToSchema(config: SanitizedConfig): {
     validationRules,
   }
 }
+
+const NoProductionIntrospection: GraphQL.ValidationRule = (context) => ({
+  Field(node) {
+    if (process.env.NODE_ENV === 'production') {
+      if (node.name.value === '__schema' || node.name.value === '__type') {
+        context.reportError(
+          new GraphQL.GraphQLError(
+            'GraphQL introspection is not allowed, but the query contained __schema or __type',
+            { nodes: [node] },
+          ),
+        )
+      }
+    }
+  },
+})

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -113,7 +113,7 @@ export function configToSchema(config: SanitizedConfig): {
       variables: args.variableValues,
       // onComplete: (complexity) => { console.log('Query Complexity:', complexity); },
     }),
-    ...(config.graphQL.disablePlaygroundInProduction ? [NoProductionIntrospection] : []),
+    ...(config.graphQL.disableIntrospectionInProduction ? [NoProductionIntrospection] : []),
     ...(typeof config?.graphQL?.validationRules === 'function'
       ? config.graphQL.validationRules(args)
       : []),

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -123,6 +123,7 @@ export const addDefaultsToConfig = (config: Config): Config => {
   config.endpoints = config.endpoints ?? []
   config.globals = config.globals ?? []
   config.graphQL = {
+    disableIntrospectionInProduction: true,
     disablePlaygroundInProduction: true,
     maxComplexity: 1000,
     schemaOutputFile: `${typeof process?.cwd === 'function' ? process.cwd() : ''}/schema.graphql`,

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1029,6 +1029,17 @@ export type Config = {
    */
   graphQL?: {
     disable?: boolean
+    /**
+     * Disable introspection queries in production.
+     *
+     * @default true
+     */
+    disableIntrospectionInProduction?: boolean
+    /**
+     * Disable the GraphQL Playground in production.
+     *
+     * @default true
+     */
     disablePlaygroundInProduction?: boolean
     maxComplexity?: number
     /**


### PR DESCRIPTION
Disables introspection queries when `disableIntrospectionInProduction` is true (which it is by default).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210561338171139