### PR TITLE
fix(db-postgres): localized array field fallback to an empty array locales without data

### DIFF
--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -171,6 +171,14 @@ export const traverseFields = <T extends Record<string, unknown>>({
 
             return arrayResult
           }, {})
+          // Fallback to [] locales without data
+          if (config.localization) {
+            for (const locale of config.localization.localeCodes) {
+              if (!result[field.name][locale]) {
+                result[field.name][locale] = []
+              }
+            }
+          }
         } else {
           result[field.name] = fieldData.reduce((acc, row, i) => {
             if (row._uuid) {


### PR DESCRIPTION
Fixes 
```
Localization › Localization with fallback true › Localized - Arrays › should use empty array as value
```