### PR TITLE
fix: querying `hasMany: true` select fields inside polymorphic joins

### DIFF
--- a/packages/db-sqlite/src/createJSONQuery/index.ts
+++ b/packages/db-sqlite/src/createJSONQuery/index.ts
@@ -67,7 +67,7 @@ const createConstraint = ({
   return `EXISTS (
   SELECT 1
   FROM json_each(${alias}.value -> '${pathSegments[0]}') AS ${newAlias}
-  WHERE COALESCE(${newAlias}.value${pathSegments.length > 1 ? ` ->> '${pathSegments[1]}'` : ''}, '') ${formattedOperator} '${formattedValue}'
+  WHERE COALESCE(${newAlias}.value ->> '${pathSegments[1]}', '') ${formattedOperator} '${formattedValue}'
   )`
 }
 

--- a/packages/db-sqlite/src/createJSONQuery/index.ts
+++ b/packages/db-sqlite/src/createJSONQuery/index.ts
@@ -60,29 +60,50 @@ const createConstraint = ({
     formattedOperator = '='
   }
 
+  if (pathSegments.length === 1) {
+    return `EXISTS (SELECT 1 FROM json_each("${pathSegments[0]}") AS ${newAlias} WHERE ${newAlias}.value ${formattedOperator} '${formattedValue}')`
+  }
+
   return `EXISTS (
   SELECT 1
   FROM json_each(${alias}.value -> '${pathSegments[0]}') AS ${newAlias}
-  WHERE COALESCE(${newAlias}.value ->> '${pathSegments[1]}', '') ${formattedOperator} '${formattedValue}'
+  WHERE COALESCE(${newAlias}.value${pathSegments.length > 1 ? ` ->> '${pathSegments[1]}'` : ''}, '') ${formattedOperator} '${formattedValue}'
   )`
 }
 
 export const createJSONQuery = ({
+  column,
   operator,
   pathSegments,
+  rawColumn,
   table,
   treatAsArray,
+  treatRootAsArray,
   value,
 }: CreateJSONQueryArgs): string => {
+  if ((operator === 'in' || operator === 'not_in') && Array.isArray(value)) {
+    let sql = ''
+    for (const [i, v] of value.entries()) {
+      sql = `${sql}${createJSONQuery({ column, operator: operator === 'in' ? 'equals' : 'not_equals', pathSegments, rawColumn, table, treatAsArray, treatRootAsArray, value: v })} ${i === value.length - 1 ? '' : ` ${operator === 'in' ? 'OR' : 'AND'} `}`
+    }
+    return sql
+  }
+
   if (treatAsArray?.includes(pathSegments[1]!) && table) {
     return fromArray({
       operator,
       pathSegments,
       table,
       treatAsArray,
-      value,
+      value: value as CreateConstraintArgs['value'],
     })
   }
 
-  return createConstraint({ alias: table, operator, pathSegments, treatAsArray, value })
+  return createConstraint({
+    alias: table,
+    operator,
+    pathSegments,
+    treatAsArray,
+    value: value as CreateConstraintArgs['value'],
+  })
 }

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -1,12 +1,14 @@
+import type { SQL } from 'drizzle-orm'
 import type { LibSQLDatabase } from 'drizzle-orm/libsql'
 import type { SQLiteSelect, SQLiteSelectBase } from 'drizzle-orm/sqlite-core'
 
-import { and, asc, count, desc, eq, or, sql } from 'drizzle-orm'
+import { and, asc, count, desc, eq, getTableName, or, sql } from 'drizzle-orm'
 import {
   appendVersionToQueryKey,
   buildVersionCollectionFields,
   combineQueries,
   type FlattenedField,
+  getFieldByPath,
   getQueryDraftsSort,
   type JoinQuery,
   type SelectMode,
@@ -31,7 +33,7 @@ import {
   resolveBlockTableName,
 } from '../utilities/validateExistingBlockIsIdentical.js'
 
-const flattenAllWherePaths = (where: Where, paths: string[]) => {
+const flattenAllWherePaths = (where: Where, paths: { path: string; ref: any }[]) => {
   for (const k in where) {
     if (['AND', 'OR'].includes(k.toUpperCase())) {
       if (Array.isArray(where[k])) {
@@ -41,7 +43,7 @@ const flattenAllWherePaths = (where: Where, paths: string[]) => {
       }
     } else {
       // TODO: explore how to support arrays/relationship querying.
-      paths.push(k.split('.').join('_'))
+      paths.push({ path: k.split('.').join('_'), ref: where })
     }
   }
 }
@@ -59,7 +61,11 @@ const buildSQLWhere = (where: Where, alias: string) => {
       }
     } else {
       const payloadOperator = Object.keys(where[k])[0]
+
       const value = where[k][payloadOperator]
+      if (payloadOperator === '$raw') {
+        return sql.raw(value)
+      }
 
       return operatorMap[payloadOperator](sql.raw(`"${alias}"."${k.split('.').join('_')}"`), value)
     }
@@ -472,7 +478,7 @@ export const traverseFields = ({
 
           const sortPath = sanitizedSort.split('.').join('_')
 
-          const wherePaths: string[] = []
+          const wherePaths: { path: string; ref: any }[] = []
 
           if (where) {
             flattenAllWherePaths(where, wherePaths)
@@ -492,9 +498,44 @@ export const traverseFields = ({
               sortPath: sql`${sortColumn ? sortColumn : null}`.as('sortPath'),
             }
 
+            const collectionQueryWhere: any[] = []
             // Select for WHERE and Fallback NULL
-            for (const path of wherePaths) {
-              if (adapter.tables[joinCollectionTableName][path]) {
+            for (const { path, ref } of wherePaths) {
+              const collectioConfig = adapter.payload.collections[collection].config
+              const field = getFieldByPath({ fields: collectioConfig.flattenedFields, path })
+
+              if (field && field.field.type === 'select' && field.field.hasMany) {
+                const tableName = adapter.tableNameMap.get(
+                  `${toSnakeCase(collection)}_${toSnakeCase(path)}`,
+                )
+
+                if (adapter.name === 'postgres') {
+                  selectFields[path] = sql
+                    .raw(
+                      `(select jsonb_agg(${tableName}.value) from ${tableName} where ${tableName}.parent_id = ${getTableName(table)}.id)`,
+                    )
+                    .as(path)
+                } else {
+                  selectFields[path] = sql
+                    .raw(
+                      `(select json_group_array(${tableName}.value) from ${tableName} where ${tableName}.parent_id = ${getTableName(table)}.id)`,
+                    )
+                    .as(path)
+                }
+
+                const constraint = ref[path]
+                const operator = Object.keys(constraint)[0]
+                const value: any = Object.values(constraint)[0]
+
+                const query = adapter.createJSONQuery({
+                  column: `"${path}"`,
+                  operator,
+                  pathSegments: [field.field.name],
+                  table: getTableName(table),
+                  value,
+                })
+                ref[path] = { $raw: query }
+              } else if (adapter.tables[joinCollectionTableName][path]) {
                 selectFields[path] = sql`${adapter.tables[joinCollectionTableName][path]}`.as(path)
                 // Allow to filter by collectionSlug
               } else if (path !== 'relationTo') {
@@ -502,7 +543,10 @@ export const traverseFields = ({
               }
             }
 
-            const query = db.select(selectFields).from(adapter.tables[joinCollectionTableName])
+            let query: any = db.select(selectFields).from(adapter.tables[joinCollectionTableName])
+            if (collectionQueryWhere.length) {
+              query = query.where(and(...collectionQueryWhere))
+            }
             if (currentQuery === null) {
               currentQuery = query as unknown as SQLSelect
             } else {

--- a/packages/drizzle/src/postgres/createJSONQuery/index.ts
+++ b/packages/drizzle/src/postgres/createJSONQuery/index.ts
@@ -28,6 +28,8 @@ export const createJSONQuery = ({ column, operator, pathSegments, value }: Creat
     })
     .join('.')
 
+  const fullPath = pathSegments.length === 1 ? '$[*]' : `$.${jsonPaths}`
+
   let sql = ''
 
   if (['in', 'not_in'].includes(operator) && Array.isArray(value)) {
@@ -35,13 +37,13 @@ export const createJSONQuery = ({ column, operator, pathSegments, value }: Creat
       sql = `${sql}${createJSONQuery({ column, operator: operator === 'in' ? 'equals' : 'not_equals', pathSegments, value: item })}${i === value.length - 1 ? '' : ` ${operator === 'in' ? 'OR' : 'AND'} `}`
     })
   } else if (operator === 'exists') {
-    sql = `${value === false ? 'NOT ' : ''}jsonb_path_exists(${columnName}, '$.${jsonPaths}')`
+    sql = `${value === false ? 'NOT ' : ''}jsonb_path_exists(${columnName}, '${fullPath}')`
   } else if (['not_like'].includes(operator)) {
     const mappedOperator = operatorMap[operator]
 
-    sql = `NOT jsonb_path_exists(${columnName}, '$.${jsonPaths} ? (@ ${mappedOperator.substring(1)} ${sanitizeValue(value, operator)})')`
+    sql = `NOT jsonb_path_exists(${columnName}, '${fullPath} ? (@ ${mappedOperator.substring(1)} ${sanitizeValue(value, operator)})')`
   } else {
-    sql = `jsonb_path_exists(${columnName}, '$.${jsonPaths} ? (@ ${operatorMap[operator]} ${sanitizeValue(value, operator)})')`
+    sql = `jsonb_path_exists(${columnName}, '${fullPath} ? (@ ${operatorMap[operator]} ${sanitizeValue(value, operator)})')`
   }
 
   return sql

--- a/packages/drizzle/src/types.ts
+++ b/packages/drizzle/src/types.ts
@@ -161,10 +161,11 @@ export type CreateJSONQueryArgs = {
   column?: Column | string
   operator: string
   pathSegments: string[]
+  rawColumn?: SQL<unknown>
   table?: string
   treatAsArray?: string[]
   treatRootAsArray?: boolean
-  value: boolean | number | string
+  value: boolean | number | number[] | string | string[]
 }
 
 /**


### PR DESCRIPTION
This PR fixes queries like this:

```ts
const findFolder = await payload.find({
  collection: 'payload-folders',
  where: {
    id: {
      equals: folderDoc.id,
    },
  },
  joins: {
    documentsAndFolders: {
      limit: 100_000,
      sort: 'name',
      where: {
        and: [
          {
            relationTo: {
              equals: 'payload-folders',
            },
          },
          {
            folderType: {
              in: ['folderPoly1'], // previously this didn't work
            },
          },
        ],
      },
    },
  },
})
```

Additionally, this PR potentially fixes querying JSON fields by the top level path, for example if your JSON field has a value like: `[1, 2]`, previously `where: { json: { equals: 1 } }` didn't work, however with a value like `{ nested: [1, 2] }` and a query `where: { 'json.nested': { equals: 1 } }`it did.