### PR TITLE
docs: fix typo, example was not valid JSON

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -230,7 +230,7 @@ const config = buildConfig({
       slug: 'tenants',
       admin: {
         useAsTitle: 'name'
-      }
+      },
       fields: [
         // remember, you own these fields
         // these are merely suggestions/examples


### PR DESCRIPTION
### What?
A comma is missing in the example code. This results in not valid JSON.

### Why?
I stumbled upon it, while setting up a Tenant-based Payload for the first time.

### How?
Adding a comma results in valid JSON.

Fixes #
Added a comma. ;)