### PR TITLE
fix: empty folderType arrays break relational dbs

### DIFF
--- a/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
+++ b/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
@@ -80,10 +80,10 @@ export const FolderTypeField = ({
       if (!readOnly || disabled) {
         let newValue: string | string[] = null
         if (selectedOption && hasMany) {
-          if (Array.isArray(selectedOption)) {
+          if (Array.isArray(selectedOption) && selectedOption.length > 0) {
             newValue = selectedOption.map((option) => option.value)
           } else {
-            newValue = []
+            newValue = null
           }
         } else if (selectedOption && !Array.isArray(selectedOption)) {
           newValue = selectedOption.value

--- a/packages/ui/src/utilities/getFolderResultsComponentAndData.tsx
+++ b/packages/ui/src/utilities/getFolderResultsComponentAndData.tsx
@@ -122,11 +122,6 @@ export const getFolderResultsComponentAndData = async ({
                 },
                 {
                   folderType: {
-                    equals: [],
-                  },
-                },
-                {
-                  folderType: {
                     equals: null,
                   },
                 },


### PR DESCRIPTION
Relational databases were broken with folders because it was querying on:
```ts
{
  folderType: {
    equals: []
  }
}
```

Which does not work since the select hasMany stores values in a separate table.