### PR TITLE
fix: give SerializedRootNode a "root" constant

### DIFF
--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -1,5 +1,6 @@
 import type {
   SerializedLineBreakNode as _SerializedLineBreakNode,
+  SerializedRootNode as _SerializedRootNode,
   SerializedTabNode as _SerializedTabNode,
   SerializedTextNode as _SerializedTextNode,
   SerializedEditorState,
@@ -40,6 +41,12 @@ export type {
   SerializedUploadNode,
 }
 
+export type SerializedRootNode<T extends SerializedLexicalNode = SerializedLexicalNode> = Spread<
+  {
+    type: 'root'
+  },
+  _SerializedRootNode<T>
+>
 export type SerializedParagraphNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
   Spread<
     {


### PR DESCRIPTION
When working with rich text trees, you typically want to perform a different action depending on the type of the current node. This is best done by switching on `node.type`. If each node has a distinct, string constant as their type, you get a lot of help and safety from the compiler, to ensure you've handled all nodes.

SerializedRootNode makes this impossible, since it has `type: string`, rather than a more specific constant like `type: "paragraph"`. The moment it's included in such a switch statement, all type safety goes out the window, as far as the switch statement is concerned.

This PR aligns it with all other node types, by giving it `type: "root"`, as is[ done in the `getType` method in the Lexical repository.](https://github.com/facebook/lexical/blob/2f093c65f06958584491f848ffaca6c8e6c4f18e/packages/lexical/src/nodes/LexicalRootNode.ts#L29-L31)