### PR TITLE
feat: allow joins, select, populate, depth and draft to /me REST API operation

### DIFF
--- a/packages/payload/src/auth/endpoints/me.ts
+++ b/packages/payload/src/auth/endpoints/me.ts
@@ -1,10 +1,12 @@
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
+import type { JoinParams } from '../../utilities/sanitizeJoinParams.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
+import { sanitizeJoinParams } from '../../utilities/sanitizeJoinParams.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
 import { extractJWT } from '../extractJWT.js'
@@ -14,16 +16,35 @@ export const meHandler: PayloadHandler = async (req) => {
   const { searchParams } = req
   const collection = getRequestCollection(req)
   const currentToken = extractJWT(req)
-  const depth = searchParams.get('depth')
+  const depthFromSearchParams = searchParams.get('depth')
+  const draftFromSearchParams = searchParams.get('depth')
+
+  const {
+    depth: depthFromQuery,
+    draft: draftFromQuery,
+    joins,
+    populate,
+    select,
+  } = req.query as {
+    depth?: string
+    draft?: string
+    joins?: JoinParams
+    populate?: Record<string, unknown>
+    select?: Record<string, unknown>
+  }
+
+  const depth = depthFromQuery || depthFromSearchParams
+  const draft = draftFromQuery || draftFromSearchParams
 
   const result = await meOperation({
     collection,
     currentToken: currentToken!,
     depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: searchParams.get('draft') === 'true',
-    populate: sanitizePopulateParam(req.query.populate),
+    draft: draft === 'true',
+    joins: sanitizeJoinParams(joins),
+    populate: sanitizePopulateParam(populate),
     req,
-    select: sanitizeSelectParam(req.query.select),
+    select: sanitizeSelectParam(select),
   })
 
   if (collection.config.auth.removeTokenFromResponses) {

--- a/packages/payload/src/auth/endpoints/me.ts
+++ b/packages/payload/src/auth/endpoints/me.ts
@@ -4,17 +4,26 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
+import { isNumber } from '../../utilities/isNumber.js'
+import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
+import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
 import { extractJWT } from '../extractJWT.js'
 import { meOperation } from '../operations/me.js'
 
 export const meHandler: PayloadHandler = async (req) => {
+  const { searchParams } = req
   const collection = getRequestCollection(req)
   const currentToken = extractJWT(req)
+  const depth = searchParams.get('depth')
 
   const result = await meOperation({
     collection,
     currentToken: currentToken!,
+    depth: isNumber(depth) ? Number(depth) : undefined,
+    draft: searchParams.get('draft') === 'true',
+    populate: sanitizePopulateParam(req.query.populate),
     req,
+    select: sanitizeSelectParam(req.query.select),
   })
 
   if (collection.config.auth.removeTokenFromResponses) {

--- a/packages/payload/src/auth/operations/me.ts
+++ b/packages/payload/src/auth/operations/me.ts
@@ -2,7 +2,7 @@ import { decodeJwt } from 'jose'
 
 import type { Collection } from '../../collections/config/types.js'
 import type { TypedUser } from '../../index.js'
-import type { PayloadRequest } from '../../types/index.js'
+import type { JoinQuery, PayloadRequest, PopulateType, SelectType } from '../../types/index.js'
 import type { ClientUser } from '../types.js'
 
 export type MeOperationResult = {
@@ -22,11 +22,16 @@ export type MeOperationResult = {
 export type Arguments = {
   collection: Collection
   currentToken?: string
+  depth?: number
+  draft?: boolean
+  joins?: JoinQuery
+  populate?: PopulateType
   req: PayloadRequest
+  select?: SelectType
 }
 
 export const meOperation = async (args: Arguments): Promise<MeOperationResult> => {
-  const { collection, currentToken, req } = args
+  const { collection, currentToken, depth, draft, joins, populate, req, select } = args
 
   let result: MeOperationResult = {
     user: null!,
@@ -39,9 +44,13 @@ export const meOperation = async (args: Arguments): Promise<MeOperationResult> =
     const user = (await req.payload.findByID({
       id: req.user.id,
       collection: collection.config.slug,
-      depth: isGraphQL ? 0 : collection.config.auth.depth,
+      depth: isGraphQL ? 0 : (depth ?? collection.config.auth.depth),
+      draft,
+      joins,
       overrideAccess: false,
+      populate,
       req,
+      select,
       showHiddenFields: false,
     })) as TypedUser
 

--- a/test/select/collections/Users/index.ts
+++ b/test/select/collections/Users/index.ts
@@ -1,0 +1,21 @@
+import type { CollectionConfig } from 'payload'
+
+export const UsersCollection: CollectionConfig = {
+  slug: 'users',
+  admin: {
+    useAsTitle: 'email',
+  },
+  auth: true,
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      defaultValue: 'Payload dev',
+    },
+    {
+      name: 'number',
+      type: 'number',
+      defaultValue: 42,
+    },
+  ],
+}

--- a/test/select/config.ts
+++ b/test/select/config.ts
@@ -15,6 +15,7 @@ import { LocalizedPostsCollection } from './collections/LocalizedPosts/index.js'
 import { Pages } from './collections/Pages/index.js'
 import { Points } from './collections/Points/index.js'
 import { PostsCollection } from './collections/Posts/index.js'
+import { UsersCollection } from './collections/Users/index.js'
 import { VersionedPostsCollection } from './collections/VersionedPosts/index.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -42,6 +43,7 @@ export default buildConfigWithDefaults({
       fields: [],
     },
     CustomID,
+    UsersCollection,
   ],
   globals: [
     {

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -1,6 +1,8 @@
+import type { Payload } from 'payload'
+
 import { randomUUID } from 'crypto'
 import path from 'path'
-import { deepCopyObject, type Payload } from 'payload'
+import { deepCopyObject } from 'payload'
 import { assert } from 'ts-essentials'
 import { fileURLToPath } from 'url'
 
@@ -13,9 +15,11 @@ import type {
   Page,
   Point,
   Post,
+  User,
   VersionedPost,
 } from './payload-types.js'
 
+import { devUser } from '../credentials.js'
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
 
 let payload: Payload
@@ -1967,6 +1971,65 @@ describe('Select', () => {
 
         expect(res).toMatchObject(expected)
       })
+    })
+  })
+
+  describe('REST API - Logged in', () => {
+    let token: string | undefined
+    let loggedInUser: undefined | User
+
+    beforeAll(async () => {
+      const response = await restClient.POST(`/users/login`, {
+        body: JSON.stringify({
+          email: devUser.email,
+          password: devUser.password,
+        }),
+      })
+
+      const data = await response.json()
+      token = data.token
+      loggedInUser = data.user
+    })
+
+    it('should return a logged in user from /me', async () => {
+      const response = await restClient.GET(`/users/me`, {
+        headers: {
+          Authorization: `JWT ${token}`,
+        },
+        query: {
+          depth: 0,
+          select: {
+            name: true,
+          } satisfies Config['collectionsSelect']['users'],
+        },
+      })
+
+      const data = await response.json()
+
+      console.log({ data })
+
+      expect(response.status).toBe(200)
+      expect(data.user.name).toBeDefined()
+      expect(data.user.email).not.toBeDefined()
+      expect(data.user.number).not.toBeDefined()
+    })
+
+    it('should return all fields by default in user from /me', async () => {
+      const response = await restClient.GET(`/users/me`, {
+        headers: {
+          Authorization: `JWT ${token}`,
+        },
+        query: {
+          depth: 0,
+        },
+      })
+
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.user.email).toBeDefined()
+      expect(data.user.name).toBeDefined()
+      expect(data.user.number).toBeDefined()
     })
   })
 

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -1987,11 +1987,12 @@ describe('Select', () => {
       })
 
       const data = await response.json()
+
       token = data.token
       loggedInUser = data.user
     })
 
-    it('should return a logged in user from /me', async () => {
+    it('should return only select fields in user from /me', async () => {
       const response = await restClient.GET(`/users/me`, {
         headers: {
           Authorization: `JWT ${token}`,
@@ -2005,8 +2006,6 @@ describe('Select', () => {
       })
 
       const data = await response.json()
-
-      console.log({ data })
 
       expect(response.status).toBe(200)
       expect(data.user.name).toBeDefined()

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -100,7 +100,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {
     'global-post': GlobalPost;
@@ -142,7 +142,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   text?: string | null;
   number?: number | null;
   select?: ('a' | 'b') | null;
@@ -182,17 +182,17 @@ export interface Post {
   };
   unnamedTabText?: string | null;
   unnamedTabNumber?: number | null;
-  hasOne?: (string | null) | Rel;
-  hasMany?: (string | Rel)[] | null;
-  hasManyUpload?: (string | Upload)[] | null;
+  hasOne?: (number | null) | Rel;
+  hasMany?: (number | Rel)[] | null;
+  hasManyUpload?: (number | Upload)[] | null;
   hasOnePoly?: {
     relationTo: 'rels';
-    value: string | Rel;
+    value: number | Rel;
   } | null;
   hasManyPoly?:
     | {
         relationTo: 'rels';
-        value: string | Rel;
+        value: number | Rel;
       }[]
     | null;
   updatedAt: string;
@@ -203,7 +203,7 @@ export interface Post {
  * via the `definition` "rels".
  */
 export interface Rel {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
 }
@@ -212,7 +212,7 @@ export interface Rel {
  * via the `definition` "upload".
  */
 export interface Upload {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -230,7 +230,7 @@ export interface Upload {
  * via the `definition` "localized-posts".
  */
 export interface LocalizedPost {
-  id: string;
+  id: number;
   text?: string | null;
   number?: number | null;
   select?: ('a' | 'b') | null;
@@ -301,7 +301,7 @@ export interface LocalizedPost {
  * via the `definition` "versioned-posts".
  */
 export interface VersionedPost {
-  id: string;
+  id: number;
   text?: string | null;
   number?: number | null;
   array?:
@@ -327,7 +327,7 @@ export interface VersionedPost {
  * via the `definition` "deep-posts".
  */
 export interface DeepPost {
-  id: string;
+  id: number;
   group?: {
     array?:
       | {
@@ -369,22 +369,22 @@ export interface DeepPost {
  * via the `definition` "pages".
  */
 export interface Page {
-  id: string;
-  relatedPage?: (string | null) | Page;
+  id: number;
+  relatedPage?: (number | null) | Page;
   content?:
     | {
         title: string;
         link: {
           docPoly?: {
             relationTo: 'pages';
-            value: string | Page;
+            value: number | Page;
           } | null;
-          doc?: (string | null) | Page;
-          docMany?: (string | Page)[] | null;
+          doc?: (number | null) | Page;
+          docMany?: (number | Page)[] | null;
           docHasManyPoly?:
             | {
                 relationTo: 'pages';
-                value: string | Page;
+                value: number | Page;
               }[]
             | null;
           label: string;
@@ -440,7 +440,7 @@ export interface Page {
  * via the `definition` "points".
  */
 export interface Point {
-  id: string;
+  id: number;
   text?: string | null;
   /**
    * @minItems 2
@@ -455,7 +455,7 @@ export interface Point {
  * via the `definition` "force-select".
  */
 export interface ForceSelect {
-  id: string;
+  id: number;
   text?: string | null;
   forceSelected?: string | null;
   array?:
@@ -482,7 +482,9 @@ export interface CustomId {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
+  name?: string | null;
+  number?: number | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -492,6 +494,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -499,43 +508,43 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'localized-posts';
-        value: string | LocalizedPost;
+        value: number | LocalizedPost;
       } | null)
     | ({
         relationTo: 'versioned-posts';
-        value: string | VersionedPost;
+        value: number | VersionedPost;
       } | null)
     | ({
         relationTo: 'deep-posts';
-        value: string | DeepPost;
+        value: number | DeepPost;
       } | null)
     | ({
         relationTo: 'pages';
-        value: string | Page;
+        value: number | Page;
       } | null)
     | ({
         relationTo: 'points';
-        value: string | Point;
+        value: number | Point;
       } | null)
     | ({
         relationTo: 'force-select';
-        value: string | ForceSelect;
+        value: number | ForceSelect;
       } | null)
     | ({
         relationTo: 'upload';
-        value: string | Upload;
+        value: number | Upload;
       } | null)
     | ({
         relationTo: 'rels';
-        value: string | Rel;
+        value: number | Rel;
       } | null)
     | ({
         relationTo: 'custom-ids';
@@ -543,12 +552,12 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -558,10 +567,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -581,7 +590,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -917,6 +926,8 @@ export interface CustomIdsSelect<T extends boolean = true> {
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  name?: T;
+  number?: T;
   updatedAt?: T;
   createdAt?: T;
   email?: T;
@@ -926,6 +937,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -964,7 +982,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "global-post".
  */
 export interface GlobalPost {
-  id: string;
+  id: number;
   text?: string | null;
   number?: number | null;
   updatedAt?: string | null;
@@ -975,7 +993,7 @@ export interface GlobalPost {
  * via the `definition` "force-select-global".
  */
 export interface ForceSelectGlobal {
-  id: string;
+  id: number;
   text?: string | null;
   forceSelected?: string | null;
   array?:


### PR DESCRIPTION
While we can use `joins`, `select`, `populate`, `depth` or `draft` on auth collections when finding or finding by ID, these arguments weren't supported for `/me` which meant that in some situations like in our ecommerce template we couldn't optimise these calls.

A workaround would be to make a call to `/me` and then get the user ID to then use for a `findByID` operation.