### PR TITLE
fix(ui): local image src changing when title changes

### DIFF
--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -181,19 +181,19 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
     typeof uploadConfig?.pasteURL === 'object' && uploadConfig.pasteURL.allowList?.length > 0
 
   const handleFileChange = useCallback(
-    (newFile: File) => {
-      if (newFile instanceof File) {
-        setFileSrc(URL.createObjectURL(newFile))
+    ({ file, isNewFile = true }: { file: File | null; isNewFile?: boolean }) => {
+      if (isNewFile && file instanceof File) {
+        setFileSrc(URL.createObjectURL(file))
       }
 
-      setValue(newFile)
+      setValue(file)
       setShowUrlInput(false)
       setUploadControlFileUrl('')
       setUploadControlFileName(null)
       setUploadControlFile(null)
 
       if (typeof onChange === 'function') {
-        onChange(newFile)
+        onChange(file)
       }
     },
     [onChange, setValue, setUploadControlFile, setUploadControlFileName, setUploadControlFileUrl],
@@ -213,7 +213,7 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
       const updatedFileName = e.target.value
 
       if (value) {
-        handleFileChange(renameFile(value, updatedFileName))
+        handleFileChange({ file: renameFile(value, updatedFileName), isNewFile: false })
         setFilename(updatedFileName)
       }
     },
@@ -223,14 +223,14 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
   const handleFileSelection = useCallback(
     (files: FileList) => {
       const fileToUpload = files?.[0]
-      handleFileChange(fileToUpload)
+      handleFileChange({ file: fileToUpload })
     },
     [handleFileChange],
   )
 
   const handleFileRemoval = useCallback(() => {
     setRemovedFile(true)
-    handleFileChange(null)
+    handleFileChange({ file: null })
     setFileSrc('')
     setFileUrl('')
     resetUploadEdits()
@@ -272,7 +272,7 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
       const fileName = uploadControlFileName || decodeURIComponent(fileUrl.split('/').pop() || '')
       const file = new File([blob], fileName, { type: blob.type })
 
-      handleFileChange(file)
+      handleFileChange({ file })
       setUploadStatus('idle')
       return // Exit if client-side fetch succeeds
     } catch (_clientError) {
@@ -297,7 +297,7 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
       const fileName = decodeURIComponent(fileUrl.split('/').pop() || '')
       const file = new File([blob], fileName, { type: blob.type })
 
-      handleFileChange(file)
+      handleFileChange({ file })
       setUploadStatus('idle')
     } catch (_serverError) {
       toast.error('The provided URL is not allowed.')
@@ -365,7 +365,7 @@ export const Upload_v4: React.FC<UploadProps_v4> = (props) => {
   useEffect(() => {
     const handleControlFile = () => {
       if (uploadControlFile) {
-        handleFileChange(uploadControlFile)
+        handleFileChange({ file: uploadControlFile })
       }
     }
 


### PR DESCRIPTION
When changing the title of a newly uploaded image, the image would flicker because the `createObjectURL` was running and creating a new local file url. This change allows `handleFileChange` to run and not affect the url if the file being added is not a new file.

### Before

https://github.com/user-attachments/assets/9e21101e-c4cc-4fc3-b510-18f1a0d9fb3a



### After

https://github.com/user-attachments/assets/9f310e10-d29c-49a9-bd28-cb6da6c5651a

