### PR TITLE
fix: fields with read access should not appear in list filters

### DIFF
--- a/test/admin/collections/Posts.ts
+++ b/test/admin/collections/Posts.ts
@@ -293,6 +293,32 @@ export const Posts: CollectionConfig = {
       name: 'file',
       type: 'text',
     },
+    {
+      name: 'shouldDisableListFilter',
+      type: 'text',
+      admin: {
+        disableListFilter: false,
+      },
+      access: {
+        read: ({ req }) => Boolean(req.user),
+      },
+    },
+    {
+      name: 'groupWithReadAccessFunction',
+      type: 'group',
+      access: {
+        read: ({ req }) => Boolean(req.user),
+      },
+      fields: [
+        {
+          name: 'shouldDisableNestedListFilter',
+          type: 'text',
+          admin: {
+            disableListFilter: false,
+          },
+        },
+      ],
+    },
   ],
   labels: {
     plural: slugPluralLabel,

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -749,6 +749,27 @@ describe('List View', () => {
       ).toBeHidden()
     })
 
+    test('should not show field filter for fields with read access functions', async () => {
+      await page.goto(postsUrl.list)
+      await openListFilters(page, {})
+      await page.locator('.where-builder__add-first-filter').click()
+
+      const initialField = page.locator('.condition__field')
+      await initialField.click()
+
+      await expect(
+        initialField.locator('.rs__option', {
+          hasText: 'Should Disable List Filter',
+        }),
+      ).toBeHidden()
+
+      await expect(
+        initialField.locator('.rs__option', {
+          hasText: 'Group With Read Access Function',
+        }),
+      ).toBeHidden()
+    })
+
     test('should simply disable field filter when admin.disableListFilter is true but still exists in the query', async () => {
       await page.goto(
         `${postsUrl.list}${qs.stringify(


### PR DESCRIPTION
Fields with read access should not be filterable in the admin panel since they are not searchable. Currently, if you attempt to search on a field with a read access function defined an API error is thrown because those fields are not searchable for security reasons. This is solely a "ui" update but it is done by sanitizing the config to ensure the fields are disabled from list filters.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210906557689764