### PR TITLE
fix: payload auth api-key algorithm compatibility

### DIFF
--- a/packages/payload/src/auth/baseFields/apiKey.ts
+++ b/packages/payload/src/auth/baseFields/apiKey.ts
@@ -50,7 +50,7 @@ export const apiKeyFields = [
           }
           if (data?.apiKey) {
             return crypto
-              .createHmac('sha1', req.payload.secret)
+              .createHmac('sha256', req.payload.secret)
               .update(data.apiKey as string)
               .digest('hex')
           }

--- a/packages/payload/src/auth/strategies/apiKey.ts
+++ b/packages/payload/src/auth/strategies/apiKey.ts
@@ -12,16 +12,34 @@ export const APIKeyAuthentication =
 
     if (authHeader?.startsWith(`${collectionConfig.slug} API-Key `)) {
       const apiKey = authHeader.replace(`${collectionConfig.slug} API-Key `, '')
-      const apiKeyIndex = crypto.createHmac('sha1', payload.secret).update(apiKey).digest('hex')
+
+      // TODO: V4 remove extra algorithm check
+      // api keys saved prior to v3.46.0 will have sha1
+      const sha1APIKeyIndex = crypto.createHmac('sha1', payload.secret).update(apiKey).digest('hex')
+      const sha256APIKeyIndex = crypto
+        .createHmac('sha256', payload.secret)
+        .update(apiKey)
+        .digest('hex')
+
+      const apiKeyConstraints = [
+        {
+          apiKeyIndex: {
+            equals: sha1APIKeyIndex,
+          },
+        },
+        {
+          apiKeyIndex: {
+            equals: sha256APIKeyIndex,
+          },
+        },
+      ]
 
       try {
         const where: Where = {}
         if (collectionConfig.auth?.verify) {
           where.and = [
             {
-              apiKeyIndex: {
-                equals: apiKeyIndex,
-              },
+              or: apiKeyConstraints,
             },
             {
               _verified: {
@@ -30,9 +48,7 @@ export const APIKeyAuthentication =
             },
           ]
         } else {
-          where.apiKeyIndex = {
-            equals: apiKeyIndex,
-          }
+          where.or = apiKeyConstraints
         }
 
         const userQuery = await payload.find({


### PR DESCRIPTION
When saving api-keys in prior versions you can have sha1 generated lookup keys. This ensures compatibility with newer sha256 lookups.
