### PR TITLE
feat(plugin-import-export): adds pluginConfig options to disable Save and Download buttons in export UI

### DIFF
--- a/packages/plugin-import-export/src/components/ExportSaveButton/index.tsx
+++ b/packages/plugin-import-export/src/components/ExportSaveButton/index.tsx
@@ -24,10 +24,17 @@ export const ExportSaveButton: React.FC = () => {
       routes: { api },
       serverURL,
     },
+    getEntityConfig,
   } = useConfig()
 
   const { getData, setModified } = useForm()
   const modified = useFormModified()
+
+  const exportsCollectionConfig = getEntityConfig({ collectionSlug: 'exports' })
+
+  const disableSave = exportsCollectionConfig?.admin?.custom?.disableSave === true
+
+  const disableDownload = exportsCollectionConfig?.admin?.custom?.disableDownload === true
 
   const label = t('general:save')
 
@@ -99,10 +106,12 @@ export const ExportSaveButton: React.FC = () => {
 
   return (
     <React.Fragment>
-      <SaveButton label={label}></SaveButton>
-      <Button disabled={!modified} onClick={handleDownload} size="medium" type="button">
-        <Translation i18nKey="upload:download" t={t} />
-      </Button>
+      {!disableSave && <SaveButton label={label} />}
+      {!disableDownload && (
+        <Button disabled={!modified} onClick={handleDownload} size="medium" type="button">
+          <Translation i18nKey="upload:download" t={t} />
+        </Button>
+      )}
     </React.Fragment>
   )
 }

--- a/packages/plugin-import-export/src/getExportCollection.ts
+++ b/packages/plugin-import-export/src/getExportCollection.ts
@@ -34,6 +34,10 @@ export const getExportCollection = ({
           SaveButton: '@payloadcms/plugin-import-export/rsc#ExportSaveButton',
         },
       },
+      custom: {
+        disableDownload: pluginConfig.disableDownload ?? false,
+        disableSave: pluginConfig.disableSave ?? false,
+      },
       group: false,
       useAsTitle: 'name',
     },

--- a/packages/plugin-import-export/src/types.ts
+++ b/packages/plugin-import-export/src/types.ts
@@ -16,9 +16,19 @@ export type ImportExportPluginConfig = {
    */
   debug?: boolean
   /**
+   * If true, disables the download button in the export preview UI
+   * @default false
+   */
+  disableDownload?: boolean
+  /**
    * Enable to force the export to run synchronously
    */
   disableJobsQueue?: boolean
+  /**
+   * If true, disables the save button in the export preview UI
+   * @default false
+   */
+  disableSave?: boolean
   /**
    * This function takes the default export collection configured in the plugin and allows you to override it by modifying and returning it
    * @param collection


### PR DESCRIPTION
### What?

Adds support for two new plugin options in the import-export plugin:
- `disableSave`: disables the "Save" button in the export UI view.
- `disableDownload`: disables the "Download" button in the export UI view.

### Why?

This allows implementers to control user access to export actions based on context or feature requirements. For example, some use cases may want to preview an export without saving it, or disable downloads entirely.

### How?

- Injected `disableSave` and `disableDownload` into `admin.custom` for the `exports` collection.
- Updated the `ExportSaveButton` component to conditionally render each button based on the injected flags.
- Defaults to `false` if the values are not explicitly set in `pluginConfig`.

### Example

```ts
importExportPlugin({
  disableSave: true, // Defaults to false
  disableDownload: true, // Defaults to false
})