### PR TITLE
refactor(drizzle): use getTableName utility

### DIFF
--- a/packages/drizzle/src/utilities/getNameFromDrizzleTable.ts
+++ b/packages/drizzle/src/utilities/getNameFromDrizzleTable.ts
@@ -3,13 +3,5 @@ import type { Table } from 'drizzle-orm'
 import { getTableName } from 'drizzle-orm'
 
 export const getNameFromDrizzleTable = (table: Table): string => {
-  const symbol = Object.getOwnPropertySymbols(table).find((symb) =>
-    symb.description.includes('drizzle:BaseName'),
-  )
-  // Drizzle:Name or drizzle:BaseName sometimes returns a UUID. Example:
-  // drizzle:BaseName: payload_locked_documents_rels
-  // drizzle:Name: 131e2d64_3237_426b_8466_f28e0d2be653
-  // getTableName(table): payload_locked_documents_rels
-
-  return table[symbol] || getTableName(table)
+  return getTableName(table)
 }

--- a/packages/drizzle/src/utilities/getNameFromDrizzleTable.ts
+++ b/packages/drizzle/src/utilities/getNameFromDrizzleTable.ts
@@ -1,9 +1,15 @@
 import type { Table } from 'drizzle-orm'
 
+import { getTableName } from 'drizzle-orm'
+
 export const getNameFromDrizzleTable = (table: Table): string => {
   const symbol = Object.getOwnPropertySymbols(table).find((symb) =>
-    symb.description.includes('Name'),
+    symb.description.includes('drizzle:BaseName'),
   )
+  // Drizzle:Name or drizzle:BaseName sometimes returns a UUID. Example:
+  // drizzle:BaseName: payload_locked_documents_rels
+  // drizzle:Name: 131e2d64_3237_426b_8466_f28e0d2be653
+  // getTableName(table): payload_locked_documents_rels
 
-  return table[symbol]
+  return table[symbol] || getTableName(table)
 }


### PR DESCRIPTION
~~Sometimes, drizzle is adding the same join to the joins array twice (`addJoinTable`), despite the table being the same. This is due to a bug in `getNameFromDrizzleTable` where it would sometimes return a UUID instead of the table name.~~

~~This PR changes it to read from the drizzle:BaseName symbol instead, which is correctly returning the table name in my testing. It falls back to `getTableName`, which uses drizzle:Name.~~

This for some reason fails the tests. Instead, this PR just uses the getTableName utility now instead of searching for the symbol manually.