### PR TITLE
fix: prevent apiKey from being corrupted by refresh operation

### DIFF
--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -1,5 +1,4 @@
 import url from 'url'
-import { v4 as uuid } from 'uuid'
 
 import type { Collection } from '../../collections/config/types.js'
 import type { Document, PayloadRequest } from '../../types/index.js'
@@ -74,11 +73,10 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
     const parsedURL = url.parse(args.req.url!)
     const isGraphQL = parsedURL.pathname === config.routes.graphQL
 
-    const user = await args.req.payload.findByID({
-      id: args.req.user.id,
-      collection: args.req.user.collection,
-      depth: isGraphQL ? 0 : args.collection.config.auth.depth,
-      req: args.req,
+    let user = await req.payload.db.findOne<any>({
+      collection: collectionConfig.slug,
+      req,
+      where: { id: { equals: args.req.user.id } },
     })
 
     const sid = args.req.user._sid
@@ -88,7 +86,7 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
         throw new Forbidden(args.req.t)
       }
 
-      const existingSession = user.sessions.find(({ id }) => id === sid)
+      const existingSession = user.sessions.find(({ id }: { id: number }) => id === sid)
 
       const now = new Date()
       const tokenExpInMs = collectionConfig.auth.tokenExpiration * 1000
@@ -105,6 +103,13 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
         returning: false,
       })
     }
+
+    user = await req.payload.findByID({
+      id: user.id,
+      collection: collectionConfig.slug,
+      depth: isGraphQL ? 0 : args.collection.config.auth.depth,
+      req: args.req,
+    })
 
     if (user) {
       user.collection = args.req.user.collection


### PR DESCRIPTION
### What?

Prevents decrypted apiKey from being saved back to database in unecrypted form on the auth refresh operation.

### Why?

Refreshing a token for a logged-in user decrypts the apiKey and writes it back in plaintext, corrupting the user record.

### How?

By only updating sessions in the user object instead of the complete user object.


This PR is based upon the work of PR #13177 by @contip to fix issue #13063

Fixes #13063
