### PR TITLE
fix(ui): bulk upload action bar buttons wrapping

### DIFF
--- a/packages/ui/src/elements/BulkUpload/ActionsBar/index.scss
+++ b/packages/ui/src/elements/BulkUpload/ActionsBar/index.scss
@@ -47,6 +47,7 @@
       display: flex;
       gap: var(--base);
       margin-left: auto;
+      white-space: nowrap;
     }
 
     @include mid-break {


### PR DESCRIPTION
### What?

Added `white-space: nowrap` to the `.bulk-upload--actions-bar__buttons` class to ensure button labels remain on a single line.

### Why?

In the bulk upload action bar, buttons containing multi-word labels were wrapping to two lines, causing them to expand vertically and misalign with other controls.

### How?

Applied `white-space: nowrap` to `.bulk-upload--actions-bar__buttons` so all button labels stay on one line, maintaining consistent height and alignment.

#### Before
<img width="1469" height="525" alt="Screenshot 2025-08-15 at 9 20 07 AM" src="https://github.com/user-attachments/assets/aecc65ae-7b2f-43ba-96c8-1143fcee7f88" />

#### After
<img width="1474" height="513" alt="Screenshot 2025-08-15 at 9 19 55 AM" src="https://github.com/user-attachments/assets/438c6ee1-b966-4966-8686-37ba4619a25c" />