### PR TITLE
fix: correctly reset login attempts

### DIFF
--- a/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
+++ b/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
@@ -15,7 +15,10 @@ export const resetLoginAttempts = async ({
   payload,
   req,
 }: Args): Promise<void> => {
-  if (!('lockUntil' in doc && typeof doc.lockUntil === 'string') || doc.loginAttempts === 0) {
+  if (
+    !('lockUntil' in doc && typeof doc.lockUntil === 'string') &&
+    (!('loginAttempts' in doc) || doc.loginAttempts === 0)
+  ) {
     return
   }
   await payload.update({

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -991,7 +991,7 @@ describe('Auth', () => {
       ).rejects.toThrow('Token is either invalid or has expired.')
     })
 
-    it('should reset the login attempts after a successful login', async () => {
+    describe('Login Attempts', () => {
       async function attemptLogin(email: string, password: string) {
         return payload.login({
           collection: slug,
@@ -1003,39 +1003,93 @@ describe('Auth', () => {
         })
       }
 
-      // fail 1
-      try {
-        const failedLogin = await attemptLogin(devUser.email, 'wrong-password')
-        expect(failedLogin).toBeUndefined()
-      } catch (error) {
-        expect((error as Error).message).toBe('The email or password provided is incorrect.')
-      }
+      it('should reset the login attempts after a successful login', async () => {
+        // fail 1
+        try {
+          const failedLogin = await attemptLogin(devUser.email, 'wrong-password')
+          expect(failedLogin).toBeUndefined()
+        } catch (error) {
+          expect((error as Error).message).toBe('The email or password provided is incorrect.')
+        }
 
-      // successful login 1
-      const successfulLogin = await attemptLogin(devUser.email, devUser.password)
-      expect(successfulLogin).toBeDefined()
+        // successful login 1
+        const successfulLogin = await attemptLogin(devUser.email, devUser.password)
+        expect(successfulLogin).toBeDefined()
 
-      // fail 2
-      try {
-        const failedLogin = await attemptLogin(devUser.email, 'wrong-password')
-        expect(failedLogin).toBeUndefined()
-      } catch (error) {
-        expect((error as Error).message).toBe('The email or password provided is incorrect.')
-      }
+        // fail 2
+        try {
+          const failedLogin = await attemptLogin(devUser.email, 'wrong-password')
+          expect(failedLogin).toBeUndefined()
+        } catch (error) {
+          expect((error as Error).message).toBe('The email or password provided is incorrect.')
+        }
 
-      // successful login 2 without exceeding attempts
-      const successfulLogin2 = await attemptLogin(devUser.email, devUser.password)
-      expect(successfulLogin2).toBeDefined()
+        // successful login 2 without exceeding attempts
+        const successfulLogin2 = await attemptLogin(devUser.email, devUser.password)
+        expect(successfulLogin2).toBeDefined()
 
-      const user = await payload.findByID({
-        collection: slug,
-        id: successfulLogin2.user.id,
-        overrideAccess: true,
-        showHiddenFields: true,
+        const user = await payload.findByID({
+          collection: slug,
+          id: successfulLogin2.user.id,
+          overrideAccess: true,
+          showHiddenFields: true,
+        })
+
+        expect(user.loginAttempts).toBe(0)
+        expect(user.lockUntil).toBeNull()
       })
 
-      expect(user.loginAttempts).toBe(0)
-      expect(user.lockUntil).toBeNull()
+      it('should lock the user after too many failed login attempts', async () => {
+        const now = new Date()
+        // fail 1
+        try {
+          const failedLogin = await attemptLogin(devUser.email, 'wrong-password')
+          expect(failedLogin).toBeUndefined()
+        } catch (error) {
+          expect((error as Error).message).toBe('The email or password provided is incorrect.')
+        }
+
+        // fail 2
+        try {
+          const failedLogin = await attemptLogin(devUser.email, 'wrong-password')
+          expect(failedLogin).toBeUndefined()
+        } catch (error) {
+          expect((error as Error).message).toBe('The email or password provided is incorrect.')
+        }
+
+        // fail 3
+        try {
+          const failedLogin = await attemptLogin(devUser.email, 'wrong-password')
+          expect(failedLogin).toBeUndefined()
+        } catch (error) {
+          expect((error as Error).message).toBe(
+            'This user is locked due to having too many failed login attempts.',
+          )
+        }
+
+        const userQuery = await payload.find({
+          collection: slug,
+          overrideAccess: true,
+          showHiddenFields: true,
+          where: {
+            email: {
+              equals: devUser.email,
+            },
+          },
+        })
+
+        expect(userQuery.docs[0]).toBeDefined()
+
+        if (userQuery.docs[0]) {
+          const user = userQuery.docs[0]
+          expect(user.loginAttempts).toBe(2)
+          expect(user.lockUntil).toBeDefined()
+          expect(typeof user.lockUntil).toBe('string')
+          if (typeof user.lockUntil === 'string') {
+            expect(new Date(user.lockUntil).getTime()).toBeGreaterThan(now.getTime())
+          }
+        }
+      })
     })
   })
 

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -1090,6 +1090,35 @@ describe('Auth', () => {
           }
         }
       })
+
+      it('should allow force unlocking of a user', async () => {
+        await payload.unlock({
+          collection: slug,
+          data: {
+            email: devUser.email,
+          } as any,
+          overrideAccess: true,
+        })
+
+        const userQuery = await payload.find({
+          collection: slug,
+          overrideAccess: true,
+          showHiddenFields: true,
+          where: {
+            email: {
+              equals: devUser.email,
+            },
+          },
+        })
+
+        expect(userQuery.docs[0]).toBeDefined()
+
+        if (userQuery.docs[0]) {
+          const user = userQuery.docs[0]
+          expect(user.loginAttempts).toBe(0)
+          expect(user.lockUntil).toBeNull()
+        }
+      })
     })
   })
 


### PR DESCRIPTION
Login attempts were not being reset correctly which led to situations where a failed login attempt followed by a successful login attempt would keep the loginAttempts at 1.


### Before 
Example with maxAttempts of 2:
- failed login -> `loginAttempts: 1`
- successful login -> `loginAttempts: 1`
- failed login -> `loginAttempts: 2`
- successful login -> `"This user is locked due to having too many failed login attempts."`

### After 
Example with maxAttempts of 2:
- failed login -> `loginAttempts: 1`
- successful login -> `loginAttempts: 0`
- failed login -> `loginAttempts: 1`
- successful login -> `loginAttempts: 0`