### PR TITLE
fix(plugin-import-export): export field dropdown to properly label and path fields in named/unnamed tabs

### DIFF
--- a/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
+++ b/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
@@ -83,13 +83,24 @@ export const reduceFields = ({
             (tabFields, tab) => {
               if ('fields' in tab) {
                 const isNamedTab = 'name' in tab && tab.name
+
+                const newPath = isNamedTab ? `${path}${path ? '.' : ''}${tab.name}` : path
+
                 return [
                   ...tabFields,
                   ...reduceFields({
                     disabledFields,
                     fields: tab.fields,
-                    labelPrefix,
-                    path: isNamedTab ? createNestedClientFieldPath(path, field) : path,
+                    labelPrefix: isNamedTab
+                      ? combineLabel({
+                          field: {
+                            name: tab.name,
+                            label: tab.label ?? tab.name,
+                          } as any,
+                          prefix: labelPrefix,
+                        })
+                      : labelPrefix,
+                    path: newPath,
                   }),
                 ]
               }

--- a/test/plugin-import-export/collections/Pages.ts
+++ b/test/plugin-import-export/collections/Pages.ts
@@ -95,7 +95,6 @@ export const Pages: CollectionConfig = {
       ],
     },
     {
-      name: 'tabs',
       type: 'tabs',
       tabs: [
         {


### PR DESCRIPTION
### What?

Fixes the export field selection dropdown to correctly differentiate between fields in named and unnamed tabs.

### Why?

Previously, when a `tabs` field contained both named and unnamed tabs, subfields with the same `name` would appear as duplicates in the dropdown (e.g. `Tab To CSV`, `Tab To CSV`). Additionally, selecting a field from a named tab would incorrectly map it to the unnamed version due to shared labels and missing path prefixes.

### How?

- Updated the `reduceFields` utility to manually construct the field path and label using the tab’s `name` if present.
- Ensured unnamed tabs treat subfields as top-level and skip prefixing altogether.
- Adjusted label prefix logic to show `Named Tab > Field Name` when appropriate.


#### Before
<img width="169" height="79" alt="Screenshot 2025-07-15 at 2 55 14 PM" src="https://github.com/user-attachments/assets/2ab2d19e-41a3-4be2-8496-1da2a79f88e1" />

#### After
<img width="211" height="79" alt="Screenshot 2025-07-15 at 2 50 38 PM" src="https://github.com/user-attachments/assets/0620e96a-71cd-4eb1-9396-30d461ed47a5" />