### PR TITLE
fix: exit payload jobs:run process after completion

### DIFF
--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -133,7 +133,7 @@ export const bin = async () => {
 
       await payload.destroy() // close database connections after running jobs so process can exit cleanly
 
-      return
+      process.exit(0)
     }
   }
 


### PR DESCRIPTION
### What?

Exit the process after running jobs.

### Why?

When running the `payload jobs:run` bin script with a postgres database the process hangs forever. 

### How?

Execute `process.exit(0)` after running all jobs.
