### PR TITLE
fix(next): prevent live preview url functions from firing unnecessarily

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -329,31 +329,36 @@ export const renderDocument = async ({
     viewType,
   }
 
-  const isLivePreviewEnabledAtRoot =
+  const isLivePreviewEnabled = Boolean(
     config.admin?.livePreview?.collections?.includes(collectionSlug) ||
-    config.admin?.livePreview?.globals?.includes(globalSlug)
+      config.admin?.livePreview?.globals?.includes(globalSlug) ||
+      collectionConfig?.admin?.livePreview ||
+      globalConfig?.admin?.livePreview,
+  )
 
   const livePreviewConfig: LivePreviewConfig = {
-    ...(isLivePreviewEnabledAtRoot ? config.admin.livePreview : {}),
+    ...(isLivePreviewEnabled ? config.admin.livePreview : {}),
     ...(collectionConfig?.admin?.livePreview || {}),
     ...(globalConfig?.admin?.livePreview || {}),
   }
 
   const livePreviewURL =
-    typeof livePreviewConfig?.url === 'function'
-      ? await livePreviewConfig.url({
-          collectionConfig,
-          data: doc,
-          globalConfig,
-          locale,
-          req,
-          /**
-           * @deprecated
-           * Use `req.payload` instead. This will be removed in the next major version.
-           */
-          payload: initPageResult.req.payload,
-        })
-      : livePreviewConfig?.url
+    operation !== 'create'
+      ? typeof livePreviewConfig?.url === 'function'
+        ? await livePreviewConfig.url({
+            collectionConfig,
+            data: doc,
+            globalConfig,
+            locale,
+            req,
+            /**
+             * @deprecated
+             * Use `req.payload` instead. This will be removed in the next major version.
+             */
+            payload: initPageResult.req.payload,
+          })
+        : livePreviewConfig?.url
+      : ''
 
   return {
     data: doc,
@@ -384,8 +389,8 @@ export const renderDocument = async ({
       >
         <LivePreviewProvider
           breakpoints={livePreviewConfig?.breakpoints}
+          isLivePreviewEnabled={isLivePreviewEnabled && operation !== 'create'}
           isLivePreviewing={entityPreferences?.value?.editViewType === 'live-preview'}
-          operation={operation}
           url={livePreviewURL}
         >
           {showHeader && !drawerSlug && (

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -329,8 +329,12 @@ export const renderDocument = async ({
     viewType,
   }
 
+  const isLivePreviewEnabledAtRoot =
+    config.admin?.livePreview?.collections?.includes(collectionSlug) ||
+    config.admin?.livePreview?.globals?.includes(globalSlug)
+
   const livePreviewConfig: LivePreviewConfig = {
-    ...(config.admin.livePreview || {}),
+    ...(isLivePreviewEnabledAtRoot ? config.admin.livePreview : {}),
     ...(collectionConfig?.admin?.livePreview || {}),
     ...(globalConfig?.admin?.livePreview || {}),
   }

--- a/packages/ui/src/providers/LivePreview/index.tsx
+++ b/packages/ui/src/providers/LivePreview/index.tsx
@@ -21,8 +21,8 @@ export type LivePreviewProviderProps = {
     height: number
     width: number
   }
+  isLivePreviewEnabled?: boolean
   isLivePreviewing: boolean
-  operation?: 'create' | 'update'
   url: string
 }
 
@@ -37,8 +37,8 @@ const getAbsoluteUrl = (url) => {
 export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = ({
   breakpoints: incomingBreakpoints,
   children,
+  isLivePreviewEnabled,
   isLivePreviewing: incomingIsLivePreviewing,
-  operation,
   url: incomingUrl,
 }) => {
   const [previewWindowType, setPreviewWindowType] = useState<'iframe' | 'popup'>('iframe')
@@ -225,13 +225,6 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = ({
       true,
     )
   }, [isLivePreviewing, setPreference, collectionSlug, globalSlug])
-
-  const isLivePreviewEnabled = Boolean(
-    operation !== 'create' &&
-      ((collectionSlug && config?.admin?.livePreview?.collections?.includes(collectionSlug)) ||
-        (globalSlug && config.admin?.livePreview?.globals?.includes(globalSlug)) ||
-        entityConfig?.admin?.livePreview),
-  )
 
   return (
     <LivePreviewContext


### PR DESCRIPTION
Ensures Live Preview url functions aren't fired during create or on collections that do not have Live Preview enabled.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210743577153852