### PR TITLE
fix(ui): increase timeout for opening list drawer in RelationshipInput

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -779,7 +779,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
                   // and when the devtools are closed. Temporary solution, we can probably do better.
                   setTimeout(() => {
                     openListDrawer()
-                  }, 50)
+                  }, 100)
                 } else if (appearance === 'select') {
                   setMenuIsOpen(true)
                   if (!hasLoadedFirstPageRef.current) {


### PR DESCRIPTION
As stated in #12529, the setTimeout was defined through trial and error as it wasn't possible to reproduce the bug with the devtools open and therefore with the CPU throttled. One user reported still experiencing the bug.

I'm increasing the timeout to 100ms, which seems acceptable enough to keep postponing a better fix, considering the bug isn't that critical.

If we find it keeps happening, we'll probably need to investigate the root cause.