### PR TITLE
fix(richtext-lexical, ui): regression opening relationship field with appearance: "drawer" inside rich text inline block

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -779,7 +779,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
                   // and when the devtools are closed. Temporary solution, we can probably do better.
                   setTimeout(() => {
                     openListDrawer()
-                  }, 50)
+                  }, 100)
                 } else if (appearance === 'select') {
                   setMenuIsOpen(true)
                   if (!hasLoadedFirstPageRef.current) {


### PR DESCRIPTION
Root cause remains unknown. This commit extends the temporary workaround from commit bc6feebde946fe5bfb20b7c21b3e1b83efb686ce by increasing the timeout value agreed with @GermanJablo 

Related PR: https://github.com/payloadcms/payload/pull/12529

