### PR TITLE
fix(translations): missing closing brace in rs latin translation for lastSavedAgo

### DIFF
--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -521,7 +521,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     currentPublishedVersion: 'Trenutna Objavljena Verzija',
     draft: 'Nacrt',
     draftSavedSuccessfully: 'Nacrt uspešno sačuvan.',
-    lastSavedAgo: 'Zadnji put sačuvano pre {{distance}',
+    lastSavedAgo: 'Zadnji put sačuvano pre {{distance}}',
     modifiedOnly: 'Samo izmenjen',
     moreVersions: 'Više verzija...',
     noFurtherVersionsFound: 'Nisu pronađene naredne verzije',


### PR DESCRIPTION
Fixed missing closing brace in the translations package for the language rs latin.
<img width="885" height="200" alt="image" src="https://github.com/user-attachments/assets/12d00305-6cc9-46ce-87e8-2c66f9d9e63c" />
Here is the code diff.
