### PR TITLE
fix(ui): skip disabled fields when adding OR filter conditions in list view

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -185,7 +185,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
             onClick={async () => {
               await addCondition({
                 andIndex: 0,
-                field: reducedFields[0],
+                field: reducedFields.find((field) => !field.field.admin?.disableListFilter),
                 orIndex: conditions.length,
                 relation: 'or',
               })


### PR DESCRIPTION
### What?

Fixes a bug where adding an additional OR filter condition in the list view selects a field with `admin.disableListFilter: true`, causing all filter fields to appear disabled.

### Why?

When the first field in a collection has `disableListFilter` set to `true`, adding a second OR condition defaults to using that field. This leads to a broken filter UI where no valid fields are selectable.

### How?

Replaces the hardcoded usage of `reducedFields[0]` with a call to `reducedFields.find(...) `that skips fields with `disableListFilter: true`, consistent with the logic already used when adding the first filter condition.

Fixes #12993 