### PR TITLE
fix(eslint): resolve VS Code plugin error with PNPM

### DIFF
--- a/templates/blank/.npmrc
+++ b/templates/blank/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+public-hoist-pattern[]=*eslint*

--- a/templates/website/.npmrc
+++ b/templates/website/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps=true
+public-hoist-pattern[]=*eslint*
 enable-pre-post-scripts=true

--- a/templates/with-vercel-website/.npmrc
+++ b/templates/with-vercel-website/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps=true
+public-hoist-pattern[]=*eslint*
 enable-pre-post-scripts=true


### PR DESCRIPTION
Recent versions of PNPM (v10+) no longer automatically hoist ESLint packages to the root of the `node_modules` directory. This change causes the VS Code ESLint extension to fail, as it cannot find its required modules.

This commit adds `public-hoist-pattern[]=*eslint*` to the `.npmrc` file. This configuration explicitly tells PNPM to hoist ESLint-related packages, restoring the functionality of the VS Code ESLint extension without resorting to a fully hoisted `node_modules` structure.


### What?

This PR updates the `.npmrc` file to include a `publicHoistPattern` [PNPM workspace settings](https://pnpm.io/settings#publichoistpattern) for ESLint packages.

### Why?

The VS Code ESLint extension fails to initialize in new PayloadCMS projects that use PNPM. This is caused by a breaking change in PNPM v10 which no longer hoists ESLint packages by default, leading to a `MODULE_NOT_FOUND` error. This change is discussed in the pnpm repository issue https://github.com/pnpm/pnpm/issues/8378.

**Relevant error**

```sh
[Error - 12:03:47 PM] Calculating config file for file:///package.json) failed.
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/eslintrc' imported from /eslint.config.mjs
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:268:9)
    at packageResolve (node:internal/modules/esm/resolve:778:81)
    at moduleResolve (node:internal/modules/esm/resolve:864:18)
    at defaultResolve (node:internal/modules/esm/resolve:994:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:780:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:704:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:687:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:305:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:137:49)
```

### How?
This change adds `public-hoist-pattern[]=*eslint*` to the `.npmrc` file. This configuration explicitly instructs PNPM to hoist all ESLint-related packages to the root of the node_modules directory, making them accessible to the VS Code ESLint extension and resolving the error.


> [!NOTE]
>  [ESLint recommendation's](https://eslint.org/docs/latest/use/getting-started#manual-set-up) was considered as well to use `node-linker=hoisted`. However, that approach alters PNPM's default dependency resolution strategy to mimic NPM, which is a broader change than necessary. The `public-hoist-pattern` is a more targeted solution that fixes the tooling incompatibility while preserving the benefits of PNPM's standard non-hoisted node modules structure.
