### PR TITLE
test: reduce queue test amount

### DIFF
--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -1397,7 +1397,7 @@ describe('Queues', () => {
       // TODO: This test is flaky on supabase in CI, so we skip it for now
       return
     }
-    const amount = 500
+    const amount = 50
     payload.config.jobs.deleteJobOnComplete = false
 
     const job = await payload.jobs.queue({


### PR DESCRIPTION
Reduce the number of queued jobs run. CI is having a hard time with this test because it times out. This change can be temporary but it is blocking a lot of PR's causing users to re-run CI multiple times on almost every PR.
