### PR TITLE
fix(ui): monomorphic relationship fields should not show relationTo option labels

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -101,7 +101,6 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
   const [options, dispatchOptions] = useReducer(optionsReducer, [])
 
   const valueRef = useRef(value)
-  // the line below seems odd
 
   const [DocumentDrawer, , { isDrawerOpen, openDrawer }] = useDocumentDrawer({
     id: currentlyOpenRelationship.id,
@@ -473,11 +472,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
       const docID = args.doc.id
 
       if (hasMany) {
-        const currentValue = valueRef.current
-          ? Array.isArray(valueRef.current)
-            ? valueRef.current
-            : [valueRef.current]
-          : []
+        const currentValue = value ? (Array.isArray(value) ? value : [value]) : []
 
         const valuesToSet = currentValue.map((option: ValueWithRelation) => {
           return {
@@ -491,7 +486,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
         onChange({ relationTo: args.collectionConfig.slug, value: docID })
       }
     },
-    [i18n, config, hasMany, onChange],
+    [i18n, config, hasMany, onChange, value],
   )
 
   const onDuplicate = useCallback<DocumentDrawerProps['onDuplicate']>(
@@ -507,8 +502,8 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
       if (hasMany) {
         onChange(
-          valueRef.current
-            ? (valueRef.current as ValueWithRelation[]).concat({
+          value
+            ? value.concat({
                 relationTo: args.collectionConfig.slug,
                 value: args.doc.id,
               })
@@ -521,7 +516,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
         })
       }
     },
-    [i18n, config, hasMany, onChange],
+    [i18n, config, hasMany, onChange, value],
   )
 
   const onDelete = useCallback<DocumentDrawerProps['onDelete']>(
@@ -536,8 +531,8 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
       if (hasMany) {
         onChange(
-          valueRef.current
-            ? (valueRef.current as ValueWithRelation[]).filter((option) => {
+          value
+            ? value.filter((option) => {
                 return option.value !== args.id
               })
             : null,
@@ -548,7 +543,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
       return
     },
-    [i18n, config, hasMany, onChange],
+    [i18n, config, hasMany, onChange, value],
   )
 
   const filterOption = useCallback((item: Option, searchFilter: string) => {
@@ -669,6 +664,12 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
       openDrawerWhenRelationChanges.current = false
     }
   }, [openDrawer, currentlyOpenRelationship])
+
+  useEffect(() => {
+    // needed to sync the ref value when other fields influence the value
+    // i.e. when a drawer is opened and the value is set
+    valueRef.current = value
+  }, [value])
 
   const valueToRender = findOptionsByValue({ allowEdit, options, value })
 

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -49,6 +49,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
     Description,
     Error,
     filterOptions,
+    formatDisplayedOptions,
     hasMany,
     initialValue,
     isSortable = true,
@@ -101,8 +102,6 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
   const valueRef = useRef(value)
   // the line below seems odd
-
-  valueRef.current = value
 
   const [DocumentDrawer, , { isDrawerOpen, openDrawer }] = useDocumentDrawer({
     id: currentlyOpenRelationship.id,
@@ -742,14 +741,18 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
                   ? (selected) => {
                       if (hasMany) {
                         if (selected === null) {
+                          valueRef.current = []
                           onChange([])
                         } else {
+                          valueRef.current = selected as ValueWithRelation[]
                           onChange(selected as ValueWithRelation[])
                         }
                       } else if (hasMany === false) {
                         if (selected === null) {
+                          valueRef.current = null
                           onChange(null)
                         } else {
+                          valueRef.current = selected as ValueWithRelation
                           onChange(selected as ValueWithRelation)
                         }
                       }
@@ -822,7 +825,11 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
                       }),
                 })
               }}
-              options={options}
+              options={
+                typeof formatDisplayedOptions === 'function'
+                  ? formatDisplayedOptions(options)
+                  : options
+              }
               placeholder={placeholder}
               showError={showError}
               value={valueToRender ?? null}

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -196,6 +196,9 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
       description={description}
       Error={Error}
       filterOptions={filterOptions}
+      formatDisplayedOptions={
+        isPolymorphic ? undefined : (options) => options.map((opt) => opt.options).flat()
+      }
       isSortable={isSortable}
       Label={Label}
       label={label}

--- a/packages/ui/src/fields/Relationship/types.ts
+++ b/packages/ui/src/fields/Relationship/types.ts
@@ -100,6 +100,7 @@ export type RelationshipInputProps = {
   readonly description?: StaticDescription
   readonly Error?: React.ReactNode
   readonly filterOptions?: FilterOptionsResult
+  readonly formatDisplayedOptions?: (options: OptionGroup[]) => Option[] | OptionGroup[]
   readonly isSortable?: boolean
   readonly Label?: React.ReactNode
   readonly label?: StaticLabel

--- a/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -240,7 +240,7 @@ describe('lexicalBlocks', () => {
       )
 
       await dependsOnDocData.locator('.rs__control').click()
-      await expect(newBlock.locator('.rs__menu')).toHaveText('Text Fieldsinvalid')
+      await expect(newBlock.locator('.rs__menu')).toHaveText('invalid')
       await dependsOnDocData.locator('.rs__control').click()
 
       await dependsOnSiblingData.locator('.rs__control').click()
@@ -281,7 +281,7 @@ describe('lexicalBlocks', () => {
       await dependsOnDocData.locator('.rs__control').click()
 
       await dependsOnSiblingData.locator('.rs__control').click()
-      await expect(newBlock.locator('.rs__menu')).toHaveText('Text Fieldsinvalid')
+      await expect(newBlock.locator('.rs__menu')).toHaveText('invalid')
       await dependsOnSiblingData.locator('.rs__control').click()
 
       await dependsOnBlockData.locator('.rs__control').click()
@@ -322,7 +322,7 @@ describe('lexicalBlocks', () => {
       await dependsOnSiblingData.locator('.rs__control').click()
 
       await dependsOnBlockData.locator('.rs__control').click()
-      await expect(newBlock.locator('.rs__menu')).toHaveText('Text Fieldsinvalid')
+      await expect(newBlock.locator('.rs__menu')).toHaveText('invalid')
       await dependsOnBlockData.locator('.rs__control').click()
 
       await saveDocAndAssert(page)


### PR DESCRIPTION
Monomorphic relationship options should not show `relationTo` labels.

### Before
<img width="284" height="179" alt="image" src="https://github.com/user-attachments/assets/24077737-7d0f-4966-ba56-0c65532053e7" />

### After
<img width="290" height="175" alt="CleanShot 2025-07-22 at 20 36 39" src="https://github.com/user-attachments/assets/d6370bda-f238-455c-a22e-2acadb2663f9" />
