### PR TITLE
fix(ui): monomorphic joins tables not fetching draft documents

### DIFF
--- a/packages/ui/src/utilities/buildTableState.ts
+++ b/packages/ui/src/utilities/buildTableState.ts
@@ -214,6 +214,7 @@ const buildTableState = async (
       data = await payload.find({
         collection: collectionSlug,
         depth: 0,
+        draft: true,
         limit: query?.limit ? parseInt(query.limit, 10) : undefined,
         locale: req.locale,
         overrideAccess: false,

--- a/test/joins/collections/CategoriesVersions.ts
+++ b/test/joins/collections/CategoriesVersions.ts
@@ -1,12 +1,14 @@
 import type { CollectionConfig } from 'payload'
 
-import { versionsSlug } from './Versions.js'
-
-export const categoriesVersionsSlug = 'categories-versions'
+import { categoriesVersionsSlug, versionsSlug } from '../shared.js'
 
 export const CategoriesVersions: CollectionConfig = {
   slug: categoriesVersionsSlug,
   fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
     {
       name: 'relatedVersions',
       type: 'join',

--- a/test/joins/collections/Versions.ts
+++ b/test/joins/collections/Versions.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-export const versionsSlug = 'versions'
+import { versionsSlug } from '../shared.js'
 
 export const Versions: CollectionConfig = {
   slug: versionsSlug,

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -519,6 +519,7 @@ export interface Version {
  */
 export interface CategoriesVersion {
   id: string;
+  title?: string | null;
   relatedVersions?: {
     docs?: (string | Version)[];
     hasNextPage?: boolean;
@@ -1142,6 +1143,7 @@ export interface VersionsSelect<T extends boolean = true> {
  * via the `definition` "categories-versions_select".
  */
 export interface CategoriesVersionsSelect<T extends boolean = true> {
+  title?: T;
   relatedVersions?: T;
   relatedVersionsMany?: T;
   updatedAt?: T;

--- a/test/joins/shared.ts
+++ b/test/joins/shared.ts
@@ -19,6 +19,8 @@ export const categoriesJoinRestrictedSlug = 'categories-join-restricted'
 export const collectionRestrictedSlug = 'collection-restricted'
 
 export const restrictedCategoriesSlug = 'restricted-categories'
+export const categoriesVersionsSlug = 'categories-versions'
+export const versionsSlug = 'versions'
 
 export const collectionSlugs = [
   categoriesSlug,


### PR DESCRIPTION
Monomorphic join fields were not using the `draft` argument when fetching documents to display in the table. This change makes the join field treatment of drafts consistent with the `relationship` type fields.

Added e2e test to cover.