### PR TITLE
fix(ui): incorrect blocks label sizing

### DIFF
--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -319,7 +319,13 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
               <RenderCustomComponent
                 CustomComponent={Label}
                 Fallback={
-                  <FieldLabel label={label} localized={localized} path={path} required={required} />
+                  <FieldLabel
+                    as="span"
+                    label={label}
+                    localized={localized}
+                    path={path}
+                    required={required}
+                  />
                 }
               />
             </h3>

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -1552,7 +1552,7 @@ describe('lexicalMain', () => {
     await closeTagInMultiSelect.click()
     await expect(decoratorLocator).toBeHidden()
 
-    const labelInsideCollapsableBody = page.locator('label').getByText('Sub Blocks')
+    const labelInsideCollapsableBody = page.locator('h3>span').getByText('Sub Blocks')
     await labelInsideCollapsableBody.click()
     await expectInsideSelectedDecorator(labelInsideCollapsableBody)
 

--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -48,6 +48,7 @@ describe('Sort functionality', () => {
   test('Orderable collection', async () => {
     const url = new AdminUrlUtil(serverURL, orderableSlug)
     await page.goto(`${url.list}?sort=-_order`)
+    await page.locator('.collection-list button', { hasText: 'Seed' }).click()
     // SORT BY ORDER ASCENDING
     await page.locator('.sort-header button').nth(0).click()
     await assertRows(0, 'A', 'B', 'C', 'D')


### PR DESCRIPTION
Blocks container labels should match the Array and Tab labels. Uses same styling approach as Array labels.

### Before
<img width="229" height="260" alt="CleanShot 2025-07-24 at 12 26 38" src="https://github.com/user-attachments/assets/9c4eb7c5-3638-4b47-805b-1206f195f5eb" />

### After
<img width="245" height="259" alt="CleanShot 2025-07-24 at 12 27 00" src="https://github.com/user-attachments/assets/c04933b4-226f-403b-9913-24ba00857aab" />
