### PR TITLE
fix(ui): bulk upload issues

### DIFF
--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -127,7 +127,7 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
   const initialStateRef = React.useRef<FormState>(null)
   const getFormDataRef = React.useRef<() => Data>(() => ({}))
 
-  const actionURL = `${api}/${collectionSlug}`
+  const actionURL = `${serverURL}${api}/${collectionSlug}`
 
   const initializeSharedDocPermissions = React.useCallback(async () => {
     const params = {
@@ -301,6 +301,7 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
               collectionSlug,
               getUploadHandler({ collectionSlug }),
             ),
+            credentials: 'include',
             method: 'POST',
           })
 

--- a/packages/ui/src/elements/BulkUpload/FormsManager/reducer.ts
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/reducer.ts
@@ -1,5 +1,7 @@
 import type { FormState, UploadEdits } from 'payload'
 
+import { v4 as uuidv4 } from 'uuid'
+
 export type State = {
   activeIndex: number
   forms: {
@@ -50,7 +52,7 @@ export function formsManagementReducer(state: State, action: Action): State {
       for (let i = 0; i < action.files.length; i++) {
         newForms[i] = {
           errorCount: 0,
-          formID: crypto.randomUUID(),
+          formID: crypto.randomUUID ? crypto.randomUUID() : uuidv4(),
           formState: {
             ...(action.initialState || {}),
             file: {

--- a/packages/ui/src/elements/Table/OrderableTable.tsx
+++ b/packages/ui/src/elements/Table/OrderableTable.tsx
@@ -119,8 +119,9 @@ export const OrderableTable: React.FC<Props> = ({
         target,
       }
 
-      const response = await fetch(`${config.routes.api}/reorder`, {
+      const response = await fetch(`${config.serverURL}${config.routes.api}/reorder`, {
         body: JSON.stringify(jsonBody),
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
### What?
This PR contains a couple of fixes to the bulk upload process:
- Credentials not being passed when fetching, leading to auth issues
- Provide a fallback to crypto.randomUUID which is only available when using HTTPS or localhost

### Why?
I use [separate admin and API URLs](#12682) and work off a remote dev server using custom hostnames. These issues may not impact the happy path of using localhost, but are dealbreakers in this environment.

### Fixes #
_These are issues I found myself, I fixed them rather than raising issues for somebody else to pick up, but I can create issues to link to if required._
