### PR TITLE
chore: fix payload bundle script

### DIFF
--- a/packages/payload/bundle.js
+++ b/packages/payload/bundle.js
@@ -7,11 +7,11 @@ const dirname = path.dirname(filename)
 
 async function build() {
   const resultIndex = await esbuild.build({
-    entryPoints: ['src/exports/index.ts'],
+    entryPoints: ['src/index.ts'],
     bundle: true,
     platform: 'node',
     format: 'esm',
-    outfile: 'dist/exports/index.js',
+    outfile: 'dist/index.js',
     splitting: false,
     external: [
       'lodash',


### PR DESCRIPTION
This fixes the payload bundle script. While not run by default, it's useful for checking the payload bundle size by manually running `cd packages/payload && node bundle.js`.