### PR TITLE
fix(ui): nested fields with admin.disableListColumn still appear as columns in list view

### DIFF
--- a/packages/ui/src/providers/TableColumns/buildColumnState/filterFields.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/filterFields.tsx
@@ -3,35 +3,48 @@ import type { ClientField, Field } from 'payload'
 import { fieldIsHiddenOrDisabled, fieldIsID } from 'payload/shared'
 
 /**
- * Filters fields that are hidden, disabled, or have `disableListColumn` set to `true`
- * Does so recursively for `tabs` fields.
+ * Filters fields that are hidden, disabled, or have `disableListColumn` set to `true`.
+ * Recurses through `tabs` and any container with `.fields` (e.g., `row`, `group`, `collapsible`).
  */
 export const filterFields = <T extends ClientField | Field>(incomingFields: T[]): T[] => {
   const shouldSkipField = (field: T): boolean =>
     (field.type !== 'ui' && fieldIsHiddenOrDisabled(field) && !fieldIsID(field)) ||
     field?.admin?.disableListColumn === true
 
-  const fields: T[] = incomingFields?.reduce((acc, field) => {
-    if (shouldSkipField(field)) {
+  const recurse = (fields: T[] | undefined): T[] =>
+    (fields ?? []).reduce<T[]>((acc, field) => {
+      if (shouldSkipField(field)) {
+        return acc
+      }
+
+      // handle tabs
+      if (field.type === 'tabs' && 'tabs' in field) {
+        const formattedField: T = {
+          ...field,
+          tabs: field.tabs.map((tab) => ({
+            ...tab,
+            fields: recurse(tab.fields as T[]),
+          })),
+        }
+        acc.push(formattedField)
+        return acc
+      }
+
+      // handle fields with sub fields (row, group, collapsible, etc.)
+      if ('fields' in field && Array.isArray(field.fields)) {
+        const formattedField: T = {
+          ...field,
+          fields: recurse(field.fields as T[]),
+        }
+        acc.push(formattedField)
+        return acc
+      }
+
+      // leaf
+      acc.push(field)
       return acc
-    }
+    }, [])
 
-    // extract top-level `tabs` fields and filter out the same
-    const formattedField: T =
-      field.type === 'tabs' && 'tabs' in field
-        ? {
-            ...field,
-            tabs: field.tabs.map((tab) => ({
-              ...tab,
-              fields: tab.fields.filter((tabField) => !shouldSkipField(tabField)),
-            })),
-          }
-        : field
-
-    acc.push(formattedField)
-
-    return acc
-  }, [])
-
+  const fields: T[] = recurse(incomingFields)
   return fields
 }

--- a/packages/ui/src/providers/TableColumns/buildColumnState/filterFields.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/filterFields.tsx
@@ -11,40 +11,36 @@ export const filterFields = <T extends ClientField | Field>(incomingFields: T[])
     (field.type !== 'ui' && fieldIsHiddenOrDisabled(field) && !fieldIsID(field)) ||
     field?.admin?.disableListColumn === true
 
-  const recurse = (fields: T[] | undefined): T[] =>
-    (fields ?? []).reduce<T[]>((acc, field) => {
-      if (shouldSkipField(field)) {
-        return acc
-      }
-
-      // handle tabs
-      if (field.type === 'tabs' && 'tabs' in field) {
-        const formattedField: T = {
-          ...field,
-          tabs: field.tabs.map((tab) => ({
-            ...tab,
-            fields: recurse(tab.fields as T[]),
-          })),
-        }
-        acc.push(formattedField)
-        return acc
-      }
-
-      // handle fields with sub fields (row, group, collapsible, etc.)
-      if ('fields' in field && Array.isArray(field.fields)) {
-        const formattedField: T = {
-          ...field,
-          fields: recurse(field.fields as T[]),
-        }
-        acc.push(formattedField)
-        return acc
-      }
-
-      // leaf
-      acc.push(field)
+  return (incomingFields ?? []).reduce<T[]>((acc, field) => {
+    if (shouldSkipField(field)) {
       return acc
-    }, [])
+    }
 
-  const fields: T[] = recurse(incomingFields)
-  return fields
+    // handle tabs
+    if (field.type === 'tabs' && 'tabs' in field) {
+      const formattedField: T = {
+        ...field,
+        tabs: field.tabs.map((tab) => ({
+          ...tab,
+          fields: filterFields(tab.fields as T[]),
+        })),
+      }
+      acc.push(formattedField)
+      return acc
+    }
+
+    // handle fields with subfields (row, group, collapsible, etc.)
+    if ('fields' in field && Array.isArray(field.fields)) {
+      const formattedField: T = {
+        ...field,
+        fields: filterFields(field.fields as T[]),
+      }
+      acc.push(formattedField)
+      return acc
+    }
+
+    // leaf
+    acc.push(field)
+    return acc
+  }, [])
 }

--- a/test/admin/collections/Posts.ts
+++ b/test/admin/collections/Posts.ts
@@ -8,7 +8,15 @@ import { postsCollectionSlug, uploadCollectionSlug } from '../slugs.js'
 export const Posts: CollectionConfig = {
   slug: postsCollectionSlug,
   admin: {
-    defaultColumns: ['id', 'number', 'title', 'description', 'demoUIField'],
+    defaultColumns: [
+      'id',
+      'number',
+      'title',
+      'description',
+      'demoUIField',
+      'disableListColumnTextInRow',
+      'someGroup.disableListColumnTextInGroup',
+    ],
     description: 'This is a custom collection description.',
     group: 'One',
     listSearchableFields: ['id', 'title', 'description', 'number'],
@@ -299,6 +307,31 @@ export const Posts: CollectionConfig = {
       access: {
         read: () => false,
       },
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'disableListColumnTextInRow',
+          type: 'text',
+          admin: {
+            disableListColumn: true,
+          },
+        },
+      ],
+    },
+    {
+      name: 'someGroup',
+      type: 'group',
+      fields: [
+        {
+          name: 'disableListColumnTextInGroup',
+          type: 'text',
+          admin: {
+            disableListColumn: true,
+          },
+        },
+      ],
     },
   ],
   labels: {

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -915,6 +915,18 @@ describe('List View', () => {
       ).toBeVisible()
     })
 
+    test('should hide nested field in row in list table columns when admin.disableListColumn is true', async () => {
+      await page.goto(postsUrl.list)
+      await expect(page.locator('.table #heading-disableListColumnTextInRow')).toBeHidden()
+    })
+
+    test('should hide nested field in group in list table column when admin.disableListColumn is true', async () => {
+      await page.goto(postsUrl.list)
+      await expect(
+        page.locator('.table #heading-someGroup__disableListColumnTextInGroup'),
+      ).toBeHidden()
+    })
+
     test('should toggle columns and effect table', async () => {
       const tableHeaders = 'table > thead > tr > th'
 

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -275,6 +275,10 @@ export interface Post {
   selectField?: ('option1' | 'option2')[] | null;
   file?: string | null;
   noReadAccessField?: string | null;
+  disableListColumnTextInRow?: string | null;
+  someGroup?: {
+    disableListColumnTextInGroup?: string | null;
+  };
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -824,6 +828,12 @@ export interface PostsSelect<T extends boolean = true> {
   selectField?: T;
   file?: T;
   noReadAccessField?: T;
+  disableListColumnTextInRow?: T;
+  someGroup?:
+    | T
+    | {
+        disableListColumnTextInGroup?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   _status?: T;


### PR DESCRIPTION
### What?

This PR makes `filterFields` recurse into **fields with subfields** (e.g., tabs, row, group, collapsible, array) so nested fields with `admin.disableListColumn: true` (or hidden/disabled fields) are properly excluded.

### Why?

Nested fields with `admin.disableListColumn: true` were still appearing in the list view. 

Example: a text field inside a `row` or `group` continued to show as a column despite being marked `disableListColumn`.

### How?

- Call `filterFields` recursively for `tab.fields` and for any field exposing a `fields` array.

Fixes #13496 