### PR TITLE
fix: keep apiKey encrypted in refresh operation (#13063)

### DIFF
--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -1,5 +1,4 @@
 import url from 'url'
-import { v4 as uuid } from 'uuid'
 
 import type { Collection } from '../../collections/config/types.js'
 import type { Document, PayloadRequest } from '../../types/index.js'
@@ -74,11 +73,10 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
     const parsedURL = url.parse(args.req.url!)
     const isGraphQL = parsedURL.pathname === config.routes.graphQL
 
-    const user = await args.req.payload.findByID({
-      id: args.req.user.id,
-      collection: args.req.user.collection,
-      depth: isGraphQL ? 0 : args.collection.config.auth.depth,
-      req: args.req,
+    let user = await req.payload.db.findOne<any>({
+      collection: collectionConfig.slug,
+      req,
+      where: { id: { equals: args.req.user.id } },
     })
 
     const sid = args.req.user._sid
@@ -88,7 +86,7 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
         throw new Forbidden(args.req.t)
       }
 
-      const existingSession = user.sessions.find(({ id }) => id === sid)
+      const existingSession = user.sessions.find(({ id }: { id: number }) => id === sid)
 
       const now = new Date()
       const tokenExpInMs = collectionConfig.auth.tokenExpiration * 1000
@@ -105,6 +103,13 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
         returning: false,
       })
     }
+
+    user = await req.payload.findByID({
+      id: user.id,
+      collection: collectionConfig.slug,
+      depth: isGraphQL ? 0 : args.collection.config.auth.depth,
+      req: args.req,
+    })
 
     if (user) {
       user.collection = args.req.user.collection


### PR DESCRIPTION
### What?
Prevents decrypted apiKey from being saved back to database on the auth refresh operation.

### Why?
References issue #13063: refreshing a token for a logged-in user decrypted `apiKey` and wrote it back in plaintext, corrupting the user record.

### How?
The user is now fetched with `db.findOne` instead of `findByID`, preserving the encryption of the key when saved back to the database using `db.updateOne`.  The user record is then re-fetched using `findByID`, allowing for the decrypted key to be provided in the response.

### Tests
* ✅ keeps apiKey encrypted in DB after refresh
* ✅ returns user with decrypted apiKey after refresh

Fixes #13063


