### PR TITLE
fix: deduplicate custom array id fields

### DIFF
--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -200,7 +200,10 @@ export const sanitizeFields = async ({
     }
 
     if (field.type === 'array' && field.fields) {
-      field.fields.push(baseIDField)
+      const hasCustomID = field.fields.some((f) => 'name' in f && f.name === 'id')
+      if (!hasCustomID) {
+        field.fields.push(baseIDField)
+      }
     }
 
     if ((field.type === 'blocks' || field.type === 'array') && field.label) {

--- a/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
+++ b/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
@@ -196,9 +196,6 @@ export const reduceFields = ({
 
       const fieldPath = pathPrefix ? createNestedClientFieldPath(pathPrefix, field) : field.name
 
-      // Deduplication: preserve the first field seen for this path to ensure custom-defined fields override system-injected ones
-      const existingIndex = reduced.findIndex((f) => f.value === fieldPath)
-
       const formattedField: ReducedField = {
         label: formattedLabel,
         plainTextLabel: `${labelPrefix ? labelPrefix + ' > ' : ''}${localizedLabel}`,
@@ -208,10 +205,7 @@ export const reduceFields = ({
         operators,
       }
 
-      if (existingIndex === -1) {
-        reduced.push(formattedField)
-      }
-
+      reduced.push(formattedField)
       return reduced
     }
     return reduced

--- a/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
+++ b/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
@@ -196,6 +196,9 @@ export const reduceFields = ({
 
       const fieldPath = pathPrefix ? createNestedClientFieldPath(pathPrefix, field) : field.name
 
+      // Deduplication: preserve the first field seen for this path to ensure custom-defined fields override system-injected ones
+      const existingIndex = reduced.findIndex((f) => f.value === fieldPath)
+
       const formattedField: ReducedField = {
         label: formattedLabel,
         plainTextLabel: `${labelPrefix ? labelPrefix + ' > ' : ''}${localizedLabel}`,
@@ -205,7 +208,10 @@ export const reduceFields = ({
         operators,
       }
 
-      reduced.push(formattedField)
+      if (existingIndex === -1) {
+        reduced.push(formattedField)
+      }
+
       return reduced
     }
     return reduced

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -260,6 +260,23 @@ const ArrayFields: CollectionConfig = {
         },
       ],
     },
+    {
+      name: 'arrayWithCustomID',
+      type: 'array',
+      fields: [
+        {
+          name: 'id',
+          type: 'text',
+          admin: {
+            disableListFilter: true,
+          },
+        },
+        {
+          name: 'text',
+          type: 'text',
+        },
+      ],
+    },
   ],
   slug: arrayFieldsSlug,
   versions: true,

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -2068,6 +2068,21 @@ describe('Fields', () => {
         }),
       ).rejects.toThrow('The following field is invalid: Items 1 > Sub Array 1 > Text In Row')
     })
+
+    it('should not have multiple instances of the id field in an array with a nested custom id field', () => {
+      const arraysCollection = payload.config.collections.find(
+        (collection) => collection.slug === arrayFieldsSlug,
+      )
+
+      const arrayWithNestedCustomIDField = arraysCollection?.fields.find(
+        (f) => f.name === 'arrayWithCustomID',
+      )
+
+      const idFields = arrayWithNestedCustomIDField?.fields.filter((f) => f.name === 'id')
+
+      expect(idFields).toHaveLength(1)
+      expect(idFields[0].admin?.disableListFilter).toBe(true)
+    })
   })
 
   describe('group', () => {

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -355,6 +355,12 @@ export interface ArrayField {
         id?: string | null;
       }[]
     | null;
+  arrayWithCustomID?:
+    | {
+        id?: string | null;
+        text?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1976,6 +1982,12 @@ export interface ArrayFieldsSelect<T extends boolean = true> {
     | {
         text?: T;
         id?: T;
+      };
+  arrayWithCustomID?:
+    | T
+    | {
+        id?: T;
+        text?: T;
       };
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
When adding a custom ID field to an array's config, both the default field provided by Payload, and the custom ID field, exist in the resulting config. This can lead to problems when the looking up the field's config, where either one or the other will be returned.

Fixes #12978 