### PR TITLE
docs: add `status` to forbidden field names when using Postgres and drafts are enabled

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -157,6 +157,7 @@ The following field names are forbidden and cannot be used:
 - `salt`
 - `hash`
 - `file`
+- `status` - with Postgres Adapter and when drafts are enabled
 
 ### Field-level Hooks
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13144