### PR TITLE
fix(db-mongodb): nested sorting by ID

### DIFF
--- a/packages/db-mongodb/src/queries/buildSortParam.ts
+++ b/packages/db-mongodb/src/queries/buildSortParam.ts
@@ -77,6 +77,9 @@ const relationshipSort = ({
     ) {
       const relationshipPath = segments.slice(0, i + 1).join('.')
       let sortFieldPath = segments.slice(i + 1, segments.length).join('.')
+      if (sortFieldPath.endsWith('.id')) {
+        sortFieldPath = sortFieldPath.split('.').slice(0, -1).join('.')
+      }
       if (Array.isArray(field.relationTo)) {
         throw new APIError('Not supported')
       }

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -47,6 +47,16 @@ export default buildConfigWithDefaults({
       ],
     },
     {
+      slug: 'categories-custom-id',
+      versions: { drafts: true },
+      fields: [
+        {
+          type: 'number',
+          name: 'id',
+        },
+      ],
+    },
+    {
       slug: postsSlug,
       fields: [
         {
@@ -59,6 +69,11 @@ export default buildConfigWithDefaults({
           type: 'relationship',
           relationTo: 'categories',
           name: 'category',
+        },
+        {
+          type: 'relationship',
+          relationTo: 'categories-custom-id',
+          name: 'categoryCustomID',
         },
         {
           name: 'localized',
@@ -515,6 +530,11 @@ export default buildConfigWithDefaults({
           name: 'postCategoryID',
           type: 'json',
           virtual: 'post.category.id',
+        },
+        {
+          name: 'postCategoryCustomID',
+          type: 'number',
+          virtual: 'post.categoryCustomID.id',
         },
         {
           name: 'postID',

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2255,6 +2255,51 @@ describe('database', () => {
       expect(globalData.postTitle).toBe('post')
     })
 
+    it('should allow to sort by a virtual field with a reference to an ID', async () => {
+      const category_1 = await payload.create({
+        collection: 'categories-custom-id',
+        data: { id: 1 },
+      })
+      const category_2 = await payload.create({
+        collection: 'categories-custom-id',
+        data: { id: 2 },
+      })
+      const post_1 = await payload.create({
+        collection: 'posts',
+        data: { categoryCustomID: category_1.id, title: 'p-1' },
+      })
+      const post_2 = await payload.create({
+        collection: 'posts',
+        data: { categoryCustomID: category_2.id, title: 'p-2' },
+      })
+      const virtual_1 = await payload.create({
+        collection: 'virtual-relations',
+        data: { post: post_1.id },
+      })
+      const virtual_2 = await payload.create({
+        collection: 'virtual-relations',
+        data: { post: post_2.id },
+      })
+
+      const res = (
+        await payload.find({
+          collection: 'virtual-relations',
+          sort: 'postCategoryCustomID',
+        })
+      ).docs
+      expect(res[0].id).toBe(virtual_1.id)
+      expect(res[1].id).toBe(virtual_2.id)
+
+      const res2 = (
+        await payload.find({
+          collection: 'virtual-relations',
+          sort: '-postCategoryCustomID',
+        })
+      ).docs
+      expect(res2[1].id).toBe(virtual_1.id)
+      expect(res2[0].id).toBe(virtual_2.id)
+    })
+
     it('should allow to sort by a virtual field with a refence, Local / GraphQL', async () => {
       const post_1 = await payload.create({ collection: 'posts', data: { title: 'A' } })
       const post_2 = await payload.create({ collection: 'posts', data: { title: 'B' } })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2256,6 +2256,7 @@ describe('database', () => {
     })
 
     it('should allow to sort by a virtual field with a reference to an ID', async () => {
+      await payload.delete({ collection: 'virtual-relations', where: {} })
       const category_1 = await payload.create({
         collection: 'categories-custom-id',
         data: { id: 1 },

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -68,6 +68,7 @@ export interface Config {
   blocks: {};
   collections: {
     categories: Category;
+    'categories-custom-id': CategoriesCustomId;
     posts: Post;
     'error-on-unnamed-fields': ErrorOnUnnamedField;
     'default-values': DefaultValue;
@@ -93,6 +94,7 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
+    'categories-custom-id': CategoriesCustomIdSelect<false> | CategoriesCustomIdSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     'error-on-unnamed-fields': ErrorOnUnnamedFieldsSelect<false> | ErrorOnUnnamedFieldsSelect<true>;
     'default-values': DefaultValuesSelect<false> | DefaultValuesSelect<true>;
@@ -172,12 +174,23 @@ export interface Category {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories-custom-id".
+ */
+export interface CategoriesCustomId {
+  id: number;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
 export interface Post {
   id: string;
   title: string;
   category?: (string | null) | Category;
+  categoryCustomID?: (number | null) | CategoriesCustomId;
   localized?: string | null;
   text?: string | null;
   number?: number | null;
@@ -406,6 +419,7 @@ export interface VirtualRelation {
     | number
     | boolean
     | null;
+  postCategoryCustomID?: number | null;
   postID?:
     | {
         [k: string]: unknown;
@@ -568,6 +582,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -580,6 +601,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'categories';
         value: string | Category;
+      } | null)
+    | ({
+        relationTo: 'categories-custom-id';
+        value: number | CategoriesCustomId;
       } | null)
     | ({
         relationTo: 'posts';
@@ -707,11 +732,22 @@ export interface CategoriesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories-custom-id_select".
+ */
+export interface CategoriesCustomIdSelect<T extends boolean = true> {
+  id?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts_select".
  */
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   category?: T;
+  categoryCustomID?: T;
   localized?: T;
   text?: T;
   number?: T;
@@ -919,6 +955,7 @@ export interface VirtualRelationsSelect<T extends boolean = true> {
   postTitleHidden?: T;
   postCategoryTitle?: T;
   postCategoryID?: T;
+  postCategoryCustomID?: T;
   postID?: T;
   postLocalized?: T;
   post?: T;
@@ -1074,6 +1111,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Fixes sorting when the `sort` path contains a relationship and ends with `id`, for example `sort: 'post.category.id'`.