### PR TITLE
fix(ui): group/array error paths persisting when valid

### DIFF
--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -38,6 +38,7 @@ export const mergeServerFormState = ({
     newState[path] = {
       ...currentState[path],
       ...incomingField,
+      errorPaths: incomingField.errorPaths || [],
     }
 
     /**

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -38,7 +38,14 @@ export const mergeServerFormState = ({
     newState[path] = {
       ...currentState[path],
       ...incomingField,
-      errorPaths: incomingField.errorPaths || [],
+    }
+
+    if (
+      currentState[path] &&
+      'errorPaths' in currentState[path] &&
+      !('errorPaths' in incomingField)
+    ) {
+      newState[path].errorPaths = []
     }
 
     /**

--- a/test/field-error-states/shared.ts
+++ b/test/field-error-states/shared.ts
@@ -8,6 +8,7 @@ export const collectionSlugs: {
   validateDraftsOnAutosave: 'validate-drafts-on-autosave',
   prevValue: 'prev-value',
   prevValueRelation: 'prev-value-relation',
+  errorFields: 'error-fields',
 }
 
 export const globalSlugs: {

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -309,6 +309,7 @@ describe('Form State', () => {
   it('should merge array rows without losing rows added to local state', () => {
     const currentState: FormState = {
       array: {
+        errorPaths: [],
         rows: [
           {
             id: '1',
@@ -358,6 +359,7 @@ describe('Form State', () => {
     // Row 2 should still exist
     expect(newState).toStrictEqual({
       array: {
+        errorPaths: [],
         passesCondition: true,
         valid: true,
         rows: [


### PR DESCRIPTION
Fields such as groups and arrays would not always reset errorPaths when there were no more errors. The server and client state was not being merged safely and the client state was always persisting when the server sent back no errorPaths, i.e. itterable fields with fully valid children. This change ensures errorPaths is defaulted to an empty array if it is not present on the incoming field.

Likely a regression from https://github.com/payloadcms/payload/pull/9388.

Adds e2e test.