### PR TITLE
fix(ui): disabled and styles add row button correctly

### DIFF
--- a/packages/ui/src/elements/ClipboardAction/index.tsx
+++ b/packages/ui/src/elements/ClipboardAction/index.tsx
@@ -16,10 +16,11 @@ import { clipboardCopy, clipboardPaste } from './clipboardUtilities.js'
 const baseClass = 'clipboard-action'
 
 type Props = {
+  allowCopy?: boolean
+  allowPaste?: boolean
   className?: string
   copyClassName?: string
-  disableCopy?: boolean
-  disablePaste?: boolean
+  disabled?: boolean
   getDataToCopy: () => FormStateWithoutComponents
   isRow?: boolean
   onPaste: OnPasteFn
@@ -31,10 +32,11 @@ type Props = {
  * @note This component doesn't use the Clipboard API, but localStorage. See rationale in #11513
  */
 export const ClipboardAction: FC<Props> = ({
+  allowCopy,
+  allowPaste,
   className,
   copyClassName,
-  disableCopy,
-  disablePaste,
+  disabled,
   isRow,
   onPaste,
   pasteClassName,
@@ -81,16 +83,21 @@ export const ClipboardAction: FC<Props> = ({
     }
   }, [onPaste, rest, path, t])
 
+  if (!allowPaste && !allowCopy) {
+    return null
+  }
+
   return (
     <Popup
       button={<MoreIcon />}
       className={classes}
+      disabled={disabled}
       horizontalAlign="center"
       render={({ close }) => (
         <PopupList.ButtonGroup>
           <PopupList.Button
             className={copyClassName}
-            disabled={disableCopy}
+            disabled={!allowCopy}
             onClick={() => {
               void handleCopy()
               close()
@@ -100,7 +107,7 @@ export const ClipboardAction: FC<Props> = ({
           </PopupList.Button>
           <PopupList.Button
             className={pasteClassName}
-            disabled={disablePaste}
+            disabled={!allowPaste}
             onClick={() => {
               void handlePaste()
               close()

--- a/packages/ui/src/fields/Array/index.scss
+++ b/packages/ui/src/fields/Array/index.scss
@@ -76,11 +76,25 @@
 
     &__add-row {
       align-self: flex-start;
-      color: var(--theme-elevation-400);
       margin: 2px 0;
+      --btn-color: var(--theme-elevation-400);
 
-      &:hover {
-        color: var(--theme-elevation-800);
+      &:hover:not(:disabled) {
+        --btn-color: var(--theme-elevation-800);
+      }
+
+      &:disabled {
+        --btn-color: var(--theme-elevation-300);
+      }
+
+      .btn__label {
+        color: var(--btn-color);
+      }
+      .btn__icon {
+        border-color: var(--btn-color);
+        path {
+          stroke: var(--btn-color);
+        }
       }
     }
   }

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -30,7 +30,6 @@ import { useForm, useFormSubmitted } from '../../forms/Form/context.js'
 import { extractRowsAndCollapsedIDs, toggleAllRows } from '../../forms/Form/rowHelpers.js'
 import { NullifyLocaleField } from '../../forms/NullifyField/index.js'
 import { useField } from '../../forms/useField/index.js'
-import './index.scss'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
@@ -39,6 +38,7 @@ import { useTranslation } from '../../providers/Translation/index.js'
 import { scrollToID } from '../../utilities/scrollToID.js'
 import { fieldBaseClass } from '../shared/index.js'
 import { ArrayRow } from './ArrayRow.js'
+import './index.scss'
 
 const baseClass = 'array-field'
 
@@ -365,7 +365,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
               <ClipboardAction
                 className={`${baseClass}__header-action`}
                 disableCopy={!(rows?.length > 0)}
-                disablePaste={readOnly}
+                disablePaste={readOnly || disabled}
                 fields={fields}
                 getDataToCopy={getDataToCopy}
                 onPaste={pasteField}
@@ -459,6 +459,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
         <Button
           buttonStyle="icon-label"
           className={`${baseClass}__add-row`}
+          disabled={disabled}
           icon="plus"
           iconPosition="left"
           iconStyle="with-border"

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -363,9 +363,10 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
             )}
             <li>
               <ClipboardAction
+                allowCopy={rows?.length > 0}
+                allowPaste={!readOnly}
                 className={`${baseClass}__header-action`}
-                disableCopy={!(rows?.length > 0)}
-                disablePaste={readOnly || disabled}
+                disabled={disabled}
                 fields={fields}
                 getDataToCopy={getDataToCopy}
                 onPaste={pasteField}

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -352,10 +352,11 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
             )}
             <li>
               <ClipboardAction
+                allowCopy={rows?.length > 0}
+                allowPaste={!readOnly}
                 blocks={clientBlocks}
                 className={`${baseClass}__header-action`}
-                disableCopy={!(rows?.length > 0)}
-                disablePaste={readOnly}
+                disabled={disabled}
                 getDataToCopy={() =>
                   reduceFormStateByPath({
                     formState: { ...getFields() },

--- a/packages/ui/src/forms/useField/index.tsx
+++ b/packages/ui/src/forms/useField/index.tsx
@@ -19,7 +19,6 @@ import {
   useForm,
   useFormFields,
   useFormInitializing,
-  useFormModified,
   useFormProcessing,
   useFormSubmitted,
 } from '../Form/context.js'
@@ -60,7 +59,6 @@ export const useField = <TValue,>(options?: Options): FieldType<TValue> => {
 
   const { getData, getDataByPath, getSiblingData, setModified } = useForm()
   const documentForm = useDocumentForm()
-  const modified = useFormModified()
 
   const filterOptions = field?.filterOptions
   const value = field?.value as TValue


### PR DESCRIPTION
Disables add row button using disabled prop from useField - i.e. when the form is processing or initializing.

This fixes a flaky array test that clicks the button before the form has finished initializing/processing.

Also corrects the add row button color styles with specificity.
