### PR TITLE
fix: login operation not returning collection and _strategy

### DIFF
--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -214,7 +214,6 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     user._strategy = 'local-jwt'
 
     const authResult = await authenticateLocalStrategy({ doc: user, password })
-
     user = sanitizeInternalFields(user)
 
     const maxLoginAttemptsEnabled = args.collection.config.auth.maxLoginAttempts > 0
@@ -261,7 +260,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
       await payload.db.updateOne({
         id: user.id,
         collection: collectionConfig.slug,
-        data: user,
+        data: { ...user },
         req,
         returning: false,
       })

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -256,8 +256,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
         user.sessions = removeExpiredSessions(user.sessions)
         user.sessions.push(session)
       }
-      const userCollection = user.collection
-      const userStrategy = user._strategy
+
       await payload.db.updateOne({
         id: user.id,
         collection: collectionConfig.slug,
@@ -265,8 +264,9 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
         req,
         returning: false,
       })
-      user.collection = userCollection
-      user._strategy = userStrategy
+
+      user.collection = collectionConfig.slug
+      user._strategy = 'local-jwt'
 
       fieldsToSignArgs.sid = newSessionID
     }

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -256,14 +256,17 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
         user.sessions = removeExpiredSessions(user.sessions)
         user.sessions.push(session)
       }
-
+      const userCollection = user.collection
+      const userStrategy = user._strategy
       await payload.db.updateOne({
         id: user.id,
         collection: collectionConfig.slug,
-        data: { ...user },
+        data: user,
         req,
         returning: false,
       })
+      user.collection = userCollection
+      user._strategy = userStrategy
 
       fieldsToSignArgs.sid = newSessionID
     }

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -4,6 +4,7 @@ import type { SanitizedConfig } from 'payload'
 import { expect, test } from '@playwright/test'
 import { devUser } from 'credentials.js'
 import path from 'path'
+import { formatAdminURL } from 'payload/shared'
 import { fileURLToPath } from 'url'
 import { v4 as uuid } from 'uuid'
 
@@ -18,6 +19,7 @@ import {
   saveDocAndAssert,
 } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
+import { openNav } from '../helpers/e2e/toggleNav.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../helpers/reInitializeDB.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
@@ -195,6 +197,20 @@ describe('Auth', () => {
       await saveDocAndAssert(page)
       await expect(page.locator('#users-api-result')).toHaveText('Goodbye, world!')
       await expect(page.locator('#use-auth-result')).toHaveText('Goodbye, world!')
+    })
+
+    test('should allow log out after login', async () => {
+      const logoutRoute = formatAdminURL({
+        serverURL,
+        adminRoute: '/admin',
+        path: '/logout',
+      })
+      await page.goto(logoutRoute)
+      await expect(page.locator('.login')).toBeVisible()
+      await page.locator('.login .form-submit > button').click()
+      await openNav(page)
+      await page.locator('.nav__controls [aria-label="Log out"]').click()
+      await expect(page.locator('.login')).toBeVisible()
     })
   })
 

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -4,7 +4,6 @@ import type { SanitizedConfig } from 'payload'
 import { expect, test } from '@playwright/test'
 import { devUser } from 'credentials.js'
 import path from 'path'
-import { formatAdminURL } from 'payload/shared'
 import { fileURLToPath } from 'url'
 import { v4 as uuid } from 'uuid'
 
@@ -19,7 +18,6 @@ import {
   saveDocAndAssert,
 } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
-import { openNav } from '../helpers/e2e/toggleNav.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../helpers/reInitializeDB.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
@@ -197,20 +195,6 @@ describe('Auth', () => {
       await saveDocAndAssert(page)
       await expect(page.locator('#users-api-result')).toHaveText('Goodbye, world!')
       await expect(page.locator('#use-auth-result')).toHaveText('Goodbye, world!')
-    })
-
-    test('should allow log out after login', async () => {
-      const logoutRoute = formatAdminURL({
-        serverURL,
-        adminRoute: '/admin',
-        path: '/logout',
-      })
-      await page.goto(logoutRoute)
-      await expect(page.locator('.login')).toBeVisible()
-      await page.locator('.login .form-submit > button').click()
-      await openNav(page)
-      await page.locator('.nav__controls [aria-label="Log out"]').click()
-      await expect(page.locator('.login')).toBeVisible()
     })
   })
 

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -112,6 +112,9 @@ describe('Auth', () => {
       const data = await response.json()
 
       expect(response.status).toBe(200)
+      expect(data.user).toBeDefined()
+      expect(data.user.collection).toBe(slug)
+      expect(data.user._strategy).toBeDefined()
       expect(data.token).toBeDefined()
     })
 


### PR DESCRIPTION
The login operation with sessions enabled calls updateOne, in mongodb, data that does not match the schema is removed. `collection` and `_strategy` are not part of the schema so they need to be reassigned after the user is updated.

Adds int test.