### PR TITLE
docs: clarify "type": "module" requirement for type generation in Next.js projects

### DIFF
--- a/docs/typescript/generating-types.mdx
+++ b/docs/typescript/generating-types.mdx
@@ -18,6 +18,20 @@ payload generate:types
 
 You can run this command whenever you need to regenerate your types, and then you can use these types in your Payload code directly.
 
+### ⚠️ Note for Next.js users
+
+In a default Next.js project (which does **not** include `"type": "module"` in `package.json`), you might encounter an error when running `payload generate:types`.
+
+To fix this, add the following line to your `package.json`:
+
+```json
+{
+  "type": "module"
+}
+```
+
+> 💡 This enables ECMAScript Modules (ESM) which are required for the type generation script to run correctly.
+
 ## Disable declare statement
 
 By default, `generate:types` will add a `declare` statement to your types file, which automatically enables type inference within Payload.


### PR DESCRIPTION
### Summary

This update adds a dedicated section under the **"Types generation script"** heading to explain an issue commonly encountered by users working with Payload in a default **Next.js** setup.

### Problem

When running:

```bash
payload generate:types
```

users may face an error due to the absence of the `"type": "module"` field in their `package.json` file. This happens because the type generation script relies on **ECMAScript Module (ESM)** resolution, which is not enabled by default in most Next.js configurations.

### Solution

The documentation now explicitly instructs users to add `"type": "module"` to their `package.json` file. This:

* Prevents confusion and build errors
* Reduces developer frustration and support requests
* Aligns the documentation with modern TypeScript + Next.js workflows

### Why it matters

This small clarification ensures that new users integrating Payload CMS into Next.js projects have a smoother experience when generating types, without hitting unnecessary roadblocks.

---

