### PR TITLE
fix(ui): autosave-enabled document drawers close unexpectedly within the join field

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -110,17 +110,18 @@ export const renderDocument = async ({
 
   // Fetch the doc required for the view
   let doc =
-    initialData ||
-    (await getDocumentData({
-      id: idFromArgs,
-      collectionSlug,
-      globalSlug,
-      locale,
-      payload,
-      req,
-      segments,
-      user,
-    }))
+    !idFromArgs && !globalSlug
+      ? initialData || null
+      : await getDocumentData({
+          id: idFromArgs,
+          collectionSlug,
+          globalSlug,
+          locale,
+          payload,
+          req,
+          segments,
+          user,
+        })
 
   if (isEditing && !doc) {
     // If it's a collection document that doesn't exist, redirect to collection list

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -7,6 +7,7 @@ import React, { Fragment, useCallback, useEffect, useState } from 'react'
 import type { DocumentDrawerContextType } from '../DocumentDrawer/Provider.js'
 import type { Props } from './types.js'
 
+import { useRelatedCollections } from '../../hooks/useRelatedCollections.js'
 import { PlusIcon } from '../../icons/Plus/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
@@ -16,7 +17,6 @@ import { Popup } from '../Popup/index.js'
 import * as PopupList from '../Popup/PopupButtonList/index.js'
 import { Tooltip } from '../Tooltip/index.js'
 import './index.scss'
-import { useRelatedCollections } from './useRelatedCollections.js'
 
 const baseClass = 'relationship-add-new'
 

--- a/packages/ui/src/elements/DocumentDrawer/Provider.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/Provider.tsx
@@ -26,7 +26,7 @@ export type DocumentDrawerContextProps = {
   }) => Promise<FormState | void> | void
 }
 
-export type DocumentDrawerContextType = DocumentDrawerContextProps
+export type DocumentDrawerContextType = {} & DocumentDrawerContextProps
 
 export const DocumentDrawerCallbacksContext = createContext({} as DocumentDrawerContextType)
 

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -2,11 +2,16 @@
 import { useModal } from '@faceless-ui/modal'
 import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
 
-import type { DocumentDrawerProps, DocumentTogglerProps, UseDocumentDrawer } from './types.js'
+import type {
+  DocumentDrawerProps,
+  DocumentTogglerProps,
+  UseDocumentDrawer,
+  UseDocumentDrawerContext,
+} from './types.js'
 
+import { useRelatedCollections } from '../../hooks/useRelatedCollections.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
-import { useRelatedCollections } from '../AddNewRelation/useRelatedCollections.js'
 import { Drawer, DrawerToggler } from '../Drawer/index.js'
 import { DocumentDrawerContent } from './DrawerContent.js'
 import './index.scss'
@@ -64,6 +69,25 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = (props) => {
   )
 }
 
+/**
+ * A hook to manage documents from a drawer modal.
+ * It provides the components and methods needed to open, close, and interact with the drawer.
+ * @example
+ * const [DocumentDrawer, DocumentDrawerToggler, { openDrawer, closeDrawer }] = useDocumentDrawer({
+ *   collectionSlug: 'posts',
+ *   id: postId, // optional, if not provided, it will render the "create new" view
+ * })
+ *
+ * // ...
+ *
+ * return (
+ *   <div>
+ *     <DocumentDrawerToggler collectionSlug="posts" id={postId}>
+ *       Edit Post
+ *    </DocumentDrawerToggler>
+ *    <DocumentDrawer collectionSlug="posts" id={postId} />
+ *  </div>
+ */
 export const useDocumentDrawer: UseDocumentDrawer = ({
   id,
   collectionSlug,
@@ -97,7 +121,7 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
     openModal(drawerSlug)
   }, [openModal, drawerSlug])
 
-  const MemoizedDrawer = useMemo(() => {
+  const MemoizedDrawer = useMemo<React.FC<DocumentDrawerProps>>(() => {
     return (props) => (
       <DocumentDrawer
         {...props}
@@ -110,7 +134,7 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
     )
   }, [id, drawerSlug, collectionSlug, overrideEntityVisibility])
 
-  const MemoizedDrawerToggler = useMemo(() => {
+  const MemoizedDrawerToggler = useMemo<React.FC<DocumentTogglerProps>>(() => {
     return (props) => (
       <DocumentDrawerToggler
         {...props}
@@ -121,7 +145,7 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
     )
   }, [id, drawerSlug, collectionSlug])
 
-  const MemoizedDrawerState = useMemo(
+  const MemoizedDrawerState = useMemo<UseDocumentDrawerContext>(
     () => ({
       closeDrawer,
       drawerDepth: editDepth,

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -31,13 +31,13 @@ const formatDocumentDrawerSlug = ({
 }) => `doc-drawer_${collectionSlug}_${depth}${id ? `_${id}` : ''}_${uuid}`
 
 export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
-  id,
   children,
   className,
   collectionSlug,
   disabled,
   drawerSlug,
   onClick,
+  operation,
   ...rest
 }) => {
   const { t } = useTranslation()
@@ -45,7 +45,7 @@ export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
 
   return (
     <DrawerToggler
-      aria-label={t(!id ? 'fields:addNewLabel' : 'general:editLabel', {
+      aria-label={t(operation === 'create' ? 'fields:addNewLabel' : 'general:editLabel', {
         label: collectionConfig?.labels.singular,
       })}
       className={[className, `${documentDrawerBaseClass}__toggler`].filter(Boolean).join(' ')}
@@ -140,7 +140,7 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
         {...props}
         collectionSlug={collectionSlug}
         drawerSlug={drawerSlug}
-        id={id?.toString()}
+        operation={!id ? 'create' : 'update'}
       />
     )
   }, [id, drawerSlug, collectionSlug])

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -140,7 +140,7 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
         {...props}
         collectionSlug={collectionSlug}
         drawerSlug={drawerSlug}
-        id={id}
+        id={id?.toString()}
       />
     )
   }, [id, drawerSlug, collectionSlug])

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -30,23 +30,33 @@ export type DocumentTogglerProps = {
   readonly collectionSlug: string
   readonly disabled?: boolean
   readonly drawerSlug?: string
-  readonly id?: string
+  readonly id?: number | string
   readonly onClick?: () => void
 } & Readonly<HTMLAttributes<HTMLButtonElement>>
 
+export type UseDocumentDrawerContext = {
+  closeDrawer: () => void
+  drawerDepth: number
+  drawerSlug: string
+  isDrawerOpen: boolean
+  openDrawer: () => void
+  toggleDrawer: () => void
+}
+
 export type UseDocumentDrawer = (args: {
+  /**
+   * The slug of the collection to which the document belongs.
+   */
   collectionSlug: string
+  /**
+   * The ID of the document to be edited.
+   * When provided, will be fetched and displayed in the drawer.
+   * If omitted, will render the "create new" view for the given collection.
+   */
   id?: number | string
   overrideEntityVisibility?: boolean
 }) => [
   React.FC<Omit<DocumentDrawerProps, 'collectionSlug' | 'id'>>, // drawer
   React.FC<Omit<DocumentTogglerProps, 'collectionSlug' | 'id'>>, // toggler
-  {
-    closeDrawer: () => void
-    drawerDepth: number
-    drawerSlug: string
-    isDrawerOpen: boolean
-    openDrawer: () => void
-    toggleDrawer: () => void
-  },
+  UseDocumentDrawerContext,
 ]

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -30,7 +30,10 @@ export type DocumentTogglerProps = {
   readonly collectionSlug: string
   readonly disabled?: boolean
   readonly drawerSlug?: string
-  readonly id?: number | string
+  /**
+   * The `id` HTML attribute for the toggler button.
+   */
+  readonly id?: string
   readonly onClick?: () => void
 } & Readonly<HTMLAttributes<HTMLButtonElement>>
 
@@ -56,7 +59,18 @@ export type UseDocumentDrawer = (args: {
   id?: number | string
   overrideEntityVisibility?: boolean
 }) => [
-  React.FC<Omit<DocumentDrawerProps, 'collectionSlug' | 'id'>>, // drawer
-  React.FC<Omit<DocumentTogglerProps, 'collectionSlug' | 'id'>>, // toggler
+  // drawer
+  React.FC<
+    {
+      children?: React.ReactNode
+    } & Omit<DocumentDrawerProps, 'collectionSlug' | 'id'>
+  >,
+  // toggler
+  React.FC<
+    {
+      children?: React.ReactNode
+    } & Omit<DocumentTogglerProps, 'collectionSlug' | 'id'>
+  >,
+  // context
   UseDocumentDrawerContext,
 ]

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -60,13 +60,13 @@ export type UseDocumentDrawer = (args: {
   React.FC<
     {
       children?: React.ReactNode
-    } & Omit<DocumentDrawerProps, 'collectionSlug' | 'id'>
+    } & Omit<DocumentDrawerProps, 'collectionSlug' | 'operation'>
   >,
   // toggler
   React.FC<
     {
       children?: React.ReactNode
-    } & Omit<DocumentTogglerProps, 'collectionSlug' | 'id'>
+    } & Omit<DocumentTogglerProps, 'collectionSlug' | 'operation'>
   >,
   // context
   UseDocumentDrawerContext,

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -1,4 +1,4 @@
-import type { Data, FormState } from 'payload'
+import type { Data, FormState, Operation } from 'payload'
 import type React from 'react'
 import type { HTMLAttributes } from 'react'
 
@@ -30,11 +30,8 @@ export type DocumentTogglerProps = {
   readonly collectionSlug: string
   readonly disabled?: boolean
   readonly drawerSlug?: string
-  /**
-   * The `id` HTML attribute for the toggler button.
-   */
-  readonly id?: string
   readonly onClick?: () => void
+  readonly operation: Operation
 } & Readonly<HTMLAttributes<HTMLButtonElement>>
 
 export type UseDocumentDrawerContext = {

--- a/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.scss
+++ b/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.scss
@@ -2,5 +2,15 @@
   .drawer-link {
     display: flex;
     gap: calc(var(--base) / 2);
+
+    &__button {
+      border: none;
+      background: none;
+      padding: 0;
+      cursor: pointer;
+      color: var(--color-text);
+      font-size: inherit;
+      line-height: inherit;
+    }
   }
 }

--- a/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.scss
+++ b/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.scss
@@ -3,7 +3,7 @@
     display: flex;
     gap: calc(var(--base) / 2);
 
-    &__button {
+    &__doc-drawer-toggler {
       border: none;
       background: none;
       padding: 0;

--- a/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
@@ -19,7 +19,7 @@ export const DrawerLink: React.FC<{
     <div className="drawer-link">
       <DefaultCell {...cellProps} className="drawer-link__cell" link={false} onClick={null} />
       <button
-        className="drawer-link__button"
+        className="drawer-link__doc-drawer-toggler"
         onClick={() => {
           onDrawerOpen(cellProps.rowData.id)
         }}

--- a/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import type { UseDocumentDrawer } from '../../../DocumentDrawer/types.js'
+import type { OnDrawerOpen } from '../../index.js'
 
 import { EditIcon } from '../../../../icons/Edit/index.js'
 import { useCellProps } from '../../../../providers/TableColumns/RenderDefaultCell/index.js'
@@ -10,18 +10,23 @@ import { DefaultCell } from '../../../Table/DefaultCell/index.js'
 import './index.scss'
 
 export const DrawerLink: React.FC<{
-  readonly DrawerToggler?: ReturnType<UseDocumentDrawer>[0]
-}> = (props) => {
-  const { DrawerToggler } = props
-
+  currentDrawerID?: string
+  onDrawerOpen: OnDrawerOpen
+}> = ({ onDrawerOpen }) => {
   const cellProps = useCellProps()
 
   return (
     <div className="drawer-link">
       <DefaultCell {...cellProps} className="drawer-link__cell" link={false} onClick={null} />
-      <DrawerToggler>
+      <button
+        className="drawer-link__button"
+        onClick={() => {
+          onDrawerOpen(cellProps.rowData.id)
+        }}
+        type="button"
+      >
         <EditIcon />
-      </DrawerToggler>
+      </button>
     </div>
   )
 }

--- a/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
@@ -1,57 +1,27 @@
 'use client'
 
-import React, { useCallback } from 'react'
+import React from 'react'
 
-import type { DocumentDrawerProps } from '../../../DocumentDrawer/types.js'
+import type { UseDocumentDrawer } from '../../../DocumentDrawer/types.js'
 
 import { EditIcon } from '../../../../icons/Edit/index.js'
 import { useCellProps } from '../../../../providers/TableColumns/RenderDefaultCell/index.js'
-import { useDocumentDrawer } from '../../../DocumentDrawer/index.js'
 import { DefaultCell } from '../../../Table/DefaultCell/index.js'
 import './index.scss'
 
 export const DrawerLink: React.FC<{
-  readonly onDrawerDelete?: DocumentDrawerProps['onDelete']
-  readonly onDrawerSave?: DocumentDrawerProps['onSave']
+  readonly DrawerToggler?: ReturnType<UseDocumentDrawer>[0]
 }> = (props) => {
-  const { onDrawerDelete: onDrawerDeleteFromProps, onDrawerSave: onDrawerSaveFromProps } = props
+  const { DrawerToggler } = props
 
   const cellProps = useCellProps()
-
-  const [DocumentDrawer, DocumentDrawerToggler, { closeDrawer }] = useDocumentDrawer({
-    id: cellProps?.rowData.id,
-    collectionSlug: cellProps?.collectionSlug,
-  })
-
-  const onDrawerSave = useCallback<DocumentDrawerProps['onSave']>(
-    (args) => {
-      closeDrawer()
-
-      if (typeof onDrawerSaveFromProps === 'function') {
-        void onDrawerSaveFromProps(args)
-      }
-    },
-    [closeDrawer, onDrawerSaveFromProps],
-  )
-
-  const onDrawerDelete = useCallback<DocumentDrawerProps['onDelete']>(
-    (args) => {
-      closeDrawer()
-
-      if (typeof onDrawerDeleteFromProps === 'function') {
-        void onDrawerDeleteFromProps(args)
-      }
-    },
-    [closeDrawer, onDrawerDeleteFromProps],
-  )
 
   return (
     <div className="drawer-link">
       <DefaultCell {...cellProps} className="drawer-link__cell" link={false} onClick={null} />
-      <DocumentDrawerToggler>
+      <DrawerToggler>
         <EditIcon />
-      </DocumentDrawerToggler>
-      <DocumentDrawer onDelete={onDrawerDelete} onSave={onDrawerSave} />
+      </DrawerToggler>
     </div>
   )
 }

--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -103,7 +103,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
           ...initialDataFromProps,
           docs: Array.isArray(initialDataFromProps.docs)
             ? initialDataFromProps.docs.reduce((acc, doc) => {
-                if (typeof doc === 'string') {
+                if (typeof doc === 'string' || typeof doc === 'number') {
                   return [
                     ...acc,
                     {
@@ -111,6 +111,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
                     },
                   ]
                 }
+
                 return [...acc, doc]
               }, [])
             : [],

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -636,6 +636,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
   const prevValue = useRef(value)
   const isFirstRenderRef = useRef(true)
+
   // ///////////////////////////////////
   // Ensure we have an option for each value
   // ///////////////////////////////////

--- a/packages/ui/src/hooks/useRelatedCollections.ts
+++ b/packages/ui/src/hooks/useRelatedCollections.ts
@@ -3,8 +3,11 @@ import type { ClientCollectionConfig } from 'payload'
 
 import { useState } from 'react'
 
-import { useConfig } from '../../providers/Config/index.js'
+import { useConfig } from '../providers/Config/index.js'
 
+/**
+ * Gets the corresponding client collection config(s) for the given collection slug.
+ */
 export const useRelatedCollections = (relationTo: string | string[]): ClientCollectionConfig[] => {
   const { getEntityConfig } = useConfig()
 

--- a/test/helpers/e2e/waitForAutoSaveToRunAndComplete.ts
+++ b/test/helpers/e2e/waitForAutoSaveToRunAndComplete.ts
@@ -1,11 +1,11 @@
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 import { expect } from '@playwright/test'
 import { wait } from 'payload/shared'
 import { POLL_TOPASS_TIMEOUT } from 'playwright.config.js'
 
 export async function waitForAutoSaveToRunAndComplete(
-  page: Page,
+  page: Locator | Page,
   expectation: 'error' | 'success' = 'success',
 ) {
   await expect(async () => {

--- a/test/joins/collections/CategoriesVersions.ts
+++ b/test/joins/collections/CategoriesVersions.ts
@@ -4,6 +4,10 @@ import { categoriesVersionsSlug, versionsSlug } from '../shared.js'
 
 export const CategoriesVersions: CollectionConfig = {
   slug: categoriesVersionsSlug,
+  labels: {
+    singular: 'Category With Versions',
+    plural: 'Categories With Versions',
+  },
   fields: [
     {
       name: 'title',

--- a/test/joins/collections/CategoriesVersions.ts
+++ b/test/joins/collections/CategoriesVersions.ts
@@ -19,12 +19,12 @@ export const CategoriesVersions: CollectionConfig = {
       collection: versionsSlug,
       on: 'categoryVersion',
     },
-    // {
-    //   name: 'relatedVersionsMany',
-    //   type: 'join',
-    //   collection: versionsSlug,
-    //   on: 'categoryVersions',
-    // },
+    {
+      name: 'relatedVersionsMany',
+      type: 'join',
+      collection: versionsSlug,
+      on: 'categoryVersions',
+    },
   ],
   versions: {
     drafts: true,

--- a/test/joins/collections/CategoriesVersions.ts
+++ b/test/joins/collections/CategoriesVersions.ts
@@ -19,12 +19,12 @@ export const CategoriesVersions: CollectionConfig = {
       collection: versionsSlug,
       on: 'categoryVersion',
     },
-    {
-      name: 'relatedVersionsMany',
-      type: 'join',
-      collection: versionsSlug,
-      on: 'categoryVersions',
-    },
+    // {
+    //   name: 'relatedVersionsMany',
+    //   type: 'join',
+    //   collection: versionsSlug,
+    //   on: 'categoryVersions',
+    // },
   ],
   versions: {
     drafts: true,

--- a/test/joins/collections/Versions.ts
+++ b/test/joins/collections/Versions.ts
@@ -4,6 +4,10 @@ import { versionsSlug } from '../shared.js'
 
 export const Versions: CollectionConfig = {
   slug: versionsSlug,
+  labels: {
+    singular: 'Post With Versions',
+    plural: 'Posts With Versions',
+  },
   fields: [
     {
       name: 'title',
@@ -28,6 +32,8 @@ export const Versions: CollectionConfig = {
     },
   ],
   versions: {
-    drafts: true,
+    drafts: {
+      autosave: true,
+    },
   },
 }

--- a/test/joins/collections/Versions.ts
+++ b/test/joins/collections/Versions.ts
@@ -23,12 +23,14 @@ export const Versions: CollectionConfig = {
       name: 'categoryVersion',
       relationTo: 'categories-versions',
       type: 'relationship',
+      label: 'Category With Versions',
     },
     {
       name: 'categoryVersions',
       relationTo: 'categories-versions',
       type: 'relationship',
       hasMany: true,
+      label: 'Categories With Versions (Has Many)',
     },
   ],
   versions: {

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -183,12 +183,15 @@ describe('Join Field', () => {
     const button = joinField.locator('button.doc-drawer__toggler.relationship-table__add-new')
     await expect(button).toBeVisible()
     await button.click()
+
     const drawer = page.locator('[id^=doc-drawer_hidden-posts_1_]')
     await expect(drawer).toBeVisible()
     const titleField = drawer.locator('#field-title')
     await expect(titleField).toBeVisible()
     await titleField.fill('Test Hidden Post')
-    await drawer.locator('button[id="action-save"]').click()
+
+    await saveDocAndAssert(page, '[id^=doc-drawer_hidden-posts_1_] button#action-save')
+
     await expect(joinField.locator('.relationship-table tbody tr.row-2')).toBeVisible()
   })
 
@@ -239,7 +242,7 @@ describe('Join Field', () => {
     const joinField = page.locator('#field-relatedPosts.field-type.join')
     await expect(joinField).toBeVisible()
     const actionColumn = joinField.locator('tbody tr td:nth-child(2)').first()
-    const toggler = actionColumn.locator('button.doc-drawer__toggler')
+    const toggler = actionColumn.locator('button.drawer-link__doc-drawer-toggler')
     await expect(toggler).toBeVisible()
     const link = actionColumn.locator('a')
     await expect(link).toBeHidden()
@@ -252,7 +255,7 @@ describe('Join Field', () => {
     })
 
     const newActionColumn = joinField.locator('tbody tr td:nth-child(2)').first()
-    const newToggler = newActionColumn.locator('button.doc-drawer__toggler')
+    const newToggler = newActionColumn.locator('button.drawer-link__doc-drawer-toggler')
     await expect(newToggler).toBeVisible()
     const newLink = newActionColumn.locator('a')
     await expect(newLink).toBeHidden()
@@ -305,12 +308,9 @@ describe('Join Field', () => {
 
     await expect(joinField.locator('tbody tr')).toHaveCount(3)
 
-    const addButton = joinField.locator(
-      '.relationship-table__actions button.drawer-link__doc-drawer-toggler',
-      {
-        hasText: exactText('Add new'),
-      },
-    )
+    const addButton = joinField.locator('.relationship-table__actions button.doc-drawer__toggler', {
+      hasText: exactText('Add new'),
+    })
 
     await expect(addButton).toBeVisible()
 
@@ -325,7 +325,8 @@ describe('Join Field', () => {
     const titleField = drawer.locator('#field-title')
     await expect(titleField).toBeVisible()
     await titleField.fill('Test Post 4')
-    await drawer.locator('button[id="action-save"]').click()
+
+    await saveDocAndAssert(page, '[id^=doc-drawer_posts_1_] button#action-save')
     await expect(drawer).toBeHidden()
 
     await expect(
@@ -352,15 +353,17 @@ describe('Join Field', () => {
     const titleField = drawer.locator('#field-title')
     await expect(titleField).toBeVisible()
 
-    const updatedTitle = 'Test Post 1 Updated'
-
+    const updatedTitle = 'Test Post 1 (Updated)'
     await titleField.fill(updatedTitle)
-    await drawer.locator('button[id="action-save"]').click()
+
+    await saveDocAndAssert(page, '[id^=doc-drawer_posts_1_] button#action-save')
+    await drawer.locator('.doc-drawer__header-close').click()
     await expect(drawer).toBeHidden()
+
     await expect(joinField.locator('tbody .row-1')).toContainText(updatedTitle)
   })
 
-  test('should edit joined document when autosave is enabled', async () => {
+  test('should edit joined document and update relationship table when autosave is enabled', async () => {
     const categoryVersionsDoc = await payload.create({
       collection: categoriesVersionsSlug,
       data: {
@@ -450,8 +453,10 @@ describe('Join Field', () => {
     await expect(titleField).toBeVisible()
     await titleField.fill('Test polymorphic Post')
     await expect(drawer.locator('#field-polymorphic')).toContainText('example')
-    await drawer.locator('button[id="action-save"]').click()
+
+    await saveDocAndAssert(page, '[id^=doc-drawer_posts_1_] button#action-save')
     await expect(drawer).toBeHidden()
+
     await expect(joinField.locator('tbody .row-1')).toContainText('Test polymorphic Post')
   })
   test('should create join collection from polymorphic, hasMany relationships', async () => {
@@ -465,8 +470,10 @@ describe('Join Field', () => {
     await expect(titleField).toBeVisible()
     await titleField.fill('Test polymorphic Post')
     await expect(drawer.locator('#field-polymorphics')).toContainText('example')
-    await drawer.locator('button[id="action-save"]').click()
+
+    await saveDocAndAssert(page, '[id^=doc-drawer_posts_1_] button#action-save')
     await expect(drawer).toBeHidden()
+
     await expect(joinField.locator('tbody .row-1')).toContainText('Test polymorphic Post')
   })
   test('should create join collection from polymorphic localized relationships', async () => {
@@ -480,8 +487,10 @@ describe('Join Field', () => {
     await expect(titleField).toBeVisible()
     await titleField.fill('Test polymorphic Post')
     await expect(drawer.locator('#field-localizedPolymorphic')).toContainText('example')
-    await drawer.locator('button[id="action-save"]').click()
+
+    await saveDocAndAssert(page, '[id^=doc-drawer_posts_1_] button#action-save')
     await expect(drawer).toBeHidden()
+
     await expect(joinField.locator('tbody .row-1')).toContainText('Test polymorphic Post')
   })
   test('should create join collection from polymorphic, hasMany, localized relationships', async () => {
@@ -495,8 +504,10 @@ describe('Join Field', () => {
     await expect(titleField).toBeVisible()
     await titleField.fill('Test polymorphic Post')
     await expect(drawer.locator('#field-localizedPolymorphics')).toContainText('example')
-    await drawer.locator('button[id="action-save"]').click()
+
+    await saveDocAndAssert(page, '[id^=doc-drawer_posts_1_] button#action-save')
     await expect(drawer).toBeHidden()
+
     await expect(joinField.locator('tbody .row-1')).toContainText('Test polymorphic Post')
   })
 
@@ -513,12 +524,9 @@ describe('Join Field', () => {
     await expect(joinField).toBeVisible()
 
     // TODO: change this to edit the first row in the join table
-    const addButton = joinField.locator(
-      '.relationship-table__actions button.drawer-link__doc-drawer-toggler',
-      {
-        hasText: exactText('Add new'),
-      },
-    )
+    const addButton = joinField.locator('.relationship-table__actions button.doc-drawer__toggler', {
+      hasText: exactText('Add new'),
+    })
 
     await expect(addButton).toBeVisible()
 
@@ -534,6 +542,7 @@ describe('Join Field', () => {
     await titleField.fill('Edited title for upload')
     await drawer.locator('button[id="action-save"]').click()
     await expect(drawer).toBeHidden()
+
     await expect(
       joinField.locator('tbody tr td:nth-child(2)', {
         hasText: exactText('Edited title for upload'),
@@ -586,6 +595,7 @@ describe('Join Field', () => {
     await expect(
       joinField.locator('.relationship-table tbody .row-1 .cell-collection .pill__label'),
     ).toHaveText('Example Page')
+
     await expect(
       joinField.locator('.relationship-table tbody .row-1 .cell-title .drawer-link__cell'),
     ).toHaveText('Some new page')

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -305,9 +305,12 @@ describe('Join Field', () => {
 
     await expect(joinField.locator('tbody tr')).toHaveCount(3)
 
-    const addButton = joinField.locator('.relationship-table__actions button.doc-drawer__toggler', {
-      hasText: exactText('Add new'),
-    })
+    const addButton = joinField.locator(
+      '.relationship-table__actions button.drawer-link__doc-drawer-toggler',
+      {
+        hasText: exactText('Add new'),
+      },
+    )
 
     await expect(addButton).toBeVisible()
 
@@ -339,7 +342,7 @@ describe('Join Field', () => {
     await expect(joinField).toBeVisible()
 
     const editButton = joinField.locator(
-      'tbody tr:first-child td:nth-child(2) button.doc-drawer__toggler',
+      'tbody tr:first-child td:nth-child(2) button.drawer-link__doc-drawer-toggler',
     )
 
     await expect(editButton).toBeVisible()
@@ -379,7 +382,7 @@ describe('Join Field', () => {
     await expect(joinField).toBeVisible()
 
     const editButton = joinField.locator(
-      'tbody tr:first-child td:nth-child(2) button.doc-drawer__toggler',
+      'tbody tr:first-child td:nth-child(2) button.drawer-link__doc-drawer-toggler',
     )
 
     await expect(editButton).toBeVisible()
@@ -413,7 +416,7 @@ describe('Join Field', () => {
     await expect(rows).toHaveCount(expectedRows)
 
     const editButton = joinField.locator(
-      'tbody tr:first-child td:nth-child(2) button.doc-drawer__toggler',
+      'tbody tr:first-child td:nth-child(2) button.drawer-link__doc-drawer-toggler',
     )
     await expect(editButton).toBeVisible()
     await editButton.click()
@@ -510,9 +513,12 @@ describe('Join Field', () => {
     await expect(joinField).toBeVisible()
 
     // TODO: change this to edit the first row in the join table
-    const addButton = joinField.locator('.relationship-table__actions button.doc-drawer__toggler', {
-      hasText: exactText('Add new'),
-    })
+    const addButton = joinField.locator(
+      '.relationship-table__actions button.drawer-link__doc-drawer-toggler',
+      {
+        hasText: exactText('Add new'),
+      },
+    )
 
     await expect(addButton).toBeVisible()
 

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -127,7 +127,6 @@ export interface Config {
     };
     'categories-versions': {
       relatedVersions: 'versions';
-      relatedVersionsMany: 'versions';
     };
     'self-joins': {
       joins: 'self-joins';
@@ -521,11 +520,6 @@ export interface CategoriesVersion {
   id: string;
   title?: string | null;
   relatedVersions?: {
-    docs?: (string | Version)[];
-    hasNextPage?: boolean;
-    totalDocs?: number;
-  };
-  relatedVersionsMany?: {
     docs?: (string | Version)[];
     hasNextPage?: boolean;
     totalDocs?: number;
@@ -1146,7 +1140,6 @@ export interface VersionsSelect<T extends boolean = true> {
 export interface CategoriesVersionsSelect<T extends boolean = true> {
   title?: T;
   relatedVersions?: T;
-  relatedVersionsMany?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -127,6 +127,7 @@ export interface Config {
     };
     'categories-versions': {
       relatedVersions: 'versions';
+      relatedVersionsMany: 'versions';
     };
     'self-joins': {
       joins: 'self-joins';
@@ -520,6 +521,11 @@ export interface CategoriesVersion {
   id: string;
   title?: string | null;
   relatedVersions?: {
+    docs?: (string | Version)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  relatedVersionsMany?: {
     docs?: (string | Version)[];
     hasNextPage?: boolean;
     totalDocs?: number;
@@ -1140,6 +1146,7 @@ export interface VersionsSelect<T extends boolean = true> {
 export interface CategoriesVersionsSelect<T extends boolean = true> {
   title?: T;
   relatedVersions?: T;
+  relatedVersionsMany?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/test/joins/shared.ts
+++ b/test/joins/shared.ts
@@ -19,11 +19,14 @@ export const categoriesJoinRestrictedSlug = 'categories-join-restricted'
 export const collectionRestrictedSlug = 'collection-restricted'
 
 export const restrictedCategoriesSlug = 'restricted-categories'
+
 export const categoriesVersionsSlug = 'categories-versions'
+
 export const versionsSlug = 'versions'
 
 export const collectionSlugs = [
   categoriesSlug,
+  categoriesVersionsSlug,
   postsSlug,
   localizedPostsSlug,
   localizedCategoriesSlug,

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -13,9 +13,9 @@ import { ensureCompilationIsDone, initPageConsoleErrorCatch, saveDocAndAssert } 
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { navigateToDoc, navigateToTrashedDoc } from '../helpers/e2e/navigateToDoc.js'
 import { deletePreferences } from '../helpers/e2e/preferences.js'
+import { waitForAutoSaveToRunAndComplete } from '../helpers/e2e/waitForAutoSaveToRunAndComplete.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../helpers/reInitializeDB.js'
-import { waitForAutoSaveToRunAndComplete } from '../helpers/waitForAutoSaveToRunAndComplete.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import {
   ensureDeviceIsCentered,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -42,9 +42,9 @@ import {
 } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { assertNetworkRequests } from '../helpers/e2e/assertNetworkRequests.js'
+import { waitForAutoSaveToRunAndComplete } from '../helpers/e2e/waitForAutoSaveToRunAndComplete.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../helpers/reInitializeDB.js'
-import { waitForAutoSaveToRunAndComplete } from '../helpers/waitForAutoSaveToRunAndComplete.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import {
   autosaveCollectionSlug,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,8 +21,15 @@
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "sourceMap": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["node", "jest"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": true,
     "isolatedModules": true,
     "plugins": [
@@ -31,36 +38,72 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/_community/config.ts"],
-      "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
-      "@payloadcms/live-preview": ["./packages/live-preview/src"],
-      "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
-      "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],
-      "@payloadcms/ui": ["./packages/ui/src/exports/client/index.ts"],
-      "@payloadcms/ui/shared": ["./packages/ui/src/exports/shared/index.ts"],
-      "@payloadcms/ui/rsc": ["./packages/ui/src/exports/rsc/index.ts"],
-      "@payloadcms/ui/scss": ["./packages/ui/src/scss.scss"],
-      "@payloadcms/ui/scss/app.scss": ["./packages/ui/src/scss/app.scss"],
-      "@payloadcms/next/*": ["./packages/next/src/exports/*.ts"],
+      "@payload-config": [
+        "./test/joins/config.ts"
+      ],
+      "@payloadcms/admin-bar": [
+        "./packages/admin-bar/src"
+      ],
+      "@payloadcms/live-preview": [
+        "./packages/live-preview/src"
+      ],
+      "@payloadcms/live-preview-react": [
+        "./packages/live-preview-react/src/index.ts"
+      ],
+      "@payloadcms/live-preview-vue": [
+        "./packages/live-preview-vue/src/index.ts"
+      ],
+      "@payloadcms/ui": [
+        "./packages/ui/src/exports/client/index.ts"
+      ],
+      "@payloadcms/ui/shared": [
+        "./packages/ui/src/exports/shared/index.ts"
+      ],
+      "@payloadcms/ui/rsc": [
+        "./packages/ui/src/exports/rsc/index.ts"
+      ],
+      "@payloadcms/ui/scss": [
+        "./packages/ui/src/scss.scss"
+      ],
+      "@payloadcms/ui/scss/app.scss": [
+        "./packages/ui/src/scss/app.scss"
+      ],
+      "@payloadcms/next/*": [
+        "./packages/next/src/exports/*.ts"
+      ],
       "@payloadcms/richtext-lexical/client": [
         "./packages/richtext-lexical/src/exports/client/index.ts"
       ],
-      "@payloadcms/richtext-lexical/rsc": ["./packages/richtext-lexical/src/exports/server/rsc.ts"],
-      "@payloadcms/richtext-slate/rsc": ["./packages/richtext-slate/src/exports/server/rsc.ts"],
+      "@payloadcms/richtext-lexical/rsc": [
+        "./packages/richtext-lexical/src/exports/server/rsc.ts"
+      ],
+      "@payloadcms/richtext-slate/rsc": [
+        "./packages/richtext-slate/src/exports/server/rsc.ts"
+      ],
       "@payloadcms/richtext-slate/client": [
         "./packages/richtext-slate/src/exports/client/index.ts"
       ],
-      "@payloadcms/plugin-seo/client": ["./packages/plugin-seo/src/exports/client.ts"],
-      "@payloadcms/plugin-sentry/client": ["./packages/plugin-sentry/src/exports/client.ts"],
-      "@payloadcms/plugin-stripe/client": ["./packages/plugin-stripe/src/exports/client.ts"],
-      "@payloadcms/plugin-search/client": ["./packages/plugin-search/src/exports/client.ts"],
+      "@payloadcms/plugin-seo/client": [
+        "./packages/plugin-seo/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-sentry/client": [
+        "./packages/plugin-sentry/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-stripe/client": [
+        "./packages/plugin-stripe/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-search/client": [
+        "./packages/plugin-search/src/exports/client.ts"
+      ],
       "@payloadcms/plugin-form-builder/client": [
         "./packages/plugin-form-builder/src/exports/client.ts"
       ],
       "@payloadcms/plugin-import-export/rsc": [
         "./packages/plugin-import-export/src/exports/rsc.ts"
       ],
-      "@payloadcms/plugin-multi-tenant/rsc": ["./packages/plugin-multi-tenant/src/exports/rsc.ts"],
+      "@payloadcms/plugin-multi-tenant/rsc": [
+        "./packages/plugin-multi-tenant/src/exports/rsc.ts"
+      ],
       "@payloadcms/plugin-multi-tenant/utilities": [
         "./packages/plugin-multi-tenant/src/exports/utilities.ts"
       ],
@@ -70,25 +113,42 @@
       "@payloadcms/plugin-multi-tenant/client": [
         "./packages/plugin-multi-tenant/src/exports/client.ts"
       ],
-      "@payloadcms/plugin-multi-tenant": ["./packages/plugin-multi-tenant/src/index.ts"],
+      "@payloadcms/plugin-multi-tenant": [
+        "./packages/plugin-multi-tenant/src/index.ts"
+      ],
       "@payloadcms/plugin-multi-tenant/translations/languages/all": [
         "./packages/plugin-multi-tenant/src/translations/index.ts"
       ],
       "@payloadcms/plugin-multi-tenant/translations/languages/*": [
         "./packages/plugin-multi-tenant/src/translations/languages/*.ts"
       ],
-      "@payloadcms/next": ["./packages/next/src/exports/*"],
-      "@payloadcms/storage-azure/client": ["./packages/storage-azure/src/exports/client.ts"],
-      "@payloadcms/storage-s3/client": ["./packages/storage-s3/src/exports/client.ts"],
+      "@payloadcms/next": [
+        "./packages/next/src/exports/*"
+      ],
+      "@payloadcms/storage-azure/client": [
+        "./packages/storage-azure/src/exports/client.ts"
+      ],
+      "@payloadcms/storage-s3/client": [
+        "./packages/storage-s3/src/exports/client.ts"
+      ],
       "@payloadcms/storage-vercel-blob/client": [
         "./packages/storage-vercel-blob/src/exports/client.ts"
       ],
-      "@payloadcms/storage-gcs/client": ["./packages/storage-gcs/src/exports/client.ts"],
+      "@payloadcms/storage-gcs/client": [
+        "./packages/storage-gcs/src/exports/client.ts"
+      ],
       "@payloadcms/storage-uploadthing/client": [
         "./packages/storage-uploadthing/src/exports/client.ts"
       ]
     }
   },
-  "include": ["${configDir}/src"],
-  "exclude": ["${configDir}/dist", "${configDir}/build", "${configDir}/temp", "**/*.spec.ts"]
+  "include": [
+    "${configDir}/src"
+  ],
+  "exclude": [
+    "${configDir}/dist",
+    "${configDir}/build",
+    "${configDir}/temp",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
Fixes #12975.

When editing autosave-enabled documents through the join field, the document drawer closes unexpectedly on every autosave interval, making it nearly impossible to use.

This is because as of #12842, the underlying relationship table re-renders on every autosave event, remounting the drawer each time. The fix is to lift the drawer out of table's rendering tree and into the join field itself. This way all rows share the same drawer, whose rendering lifecycle has been completely decoupled from the table's state.

Note: this is very similar to how relationship fields achieve similar functionality.

This PR also adds jsdocs to the `useDocumentDrawer` hook and strengthens its types.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210906078627353