### PR TITLE
fix(ui): correct type for block and array row label component props

### DIFF
--- a/packages/payload/src/admin/fields/Array.ts
+++ b/packages/payload/src/admin/fields/Array.ts
@@ -66,3 +66,17 @@ export type ArrayFieldErrorClientComponent = FieldErrorClientComponent<ArrayFiel
 
 export type ArrayFieldDiffServerComponent = FieldDiffServerComponent<ArrayField, ArrayFieldClient>
 export type ArrayFieldDiffClientComponent = FieldDiffClientComponent<ArrayFieldClient>
+
+type ArrayRowLabelBase = {
+  rowLabel: string
+  rowNumber: number
+}
+export type ArrayRowLabelClientProps = ArrayRowLabelBase &
+  ClientFieldBase<ArrayFieldClientWithoutType> &
+  FieldPaths
+export type ArrayRowLabelClientComponent = React.ComponentType<ArrayRowLabelClientProps>
+
+export type ArrayRowLabelServerProps = ArrayRowLabelBase &
+  FieldPaths &
+  ServerFieldBase<ArrayField, ArrayFieldClientWithoutType>
+export type ArrayRowLabelServerComponent = React.ComponentType<ArrayRowLabelServerProps>

--- a/packages/payload/src/admin/fields/Array.ts
+++ b/packages/payload/src/admin/fields/Array.ts
@@ -70,13 +70,10 @@ export type ArrayFieldDiffClientComponent = FieldDiffClientComponent<ArrayFieldC
 type ArrayRowLabelBase = {
   rowLabel: string
   rowNumber: number
-}
-export type ArrayRowLabelClientProps = ArrayRowLabelBase &
-  ClientFieldBase<ArrayFieldClientWithoutType> &
-  FieldPaths
+} & FieldPaths
+export type ArrayRowLabelClientProps = ArrayRowLabelBase & ClientFieldBase<ArrayFieldClient>
 export type ArrayRowLabelClientComponent = React.ComponentType<ArrayRowLabelClientProps>
 
-export type ArrayRowLabelServerProps = ArrayRowLabelBase &
-  FieldPaths &
-  ServerFieldBase<ArrayField, ArrayFieldClientWithoutType>
+export type ArrayRowLabelServerPropsOnly = ServerFieldBase<ArrayField, ArrayFieldClientWithoutType>
+export type ArrayRowLabelServerProps = ArrayRowLabelBase & ArrayRowLabelServerPropsOnly
 export type ArrayRowLabelServerComponent = React.ComponentType<ArrayRowLabelServerProps>

--- a/packages/payload/src/admin/fields/Blocks.ts
+++ b/packages/payload/src/admin/fields/Blocks.ts
@@ -48,10 +48,11 @@ export type BlocksFieldClientComponent = FieldClientComponent<
 export type BlocksFieldLabelServerComponent = FieldLabelServerComponent<
   BlocksField,
   BlocksFieldClientWithoutType
->
+> &
+  FieldPaths
 
 export type BlocksFieldLabelClientComponent =
-  FieldLabelClientComponent<BlocksFieldClientWithoutType>
+  FieldLabelClientComponent<BlocksFieldClientWithoutType> & FieldPaths
 
 type BlockRowLabelBase = {
   blockType: string
@@ -59,13 +60,15 @@ type BlockRowLabelBase = {
   rowNumber: number
 }
 
-export type BlockRowLabelClientComponent = React.ComponentType<
-  BlockRowLabelBase & ClientFieldBase<BlocksFieldClientWithoutType>
->
+export type BlockRowLabelClientProps = BlockRowLabelBase &
+  ClientFieldBase<BlocksFieldClientWithoutType> &
+  FieldPaths
+export type BlockRowLabelClientComponent = React.ComponentType<BlockRowLabelClientProps>
 
-export type BlockRowLabelServerComponent = React.ComponentType<
-  BlockRowLabelBase & ServerFieldBase<BlocksField, BlocksFieldClientWithoutType>
->
+export type BlockRowLabelServerProps = BlockRowLabelBase &
+  FieldPaths &
+  ServerFieldBase<BlocksField, BlocksFieldClientWithoutType>
+export type BlockRowLabelServerComponent = React.ComponentType<BlockRowLabelServerProps>
 
 export type BlocksFieldDescriptionServerComponent = FieldDescriptionServerComponent<
   BlocksField,

--- a/packages/payload/src/admin/fields/Blocks.ts
+++ b/packages/payload/src/admin/fields/Blocks.ts
@@ -58,16 +58,17 @@ type BlockRowLabelBase = {
   blockType: string
   rowLabel: string
   rowNumber: number
-}
+} & FieldPaths
 
 export type BlockRowLabelClientProps = BlockRowLabelBase &
-  ClientFieldBase<BlocksFieldClientWithoutType> &
-  FieldPaths
+  ClientFieldBase<BlocksFieldClientWithoutType>
 export type BlockRowLabelClientComponent = React.ComponentType<BlockRowLabelClientProps>
 
-export type BlockRowLabelServerProps = BlockRowLabelBase &
-  FieldPaths &
-  ServerFieldBase<BlocksField, BlocksFieldClientWithoutType>
+export type BlockRowLabelServerPropsOnly = ServerFieldBase<
+  BlocksField,
+  BlocksFieldClientWithoutType
+>
+export type BlockRowLabelServerProps = BlockRowLabelBase & BlockRowLabelServerPropsOnly
 export type BlockRowLabelServerComponent = React.ComponentType<BlockRowLabelServerProps>
 
 export type BlocksFieldDescriptionServerComponent = FieldDescriptionServerComponent<

--- a/packages/payload/src/admin/forms/Field.ts
+++ b/packages/payload/src/admin/forms/Field.ts
@@ -18,9 +18,9 @@ import type {
 
 export type ClientFieldWithOptionalType = MarkOptional<ClientField, 'type'>
 
-export type ClientComponentProps = {
+export type ClientComponentProps<FieldT = ClientBlock | ClientField | ClientTab> = {
   customComponents?: FormField['customComponents']
-  field: ClientBlock | ClientField | ClientTab
+  field: FieldT
   forceRender?: boolean
   permissions?: SanitizedFieldPermissions
   readOnly?: boolean
@@ -68,12 +68,15 @@ export type FieldPaths = {
   path: string
 }
 
-export type ServerComponentProps = {
-  clientField: ClientFieldWithOptionalType
+export type ServerComponentProps<
+  ServerFieldT extends Field = Field,
+  ClientFieldT extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,
+> = {
+  clientField: ClientFieldT
   clientFieldSchemaMap: ClientFieldSchemaMap
   collectionSlug: string
   data: Data
-  field: Field
+  field: ServerFieldT
   /**
    * The fieldSchemaMap that is created before form state is built is made available here.
    */

--- a/packages/payload/src/admin/types.ts
+++ b/packages/payload/src/admin/types.ts
@@ -102,11 +102,17 @@ export type {
   ArrayFieldLabelServerComponent,
   ArrayFieldServerComponent,
   ArrayFieldServerProps,
+  ArrayRowLabelClientComponent,
+  ArrayRowLabelClientProps,
+  ArrayRowLabelServerComponent,
+  ArrayRowLabelServerProps,
 } from './fields/Array.js'
 
 export type {
   BlockRowLabelClientComponent,
+  BlockRowLabelClientProps,
   BlockRowLabelServerComponent,
+  BlockRowLabelServerProps,
   BlocksFieldClientComponent,
   BlocksFieldClientProps,
   BlocksFieldDescriptionClientComponent,

--- a/packages/payload/src/admin/types.ts
+++ b/packages/payload/src/admin/types.ts
@@ -106,6 +106,7 @@ export type {
   ArrayRowLabelClientProps,
   ArrayRowLabelServerComponent,
   ArrayRowLabelServerProps,
+  ArrayRowLabelServerPropsOnly,
 } from './fields/Array.js'
 
 export type {
@@ -113,6 +114,7 @@ export type {
   BlockRowLabelClientProps,
   BlockRowLabelServerComponent,
   BlockRowLabelServerProps,
+  BlockRowLabelServerPropsOnly,
   BlocksFieldClientComponent,
   BlocksFieldClientProps,
   BlocksFieldDescriptionClientComponent,

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -170,7 +170,7 @@ export const createClientBlocks = ({
   return clientBlocks
 }
 
-export const createClientField = ({
+export const createClientField = <ClientFieldT extends ClientField = ClientField>({
   defaultIDType,
   field: incomingField,
   i18n,
@@ -180,8 +180,8 @@ export const createClientField = ({
   field: Field
   i18n: I18nClient
   importMap: ImportMap
-}): ClientField => {
-  const clientField: ClientField = {} as ClientField
+}): ClientFieldT => {
+  const clientField: ClientFieldT = {} as ClientFieldT
 
   for (const key in incomingField) {
     if (serverOnlyFieldProperties.includes(key as any)) {

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -1,4 +1,8 @@
 import type {
+  ArrayRowLabelClientProps,
+  ArrayRowLabelServerProps,
+  BlockRowLabelClientProps,
+  BlockRowLabelServerProps,
   ClientComponentProps,
   ClientField,
   FieldPaths,
@@ -13,7 +17,6 @@ import { fieldIsHiddenOrDisabled } from 'payload/shared'
 import type { RenderFieldMethod } from './types.js'
 
 import { RenderServerComponent } from '../../elements/RenderServerComponent/index.js'
-
 // eslint-disable-next-line payload/no-imports-from-exports-dir -- MUST reference the exports dir: https://github.com/payloadcms/payload/issues/12002#issuecomment-2791493587
 import { FieldDescription, WatchCondition } from '../../exports/client/index.js'
 
@@ -126,17 +129,18 @@ export const renderField: RenderFieldMethod = ({
 
           row.customComponents.RowLabel = !mockRSCs
             ? RenderServerComponent({
-                clientProps,
-                Component: fieldConfig.admin.components.RowLabel,
-                importMap: req.payload.importMap,
-                key: `${rowIndex}`,
-                serverProps: {
-                  ...serverProps,
+                clientProps: {
+                  ...(clientProps as Partial<ArrayRowLabelClientProps> satisfies Partial<ArrayRowLabelClientProps>),
                   rowLabel: `${getTranslation(fieldConfig.labels.singular, req.i18n)} ${String(
                     rowIndex + 1,
                   ).padStart(2, '0')}`,
                   rowNumber: rowIndex + 1,
-                },
+                } satisfies Partial<ArrayRowLabelClientProps>,
+                Component: fieldConfig.admin.components.RowLabel,
+                importMap: req.payload.importMap,
+                key: `${rowIndex}`,
+                serverProps:
+                  serverProps as Partial<ArrayRowLabelServerProps> satisfies Partial<ArrayRowLabelServerProps>,
               })
             : 'Mock'
         }
@@ -175,18 +179,20 @@ export const renderField: RenderFieldMethod = ({
 
           fieldState.rows[rowIndex].customComponents.RowLabel = !mockRSCs
             ? RenderServerComponent({
-                clientProps,
-                Component: blockConfig.admin.components.Label,
-                importMap: req.payload.importMap,
-                key: `${rowIndex}`,
-                serverProps: {
-                  ...serverProps,
+                clientProps: {
+                  ...(clientProps as Partial<BlockRowLabelClientProps>),
                   blockType: row.blockType,
+                  readOnly: Boolean(fieldConfig.admin.readOnly),
                   rowLabel: `${getTranslation(blockConfig.labels.singular, req.i18n)} ${String(
                     rowIndex + 1,
                   ).padStart(2, '0')}`,
                   rowNumber: rowIndex + 1,
-                },
+                } satisfies Partial<BlockRowLabelClientProps>,
+                Component: blockConfig.admin.components.Label,
+                importMap: req.payload.importMap,
+                key: `${rowIndex}`,
+                serverProps:
+                  serverProps as Partial<BlockRowLabelServerProps> satisfies Partial<BlockRowLabelServerProps>,
               })
             : 'Mock'
         }


### PR DESCRIPTION
Corrects exported types for array and block row label components. Appends correct data to clientProps for the row label client components.