### PR TITLE
fix(ui): deprecated Sass import rules

### DIFF
--- a/packages/ui/src/scss/app.scss
+++ b/packages/ui/src/scss/app.scss
@@ -1,8 +1,12 @@
+@use "sass:meta";
+@use "queries";
+@use "vars";
+
 @layer payload-default, payload;
 
-@import 'styles';
-@import './toasts.scss';
-@import './colors.scss';
+@include meta.load-css('styles');
+@include meta.load-css('toasts.scss');
+@include meta.load-css('colors.scss');
 
 @layer payload-default {
   :root {
@@ -10,26 +14,26 @@
     --base-body-size: 13;
     --base: calc((var(--base-px) / var(--base-body-size)) * 1rem);
 
-    --breakpoint-xs-width: #{$breakpoint-xs-width};
-    --breakpoint-s-width: #{$breakpoint-s-width};
-    --breakpoint-m-width: #{$breakpoint-m-width};
-    --breakpoint-l-width: #{$breakpoint-l-width};
+    --breakpoint-xs-width: #{vars.$breakpoint-xs-width};
+    --breakpoint-s-width: #{vars.$breakpoint-s-width};
+    --breakpoint-m-width: #{vars.$breakpoint-m-width};
+    --breakpoint-l-width: #{vars.$breakpoint-l-width};
     --scrollbar-width: 17px;
 
     --theme-bg: var(--theme-elevation-0);
     --theme-input-bg: var(--theme-elevation-0);
     --theme-text: var(--theme-elevation-800);
     --theme-overlay: rgba(5, 5, 5, 0.5);
-    --theme-baseline: #{$baseline-px};
-    --theme-baseline-body-size: #{$baseline-body-size};
+    --theme-baseline: #{vars.$baseline-px};
+    --theme-baseline-body-size: #{vars.$baseline-body-size};
     --font-body:
       -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     --font-serif: 'Georgia', 'Bitstream Charter', 'Charis SIL', Utopia, 'URW Bookman L', serif;
     --font-mono: 'SF Mono', Menlo, Consolas, Monaco, monospace;
 
-    --style-radius-s: #{$style-radius-s};
-    --style-radius-m: #{$style-radius-m};
-    --style-radius-l: #{$style-radius-l};
+    --style-radius-s: #{vars.$style-radius-s};
+    --style-radius-m: #{vars.$style-radius-m};
+    --style-radius-l: #{vars.$style-radius-l};
 
     --z-popup: 10;
     --z-nav: 20;
@@ -39,21 +43,21 @@
     --accessibility-outline: 2px solid var(--theme-text);
     --accessibility-outline-offset: 2px;
 
-    --gutter-h: #{base(3)};
+    --gutter-h: #{vars.base(3)};
     --spacing-view-bottom: var(--gutter-h);
     --doc-controls-height: calc(var(--base) * 2.8);
     --app-header-height: calc(var(--base) * 2.8);
     --nav-width: 275px;
     --nav-trans-time: 150ms;
 
-    @include mid-break {
-      --gutter-h: #{base(2)};
+    @include queries.mid-break {
+      --gutter-h: #{vars.base(2)};
       --app-header-height: calc(var(--base) * 2.4);
       --doc-controls-height: calc(var(--base) * 2.4);
     }
 
-    @include small-break {
-      --gutter-h: #{base(0.8)};
+    @include queries.small-break {
+      --gutter-h: #{vars.base(0.8)};
       --spacing-view-bottom: calc(var(--base) * 2);
       --nav-width: 100vw;
     }
@@ -88,7 +92,7 @@
       }
     }
 
-    @include mid-break {
+    @include queries.mid-break {
       font-size: 12px;
     }
   }
@@ -154,7 +158,7 @@
 
   ul,
   ol {
-    padding-left: $baseline;
+    padding-left: vars.$baseline;
     margin: 0;
   }
 

--- a/packages/ui/src/scss/styles.scss
+++ b/packages/ui/src/scss/styles.scss
@@ -1,11 +1,11 @@
-@import 'vars';
-@import 'z-index';
+@use 'vars';
+@use 'z-index';
 
 //////////////////////////////
 // IMPORT OVERRIDES
 //////////////////////////////
 
-@import 'type';
-@import 'queries';
-@import 'resets';
-@import 'svg';
+@use 'type';
+@use 'queries';
+@use 'resets';
+@use 'svg';

--- a/packages/ui/src/scss/toastify.scss
+++ b/packages/ui/src/scss/toastify.scss
@@ -1,18 +1,18 @@
-@import 'vars';
-@import 'queries';
+@use 'vars';
+@use 'queries';
 
 @layer payload-default {
   .Toastify {
     .Toastify__toast-container {
-      left: base(5);
+      left: vars.base(5);
       transform: none;
-      right: base(5);
+      right: vars.base(5);
       width: auto;
     }
 
     .Toastify__toast {
-      padding: base(0.5);
-      border-radius: $style-radius-m;
+      padding: vars.base(0.5);
+      border-radius: vars.$style-radius-m;
       font-weight: 600;
     }
 
@@ -51,10 +51,10 @@
       color: inherit;
     }
 
-    @include mid-break {
+    @include queries.mid-break {
       .Toastify__toast-container {
-        left: $baseline;
-        right: $baseline;
+        left: vars.$baseline;
+        right: vars.$baseline;
       }
     }
   }

--- a/packages/ui/src/scss/toasts.scss
+++ b/packages/ui/src/scss/toasts.scss
@@ -1,4 +1,4 @@
-@import './styles.scss';
+@use 'styles.scss';
 
 @layer payload-default {
   .payload-toast-container {

--- a/packages/ui/src/scss/type.scss
+++ b/packages/ui/src/scss/type.scss
@@ -1,5 +1,5 @@
-@import 'vars';
-@import 'queries';
+@use 'vars';
+@use 'queries';
 
 /////////////////////////////
 // HEADINGS
@@ -18,53 +18,53 @@
 
   %h1 {
     margin: 0;
-    font-size: base(1.6);
-    line-height: base(1.8);
+    font-size: vars.base(1.6);
+    line-height: vars.base(1.8);
 
-    @include small-break {
+    @include queries.small-break {
       letter-spacing: -0.5px;
-      font-size: base(1.25);
+      font-size: vars.base(1.25);
     }
   }
 
   %h2 {
     margin: 0;
-    font-size: base(1.3);
-    line-height: base(1.6);
+    font-size: vars.base(1.3);
+    line-height: vars.base(1.6);
 
-    @include small-break {
-      font-size: base(0.85);
+    @include queries.small-break {
+      font-size: vars.base(0.85);
     }
   }
 
   %h3 {
     margin: 0;
-    font-size: base(1);
-    line-height: base(1.2);
+    font-size: vars.base(1);
+    line-height: vars.base(1.2);
 
-    @include small-break {
-      font-size: base(0.65);
+    @include queries.small-break {
+      font-size: vars.base(0.65);
       line-height: 1.25;
     }
   }
 
   %h4 {
     margin: 0;
-    font-size: base(0.8);
-    line-height: base(1);
+    font-size: vars.base(0.8);
+    line-height: vars.base(1);
     letter-spacing: -0.375px;
   }
 
   %h5 {
     margin: 0;
-    font-size: base(0.65);
-    line-height: base(0.8);
+    font-size: vars.base(0.65);
+    line-height: vars.base(0.8);
   }
 
   %h6 {
     margin: 0;
-    font-size: base(0.6);
-    line-height: base(0.8);
+    font-size: vars.base(0.6);
+    line-height: vars.base(0.8);
   }
 
   %small {
@@ -78,30 +78,30 @@
   /////////////////////////////
 
   %large-body {
-    font-size: base(0.6);
-    line-height: base(1);
-    letter-spacing: base(0.02);
+    font-size: vars.base(0.6);
+    line-height: vars.base(1);
+    letter-spacing: vars.base(0.02);
 
-    @include mid-break {
-      font-size: base(0.7);
-      line-height: base(1);
+    @include queries.mid-break {
+      font-size: vars.base(0.7);
+      line-height: vars.base(1);
     }
 
-    @include small-break {
-      font-size: base(0.55);
-      line-height: base(0.75);
+    @include queries.small-break {
+      font-size: vars.base(0.55);
+      line-height: vars.base(0.75);
     }
   }
 
   %body {
-    font-size: $baseline-body-size;
-    line-height: $baseline-px;
+    font-size: vars.$baseline-body-size;
+    line-height: vars.$baseline-px;
     font-weight: normal;
     font-family: var(--font-body);
   }
 
   %code {
-    font-size: base(0.4);
+    font-size: vars.base(0.4);
     color: var(--theme-elevation-400);
 
     span {


### PR DESCRIPTION
### What?
Ran Sass migrator on Sass files in @payloadcms/ui

### Why?
Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
More info and automated migrator: https://sass-lang.com/d/import

### How?
https://sass-lang.com/documentation/cli/migrator/
