### PR TITLE
chore(templates): fix typo in e2e tests (headging -> heading)

### DIFF
--- a/templates/_template/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/_template/tests/e2e/frontend.e2e.spec.ts
@@ -13,8 +13,8 @@ test.describe('Frontend', () => {
 
     await expect(page).toHaveTitle(/Payload Blank Template/)
 
-    const headging = page.locator('h1').first()
+    const heading = page.locator('h1').first()
 
-    await expect(headging).toHaveText('Welcome to your new project.')
+    await expect(heading).toHaveText('Welcome to your new project.')
   })
 })

--- a/templates/blank/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/blank/tests/e2e/frontend.e2e.spec.ts
@@ -13,8 +13,8 @@ test.describe('Frontend', () => {
 
     await expect(page).toHaveTitle(/Payload Blank Template/)
 
-    const headging = page.locator('h1').first()
+    const heading = page.locator('h1').first()
 
-    await expect(headging).toHaveText('Welcome to your new project.')
+    await expect(heading).toHaveText('Welcome to your new project.')
   })
 })

--- a/templates/website/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/website/tests/e2e/frontend.e2e.spec.ts
@@ -13,8 +13,8 @@ test.describe('Frontend', () => {
 
     await expect(page).toHaveTitle(/Payload Website Template/)
 
-    const headging = page.locator('h1').first()
+    const heading = page.locator('h1').first()
 
-    await expect(headging).toHaveText('Payload Website Template')
+    await expect(heading).toHaveText('Payload Website Template')
   })
 })

--- a/templates/with-postgres/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/with-postgres/tests/e2e/frontend.e2e.spec.ts
@@ -13,8 +13,8 @@ test.describe('Frontend', () => {
 
     await expect(page).toHaveTitle(/Payload Blank Template/)
 
-    const headging = page.locator('h1').first()
+    const heading = page.locator('h1').first()
 
-    await expect(headging).toHaveText('Welcome to your new project.')
+    await expect(heading).toHaveText('Welcome to your new project.')
   })
 })

--- a/templates/with-vercel-mongodb/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/with-vercel-mongodb/tests/e2e/frontend.e2e.spec.ts
@@ -13,8 +13,8 @@ test.describe('Frontend', () => {
 
     await expect(page).toHaveTitle(/Payload Blank Template/)
 
-    const headging = page.locator('h1').first()
+    const heading = page.locator('h1').first()
 
-    await expect(headging).toHaveText('Welcome to your new project.')
+    await expect(heading).toHaveText('Welcome to your new project.')
   })
 })

--- a/templates/with-vercel-postgres/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/with-vercel-postgres/tests/e2e/frontend.e2e.spec.ts
@@ -13,8 +13,8 @@ test.describe('Frontend', () => {
 
     await expect(page).toHaveTitle(/Payload Blank Template/)
 
-    const headging = page.locator('h1').first()
+    const heading = page.locator('h1').first()
 
-    await expect(headging).toHaveText('Welcome to your new project.')
+    await expect(heading).toHaveText('Welcome to your new project.')
   })
 })

--- a/templates/with-vercel-website/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/with-vercel-website/tests/e2e/frontend.e2e.spec.ts
@@ -13,8 +13,8 @@ test.describe('Frontend', () => {
 
     await expect(page).toHaveTitle(/Payload Website Template/)
 
-    const headging = page.locator('h1').first()
+    const heading = page.locator('h1').first()
 
-    await expect(headging).toHaveText('Payload Website Template')
+    await expect(heading).toHaveText('Payload Website Template')
   })
 })


### PR DESCRIPTION
### What?

Small typo in templates e2e tests: `headging` 