### PR TITLE
docs: remove asterisk from optional url property in live preview docs

### DIFF
--- a/docs/live-preview/overview.mdx
+++ b/docs/live-preview/overview.mdx
@@ -45,12 +45,10 @@ The following options are available:
 
 | Path              | Description                                                                                                                                           |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`url`** \*      | String, or function that returns a string, pointing to your front-end application. This value is used as the iframe `src`. [More details](#url).      |
+| **`url`**      | String, or function that returns a string, pointing to your front-end application. This value is used as the iframe `src`. [More details](#url).      |
 | **`breakpoints`** | Array of breakpoints to be used as “device sizes” in the preview window. Each item appears as an option in the toolbar. [More details](#breakpoints). |
 | **`collections`** | Array of collection slugs to enable Live Preview on.                                                                                                  |
 | **`globals`**     | Array of global slugs to enable Live Preview on.                                                                                                      |
-
-_\* An asterisk denotes that a property is required._
 
 ### URL
 


### PR DESCRIPTION
### What?

url option is not required for Link Preview, so I removed the asterisk.

### Why?

Here is the type definition

[Type Definition Link](https://github.com/payloadcms/payload/blob/c6105f1e0d66ebbd7e82379f8f52e9b4647e43ef/packages/payload/src/config/types.ts#L159)