### PR TITLE
fix(drizzle): use correct syntax for type imports in migration template

### DIFF
--- a/packages/drizzle/src/utilities/getMigrationTemplate.ts
+++ b/packages/drizzle/src/utilities/getMigrationTemplate.ts
@@ -11,7 +11,7 @@ export const getMigrationTemplate = ({
   imports,
   packageName,
   upSQL,
-}: MigrationTemplateArgs): string => `import { MigrateUpArgs, MigrateDownArgs, sql } from '${packageName}'
+}: MigrationTemplateArgs): string => `import { type MigrateUpArgs, type MigrateDownArgs, sql } from '${packageName}'
 ${imports ? `${imports}\n` : ''}
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
 ${indent(upSQL)}


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

When creating migrations with `payload migrate:create` the resulting file will have the following import line:

```ts
// Wrong
import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
```

If in the TS config `verbatimModuleSyntax` is enabled, this will throw an error because the first two imports are a type and using the type-only import syntax.

This PR fixes the templates and changes the import line to:

```ts
// Correct
import { type MigrateUpArgs, type MigrateDownArgs, sql } from '@payloadcms/db-postgres'
```

I wanna fix this because after creating a migration I have to fix the created file before I can execute the migration, which is annoying.