### PR TITLE
test: add failing `image/svg+xml` test case

### DIFF
--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -40,6 +40,7 @@ import {
   restrictFileTypesSlug,
   skipAllowListSafeFetchMediaSlug,
   skipSafeFetchMediaSlug,
+  svgOnlySlug,
   threeDimensionalSlug,
   unstoredMediaSlug,
   versionSlug,
@@ -910,6 +911,14 @@ export default buildConfigWithDefaults({
     BulkUploadsCollection,
     SimpleRelationshipCollection,
     FileMimeType,
+    {
+      slug: svgOnlySlug,
+      fields: [],
+      upload: {
+        mimeTypes: ['image/svg+xml'],
+        staticDir: path.resolve(dirname, './svg-only'),
+      },
+    },
   ],
   onInit: async (payload) => {
     const uploadsDir = path.resolve(dirname, './media')

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -25,6 +25,7 @@ import {
   restrictFileTypesSlug,
   skipAllowListSafeFetchMediaSlug,
   skipSafeFetchMediaSlug,
+  svgOnlySlug,
   unstoredMediaSlug,
   usersSlug,
 } from './shared.js'
@@ -370,6 +371,21 @@ describe('Collections - Uploads', () => {
   })
 
   describe('Local API', () => {
+    describe('create', () => {
+      it('should create documents when passing filePath', async () => {
+        const expectedPath = path.join(dirname, './svg-only')
+
+        const svgFilePath = path.resolve(dirname, './svgWithXml.svg')
+        const doc = await payload.create({
+          collection: svgOnlySlug as CollectionSlug,
+          data: {},
+          filePath: svgFilePath,
+        })
+
+        expect(await fileExists(path.join(expectedPath, doc.filename))).toBe(true)
+      })
+    })
+
     describe('update', () => {
       it('should remove existing media on re-upload - by ID', async () => {
         // Create temp file

--- a/test/uploads/shared.ts
+++ b/test/uploads/shared.ts
@@ -37,3 +37,4 @@ export const constructorOptionsSlug = 'constructor-options'
 export const bulkUploadsSlug = 'bulk-uploads'
 
 export const fileMimeTypeSlug = 'file-mime-type'
+export const svgOnlySlug = 'svg-only'

--- a/test/uploads/svgWithXml.svg
+++ b/test/uploads/svgWithXml.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+   width="1"
+   height="1">
+    <rect
+       width="1"
+       height="1"
+       style="fill:#666;" />
+</svg>


### PR DESCRIPTION
Seemingly as of 6d1a287dd1e1391425af3fa73842a7bd9ad7ec69, SVG files with the opening `<xml>` line are misrecognized as `application/xml`, preventing their upload in collections with `mimeType: 'image/svg+xml'`. This was still working with `3.46.0`.

This PR adds a failing test to encourage a fix, and to prevent future regressions.
