### PR TITLE
feat(plugin-import-export): adds support for disabling fields

### DIFF
--- a/packages/plugin-import-export/src/components/FieldsToExport/index.tsx
+++ b/packages/plugin-import-export/src/components/FieldsToExport/index.tsx
@@ -27,7 +27,14 @@ export const FieldsToExport: SelectFieldClientComponent = (props) => {
   const { query } = useListQuery()
 
   const collectionConfig = getEntityConfig({ collectionSlug: collectionSlug ?? collection })
-  const fieldOptions = reduceFields({ fields: collectionConfig?.fields })
+
+  const disabledFields =
+    collectionConfig?.admin?.custom?.['plugin-import-export']?.disabledFields ?? []
+
+  const fieldOptions = reduceFields({
+    disabledFields,
+    fields: collectionConfig?.fields,
+  })
 
   useEffect(() => {
     if (id || !collectionSlug) {

--- a/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
+++ b/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
@@ -43,10 +43,12 @@ const combineLabel = ({
 }
 
 export const reduceFields = ({
+  disabledFields = [],
   fields,
   labelPrefix = null,
   path = '',
 }: {
+  disabledFields?: string[]
   fields: ClientField[]
   labelPrefix?: React.ReactNode
   path?: string
@@ -66,6 +68,7 @@ export const reduceFields = ({
         return [
           ...fieldsToUse,
           ...reduceFields({
+            disabledFields,
             fields: field.fields,
             labelPrefix: combineLabel({ field, prefix: labelPrefix }),
             path: createNestedClientFieldPath(path, field),
@@ -83,6 +86,7 @@ export const reduceFields = ({
                 return [
                   ...tabFields,
                   ...reduceFields({
+                    disabledFields,
                     fields: tab.fields,
                     labelPrefix,
                     path: isNamedTab ? createNestedClientFieldPath(path, field) : path,
@@ -97,6 +101,11 @@ export const reduceFields = ({
       }
 
       const val = createNestedClientFieldPath(path, field)
+
+      // If the field is disabled, skip it
+      if (disabledFields.includes(val)) {
+        return fieldsToUse
+      }
 
       const formattedField = {
         id: val,

--- a/packages/plugin-import-export/src/components/Preview/index.tsx
+++ b/packages/plugin-import-export/src/components/Preview/index.tsx
@@ -46,6 +46,14 @@ export const Preview = () => {
     (collection) => collection.slug === collectionSlug,
   )
 
+  const disabledFieldsUnderscored = React.useMemo(() => {
+    return (
+      collectionConfig?.admin?.custom?.['plugin-import-export']?.disabledFields?.map((f: string) =>
+        f.replace(/\./g, '_'),
+      ) ?? []
+    )
+  }, [collectionConfig])
+
   const isCSV = format === 'csv'
 
   React.useEffect(() => {
@@ -95,7 +103,10 @@ export const Preview = () => {
                 const regex = fieldToRegex(field)
                 return allKeys.filter((key) => regex.test(key))
               })
-            : allKeys.filter((key) => !defaultMetaFields.includes(key))
+            : allKeys.filter(
+                (key) =>
+                  !defaultMetaFields.includes(key) && !disabledFieldsUnderscored.includes(key),
+              )
 
         const fieldKeys =
           Array.isArray(fields) && fields.length > 0
@@ -136,7 +147,18 @@ export const Preview = () => {
     }
 
     void fetchData()
-  }, [collectionConfig, collectionSlug, draft, fields, i18n, limit, locale, sort, where])
+  }, [
+    collectionConfig,
+    collectionSlug,
+    disabledFieldsUnderscored,
+    draft,
+    fields,
+    i18n,
+    limit,
+    locale,
+    sort,
+    where,
+  ])
 
   return (
     <div className={baseClass}>


### PR DESCRIPTION
### What?

Adds support for excluding specific fields from the import-export plugin using a custom field config.

### Why?

Some fields should not be included in exports or previews. This feature allows users to flag those fields directly in the field config.

### How?

- Introduced a `plugin-import-export.disabled: true` custom field property.
- Automatically collects and stores disabled field accessors in `collection.admin.custom['plugin-import-export'].disabledFields`.
- Excludes these fields from the export field selector, preview table, and final export output (CSV/JSON).