### PR TITLE
feat: re-use adapter logic for upload updates

### DIFF
--- a/packages/payload/src/uploads/endpoints/getFile.ts
+++ b/packages/payload/src/uploads/endpoints/getFile.ts
@@ -6,6 +6,8 @@ import { status as httpStatus } from 'http-status'
 import path from 'path'
 
 import type { PayloadHandler } from '../../config/types.js'
+import type { Collection, PayloadRequest } from '../../index.js'
+import type { File } from '../types.js'
 
 import { APIError } from '../../errors/APIError.js'
 import { checkFileAccess } from '../../uploads/checkFileAccess.js'
@@ -14,11 +16,11 @@ import { getFileTypeFallback } from '../../uploads/getFileTypeFallback.js'
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
 
-export const getFileHandler: PayloadHandler = async (req) => {
-  const collection = getRequestCollection(req)
-
-  const filename = req.routeParams?.filename as string
-
+export const getFileResponse = async (
+  req: PayloadRequest,
+  collection: Collection,
+  filename: string,
+): Promise<Response> => {
   if (!collection.config.upload) {
     throw new APIError(
       `This collection is not an upload collection: ${collection.config.slug}`,
@@ -105,4 +107,27 @@ export const getFileHandler: PayloadHandler = async (req) => {
     }),
     status: httpStatus.OK,
   })
+}
+
+export const getFile = async (
+  req: PayloadRequest,
+  collection: Collection,
+  filename: string,
+): Promise<File> => {
+  const res = await getFileResponse(req, collection, filename)
+  const buffer = Buffer.from(await res.arrayBuffer())
+
+  return {
+    name: filename,
+    data: buffer,
+    mimetype: res.headers.get('content-type') || undefined!,
+    size: Number(res.headers.get('content-length')) || 0,
+  }
+}
+
+export const getFileHandler: PayloadHandler = async (req) => {
+  const collection = getRequestCollection(req)
+  const filename = req.routeParams?.filename as string
+
+  return getFileResponse(req, collection, filename)
 }

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -12,6 +12,7 @@ import type { FileData, FileToSave, ProbedImageSize, UploadEdits } from './types
 import { FileRetrievalError, FileUploadError, Forbidden, MissingFile } from '../errors/index.js'
 import { canResizeImage } from './canResizeImage.js'
 import { cropImage } from './cropImage.js'
+import { getFile } from './endpoints/getFile.js'
 import { getExternalFile } from './getExternalFile.js'
 import { getFileByPath } from './getFileByPath.js'
 import { getImageSize } from './getImageSize.js'
@@ -38,7 +39,7 @@ type Result<T> = Promise<{
 }>
 
 export const generateFileData = async <T>({
-  collection: { config: collectionConfig },
+  collection,
   data,
   isDuplicating,
   operation,
@@ -47,6 +48,8 @@ export const generateFileData = async <T>({
   req,
   throwOnMissingFile,
 }: Args<T>): Result<T> => {
+  const { config: collectionConfig } = collection
+
   if (!collectionConfig.upload) {
     return {
       data,
@@ -95,6 +98,8 @@ export const generateFileData = async <T>({
         const response = await getFileByPath(filePath)
         file = response
         overwriteExistingFiles = true
+      } else if (filename && collectionConfig.upload.adapter) {
+        file = await getFile(req, collection, filename)
       } else if (filename && url) {
         file = await getExternalFile({
           data: incomingFileData as unknown as FileData,

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -98,7 +98,7 @@ export const generateFileData = async <T>({
         const response = await getFileByPath(filePath)
         file = response
         overwriteExistingFiles = true
-      } else if (filename && collectionConfig.upload.adapter) {
+      } else if (filename && operation === 'update') {
         file = await getFile(req, collection, filename)
       } else if (filename && url) {
         file = await getExternalFile({


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### Context:

I'm running Payload in a private subnet with a cookie-based auth gateway (which federates to an SSO provider).

### Problem:

In a deployed setting, updating the focus point or crop area for an image and re-saving it results in a generic 500.

I tracked it down to this code section:

https://github.com/payloadcms/payload/blob/2650eb7d44426780bfebd3c2c7666b1d1ceeb28d/packages/payload/src/uploads/generateFileData.ts#L99

The codepath re-uses the http machinery to fetch the image from wherever it may be stored.  The issue here is that upload URLs are based on server hostname, which is correct for users/browsers, but with my setup Payload cannot send requests to itself that way.

Architecturally, I'm guessing that the fetch call is to accommodate the side loading feature where you can paste the direct asset URL.  However, I'm wondering if it's unnecessary to invoke the whole http flow to re-fetch an asset that was already uploaded.

### Changes:

With the above in mind, I refactored `getFile.ts` to split up the logic such that it's reusable internally without making a full request.  This enables payload to use the configured upload adapters directly, using the same code path as the regular REST endpoint.

Then, if we're doing an update operation, we can go directly to the cloud storage plugin instead of making a round trip to the API endpoint.
