### PR TITLE
fix: job queue error when running tasks in parallel on sqlite

### DIFF
--- a/test/queues/getConfig.ts
+++ b/test/queues/getConfig.ts
@@ -19,6 +19,7 @@ import { UpdatePostStep2Task } from './tasks/UpdatePostStep2Task.js'
 import { UpdatePostTask } from './tasks/UpdatePostTask.js'
 import { externalWorkflow } from './workflows/externalWorkflow.js'
 import { failsImmediatelyWorkflow } from './workflows/failsImmediately.js'
+import { fastParallelTaskWorkflow } from './workflows/fastParallelTaskWokflow.js'
 import { inlineTaskTestWorkflow } from './workflows/inlineTaskTest.js'
 import { inlineTaskTestDelayedWorkflow } from './workflows/inlineTaskTestDelayed.js'
 import { longRunningWorkflow } from './workflows/longRunning.js'
@@ -164,6 +165,7 @@ export const getConfig: () => Partial<Config> = () => ({
       subTaskFailsWorkflow,
       longRunningWorkflow,
       parallelTaskWorkflow,
+      fastParallelTaskWorkflow,
     ],
   },
   editor: lexicalEditor(),

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -1424,6 +1424,8 @@ describe('Queues', () => {
       id: job.id,
     })
 
+    // error can be defined while hasError is true, as hasError: true is only set if the job cannot retry anymore.
+    expect(jobAfterRun.error).toBeNull()
     expect(jobAfterRun.hasError).toBe(false)
     expect(jobAfterRun.log?.length).toBe(amount)
 
@@ -1442,6 +1444,30 @@ describe('Queues', () => {
       expect(logEntry).toBeDefined()
       expect((logEntry?.output as any)?.simpleID).toBe(simpleDoc?.id)
     }
+  })
+
+  it('can reliably run workflows with parallel tasks that complete immediately', async () => {
+    const amount = 2
+    payload.config.jobs.deleteJobOnComplete = false
+
+    const job = await payload.jobs.queue({
+      workflow: 'fastParallelTask',
+      input: {
+        amount,
+      },
+    })
+
+    await payload.jobs.run({ silent: false })
+
+    const jobAfterRun = await payload.findByID({
+      collection: 'payload-jobs',
+      id: job.id,
+    })
+
+    // error can be defined while hasError is true, as hasError: true is only set if the job cannot retry anymore.
+    expect(jobAfterRun.error).toBeNull()
+    expect(jobAfterRun.hasError).toBe(false)
+    expect(jobAfterRun.log?.length).toBe(amount)
   })
 
   it('can create and autorun jobs', async () => {

--- a/test/queues/payload-types.ts
+++ b/test/queues/payload-types.ts
@@ -132,6 +132,7 @@ export interface Config {
       subTaskFails: WorkflowSubTaskFails;
       longRunning: WorkflowLongRunning;
       parallelTask: WorkflowParallelTask;
+      fastParallelTask: WorkflowFastParallelTask;
     };
   };
 }
@@ -332,6 +333,7 @@ export interface PayloadJob {
         | 'subTaskFails'
         | 'longRunning'
         | 'parallelTask'
+        | 'fastParallelTask'
       )
     | null;
   taskSlug?:
@@ -817,6 +819,15 @@ export interface WorkflowLongRunning {
  * via the `definition` "WorkflowParallelTask".
  */
 export interface WorkflowParallelTask {
+  input: {
+    amount: number;
+  };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "WorkflowFastParallelTask".
+ */
+export interface WorkflowFastParallelTask {
   input: {
     amount: number;
   };

--- a/test/queues/workflows/fastParallelTaskWokflow.ts
+++ b/test/queues/workflows/fastParallelTaskWokflow.ts
@@ -1,0 +1,34 @@
+import type { WorkflowConfig } from 'payload'
+
+export const fastParallelTaskWorkflow: WorkflowConfig<'fastParallelTask'> = {
+  slug: 'fastParallelTask',
+  inputSchema: [
+    {
+      name: 'amount',
+      type: 'number',
+      required: true,
+    },
+  ],
+  handler: async ({ job, inlineTask }) => {
+    const taskFunctions = []
+    for (let i = 0; i < job.input.amount; i++) {
+      const idx = i + 1
+      taskFunctions.push(async () => {
+        return await inlineTask(`fast parallel task ${idx}`, {
+          input: {
+            test: idx,
+          },
+          task: () => {
+            return {
+              output: {
+                taskID: idx.toString(),
+              },
+            }
+          },
+        })
+      })
+    }
+
+    await Promise.all(taskFunctions.map((f) => f()))
+  },
+}


### PR DESCRIPTION
Only happens on sqlite. Postgres works fine.

## What happens on postgres (2 parallel tasks)

```bash
Updating log!! [
  {
    id: '68959a7691271bba6fd3123b',
    completedAt: '2025-08-08T06:34:30.241Z',
    executedAt: '2025-08-08T06:34:30.241Z',
    input: { test: 1 },
    output: { taskID: '1' },
    parent: undefined,
    state: 'succeeded',
    taskID: 'fast parallel task 1',
    taskSlug: 'inline'
  }
]
Updating log!! [
  {
    id: '68959a7691271bba6fd3123b',
    completedAt: '2025-08-08T06:34:30.241Z',
    executedAt: '2025-08-08T06:34:30.241Z',
    input: { test: 1 },
    output: { taskID: '1' },
    parent: undefined,
    state: 'succeeded',
    taskID: 'fast parallel task 1',
    taskSlug: 'inline'
  },
  {
    id: '68959a7691271bba6fd3123c',
    completedAt: '2025-08-08T06:34:30.241Z',
    executedAt: '2025-08-08T06:34:30.241Z',
    input: { test: 2 },
    output: { taskID: '2' },
    parent: undefined,
    state: 'succeeded',
    taskID: 'fast parallel task 2',
    taskSlug: 'inline'
  }
]
Log updated
Log updated
SUCCESS
```
## What happens on sqlite (2 parallel tasks)

```bash
Updating log!! [
  {
    id: '68959a7691271bba6fd3123b',
    completedAt: '2025-08-08T06:34:30.241Z',
    executedAt: '2025-08-08T06:34:30.241Z',
    input: { test: 1 },
    output: { taskID: '1' },
    parent: undefined,
    state: 'succeeded',
    taskID: 'fast parallel task 1',
    taskSlug: 'inline'
  }
]
Updating log!! [
  {
    id: '68959a7691271bba6fd3123b',
    completedAt: '2025-08-08T06:34:30.241Z',
    executedAt: '2025-08-08T06:34:30.241Z',
    input: { test: 1 },
    output: { taskID: '1' },
    parent: undefined,
    state: 'succeeded',
    taskID: 'fast parallel task 1',
    taskSlug: 'inline'
  },
  {
    id: '68959a7691271bba6fd3123c',
    completedAt: '2025-08-08T06:34:30.241Z',
    executedAt: '2025-08-08T06:34:30.241Z',
    input: { test: 2 },
    output: { taskID: '2' },
    parent: undefined,
    state: 'succeeded',
    taskID: 'fast parallel task 2',
    taskSlug: 'inline'
  }
]
Caught error Error: UNIQUE constraint failed: payload_jobs_log.id
    at Object.next (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/libsql@0.4.7/node_modules/libsql/index.js:335:20)
    at Statement.all (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/libsql@0.4.7/node_modules/libsql/index.js:360:16)
    at executeStmt (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5/node_modules/@libsql/client/lib-cjs/sqlite3.js:285:34)
    at Sqlite3Client.execute (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5/node_modules/@libsql/client/lib-cjs/sqlite3.js:101:16)
    at /Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/drizzle-orm@0.44.2_@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5__@opentelemetr_asjmtflojkxlnxrshoh4fj5f6u/node_modules/src/libsql/session.ts:288:58
    at LibSQLPreparedQuery.queryWithCache (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/drizzle-orm@0.44.2_@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5__@opentelemetr_asjmtflojkxlnxrshoh4fj5f6u/node_modules/src/sqlite-core/session.ts:79:18)
    at LibSQLPreparedQuery.values (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/drizzle-orm@0.44.2_@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5__@opentelemetr_asjmtflojkxlnxrshoh4fj5f6u/node_modules/src/libsql/session.ts:286:21)
    at LibSQLPreparedQuery.all (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/drizzle-orm@0.44.2_@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5__@opentelemetr_asjmtflojkxlnxrshoh4fj5f6u/node_modules/src/libsql/session.ts:214:27)
    at QueryPromise.all (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/drizzle-orm@0.44.2_@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5__@opentelemetr_asjmtflojkxlnxrshoh4fj5f6u/node_modules/src/sqlite-core/query-builders/insert.ts:402:26)
    at QueryPromise.execute (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/drizzle-orm@0.44.2_@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5__@opentelemetr_asjmtflojkxlnxrshoh4fj5f6u/node_modules/src/sqlite-core/query-builders/insert.ts:414:40)
    at QueryPromise.then (/Users/alessio/Documents/GitHub/payload/node_modules/.pnpm/drizzle-orm@0.44.2_@libsql+client@0.14.0_bufferutil@4.0.8_utf-8-validate@6.0.5__@opentelemetr_asjmtflojkxlnxrshoh4fj5f6u/node_modules/src/query-promise.ts:31:15) {
  rawCode: 1555,
  code: 'SQLITE_CONSTRAINT_PRIMARYKEY',
  libsqlError: true
}
Log updated
FAIL
```

## TODO

- [x] Add test that reproduces the issue
- [ ] Fix the issue

## Possible Solutions (notes):

### Solution 1: Optimize db.updateJobs to atomically update the jobs log table (it's its own table, each log = 1 row which makes it easy) without nuking the entire table

Problem: won't be fool-proof for mongodb. What if the 2nd task finished before the 1st one? In that case, the final job log (same document in mongodb) will just contain 1 single item, as the following will have happened:

1. Job log update for task 2 goes through first (2 items)
2. Job log for task 1 goes through next (1 item)
3. Final result: 1 job log item is missing

The chance of this happening is not very likely, as I believe the second job log addition will mutate the job log object of the first task, so it could squeeze itself through. But in theory this race condition can be a problem.

Possible solution: add support for **atomic array updates** across all db adapter (`data: { array: { $push { ... } } }`)



### Solution 2: Disallow the use of Promise.all. Pass concurrency utility that manages this in a safe way to task and workflow handler args

Users will **have** to use this utility in any Promise.all where there **may** be a task execution nested anywhere within the code executed within

When using this concurrency utility, we can skip the job log update for each task, and do it one single time once all tasks have been completed.

=> this will actually be a performance boost. {amount of parallel tasks} db updates => 1 db update

Keep in mind: we need to explicitly handle scenarios where some tasks may fail. => stop promises execution if one single task fails. What do we do with remaining unfinished (but possibly started) tasks?

Fail them? Ignore them and just not add them to job log?

**Probably fail them, so the user has the chance to revert possible db mutations done in these tasks.**

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211001438499053