### PR TITLE
fix(ui): autosave form state discards local changes

### DIFF
--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -150,6 +150,9 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
 
           if (!skipSubmission && modifiedRef.current && url) {
             const result = await submit({
+              acceptValues: {
+                overrideLocalChanges: false,
+              },
               action: url,
               context: {
                 incrementVersionCount: false,
@@ -157,7 +160,6 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
               disableFormWhileProcessing: false,
               disableSuccessStatus: true,
               method,
-              overrideLocalChanges: false,
               overrides: {
                 _status: 'draft',
               },

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -157,6 +157,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
               disableFormWhileProcessing: false,
               disableSuccessStatus: true,
               method,
+              overrideLocalChanges: false,
               overrides: {
                 _status: 'draft',
               },

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -189,11 +189,12 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
     }
 
     case 'MERGE_SERVER_STATE': {
-      const { acceptValues, prevStateRef, serverState } = action
+      const { acceptValues, formStateAtTimeOfRequest, prevStateRef, serverState } = action
 
       const newState = mergeServerFormState({
         acceptValues,
         currentState: state || {},
+        formStateAtTimeOfRequest,
         incomingState: serverState,
       })
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -318,19 +318,17 @@ export const Form: React.FC<FormProps> = (props) => {
         overrides = overridesFromArgs
       }
 
-      const serializableFields = deepCopyObjectSimpleWithoutReactComponents(
-        contextRef.current.fields,
-      )
+      const formStateCopy = deepCopyObjectSimpleWithoutReactComponents(contextRef.current.fields)
 
       // If submit handler comes through via props, run that
       if (onSubmit) {
-        const data = reduceFieldsToValues(serializableFields, true)
+        const data = reduceFieldsToValues(formStateCopy, true)
 
         for (const [key, value] of Object.entries(overrides)) {
           data[key] = value
         }
 
-        onSubmit(serializableFields, data)
+        onSubmit(formStateCopy, data)
       }
 
       if (!hasFormSubmitAction) {
@@ -343,6 +341,7 @@ export const Form: React.FC<FormProps> = (props) => {
       }
 
       const formData = await contextRef.current.createFormData(overrides, {
+        formState: formStateCopy,
         mergeOverrideData: Boolean(typeof overridesFromArgs !== 'function'),
       })
 
@@ -386,7 +385,7 @@ export const Form: React.FC<FormProps> = (props) => {
               dispatchFields({
                 type: 'MERGE_SERVER_STATE',
                 acceptValues,
-                formStateAtTimeOfRequest: serializableFields,
+                formStateAtTimeOfRequest: formStateCopy,
                 prevStateRef: prevFormState,
                 serverState: newFormState,
               })
@@ -505,8 +504,8 @@ export const Form: React.FC<FormProps> = (props) => {
   )
 
   const createFormData = useCallback<CreateFormData>(
-    async (overrides, { mergeOverrideData = true }) => {
-      let data = reduceFieldsToValues(contextRef.current.fields, true)
+    async (overrides, { formState, mergeOverrideData = true }) => {
+      let data = reduceFieldsToValues(formState || contextRef.current.fields, true)
 
       let file = data?.file
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -208,6 +208,7 @@ export const Form: React.FC<FormProps> = (props) => {
         disableFormWhileProcessing = true,
         disableSuccessStatus: disableSuccessStatusFromArgs,
         method: methodToUse = method,
+        overrideLocalChanges,
         overrides: overridesFromArgs = {},
         skipValidation,
       } = options || ({} as SubmitOptions)
@@ -317,12 +318,12 @@ export const Form: React.FC<FormProps> = (props) => {
         overrides = overridesFromArgs
       }
 
+      const serializableFields = deepCopyObjectSimpleWithoutReactComponents(
+        contextRef.current.fields,
+      )
+
       // If submit handler comes through via props, run that
       if (onSubmit) {
-        const serializableFields = deepCopyObjectSimpleWithoutReactComponents(
-          contextRef.current.fields,
-        )
-
         const data = reduceFieldsToValues(serializableFields, true)
 
         for (const [key, value] of Object.entries(overrides)) {
@@ -384,7 +385,10 @@ export const Form: React.FC<FormProps> = (props) => {
             if (newFormState) {
               dispatchFields({
                 type: 'MERGE_SERVER_STATE',
-                acceptValues: true,
+                acceptValues: {
+                  overrideLocalChanges,
+                },
+                formStateAtTimeOfRequest: serializableFields,
                 prevStateRef: prevFormState,
                 serverState: newFormState,
               })

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -203,12 +203,12 @@ export const Form: React.FC<FormProps> = (props) => {
   const submit = useCallback<Submit>(
     async (options, e) => {
       const {
+        acceptValues = true,
         action: actionArg = action,
         context,
         disableFormWhileProcessing = true,
         disableSuccessStatus: disableSuccessStatusFromArgs,
         method: methodToUse = method,
-        overrideLocalChanges,
         overrides: overridesFromArgs = {},
         skipValidation,
       } = options || ({} as SubmitOptions)
@@ -385,9 +385,7 @@ export const Form: React.FC<FormProps> = (props) => {
             if (newFormState) {
               dispatchFields({
                 type: 'MERGE_SERVER_STATE',
-                acceptValues: {
-                  overrideLocalChanges,
-                },
+                acceptValues,
                 formStateAtTimeOfRequest: serializableFields,
                 prevStateRef: prevFormState,
                 serverState: newFormState,

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -54,7 +54,7 @@ export const mergeServerFormState = ({
      */
     if (
       !incomingField.addedByServer &&
-      (acceptValues === true ||
+      (!acceptValues ||
         // See `acceptValues` type definition for more details
         (typeof acceptValues === 'object' &&
           acceptValues !== null &&

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -116,7 +116,14 @@ export type CreateFormData = (
    * If mergeOverrideData true, the data will be merged with the existing data in the form state.
    * @default true
    */
-  options?: { mergeOverrideData?: boolean },
+  options?: {
+    /**
+     * If provided, will use this form state to create the FormData.
+     * Otherwise, will use the current form state on the form state ref.
+     */
+    formState?: FormState
+    mergeOverrideData?: boolean
+  },
 ) => FormData | Promise<FormData>
 
 export type GetFields = () => FormState

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -86,6 +86,11 @@ export type SubmitOptions = {
    */
   disableSuccessStatus?: boolean
   method?: string
+  /**
+   * If true, will override any local changes made to the form state.
+   * This is useful for autosave, for example, where hooks may have modified the fields value while you were still making changes.
+   */
+  overrideLocalChanges?: boolean
   overrides?: ((formState) => FormData) | Record<string, unknown>
   /**
    * When true, will skip validation before submitting the form.
@@ -175,7 +180,16 @@ export type ADD_ROW = {
 }
 
 export type MERGE_SERVER_STATE = {
-  acceptValues?: boolean
+  acceptValues?:
+    | {
+        /**
+         * If true, will accept all values, except for those that have changed locally since the request was made.
+         * This is useful for autosave, for example, where hooks may have modified the fields value while you were still making changes.
+         */
+        overrideLocalChanges?: boolean
+      }
+    | boolean
+  formStateAtTimeOfRequest?: FormState
   prevStateRef: React.RefObject<FormState>
   serverState: FormState
   type: 'MERGE_SERVER_STATE'

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -10,6 +10,8 @@ import type {
 import type React from 'react'
 import type { Dispatch } from 'react'
 
+import type { AcceptValues } from './mergeServerFormState.js'
+
 export type Preferences = {
   [key: string]: unknown
 }
@@ -69,6 +71,7 @@ export type FormProps = {
 )
 
 export type SubmitOptions = {
+  acceptValues?: AcceptValues
   action?: string
   /**
    * @experimental - Note: this property is experimental and may change in the future. Use as your own discretion.
@@ -86,11 +89,6 @@ export type SubmitOptions = {
    */
   disableSuccessStatus?: boolean
   method?: string
-  /**
-   * If true, will override any local changes made to the form state.
-   * This is useful for autosave, for example, where hooks may have modified the fields value while you were still making changes.
-   */
-  overrideLocalChanges?: boolean
   overrides?: ((formState) => FormData) | Record<string, unknown>
   /**
    * When true, will skip validation before submitting the form.
@@ -180,15 +178,7 @@ export type ADD_ROW = {
 }
 
 export type MERGE_SERVER_STATE = {
-  acceptValues?:
-    | {
-        /**
-         * If true, will accept all values, except for those that have changed locally since the request was made.
-         * This is useful for autosave, for example, where hooks may have modified the fields value while you were still making changes.
-         */
-        overrideLocalChanges?: boolean
-      }
-    | boolean
+  acceptValues?: AcceptValues
   formStateAtTimeOfRequest?: FormState
   prevStateRef: React.RefObject<FormState>
   serverState: FormState

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -118,10 +118,9 @@ export type CreateFormData = (
    */
   options?: {
     /**
-     * If provided, will use this form state to create the FormData.
-     * Otherwise, will use the current form state on the form state ref.
+     * If provided, will use this instead of of derived data from the current form state.
      */
-    formState?: FormState
+    data?: Data
     mergeOverrideData?: boolean
   },
 ) => FormData | Promise<FormData>

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -1,9 +1,6 @@
 import type {
-  ArrayField,
-  BlocksField,
   BuildFormStateArgs,
   ClientFieldSchemaMap,
-  CollapsedPreferences,
   Data,
   DocumentPreferences,
   Field,
@@ -153,6 +150,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
   } = args
 
   if (!args.clientFieldSchemaMap && args.renderFieldFn) {
+    // eslint-disable-next-line no-console
     console.warn(
       'clientFieldSchemaMap is not passed to addFieldStatePromise - this will reduce performance',
     )

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -566,7 +566,58 @@ describe('Form State', () => {
     expect(newState === currentState).toBe(true)
   })
 
-  it('should not accept values from the server if they have been modified locally since the request was made', () => {
+  it('should accept all values from the server regardless of local modifications, e.g. on submit', () => {
+    const currentState = {
+      title: {
+        value: 'Test Post (modified on the client)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+      computedTitle: {
+        value: 'Test Post (computed on the client)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+    }
+
+    const formStateAtTimeOfRequest = {
+      ...currentState,
+      title: {
+        value: 'Test Post (modified on the client 2)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+    }
+
+    const incomingStateFromServer = {
+      title: {
+        value: 'Test Post (modified on the server)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+      computedTitle: {
+        value: 'Test Post (computed on the server)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+    }
+
+    const newState = mergeServerFormState({
+      acceptValues: true,
+      currentState,
+      formStateAtTimeOfRequest,
+      incomingState: incomingStateFromServer,
+    })
+
+    expect(newState).toStrictEqual(incomingStateFromServer)
+  })
+
+  it('should not accept values from the server if they have been modified locally since the request was made, e.g. on autosave', () => {
     const currentState = {
       title: {
         value: 'Test Post (modified on the client 1)',

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -565,4 +565,58 @@ describe('Form State', () => {
 
     expect(newState === currentState).toBe(true)
   })
+
+  it('should not accept values from the server if they have been modified locally since the request was made', () => {
+    const currentState = {
+      title: {
+        value: 'Test Post (modified on the client 1)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+      computedTitle: {
+        value: 'Test Post',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+    }
+
+    const formStateAtTimeOfRequest = {
+      ...currentState,
+      title: {
+        value: 'Test Post (modified on the client 2)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+    }
+
+    const incomingStateFromServer = {
+      title: {
+        value: 'Test Post (modified on the server)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+      computedTitle: {
+        value: 'Test Post (modified on the server)',
+        initialValue: 'Test Post',
+        valid: true,
+        passesCondition: true,
+      },
+    }
+
+    const newState = mergeServerFormState({
+      acceptValues: { overrideLocalChanges: false },
+      currentState,
+      formStateAtTimeOfRequest,
+      incomingState: incomingStateFromServer,
+    })
+
+    expect(newState).toStrictEqual({
+      ...currentState,
+      computedTitle: incomingStateFromServer.computedTitle, // This field was not modified locally, so should be updated from the server
+    })
+  })
 })

--- a/test/versions/collections/Autosave.ts
+++ b/test/versions/collections/Autosave.ts
@@ -67,6 +67,16 @@ const AutosavePosts: CollectionConfig = {
       type: 'textarea',
       required: true,
     },
+    {
+      name: 'array',
+      type: 'array',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+      ],
+    },
   ],
 }
 

--- a/test/versions/collections/Autosave.ts
+++ b/test/versions/collections/Autosave.ts
@@ -16,7 +16,7 @@ const AutosavePosts: CollectionConfig = {
     maxPerDoc: 35,
     drafts: {
       autosave: {
-        interval: 2000,
+        interval: 100,
       },
       schedulePublish: true,
     },

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1286,12 +1286,31 @@ describe('Versions', () => {
       page.removeListener('dialog', acceptAlert)
     })
 
-    test('- with autosave - applies afterChange hooks to form state after autosave runs', async () => {
+    test('- with autosave - applies field hooks to form state after autosave runs', async () => {
       const url = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
       await page.goto(url.create)
       const titleField = page.locator('#field-title')
       await titleField.fill('Initial')
+
       await waitForAutoSaveToRunAndComplete(page)
+
+      const computedTitleField = page.locator('#field-computedTitle')
+      await expect(computedTitleField).toHaveValue('Initial')
+    })
+
+    test('- with autosave - does not override local changes to form state after autosave runs', async () => {
+      const url = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
+      await page.goto(url.create)
+      const titleField = page.locator('#field-title')
+
+      // press slower than the autosave interval, but not faster than the response and processing
+      await titleField.pressSequentially('Initial', {
+        delay: 150,
+      })
+
+      await waitForAutoSaveToRunAndComplete(page)
+
+      await expect(titleField).toHaveValue('Initial')
       const computedTitleField = page.locator('#field-computedTitle')
       await expect(computedTitleField).toHaveValue('Initial')
     })

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -199,6 +199,12 @@ export interface AutosavePost {
   title: string;
   computedTitle?: string | null;
   description: string;
+  array?:
+    | {
+        text?: string | null;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -788,6 +794,12 @@ export interface AutosavePostsSelect<T extends boolean = true> {
   title?: T;
   computedTitle?: T;
   description?: T;
+  array?:
+    | T
+    | {
+        text?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   _status?: T;


### PR DESCRIPTION
Follow-up to #13416. Supersedes #13434.

When autosave is triggered and the user continues to modify fields, their changes are overridden by the server's value, i.e. the value at the time the form state request was made. This makes it almost impossible to edit fields when using a small autosave interval and/or a slow network.

This is because autosave is now merged into form state, which by default uses `acceptValues: true`. This does exactly what it sounds like, accepts all the values from the server—which may be stale if client-side changes have been made. We ignore these values for onChange events, because the user is actively making changes. But during form submissions, we can accept them because the form is disabled while processing anyway.

This pattern allows us to render "computed values" from the server, i.e. a field with an `beforeChange` hook that modifies its value.

Autosave, on the other hand, happens in the background _while the form is still active_. This means changes may have been made since sending the request. We still need to accept computed values from the server, but we need to avoid doing this if the user has active changes since the time of the request.

Update: this approach was improved in https://github.com/payloadcms/payload/pull/13460.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211027929253429