### PR TITLE
fix(templates): wrong link in demo content (custom components)

### DIFF
--- a/examples/localization/src/payload.config.ts
+++ b/examples/localization/src/payload.config.ts
@@ -53,7 +53,7 @@ export default buildConfig({
   admin: {
     components: {
       // The `BeforeLogin` component renders a message that you see while logging into your admin panel.
-      // Feel free to delete this at any time. Simply remove the line below and the import `BeforeLogin` statement on line 15.
+      // Feel free to delete this at any time. Simply remove the line below.
       beforeLogin: ['@/components/BeforeLogin'],
       afterDashboard: ['@/components/AfterDashboard'],
     },

--- a/templates/website/src/components/BeforeDashboard/index.tsx
+++ b/templates/website/src/components/BeforeDashboard/index.tsx
@@ -60,7 +60,7 @@ const BeforeDashboard: React.FC = () => {
       </ul>
       {'Pro Tip: This block is a '}
       <a
-        href="https://payloadcms.com/docs/admin/custom-components/overview#base-component-overrides"
+        href="https://payloadcms.com/docs/custom-components/overview"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/templates/website/src/payload.config.ts
+++ b/templates/website/src/payload.config.ts
@@ -24,10 +24,10 @@ export default buildConfig({
   admin: {
     components: {
       // The `BeforeLogin` component renders a message that you see while logging into your admin panel.
-      // Feel free to delete this at any time. Simply remove the line below and the import `BeforeLogin` statement on line 15.
+      // Feel free to delete this at any time. Simply remove the line below.
       beforeLogin: ['@/components/BeforeLogin'],
       // The `BeforeDashboard` component renders the 'welcome' block that you see after logging into your admin panel.
-      // Feel free to delete this at any time. Simply remove the line below and the import `BeforeDashboard` statement on line 15.
+      // Feel free to delete this at any time. Simply remove the line below.
       beforeDashboard: ['@/components/BeforeDashboard'],
     },
     importMap: {

--- a/templates/with-vercel-website/src/components/BeforeDashboard/index.tsx
+++ b/templates/with-vercel-website/src/components/BeforeDashboard/index.tsx
@@ -60,7 +60,7 @@ const BeforeDashboard: React.FC = () => {
       </ul>
       {'Pro Tip: This block is a '}
       <a
-        href="https://payloadcms.com/docs/admin/custom-components/overview#base-component-overrides"
+        href="https://payloadcms.com/docs/custom-components/overview"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/templates/with-vercel-website/src/payload.config.ts
+++ b/templates/with-vercel-website/src/payload.config.ts
@@ -24,10 +24,10 @@ export default buildConfig({
   admin: {
     components: {
       // The `BeforeLogin` component renders a message that you see while logging into your admin panel.
-      // Feel free to delete this at any time. Simply remove the line below and the import `BeforeLogin` statement on line 15.
+      // Feel free to delete this at any time. Simply remove the line below.
       beforeLogin: ['@/components/BeforeLogin'],
       // The `BeforeDashboard` component renders the 'welcome' block that you see after logging into your admin panel.
-      // Feel free to delete this at any time. Simply remove the line below and the import `BeforeDashboard` statement on line 15.
+      // Feel free to delete this at any time. Simply remove the line below.
       beforeDashboard: ['@/components/BeforeDashboard'],
     },
     importMap: {


### PR DESCRIPTION
### What?

The "custom component" link in the dashboard of the website demo is wrong:
![image](https://github.com/user-attachments/assets/ee716a87-c515-4561-932d-f1c1fcccfd5e)
