### PR TITLE
ci: use .tool-versions file in setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -82,7 +82,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ env.STORE_PATH }}
-        key: ${{ inputs.pnpm-install-cache-key || 'pnpm-store-' + hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ inputs.pnpm-install-cache-key || 'pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}' }}
         restore-keys: |
           pnpm-store-${{ env.PNPM_VERSION }}-
           pnpm-store-
@@ -94,5 +94,5 @@ runs:
 
       # Set the cache key output
     - run: |
-        echo "pnpm-install-cache-key=${{ inputs.pnpm-install-cache-key || 'pnpm-store-' + hashFiles('**/pnpm-lock.yaml') }}" >> $GITHUB_ENV
+        echo "pnpm-install-cache-key=${{ inputs.pnpm-install-cache-key || 'pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}' }}" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -83,7 +83,7 @@ runs:
         if [ -n "${{ inputs.pnpm-install-cache-key }}" ]; then
           PNPM_INSTALL_CACHE_KEY="${{ inputs.pnpm-install-cache-key }}"
         else
-          PNPM_INSTALL_CACHE_KEY="pnpm-store-$(hashFiles '**/pnpm-lock.yaml')"
+          PNPM_INSTALL_CACHE_KEY="pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}"
         fi
         echo "Computed PNPM_INSTALL_CACHE_KEY: $PNPM_INSTALL_CACHE_KEY"
         echo "PNPM_INSTALL_CACHE_KEY=$PNPM_INSTALL_CACHE_KEY" >> $GITHUB_ENV

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -77,12 +77,23 @@ runs:
         echo "STORE_PATH=$STORE_PATH" >> $GITHUB_ENV
         echo "Pnpm store path resolved to: $STORE_PATH"
 
+    - name: Compute Cache Key
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.pnpm-install-cache-key }}" ]; then
+          PNPM_INSTALL_CACHE_KEY="${{ inputs.pnpm-install-cache-key }}"
+        else
+          PNPM_INSTALL_CACHE_KEY="pnpm-store-$(hashFiles '**/pnpm-lock.yaml')"
+        fi
+        echo "Computed PNPM_INSTALL_CACHE_KEY: $PNPM_INSTALL_CACHE_KEY"
+        echo "PNPM_INSTALL_CACHE_KEY=$PNPM_INSTALL_CACHE_KEY" >> $GITHUB_ENV
+
     - name: Restore pnpm install cache
       if: ${{ inputs.pnpm-restore-cache == 'true' }}
       uses: actions/cache@v4
       with:
         path: ${{ env.STORE_PATH }}
-        key: ${{ inputs.pnpm-install-cache-key || 'pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}' }}
+        key: ${{ env.PNPM_INSTALL_CACHE_KEY }}
         restore-keys: |
           pnpm-store-${{ env.PNPM_VERSION }}-
           pnpm-store-
@@ -94,5 +105,5 @@ runs:
 
       # Set the cache key output
     - run: |
-        echo "pnpm-install-cache-key=${{ inputs.pnpm-install-cache-key || 'pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}' }}" >> $GITHUB_ENV
+        echo "pnpm-install-cache-key=${{ env.PNPM_INSTALL_CACHE_KEY }}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,15 +9,12 @@ inputs:
     description: Pnpm version override
   pnpm-run-install:
     description: Whether to run pnpm install
-    required: false
     default: true
   pnpm-restore-cache:
     description: Whether to restore cache
-    required: false
     default: true
   pnpm-install-cache-key:
-    description: The cache key for the pnpm install cache
-    default: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+    description: The cache key override for the pnpm install cache
 
 outputs:
   pnpm-store-path:
@@ -85,7 +82,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ env.STORE_PATH }}
-        key: ${{ inputs.pnpm-install-cache-key }}
+        key: ${{ inputs.pnpm-install-cache-key || 'pnpm-store-' + hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           pnpm-store-${{ env.PNPM_VERSION }}-
           pnpm-store-
@@ -97,5 +94,5 @@ runs:
 
       # Set the cache key output
     - run: |
-        echo "pnpm-install-cache-key=${{ inputs.pnpm-install-cache-key }}" >> $GITHUB_ENV
+        echo "pnpm-install-cache-key=${{ inputs.pnpm-install-cache-key || 'pnpm-store-' + hashFiles('**/pnpm-lock.yaml') }}" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,13 +4,9 @@ description: |
 
 inputs:
   node-version:
-    description: Node.js version
-    required: true
-    default: 23.11.0
+    description: Node.js version override
   pnpm-version:
-    description: Pnpm version
-    required: true
-    default: 9.7.1
+    description: Pnpm version override
   pnpm-run-install:
     description: Whether to run pnpm install
     required: false
@@ -37,15 +33,44 @@ runs:
       shell: bash
       run: sudo ethtool -K eth0 tx off rx off
 
+    - name: Get versions from .tool-versions or use overrides
+      shell: bash
+      run: |
+        # if node-version input is provided, use it; otherwise, read from .tool-versions
+        if [ "${{ inputs.node-version }}" ]; then
+          echo "Node version override provided: ${{ inputs.node-version }}"
+          echo "NODE_VERSION=${{ inputs.node-version }}" >> $GITHUB_ENV
+        elif [ -f .tool-versions ]; then
+          NODE_VERSION=$(grep '^nodejs ' .tool-versions | awk '{print $2}')
+          echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
+          echo "Node version resolved to: $NODE_VERSION"
+        else
+          echo "No .tool-versions file found and no node-version input provided. Invalid configuration."
+          exit 1
+        fi
+
+        # if pnpm-version input is provided, use it; otherwise, read from .tool-versions
+        if [ "${{ inputs.pnpm-version }}" ]; then
+          echo "Pnpm version override provided: ${{ inputs.pnpm-version }}"
+          echo "PNPM_VERSION=${{ inputs.pnpm-version }}" >> $GITHUB_ENV
+        elif [ -f .tool-versions ]; then
+          PNPM_VERSION=$(grep '^pnpm ' .tool-versions | awk '{print $2}')
+          echo "PNPM_VERSION=$PNPM_VERSION" >> $GITHUB_ENV
+          echo "Pnpm version resolved to: $PNPM_VERSION"
+        else
+          echo "No .tool-versions file found and no pnpm-version input provided. Invalid configuration."
+          exit 1
+        fi
+
     - name: Setup Node@${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version: ${{ env.NODE_VERSION }}
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: ${{ inputs.pnpm-version }}
+        version: ${{ env.PNPM_VERSION }}
         run_install: false
 
     - name: Get pnpm store path
@@ -62,7 +87,7 @@ runs:
         path: ${{ env.STORE_PATH }}
         key: ${{ inputs.pnpm-install-cache-key }}
         restore-keys: |
-          pnpm-store-${{ inputs.pnpm-version }}-
+          pnpm-store-${{ env.PNPM_VERSION }}-
           pnpm-store-
 
     - name: Run pnpm install

--- a/.github/workflows/audit-dependencies.yml
+++ b/.github/workflows/audit-dependencies.yml
@@ -16,8 +16,6 @@ on:
         default: false
 
 env:
-  NODE_VERSION: 23.11.0
-  PNPM_VERSION: 9.7.1
   DO_NOT_TRACK: 1 # Disable Turbopack telemetry
   NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
 
@@ -29,9 +27,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Run audit dependencies script
         id: audit_dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Node setup
         uses: ./.github/actions/setup
-        with:
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Lint
         run: pnpm lint -- --quiet
@@ -85,8 +83,6 @@ jobs:
 
       - name: Node setup
         uses: ./.github/actions/setup
-        with:
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - run: pnpm run build:all
         env:
@@ -110,7 +106,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4
@@ -135,7 +130,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4
@@ -197,7 +191,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4
@@ -320,7 +313,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4
@@ -455,7 +447,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4
@@ -559,7 +550,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4
@@ -657,7 +647,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4
@@ -717,7 +706,6 @@ jobs:
         with:
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
-          pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Restore build
         uses: actions/cache@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: 23.11.0
-  PNPM_VERSION: 9.7.1
   DO_NOT_TRACK: 1 # Disable Turbopack telemetry
   NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
 
@@ -72,8 +70,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Lint
@@ -90,8 +86,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - run: pnpm run build:all
@@ -114,8 +108,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -141,8 +133,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -205,8 +195,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -330,8 +318,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -467,8 +453,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -573,8 +557,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -673,8 +655,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -735,8 +715,6 @@ jobs:
       - name: Node setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
           pnpm-run-install: false
           pnpm-restore-cache: false # Full build is restored below
           pnpm-install-cache-key: pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/post-release-templates.yml
+++ b/.github/workflows/post-release-templates.yml
@@ -7,8 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 23.11.0
-  PNPM_VERSION: 9.7.1
   DO_NOT_TRACK: 1 # Disable Turbopack telemetry
   NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
 
@@ -60,9 +58,6 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Start PostgreSQL
         uses: CasperWA/postgresql-action@v1.2

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -12,8 +12,6 @@ on:
         default: ''
 
 env:
-  NODE_VERSION: 23.11.0
-  PNPM_VERSION: 9.7.1
   DO_NOT_TRACK: 1 # Disable Turbopack telemetry
   NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -7,8 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 23.11.0
-  PNPM_VERSION: 9.7.1
   DO_NOT_TRACK: 1 # Disable Turbopack telemetry
   NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
 
@@ -23,9 +21,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
       - name: Load npm token
         run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
         env:


### PR DESCRIPTION
Parse `.tool-versions` file in the composite node setup action. This will make it the source of truth and easier to bump node/pnpm versions in the future.