### PR TITLE
revert(ui): should select document after creation from relationship field (#12842)

### DIFF
--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -52,13 +52,7 @@ export const AddNewRelation: React.FC<Props> = ({
 
   const onSave: DocumentDrawerContextType['onSave'] = useCallback(
     ({ doc, operation }) => {
-      // if autosave is enabled, the operation will be 'update'
-      const isAutosaveEnabled =
-        typeof collectionConfig?.versions?.drafts === 'object'
-          ? collectionConfig.versions.drafts.autosave
-          : false
-
-      if (operation === 'create' || (operation === 'update' && isAutosaveEnabled)) {
+      if (operation === 'create') {
         // ensure the value is not already in the array
         let isNewValue = false
         if (!value) {

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -23,7 +23,6 @@ import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { formatTimeToNow } from '../../utilities/formatDocTitle/formatDateTitle.js'
 import { reduceFieldsToValuesWithValidation } from '../../utilities/reduceFieldsToValuesWithValidation.js'
-import { useDocumentDrawerContext } from '../DocumentDrawer/Provider.js'
 import { LeaveWithoutSaving } from '../LeaveWithoutSaving/index.js'
 import './index.scss'
 
@@ -56,8 +55,6 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     setUnpublishedVersionCount,
     updateSavedDocumentData,
   } = useDocumentInfo()
-
-  const { onSave: onSaveFromDocumentDrawer } = useDocumentDrawerContext()
 
   const { reportUpdate } = useDocumentEvents()
   const { dispatchFields, isValid, setBackgroundProcessing, setIsValid, setSubmitted } = useForm()
@@ -95,18 +92,18 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   // Store fields in ref so the autosave func
   // can always retrieve the most to date copies
   // after the timeout has executed
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
+   
   fieldRef.current = fields
 
   // Store modified in ref so the autosave func
   // can bail out if modified becomes false while
   // timing out during autosave
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
+   
   modifiedRef.current = modified
 
   // Store locale in ref so the autosave func
   // can always retrieve the most to date locale
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
+   
   localeRef.current = locale
 
   const { queueTask } = useQueues()
@@ -186,8 +183,6 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
                 // We need to log the time in order to figure out if we need to trigger the state off later
                 endTimestamp = newDate.getTime()
 
-                const json = await res.json()
-
                 if (res.status === 200) {
                   setLastUpdateTime(newDate.getTime())
 
@@ -197,20 +192,13 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
                     updatedAt: newDate.toISOString(),
                   })
 
-                  // if onSaveFromDocumentDrawer is defined, call it
-                  if (typeof onSaveFromDocumentDrawer === 'function') {
-                    void onSaveFromDocumentDrawer({
-                      ...json,
-                      operation: 'update',
-                    })
-                  }
-
                   if (!mostRecentVersionIsAutosaved) {
                     incrementVersionCount()
                     setMostRecentVersionIsAutosaved(true)
                     setUnpublishedVersionCount((prev) => prev + 1)
                   }
                 }
+                const json = await res.json()
 
                 if (versionsConfig?.drafts && versionsConfig?.drafts?.validate && json?.errors) {
                   if (Array.isArray(json.errors)) {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -175,37 +175,6 @@ describe('Versions', () => {
       }).toPass({ timeout: 10000, intervals: [100] })
     })
 
-    test('autosave relationships - should select doc after creating from relationship field', async () => {
-      await page.goto(postURL.create)
-      const autosaveRelationField = page.locator('#field-relationToAutosaves')
-      await expect(autosaveRelationField).toBeVisible()
-      const addNewButton = autosaveRelationField.locator(
-        '.relationship-add-new__add-button.doc-drawer__toggler',
-      )
-      await addNewButton.click()
-      const titleField = page.locator('#field-title')
-      const descriptionField = page.locator('#field-description')
-      await titleField.fill('test')
-      await descriptionField.fill('test')
-
-      const createdDate = await page.textContent(
-        'li:has(p:has-text("Created:")) .doc-controls__value',
-      )
-
-      // wait for modified date and created date to be different
-      await expect(async () => {
-        const modifiedDateLocator = page.locator(
-          'li:has(p:has-text("Last Modified:")) .doc-controls__value',
-        )
-        await expect(modifiedDateLocator).not.toHaveText(createdDate ?? '')
-      }).toPass({ timeout: POLL_TOPASS_TIMEOUT, intervals: [100] })
-
-      const closeDrawer = page.locator('.doc-drawer__header-close')
-      await closeDrawer.click()
-      const fieldValue = autosaveRelationField.locator('.value-container')
-      await expect(fieldValue).toContainText('test')
-    })
-
     test('should show collection versions view level action in collection versions view', async () => {
       await page.goto(url.list)
       await page.locator('tbody tr .cell-title a').first().click()


### PR DESCRIPTION
Fixes #12975 by reverting #12842.

Right now autosave-enabled documents opened within a drawer will unnecessarily hard refresh on every autosave interval, causing loss of input focus, etc. Within join fields specifically, the drawer will also close, making it very difficult to edit the underlying relationship.

The feature within that PR is still valid, which is to propagate autosave events to the underlying field. We just need to either temporarily revert this change or move forward with a different fix before the next release.

Here's a demonstration of the bug:

https://github.com/user-attachments/assets/62f55d4e-b620-4c70-aa86-54cd08358caa