### PR TITLE
feat: add export parseParams to db-mongodb

### DIFF
--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -52,6 +52,7 @@ import { queryDrafts } from './queryDrafts.js'
 import { beginTransaction } from './transactions/beginTransaction.js'
 import { commitTransaction } from './transactions/commitTransaction.js'
 import { rollbackTransaction } from './transactions/rollbackTransaction.js'
+import { parseParams } from './queries/parseParams.js'
 import { updateGlobal } from './updateGlobal.js'
 import { updateGlobalVersion } from './updateGlobalVersion.js'
 import { updateJobs } from './updateJobs.js'
@@ -270,6 +271,7 @@ export function mongooseAdapter({
       migrateFresh,
       migrationDir,
       packageName: '@payloadcms/db-mongodb',
+      parseParams,
       payload,
       prodMigrations,
       queryDrafts,


### PR DESCRIPTION
### What?
Export the `parseParams()` function from mongo-db so it can be used in payload projects
 
### Why?
Building aggregations from searchParams with additional filters easily

### How?
Export `parseParams()` from the mongo-db package
