### PR TITLE
ci: update release-commenter permissions

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,6 +17,9 @@ env:
 
 jobs:
   post_release:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'workflow_dispatch' }}
     steps:


### PR DESCRIPTION
Permissions for release commenter needed to be explicit.

Docs from upstream: https://github.com/apexskier/github-release-commenter/pull/549