### PR TITLE
feat(ui): add API key visibility toggle

### DIFF
--- a/packages/ui/src/views/Edit/Auth/APIKey.tsx
+++ b/packages/ui/src/views/Edit/Auth/APIKey.tsx
@@ -6,7 +6,6 @@ import { text } from 'payload/shared'
 import React, { useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
-import { Button } from '../../../elements/Button/index.js'
 import { CopyToClipboard } from '../../../elements/CopyToClipboard/index.js'
 import { GenerateConfirmation } from '../../../elements/GenerateConfirmation/index.js'
 import { useFormFields } from '../../../forms/Form/context.js'

--- a/packages/ui/src/views/Edit/Auth/APIKey.tsx
+++ b/packages/ui/src/views/Edit/Auth/APIKey.tsx
@@ -6,10 +6,12 @@ import { text } from 'payload/shared'
 import React, { useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { Button } from '../../../elements/Button/index.js'
 import { CopyToClipboard } from '../../../elements/CopyToClipboard/index.js'
 import { GenerateConfirmation } from '../../../elements/GenerateConfirmation/index.js'
 import { useFormFields } from '../../../forms/Form/context.js'
 import { useField } from '../../../forms/useField/index.js'
+import { EyeIcon } from '../../../icons/Eye/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useDocumentInfo } from '../../../providers/DocumentInfo/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
@@ -24,6 +26,7 @@ export const APIKey: React.FC<{ readonly enabled: boolean; readonly readOnly?: b
 }) => {
   const [initialAPIKey] = useState(uuidv4())
   const [highlightedField, setHighlightedField] = useState(false)
+  const [showKey, setShowKey] = useState(false)
   const { i18n, t } = useTranslation()
   const { config, getEntityConfig } = useConfig()
   const { collectionSlug } = useDocumentInfo()
@@ -68,10 +71,10 @@ export const APIKey: React.FC<{ readonly enabled: boolean; readonly readOnly?: b
 
   const APIKeyLabel = useMemo(
     () => (
-      <div className={`${baseClass}__label`}>
+      <label className={`${baseClass}__label field-label`} htmlFor="apiKey">
         <span>{apiKeyLabel}</span>
         <CopyToClipboard value={apiKeyValue as string} />
-      </div>
+      </label>
     ),
     [apiKeyLabel, apiKeyValue],
   )
@@ -117,15 +120,22 @@ export const APIKey: React.FC<{ readonly enabled: boolean; readonly readOnly?: b
     <React.Fragment>
       <div className={[fieldBaseClass, 'api-key', 'read-only'].filter(Boolean).join(' ')}>
         {APIKeyLabel}
-        <input
-          aria-label={apiKeyLabel}
-          className={highlightedField ? 'highlight' : undefined}
-          disabled
-          id="apiKey"
-          name="apiKey"
-          type="text"
-          value={(value as string) || ''}
-        />
+        <div className={`${baseClass}__input-wrap`}>
+          <input
+            aria-label={apiKeyLabel}
+            className={highlightedField ? 'highlight' : undefined}
+            disabled
+            id="apiKey"
+            name="apiKey"
+            type={showKey ? 'text' : 'password'}
+            value={(value as string) || ''}
+          />
+          <div className={`${baseClass}__button-wrap`}>
+            <button onClick={() => setShowKey(!showKey)} type="button">
+              <EyeIcon active={showKey} />
+            </button>
+          </div>
+        </div>
       </div>
       {!readOnly && (
         <GenerateConfirmation highlightField={highlightField} setKey={() => setValue(uuidv4())} />

--- a/packages/ui/src/views/Edit/Auth/APIKey.tsx
+++ b/packages/ui/src/views/Edit/Auth/APIKey.tsx
@@ -6,6 +6,7 @@ import { text } from 'payload/shared'
 import React, { useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { Button } from '../../../elements/Button/index.js'
 import { CopyToClipboard } from '../../../elements/CopyToClipboard/index.js'
 import { GenerateConfirmation } from '../../../elements/GenerateConfirmation/index.js'
 import { useFormFields } from '../../../forms/Form/context.js'
@@ -129,10 +130,13 @@ export const APIKey: React.FC<{ readonly enabled: boolean; readonly readOnly?: b
             type={showKey ? 'text' : 'password'}
             value={(value as string) || ''}
           />
-          <div className={`${baseClass}__button-wrap`}>
-            <button onClick={() => setShowKey(!showKey)} type="button">
-              <EyeIcon active={showKey} />
-            </button>
+          <div className={`${baseClass}__toggle-button-wrap`}>
+            <Button
+              buttonStyle="none"
+              className={`${baseClass}__toggle-button`}
+              icon={<EyeIcon active={showKey} />}
+              onClick={() => setShowKey((prev) => !prev)}
+            />
           </div>
         </div>
       </div>

--- a/packages/ui/src/views/Edit/Auth/index.scss
+++ b/packages/ui/src/views/Edit/Auth/index.scss
@@ -67,6 +67,7 @@
         display: flex;
         align-items: center;
         cursor: pointer;
+        box-shadow: none;
       }
     }
 

--- a/packages/ui/src/views/Edit/Auth/index.scss
+++ b/packages/ui/src/views/Edit/Auth/index.scss
@@ -44,6 +44,35 @@
 
     input {
       @include formInput;
+      width: 100%;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  .api-key {
+    &__button-wrap {
+      display: flex;
+      align-self: stretch;
+
+      button {
+        @include formInput;
+        background: var(--theme-elevation-100);
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        position: relative;
+        height: 100%;
+        margin: 0 0 0 -1px;
+        padding: 0 base(0.5);
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+      }
+    }
+
+    &__input-wrap {
+      display: flex;
+      align-items: center;
     }
   }
 

--- a/packages/ui/src/views/Edit/Auth/index.scss
+++ b/packages/ui/src/views/Edit/Auth/index.scss
@@ -68,7 +68,7 @@
         margin: 0 0 0 -1px;
         padding: 0 calc(var(--base) / 2);
         box-shadow: none;
-        --btn-icon-size: calc(var(--base));
+        --btn-icon-size: var(--base);
       }
     }
   }

--- a/packages/ui/src/views/Edit/Auth/index.scss
+++ b/packages/ui/src/views/Edit/Auth/index.scss
@@ -37,43 +37,39 @@
         gap: calc(var(--base) / 2);
       }
     }
-  }
 
-  .field-type.api-key {
-    margin-bottom: var(--base);
+    .field-type.api-key {
+      margin-bottom: var(--base);
 
-    input {
-      @include formInput;
-      width: 100%;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
+      input {
+        @include formInput;
+        width: 100%;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
     }
-  }
 
-  .api-key {
-    &__button-wrap {
-      display: flex;
-      align-self: stretch;
+    .api-key {
+      &__input-wrap {
+        display: flex;
+        align-items: center;
+      }
 
-      button {
+      &__toggle-button-wrap {
+        display: flex;
+        align-self: stretch;
+      }
+
+      &__toggle-button {
         @include formInput;
         background: var(--theme-elevation-100);
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
-        position: relative;
-        height: 100%;
         margin: 0 0 0 -1px;
-        padding: 0 base(0.5);
-        display: flex;
-        align-items: center;
-        cursor: pointer;
+        padding: 0 calc(var(--base) / 2);
         box-shadow: none;
+        --btn-icon-size: calc(var(--base));
       }
-    }
-
-    &__input-wrap {
-      display: flex;
-      align-items: center;
     }
   }
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
I added a visibility toggle to the API key field. 

Key hidden:
<img width="532" alt="image" src="https://github.com/user-attachments/assets/cca266bc-5732-46f4-b9ee-ceb8088696db" />

Key visible:
<img width="527" alt="image" src="https://github.com/user-attachments/assets/ed52a9e4-ed0f-472d-8a80-85e933bc606b" />



### Why?
When visiting a collection item that has an API key enabled, the API key is exposed and openly visible. 
This can cause unexpected leakage of the key.

Current field:
<img width="545" alt="image" src="https://github.com/user-attachments/assets/3c591d24-af2b-4502-a60a-2a93efd224c2" />


### How?
I added a `showKey` state to the component, which can be toggled. 
The toggle is placed next to the input field, following the same UX/UI pattern as the "Add new" button for the relationship field.