### PR TITLE
fix: deletedAt in TypeWithID not accepting null from generated types

### DIFF
--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -688,7 +688,7 @@ export type AuthCollection = {
 }
 
 export type TypeWithID = {
-  deletedAt?: string
+  deletedAt?: null | string
   docId?: any
   id: number | string
 }
@@ -696,7 +696,7 @@ export type TypeWithID = {
 export type TypeWithTimestamps = {
   [key: string]: unknown
   createdAt: string
-  deletedAt?: string
+  deletedAt?: null | string
   id: number | string
   updatedAt: string
 }


### PR DESCRIPTION
### What?

Updated `TypeWithID` so `deletedAt` can accept `null`.

### Why?

Generated collection types for trash use:

```
deletedAt?: string | null
```

`TypeWithID` previously only allowed `string | undefined`, so assigning documents with `deletedAt: null` caused TypeScript errors.

Aligning the types fixes this mismatch and ensures `TypeWithID` is compatible with the generated types.

### How?

Modified the `TypeWithID` definition to:

```
export type TypeWithID = {
  deletedAt?: string | null
  docId?: any
  id: number | string
}
```

This makes `deletedAt` effectively `string | null | undefined`, matching generated types and eliminating type errors.

Fixes #13341 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210980042931825