### PR TITLE
fix: ensure we perform ssrf check within dispatcher

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -156,7 +156,6 @@ export { extractAccessFromPermission } from './auth/extractAccessFromPermission.
 export { getAccessResults } from './auth/getAccessResults.js'
 export { getFieldsToSign } from './auth/getFieldsToSign.js'
 export { getLoginOptions } from './auth/getLoginOptions.js'
-
 export interface GeneratedTypes {
   authUntyped: {
     [slug: string]: {
@@ -1536,9 +1535,10 @@ export { importHandlerPath } from './queues/operations/runJobs/runJob/importHand
 export { getLocalI18n } from './translations/getLocalI18n.js'
 export * from './types/index.js'
 export { getFileByPath } from './uploads/getFileByPath.js'
+export { _internal_safeFetchGlobal } from './uploads/safeFetch.js'
 export type * from './uploads/types.js'
-export { addDataAndFileToRequest } from './utilities/addDataAndFileToRequest.js'
 
+export { addDataAndFileToRequest } from './utilities/addDataAndFileToRequest.js'
 export { addLocalesToRequestFromData, sanitizeLocales } from './utilities/addLocalesToRequest.js'
 export { commitTransaction } from './utilities/commitTransaction.js'
 export {
@@ -1610,8 +1610,8 @@ export { deleteCollectionVersions } from './versions/deleteCollectionVersions.js
 export { appendVersionToQueryKey } from './versions/drafts/appendVersionToQueryKey.js'
 export { getQueryDraftsSort } from './versions/drafts/getQueryDraftsSort.js'
 export { enforceMaxVersions } from './versions/enforceMaxVersions.js'
-export { getLatestCollectionVersion } from './versions/getLatestCollectionVersion.js'
 
+export { getLatestCollectionVersion } from './versions/getLatestCollectionVersion.js'
 export { getLatestGlobalVersion } from './versions/getLatestGlobalVersion.js'
 export { saveVersion } from './versions/saveVersion.js'
 export type { SchedulePublishTaskInput } from './versions/schedule/types.js'

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -587,6 +587,8 @@ describe('Collections - Uploads', () => {
             hostname = hostname.slice(1, -1)
           }
 
+          // Here we're essentially mocking our own DNS provider, to get 'https://www.payloadcms.com/test.png' to resolve to the IP
+          // we'd like to test for
           // @ts-expect-error this does not need to be mocked 100% correctly
           _internal_safeFetchGlobal.lookup = (_hostname, _options, callback) => {
             // eslint-disable-next-line jest/no-conditional-in-test
@@ -600,7 +602,7 @@ describe('Collections - Uploads', () => {
                 filename: 'test.png',
                 // Need to pass a domain for lookup to be called. We monkey patch the IP lookup function above
                 // to return the IP address we want to test.
-                url: 'https://www.payloadcms.com/file.png',
+                url: 'https://www.payloadcms.com/test.png',
               },
             }),
           ).rejects.toThrow(

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -3,7 +3,7 @@ import type { CollectionSlug, Payload } from 'payload'
 import { randomUUID } from 'crypto'
 import fs from 'fs'
 import path from 'path'
-import { getFileByPath } from 'payload'
+import { _internal_safeFetchGlobal, getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
 import { promisify } from 'util'
 
@@ -575,6 +575,44 @@ describe('Collections - Uploads', () => {
       `(
         'should block or filter uploading from $collection with URL: $url',
         async ({ url, collection, errorContains }) => {
+          const globalCachedFn = _internal_safeFetchGlobal.lookup
+
+          let hostname = new URL(url).hostname
+
+          const isIPV6 = hostname.includes('::')
+
+          // Strip brackets from IPv6 addresses
+          // eslint-disable-next-line jest/no-conditional-in-test
+          if (isIPV6) {
+            hostname = hostname.slice(1, -1)
+          }
+
+          // @ts-expect-error this does not need to be mocked 100% correctly
+          _internal_safeFetchGlobal.lookup = (_hostname, _options, callback) => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            callback(null, hostname as any, isIPV6 ? 6 : 4)
+          }
+
+          await expect(
+            payload.create({
+              collection,
+              data: {
+                filename: 'test.png',
+                // Need to pass a domain for lookup to be called. We monkey patch the IP lookup function above
+                // to return the IP address we want to test.
+                url: 'https://www.payloadcms.com/file.png',
+              },
+            }),
+          ).rejects.toThrow(
+            expect.objectContaining({
+              name: 'FileRetrievalError',
+              message: expect.stringContaining(errorContains),
+            }),
+          )
+
+          _internal_safeFetchGlobal.lookup = globalCachedFn
+
+          // Now ensure this throws if we pass the IP address directly, without the mock
           await expect(
             payload.create({
               collection,


### PR DESCRIPTION
Previously, we were performing this check before calling the fetch function. This changes it to perform the check within the dispatcher.

It adjusts the int tests to both trigger the dispatcher lookup function (which is only triggered when not already passing a valid IP) and the check before calling fetch

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210733180484570