### PR TITLE
feat: adds trash support to the count operation

### DIFF
--- a/packages/graphql/src/resolvers/collections/count.ts
+++ b/packages/graphql/src/resolvers/collections/count.ts
@@ -9,6 +9,7 @@ export type Resolver = (
   args: {
     data: Record<string, unknown>
     locale?: string
+    trash?: boolean
     where?: Where
   },
   context: {
@@ -30,6 +31,7 @@ export function countResolver(collection: Collection): Resolver {
     const options = {
       collection,
       req: isolateObjectProperty(req, 'transactionID'),
+      trash: args.trash,
       where: args.where,
     }
 

--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -239,6 +239,7 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
         }),
         args: {
           draft: { type: GraphQLBoolean },
+          trash: { type: GraphQLBoolean },
           where: { type: collection.graphQL.whereInputType },
           ...(config.localization
             ? {

--- a/packages/payload/src/collections/endpoints/count.ts
+++ b/packages/payload/src/collections/endpoints/count.ts
@@ -8,13 +8,15 @@ import { countOperation } from '../operations/count.js'
 
 export const countHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
-  const { where } = req.query as {
+  const { trash, where } = req.query as {
+    trash?: string
     where?: Where
   }
 
   const result = await countOperation({
     collection,
     req,
+    trash: trash === 'true',
     where,
   })
 

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -42,6 +42,15 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   req?: Partial<PayloadRequest>
   /**
+   * When set to `true`, the query will include both normal and trashed documents.
+   * To query only trashed documents, pass `trash: true` and combine with a `where` clause filtering by `deletedAt`.
+   * By default (`false`), the query will only include normal documents and exclude those with a `deletedAt` field.
+   *
+   * This argument has no effect unless `trash` is enabled on the collection.
+   * @default false
+   */
+  trash?: boolean
+  /**
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
@@ -55,7 +64,13 @@ export async function countLocal<TSlug extends CollectionSlug>(
   payload: Payload,
   options: Options<TSlug>,
 ): Promise<{ totalDocs: number }> {
-  const { collection: collectionSlug, disableErrors, overrideAccess = true, where } = options
+  const {
+    collection: collectionSlug,
+    disableErrors,
+    overrideAccess = true,
+    trash = false,
+    where,
+  } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -70,6 +85,7 @@ export async function countLocal<TSlug extends CollectionSlug>(
     disableErrors,
     overrideAccess,
     req: await createLocalReq(options as CreateLocalReqOptions, payload),
+    trash,
     where,
   })
 }


### PR DESCRIPTION
### What?

- Updated the `countOperation` to respect the `trash` argument.

### Why?

- Previously, `count` would incorrectly include trashed documents even when `trash` was not specified.
- This change aligns `count` behavior with `find` and other operations, providing accurate counts for normal and trashed documents.

### How?

- Applied `appendNonTrashedFilter` in `countOperation` to automatically exclude soft-deleted docs when `trash: false` (default).
- Added `trash` argument support in Local API, REST API (`/count` endpoints), and GraphQL (`count<Collection>` queries).