### PR TITLE
docs: improved sentences in installation page to improve clarity. 

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -31,9 +31,9 @@ Then just follow the prompts! You'll get set up with a new folder and a function
 
 ## Adding to an existing app
 
-Adding Payload to an existing Next.js app is super straightforward. You can either run the `npx create-payload-app` command inside your Next.js project's folder, or manually install Payload by following the steps below.
+Adding Payload to an existing Next.js application is straightforward. You have two options: run the `npx create-payload-app` command inside your project folder, or manually install Payload using the steps below.
 
-If you don't have a Next.js app already, but you still want to start a project from a blank Next.js app, you can create a new Next.js app using `npx create-next-app` - and then just follow the steps below to install Payload.
+Don't have a Next.js app yet? Create one with `npx create-next-app`, then follow the manual installation steps below.
 
 <Banner type="info">
   **Note:** Next.js version 15 or higher is required for Payload.
@@ -41,7 +41,7 @@ If you don't have a Next.js app already, but you still want to start a project f
 
 #### 1. Install the relevant packages
 
-First, you'll want to add the required Payload packages to your project and can do so by running the command below:
+Firstly, add the required Payload packages to your project by running the command below:
 
 ```bash
 pnpm i payload @payloadcms/next @payloadcms/richtext-lexical sharp graphql
@@ -54,7 +54,7 @@ pnpm i payload @payloadcms/next @payloadcms/richtext-lexical sharp graphql
 
 Next, install a [Database Adapter](/docs/database/overview). Payload requires a Database Adapter to establish a database connection. Payload works with all types of databases, but the most common are MongoDB and Postgres.
 
-To install a Database Adapter, you can run **one** of the following commands:
+To install a Database Adapter, run **one** of the following commands:
 
 - To install the [MongoDB Adapter](../database/mongodb), run:
 


### PR DESCRIPTION

### What?
-  I improved sentences in the installation page for better clarity. 
-  Fixed sentences that read passively into active voices.
- Removed repetitive mention of "Next.js" in the **Adding to an existing app** section.

### Why?
- Active voices create direct, actionable guidance for readers. Also, it makes them feel confident in the outcome of the guide/tutorial, especially since the installation page is one of the first points of contact in the documentation.
- Simpler and clearer sentences allow readers to focus on key details without getting distracted by fluff.

