### PR TITLE
fix(db-postgres): search is broken when `useAsTitle` is not specified

### DIFF
--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -219,7 +219,10 @@ export function parseParams({
 
                 if (
                   operator === 'like' &&
-                  (field.type === 'number' || table[columnName].columnType === 'PgUUID')
+                  (field.type === 'number' ||
+                    field.type === 'relationship' ||
+                    field.type === 'upload' ||
+                    table[columnName].columnType === 'PgUUID')
                 ) {
                   operator = 'equals'
                 }

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3001,6 +3001,21 @@ describe('database', () => {
     }
   })
 
+  it('should allow to query like by ID with draft: true', async () => {
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title: 'category123' },
+    })
+    const res = await payload.find({
+      collection: 'categories',
+      draft: true,
+      // eslint-disable-next-line jest/no-conditional-in-test
+      where: { id: { like: typeof category.id === 'number' ? `${category.id}` : category.id } },
+    })
+    expect(res.docs).toHaveLength(1)
+    expect(res.docs[0].id).toBe(category.id)
+  })
+
   it('should allow incremental number update', async () => {
     const post = await payload.create({ collection: 'posts', data: { number: 1, title: 'post' } })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13171