### PR TITLE
fix: bun undici polyfill issue, only initialize safeDispatcher if skipSafeFetch is false

### DIFF
--- a/packages/payload/src/uploads/safeFetch.ts
+++ b/packages/payload/src/uploads/safeFetch.ts
@@ -49,7 +49,8 @@ const ssrfFilterInterceptor: Dispatcher.DispatcherComposeInterceptor = (dispatch
   }
 }
 
-const safeDispatcher = new Agent().compose(ssrfFilterInterceptor)
+// const safeDispatcher = new Agent().compose(ssrfFilterInterceptor)
+let safeDispatcher ;
 
 /**
  * A "safe" version of undici's fetch that prevents SSRF attacks.
@@ -59,6 +60,9 @@ const safeDispatcher = new Agent().compose(ssrfFilterInterceptor)
  * - Undici was used because it supported interceptors as well as "credentials: include". Native fetch
  */
 export const safeFetch = async (...args: Parameters<typeof undiciFetch>) => {
+  if(!safeDispatcher){
+        safeDispatcher = new Agent().compose(ssrfFilterInterceptor);
+    }
   const [unverifiedUrl, options] = args
 
   try {


### PR DESCRIPTION
hi, 
currently we are initializing safeDispatcher outside of the safeFetch function, which is causing edge case issue with bun and undici polyfill

like this 
https://github.com/payloadcms/payload/blob/30fc7e3012dae81b3f727b35ff6917e75f271df1/packages/payload/src/uploads/safeFetch.ts#L52

if we move this to the function safeFetch  , we can get rid of edge case (see below) , if user set `skipSafeFetch: true`.

i have implemented this like that in this PR, till bun fixes undici polyfill issue this is a temporary fix.


related issues payload
https://github.com/payloadcms/payload/pull/12622#issuecomment-2993559728 https://github.com/payloadcms/payload/pull/12622#issuecomment-3025004727


related issues Bun
https://github.com/oven-sh/bun/issues/17799
https://github.com/oven-sh/bun/issues/20022

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
