### PR TITLE
fix(db-mongodb): updateOne mutates the data object and does not transform it for read

### DIFF
--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -55,6 +55,7 @@ export const updateOne: UpdateOne = async function updateOne(
   try {
     if (returning === false) {
       await Model.updateOne(query, data, options)
+      transform({ adapter: this, data, fields, operation: 'read' })
       return null
     } else {
       result = await Model.findOneAndUpdate(query, data, options)

--- a/packages/db-mongodb/src/utilities/transform.ts
+++ b/packages/db-mongodb/src/utilities/transform.ts
@@ -417,7 +417,7 @@ export const transform = ({
 
   if (operation === 'read') {
     delete data['__v']
-    data.id = data._id
+    data.id = data._id || data.id
     delete data['_id']
 
     if (data.id instanceof Types.ObjectId) {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13045

`updateOne` when returning is `false` mutates the data object for write operations on the DB, but that causes an issue when using that data object later on since all of the id's are mutated to objectIDs and never transformed back into read id's.

This fix ensures that the transform happens even when the result is not returned.