### PR TITLE
fix(ui): hide type column in non-polymorphic join fields

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -147,7 +147,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
             : `_${field.collection}_${field.name}_order`,
         parent,
         query: newQuery,
-        renderRowTypes: true,
+        renderRowTypes: isPolymorphic,
         tableAppearance: 'condensed',
       })
 
@@ -170,6 +170,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
       getTableState,
       relationTo,
       parent,
+      isPolymorphic,
     ],
   )
 


### PR DESCRIPTION
## What / Why
Relationship tables were always rendering a "Type" column that displays the collection name, even for non-polymorphic relationships. This column is only useful for polymorphic relationships where users need to distinguish between different collection types. For single-collection relationships, this column was redundant since the collection type is already clear from the field label and context.

## Changes introduced
- `packages/ui/src/elements/RelationshipTable/index.tsx`
  - Changed `renderRowTypes: true` to `renderRowTypes: isPolymorphic`
  - Added `isPolymorphic` to the dependency array for proper re-rendering

## Behavior after the fix
- **Non-polymorphic relationships**: Type column is hidden, providing cleaner table layout
- **Polymorphic relationships**: Type column still shows to help users distinguish collection types
- Improved horizontal space utilization in relationship tables
- Better visual focus on actual data columns

## How to test manually
1. Run `pnpm dev` (or create similar test setup)
2. Create collections with both types of join fields:
   - **Non-polymorphic**: Join field pointing to single collection (e.g., Posts → Media)
   - **Polymorphic**: Join field pointing to multiple collections (e.g., Categories → [Posts, Media])
3. Navigate to documents with these join fields
4. **Non-polymorphic relationship**: Verify no "Type" column appears in the relationship table
5. **Polymorphic relationship**: Verify "Type" column appears with collection type pills
6. Test the interface functionality in both cases

## Screenshots
### Before/After Comparison
![Type column visibility optimization](https://github.com/user-attachments/assets/5f49dbe3-3d24-4e21-b005-1f49c9966a6f)