### PR TITLE
docs(db-mongodb): document Local API default limit & unlimited usage (closes #13417)

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -161,6 +161,31 @@ const result = await payload.find({
   showHiddenFields: true,
 })
 ```
+### Pagination & limits
+
+By default, Local API `find` uses the collection’s pagination settings. If no `limit` is provided, the per-page default comes from your Collection’s `pagination.defaultLimit` (defaults to **10**). See [Collection Config → pagination](../configuration/collections).
+
+To return **all** matched documents (disable pagination), either:
+
+- pass `limit: 0` (disables pagination), or
+- set `pagination: false`.
+
+```ts
+// Use the collection default (pagination.defaultLimit, defaults to 10)
+const page = await payload.find({
+  collection: 'posts',
+})
+
+// Return all matched documents (no pagination)
+const all = await payload.find({
+  collection: 'posts',
+  limit: 0,           // disables pagination
+  // or: pagination: false
+})
+
+```
+> See also: [Pagination](/docs/queries/pagination) and [Querying your Documents](/docs/queries/overview).
+
 
 ### Find by ID#collection-find-by-id
 


### PR DESCRIPTION
Closes #13417

### What?
- Add a “Pagination & limits” note to the Local API docs.
- Clarify that when no `limit` is provided, the per-page default comes from the Collection’s `pagination.defaultLimit` (defaults to 10).
- Show two ways to return all matched documents: `limit: 0` (disables pagination) or `pagination: false`.
- Add links to the Pagination and Collection Config docs.

### Why?
- Readers of the Local API page couldn’t easily discover the default limit or how to request an unlimited/all-docs query.

### How?
- Edited **`docs/local-api/overview.mdx`** only.
- Inserted the new “Pagination & limits” section immediately after the **Find** example.
- Docs-only change; no runtime code touched.

