### PR TITLE
fix(ui): hidden input should wait for form initialization

### DIFF
--- a/packages/ui/src/fields/Hidden/index.tsx
+++ b/packages/ui/src/fields/Hidden/index.tsx
@@ -15,15 +15,15 @@ import { withCondition } from '../../forms/withCondition/index.js'
 const HiddenFieldComponent: React.FC<HiddenFieldProps> = (props) => {
   const { disableModifyingForm = true, path: pathFromProps, value: valueFromProps } = props
 
-  const { path, setValue, value } = useField({
+  const { formInitializing, path, setValue, value } = useField({
     potentiallyStalePath: pathFromProps,
   })
 
   useEffect(() => {
-    if (valueFromProps !== undefined) {
+    if (valueFromProps !== undefined && !formInitializing) {
       setValue(valueFromProps, disableModifyingForm)
     }
-  }, [valueFromProps, setValue, disableModifyingForm])
+  }, [valueFromProps, setValue, disableModifyingForm, formInitializing])
 
   return (
     <input


### PR DESCRIPTION
Hidden inputs are setting their values before the form initializes. This change ensures that the form has initialized before attempting to set the form field value.

This change would have also fixed https://github.com/payloadcms/payload/issues/13040