### PR TITLE
fix(ui): bulk upload redirecting to relationship documents when added

### DIFF
--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 import { toast } from 'sonner'
 
 import { useConfig } from '../../providers/Config/index.js'
+import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { UploadControlsProvider } from '../../providers/UploadControls/index.js'
 import { Drawer, useDrawerDepth } from '../Drawer/index.js'
@@ -77,7 +78,9 @@ export function BulkUploadDrawer() {
     <Drawer gutter={false} Header={null} slug={drawerSlug}>
       <FormsManagerProvider>
         <UploadControlsProvider>
-          <DrawerContent />
+          <EditDepthProvider>
+            <DrawerContent />
+          </EditDepthProvider>
         </UploadControlsProvider>
       </FormsManagerProvider>
     </Drawer>

--- a/test/uploads/collections/BulkUploads/index.ts
+++ b/test/uploads/collections/BulkUploads/index.ts
@@ -1,0 +1,23 @@
+import type { CollectionConfig } from 'payload'
+
+import { bulkUploadsSlug } from '../../shared.js'
+
+export const BulkUploadsCollection: CollectionConfig = {
+  slug: bulkUploadsSlug,
+  upload: true,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      type: 'text',
+      name: 'title',
+      required: true,
+    },
+    {
+      name: 'relationship',
+      type: 'relationship',
+      relationTo: ['simple-relationship'],
+    },
+  ],
+}

--- a/test/uploads/collections/SimpleRelationship/index.ts
+++ b/test/uploads/collections/SimpleRelationship/index.ts
@@ -1,0 +1,14 @@
+import type { CollectionConfig } from 'payload'
+
+export const SimpleRelationshipCollection: CollectionConfig = {
+  slug: 'simple-relationship',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      type: 'text',
+      name: 'title',
+    },
+  ],
+}

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -11,7 +11,9 @@ import { AdminThumbnailFunction } from './collections/AdminThumbnailFunction/ind
 import { AdminThumbnailSize } from './collections/AdminThumbnailSize/index.js'
 import { AdminThumbnailWithSearchQueries } from './collections/AdminThumbnailWithSearchQueries/index.js'
 import { AdminUploadControl } from './collections/AdminUploadControl/index.js'
+import { BulkUploadsCollection } from './collections/BulkUploads/index.js'
 import { CustomUploadFieldCollection } from './collections/CustomUploadField/index.js'
+import { SimpleRelationshipCollection } from './collections/SimpleRelationship/index.js'
 import { Uploads1 } from './collections/Upload1/index.js'
 import { Uploads2 } from './collections/Upload2/index.js'
 import {
@@ -859,6 +861,8 @@ export default buildConfigWithDefaults({
         staticDir: path.resolve(dirname, './media'),
       },
     },
+    BulkUploadsCollection,
+    SimpleRelationshipCollection,
   ],
   onInit: async (payload) => {
     const uploadsDir = path.resolve(dirname, './media')

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -28,6 +28,7 @@ import {
   adminUploadControlSlug,
   animatedTypeMedia,
   audioSlug,
+  bulkUploadsSlug,
   constructorOptionsSlug,
   customFileNameMediaSlug,
   customUploadFieldSlug,
@@ -80,6 +81,7 @@ let constructorOptionsURL: AdminUrlUtil
 let consoleErrorsFromPage: string[] = []
 let collectErrorsFromPage: () => boolean
 let stopCollectingErrorsFromPage: () => boolean
+let bulkUploadsURL: AdminUrlUtil
 
 describe('Uploads', () => {
   let page: Page
@@ -116,6 +118,7 @@ describe('Uploads', () => {
     withoutEnlargementResizeOptionsURL = new AdminUrlUtil(serverURL, withoutEnlargeSlug)
     threeDimensionalURL = new AdminUrlUtil(serverURL, threeDimensionalSlug)
     constructorOptionsURL = new AdminUrlUtil(serverURL, constructorOptionsSlug)
+    bulkUploadsURL = new AdminUrlUtil(serverURL, bulkUploadsSlug)
 
     const context = await browser.newContext()
     page = await context.newPage()
@@ -1172,6 +1175,26 @@ describe('Uploads', () => {
 
       // ensure the prefix field is still filled with the original value
       await expect(page.locator('#field-prefix')).toHaveValue('should-preserve')
+    })
+
+    test('should not redirect to created relationship document inside the bulk upload drawer', async () => {
+      await page.goto(bulkUploadsURL.list)
+      await page.locator('.list-header__title-actions button', { hasText: 'Bulk Upload' }).click()
+      await page.setInputFiles('.dropzone input[type="file"]', path.resolve(dirname, './image.png'))
+
+      await page.locator('#field-title').fill('Upload title 1')
+      const bulkUploadForm = page.locator('.bulk-upload--file-manager')
+      const relationshipField = bulkUploadForm.locator('#field-relationship')
+      await relationshipField.locator('.relationship-add-new__add-button').click()
+
+      const collectionForm = page.locator('.collection-edit')
+      await collectionForm.locator('#field-title').fill('Related Document Title')
+      await saveDocAndAssert(page)
+      await collectionForm.locator('.doc-drawer__header-close').click()
+
+      await expect(bulkUploadForm.locator('.relationship--single-value__text')).toHaveText(
+        'Related Document Title',
+      )
     })
   })
 

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -81,6 +81,8 @@ export interface Config {
     'focal-no-sizes': FocalNoSize;
     media: Media;
     'allow-list-media': AllowListMedia;
+    'skip-safe-fetch-media': SkipSafeFetchMedia;
+    'skip-allow-list-safe-fetch-media': SkipAllowListSafeFetchMedia;
     'animated-type-media': AnimatedTypeMedia;
     enlarge: Enlarge;
     'without-enlarge': WithoutEnlarge;
@@ -108,6 +110,8 @@ export interface Config {
     'list-view-preview': ListViewPreview;
     'three-dimensional': ThreeDimensional;
     'constructor-options': ConstructorOption;
+    'bulk-uploads': BulkUpload;
+    'simple-relationship': SimpleRelationship;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -129,6 +133,8 @@ export interface Config {
     'focal-no-sizes': FocalNoSizesSelect<false> | FocalNoSizesSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     'allow-list-media': AllowListMediaSelect<false> | AllowListMediaSelect<true>;
+    'skip-safe-fetch-media': SkipSafeFetchMediaSelect<false> | SkipSafeFetchMediaSelect<true>;
+    'skip-allow-list-safe-fetch-media': SkipAllowListSafeFetchMediaSelect<false> | SkipAllowListSafeFetchMediaSelect<true>;
     'animated-type-media': AnimatedTypeMediaSelect<false> | AnimatedTypeMediaSelect<true>;
     enlarge: EnlargeSelect<false> | EnlargeSelect<true>;
     'without-enlarge': WithoutEnlargeSelect<false> | WithoutEnlargeSelect<true>;
@@ -156,6 +162,8 @@ export interface Config {
     'list-view-preview': ListViewPreviewSelect<false> | ListViewPreviewSelect<true>;
     'three-dimensional': ThreeDimensionalSelect<false> | ThreeDimensionalSelect<true>;
     'constructor-options': ConstructorOptionsSelect<false> | ConstructorOptionsSelect<true>;
+    'bulk-uploads': BulkUploadsSelect<false> | BulkUploadsSelect<true>;
+    'simple-relationship': SimpleRelationshipSelect<false> | SimpleRelationshipSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -743,6 +751,42 @@ export interface FocalNoSize {
  * via the `definition` "allow-list-media".
  */
 export interface AllowListMedia {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "skip-safe-fetch-media".
+ */
+export interface SkipSafeFetchMedia {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "skip-allow-list-safe-fetch-media".
+ */
+export interface SkipAllowListSafeFetchMedia {
   id: string;
   updatedAt: string;
   createdAt: string;
@@ -1389,6 +1433,39 @@ export interface ConstructorOption {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "bulk-uploads".
+ */
+export interface BulkUpload {
+  id: string;
+  title: string;
+  relationship?: {
+    relationTo: 'simple-relationship';
+    value: string | SimpleRelationship;
+  } | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "simple-relationship".
+ */
+export interface SimpleRelationship {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -1402,6 +1479,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -1466,6 +1550,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'allow-list-media';
         value: string | AllowListMedia;
+      } | null)
+    | ({
+        relationTo: 'skip-safe-fetch-media';
+        value: string | SkipSafeFetchMedia;
+      } | null)
+    | ({
+        relationTo: 'skip-allow-list-safe-fetch-media';
+        value: string | SkipAllowListSafeFetchMedia;
       } | null)
     | ({
         relationTo: 'animated-type-media';
@@ -1574,6 +1666,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'constructor-options';
         value: string | ConstructorOption;
+      } | null)
+    | ({
+        relationTo: 'bulk-uploads';
+        value: string | BulkUpload;
+      } | null)
+    | ({
+        relationTo: 'simple-relationship';
+        value: string | SimpleRelationship;
       } | null)
     | ({
         relationTo: 'users';
@@ -2200,6 +2300,40 @@ export interface MediaSelect<T extends boolean = true> {
  * via the `definition` "allow-list-media_select".
  */
 export interface AllowListMediaSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "skip-safe-fetch-media_select".
+ */
+export interface SkipSafeFetchMediaSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "skip-allow-list-safe-fetch-media_select".
+ */
+export interface SkipAllowListSafeFetchMediaSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   url?: T;
@@ -2895,6 +3029,34 @@ export interface ConstructorOptionsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "bulk-uploads_select".
+ */
+export interface BulkUploadsSelect<T extends boolean = true> {
+  title?: T;
+  relationship?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "simple-relationship_select".
+ */
+export interface SimpleRelationshipSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
@@ -2907,6 +3069,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/uploads/shared.ts
+++ b/test/uploads/shared.ts
@@ -30,3 +30,4 @@ export const skipAllowListSafeFetchMediaSlug = 'skip-allow-list-safe-fetch-media
 export const listViewPreviewSlug = 'list-view-preview'
 export const threeDimensionalSlug = 'three-dimensional'
 export const constructorOptionsSlug = 'constructor-options'
+export const bulkUploadsSlug = 'bulk-uploads'


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12786

The bulk upload drawer in the list view had no edit depth being set so the document drawer was redirecting to relationship documents when created with the `AddRelationship` button.