### PR TITLE
fix(next): respect collection-level live preview config

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -329,20 +329,10 @@ export const renderDocument = async ({
     viewType,
   }
 
-  let livePreviewConfig: LivePreviewConfig = config.admin.livePreview
-
-  if (collectionConfig) {
-    livePreviewConfig = {
-      ...(livePreviewConfig || {}),
-      ...(collectionConfig.admin.livePreview || {}),
-    }
-  }
-
-  if (globalConfig) {
-    livePreviewConfig = {
-      ...(livePreviewConfig || {}),
-      ...(globalConfig.admin.livePreview || {}),
-    }
+  const livePreviewConfig: LivePreviewConfig = {
+    ...(config.admin.livePreview || {}),
+    ...(collectionConfig?.admin?.livePreview || {}),
+    ...(globalConfig?.admin?.livePreview || {}),
   }
 
   const livePreviewURL =

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -6,6 +6,7 @@ import type {
   DocumentViewServerProps,
   DocumentViewServerPropsOnly,
   EditViewComponent,
+  LivePreviewConfig,
   PayloadComponent,
   RenderDocumentVersionsProperties,
 } from 'payload'
@@ -91,7 +92,6 @@ export const renderDocument = async ({
       payload: {
         config,
         config: {
-          admin: { livePreview: livePreviewConfig },
           routes: { admin: adminRoute, api: apiRoute },
           serverURL,
         },
@@ -327,6 +327,22 @@ export const renderDocument = async ({
     ...documentSlots,
     documentSubViewType,
     viewType,
+  }
+
+  let livePreviewConfig: LivePreviewConfig = config.admin.livePreview
+
+  if (collectionConfig) {
+    livePreviewConfig = {
+      ...(livePreviewConfig || {}),
+      ...(collectionConfig.admin.livePreview || {}),
+    }
+  }
+
+  if (globalConfig) {
+    livePreviewConfig = {
+      ...(livePreviewConfig || {}),
+      ...(globalConfig.admin.livePreview || {}),
+    }
   }
 
   const livePreviewURL =

--- a/packages/ui/src/providers/LivePreview/index.tsx
+++ b/packages/ui/src/providers/LivePreview/index.tsx
@@ -226,6 +226,13 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = ({
     )
   }, [isLivePreviewing, setPreference, collectionSlug, globalSlug])
 
+  const isLivePreviewEnabled = Boolean(
+    operation !== 'create' &&
+      ((collectionSlug && config?.admin?.livePreview?.collections?.includes(collectionSlug)) ||
+        (globalSlug && config.admin?.livePreview?.globals?.includes(globalSlug)) ||
+        entityConfig?.admin?.livePreview),
+  )
+
   return (
     <LivePreviewContext
       value={{
@@ -235,13 +242,7 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = ({
         fieldSchemaJSON,
         iframeHasLoaded,
         iframeRef,
-        isLivePreviewEnabled: Boolean(
-          (operation !== 'create' &&
-            collectionSlug &&
-            config?.admin?.livePreview?.collections?.includes(collectionSlug)) ||
-            (globalSlug && config.admin?.livePreview?.globals?.includes(globalSlug)) ||
-            entityConfig?.admin?.livePreview,
-        ),
+        isLivePreviewEnabled,
         isLivePreviewing,
         isPopupOpen,
         listeningForMessages,

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -203,6 +203,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -341,6 +348,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -248,7 +248,7 @@ export async function saveDocHotkeyAndAssert(page: Page): Promise<void> {
 
 export async function saveDocAndAssert(
   page: Page,
-  selector: '#access-save' | '#action-publish' | '#action-save-draft' | string = '#action-save',
+  selector: '#action-publish' | '#action-save' | '#action-save-draft' | string = '#action-save',
   expectation: 'error' | 'success' = 'success',
 ): Promise<void> {
   await wait(500) // TODO: Fix this

--- a/test/live-preview/collections/Categories.ts
+++ b/test/live-preview/collections/Categories.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from 'payload'
 
 import { categoriesSlug } from '../shared.js'
 
-const Categories: CollectionConfig = {
+export const Categories: CollectionConfig = {
   slug: categoriesSlug,
   admin: {
     useAsTitle: 'title',
@@ -17,5 +17,3 @@ const Categories: CollectionConfig = {
     },
   ],
 }
-
-export default Categories

--- a/test/live-preview/collections/CollectionLevelConfig.ts
+++ b/test/live-preview/collections/CollectionLevelConfig.ts
@@ -1,0 +1,24 @@
+import type { CollectionConfig } from 'payload'
+
+import { collectionLevelConfigSlug } from '../shared.js'
+import { formatLivePreviewURL } from '../utilities/formatLivePreviewURL.js'
+
+export const CollectionLevelConfig: CollectionConfig = {
+  slug: collectionLevelConfigSlug,
+  admin: {
+    description: "Live Preview is enabled on this collection's own config, not the root config.",
+    useAsTitle: 'title',
+    livePreview: {
+      url: formatLivePreviewURL,
+    },
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}

--- a/test/live-preview/collections/CollectionLevelConfig.ts
+++ b/test/live-preview/collections/CollectionLevelConfig.ts
@@ -1,7 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
 import { collectionLevelConfigSlug } from '../shared.js'
-import { formatLivePreviewURL } from '../utilities/formatLivePreviewURL.js'
 
 export const CollectionLevelConfig: CollectionConfig = {
   slug: collectionLevelConfigSlug,
@@ -9,7 +8,7 @@ export const CollectionLevelConfig: CollectionConfig = {
     description: "Live Preview is enabled on this collection's own config, not the root config.",
     useAsTitle: 'title',
     livePreview: {
-      url: formatLivePreviewURL,
+      url: 'http://localhost:3000/live-preview',
     },
   },
   access: {

--- a/test/live-preview/config.ts
+++ b/test/live-preview/config.ts
@@ -3,7 +3,8 @@ import path from 'path'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import Categories from './collections/Categories.js'
+import { Categories } from './collections/Categories.js'
+import { CollectionLevelConfig } from './collections/CollectionLevelConfig.js'
 import { Media } from './collections/Media.js'
 import { Pages } from './collections/Pages.js'
 import { Posts } from './collections/Posts.js'
@@ -44,7 +45,17 @@ export default buildConfigWithDefaults({
   },
   cors: ['http://localhost:3000', 'http://localhost:3001'],
   csrf: ['http://localhost:3000', 'http://localhost:3001'],
-  collections: [Users, Pages, Posts, SSR, SSRAutosave, Tenants, Categories, Media],
+  collections: [
+    Users,
+    Pages,
+    Posts,
+    SSR,
+    SSRAutosave,
+    Tenants,
+    Categories,
+    Media,
+    CollectionLevelConfig,
+  ],
   globals: [Header, Footer],
   onInit: seed,
   typescript: {

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -147,7 +147,7 @@ describe('Live Preview', () => {
     await page.goto(collURL.create)
     await page.locator('#field-title').fill('Collection Level Config')
     await saveDocAndAssert(page)
-    await goToCollectionLivePreview(page, collURL)
+    await toggleLivePreview(page)
     await expect(page.locator('iframe.live-preview-iframe')).toBeVisible()
   })
 

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -102,6 +102,22 @@ describe('Live Preview', () => {
     await expect(page.locator('iframe.live-preview-iframe')).toBeHidden()
   })
 
+  test('collection - does not enable live preview is collections that are not configured', async () => {
+    const usersURL = new AdminUrlUtil(serverURL, 'users')
+    await navigateToDoc(page, usersURL)
+    const toggler = page.locator('#live-preview-toggler')
+    await expect(toggler).toBeHidden()
+  })
+
+  test('collection - respect collection-level live preview config', async () => {
+    const collURL = new AdminUrlUtil(serverURL, collectionLevelConfigSlug)
+    await page.goto(collURL.create)
+    await page.locator('#field-title').fill('Collection Level Config')
+    await saveDocAndAssert(page)
+    await toggleLivePreview(page)
+    await expect(page.locator('iframe.live-preview-iframe')).toBeVisible()
+  })
+
   test('saves live preview state to preferences and loads it on next visit', async () => {
     await deletePreferences({
       payload,
@@ -140,15 +156,6 @@ describe('Live Preview', () => {
     await goToCollectionLivePreview(page, pagesURLUtil)
     const iframe = page.locator('iframe.live-preview-iframe')
     await expect(iframe).toBeVisible()
-  })
-
-  test('collection - respect collection-level live preview config', async () => {
-    const collURL = new AdminUrlUtil(serverURL, collectionLevelConfigSlug)
-    await page.goto(collURL.create)
-    await page.locator('#field-title').fill('Collection Level Config')
-    await saveDocAndAssert(page)
-    await toggleLivePreview(page)
-    await expect(page.locator('iframe.live-preview-iframe')).toBeVisible()
   })
 
   test('collection csr — re-renders iframe client-side when form state changes', async () => {

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -27,6 +27,7 @@ import {
   toggleLivePreview,
 } from './helpers.js'
 import {
+  collectionLevelConfigSlug,
   desktopBreakpoint,
   mobileBreakpoint,
   pagesSlug,
@@ -139,6 +140,15 @@ describe('Live Preview', () => {
     await goToCollectionLivePreview(page, pagesURLUtil)
     const iframe = page.locator('iframe.live-preview-iframe')
     await expect(iframe).toBeVisible()
+  })
+
+  test('collection - respect collection-level live preview config', async () => {
+    const collURL = new AdminUrlUtil(serverURL, collectionLevelConfigSlug)
+    await page.goto(collURL.create)
+    await page.locator('#field-title').fill('Collection Level Config')
+    await saveDocAndAssert(page)
+    await goToCollectionLivePreview(page, collURL)
+    await expect(page.locator('iframe.live-preview-iframe')).toBeVisible()
   })
 
   test('collection csr — re-renders iframe client-side when form state changes', async () => {

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -146,6 +146,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -929,6 +936,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -75,6 +75,7 @@ export interface Config {
     tenants: Tenant;
     categories: Category;
     media: Media;
+    'collection-level-config': CollectionLevelConfig;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -89,6 +90,7 @@ export interface Config {
     tenants: TenantsSelect<false> | TenantsSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    'collection-level-config': CollectionLevelConfigSelect<false> | CollectionLevelConfigSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -842,6 +844,18 @@ export interface SsrAutosave {
   _status?: ('draft' | 'published') | null;
 }
 /**
+ * Live Preview is enabled on this collection's own config, not the root config.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-level-config".
+ */
+export interface CollectionLevelConfig {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
@@ -879,6 +893,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media';
         value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'collection-level-config';
+        value: string | CollectionLevelConfig;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -1408,6 +1426,15 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-level-config_select".
+ */
+export interface CollectionLevelConfigSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/live-preview/shared.ts
+++ b/test/live-preview/shared.ts
@@ -5,6 +5,7 @@ export const ssrAutosavePagesSlug = 'ssr-autosave'
 export const postsSlug = 'posts'
 export const mediaSlug = 'media'
 export const categoriesSlug = 'categories'
+export const collectionLevelConfigSlug = 'collection-level-config'
 export const usersSlug = 'users'
 
 export const mobileBreakpoint = {


### PR DESCRIPTION
Fixes #13035.

We broke collection-level live preview configs in #12860.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210743577153860