### PR TITLE
fix(ui): replace deprecated `document.execCommand('copy')` API with `navigator`

### DIFF
--- a/packages/ui/src/elements/CopyToClipboard/index.scss
+++ b/packages/ui/src/elements/CopyToClipboard/index.scss
@@ -8,14 +8,6 @@
     vertical-align: middle;
     border-radius: 100%;
 
-    textarea {
-      position: absolute;
-      opacity: 0;
-      z-index: -1;
-      height: 0px;
-      width: 0px;
-    }
-
     &:focus,
     &:active {
       outline: none;

--- a/packages/ui/src/elements/CopyToClipboard/index.tsx
+++ b/packages/ui/src/elements/CopyToClipboard/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useRef, useState } from 'react'
+import React, { useState } from 'react'
 
 import { CopyIcon } from '../../icons/Copy/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
@@ -15,7 +15,6 @@ export type Props = {
 }
 
 export const CopyToClipboard: React.FC<Props> = ({ defaultMessage, successMessage, value }) => {
-  const ref = useRef(null)
   const [copied, setCopied] = useState(false)
   const [hovered, setHovered] = useState(false)
   const { t } = useTranslation()
@@ -24,13 +23,9 @@ export const CopyToClipboard: React.FC<Props> = ({ defaultMessage, successMessag
     return (
       <button
         className={baseClass}
-        onClick={() => {
-          if (ref && ref.current) {
-            ref.current.select()
-            ref.current.setSelectionRange(0, value.length + 1)
-            document.execCommand('copy')
-            setCopied(true)
-          }
+        onClick={async () => {
+          await navigator.clipboard.writeText(value)
+          setCopied(true)
         }}
         onMouseEnter={() => {
           setHovered(true)
@@ -47,7 +42,6 @@ export const CopyToClipboard: React.FC<Props> = ({ defaultMessage, successMessag
           {copied && (successMessage ?? t('general:copied'))}
           {!copied && (defaultMessage ?? t('general:copy'))}
         </Tooltip>
-        <textarea readOnly ref={ref} tabIndex={-1} value={value} />
       </button>
     )
   }

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -131,6 +131,7 @@ describe('Uploads', () => {
     svgOnlyURL = new AdminUrlUtil(serverURL, svgOnlySlug)
 
     const context = await browser.newContext()
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
     page = await context.newPage()
 
     const { consoleErrors, collectErrors, stopCollectingErrors } = initPageConsoleErrorCatch(page, {
@@ -212,6 +213,22 @@ describe('Uploads', () => {
     await page.locator('.doc-drawer__header-close').click()
 
     await expect(filename).toContainText('test-image.png')
+  })
+
+  test('should copy the file url field to the clipboard', async () => {
+    const mediaDoc = (
+      await payload.find({
+        collection: mediaSlug,
+        depth: 0,
+        limit: 1,
+        pagination: false,
+      })
+    ).docs[0]
+
+    await page.goto(mediaURL.edit(mediaDoc!.id))
+    await page.locator('.copy-to-clipboard').click()
+    const clipbaordContent = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipbaordContent).toBe(mediaDoc?.url)
   })
 
   test('should create file upload', async () => {

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -98,6 +98,7 @@ export interface Config {
     'externally-served-media': ExternallyServedMedia;
     'uploads-1': Uploads1;
     'uploads-2': Uploads2;
+    'any-images': AnyImage;
     'admin-thumbnail-function': AdminThumbnailFunction;
     'admin-thumbnail-with-search-queries': AdminThumbnailWithSearchQuery;
     'admin-thumbnail-size': AdminThumbnailSize;
@@ -157,6 +158,7 @@ export interface Config {
     'externally-served-media': ExternallyServedMediaSelect<false> | ExternallyServedMediaSelect<true>;
     'uploads-1': Uploads1Select<false> | Uploads1Select<true>;
     'uploads-2': Uploads2Select<false> | Uploads2Select<true>;
+    'any-images': AnyImagesSelect<false> | AnyImagesSelect<true>;
     'admin-thumbnail-function': AdminThumbnailFunctionSelect<false> | AdminThumbnailFunctionSelect<true>;
     'admin-thumbnail-with-search-queries': AdminThumbnailWithSearchQueriesSelect<false> | AdminThumbnailWithSearchQueriesSelect<true>;
     'admin-thumbnail-size': AdminThumbnailSizeSelect<false> | AdminThumbnailSizeSelect<true>;
@@ -1315,6 +1317,24 @@ export interface AdminThumbnailSize {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "any-images".
+ */
+export interface AnyImage {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "admin-thumbnail-function".
  */
 export interface AdminThumbnailFunction {
@@ -1777,6 +1797,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'uploads-2';
         value: string | Uploads2;
+      } | null)
+    | ({
+        relationTo: 'any-images';
+        value: string | AnyImage;
       } | null)
     | ({
         relationTo: 'admin-thumbnail-function';
@@ -3021,6 +3045,23 @@ export interface Uploads2Select<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "any-images_select".
+ */
+export interface AnyImagesSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "admin-thumbnail-function_select".
  */
 export interface AdminThumbnailFunctionSelect<T extends boolean = true> {
@@ -3450,6 +3491,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }


### PR DESCRIPTION
Replaces the deprecated API which might cause issues with the copy button.

Also adds an E2E test for the copy button