### PR TITLE
docs(richtext-lexical): add documentation page about official features

### DIFF
--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -1,0 +1,604 @@
+---
+description: Features officially maintained by Payload.
+keywords: lexical, rich text, editor, headless cms, official, features
+label: Official Features
+order: 35
+title: Official Features
+---
+
+Below are all the Rich Text Features Payload offers. Everything is customizable; you can [create your own features](/docs/rich-text/custom-features), modify ours and share them with the community.
+
+## Text Formatting Features
+
+The following features allow you to modify text formatting. Adding these features to the editor will also cause the corresponding buttons to appear in the inline and fixed toolbars.
+
+| Feature                  | Markdown Support         | Keyboard Shortcut |
+| ------------------------ | ------------------------ | ----------------- |
+| **BoldFeature**          | `**bold**` or `__bold__` | Ctrl/Cmd + B      |
+| **ItalicFeature**        | `*italic*` or `_italic_` | Ctrl/Cmd + I      |
+| **UnderlineFeature**     | none                     | Ctrl/Cmd + U      |
+| **StrikethroughFeature** | `~~strikethrough~~`      | none              |
+| **SubscriptFeature**     | none                     | none              |
+| **SuperscriptFeature**   | none                     | none              |
+| **InlineCodeFeature**    | \`code\`                 | none              |
+
+**Ejemplo de uso:**
+
+```typescript
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+
+// Todas estas características están incluidas por defecto
+export default {
+  fields: [
+    {
+      name: 'content',
+      type: 'richText',
+      editor: lexicalEditor({
+        // No es necesario agregar las características de formato - ya están incluidas
+      }),
+    },
+  ],
+}
+```
+
+## Block-Level Features
+
+### **ParagraphFeature**
+
+Handles paragraph nodes and provides slash menu entries.
+
+```typescript
+import { ParagraphFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Default block type for content
+- Slash menu entry for explicit paragraph creation
+- Automatically created when starting to type
+
+### **HeadingFeature**
+
+Adds support for heading nodes (H1-H6) with markdown support.
+
+```typescript
+import { HeadingFeature } from '@payloadcms/richtext-lexical'
+
+// With default configuration (all headings enabled)
+HeadingFeature()
+
+// With custom heading sizes
+HeadingFeature({
+  enabledHeadingSizes: ['h1', 'h2', 'h3'], // Only H1, H2, H3
+})
+```
+
+**Configuration Options:**
+
+- `enabledHeadingSizes`: Array of heading types to enable (default: `['h1', 'h2', 'h3', 'h4', 'h5', 'h6']`)
+
+**Key Features:**
+
+- Toolbar dropdown in both fixed and inline toolbars
+- Slash menu entries for each enabled heading
+- Markdown transformers for `# Heading 1`, `## Heading 2`, etc.
+- Proper semantic HTML output
+
+### **AlignFeature**
+
+Allows text alignment (left, center, right).
+
+```typescript
+import { AlignFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Toolbar buttons for alignment options
+- Keyboard shortcuts for alignment
+- Supports both text and block alignment
+
+### **IndentFeature**
+
+Allows text indentation with tab key support.
+
+```typescript
+import { IndentFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Tab key support for indentation
+- Shift+Tab for outdenting
+- Toolbar buttons for indent/outdent
+- Supports nested indentation
+
+## List Features
+
+### **UnorderedListFeature**
+
+Adds support for unordered lists (bulleted lists).
+
+```typescript
+import { UnorderedListFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Toolbar button in both fixed and inline toolbars
+- Slash menu entry
+- Markdown transformer for `- item` or `* item`
+- Nested list support
+- Keyboard shortcuts for list creation
+
+### **OrderedListFeature**
+
+Adds support for ordered lists (numbered lists).
+
+```typescript
+import { OrderedListFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Toolbar button in both fixed and inline toolbars
+- Slash menu entry
+- Markdown transformer for `1. item`
+- Nested list support
+- Automatic numbering
+
+### **ChecklistFeature**
+
+Adds support for interactive checklists.
+
+```typescript
+import { ChecklistFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Toolbar button in both fixed and inline toolbars
+- Slash menu entry
+- Interactive checkboxes
+- Markdown transformer for `- [ ] item` and `- [x] item`
+- Keyboard shortcuts for toggling checks
+
+## Link and Relationship Features
+
+### **LinkFeature**
+
+Allows creation of internal and external links with extensive customization.
+
+```typescript
+import { LinkFeature } from '@payloadcms/richtext-lexical'
+
+// Basic configuration
+LinkFeature()
+
+// Advanced configuration with custom fields
+LinkFeature({
+  fields: ({ defaultFields }) => [
+    ...defaultFields,
+    {
+      name: 'rel',
+      type: 'select',
+      hasMany: true,
+      options: ['noopener', 'noreferrer', 'nofollow'],
+      label: 'Rel Attribute',
+    },
+    {
+      name: 'customClass',
+      type: 'text',
+      label: 'CSS Class',
+    },
+  ],
+  enabledCollections: ['pages', 'posts'], // Only these collections for internal links
+  maxDepth: 2, // Population depth for internal links
+  disableAutoLinks: false, // Allow auto-conversion of URLs
+})
+```
+
+**Configuration Options:**
+
+- `fields`: Function or array to customize link fields
+- `enabledCollections`: Collections available for internal linking
+- `disabledCollections`: Collections to exclude from internal linking
+- `maxDepth`: Maximum population depth for internal links
+- `disableAutoLinks`: Disable automatic URL conversion
+
+**Key Features:**
+
+- Toolbar button and floating link editor
+- Support for both internal and external links
+- Custom fields for additional link metadata
+- Auto-conversion of pasted URLs (unless disabled)
+- Validation for URL formats
+
+### **RelationshipFeature**
+
+Allows creation of block-level relationships to other documents.
+
+```typescript
+import { RelationshipFeature } from '@payloadcms/richtext-lexical'
+
+// Basic configuration
+RelationshipFeature()
+
+// Advanced configuration
+RelationshipFeature({
+  enabledCollections: ['pages', 'posts'], // Only these collections
+  maxDepth: 2, // Population depth
+})
+```
+
+**Configuration Options:**
+
+- `enabledCollections`: Collections available for relationships
+- `disabledCollections`: Collections to exclude
+- `maxDepth`: Maximum population depth
+
+**Key Features:**
+
+- Toolbar button and slash menu entry
+- Document picker drawer
+- Block-level relationship display
+- Automatic population of related documents
+- GraphQL support
+
+## Media Features
+
+### **UploadFeature**
+
+Allows insertion of upload/media nodes with support for additional fields.
+
+```typescript
+import { UploadFeature } from '@payloadcms/richtext-lexical'
+
+// Basic configuration
+UploadFeature()
+
+// Advanced configuration with custom fields
+UploadFeature({
+  collections: {
+    uploads: {
+      fields: [
+        {
+          name: 'caption',
+          type: 'richText',
+          editor: lexicalEditor(),
+        },
+        {
+          name: 'alt',
+          type: 'text',
+          label: 'Alt Text',
+        },
+      ],
+    },
+  },
+  maxDepth: 1, // Population depth
+})
+```
+
+**Configuration Options:**
+
+- `collections`: Object defining additional fields for each upload collection
+- `maxDepth`: Maximum population depth for uploads
+
+**Key Features:**
+
+- Toolbar button and slash menu entry
+- Support for all file types (images, documents, etc.)
+- Custom fields for additional metadata
+- Automatic HTML conversion (responsive images, links for non-images)
+- Upload drawer integration
+
+### **BlockquoteFeature**
+
+Allows creation of blockquotes.
+
+```typescript
+import { BlockquoteFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Toolbar button in both fixed and inline toolbars
+- Slash menu entry
+- Markdown transformer for `> quote`
+- Proper semantic HTML output
+
+### **HorizontalRuleFeature**
+
+Adds horizontal rules/separators.
+
+```typescript
+import { HorizontalRuleFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Toolbar button and slash menu entry
+- Markdown transformer for `---`
+- Renders as `<hr>` element
+- Keyboard shortcuts for insertion
+
+## Toolbar Features
+
+### **InlineToolbarFeature**
+
+The floating toolbar that appears when text is selected.
+
+```typescript
+import { InlineToolbarFeature } from '@payloadcms/richtext-lexical'
+
+// Included by default - no configuration needed
+```
+
+**Key Features:**
+
+- Appears when text is selected
+- Contains formatting options relevant to selected text
+- Automatically positioned to avoid viewport edges
+- Customizable through toolbar groups
+
+### **FixedToolbarFeature**
+
+A persistent toolbar pinned to the top of the editor.
+
+```typescript
+import { FixedToolbarFeature } from '@payloadcms/richtext-lexical'
+
+// Basic configuration
+FixedToolbarFeature()
+
+// Advanced configuration
+FixedToolbarFeature({
+  applyToFocusedEditor: false, // Apply to current editor vs focused editor
+  disableIfParentHasFixedToolbar: false, // Disable if parent has fixed toolbar
+  customGroups: {
+    format: {
+      // Custom configuration for format group
+    },
+  },
+})
+```
+
+**Configuration Options:**
+
+- `applyToFocusedEditor`: Whether to apply to focused editor or current editor
+- `disableIfParentHasFixedToolbar`: Disable if parent editor has fixed toolbar
+- `customGroups`: Custom configuration for toolbar groups
+
+**Key Features:**
+
+- Always visible at the top of the editor
+- Sticky positioning
+- Can coexist with inline toolbar
+- Customizable groups and items
+
+## Advanced Features
+
+### **BlocksFeature**
+
+Allows use of Payload's Blocks Field directly in the editor.
+
+```typescript
+import { BlocksFeature } from '@payloadcms/richtext-lexical'
+
+BlocksFeature({
+  blocks: [
+    {
+      slug: 'callout',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'type',
+          type: 'select',
+          options: ['info', 'warning', 'error'],
+          defaultValue: 'info',
+        },
+      ],
+    },
+  ],
+  inlineBlocks: [
+    {
+      slug: 'mention',
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+  ],
+})
+```
+
+**Configuration Options:**
+
+- `blocks`: Array of block configurations (block-level)
+- `inlineBlocks`: Array of inline block configurations
+
+**Key Features:**
+
+- Full Payload Blocks Field integration
+- Support for both block-level and inline blocks
+- Custom components for block rendering
+- Validation and field schemas
+- GraphQL support
+
+### **TreeViewFeature**
+
+Adds a debug panel showing the editor's internal state.
+
+```typescript
+import { TreeViewFeature } from '@payloadcms/richtext-lexical'
+
+// Simple configuration
+TreeViewFeature()
+```
+
+**Key Features:**
+
+- Live view of editor state
+- DOM tree visualization
+- Time travel debugging
+- Toggle between different view modes
+- Useful for development and debugging
+
+## Experimental Features
+
+### **EXPERIMENTAL_TableFeature**
+
+Adds support for tables (experimental).
+
+```typescript
+import { EXPERIMENTAL_TableFeature } from '@payloadcms/richtext-lexical'
+
+// Basic configuration
+EXPERIMENTAL_TableFeature()
+```
+
+**⚠️ Warning:** This feature is experimental and may receive breaking changes in future releases.
+
+**Key Features:**
+
+- Table creation and editing
+- Row and column manipulation
+- Cell merging and splitting
+- Keyboard navigation
+
+### **EXPERIMENTAL_TextStateFeature**
+
+Allows storing key-value attributes in text nodes with inline styles.
+
+```typescript
+import {
+  EXPERIMENTAL_TextStateFeature,
+  defaultColors,
+} from '@payloadcms/richtext-lexical'
+
+EXPERIMENTAL_TextStateFeature({
+  state: {
+    color: {
+      ...defaultColors.text,
+      // Custom colors
+      brand: {
+        label: 'Brand Blue',
+        css: { color: '#0066cc' },
+      },
+    },
+    backgroundColor: {
+      ...defaultColors.background,
+      // Custom backgrounds
+      highlight: {
+        label: 'Highlight',
+        css: { backgroundColor: '#ffff00' },
+      },
+    },
+  },
+})
+```
+
+**⚠️ Warning:** This feature is experimental and may receive breaking changes in future releases.
+
+**Configuration Options:**
+
+- `state`: Object defining available state keys and their values
+
+**Key Features:**
+
+- Custom text styling with CSS
+- Predefined color palettes
+- Inline style application
+- Extensible state system
+
+## Migration Features
+
+### **SlateToLexicalFeature**
+
+Converts Slate editor data to Lexical format.
+
+```typescript
+import { SlateToLexicalFeature } from '@payloadcms/richtext-lexical/migrate'
+
+SlateToLexicalFeature({
+  converters: ({ defaultConverters }) => [
+    ...defaultConverters,
+    // Custom converters
+  ],
+  disableHooks: false, // Disable afterRead hooks
+})
+```
+
+### **LexicalPluginToLexicalFeature**
+
+Converts legacy Lexical Plugin data to new format.
+
+```typescript
+import { LexicalPluginToLexicalFeature } from '@payloadcms/richtext-lexical/migrate'
+
+LexicalPluginToLexicalFeature({
+  converters: ({ defaultConverters }) => [
+    ...defaultConverters,
+    // Custom converters
+  ],
+  quiet: true, // Suppress conversion warnings
+})
+```
+
+## Creating Custom Features
+
+Features follow a consistent pattern with both server and client components:
+
+```typescript
+// server/index.ts
+import { createServerFeature } from '@payloadcms/richtext-lexical'
+
+export const MyCustomFeature = createServerFeature<MyProps>({
+  key: 'myCustomFeature',
+  feature: ({ props }) => ({
+    ClientFeature: '@my-package/client#MyCustomFeatureClient',
+    // Server-side configuration
+    nodes: [MyCustomNode],
+    markdownTransformers: [MyMarkdownTransformer],
+    i18n: myTranslations,
+  }),
+})
+```
+
+```typescript
+// client/index.ts
+import { createClientFeature } from '@payloadcms/richtext-lexical'
+
+export const MyCustomFeatureClient = createClientFeature<MyProps>({
+  // Client-side configuration
+  nodes: [MyCustomNode],
+  plugins: [MyCustomPlugin],
+  toolbarFixed: { groups: myToolbarGroups },
+  slashMenu: { groups: mySlashMenuGroups },
+})
+```
+
+This documentation provides a comprehensive overview of all official Lexical features. Each feature is designed to be modular, configurable, and extensible to meet your specific needs.

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -10,33 +10,33 @@ Below are all the Rich Text Features Payload offers. Everything is customizable;
 
 ## Features Overview
 
-| Feature Name                        | Included by default | Description                                                                                                                                                                         |
-| ----------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`BoldFeature`**                   | Yes                 | Adds support for bold text formatting.                                                                                                                                              |
-| **`ItalicFeature`**                 | Yes                 | Adds support for italic text formatting.                                                                                                                                            |
-| **`UnderlineFeature`**              | Yes                 | Adds support for underlined text formatting.                                                                                                                                        |
-| **`StrikethroughFeature`**          | Yes                 | Adds support for strikethrough text formatting.                                                                                                                                     |
-| **`SubscriptFeature`**              | Yes                 | Adds support for subscript text formatting.                                                                                                                                         |
-| **`SuperscriptFeature`**            | Yes                 | Adds support for superscript text formatting.                                                                                                                                       |
-| **`InlineCodeFeature`**             | Yes                 | Adds support for inline code formatting.                                                                                                                                            |
-| **`ParagraphFeature`**              | Yes                 | Provides entries in both the slash menu and toolbar dropdown for explicit paragraph creation or conversion.                                                                         |
-| **`HeadingFeature`**                | Yes                 | Adds Heading Nodes (by default, H1 - H6, but that can be customized)                                                                                                                |
-| **`AlignFeature`**                  | Yes                 | Adds support for text alignment (left, center, right, justify)                                                                                                                      |
-| **`IndentFeature`**                 | Yes                 | Adds support for text indentation with toolbar buttons                                                                                                                              |
-| **`UnorderedListFeature`**          | Yes                 | Adds support for unordered lists (ul)                                                                                                                                               |
-| **`OrderedListFeature`**            | Yes                 | Adds support for ordered lists (ol)                                                                                                                                                 |
-| **`ChecklistFeature`**              | Yes                 | Adds support for interactive checklists                                                                                                                                             |
-| **`LinkFeature`**                   | Yes                 | Allows you to create internal and external links                                                                                                                                    |
-| **`RelationshipFeature`**           | Yes                 | Allows you to create block-level (not inline) relationships to other documents                                                                                                      |
-| **`BlockquoteFeature`**             | Yes                 | Allows you to create block-level quotes                                                                                                                                             |
-| **`UploadFeature`**                 | Yes                 | Allows you to create block-level upload nodes - this supports all kinds of uploads, not just images                                                                                 |
-| **`HorizontalRuleFeature`**         | Yes                 | Adds support for horizontal rules / separators. Basically displays an `<hr>` element                                                                                                |
-| **`InlineToolbarFeature`**          | Yes                 | Provides a floating toolbar which appears when you select text. This toolbar only contains actions relevant for selected text                                                       |
-| **`FixedToolbarFeature`**           | No                  | Provides a persistent toolbar pinned to the top and always visible. Both inline and fixed toolbars can be enabled at the same time.                                                 |
-| **`BlocksFeature`**                 | No                  | Allows you to use Payload's [Blocks Field](../fields/blocks) directly inside your editor. In the feature props, you can specify the allowed blocks - just like in the Blocks field. |
-| **`TreeViewFeature`**               | No                  | Provides a debug box under the editor, which allows you to see the current editor state live, the dom, as well as time travel. Very useful for debugging                            |
-| **`EXPERIMENTAL_TableFeature`**     | No                  | Adds support for tables. This feature may be removed or receive breaking changes in the future - even within a stable lexical release, without needing a major release.             |
-| **`EXPERIMENTAL_TextStateFeature`** | No                  | Allows you to store key-value attributes within TextNodes and assign them inline styles.                                                                                            |
+| Feature Name                    | Included by default | Description                                                                                                                                                                         |
+| ------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`BoldFeature`**               | Yes                 | Adds support for bold text formatting.                                                                                                                                              |
+| **`ItalicFeature`**             | Yes                 | Adds support for italic text formatting.                                                                                                                                            |
+| **`UnderlineFeature`**          | Yes                 | Adds support for underlined text formatting.                                                                                                                                        |
+| **`StrikethroughFeature`**      | Yes                 | Adds support for strikethrough text formatting.                                                                                                                                     |
+| **`SubscriptFeature`**          | Yes                 | Adds support for subscript text formatting.                                                                                                                                         |
+| **`SuperscriptFeature`**        | Yes                 | Adds support for superscript text formatting.                                                                                                                                       |
+| **`InlineCodeFeature`**         | Yes                 | Adds support for inline code formatting.                                                                                                                                            |
+| **`ParagraphFeature`**          | Yes                 | Provides entries in both the slash menu and toolbar dropdown for explicit paragraph creation or conversion.                                                                         |
+| **`HeadingFeature`**            | Yes                 | Adds Heading Nodes (by default, H1 - H6, but that can be customized)                                                                                                                |
+| **`AlignFeature`**              | Yes                 | Adds support for text alignment (left, center, right, justify)                                                                                                                      |
+| **`IndentFeature`**             | Yes                 | Adds support for text indentation with toolbar buttons                                                                                                                              |
+| **`UnorderedListFeature`**      | Yes                 | Adds support for unordered lists (ul)                                                                                                                                               |
+| **`OrderedListFeature`**        | Yes                 | Adds support for ordered lists (ol)                                                                                                                                                 |
+| **`ChecklistFeature`**          | Yes                 | Adds support for interactive checklists                                                                                                                                             |
+| **`LinkFeature`**               | Yes                 | Allows you to create internal and external links                                                                                                                                    |
+| **`RelationshipFeature`**       | Yes                 | Allows you to create block-level (not inline) relationships to other documents                                                                                                      |
+| **`BlockquoteFeature`**         | Yes                 | Allows you to create block-level quotes                                                                                                                                             |
+| **`UploadFeature`**             | Yes                 | Allows you to create block-level upload nodes - this supports all kinds of uploads, not just images                                                                                 |
+| **`HorizontalRuleFeature`**     | Yes                 | Adds support for horizontal rules / separators. Basically displays an `<hr>` element                                                                                                |
+| **`InlineToolbarFeature`**      | Yes                 | Provides a floating toolbar which appears when you select text. This toolbar only contains actions relevant for selected text                                                       |
+| **`FixedToolbarFeature`**       | No                  | Provides a persistent toolbar pinned to the top and always visible. Both inline and fixed toolbars can be enabled at the same time.                                                 |
+| **`BlocksFeature`**             | No                  | Allows you to use Payload's [Blocks Field](../fields/blocks) directly inside your editor. In the feature props, you can specify the allowed blocks - just like in the Blocks field. |
+| **`TreeViewFeature`**           | No                  | Provides a debug box under the editor, which allows you to see the current editor state live, the dom, as well as time travel. Very useful for debugging                            |
+| **`EXPERIMENTAL_TableFeature`** | No                  | Adds support for tables. This feature may be removed or receive breaking changes in the future - even within a stable lexical release, without needing a major release.             |
+| **`TextStateFeature`**          | No                  | Allows you to store key-value attributes within TextNodes and assign them inline styles.                                                                                            |
 
 ## In depth
 
@@ -419,7 +419,7 @@ BlocksFeature({
 - Description: Adds support for tables with toolbar button and slash menu entry for creation and editing.
 - Included by default: No
 
-### EXPERIMENTAL_TextStateFeature
+### TextStateFeature
 
 - Description: Allows storing key-value attributes in text nodes with inline styles and toolbar dropdown for style selection.
 - Included by default: No

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -475,3 +475,12 @@ TextStateFeature({
   },
 }),
 ```
+
+{/\*
+This is what the example above will look like:
+
+<LightDarkImage
+  srcLight="https://payloadcms.com/images/docs/TextStateFeature.png"
+  alt="Example usage in light and dark mode for TextStateFeature with defaultColors and some custom styles"
+/>
+*/}

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -39,112 +39,188 @@ Adding these features to the editor will also cause the corresponding buttons to
 | **`TreeViewFeature`**               | No                  | ‐                                         | ‐                 | [see below](#treeviewfeature)               |
 | **`EXPERIMENTAL_TableFeature`**     | No                  | ‐                                         | ‐                 | [see below](#experimental_tablefeature)     |
 | **`EXPERIMENTAL_TextStateFeature`** | No                  | ‐                                         | ‐                 | [see below](#experimental_textstatefeature) |
-| **`SlateToLexicalFeature`**         | No                  | ‐                                         | ‐                 | [see below](#slatetolexicalfeature)         |
-| **`LexicalPluginToLexicalFeature`** | No                  | ‐                                         | ‐                 | [see below](#lexicalplugintolexicalfeature) |
 
-## Link and Relationship Features
+| Feature Name                        | Included by default | Description                                                                                                                                                                         |
+| ----------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`BoldFeature`**                   | Yes                 | Adds support for bold text formatting.                                                                                                                                              |
+| **`ItalicFeature`**                 | Yes                 | Adds support for italic text formatting.                                                                                                                                            |
+| **`UnderlineFeature`**              | Yes                 | Adds support for underlined text formatting.                                                                                                                                        |
+| **`StrikethroughFeature`**          | Yes                 | Adds support for strikethrough text formatting.                                                                                                                                     |
+| **`SubscriptFeature`**              | Yes                 | Adds support for subscript text formatting.                                                                                                                                         |
+| **`SuperscriptFeature`**            | Yes                 | Adds support for superscript text formatting.                                                                                                                                       |
+| **`InlineCodeFeature`**             | Yes                 | Adds support for inline code formatting.                                                                                                                                            |
+| **`ParagraphFeature`**              | Yes                 | Provides entries in both the slash menu and toolbar dropdown for explicit paragraph creation or conversion.                                                                         |
+| **`HeadingFeature`**                | Yes                 | Adds Heading Nodes (by default, H1 - H6, but that can be customized)                                                                                                                |
+| **`AlignFeature`**                  | Yes                 | Allows you to align text left, centered and right                                                                                                                                   |
+| **`IndentFeature`**                 | Yes                 | Allows you to indent text with the tab key                                                                                                                                          |
+| **`UnorderedListFeature`**          | Yes                 | Adds unordered lists (ul)                                                                                                                                                           |
+| **`OrderedListFeature`**            | Yes                 | Adds ordered lists (ol)                                                                                                                                                             |
+| **`ChecklistFeature`**              | Yes                 | Adds checklists                                                                                                                                                                     |
+| **`LinkFeature`**                   | Yes                 | Allows you to create internal and external links                                                                                                                                    |
+| **`RelationshipFeature`**           | Yes                 | Allows you to create block-level (not inline) relationships to other documents                                                                                                      |
+| **`BlockquoteFeature`**             | Yes                 | Allows you to create block-level quotes                                                                                                                                             |
+| **`UploadFeature`**                 | Yes                 | Allows you to create block-level upload nodes - this supports all kinds of uploads, not just images                                                                                 |
+| **`HorizontalRuleFeature`**         | Yes                 | Horizontal rules / separators. Basically displays an `<hr>` element                                                                                                                 |
+| **`InlineToolbarFeature`**          | Yes                 | The inline toolbar is the floating toolbar which appears when you select text. This toolbar only contains actions relevant for selected text                                        |
+| **`FixedToolbarFeature`**           | No                  | This classic toolbar is pinned to the top and always visible. Both inline and fixed toolbars can be enabled at the same time.                                                       |
+| **`BlocksFeature`**                 | No                  | Allows you to use Payload's [Blocks Field](../fields/blocks) directly inside your editor. In the feature props, you can specify the allowed blocks - just like in the Blocks field. |
+| **`TreeViewFeature`**               | No                  | Adds a debug box under the editor, which allows you to see the current editor state live, the dom, as well as time travel. Very useful for debugging                                |
+| **`EXPERIMENTAL_TableFeature`**     | No                  | Adds support for tables. This feature may be removed or receive breaking changes in the future - even within a stable lexical release, without needing a major release.             |
+| **`EXPERIMENTAL_TextStateFeature`** | No                  | Allows you to store key-value attributes within TextNodes and assign them inline styles.                                                                                            |
+
+## In depth
+
+### BoldFeature
+
+- Description: Adds support for bold text formatting, along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+- Markdown Support: `**bold**` or `__bold__`
+- Keyboard Shortcut: Ctrl/Cmd + B
+
+### ItalicFeature
+
+- Description: Adds support for italic text formatting, along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+- Markdown Support: `*italic*` or `_italic_`
+- Keyboard Shortcut: Ctrl/Cmd + I
+
+### UnderlineFeature
+
+- Description: Adds support for underlined text formatting, along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+- Keyboard Shortcut: Ctrl/Cmd + U
+
+### StrikethroughFeature
+
+- Description: Adds support for strikethrough text formatting, along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+- Markdown Support: `~~strikethrough~~`
+
+### SubscriptFeature
+
+- Description: Adds support for subscript text formatting, along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+
+### SuperscriptFeature
+
+- Description: Adds support for superscript text formatting, along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+
+### InlineCodeFeature
+
+- Description: Adds support for inline code formatting with distinct styling, along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+- Markdown Support: \`code\`
+
+### ParagraphFeature
+
+- Description: Provides entries in both the slash menu and toolbar dropdown for explicit paragraph creation or conversion.
+- Included by default: Yes
+
+### HeadingFeature
+
+- Description: Adds support for heading nodes (H1-H6) with toolbar dropdown and slash menu entries for each enabled heading size.
+- Included by default: Yes
+- Markdown Support: `# H1`, `## H2`, `### H3`, etc.
+- Options:
+
+```typescript
+HeadingFeature({
+  enabledHeadingSizes: ['h1', 'h2', 'h3'], // Default: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+})
+```
+
+### AlignFeature
+
+- Description: Allows text alignment (left, center, right, justify), along with buttons to apply it in both fixed and inline toolbars.
+- Included by default: Yes
+- Keyboard Shortcut: Ctrl/Cmd + Shift + L/E/R/J (left/center/right/justify)
+
+### IndentFeature
+
+- Description: Allows text indentation with toolbar buttons for increase/decrease indent, available in both fixed and inline toolbars.
+- Included by default: Yes
+- Keyboard Shortcut: Tab (increase), Shift + Tab (decrease)
+- Options:
+
+```typescript
+IndentFeature({
+  disabledNodes: ['paragraph'], // Nodes that should not be indented
+  disableTabNode: false, // If true, Tab only does block-level indentation
+})
+```
+
+### UnorderedListFeature
+
+- Description: Adds unordered lists (bullet points) with toolbar dropdown and slash menu entries for creation.
+- Included by default: Yes
+- Markdown Support: `-`, `*`, or `+` at start of line
+
+### OrderedListFeature
+
+- Description: Adds ordered lists (numbered lists) with toolbar dropdown and slash menu entries for creation.
+- Included by default: Yes
+- Markdown Support: `1.` at start of line
+
+### ChecklistFeature
+
+- Description: Adds interactive checklists with toolbar dropdown and slash menu entries for creation.
+- Included by default: Yes
+- Markdown Support: `- [ ]` (unchecked) or `- [x]` (checked)
 
 ### LinkFeature
 
-Allows creation of internal and external links with extensive customization.
+- Description: Allows creation of internal and external links with toolbar buttons and automatic URL conversion.
+- Included by default: Yes
+- Markdown Support: `[anchor](url)`
+- Options:
 
 ```typescript
-import { LinkFeature } from '@payloadcms/richtext-lexical'
-
-// Basic configuration
-LinkFeature()
-
-// Advanced configuration with custom fields
 LinkFeature({
   fields: ({ defaultFields }) => [
     ...defaultFields,
     {
       name: 'rel',
       type: 'select',
-      hasMany: true,
       options: ['noopener', 'noreferrer', 'nofollow'],
-      label: 'Rel Attribute',
-    },
-    {
-      name: 'customClass',
-      type: 'text',
-      label: 'CSS Class',
     },
   ],
-  enabledCollections: ['pages', 'posts'], // Only these collections for internal links
+  enabledCollections: ['pages', 'posts'], // Collections for internal links
+  disabledCollections: ['users'], // Collections to exclude
   maxDepth: 2, // Population depth for internal links
   disableAutoLinks: false, // Allow auto-conversion of URLs
 })
 ```
 
-**Configuration Options:**
-
-- `fields`: Function or array to customize link fields
-- `enabledCollections`: Collections available for internal linking
-- `disabledCollections`: Collections to exclude from internal linking
-- `maxDepth`: Maximum population depth for internal links
-- `disableAutoLinks`: Disable automatic URL conversion
-
-**Key Features:**
-
-- Toolbar button and floating link editor
-- Support for both internal and external links
-- Custom fields for additional link metadata
-- Auto-conversion of pasted URLs (unless disabled)
-- Validation for URL formats
-
 ### RelationshipFeature
 
-Allows creation of block-level relationships to other documents.
+- Description: Allows creation of block-level relationships to other documents with toolbar button and slash menu entry.
+- Included by default: Yes
+- Options:
 
 ```typescript
-import { RelationshipFeature } from '@payloadcms/richtext-lexical'
-
-// Basic configuration
-RelationshipFeature()
-
-// Advanced configuration
 RelationshipFeature({
-  enabledCollections: ['pages', 'posts'], // Only these collections
-  maxDepth: 2, // Population depth
+  enabledCollections: ['pages', 'posts'], // Collections available for relationships
+  disabledCollections: ['users'], // Collections to exclude
+  maxDepth: 2, // Population depth for relationships
 })
 ```
 
-**Configuration Options:**
-
-- `enabledCollections`: Collections available for relationships
-- `disabledCollections`: Collections to exclude
-- `maxDepth`: Maximum population depth
-
-**Key Features:**
-
-- Toolbar button and slash menu entry
-- Document picker drawer
-- Block-level relationship display
-- Automatic population of related documents
-- GraphQL support
-
-## Media Features
-
 ### UploadFeature
 
-Allows insertion of upload/media nodes with support for additional fields.
+- Description: Allows insertion of upload/media nodes with toolbar button and slash menu entry, supports all file types.
+- Included by default: Yes
+- Options:
 
 ```typescript
-import { UploadFeature } from '@payloadcms/richtext-lexical'
-
-// Basic configuration
-UploadFeature()
-
-// Advanced configuration with custom fields
 UploadFeature({
   collections: {
     uploads: {
       fields: [
         {
           name: 'caption',
-          type: 'richText',
-          editor: lexicalEditor(),
+          type: 'text',
+          label: 'Caption',
         },
         {
           name: 'alt',
@@ -154,87 +230,34 @@ UploadFeature({
       ],
     },
   },
-  maxDepth: 1, // Population depth
+  maxDepth: 1, // Population depth for uploads
 })
 ```
 
-**Configuration Options:**
-
-- `collections`: Object defining additional fields for each upload collection
-- `maxDepth`: Maximum population depth for uploads
-
-**Key Features:**
-
-- Toolbar button and slash menu entry
-- Support for all file types (images, documents, etc.)
-- Custom fields for additional metadata
-- Automatic HTML conversion (responsive images, links for non-images)
-- Upload drawer integration
-
 ### BlockquoteFeature
 
-Allows creation of blockquotes.
-
-```typescript
-import { BlockquoteFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Toolbar button in both fixed and inline toolbars
-- Slash menu entry
-- Markdown transformer for `> quote`
-- Proper semantic HTML output
+- Description: Allows creation of blockquotes with toolbar button and slash menu entry.
+- Included by default: Yes
+- Markdown Support: `> quote text`
 
 ### HorizontalRuleFeature
 
-Adds horizontal rules/separators.
-
-```typescript
-import { HorizontalRuleFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Toolbar button and slash menu entry
-- Markdown transformer for `---`
-- Renders as `<hr>` element
-- Keyboard shortcuts for insertion
-
-## Toolbar Features
+- Description: Adds horizontal rules/separators with toolbar button and slash menu entry.
+- Included by default: Yes
+- Markdown Support: `---`
 
 ### InlineToolbarFeature
 
-The floating toolbar that appears when text is selected.
-
-```typescript
-import { InlineToolbarFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Appears when text is selected
-- Contains formatting options relevant to selected text
-- Automatically positioned to avoid viewport edges
-- Customizable through toolbar groups
+- Description: The floating toolbar that appears when text is selected, containing formatting options relevant to selected text.
+- Included by default: Yes
 
 ### FixedToolbarFeature
 
-A persistent toolbar pinned to the top of the editor.
+- Description: A persistent toolbar pinned to the top of the editor that's always visible.
+- Included by default: No
+- Options:
 
 ```typescript
-import { FixedToolbarFeature } from '@payloadcms/richtext-lexical'
-
-// Basic configuration
-FixedToolbarFeature()
-
-// Advanced configuration
 FixedToolbarFeature({
   applyToFocusedEditor: false, // Apply to current editor vs focused editor
   disableIfParentHasFixedToolbar: false, // Disable if parent has fixed toolbar
@@ -246,28 +269,13 @@ FixedToolbarFeature({
 })
 ```
 
-**Configuration Options:**
-
-- `applyToFocusedEditor`: Whether to apply to focused editor or current editor
-- `disableIfParentHasFixedToolbar`: Disable if parent editor has fixed toolbar
-- `customGroups`: Custom configuration for toolbar groups
-
-**Key Features:**
-
-- Always visible at the top of the editor
-- Sticky positioning
-- Can coexist with inline toolbar
-- Customizable groups and items
-
-## Advanced Features
-
 ### BlocksFeature
 
-Allows use of Payload's Blocks Field directly in the editor.
+- Description: Allows use of Payload's Blocks Field directly in the editor with slash menu entries for each block type.
+- Included by default: No
+- Options:
 
 ```typescript
-import { BlocksFeature } from '@payloadcms/richtext-lexical'
-
 BlocksFeature({
   blocks: [
     {
@@ -277,12 +285,6 @@ BlocksFeature({
           name: 'text',
           type: 'text',
           required: true,
-        },
-        {
-          name: 'type',
-          type: 'select',
-          options: ['info', 'warning', 'error'],
-          defaultValue: 'info',
         },
       ],
     },
@@ -302,83 +304,32 @@ BlocksFeature({
 })
 ```
 
-**Configuration Options:**
-
-- `blocks`: Array of block configurations (block-level)
-- `inlineBlocks`: Array of inline block configurations
-
-**Key Features:**
-
-- Full Payload Blocks Field integration
-- Support for both block-level and inline blocks
-- Custom components for block rendering
-- Validation and field schemas
-- GraphQL support
-
 ### TreeViewFeature
 
-Adds a debug panel showing the editor's internal state.
-
-```typescript
-import { TreeViewFeature } from '@payloadcms/richtext-lexical'
-
-// Simple configuration
-TreeViewFeature()
-```
-
-**Key Features:**
-
-- Live view of editor state
-- DOM tree visualization
-- Time travel debugging
-- Toggle between different view modes
-- Useful for development and debugging
-
-## Experimental Features
+- Description: Adds a debug panel below the editor showing the editor's internal state, DOM tree, and time travel debugging.
+- Included by default: No
 
 ### EXPERIMENTAL_TableFeature
 
-Adds support for tables (experimental).
-
-```typescript
-import { EXPERIMENTAL_TableFeature } from '@payloadcms/richtext-lexical'
-
-// Basic configuration
-EXPERIMENTAL_TableFeature()
-```
-
-**⚠️ Warning:** This feature is experimental and may receive breaking changes in future releases.
-
-**Key Features:**
-
-- Table creation and editing
-- Row and column manipulation
-- Cell merging and splitting
-- Keyboard navigation
+- Description: Adds support for tables with toolbar button and slash menu entry for creation and editing.
+- Included by default: No
 
 ### EXPERIMENTAL_TextStateFeature
 
-Allows storing key-value attributes in text nodes with inline styles.
+- Description: Allows storing key-value attributes in text nodes with inline styles and toolbar dropdown for style selection.
+- Included by default: No
+- Options:
 
 ```typescript
-import {
-  EXPERIMENTAL_TextStateFeature,
-  defaultColors,
-} from '@payloadcms/richtext-lexical'
-
 EXPERIMENTAL_TextStateFeature({
   state: {
     color: {
-      ...defaultColors.text,
-      // Custom colors
       brand: {
         label: 'Brand Blue',
         css: { color: '#0066cc' },
       },
     },
     backgroundColor: {
-      ...defaultColors.background,
-      // Custom backgrounds
       highlight: {
         label: 'Highlight',
         css: { backgroundColor: '#ffff00' },
@@ -387,85 +338,3 @@ EXPERIMENTAL_TextStateFeature({
   },
 })
 ```
-
-**⚠️ Warning:** This feature is experimental and may receive breaking changes in future releases.
-
-**Configuration Options:**
-
-- `state`: Object defining available state keys and their values
-
-**Key Features:**
-
-- Custom text styling with CSS
-- Predefined color palettes
-- Inline style application
-- Extensible state system
-
-## Migration Features
-
-### SlateToLexicalFeature
-
-Converts Slate editor data to Lexical format.
-
-```typescript
-import { SlateToLexicalFeature } from '@payloadcms/richtext-lexical/migrate'
-
-SlateToLexicalFeature({
-  converters: ({ defaultConverters }) => [
-    ...defaultConverters,
-    // Custom converters
-  ],
-  disableHooks: false, // Disable afterRead hooks
-})
-```
-
-### LexicalPluginToLexicalFeature
-
-Converts legacy Lexical Plugin data to new format.
-
-```typescript
-import { LexicalPluginToLexicalFeature } from '@payloadcms/richtext-lexical/migrate'
-
-LexicalPluginToLexicalFeature({
-  converters: ({ defaultConverters }) => [
-    ...defaultConverters,
-    // Custom converters
-  ],
-  quiet: true, // Suppress conversion warnings
-})
-```
-
-## Creating Custom Features
-
-Features follow a consistent pattern with both server and client components:
-
-```typescript
-// server/index.ts
-import { createServerFeature } from '@payloadcms/richtext-lexical'
-
-export const MyCustomFeature = createServerFeature<MyProps>({
-  key: 'myCustomFeature',
-  feature: ({ props }) => ({
-    ClientFeature: '@my-package/client#MyCustomFeatureClient',
-    // Server-side configuration
-    nodes: [MyCustomNode],
-    markdownTransformers: [MyMarkdownTransformer],
-    i18n: myTranslations,
-  }),
-})
-```
-
-```typescript
-// client/index.ts
-import { createClientFeature } from '@payloadcms/richtext-lexical'
-
-export const MyCustomFeatureClient = createClientFeature<MyProps>({
-  // Client-side configuration
-  nodes: [MyCustomNode],
-  plugins: [MyCustomPlugin],
-  toolbarFixed: { groups: myToolbarGroups },
-  slashMenu: { groups: mySlashMenuGroups },
-})
-```
-
-This documentation provides a comprehensive overview of all official Lexical features. Each feature is designed to be modular, configurable, and extensible to meet your specific needs.

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -8,176 +8,43 @@ title: Official Features
 
 Below are all the Rich Text Features Payload offers. Everything is customizable; you can [create your own features](/docs/rich-text/custom-features), modify ours and share them with the community.
 
-## Text Formatting Features
+## Features Overview
 
-The following features allow you to modify text formatting. Adding these features to the editor will also cause the corresponding buttons to appear in the inline and fixed toolbars.
+Adding these features to the editor will also cause the corresponding buttons to appear in the inline and fixed toolbars.
 
-| Feature                  | Markdown Support         | Keyboard Shortcut |
-| ------------------------ | ------------------------ | ----------------- |
-| **BoldFeature**          | `**bold**` or `__bold__` | Ctrl/Cmd + B      |
-| **ItalicFeature**        | `*italic*` or `_italic_` | Ctrl/Cmd + I      |
-| **UnderlineFeature**     | none                     | Ctrl/Cmd + U      |
-| **StrikethroughFeature** | `~~strikethrough~~`      | none              |
-| **SubscriptFeature**     | none                     | none              |
-| **SuperscriptFeature**   | none                     | none              |
-| **InlineCodeFeature**    | \`code\`                 | none              |
-
-**Ejemplo de uso:**
-
-```typescript
-import { lexicalEditor } from '@payloadcms/richtext-lexical'
-
-// Todas estas características están incluidas por defecto
-export default {
-  fields: [
-    {
-      name: 'content',
-      type: 'richText',
-      editor: lexicalEditor({
-        // No es necesario agregar las características de formato - ya están incluidas
-      }),
-    },
-  ],
-}
-```
-
-## Block-Level Features
-
-### **ParagraphFeature**
-
-Handles paragraph nodes and provides slash menu entries.
-
-```typescript
-import { ParagraphFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Default block type for content
-- Slash menu entry for explicit paragraph creation
-- Automatically created when starting to type
-
-### **HeadingFeature**
-
-Adds support for heading nodes (H1-H6) with markdown support.
-
-```typescript
-import { HeadingFeature } from '@payloadcms/richtext-lexical'
-
-// With default configuration (all headings enabled)
-HeadingFeature()
-
-// With custom heading sizes
-HeadingFeature({
-  enabledHeadingSizes: ['h1', 'h2', 'h3'], // Only H1, H2, H3
-})
-```
-
-**Configuration Options:**
-
-- `enabledHeadingSizes`: Array of heading types to enable (default: `['h1', 'h2', 'h3', 'h4', 'h5', 'h6']`)
-
-**Key Features:**
-
-- Toolbar dropdown in both fixed and inline toolbars
-- Slash menu entries for each enabled heading
-- Markdown transformers for `# Heading 1`, `## Heading 2`, etc.
-- Proper semantic HTML output
-
-### **AlignFeature**
-
-Allows text alignment (left, center, right).
-
-```typescript
-import { AlignFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Toolbar buttons for alignment options
-- Keyboard shortcuts for alignment
-- Supports both text and block alignment
-
-### **IndentFeature**
-
-Allows text indentation with tab key support.
-
-```typescript
-import { IndentFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Tab key support for indentation
-- Shift+Tab for outdenting
-- Toolbar buttons for indent/outdent
-- Supports nested indentation
-
-## List Features
-
-### **UnorderedListFeature**
-
-Adds support for unordered lists (bulleted lists).
-
-```typescript
-import { UnorderedListFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Toolbar button in both fixed and inline toolbars
-- Slash menu entry
-- Markdown transformer for `- item` or `* item`
-- Nested list support
-- Keyboard shortcuts for list creation
-
-### **OrderedListFeature**
-
-Adds support for ordered lists (numbered lists).
-
-```typescript
-import { OrderedListFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Toolbar button in both fixed and inline toolbars
-- Slash menu entry
-- Markdown transformer for `1. item`
-- Nested list support
-- Automatic numbering
-
-### **ChecklistFeature**
-
-Adds support for interactive checklists.
-
-```typescript
-import { ChecklistFeature } from '@payloadcms/richtext-lexical'
-
-// Included by default - no configuration needed
-```
-
-**Key Features:**
-
-- Toolbar button in both fixed and inline toolbars
-- Slash menu entry
-- Interactive checkboxes
-- Markdown transformer for `- [ ] item` and `- [x] item`
-- Keyboard shortcuts for toggling checks
+| Feature                             | Included by default | Markdown Support                          | Keyboard Shortcut | Args                                        |
+| ----------------------------------- | ------------------- | ----------------------------------------- | ----------------- | ------------------------------------------- |
+| **`BoldFeature`**                   | Yes                 | `**bold**` or `__bold__`                  | Ctrl/Cmd + B      | ‐                                           |
+| **`ItalicFeature`**                 | Yes                 | `*italic*` or `_italic_`                  | Ctrl/Cmd + I      | ‐                                           |
+| **`UnderlineFeature`**              | Yes                 | ‐                                         | Ctrl/Cmd + U      | ‐                                           |
+| **`StrikethroughFeature`**          | Yes                 | `~~strikethrough~~`                       | ‐                 | ‐                                           |
+| **`SubscriptFeature`**              | Yes                 | ‐                                         | ‐                 | ‐                                           |
+| **`SuperscriptFeature`**            | Yes                 | ‐                                         | ‐                 | ‐                                           |
+| **`InlineCodeFeature`**             | Yes                 | \`code\`                                  | ‐                 | ‐                                           |
+| **`ParagraphFeature`**              | Yes                 | ‐                                         | ‐                 | ‐                                           |
+| **`HeadingFeature`**                | Yes                 | start with `#`, `##`, `###`, ... + space. | ‐                 | [see below](#headingfeature)                |
+| **`AlignFeature`**                  | Yes                 | ‐                                         | ‐                 | ‐                                           |
+| **`IndentFeature`**                 | Yes                 | ‐                                         | Tab/Shift+Tab     | [see below](#indentfeature)                 |
+| **`UnorderedListFeature`**          | Yes                 | start with `-` or `*`                     | ‐                 | ‐                                           |
+| **`OrderedListFeature`**            | Yes                 | start with `1.`                           | ‐                 | ‐                                           |
+| **`ChecklistFeature`**              | Yes                 | start with `- [ ]` or `- [x]`             | ‐                 | ‐                                           |
+| **`LinkFeature`**                   | Yes                 | `[anchor](url)`                           | ‐                 | [see below](#linkfeature)                   |
+| **`RelationshipFeature`**           | Yes                 | ‐                                         | ‐                 | [see below](#relationshipfeature)           |
+| **`BlockquoteFeature`**             | Yes                 | ‐                                         | ‐                 | [see below](#blockquotefeature)             |
+| **`UploadFeature`**                 | Yes                 | ‐                                         | ‐                 | [see below](#uploadfeature)                 |
+| **`HorizontalRuleFeature`**         | Yes                 | ‐                                         | ‐                 | [see below](#horizontalrulefeature)         |
+| **`InlineToolbarFeature`**          | Yes                 | ‐                                         | ‐                 | [see below](#inlinetoolbarfeature)          |
+| **`FixedToolbarFeature`**           | No                  | ‐                                         | ‐                 | [see below](#fixedtoolbarfeature)           |
+| **`BlocksFeature`**                 | No                  | ‐                                         | ‐                 | [see below](#blocksfeature)                 |
+| **`TreeViewFeature`**               | No                  | ‐                                         | ‐                 | [see below](#treeviewfeature)               |
+| **`EXPERIMENTAL_TableFeature`**     | No                  | ‐                                         | ‐                 | [see below](#experimental_tablefeature)     |
+| **`EXPERIMENTAL_TextStateFeature`** | No                  | ‐                                         | ‐                 | [see below](#experimental_textstatefeature) |
+| **`SlateToLexicalFeature`**         | No                  | ‐                                         | ‐                 | [see below](#slatetolexicalfeature)         |
+| **`LexicalPluginToLexicalFeature`** | No                  | ‐                                         | ‐                 | [see below](#lexicalplugintolexicalfeature) |
 
 ## Link and Relationship Features
 
-### **LinkFeature**
+### LinkFeature
 
 Allows creation of internal and external links with extensive customization.
 
@@ -226,7 +93,7 @@ LinkFeature({
 - Auto-conversion of pasted URLs (unless disabled)
 - Validation for URL formats
 
-### **RelationshipFeature**
+### RelationshipFeature
 
 Allows creation of block-level relationships to other documents.
 
@@ -259,7 +126,7 @@ RelationshipFeature({
 
 ## Media Features
 
-### **UploadFeature**
+### UploadFeature
 
 Allows insertion of upload/media nodes with support for additional fields.
 
@@ -304,7 +171,7 @@ UploadFeature({
 - Automatic HTML conversion (responsive images, links for non-images)
 - Upload drawer integration
 
-### **BlockquoteFeature**
+### BlockquoteFeature
 
 Allows creation of blockquotes.
 
@@ -321,7 +188,7 @@ import { BlockquoteFeature } from '@payloadcms/richtext-lexical'
 - Markdown transformer for `> quote`
 - Proper semantic HTML output
 
-### **HorizontalRuleFeature**
+### HorizontalRuleFeature
 
 Adds horizontal rules/separators.
 
@@ -340,7 +207,7 @@ import { HorizontalRuleFeature } from '@payloadcms/richtext-lexical'
 
 ## Toolbar Features
 
-### **InlineToolbarFeature**
+### InlineToolbarFeature
 
 The floating toolbar that appears when text is selected.
 
@@ -357,7 +224,7 @@ import { InlineToolbarFeature } from '@payloadcms/richtext-lexical'
 - Automatically positioned to avoid viewport edges
 - Customizable through toolbar groups
 
-### **FixedToolbarFeature**
+### FixedToolbarFeature
 
 A persistent toolbar pinned to the top of the editor.
 
@@ -394,7 +261,7 @@ FixedToolbarFeature({
 
 ## Advanced Features
 
-### **BlocksFeature**
+### BlocksFeature
 
 Allows use of Payload's Blocks Field directly in the editor.
 
@@ -448,7 +315,7 @@ BlocksFeature({
 - Validation and field schemas
 - GraphQL support
 
-### **TreeViewFeature**
+### TreeViewFeature
 
 Adds a debug panel showing the editor's internal state.
 
@@ -469,7 +336,7 @@ TreeViewFeature()
 
 ## Experimental Features
 
-### **EXPERIMENTAL_TableFeature**
+### EXPERIMENTAL_TableFeature
 
 Adds support for tables (experimental).
 
@@ -489,7 +356,7 @@ EXPERIMENTAL_TableFeature()
 - Cell merging and splitting
 - Keyboard navigation
 
-### **EXPERIMENTAL_TextStateFeature**
+### EXPERIMENTAL_TextStateFeature
 
 Allows storing key-value attributes in text nodes with inline styles.
 
@@ -536,7 +403,7 @@ EXPERIMENTAL_TextStateFeature({
 
 ## Migration Features
 
-### **SlateToLexicalFeature**
+### SlateToLexicalFeature
 
 Converts Slate editor data to Lexical format.
 
@@ -552,7 +419,7 @@ SlateToLexicalFeature({
 })
 ```
 
-### **LexicalPluginToLexicalFeature**
+### LexicalPluginToLexicalFeature
 
 Converts legacy Lexical Plugin data to new format.
 

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -505,3 +505,12 @@ TextStateFeature({
   },
 }),
 ```
+
+{/\*
+This is what the example above will look like:
+
+<LightDarkImage
+  srcLight="https://payloadcms.com/images/docs/TextStateFeature.png"
+  alt="Example usage in light and dark mode for TextStateFeature with defaultColors and some custom styles"
+/>
+*/}

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -8,37 +8,38 @@ title: Official Features
 
 Below are all the Rich Text Features Payload offers. Everything is customizable; you can [create your own features](/docs/rich-text/custom-features), modify ours and share them with the community.
 
+## How to Use Features
+
+All features are imported from `@payloadcms/richtext-lexical` and added to your editor configuration:
+
+```typescript
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+import {
+  BoldFeature,
+  ItalicFeature,
+  HeadingFeature,
+  LinkFeature,
+  FixedToolbarFeature,
+} from '@payloadcms/richtext-lexical'
+
+const editor = lexicalEditor({
+  features: [
+    // Text formatting (included by default)
+    BoldFeature(),
+    ItalicFeature(),
+
+    // With custom configuration
+    HeadingFeature({
+      enabledHeadingSizes: ['h1', 'h2', 'h3'],
+    }),
+
+    // Optional features
+    FixedToolbarFeature(),
+  ],
+})
+```
+
 ## Features Overview
-
-Adding these features to the editor will also cause the corresponding buttons to appear in the inline and fixed toolbars.
-
-| Feature                             | Included by default | Markdown Support                          | Keyboard Shortcut | Args                                        |
-| ----------------------------------- | ------------------- | ----------------------------------------- | ----------------- | ------------------------------------------- |
-| **`BoldFeature`**                   | Yes                 | `**bold**` or `__bold__`                  | Ctrl/Cmd + B      | ‐                                           |
-| **`ItalicFeature`**                 | Yes                 | `*italic*` or `_italic_`                  | Ctrl/Cmd + I      | ‐                                           |
-| **`UnderlineFeature`**              | Yes                 | ‐                                         | Ctrl/Cmd + U      | ‐                                           |
-| **`StrikethroughFeature`**          | Yes                 | `~~strikethrough~~`                       | ‐                 | ‐                                           |
-| **`SubscriptFeature`**              | Yes                 | ‐                                         | ‐                 | ‐                                           |
-| **`SuperscriptFeature`**            | Yes                 | ‐                                         | ‐                 | ‐                                           |
-| **`InlineCodeFeature`**             | Yes                 | \`code\`                                  | ‐                 | ‐                                           |
-| **`ParagraphFeature`**              | Yes                 | ‐                                         | ‐                 | ‐                                           |
-| **`HeadingFeature`**                | Yes                 | start with `#`, `##`, `###`, ... + space. | ‐                 | [see below](#headingfeature)                |
-| **`AlignFeature`**                  | Yes                 | ‐                                         | ‐                 | ‐                                           |
-| **`IndentFeature`**                 | Yes                 | ‐                                         | Tab/Shift+Tab     | [see below](#indentfeature)                 |
-| **`UnorderedListFeature`**          | Yes                 | start with `-` or `*`                     | ‐                 | ‐                                           |
-| **`OrderedListFeature`**            | Yes                 | start with `1.`                           | ‐                 | ‐                                           |
-| **`ChecklistFeature`**              | Yes                 | start with `- [ ]` or `- [x]`             | ‐                 | ‐                                           |
-| **`LinkFeature`**                   | Yes                 | `[anchor](url)`                           | ‐                 | [see below](#linkfeature)                   |
-| **`RelationshipFeature`**           | Yes                 | ‐                                         | ‐                 | [see below](#relationshipfeature)           |
-| **`BlockquoteFeature`**             | Yes                 | ‐                                         | ‐                 | [see below](#blockquotefeature)             |
-| **`UploadFeature`**                 | Yes                 | ‐                                         | ‐                 | [see below](#uploadfeature)                 |
-| **`HorizontalRuleFeature`**         | Yes                 | ‐                                         | ‐                 | [see below](#horizontalrulefeature)         |
-| **`InlineToolbarFeature`**          | Yes                 | ‐                                         | ‐                 | [see below](#inlinetoolbarfeature)          |
-| **`FixedToolbarFeature`**           | No                  | ‐                                         | ‐                 | [see below](#fixedtoolbarfeature)           |
-| **`BlocksFeature`**                 | No                  | ‐                                         | ‐                 | [see below](#blocksfeature)                 |
-| **`TreeViewFeature`**               | No                  | ‐                                         | ‐                 | [see below](#treeviewfeature)               |
-| **`EXPERIMENTAL_TableFeature`**     | No                  | ‐                                         | ‐                 | [see below](#experimental_tablefeature)     |
-| **`EXPERIMENTAL_TextStateFeature`** | No                  | ‐                                         | ‐                 | [see below](#experimental_textstatefeature) |
 
 | Feature Name                        | Included by default | Description                                                                                                                                                                         |
 | ----------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -51,20 +52,20 @@ Adding these features to the editor will also cause the corresponding buttons to
 | **`InlineCodeFeature`**             | Yes                 | Adds support for inline code formatting.                                                                                                                                            |
 | **`ParagraphFeature`**              | Yes                 | Provides entries in both the slash menu and toolbar dropdown for explicit paragraph creation or conversion.                                                                         |
 | **`HeadingFeature`**                | Yes                 | Adds Heading Nodes (by default, H1 - H6, but that can be customized)                                                                                                                |
-| **`AlignFeature`**                  | Yes                 | Allows you to align text left, centered and right                                                                                                                                   |
-| **`IndentFeature`**                 | Yes                 | Allows you to indent text with the tab key                                                                                                                                          |
-| **`UnorderedListFeature`**          | Yes                 | Adds unordered lists (ul)                                                                                                                                                           |
-| **`OrderedListFeature`**            | Yes                 | Adds ordered lists (ol)                                                                                                                                                             |
-| **`ChecklistFeature`**              | Yes                 | Adds checklists                                                                                                                                                                     |
+| **`AlignFeature`**                  | Yes                 | Adds support for text alignment (left, center, right, justify)                                                                                                                      |
+| **`IndentFeature`**                 | Yes                 | Adds support for text indentation with toolbar buttons                                                                                                                              |
+| **`UnorderedListFeature`**          | Yes                 | Adds support for unordered lists (ul)                                                                                                                                               |
+| **`OrderedListFeature`**            | Yes                 | Adds support for ordered lists (ol)                                                                                                                                                 |
+| **`ChecklistFeature`**              | Yes                 | Adds support for interactive checklists                                                                                                                                             |
 | **`LinkFeature`**                   | Yes                 | Allows you to create internal and external links                                                                                                                                    |
 | **`RelationshipFeature`**           | Yes                 | Allows you to create block-level (not inline) relationships to other documents                                                                                                      |
 | **`BlockquoteFeature`**             | Yes                 | Allows you to create block-level quotes                                                                                                                                             |
 | **`UploadFeature`**                 | Yes                 | Allows you to create block-level upload nodes - this supports all kinds of uploads, not just images                                                                                 |
-| **`HorizontalRuleFeature`**         | Yes                 | Horizontal rules / separators. Basically displays an `<hr>` element                                                                                                                 |
-| **`InlineToolbarFeature`**          | Yes                 | The inline toolbar is the floating toolbar which appears when you select text. This toolbar only contains actions relevant for selected text                                        |
-| **`FixedToolbarFeature`**           | No                  | This classic toolbar is pinned to the top and always visible. Both inline and fixed toolbars can be enabled at the same time.                                                       |
+| **`HorizontalRuleFeature`**         | Yes                 | Adds support for horizontal rules / separators. Basically displays an `<hr>` element                                                                                                |
+| **`InlineToolbarFeature`**          | Yes                 | Provides a floating toolbar which appears when you select text. This toolbar only contains actions relevant for selected text                                                       |
+| **`FixedToolbarFeature`**           | No                  | Provides a persistent toolbar pinned to the top and always visible. Both inline and fixed toolbars can be enabled at the same time.                                                 |
 | **`BlocksFeature`**                 | No                  | Allows you to use Payload's [Blocks Field](../fields/blocks) directly inside your editor. In the feature props, you can specify the allowed blocks - just like in the Blocks field. |
-| **`TreeViewFeature`**               | No                  | Adds a debug box under the editor, which allows you to see the current editor state live, the dom, as well as time travel. Very useful for debugging                                |
+| **`TreeViewFeature`**               | No                  | Provides a debug box under the editor, which allows you to see the current editor state live, the dom, as well as time travel. Very useful for debugging                            |
 | **`EXPERIMENTAL_TableFeature`**     | No                  | Adds support for tables. This feature may be removed or receive breaking changes in the future - even within a stable lexical release, without needing a major release.             |
 | **`EXPERIMENTAL_TextStateFeature`** | No                  | Allows you to store key-value attributes within TextNodes and assign them inline styles.                                                                                            |
 
@@ -146,7 +147,7 @@ HeadingFeature({
 
 ### IndentFeature
 
-- Description: Allows text indentation with toolbar buttons for increase/decrease indent, available in both fixed and inline toolbars.
+- Description: Adds support for text indentation, along with buttons to apply it in both fixed and inline toolbars.
 - Included by default: Yes
 - Keyboard Shortcut: Tab (increase), Shift + Tab (decrease)
 - Types:
@@ -178,19 +179,19 @@ IndentFeature({
 
 ### UnorderedListFeature
 
-- Description: Adds unordered lists (bullet points) with toolbar dropdown and slash menu entries for creation.
+- Description: Adds support for unordered lists (bullet points) with toolbar dropdown and slash menu entries.
 - Included by default: Yes
 - Markdown Support: `-`, `*`, or `+` at start of line
 
 ### OrderedListFeature
 
-- Description: Adds ordered lists (numbered lists) with toolbar dropdown and slash menu entries for creation.
+- Description: Adds support for ordered lists (numbered lists) with toolbar dropdown and slash menu entries.
 - Included by default: Yes
 - Markdown Support: `1.` at start of line
 
 ### ChecklistFeature
 
-- Description: Adds interactive checklists with toolbar dropdown and slash menu entries for creation.
+- Description: Adds support for interactive checklists with toolbar dropdown and slash menu entries.
 - Included by default: Yes
 - Markdown Support: `- [ ]` (unchecked) or `- [x]` (checked)
 
@@ -292,7 +293,7 @@ RelationshipFeature({
 
 ### UploadFeature
 
-- Description: Allows insertion of upload/media nodes with toolbar button and slash menu entry, supports all file types.
+- Description: Allows creation of upload/media nodes with toolbar button and slash menu entry, supports all file types.
 - Included by default: Yes
 - Types:
 
@@ -342,18 +343,18 @@ UploadFeature({
 
 ### HorizontalRuleFeature
 
-- Description: Adds horizontal rules/separators with toolbar button and slash menu entry.
+- Description: Adds support for horizontal rules/separators with toolbar button and slash menu entry.
 - Included by default: Yes
 - Markdown Support: `---`
 
 ### InlineToolbarFeature
 
-- Description: Adds a floating toolbar that appears when text is selected, containing formatting options relevant to selected text.
+- Description: Provides a floating toolbar that appears when text is selected, containing formatting options relevant to selected text.
 - Included by default: Yes
 
 ### FixedToolbarFeature
 
-- Description: A persistent toolbar pinned to the top of the editor that's always visible.
+- Description: Provides a persistent toolbar pinned to the top of the editor that's always visible.
 - Included by default: No
 - Types:
 
@@ -441,7 +442,7 @@ BlocksFeature({
 
 ### TreeViewFeature
 
-- Description: Adds a debug panel below the editor showing the editor's internal state, DOM tree, and time travel debugging.
+- Description: Provides a debug panel below the editor showing the editor's internal state, DOM tree, and time travel debugging.
 - Included by default: No
 
 ### EXPERIMENTAL_TableFeature

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -505,12 +505,3 @@ TextStateFeature({
   },
 }),
 ```
-
-{/\*
-This is what the example above will look like:
-
-<LightDarkImage
-  srcLight="https://payloadcms.com/images/docs/TextStateFeature.png"
-  alt="Example usage in light and dark mode for TextStateFeature with defaultColors and some custom styles"
-/>
-*/}

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -476,11 +476,9 @@ TextStateFeature({
 }),
 ```
 
-{/\*
 This is what the example above will look like:
 
 <LightDarkImage
-  srcLight="https://payloadcms.com/images/docs/TextStateFeature.png"
+  srcLight="https://payloadcms.com/images/docs/text-state-feature.png"
   alt="Example usage in light and dark mode for TextStateFeature with defaultColors and some custom styles"
 />
-*/}

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -479,6 +479,7 @@ TextStateFeature({
 This is what the example above will look like:
 
 <LightDarkImage
+  srcDark="https://payloadcms.com/images/docs/text-state-feature.png"
   srcLight="https://payloadcms.com/images/docs/text-state-feature.png"
   alt="Example usage in light and dark mode for TextStateFeature with defaultColors and some custom styles"
 />

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -8,37 +8,6 @@ title: Official Features
 
 Below are all the Rich Text Features Payload offers. Everything is customizable; you can [create your own features](/docs/rich-text/custom-features), modify ours and share them with the community.
 
-## How to Use Features
-
-All features are imported from `@payloadcms/richtext-lexical` and added to your editor configuration:
-
-```typescript
-import { lexicalEditor } from '@payloadcms/richtext-lexical'
-import {
-  BoldFeature,
-  ItalicFeature,
-  HeadingFeature,
-  LinkFeature,
-  FixedToolbarFeature,
-} from '@payloadcms/richtext-lexical'
-
-const editor = lexicalEditor({
-  features: [
-    // Text formatting (included by default)
-    BoldFeature(),
-    ItalicFeature(),
-
-    // With custom configuration
-    HeadingFeature({
-      enabledHeadingSizes: ['h1', 'h2', 'h3'],
-    }),
-
-    // Optional features
-    FixedToolbarFeature(),
-  ],
-})
-```
-
 ## Features Overview
 
 | Feature Name                        | Included by default | Description                                                                                                                                                                         |

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -121,8 +121,16 @@ Adding these features to the editor will also cause the corresponding buttons to
 
 - Description: Adds support for heading nodes (H1-H6) with toolbar dropdown and slash menu entries for each enabled heading size.
 - Included by default: Yes
-- Markdown Support: `# H1`, `## H2`, `### H3`, etc.
-- Options:
+- Markdown Support: `#`, `##`, `###`, ..., at start of line.
+- Types:
+
+```typescript
+type HeadingFeatureProps = {
+  enabledHeadingSizes?: HeadingTagType[] // ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+}
+```
+
+- Usage example:
 
 ```typescript
 HeadingFeature({
@@ -141,12 +149,30 @@ HeadingFeature({
 - Description: Allows text indentation with toolbar buttons for increase/decrease indent, available in both fixed and inline toolbars.
 - Included by default: Yes
 - Keyboard Shortcut: Tab (increase), Shift + Tab (decrease)
-- Options:
+- Types:
 
 ```typescript
+type IndentFeatureProps = {
+  /**
+   * The nodes that should not be indented. "type" property of the nodes you don't want to be indented.
+   * These can be: "paragraph", "heading", "listitem", "quote" or other indentable nodes if they exist.
+   */
+  disabledNodes?: string[]
+  /**
+   * If true, pressing Tab in the middle of a block such as a paragraph or heading will not insert a tabNode.
+   * Instead, Tab will only be used for block-level indentation.
+   * @default false
+   */
+  disableTabNode?: boolean
+}
+```
+
+- Usage example:
+
+```typescript
+// Allow block-level indentation only
 IndentFeature({
-  disabledNodes: ['paragraph'], // Nodes that should not be indented
-  disableTabNode: false, // If true, Tab only does block-level indentation
+  disableTabNode: true,
 })
 ```
 
@@ -173,7 +199,46 @@ IndentFeature({
 - Description: Allows creation of internal and external links with toolbar buttons and automatic URL conversion.
 - Included by default: Yes
 - Markdown Support: `[anchor](url)`
-- Options:
+- Types:
+
+```typescript
+type LinkFeatureServerProps = {
+  /**
+   * Disables the automatic creation of links
+   * from URLs typed or pasted into the editor,
+   * @default false
+   */
+  disableAutoLinks?: 'creationOnly' | true
+  /**
+   * A function or array defining additional fields for the link feature.
+   * These will be displayed in the link editor drawer.
+   */
+  fields?:
+    | ((args: {
+        config: SanitizedConfig
+        defaultFields: FieldAffectingData[]
+      }) => (Field | FieldAffectingData)[])
+    | Field[]
+  /**
+   * Sets a maximum population depth for the internal
+   * doc default field of link, regardless of the
+   * remaining depth when the field is reached.
+   */
+  maxDepth?: number
+} & ExclusiveLinkCollectionsProps
+
+type ExclusiveLinkCollectionsProps =
+  | {
+      disabledCollections?: CollectionSlug[]
+      enabledCollections?: never
+    }
+  | {
+      disabledCollections?: never
+      enabledCollections?: CollectionSlug[]
+    }
+```
+
+- Usage example:
 
 ```typescript
 LinkFeature({
@@ -186,7 +251,6 @@ LinkFeature({
     },
   ],
   enabledCollections: ['pages', 'posts'], // Collections for internal links
-  disabledCollections: ['users'], // Collections to exclude
   maxDepth: 2, // Population depth for internal links
   disableAutoLinks: false, // Allow auto-conversion of URLs
 })
@@ -196,11 +260,31 @@ LinkFeature({
 
 - Description: Allows creation of block-level relationships to other documents with toolbar button and slash menu entry.
 - Included by default: Yes
-- Options:
+- Types:
+
+```typescript
+type RelationshipFeatureProps = {
+  /**
+   * Sets a maximum population depth for this relationship, regardless of the remaining depth when the respective field is reached.
+   */
+  maxDepth?: number
+} & ExclusiveRelationshipFeatureProps
+
+type ExclusiveRelationshipFeatureProps =
+  | {
+      disabledCollections?: CollectionSlug[]
+      enabledCollections?: never
+    }
+  | {
+      disabledCollections?: never
+      enabledCollections?: CollectionSlug[]
+    }
+```
+
+- Usage example:
 
 ```typescript
 RelationshipFeature({
-  enabledCollections: ['pages', 'posts'], // Collections available for relationships
   disabledCollections: ['users'], // Collections to exclude
   maxDepth: 2, // Population depth for relationships
 })
@@ -210,7 +294,23 @@ RelationshipFeature({
 
 - Description: Allows insertion of upload/media nodes with toolbar button and slash menu entry, supports all file types.
 - Included by default: Yes
-- Options:
+- Types:
+
+```typescript
+type UploadFeatureProps = {
+  collections?: {
+    [collection: CollectionSlug]: {
+      fields: Field[]
+    }
+  }
+  /**
+   * Sets a maximum population depth for this upload (not the fields for this upload), regardless of the remaining depth when the respective field is reached.
+   */
+  maxDepth?: number
+}
+```
+
+- Usage example:
 
 ```typescript
 UploadFeature({
@@ -248,19 +348,45 @@ UploadFeature({
 
 ### InlineToolbarFeature
 
-- Description: The floating toolbar that appears when text is selected, containing formatting options relevant to selected text.
+- Description: Adds a floating toolbar that appears when text is selected, containing formatting options relevant to selected text.
 - Included by default: Yes
 
 ### FixedToolbarFeature
 
 - Description: A persistent toolbar pinned to the top of the editor that's always visible.
 - Included by default: No
-- Options:
+- Types:
+
+```typescript
+type FixedToolbarFeatureProps = {
+  /**
+   * @default false
+   * If this is enabled, the toolbar will apply
+   * to the focused editor, not the editor with
+   * the FixedToolbarFeature.
+   */
+  applyToFocusedEditor?: boolean
+  /**
+   * Custom configurations for toolbar groups
+   * Key is the group key (e.g. 'format', 'indent', 'align')
+   * Value is a partial ToolbarGroup object that will
+   * be merged with the default configuration
+   */
+  customGroups?: CustomGroups
+  /**
+   * @default false
+   * If there is a parent editor with a fixed toolbar,
+   * this will disable the toolbar for this editor.
+   */
+  disableIfParentHasFixedToolbar?: boolean
+}
+```
+
+- Usage example:
 
 ```typescript
 FixedToolbarFeature({
-  applyToFocusedEditor: false, // Apply to current editor vs focused editor
-  disableIfParentHasFixedToolbar: false, // Disable if parent has fixed toolbar
+  applyToFocusedEditor: false, // Apply to focused editor
   customGroups: {
     format: {
       // Custom configuration for format group
@@ -271,9 +397,18 @@ FixedToolbarFeature({
 
 ### BlocksFeature
 
-- Description: Allows use of Payload's Blocks Field directly in the editor with slash menu entries for each block type.
+- Description: Allows use of Payload's Blocks Field directly in the editor with toolbar buttons and slash menu entries for each block type.
 - Included by default: No
-- Options:
+- Types:
+
+```typescript
+type BlocksFeatureProps = {
+  blocks?: (Block | BlockSlug)[] | Block[]
+  inlineBlocks?: (Block | BlockSlug)[] | Block[]
+}
+```
+
+- Usage example:
 
 ```typescript
 BlocksFeature({
@@ -318,23 +453,55 @@ BlocksFeature({
 
 - Description: Allows storing key-value attributes in text nodes with inline styles and toolbar dropdown for style selection.
 - Included by default: No
-- Options:
+- Types:
 
 ```typescript
-EXPERIMENTAL_TextStateFeature({
+type TextStateFeatureProps = {
+  /**
+   * The keys of the top-level object (stateKeys) represent the attributes that the textNode can have (e.g., color).
+   * The values of the top-level object (stateValues) represent the values that the attribute can have (e.g., red, blue, etc.).
+   * Within the stateValue, you can define inline styles and labels.
+   */
+  state: { [stateKey: string]: StateValues }
+}
+
+type StateValues = {
+  [stateValue: string]: {
+    css: StyleObject
+    label: string
+  }
+}
+
+type StyleObject = {
+  [K in keyof PropertiesHyphenFallback]?:
+    | Extract<PropertiesHyphenFallback[K], string>
+    | undefined
+}
+```
+
+- Usage example:
+
+```typescript
+// We offer default colors that have good contrast and look good in dark and light mode.
+import { defaultColors, TextStateFeature } from '@payloadcms/richtext-lexical'
+
+TextStateFeature({
+  // prettier-ignore
   state: {
     color: {
-      brand: {
-        label: 'Brand Blue',
-        css: { color: '#0066cc' },
-      },
+      ...defaultColors,
+      // fancy gradients!
+      galaxy: { label: 'Galaxy', css: { background: 'linear-gradient(to right, #0000ff, #ff0000)', color: 'white' } },
+      sunset: { label: 'Sunset', css: { background: 'linear-gradient(to top, #ff5f6d, #6a3093)' } },
     },
-    backgroundColor: {
-      highlight: {
-        label: 'Highlight',
-        css: { backgroundColor: '#ffff00' },
-      },
+    // You can have both colored and underlined text at the same time.
+    // If you don't want that, you should group them within the same key.
+    // (just like I did with defaultColors and my fancy gradients)
+    underline: {
+      'solid': { label: 'Solid', css: { 'text-decoration': 'underline', 'text-underline-offset': '4px' } },
+       // You'll probably want to use the CSS light-dark() utility.
+      'yellow-dashed': { label: 'Yellow Dashed', css: { 'text-decoration': 'underline dashed', 'text-decoration-color': 'light-dark(#EAB308,yellow)', 'text-underline-offset': '4px' } },
     },
   },
-})
+}),
 ```

--- a/docs/rich-text/overview.mdx
+++ b/docs/rich-text/overview.mdx
@@ -138,39 +138,9 @@ import { CallToAction } from '../blocks/CallToAction'
 | **`defaultFeatures`** | This opinionated array contains all "recommended" default features. You can see which features are included in the default features in the table below.                                                                                                |
 | **`rootFeatures`**    | This array contains all features that are enabled in the root richText editor (the one defined in the payload.config.ts). If this field is the root richText editor, or if the root richText editor is not a lexical editor, this array will be empty. |
 
-## Features overview
+## Official Features
 
-Here's an overview of all the included features:
-
-| Feature Name                        | Included by default | Description                                                                                                                                                                         |
-| ----------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`BoldFeature`**                   | Yes                 | Handles the bold text format                                                                                                                                                        |
-| **`ItalicFeature`**                 | Yes                 | Handles the italic text format                                                                                                                                                      |
-| **`UnderlineFeature`**              | Yes                 | Handles the underline text format                                                                                                                                                   |
-| **`StrikethroughFeature`**          | Yes                 | Handles the strikethrough text format                                                                                                                                               |
-| **`SubscriptFeature`**              | Yes                 | Handles the subscript text format                                                                                                                                                   |
-| **`SuperscriptFeature`**            | Yes                 | Handles the superscript text format                                                                                                                                                 |
-| **`InlineCodeFeature`**             | Yes                 | Handles the inline-code text format                                                                                                                                                 |
-| **`ParagraphFeature`**              | Yes                 | Handles paragraphs. Since they are already a key feature of lexical itself, this Feature mainly handles the Slash and Add-Block menu entries for paragraphs                         |
-| **`HeadingFeature`**                | Yes                 | Adds Heading Nodes (by default, H1 - H6, but that can be customized)                                                                                                                |
-| **`AlignFeature`**                  | Yes                 | Allows you to align text left, centered and right                                                                                                                                   |
-| **`IndentFeature`**                 | Yes                 | Allows you to indent text with the tab key                                                                                                                                          |
-| **`UnorderedListFeature`**          | Yes                 | Adds unordered lists (ul)                                                                                                                                                           |
-| **`OrderedListFeature`**            | Yes                 | Adds ordered lists (ol)                                                                                                                                                             |
-| **`ChecklistFeature`**              | Yes                 | Adds checklists                                                                                                                                                                     |
-| **`LinkFeature`**                   | Yes                 | Allows you to create internal and external links                                                                                                                                    |
-| **`RelationshipFeature`**           | Yes                 | Allows you to create block-level (not inline) relationships to other documents                                                                                                      |
-| **`BlockquoteFeature`**             | Yes                 | Allows you to create block-level quotes                                                                                                                                             |
-| **`UploadFeature`**                 | Yes                 | Allows you to create block-level upload nodes - this supports all kinds of uploads, not just images                                                                                 |
-| **`HorizontalRuleFeature`**         | Yes                 | Horizontal rules / separators. Basically displays an `<hr>` element                                                                                                                 |
-| **`InlineToolbarFeature`**          | Yes                 | The inline toolbar is the floating toolbar which appears when you select text. This toolbar only contains actions relevant for selected text                                        |
-| **`FixedToolbarFeature`**           | No                  | This classic toolbar is pinned to the top and always visible. Both inline and fixed toolbars can be enabled at the same time.                                                       |
-| **`BlocksFeature`**                 | No                  | Allows you to use Payload's [Blocks Field](../fields/blocks) directly inside your editor. In the feature props, you can specify the allowed blocks - just like in the Blocks field. |
-| **`TreeViewFeature`**               | No                  | Adds a debug box under the editor, which allows you to see the current editor state live, the dom, as well as time travel. Very useful for debugging                                |
-| **`EXPERIMENTAL_TableFeature`**     | No                  | Adds support for tables. This feature may be removed or receive breaking changes in the future - even within a stable lexical release, without needing a major release.             |
-| **`EXPERIMENTAL_TextStateFeature`** | No                  | Allows you to store key-value attributes within TextNodes and assign them inline styles.                                                                                            |
-
-Notice how even the toolbars are features? That's how extensible our lexical editor is - you could theoretically create your own toolbar if you wanted to!
+You can find more information about the official features in our [official features docs](../rich-text/official-features).
 
 ## Creating your own, custom Feature
 


### PR DESCRIPTION
It was evident from the number of users asking questions about how to use the features that a dedicated page was needed.

Preview:
https://payloadcms.com/docs/dynamic/rich-text/official-features?branch=features-docs
