### PR TITLE
docs: shorten line length in code snippet comments to avoid horizontal scrolling

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -54,7 +54,8 @@ The plugin accepts an object with the following properties:
 ```ts
 type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   /**
-   * After a tenant is deleted, the plugin will attempt to clean up related documents
+   * After a tenant is deleted, the plugin will attempt
+   * to clean up related documents
    * - removing documents with the tenant ID
    * - removing the tenant from users
    *
@@ -67,19 +68,22 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   collections: {
     [key in CollectionSlug]?: {
       /**
-       * Set to `true` if you want the collection to behave as a global
+       * Set to `true` if you want the collection to
+       * behave as a global
        *
        * @default false
        */
       isGlobal?: boolean
       /**
-       * Set to `false` if you want to manually apply the baseListFilter
+       * Set to `false` if you want to manually apply
+       * the baseListFilter
        *
        * @default true
        */
       useBaseListFilter?: boolean
       /**
-       * Set to `false` if you want to handle collection access manually without the multi-tenant constraints applied
+       * Set to `false` if you want to handle collection access
+       * manually without the multi-tenant constraints applied
        *
        * @default true
        */
@@ -88,7 +92,8 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   }
   /**
    * Enables debug mode
-   * - Makes the tenant field visible in the admin UI within applicable collections
+   * - Makes the tenant field visible in the
+   * admin UI within applicable collections
    *
    * @default false
    */
@@ -100,22 +105,27 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
    */
   enabled?: boolean
   /**
-   * Field configuration for the field added to all tenant enabled collections
+   * Field configuration for the field added
+   * to all tenant enabled collections
    */
   tenantField?: {
     access?: RelationshipField['access']
     /**
-     * The name of the field added to all tenant enabled collections
+     * The name of the field added to all tenant
+     * enabled collections
      *
      * @default 'tenant'
      */
     name?: string
   }
   /**
-   * Field configuration for the field added to the users collection
+   * Field configuration for the field added
+   * to the users collection
    *
-   * If `includeDefaultField` is `false`, you must include the field on your users collection manually
-   * This is useful if you want to customize the field or place the field in a specific location
+   * If `includeDefaultField` is `false`, you must
+   * include the field on your users collection manually
+   * This is useful if you want to customize the field
+   * or place the field in a specific location
    */
   tenantsArrayField?:
     | {
@@ -136,7 +146,8 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
          */
         arrayTenantFieldName?: string
         /**
-         * When `includeDefaultField` is `true`, the field will be added to the users collection automatically
+         * When `includeDefaultField` is `true`, the field will
+         * be added to the users collection automatically
          */
         includeDefaultField?: true
         /**
@@ -153,7 +164,8 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
         arrayFieldName?: string
         arrayTenantFieldName?: string
         /**
-         * When `includeDefaultField` is `false`, you must include the field on your users collection manually
+         * When `includeDefaultField` is `false`, you must
+         * include the field on your users collection manually
          */
         includeDefaultField?: false
         rowFields?: never
@@ -162,7 +174,8 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   /**
    * Customize tenant selector label
    *
-   * Either a string or an object where the keys are i18n codes and the values are the string labels
+   * Either a string or an object where the keys are i18n
+   * codes and the values are the string labels
    */
   tenantSelectorLabel?:
     | Partial<{
@@ -176,7 +189,8 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
    */
   tenantsSlug?: string
   /**
-   * Function that determines if a user has access to _all_ tenants
+   * Function that determines if a user has access
+   * to _all_ tenants
    *
    * Useful for super-admin type users
    */
@@ -184,15 +198,18 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
     user: ConfigTypes extends { user: unknown } ? ConfigTypes['user'] : User,
   ) => boolean
   /**
-   * Opt out of adding access constraints to the tenants collection
+   * Opt out of adding access constraints to
+   * the tenants collection
    */
   useTenantsCollectionAccess?: boolean
   /**
-   * Opt out including the baseListFilter to filter tenants by selected tenant
+   * Opt out including the baseListFilter to filter
+   * tenants by selected tenant
    */
   useTenantsListFilter?: boolean
   /**
-   * Opt out including the baseListFilter to filter users by selected tenant
+   * Opt out including the baseListFilter to filter
+   * users by selected tenant
    */
   useUsersTenantFilter?: boolean
 }
@@ -327,14 +344,16 @@ type ContextType = {
   /**
    * Prevents a refresh when the tenant is changed
    *
-   * If not switching tenants while viewing a "global", set to true
+   * If not switching tenants while viewing a "global",
+   * set to true
    */
   setPreventRefreshOnChange: React.Dispatch<React.SetStateAction<boolean>>
   /**
    * Sets the selected tenant ID
    *
    * @param args.id - The ID of the tenant to select
-   * @param args.refresh - Whether to refresh the page after changing the tenant
+   * @param args.refresh - Whether to refresh the page
+   * after changing the tenant
    */
   setTenant: (args: {
     id: number | string | undefined

--- a/docs/rich-text/custom-features.mdx
+++ b/docs/rich-text/custom-features.mdx
@@ -474,11 +474,15 @@ const MyNodeComponent = React.lazy(() =>
 )
 
 /**
- * This node is a DecoratorNode. DecoratorNodes allow you to render React components in the editor.
+ * This node is a DecoratorNode. DecoratorNodes allow
+ * you to render React components in the editor.
  *
- * They need both createDom and decorate functions. createDom => outside of the html. decorate => React Component inside of the html.
+ * They need both createDom and decorate functions.
+ * createDom => outside of the html.
+ * decorate => React Component inside of the html.
  *
- * If we used DecoratorBlockNode instead, we would only need a decorate method
+ * If we used DecoratorBlockNode instead,
+ * we would only need a decorate method
  */
 export class MyNode extends DecoratorNode<React.ReactElement> {
   static clone(node: MyNode): MyNode {
@@ -490,9 +494,11 @@ export class MyNode extends DecoratorNode<React.ReactElement> {
   }
 
   /**
-   * Defines what happens if you copy a div element from another page and paste it into the lexical editor
+   * Defines what happens if you copy a div element
+   * from another page and paste it into the lexical editor
    *
-   * This also determines the behavior of lexical's internal HTML -> Lexical converter
+   * This also determines the behavior of lexical's
+   * internal HTML -> Lexical converter
    */
   static importDOM(): DOMConversionMap | null {
     return {
@@ -504,14 +510,18 @@ export class MyNode extends DecoratorNode<React.ReactElement> {
   }
 
   /**
-   * The data for this node is stored serialized as JSON. This is the "load function" of that node: it takes the saved data and converts it into a node.
+   * The data for this node is stored serialized as JSON.
+   * This is the "load function" of that node: it takes
+   * the saved data and converts it into a node.
    */
   static importJSON(serializedNode: SerializedMyNode): MyNode {
     return $createMyNode()
   }
 
   /**
-   * Determines how the hr element is rendered in the lexical editor. This is only the "initial" / "outer" HTML element.
+   * Determines how the hr element is rendered in the
+   * lexical editor. This is only the "initial" / "outer"
+   * HTML element.
    */
   createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement('div')
@@ -519,22 +529,28 @@ export class MyNode extends DecoratorNode<React.ReactElement> {
   }
 
   /**
-   * Allows you to render a React component within whatever createDOM returns.
+   * Allows you to render a React component within
+   * whatever createDOM returns.
    */
   decorate(): React.ReactElement {
     return <MyNodeComponent nodeKey={this.__key} />
   }
 
   /**
-   * Opposite of importDOM, this function defines what happens when you copy a div element from the lexical editor and paste it into another page.
+   * Opposite of importDOM, this function defines what
+   * happens when you copy a div element from the lexical
+   * editor and paste it into another page.
    *
-   * This also determines the behavior of lexical's internal Lexical -> HTML converter
+   * This also determines the behavior of lexical's
+   * internal Lexical -> HTML converter
    */
   exportDOM(): DOMExportOutput {
     return { element: document.createElement('div') }
   }
   /**
-   * Opposite of importJSON. This determines what data is saved in the database / in the lexical editor state.
+   * Opposite of importJSON. This determines what
+   * data is saved in the database / in the lexical
+   * editor state.
    */
   exportJSON(): SerializedLexicalNode {
     return {
@@ -556,18 +572,23 @@ export class MyNode extends DecoratorNode<React.ReactElement> {
   }
 }
 
-// This is used in the importDOM method. Totally optional if you do not want your node to be created automatically when copy & pasting certain dom elements
-// into your editor.
+// This is used in the importDOM method. Totally optional
+// if you do not want your node to be created automatically
+// when copy & pasting certain dom elements into your editor.
 function $yourConversionMethod(): DOMConversionOutput {
   return { node: $createMyNode() }
 }
 
-// This is a utility method to create a new MyNode. Utility methods prefixed with $ make it explicit that this should only be used within lexical
+// This is a utility method to create a new MyNode.
+// Utility methods prefixed with $ make it explicit
+// that this should only be used within lexical
 export function $createMyNode(): MyNode {
   return $applyNodeReplacement(new MyNode())
 }
 
-// This is just a utility method you can use to check if a node is a MyNode. This also ensures correct typing.
+// This is just a utility method you can use
+// to check if a node is a MyNode. This also
+// ensures correct typing.
 export function $isMyNode(
   node: LexicalNode | null | undefined,
 ): node is MyNode {
@@ -626,10 +647,12 @@ export const INSERT_MYNODE_COMMAND: LexicalCommand<void> = createCommand(
 )
 
 /**
- * Plugin which registers a lexical command to insert a new MyNode into the editor
+ * Plugin which registers a lexical command to
+ * insert a new MyNode into the editor
  */
 export const MyNodePlugin: PluginComponent = () => {
-  // The useLexicalComposerContext hook can be used to access the lexical editor instance
+  // The useLexicalComposerContext hook can be used
+  // to access the lexical editor instance
   const [editor] = useLexicalComposerContext()
 
   useEffect(() => {

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -124,12 +124,15 @@ HeadingFeature({
 ```ts
 type IndentFeatureProps = {
   /**
-   * The nodes that should not be indented. "type" property of the nodes you don't want to be indented.
-   * These can be: "paragraph", "heading", "listitem", "quote" or other indentable nodes if they exist.
+   * The nodes that should not be indented. "type"
+   * property of the nodes you don't want to be indented.
+   * These can be: "paragraph", "heading", "listitem",
+   * "quote" or other indentable nodes if they exist.
    */
   disabledNodes?: string[]
   /**
-   * If true, pressing Tab in the middle of a block such as a paragraph or heading will not insert a tabNode.
+   * If true, pressing Tab in the middle of a block such
+   * as a paragraph or heading will not insert a tabNode.
    * Instead, Tab will only be used for block-level indentation.
    * @default false
    */
@@ -180,7 +183,8 @@ type LinkFeatureServerProps = {
    */
   disableAutoLinks?: 'creationOnly' | true
   /**
-   * A function or array defining additional fields for the link feature.
+   * A function or array defining additional
+   * fields for the link feature.
    * These will be displayed in the link editor drawer.
    */
   fields?:
@@ -235,7 +239,9 @@ LinkFeature({
 ```ts
 type RelationshipFeatureProps = {
   /**
-   * Sets a maximum population depth for this relationship, regardless of the remaining depth when the respective field is reached.
+   * Sets a maximum population depth for this relationship,
+   * regardless of the remaining depth when the respective
+   * field is reached.
    */
   maxDepth?: number
 } & ExclusiveRelationshipFeatureProps
@@ -274,7 +280,10 @@ type UploadFeatureProps = {
     }
   }
   /**
-   * Sets a maximum population depth for this upload (not the fields for this upload), regardless of the remaining depth when the respective field is reached.
+   * Sets a maximum population depth for this upload
+   * (not the fields for this upload), regardless of
+   * the remaining depth when the respective field is
+   * reached.
    */
   maxDepth?: number
 }

--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -292,7 +292,8 @@ Reference any of the existing storage adapters for guidance on how this should b
 ```ts
 export interface GeneratedAdapter {
   /**
-   * Additional fields to be injected into the base collection and image sizes
+   * Additional fields to be injected into the base
+   * collection and image sizes
    */
   fields?: Field[]
   /**


### PR DESCRIPTION
prettier doesn't seem to cover that, and horizontal scrolling in the browser is even more annoying than in the IDE.
Regex used in the search engine: `^[ \t]*\* `