### PR TITLE
docs: remove obsolete scheduler property

### DIFF
--- a/docs/jobs-queue/schedules.mdx
+++ b/docs/jobs-queue/schedules.mdx
@@ -77,7 +77,6 @@ This configuration only queues the Job - it does not execute it immediately. To 
 ```ts
 export default buildConfig({
   jobs: {
-    scheduler: 'cron',
     autoRun: [
       {
         cron: '* * * * *', // Runs every minute


### PR DESCRIPTION
That property does not exist and was used in a previous, outdated implementation of auto scheduling