### PR TITLE
feat(plugin-import-export): adds support for forcing export format via plugin config

### DIFF
--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -1,5 +1,6 @@
 import type { Config, TaskConfig, TypedUser } from 'payload'
 
+import type { ImportExportPluginConfig } from '../types.js'
 import type { CreateExportArgs, Export } from './createExport.js'
 
 import { createExport } from './createExport.js'
@@ -7,11 +8,12 @@ import { getFields } from './getFields.js'
 
 export const getCreateCollectionExportTask = (
   config: Config,
+  pluginConfig?: ImportExportPluginConfig,
 ): TaskConfig<{
   input: Export
   output: object
 }> => {
-  const inputSchema = getFields(config).concat(
+  const inputSchema = getFields(config, pluginConfig).concat(
     {
       name: 'user',
       type: 'text',

--- a/packages/plugin-import-export/src/export/getFields.ts
+++ b/packages/plugin-import-export/src/export/getFields.ts
@@ -1,8 +1,10 @@
 import type { Config, Field, SelectField } from 'payload'
 
+import type { ImportExportPluginConfig } from '../types.js'
+
 import { getFilename } from './getFilename.js'
 
-export const getFields = (config: Config): Field[] => {
+export const getFields = (config: Config, pluginConfig?: ImportExportPluginConfig): Field[] => {
   let localeField: SelectField | undefined
   if (config.localization) {
     localeField = {
@@ -45,9 +47,14 @@ export const getFields = (config: Config): Field[] => {
               name: 'format',
               type: 'select',
               admin: {
+                // Hide if a forced format is set via plugin config
+                condition: () => !pluginConfig?.format,
                 width: '33%',
               },
-              defaultValue: 'csv',
+              defaultValue: (() => {
+                // Default to plugin-defined format, otherwise 'csv'
+                return pluginConfig?.format ?? 'csv'
+              })(),
               // @ts-expect-error - this is not correctly typed in plugins right now
               label: ({ t }) => t('plugin-import-export:field-format-label'),
               options: [

--- a/packages/plugin-import-export/src/getExportCollection.ts
+++ b/packages/plugin-import-export/src/getExportCollection.ts
@@ -47,7 +47,7 @@ export const getExportCollection = ({
         path: '/download',
       },
     ],
-    fields: getFields(config),
+    fields: getFields(config, pluginConfig),
     hooks: {
       afterChange,
       beforeOperation,

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -32,7 +32,7 @@ export const importExportPlugin =
     )
 
     // inject the createExport job into the config
-    ;((config.jobs ??= {}).tasks ??= []).push(getCreateCollectionExportTask(config))
+    ;((config.jobs ??= {}).tasks ??= []).push(getCreateCollectionExportTask(config, pluginConfig))
 
     let collectionsToUpdate = config.collections
 

--- a/packages/plugin-import-export/src/types.ts
+++ b/packages/plugin-import-export/src/types.ts
@@ -20,6 +20,16 @@ export type ImportExportPluginConfig = {
    */
   disableJobsQueue?: boolean
   /**
+   * Forces a specific export format (`csv` or `json`) and hides the format dropdown from the UI.
+   *
+   * When defined, this overrides the user's ability to choose a format manually. The export will
+   * always use the specified format, and the format selection field will be hidden.
+   *
+   * If not set, the user can choose between CSV and JSON in the export UI.
+   * @default undefined
+   */
+  format?: 'csv' | 'json'
+  /**
    * This function takes the default export collection configured in the plugin and allows you to override it by modifying and returning it
    * @param collection
    * @returns collection

--- a/test/plugin-import-export/payload-types.ts
+++ b/test/plugin-import-export/payload-types.ts
@@ -264,7 +264,7 @@ export interface Post {
 export interface Export {
   id: string;
   name?: string | null;
-  format: 'csv' | 'json';
+  format?: ('csv' | 'json') | null;
   limit?: number | null;
   sort?: string | null;
   locale?: ('all' | 'en' | 'es' | 'de') | null;
@@ -300,7 +300,7 @@ export interface Export {
 export interface ExportsTask {
   id: string;
   name?: string | null;
-  format: 'csv' | 'json';
+  format?: ('csv' | 'json') | null;
   limit?: number | null;
   sort?: string | null;
   locale?: ('all' | 'en' | 'es' | 'de') | null;
@@ -717,7 +717,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
 export interface TaskCreateCollectionExport {
   input: {
     name?: string | null;
-    format: 'csv' | 'json';
+    format?: ('csv' | 'json') | null;
     limit?: number | null;
     sort?: string | null;
     locale?: ('all' | 'en' | 'es' | 'de') | null;


### PR DESCRIPTION
### What?

Adds a new `format` option to the `plugin-import-export` config that allows users to force the export format (`csv` or `json`) and hide the format dropdown from the export UI.

### Why?

In some use cases, allowing the user to select between CSV and JSON is unnecessary or undesirable. This new option allows plugin consumers to lock the format and simplify the export interface.

### How?

- Added a `format?: 'csv' | 'json'` field to `ImportExportPluginConfig`.
- When defined, the `format` field in the export UI is:
  - Hidden via `admin.condition`
  - Pre-filled via `defaultValue`
- Updated `getFields` to accept the plugin config and apply logic accordingly.

### Example

```ts
importExportPlugin({
  format: 'json',
})