### PR TITLE
fix: ensure default values are not shown when value is hidden

### DIFF
--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -484,6 +484,12 @@ export default buildConfigWithDefaults(
             type: 'checkbox',
             hidden: true,
           },
+          {
+            name: 'hiddenWithDefault',
+            type: 'text',
+            hidden: true,
+            defaultValue: 'default value',
+          },
         ],
       },
       {

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -231,6 +231,26 @@ describe('Access Control', () => {
       expect(updatedDoc.cannotMutateRequired).toBe('cannotMutateRequired')
       expect(updatedDoc.cannotMutateNotRequired).toBe('cannotMutateNotRequired')
     })
+
+    it('should not return default values for hidden fields with values', async () => {
+      const doc = await payload.create({
+        collection: hiddenFieldsSlug,
+        data: {
+          title: 'Test Title',
+        },
+        showHiddenFields: true,
+      })
+
+      expect(doc.hiddenWithDefault).toBe('default value')
+
+      const findDoc2 = await payload.findByID({
+        id: doc.id,
+        collection: hiddenFieldsSlug,
+        overrideAccess: false,
+      })
+
+      expect(findDoc2.hiddenWithDefault).toBeUndefined()
+    })
   })
   describe('Collections', () => {
     describe('restricted collection', () => {


### PR DESCRIPTION
Fixes #12834 

`loginAttempts` was being shown in the admin panel when it should be hidden. The field is set to `hidden: true` therefore the value is removed from siblingData and passes the `allowDefaultValue` check - showing inconsistent data.

This PR ensures the default value is not returned if the field has a value but was removed due to the field being hidden.