### PR TITLE
fix(next): skip custom views without path prop in getCustomViewByRoute

### DIFF
--- a/packages/next/src/views/Root/getCustomViewByRoute.ts
+++ b/packages/next/src/views/Root/getCustomViewByRoute.ts
@@ -31,13 +31,15 @@ export const getCustomViewByRoute = ({
     (views &&
       typeof views === 'object' &&
       Object.entries(views).find(([key, view]) => {
-        const isMatching = isPathMatchingRoute({
-          currentRoute,
-          exact: view.exact,
-          path: view.path,
-          sensitive: view.sensitive,
-          strict: view.strict,
-        })
+        const isMatching =
+          view.path &&
+          isPathMatchingRoute({
+            currentRoute,
+            exact: view.exact,
+            path: view.path,
+            sensitive: view.sensitive,
+            strict: view.strict,
+          })
 
         if (isMatching) {
           viewKey = key


### PR DESCRIPTION
When using the `@payloadcms/plugin-otp` plugin, when the plugin redirects to the OTP screen, it reads the admin custom views config. If any views exist without the `path` property defined, the call to `getCustomViewByRoute` will fail with the error below:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at <anonymous> (getCustomViewByRoute.ts:32:28)
    at getCustomViewByRoute (getCustomViewByRoute.ts:31:29)
    at getRouteData (getRouteData.ts:347:20)
    at RootPage (index.tsx:75:7)
```

This fix skips any custom views that do not have `path` defined.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210774523852463