### PR TITLE
fix(drizzle): respect join.type config

### DIFF
--- a/packages/db-sqlite/src/countDistinct.ts
+++ b/packages/db-sqlite/src/countDistinct.ts
@@ -29,8 +29,8 @@ export const countDistinct: CountDistinct = async function countDistinct(
     .limit(1)
     .$dynamic()
 
-  joins.forEach(({ condition, table }) => {
-    query = query.leftJoin(table, condition)
+  joins.forEach(({ type, condition, table }) => {
+    query = query[type ?? 'leftJoin'](table, condition)
   })
 
   // When we have any joins, we need to count each individual ID only once.

--- a/packages/drizzle/src/postgres/countDistinct.ts
+++ b/packages/drizzle/src/postgres/countDistinct.ts
@@ -30,8 +30,8 @@ export const countDistinct: CountDistinct = async function countDistinct(
     .limit(1)
     .$dynamic()
 
-  joins.forEach(({ condition, table }) => {
-    query = query.leftJoin(table as PgTableWithColumns<any>, condition)
+  joins.forEach(({ type, condition, table }) => {
+    query = query[type ?? 'leftJoin'](table as PgTableWithColumns<any>, condition)
   })
 
   // When we have any joins, we need to count each individual ID only once.

--- a/packages/drizzle/src/queries/selectDistinct.ts
+++ b/packages/drizzle/src/queries/selectDistinct.ts
@@ -56,8 +56,8 @@ export const selectDistinct = ({
       query = query.where(where)
     }
 
-    joins.forEach(({ condition, table }) => {
-      query = query.leftJoin(table, condition)
+    joins.forEach(({ type, condition, table }) => {
+      query = query[type ?? 'leftJoin'](table, condition)
     })
 
     return queryModifier({


### PR DESCRIPTION
Respects join.type instead of hardcoding leftJoin