### PR TITLE
fix(templates): plugin template correct paths for exports

### DIFF
--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -6,9 +6,9 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./src/exports/index.ts",
-      "types": "./src/exports/index.ts",
-      "default": "./src/exports/index.ts"
+      "import": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./client": {
       "import": "./src/exports/client.ts",
@@ -21,8 +21,8 @@
       "default": "./src/exports/rsc.ts"
     }
   },
-  "main": "./src/exports/index.ts",
-  "types": "./src/exports/index.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "files": [
     "dist"
   ],
@@ -90,9 +90,9 @@
   "publishConfig": {
     "exports": {
       ".": {
-        "import": "./dist/exports/index.js",
-        "types": "./dist/exports/index.d.ts",
-        "default": "./dist/exports/index.js"
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       },
       "./client": {
         "import": "./dist/exports/client.js",
@@ -105,8 +105,8 @@
         "default": "./dist/exports/rsc.js"
       }
     },
-    "main": "./dist/exports/index.js",
-    "types": "./dist/exports/index.d.ts"
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
When using plugin template , initial package.json settings is wrong. They point to non-existing files in exports folder ( index.ts , index.js, index.d.ts ) , which results in broken package if published (can't import your plugin from package)

Fixes #13426
