### PR TITLE
fix(ui): ensure publishSpecificLocale works during create operation

### DIFF
--- a/packages/next/src/views/Version/VersionPillLabel/VersionPillLabel.tsx
+++ b/packages/next/src/views/Version/VersionPillLabel/VersionPillLabel.tsx
@@ -116,7 +116,7 @@ export const VersionPillLabel: React.FC<{
           )}
         </React.Fragment>
       )}
-      {localeLabel && <Pill>{localeLabel}</Pill>}
+      {localeLabel && <Pill size="small">{localeLabel}</Pill>}
     </div>
   )
 }

--- a/packages/payload/src/collections/endpoints/create.ts
+++ b/packages/payload/src/collections/endpoints/create.ts
@@ -16,6 +16,7 @@ export const createHandler: PayloadHandler = async (req) => {
   const autosave = searchParams.get('autosave') === 'true'
   const draft = searchParams.get('draft') === 'true'
   const depth = searchParams.get('depth')
+  const publishSpecificLocale = req.query.publishSpecificLocale as string | undefined
 
   const doc = await createOperation({
     autosave,
@@ -24,6 +25,7 @@ export const createHandler: PayloadHandler = async (req) => {
     depth: isNumber(depth) ? depth : undefined,
     draft,
     populate: sanitizePopulateParam(req.query.populate),
+    publishSpecificLocale,
     req,
     select: sanitizeSelectParam(req.query.select),
   })

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -47,6 +47,7 @@ export type Arguments<TSlug extends CollectionSlug> = {
   overrideAccess?: boolean
   overwriteExistingFiles?: boolean
   populate?: PopulateType
+  publishSpecificLocale?: string
   req: PayloadRequest
   select?: SelectType
   showHiddenFields?: boolean
@@ -88,6 +89,10 @@ export const createOperation = async <
       }
     }
 
+    if (args.publishSpecificLocale) {
+      args.req.locale = args.publishSpecificLocale
+    }
+
     const {
       autosave = false,
       collection: { config: collectionConfig },
@@ -99,6 +104,7 @@ export const createOperation = async <
       overrideAccess,
       overwriteExistingFiles = false,
       populate,
+      publishSpecificLocale,
       req: {
         fallbackLocale,
         locale,
@@ -267,6 +273,7 @@ export const createOperation = async <
       doc = await payload.db.create({
         collection: collectionConfig.slug,
         data: resultWithLocales,
+        locale: publishSpecificLocale ?? locale ?? undefined,
         req,
         select,
       })
@@ -286,6 +293,7 @@ export const createOperation = async <
         collection: collectionConfig,
         docWithLocales: result,
         payload,
+        publishSpecificLocale,
         req,
       })
     }

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -104,7 +104,6 @@ export const createOperation = async <
       overrideAccess,
       overwriteExistingFiles = false,
       populate,
-      publishSpecificLocale,
       req: {
         fallbackLocale,
         locale,
@@ -273,7 +272,6 @@ export const createOperation = async <
       doc = await payload.db.create({
         collection: collectionConfig.slug,
         data: resultWithLocales,
-        locale: publishSpecificLocale ?? locale ?? undefined,
         req,
         select,
       })
@@ -293,7 +291,6 @@ export const createOperation = async <
         collection: collectionConfig,
         docWithLocales: result,
         payload,
-        publishSpecificLocale,
         req,
       })
     }

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -104,6 +104,7 @@ export const createOperation = async <
       overrideAccess,
       overwriteExistingFiles = false,
       populate,
+      publishSpecificLocale,
       req: {
         fallbackLocale,
         locale,
@@ -291,6 +292,7 @@ export const createOperation = async <
         collection: collectionConfig,
         docWithLocales: result,
         payload,
+        publishSpecificLocale,
         req,
       })
     }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -248,7 +248,12 @@ export async function saveDocHotkeyAndAssert(page: Page): Promise<void> {
 
 export async function saveDocAndAssert(
   page: Page,
-  selector: '#action-publish' | '#action-save' | '#action-save-draft' | string = '#action-save',
+  selector:
+    | '#action-publish'
+    | '#action-save'
+    | '#action-save-draft'
+    | '#publish-locale'
+    | string = '#action-save',
   expectation: 'error' | 'success' = 'success',
 ): Promise<void> {
   await wait(500) // TODO: Fix this

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -618,6 +618,21 @@ describe('Localization', () => {
     await expect(searchInput).toBeVisible()
     await expect(searchInput).toHaveAttribute('placeholder', 'Search by Full title')
   })
+
+  describe('publish specific locale', () => {
+    test('should create post in correct locale with publishSpecificLocale', async () => {
+      await page.goto(urlPostsWithDrafts.create)
+      await changeLocale(page, 'es')
+      await fillValues({ title: 'Created In Spanish' })
+      const chevronButton = page.locator('.form-submit .popup__trigger-wrap > .popup-button')
+      await chevronButton.click()
+      await saveDocAndAssert(page, '#publish-locale')
+
+      await expect(page.locator('#field-title')).toHaveValue('Created In Spanish')
+      await changeLocale(page, defaultLocale)
+      await expect(page.locator('#field-title')).toBeEmpty()
+    })
+  })
 })
 
 async function fillValues(data: Partial<LocalizedPost>) {


### PR DESCRIPTION
### What?
This PR ensures that when a document is created using the `Publish in __` button, it is saved to the correct locale.

### Why?
During document creation, the buttons `Publish` or `Publish in [locale]` have the same effect. As a result, we overlooked the case where a user may specifically click `Publish in [locale]` for the first save. In this scenario, the create operation does not respect the `publishSpecificLocale` value, so the document was always saved in the default locale regardless of the intended one.

### How?
Passes the `publishSpecificLocale` value to the create operation, ensuring the document and version is saved to the correct locale.

**Fixes:** #13117 

