### PR TITLE
feat: exports new sanitizeUserDataForEmail function

### DIFF
--- a/examples/email/src/collections/Newsletter.ts
+++ b/examples/email/src/collections/Newsletter.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { sanitizeUserDataForEmail } from 'payload/shared'
 
 import { generateEmailHTML } from '../email/generateEmailHTML'
 
@@ -26,7 +27,7 @@ export const Newsletter: CollectionConfig = {
             .sendEmail({
               from: 'sender@example.com',
               html: await generateEmailHTML({
-                content: `<p>${doc.name ? `Hi ${doc.name}!` : 'Hi!'} We'll be in touch soon...</p>`,
+                content: `<p>${doc.name ? `Hi ${sanitizeUserDataForEmail(doc.name)}!` : 'Hi!'} We'll be in touch soon...</p>`,
                 headline: 'Welcome to the newsletter!',
               }),
               subject: 'Thanks for signing up!',

--- a/examples/email/src/email/generateVerificationEmail.ts
+++ b/examples/email/src/email/generateVerificationEmail.ts
@@ -1,5 +1,7 @@
 import { generateEmailHTML } from './generateEmailHTML'
 
+import { sanitizeUserDataForEmail } from 'payload/shared'
+
 type User = {
   email: string
   name?: string
@@ -16,7 +18,7 @@ export const generateVerificationEmail = async (
   const { token, user } = args
 
   return generateEmailHTML({
-    content: `<p>Hi${user.name ? ' ' + user.name : ''}! Validate your account by clicking the button below.</p>`,
+    content: `<p>Hi${user.name ? ' ' + sanitizeUserDataForEmail(user.name) : ''}! Validate your account by clicking the button below.</p>`,
     cta: {
       buttonLabel: 'Verify',
       url: `${process.env.PAYLOAD_PUBLIC_SERVER_URL}/verify?token=${token}&email=${user.email}`,

--- a/packages/payload/src/exports/shared.ts
+++ b/packages/payload/src/exports/shared.ts
@@ -112,6 +112,8 @@ export {
 
 export { reduceFieldsToValues } from '../utilities/reduceFieldsToValues.js'
 
+export { sanitizeUserDataForEmail } from '../utilities/sanitizeUserDataForEmail.js'
+
 export { setsAreEqual } from '../utilities/setsAreEqual.js'
 
 export { toKebabCase } from '../utilities/toKebabCase.js'

--- a/packages/payload/src/utilities/sanitizeUserDataForEmail.spec.ts
+++ b/packages/payload/src/utilities/sanitizeUserDataForEmail.spec.ts
@@ -1,0 +1,87 @@
+import { sanitizeUserDataForEmail } from './sanitizeUserDataForEmail'
+
+describe('sanitizeUserDataForEmail', () => {
+  it('should remove anchor tags', () => {
+    const input = '<a href="https://example.com">Click me</a>'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('Click me')
+  })
+
+  it('should remove script tags', () => {
+    const unsanitizedData = '<script>alert</script>'
+    const sanitizedData = sanitizeUserDataForEmail(unsanitizedData)
+    expect(sanitizedData).toBe('alert')
+  })
+
+  it('should remove mixed-case script tags', () => {
+    const input = '<ScRipT>alert(1)</sCrIpT>'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('alert1')
+  })
+
+  it('should remove embedded base64-encoded scripts', () => {
+    const input = '<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('')
+  })
+
+  it('should remove iframe elements', () => {
+    const input = '<iframe src="malicious.com"></iframe>Frame'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('Frame')
+  })
+
+  it('should remove javascript: links in attributes', () => {
+    const input = '<a href="javascript:alert(1)">click</a>'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('click')
+  })
+
+  it('should remove mismatched script input', () => {
+    const input = '<script>console.log("test")'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('console.log\"test\"')
+  })
+
+  it('should remove encoded scripts via HTML entities', () => {
+    const input = '&#x3C;script&#x3E;alert(1)&#x3C;/script&#x3E;'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('alert1')
+  })
+
+  it('should remove template injection syntax', () => {
+    const input = '{{7*7}}'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('77')
+  })
+
+  it('should remove invisible zero-width characters', () => {
+    const input = 'a\u200Bler\u200Bt("XSS")'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('alert\"XSS\"')
+  })
+
+  it('should remove CSS expressions within style attributes', () => {
+    const input = '<div style="width: expression(alert(\'XSS\'));">Hello</div>'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('Hello')
+  })
+
+  it('should not render SVG with onload event', () => {
+    const input = '<svg onload="alert(\'XSS\')">Graphic</svg>'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('Graphic')
+  })
+
+  it('should not allow backtick-based patterns', () => {
+    const input = '`alert("XSS")`'
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe('alert\"XSS\"')
+  })
+
+  it('should preserve allowed punctuation', () => {
+    const input = `Hello "world" - it's safe!`
+    const result = sanitizeUserDataForEmail(input)
+    expect(result).toBe(`Hello "world" - it's safe!`)
+  })
+})

--- a/packages/payload/src/utilities/sanitizeUserDataForEmail.ts
+++ b/packages/payload/src/utilities/sanitizeUserDataForEmail.ts
@@ -1,0 +1,50 @@
+/**
+ * Sanitizes user data for emails to prevent injection of HTML, executable code, or other malicious content.
+ * This function ensures the content is safe by:
+ * - Removing HTML tags
+ * - Removing control characters
+ * - Normalizing whitespace
+ * - Escaping special HTML characters
+ * - Allowing only letters, numbers, spaces, and basic punctuation
+ * - Limiting length (default 100 characters)
+ *
+ * @param data - data to sanitize
+ * @param maxLength - maximum allowed length (default is 100)
+ * @returns a sanitized string safe to include in email content
+ */
+export function sanitizeUserDataForEmail(data: unknown, maxLength = 100): string {
+  if (typeof data !== 'string') {
+    return ''
+  }
+
+  // Remove HTML tags
+  const noTags = data.replace(/<[^>]+>/g, '')
+
+  // Remove control characters except common whitespace
+  const noControls = [...noTags]
+    .filter((char) => {
+      const code = char.charCodeAt(0)
+      return (
+        (code >= 32 && code <= 126) || // standard characters
+        code === 9 || // tab
+        code === 10 || // new line
+        code === 13 // return
+      )
+    })
+    .join('')
+
+  // Normalize whitespace (spaces, tabs, new lines) to single spaces
+  const normalizedWhitespace = noControls.replace(/\s+/g, ' ')
+
+  // Escape special HTML characters
+  const escaped = normalizedWhitespace
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
+  // Allow only letters, numbers, spaces, and common punctuation
+  const cleaned = escaped.replace(/[^a-z0-9 .,!?'"-]/gi, '')
+
+  // Trim and limit length, trim again to remove trailing spaces
+  return cleaned.slice(0, maxLength).trim()
+}

--- a/packages/payload/src/utilities/sanitizeUserDataForEmail.ts
+++ b/packages/payload/src/utilities/sanitizeUserDataForEmail.ts
@@ -17,8 +17,13 @@ export function sanitizeUserDataForEmail(data: unknown, maxLength = 100): string
     return ''
   }
 
+  // Decode HTML numeric entities like &#x3C; or &#60;
+  const decodedEntities = data
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)))
+
   // Remove HTML tags
-  const noTags = data.replace(/<[^>]+>/g, '')
+  const noTags = decodedEntities.replace(/<[^>]+>/g, '')
 
   // Remove control characters except common whitespace
   const noControls = [...noTags]


### PR DESCRIPTION
### What?

Adds a new `sanitizeUserDataForEmail` function, exported from `payload/shared`.  
This function sanitizes user data passed to email templates to prevent injection of HTML, executable code, or other malicious content.

### Why?

In the existing `email` example, we directly insert `user.name` into the generated email content. Similarly, the `newsletter` collection uses `doc.name` directly in the email content. A security report identified this as a potential vulnerability that could be exploited and used to inject executable or malicious code.

Although this issue does not originate from Payload core, developers using our examples may unknowingly introduce this vulnerability into their own codebases.

### How?

Introduces the pre-built `sanitizeUserDataForEmail` function and updates relevant email examples to use it.

**Fixes `CMS2-1225-14`**