### PR TITLE
fix(ui): field elements showing over the top of Preview content

### DIFF
--- a/packages/ui/src/elements/DocumentFields/index.scss
+++ b/packages/ui/src/elements/DocumentFields/index.scss
@@ -85,6 +85,7 @@
 
     &--force-sidebar-wrap {
       display: block;
+      isolation: isolate;
 
       .document-fields {
         &__main {


### PR DESCRIPTION
When editing a document, if a Preview is open, and the window is thin enough to make the Preview window span the full width, some elements are wrapped, but not hidden and appear over the top of the content. This PR fixes that by hiding the overflow on `--force-sidebar-wrap`.

Here's a demo video of the issue, as well as adding the overflow fix:

https://github.com/user-attachments/assets/282640e7-2427-4e34-b433-a655891693de
