### PR TITLE
fix: text field validation for minLength: 1, required: false

### DIFF
--- a/packages/payload/src/fields/validations.spec.ts
+++ b/packages/payload/src/fields/validations.spec.ts
@@ -61,6 +61,11 @@ describe('Field Validations', () => {
       const result = text(val, { ...options, minLength: 10 })
       expect(result).toBe(true)
     })
+    it('should validate minLength with empty string', () => {
+      const val = ''
+      const result = text(val, { ...options, required: false, minLength: 1 })
+      expect(result).toBe('validation:longerThanMin')
+    })
     it('should validate an array of texts', async () => {
       const val = ['test']
       const result = text(val, { ...options, hasMany: true })

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -61,7 +61,7 @@ export const text: TextFieldValidation = (
   let maxLength!: number
 
   if (!required) {
-    if (!value) {
+    if (value === undefined || value === null) {
       return true
     }
   }


### PR DESCRIPTION
Fixes #13113

### How?

Does not rely on JS falseyness, instead explicitly checking for null & undefined


I'm not actually certain this is the approach we want to take. Some people might interpret "required" as not null, not-undefined and min length > 1 in the case of strings. If they do, this change to the behavior in the not-required case will break their expectations