### PR TITLE
fix(storage-s3): validate Content-Length before appending header

### DIFF
--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -100,7 +100,14 @@ export const getHandler = ({
 
       let headers = new Headers(incomingHeaders)
 
-      headers.append('Content-Length', String(object.ContentLength))
+      // Only include Content-Length when it’s present and strictly numeric.
+      // This prevents "Parse Error: Invalid character in Content-Length" when providers (e.g., MinIO)
+      // return undefined or a non-numeric value.
+      const contentLength = String(object.ContentLength);
+      if (contentLength && !isNaN(Number(contentLength))) {
+        headers.append('Content-Length', contentLength);
+      }
+
       headers.append('Content-Type', String(object.ContentType))
       headers.append('Accept-Ranges', String(object.AcceptRanges))
       headers.append('ETag', String(object.ETag))


### PR DESCRIPTION
## Description
Fixes "Parse Error: Invalid character in Content-Length" errors that occur when S3-compatible storage providers (like MinIO) return undefined or invalid ContentLength values.

## Changes
- Added validation before appending Content-Length header in `staticHandler.ts`
- Only appends Content-Length when value is present and numeric
- Prevents HTTP specification violations from undefined/invalid values

## Code Changes
```typescript
const contentLength = String(object.ContentLength);
if (contentLength && !isNaN(Number(contentLength))) {
  headers.append('Content-Length', contentLength);
}
```

## Issue
- Resolves MinIO compatibility issues where undefined ContentLength causes client parse errors
- Maintains backward compatibility when ContentLength is valid

## Testing
- [x] Tested with MinIO provider returning undefined ContentLength
- [x] Verified valid Content-Length values are still properly set
- [x] Confirmed no regression in existing S3 functionality

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
```
