### PR TITLE
fix(next): adds token to reset password initialState

### DIFF
--- a/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
+++ b/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
@@ -18,19 +18,6 @@ type Args = {
   readonly token: string
 }
 
-const initialState: FormState = {
-  'confirm-password': {
-    initialValue: '',
-    valid: false,
-    value: '',
-  },
-  password: {
-    initialValue: '',
-    valid: false,
-    value: '',
-  },
-}
-
 export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
   const i18n = useTranslation()
   const {
@@ -60,6 +47,24 @@ export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
       )
     }
   }, [adminRoute, fetchFullUser, history, loginRoute])
+
+  const initialState: FormState = {
+    'confirm-password': {
+      initialValue: '',
+      valid: false,
+      value: '',
+    },
+    password: {
+      initialValue: '',
+      valid: false,
+      value: '',
+    },
+    token: {
+      initialValue: token,
+      valid: true,
+      value: token,
+    },
+  }
 
   return (
     <Form


### PR DESCRIPTION
### What?
Adds `token` into the `initialState` for the reset password form to ensure `token` does not get passed through as `undefined`.

### Why?
Currently the reset password UI is broken because `token` is not getting passed to the form state.

### How?
Adds `token` to `initialState`

Fixes #13040
