### PR TITLE
fix(examples): only allow super admins to create users with super admin role

### DIFF
--- a/examples/multi-tenant/src/collections/Users/access/create.ts
+++ b/examples/multi-tenant/src/collections/Users/access/create.ts
@@ -14,6 +14,10 @@ export const createAccess: Access<User> = ({ req }) => {
     return true
   }
 
+  if (!isSuperAdmin(req.user) && req.data?.roles?.includes('super-admin')) {
+    return false
+  }
+
   const adminTenantAccessIDs = getUserTenantIDs(req.user, 'tenant-admin')
 
   if (adminTenantAccessIDs.length) {


### PR DESCRIPTION
### What?

This PR updates the `create` access control on the `users` collection in the `multi-tenant` example to prevent unauthorized creation of `super-admin` users.

### Why?

Previously, any authenticated user could create a new user and assign them the `super-admin` role — even if they didn’t have that role themselves. This bypassed role-based restrictions and introduced a security vulnerability, allowing users to escalate their own privileges by working around role restrictions during user creation.

### How?

The `create` access function now checks whether the current user has the `super-admin` role before allowing the creation of another `super-admin`.  If not, the request is denied.


**Fixes:** `CMS2-Q225-01`