### PR TITLE
fix(templates): fix grid item rendering on search page

### DIFF
--- a/templates/ecommerce/src/app/(app)/search/page.tsx
+++ b/templates/ecommerce/src/app/(app)/search/page.tsx
@@ -81,7 +81,7 @@ export default async function SearchPage({ searchParams }: Props) {
       {products?.docs.length > 0 ? (
         <Grid className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
           {products.docs.map((product) => {
-            return <ProductGridItem key={product.slug} product={product} />
+            return <ProductGridItem key={product.id} product={product} />
           })}
         </Grid>
       ) : null}


### PR DESCRIPTION
### What?
Product search results page grid
### Why?
The product grid items on the search page were not rendering correctly due to incorrect item key mapping in the grid component because it was using the item slug and a front end error that was getting thrown. 
### How?
The ProductGridItem component key uses the product.id instead of the product.slug in this PR and thereby suppresses the error. 