### PR TITLE
fix: version view breaks when tab field has function for label

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -329,7 +329,7 @@ const buildVersionField = ({
           versionFromSiblingData: 'name' in tab ? valueFrom?.[tab.name] : valueFrom,
           versionToSiblingData: 'name' in tab ? valueTo?.[tab.name] : valueTo,
         }).versionFields,
-        label: tab.label,
+        label: typeof tab.label === 'function' ? tab.label({ i18n, t: i18n.t }) : tab.label,
       }
       if (tabVersion?.fields?.length) {
         baseVersionField.tabs.push(tabVersion)


### PR DESCRIPTION
### What?

Fixes an issue where using a function as the `label` for a `tabs` field causes the versions UI to break.

### Why?

The versions UI was not properly resolving function labels on `tab` fields, leading to a crash when trying to render them.

### How?

Tweaked the logic so that if the label is a function, it gets called before rendering.

Fixes #13375