### PR TITLE
fix: add d1-sqlite package name to map for pr #12357

### DIFF
--- a/test/setupProd.ts
+++ b/test/setupProd.ts
@@ -8,6 +8,7 @@ const dirname = path.dirname(filename)
 export const tgzToPkgNameMap = {
   payload: 'payload-*',
   '@payloadcms/admin-bar': 'payloadcms-admin-bar-*',
+  '@payloadcms/db-d1-sqlite': 'payloadcms-db-d1-sqlite-*',
   '@payloadcms/db-mongodb': 'payloadcms-db-mongodb-*',
   '@payloadcms/db-postgres': 'payloadcms-db-postgres-*',
   '@payloadcms/db-vercel-postgres': 'payloadcms-db-vercel-postgres-*',


### PR DESCRIPTION

This pull request adds support for a new package mapping in the `test/setupProd.ts` file.

Specifically:
* [`test/setupProd.ts`](diffhunk://#diff-a244e933c83a32a51f69c507d3694b0244da76449e175639354c3e57125d6eadR11): Added a mapping for the `@payloadcms/db-d1-sqlite` package to the `tgzToPkgNameMap` object.

