### PR TITLE
fix: filtering by polymorphic relationships inside other fields

### DIFF
--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -158,7 +158,11 @@ export function getLocalizedPaths({
             // We only support querying directly (no nested querying)
             if (matchedField.type !== 'join' && typeof matchedField.relationTo !== 'string') {
               lastIncompletePath.path = pathSegments.join('.')
-              lastIncompletePath.complete = true
+              if (![matchedField.name, 'relationTo', 'value'].includes(pathSegments.at(-1)!)) {
+                lastIncompletePath.invalid = true
+              } else {
+                lastIncompletePath.complete = true
+              }
             } else {
               lastIncompletePath.complete = true
               lastIncompletePath.path = currentPath!

--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -157,19 +157,8 @@ export function getLocalizedPaths({
             // If this is a polymorphic relation,
             // We only support querying directly (no nested querying)
             if (matchedField.type !== 'join' && typeof matchedField.relationTo !== 'string') {
-              const lastSegmentIsValid =
-                ['relationTo', 'value'].includes(pathSegments[pathSegments.length - 1]!) ||
-                pathSegments.length === 1 ||
-                (pathSegments.length === 2 && pathSegments[0] === 'version')
-
               lastIncompletePath.path = pathSegments.join('.')
-
-              if (lastSegmentIsValid) {
-                lastIncompletePath.complete = true
-              } else {
-                lastIncompletePath.invalid = true
-                return paths
-              }
+              lastIncompletePath.complete = true
             } else {
               lastIncompletePath.complete = true
               lastIncompletePath.path = currentPath!

--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -250,6 +250,11 @@ export default buildConfigWithDefaults({
               relationTo: 'directors',
               hasMany: true,
             },
+            {
+              name: 'polymorphic',
+              type: 'relationship',
+              relationTo: ['directors'],
+            },
           ],
         },
       ],

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1192,6 +1192,24 @@ describe('Relationships', () => {
       expect(result.docs[0]!.id).toBe(doc.id)
     })
 
+    it('should allow querying polymorphic in an array', async () => {
+      const director = await payload.create({
+        collection: 'directors',
+        data: { name: 'direcotr' },
+      })
+      const movie = await payload.create({
+        collection: 'movies',
+        data: { array: [{ polymorphic: { relationTo: 'directors', value: director.id } }] },
+      })
+
+      const res = await payload.find({
+        collection: 'movies',
+        where: { 'array.polymorphic': { equals: { value: director.id, relationTo: 'directors' } } },
+      })
+      expect(res.docs).toHaveLength(1)
+      expect(res.docs[0].id).toBe(movie.id)
+    })
+
     it('should allow querying hasMany in array', async () => {
       const director = await payload.create({
         collection: 'directors',

--- a/test/relationships/payload-types.ts
+++ b/test/relationships/payload-types.ts
@@ -271,6 +271,10 @@ export interface Movie {
   array?:
     | {
         director?: (string | Director)[] | null;
+        polymorphic?: {
+          relationTo: 'directors';
+          value: string | Director;
+        } | null;
         id?: string | null;
       }[]
     | null;
@@ -750,6 +754,7 @@ export interface MoviesSelect<T extends boolean = true> {
     | T
     | {
         director?: T;
+        polymorphic?: T;
         id?: T;
       };
   updatedAt?: T;


### PR DESCRIPTION
Previously, filtering by a polymorphic relationship inside an array / group (unless the `name` is `version`) / tab caused `QueryError: The following path cannot be queried:`.