### PR TITLE
test: fix flaky sorting test

### DIFF
--- a/test/sort/Seed.tsx
+++ b/test/sort/Seed.tsx
@@ -1,12 +1,16 @@
 /* eslint-disable no-console */
 'use client'
+import { useRouter } from 'next/navigation'
 
 export const Seed = () => {
+  const router = useRouter()
+
   return (
     <button
       onClick={async () => {
         try {
           await fetch('/api/seed', { method: 'POST' })
+          router.refresh()
         } catch (error) {
           console.error(error)
         }

--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -48,8 +48,18 @@ describe('Sort functionality', () => {
   test('Orderable collection', async () => {
     const url = new AdminUrlUtil(serverURL, orderableSlug)
     await page.goto(url.list)
+
+    const joinFieldResolvePromise = page.waitForResponse(
+      (response) => response.url().includes('/api/orderable-join') && response.status() === 200,
+    )
+    const seedResponsePromise = page.waitForResponse(
+      (response) => response.url().includes('/api/seed') && response.status() === 200,
+    )
     await page.locator('.collection-list button', { hasText: 'Seed' }).click()
+    await seedResponsePromise
+    await joinFieldResolvePromise
     await page.goto(`${url.list}?sort=-_order`)
+
     // SORT BY ORDER ASCENDING
     await page.locator('.sort-header button').nth(0).click()
     await assertRows(0, 'A', 'B', 'C', 'D')

--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -47,8 +47,9 @@ describe('Sort functionality', () => {
   // eslint-disable-next-line playwright/expect-expect
   test('Orderable collection', async () => {
     const url = new AdminUrlUtil(serverURL, orderableSlug)
-    await page.goto(`${url.list}?sort=-_order`)
+    await page.goto(url.list)
     await page.locator('.collection-list button', { hasText: 'Seed' }).click()
+    await page.goto(`${url.list}?sort=-_order`)
     // SORT BY ORDER ASCENDING
     await page.locator('.sort-header button').nth(0).click()
     await assertRows(0, 'A', 'B', 'C', 'D')


### PR DESCRIPTION
Ensures the browser uses fresh data after seeding by refreshing the route and navigating when done.