### PR TITLE
fix(next): group by null relationship crashes list view

### DIFF
--- a/packages/next/src/views/List/handleGroupBy.ts
+++ b/packages/next/src/views/List/handleGroupBy.ts
@@ -144,8 +144,8 @@ export const handleGroupBy = async ({
 
       if (
         groupByField?.type === 'relationship' &&
-        typeof potentiallyPopulatedRelationship === 'object' &&
-        potentiallyPopulatedRelationship !== null
+        potentiallyPopulatedRelationship &&
+        typeof potentiallyPopulatedRelationship === 'object'
       ) {
         heading =
           potentiallyPopulatedRelationship[relationshipConfig.admin.useAsTitle || 'id'] ||

--- a/packages/next/src/views/List/handleGroupBy.ts
+++ b/packages/next/src/views/List/handleGroupBy.ts
@@ -144,7 +144,8 @@ export const handleGroupBy = async ({
 
       if (
         groupByField?.type === 'relationship' &&
-        typeof potentiallyPopulatedRelationship === 'object'
+        typeof potentiallyPopulatedRelationship === 'object' &&
+        potentiallyPopulatedRelationship !== null
       ) {
         heading =
           potentiallyPopulatedRelationship[relationshipConfig.admin.useAsTitle || 'id'] ||

--- a/test/group-by/e2e.spec.ts
+++ b/test/group-by/e2e.spec.ts
@@ -236,6 +236,26 @@ test.describe('Group By', () => {
     await expect(page.locator('.group-by-header')).toHaveCount(0)
   })
 
+  test('should group by relationships even when their values are null', async () => {
+    await payload.create({
+      collection: postsSlug,
+      data: {
+        title: 'My Post',
+        category: null,
+      },
+    })
+
+    await page.goto(url.list)
+
+    await addGroupBy(page, { fieldLabel: 'Category', fieldPath: 'category' })
+
+    await expect(page.locator('.table-wrap')).toHaveCount(3)
+
+    await expect(
+      page.locator('.group-by-header__heading', { hasText: exactText('No value') }),
+    ).toBeVisible()
+  })
+
   test('should sort the group-by field globally', async () => {
     await page.goto(url.list)
 


### PR DESCRIPTION
When grouping by a relationship field and it's value is `null`, the list view crashes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210916642997992