### PR TITLE
fix: omit trashed documents from appearing in folder results

### DIFF
--- a/packages/payload/src/folders/utils/buildFolderWhereConstraints.ts
+++ b/packages/payload/src/folders/utils/buildFolderWhereConstraints.ts
@@ -51,6 +51,15 @@ export async function buildFolderWhereConstraints({
         equals: collectionConfig.slug,
       },
     })
+
+    // join queries need to omit trashed documents
+    if (collectionConfig.trash) {
+      constraints.push({
+        deletedAt: {
+          exists: false,
+        },
+      })
+    }
   }
 
   const filteredConstraints = constraints.filter(Boolean)

--- a/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
+++ b/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
@@ -43,7 +43,33 @@ export async function queryDocumentsAndFoldersFromJoin({
       documentsAndFolders: {
         limit: 100_000_000,
         sort: 'name',
-        where: combineWhereConstraints([folderWhere, documentWhere], 'or'),
+        where: combineWhereConstraints(
+          [
+            combineWhereConstraints(
+              [
+                folderWhere,
+                {
+                  deletedAt: {
+                    exists: false,
+                  },
+                },
+              ],
+              'and',
+            ),
+            combineWhereConstraints(
+              [
+                documentWhere,
+                {
+                  deletedAt: {
+                    exists: false,
+                  },
+                },
+              ],
+              'and',
+            ),
+          ],
+          'or',
+        ),
       },
     },
     limit: 1,

--- a/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
+++ b/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
@@ -45,30 +45,14 @@ export async function queryDocumentsAndFoldersFromJoin({
         sort: 'name',
         where: combineWhereConstraints(
           [
-            combineWhereConstraints(
-              [
-                folderWhere,
-                {
-                  deletedAt: {
-                    exists: false,
-                  },
-                },
-              ],
-              'and',
-            ),
-            combineWhereConstraints(
-              [
-                documentWhere,
-                {
-                  deletedAt: {
-                    exists: false,
-                  },
-                },
-              ],
-              'and',
-            ),
+            combineWhereConstraints([folderWhere, documentWhere], 'or'),
+            {
+              deletedAt: {
+                exists: false,
+              },
+            },
           ],
-          'or',
+          'and',
         ),
       },
     },

--- a/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
+++ b/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
@@ -43,17 +43,7 @@ export async function queryDocumentsAndFoldersFromJoin({
       documentsAndFolders: {
         limit: 100_000_000,
         sort: 'name',
-        where: combineWhereConstraints(
-          [
-            combineWhereConstraints([folderWhere, documentWhere], 'or'),
-            {
-              deletedAt: {
-                exists: false,
-              },
-            },
-          ],
-          'and',
-        ),
+        where: combineWhereConstraints([folderWhere, documentWhere], 'or'),
       },
     },
     limit: 1,


### PR DESCRIPTION
### Issue

The folders join field query was returning trashed documents. 

### Fix
Adds a constraint to trash enabled collections, which prevents trashed documents from being surfaced in folder views.