### PR TITLE
chore(next): cleanup unused code

### DIFF
--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -145,25 +145,6 @@ export const renderListView = async (
       })
     }
 
-    let whereCondition = mergeListSearchAndWhere({
-      collectionConfig,
-      search: typeof query?.search === 'string' ? query.search : undefined,
-      where: combineWhereConstraints([query?.where, baseListFilter]),
-    })
-
-    if (query?.trash === true) {
-      whereCondition = {
-        and: [
-          whereCondition,
-          {
-            deletedAt: {
-              exists: true,
-            },
-          },
-        ],
-      }
-    }
-
     let queryPreset: QueryPreset | undefined
     let queryPresetPermissions: SanitizedCollectionPermission | undefined
 


### PR DESCRIPTION
Looks like a merge resolution kept unused code. The same condition is added a couple lines below this removal.