### PR TITLE
fix(ui): misalignment of nested toggles on document API tab

### DIFF
--- a/packages/next/src/views/API/RenderJSON/index.scss
+++ b/packages/next/src/views/API/RenderJSON/index.scss
@@ -1,17 +1,17 @@
 @import '~@payloadcms/ui/scss';
 
-$tab-width: 16px;
+$tab-width: 24px;
 
 @layer payload-default {
   .query-inspector {
-    --tab-width: 16px;
+    --tab-width: 24px;
 
     &__json-children {
       position: relative;
 
       &--nested {
         & li {
-          // padding-left: var(--tab-width);
+          padding-left: 8px;
         }
       }
 
@@ -28,7 +28,7 @@ $tab-width: 16px;
     &__row-line {
       &--nested {
         .query-inspector__json-children {
-          padding-left: calc(var(--base) * 2);
+          padding-left: var(--tab-width);
         }
       }
     }
@@ -47,10 +47,16 @@ $tab-width: 16px;
       border-bottom-right-radius: 0;
       position: relative;
       display: flex;
+      column-gap: 14px;
       row-gap: 10px;
       align-items: center;
       left: 0;
       width: calc(100% + 3px);
+      background-color: var(--theme-elevation-50);
+
+      &:not(.query-inspector__list-toggle--empty) {
+        margin-left: calc(var(--tab-width) * -1 - 10px);
+      }
 
       svg .stroke {
         stroke: var(--theme-elevation-400);
@@ -67,9 +73,6 @@ $tab-width: 16px;
     }
 
     &__toggle-row-icon {
-      position: absolute;
-      margin-left: calc(var(--tab-width) * -1 - 8px);
-
       &--open {
         transform: rotate(0deg);
       }
@@ -105,9 +108,8 @@ $tab-width: 16px;
     &__results {
       & > .query-inspector__row-line--nested {
         & > .query-inspector__list-toggle {
-          .query-inspector__bracket--position-start {
-            padding-left: var(--tab-width);
-          }
+          margin-left: 0;
+          column-gap: 6px;
 
           .query-inspector__toggle-row-icon {
             margin-left: -4px;
@@ -116,6 +118,10 @@ $tab-width: 16px;
 
         & > .query-inspector__json-children {
           padding-left: calc(var(--base) * 1);
+        }
+
+        & > .query-inspector__bracket--nested > .query-inspector__bracket--position-end {
+          padding-left: 16px;
         }
       }
     }

--- a/packages/next/src/views/API/RenderJSON/index.scss
+++ b/packages/next/src/views/API/RenderJSON/index.scss
@@ -4,12 +4,14 @@ $tab-width: 16px;
 
 @layer payload-default {
   .query-inspector {
+    --tab-width: 16px;
+
     &__json-children {
       position: relative;
 
       &--nested {
         & li {
-          padding-left: $tab-width;
+          // padding-left: var(--tab-width);
         }
       }
 
@@ -20,6 +22,14 @@ $tab-width: 16px;
         width: 1px;
         height: 100%;
         border-left: 1px dashed var(--theme-elevation-200);
+      }
+    }
+
+    &__row-line {
+      &--nested {
+        .query-inspector__json-children {
+          padding-left: calc(var(--base) * 2);
+        }
       }
     }
 
@@ -37,9 +47,9 @@ $tab-width: 16px;
       border-bottom-right-radius: 0;
       position: relative;
       display: flex;
-      gap: 10px;
+      row-gap: 10px;
       align-items: center;
-      left: -3px;
+      left: 0;
       width: calc(100% + 3px);
 
       svg .stroke {
@@ -57,6 +67,9 @@ $tab-width: 16px;
     }
 
     &__toggle-row-icon {
+      position: absolute;
+      margin-left: calc(var(--tab-width) * -1 - 8px);
+
       &--open {
         transform: rotate(0deg);
       }
@@ -82,13 +95,28 @@ $tab-width: 16px;
     &__bracket {
       position: relative;
 
-      &--nested {
-        margin-left: $tab-width;
-      }
-
       &--position-end {
-        left: 1px;
+        left: 2px;
         width: calc(100% - 5px);
+      }
+    }
+
+    // Some specific rules targetting the very top of the nested JSON structure or very first items since they need slightly different styling
+    &__results {
+      & > .query-inspector__row-line--nested {
+        & > .query-inspector__list-toggle {
+          .query-inspector__bracket--position-start {
+            padding-left: var(--tab-width);
+          }
+
+          .query-inspector__toggle-row-icon {
+            margin-left: -4px;
+          }
+        }
+
+        & > .query-inspector__json-children {
+          padding-left: calc(var(--base) * 1);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes the weird misalignment of toggles in the API tab


Before:
<img width="799" height="1011" alt="image" src="https://github.com/user-attachments/assets/5fc9768c-24de-4d89-a1ba-6dd606f76bec" />


After:
<img width="815" height="1069" alt="image" src="https://github.com/user-attachments/assets/253dfdaa-7fca-4d16-b61e-a91474b9d6c9" />

