### PR TITLE
docs: fixes typo in ternary operator for live preview docs

### DIFF
--- a/docs/live-preview/overview.mdx
+++ b/docs/live-preview/overview.mdx
@@ -90,7 +90,6 @@ const config = buildConfig({
       // highlight-start
       url: ({ data, collectionConfig, locale }) =>
         `${data.tenant.url}${
-          // Multi-tenant top-level domain
           collectionConfig.slug === 'posts'
             ? `/posts/${data.slug}`
             : `${data.slug !== 'home' ? `/${data.slug}` : ''}`

--- a/docs/live-preview/overview.mdx
+++ b/docs/live-preview/overview.mdx
@@ -88,17 +88,17 @@ const config = buildConfig({
     // ...
     livePreview: {
       // highlight-start
-      url: ({
-        data,
-        collectionConfig,
-        locale
-      }) => `${data.tenant.url}${ // Multi-tenant top-level domain
-        collectionConfig.slug === 'posts' ? `/posts/${data.slug}` : `${data.slug !== 'home' : `/${data.slug}` : ''}`
-      }${locale ? `?locale=${locale?.code}` : ''}`, // Localization query param
+      url: ({ data, collectionConfig, locale }) =>
+        `${data.tenant.url}${
+          // Multi-tenant top-level domain
+          collectionConfig.slug === 'posts'
+            ? `/posts/${data.slug}`
+            : `${data.slug !== 'home' ? `/${data.slug}` : ''}`
+        }${locale ? `?locale=${locale?.code}` : ''}`, // Localization query param
       collections: ['pages'],
     },
     // highlight-end
-  }
+  },
 })
 ```
 


### PR DESCRIPTION
resolves semantically incorrect ternary statement in live preview docs build config code example