### PR TITLE
docs: updates image paths to new screenshots

### DIFF
--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -33,7 +33,7 @@ export const Users: CollectionConfig = {
 }
 ```
 
-![Authentication Admin Panel functionality](https://payloadcms.com/images/docs/auth-admin.jpg)
+![Authentication Admin Panel functionality](https://payloadcms.com/images/docs/auth-overview.jpg)
 _Admin Panel screenshot depicting an Admins Collection with Auth enabled_
 
 ## Config Options

--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -13,8 +13,8 @@ keywords: uploads, images, media, overview, documentation, Content Management Sy
 </Banner>
 
 <LightDarkImage
-  srcLight="https://payloadcms.com/images/docs/upload-admin.jpg"
-  srcDark="https://payloadcms.com/images/docs/upload-admin.jpg"
+  srcLight="https://payloadcms.com/images/docs/uploads-overview.jpg"
+  srcDark="https://payloadcms.com/images/docs/uploads-overview.jpg"
   alt="Shows an Upload enabled collection in the Payload Admin Panel"
   caption="Admin Panel screenshot depicting a Media Collection with Upload enabled"
 />

--- a/docs/versions/autosave.mdx
+++ b/docs/versions/autosave.mdx
@@ -12,7 +12,7 @@ Extending on Payload's [Draft](/docs/versions/drafts) functionality, you can con
   Autosave relies on Versions and Drafts being enabled in order to function.
 </Banner>
 
-![Autosave Enabled](/images/docs/autosave-enabled.png)
+![Autosave Enabled](/images/docs/autosave-v3.jpg)
 _If Autosave is enabled, drafts will be created automatically as the document is modified and the Admin UI adds an indicator describing when the document was last saved to the top right of the sidebar._
 
 ## Options

--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -14,7 +14,7 @@ Payload's Draft functionality builds on top of the Versions functionality to all
 
 By enabling Versions with Drafts, your collections and globals can maintain _newer_, and _unpublished_ versions of your documents. It's perfect for cases where you might want to work on a document, update it and save your progress, but not necessarily make it publicly published right away. Drafts are extremely helpful when building preview implementations.
 
-![Drafts Enabled](/images/docs/drafts-enabled.png)
+![Drafts Enabled](/images/docs/autosave-drafts.jpg)
 _If Drafts are enabled, the typical Save button is replaced with new actions which allow you to either save a draft, or publish your changes._
 
 ## Options

--- a/docs/versions/overview.mdx
+++ b/docs/versions/overview.mdx
@@ -13,7 +13,7 @@ keywords: version history, revisions, audit log, draft, publish, restore, autosa
 
 When enabled, Payload will automatically scaffold a new Collection in your database to store versions of your document(s) over time, and the Admin UI will be extended with additional views that allow you to browse document versions, view diffs in order to see exactly what has changed in your documents (and when they changed), and restore documents back to prior versions easily.
 
-![Versions](/images/docs/versions.png)
+![Versions](/images/docs/versions-v3.jpg)
 _Comparing an old version to a newer version of a document_
 
 **With Versions, you can:**


### PR DESCRIPTION
Updates images paths for the following screenshots:

- auth-overview.jpg
- autosave-drafts.jpg
- autosave-v3.jpg
- uploads-overview.jpg
- versions-v3.jpg