### PR TITLE
fix: Enhances field-level access controls on Users collection to address s…

### DIFF
--- a/examples/auth/src/collections/Users.ts
+++ b/examples/auth/src/collections/Users.ts
@@ -6,6 +6,8 @@ import { anyone } from './access/anyone'
 import { checkRole } from './access/checkRole'
 import { loginAfterCreate } from './hooks/loginAfterCreate'
 import { protectRoles } from './hooks/protectRoles'
+import { access } from 'fs'
+import { create } from 'domain'
 
 export const Users: CollectionConfig = {
   slug: 'users',
@@ -33,6 +35,34 @@ export const Users: CollectionConfig = {
   },
   fields: [
     {
+      name: 'email',
+      type: 'email',
+      required: true,
+      unique: true,
+      access: {
+        read: adminsAndUser,
+        update: adminsAndUser,
+      },
+    },
+    {
+      name: 'password',
+      type: 'password',
+      required: true,
+      admin: {
+        description: 'Leave blank to keep the current password.',
+      },
+    },
+    {
+      name: 'resetPasswordToken',
+      type: 'text',
+      hidden: true,
+    },
+    {
+      name: 'resetPasswordExpiration',
+      type: 'date',
+      hidden: true,
+    },
+    {
       name: 'firstName',
       type: 'text',
     },
@@ -45,6 +75,11 @@ export const Users: CollectionConfig = {
       type: 'select',
       hasMany: true,
       saveToJWT: true,
+      access: {
+        read: admins,
+        update: admins,
+        create: admins,
+      },
       hooks: {
         beforeChange: [protectRoles],
       },


### PR DESCRIPTION
Enhance field-level access controls on Users collection to address security concerns

- Restricted read/update access on `email` field to admins and the user themselves
- Locked down `roles` field so only admins can create, read, or update it
