### PR TITLE
fix(next): incorrect doc link in trash view with groupBy enabled

### DIFF
--- a/packages/next/src/views/List/handleGroupBy.ts
+++ b/packages/next/src/views/List/handleGroupBy.ts
@@ -5,6 +5,7 @@ import type {
   PaginatedDocs,
   PayloadRequest,
   SanitizedCollectionConfig,
+  ViewTypes,
   Where,
 } from 'payload'
 
@@ -24,6 +25,7 @@ export const handleGroupBy = async ({
   req,
   trash = false,
   user,
+  viewType,
   where: whereWithMergedSearch,
 }: {
   clientConfig: ClientConfig
@@ -37,6 +39,7 @@ export const handleGroupBy = async ({
   req: PayloadRequest
   trash?: boolean
   user: any
+  viewType?: ViewTypes
   where: Where
 }): Promise<{
   columnState: Column[]
@@ -178,6 +181,7 @@ export const handleGroupBy = async ({
           payload: req.payload,
           query,
           useAsTitle: collectionConfig.admin.useAsTitle,
+          viewType,
         })
 
         // Only need to set `columnState` once, using the first table's column state

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -224,6 +224,7 @@ export const renderListView = async (
           req,
           trash,
           user,
+          viewType,
           where: whereWithMergedSearch,
         }))
       } else {


### PR DESCRIPTION
### What?

Fixes an issue where document links in the trash view were incorrectly generated when group-by was enabled for a collection. Previously, links in grouped tables would omit the `/trash` segment, causing navigation to crash while trying to route to the default edit view instead of the trashed document view.

### Why?

When viewing a collection in group-by mode, document rows are rendered in grouped tables via the `handleGroupBy` logic. However, these tables were unaware of whether the view was operating in trash mode, so the generated row links did not include the necessary `/trash` segment. This broke navigation when trying to view or edit trashed documents.

### How?

- Threaded the `viewType` prop through `renderListView` into the `handleGroupBy` utility.
- Passed `viewType` into each `renderTable` call within `handleGroupBy`, ensuring proper link generation.
- `renderTable` already supports `viewType` and appends `/trash` to edit links when it's set to 'trash'.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210932363334337