### PR TITLE
fix: upload with no filename gives vague error

### DIFF
--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -34,6 +34,10 @@ const validate = (value) => {
     return 'A file is required.'
   }
 
+  if (value && (!value.name || value.name === '')) {
+    return 'A file name is required.'
+  }
+
   return true
 }
 
@@ -335,6 +339,14 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
     }
   }, [isFormSubmitting])
 
+  useEffect(() => {
+    console.log(filename.length)
+    if (!filename || filename.length === 0 || filename === '') {
+      const fileName = decodeURIComponent(fileUrl.split('/').pop() || '')
+      setFilename(fileName)
+    }
+  }, [filename])
+
   const canRemoveUpload =
     docPermissions?.update && 'delete' in docPermissions && docPermissions?.delete
 
@@ -499,6 +511,7 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
                 <input
                   className={`${baseClass}__filename`}
                   onChange={handleFileNameChange}
+                  required
                   title={filename || value.name}
                   type="text"
                   value={filename || value.name}

--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -339,14 +339,6 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
     }
   }, [isFormSubmitting])
 
-  useEffect(() => {
-    console.log(filename.length)
-    if (!filename || filename.length === 0 || filename === '') {
-      const fileName = decodeURIComponent(fileUrl.split('/').pop() || '')
-      setFilename(fileName)
-    }
-  }, [filename])
-
   const canRemoveUpload =
     docPermissions?.update && 'delete' in docPermissions && docPermissions?.delete
 
@@ -511,7 +503,6 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
                 <input
                   className={`${baseClass}__filename`}
                   onChange={handleFileNameChange}
-                  required
                   title={filename || value.name}
                   type="text"
                   value={filename || value.name}


### PR DESCRIPTION
### What?
Adds validation to the file upload field to ensure a filename is provided. If the filename is missing, a clear error message is shown to the user instead of a general error.

### Why?
Currently, attempting to upload a file without a filename results in a generic error message: `Something went wrong.` This makes it unclear for users to understand what the issue is.

### How?
The upload field validation has been updated to explicitly check for a missing filename. If the filename is undefined or null, the error message `A filename is required` is now shown.

Fixes #13410
