### PR TITLE
fix: filter `payload-` cookies in `getExternalFile` only if the URL is external

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -13,22 +13,28 @@ type Args = {
 export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promise<File> => {
   const { filename, url } = data
 
+  let trimAuthCookies = true
   if (typeof url === 'string') {
     let fileURL = url
     if (!url.startsWith('http')) {
+      // URL points to the same server - we can send any cookies safely to our server.
+      trimAuthCookies = false
       const baseUrl = req.headers.get('origin') || `${req.protocol}://${req.headers.get('host')}`
       fileURL = `${baseUrl}${url}`
+    }
+
+    let cookies = (req.headers.get('cookie') ?? '').split(';')
+
+    if (trimAuthCookies) {
+      cookies = cookies.filter(
+        (cookie) => !cookie.trim().startsWith(req.payload.config.cookiePrefix),
+      )
     }
 
     const headers = uploadConfig.externalFileHeaderFilter
       ? uploadConfig.externalFileHeaderFilter(Object.fromEntries(new Headers(req.headers)))
       : {
-          cookie:
-            req.headers
-              .get('cookie')
-              ?.split(';')
-              .filter((cookie) => !cookie.trim().startsWith(req.payload.config.cookiePrefix))
-              .join(';') || '',
+          cookie: cookies.join(';'),
         }
 
     // Check if URL is allowed because of skipSafeFetch allowList


### PR DESCRIPTION
Fixes a regression from https://github.com/payloadcms/payload/pull/13215. Fixes the issue when `skipSafeFetch: true` is set https://github.com/payloadcms/payload/issues/13146#issuecomment-3066858749

This PR makes it so we still send the cookies if we do `fetch` to our server, but filter them when we `fetch` to an external server (usually a third party storage, for which we don't want to expose those cookies)