### PR TITLE
fix(ui): improve select column width for better list table layout

### DIFF
--- a/packages/ui/src/views/List/index.scss
+++ b/packages/ui/src/views/List/index.scss
@@ -41,6 +41,7 @@
         #heading-_select,
         .cell-_select {
           min-width: unset;
+          width: 1%;
         }
 
         #heading-_dragHandle,


### PR DESCRIPTION
## What / Why
The select column (containing checkboxes for bulk actions) was taking up excessive width in list views, pushing the first "real" data column unnecessarily far from the checkbox column. This created poor visual hierarchy and wasted horizontal space, especially noticeable in:
- Collections with only one or a few fields
- Views where users have selected only one column to display
- Larger viewport widths (Wide screens)

## Changes introduced
- `packages/ui/src/views/List/index.scss`
  - Added `width: 1%` to `.cell-_select` and `#heading-_select` to minimize column width

## Behavior after the fix
- Select column now uses minimal necessary width (just enough for the checkbox)
- First data column starts much closer to the select column, improving visual flow
- Better horizontal space utilization across all collection list views
- Improved layout especially for collections with fewer visible columns

## How to test manually
1. Run `pnpm dev admin` or any test suite with collections
2. Navigate to any collection list view (Posts, Users, etc.)
3. Notice the select column now takes minimal width
4. Test with different numbers of visible columns (use column selector)

## Screenshots
### Before/After Comparison
![Select column width optimization](https://github.com/user-attachments/assets/6f486527-0f5e-4311-bfa8-43eea713607d)