### PR TITLE
ci: fix post-release-templates workflow

### DIFF
--- a/.github/workflows/post-release-templates.yml
+++ b/.github/workflows/post-release-templates.yml
@@ -82,6 +82,11 @@ jobs:
         with:
           mongodb-version: 6.0
 
+        # The template generation script runs import map generation which needs the built payload bin scripts
+      - run: pnpm run build:all
+        env:
+          DO_NOT_TRACK: 1 # Disable Turbopack telemetry
+
       - name: Update template lockfiles and migrations
         run: pnpm script:gen-templates
 


### PR DESCRIPTION
Fixes the post-release-templates workflow by building payload before running the gen templates script.

Successful run: https://github.com/payloadcms/payload/actions/runs/16274012380/job/45948417979

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210784057163370