### PR TITLE
fix: select field component value prop type does not support array values

### DIFF
--- a/packages/payload/src/admin/fields/Select.ts
+++ b/packages/payload/src/admin/fields/Select.ts
@@ -25,7 +25,7 @@ type SelectFieldBaseClientProps = {
   readonly onChange?: (e: string | string[]) => void
   readonly path: string
   readonly validate?: SelectFieldValidation
-  readonly value?: string
+  readonly value?: string | string[]
 }
 
 type SelectFieldBaseServerProps = Pick<FieldPaths, 'path'>

--- a/test/admin/collections/CustomFields/fields/Select/CustomMultiSelect.tsx
+++ b/test/admin/collections/CustomFields/fields/Select/CustomMultiSelect.tsx
@@ -8,14 +8,18 @@ import React from 'react'
 export const CustomMultiSelect: SelectFieldClientComponent = (props) => {
   const { path } = props
   const { setValue, value } = useField<string[]>({ path })
+  const [options, setOptions] = React.useState<Option[]>([])
 
-  const options: Option[] = React.useMemo(
-    () => [
-      { label: 'Label 1', value: 'value1' },
-      { label: 'Label 2', value: 'value2' },
-    ],
-    [],
-  )
+  React.useEffect(() => {
+    const fetchOptions = () => {
+      const fetched: Option[] = [
+        { label: 'Label 1', value: 'value1' },
+        { label: 'Label 2', value: 'value2' },
+      ]
+      setOptions(fetched)
+    }
+    void fetchOptions()
+  }, [])
 
   const onChange = (val: string | string[]) => {
     setValue(Array.isArray(val) ? val : val ? [val] : [])

--- a/test/admin/collections/CustomFields/fields/Select/CustomMultiSelect.tsx
+++ b/test/admin/collections/CustomFields/fields/Select/CustomMultiSelect.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import type { Option, SelectFieldClientComponent } from 'payload'
+
+import { SelectField, useField } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomMultiSelect: SelectFieldClientComponent = (props) => {
+  const { path } = props
+  const { setValue, value } = useField<string[]>({ path })
+
+  const options: Option[] = React.useMemo(
+    () => [
+      { label: 'Label 1', value: 'value1' },
+      { label: 'Label 2', value: 'value2' },
+    ],
+    [],
+  )
+
+  const onChange = (val: string | string[]) => {
+    setValue(Array.isArray(val) ? val : val ? [val] : [])
+  }
+
+  return (
+    <SelectField
+      {...props}
+      field={{
+        ...props.field,
+        name: path,
+        hasMany: true,
+        options,
+      }}
+      onChange={onChange}
+      value={value ?? []}
+    />
+  )
+}

--- a/test/admin/collections/CustomFields/fields/Select/index.tsx
+++ b/test/admin/collections/CustomFields/fields/Select/index.tsx
@@ -8,28 +8,17 @@ import React from 'react'
 export const CustomSelect: SelectFieldClientComponent = (props) => {
   const { path } = props
   const { setValue, value } = useField<string>({ path })
-  const [options, setOptions] = React.useState<{ label: string; value: string }[]>([])
+  const [options, setOptions] = React.useState<Option[]>([])
 
   React.useEffect(() => {
-    const fetchOptions = () => {
-      const fetchedOptions = [
-        {
-          label: 'Label 1',
-          value: 'value1',
-        },
-        {
-          label: 'Label 2',
-          value: 'value2',
-        },
-      ]
-      setOptions(fetchedOptions)
-    }
-    void fetchOptions()
+    setOptions([
+      { label: 'Label 1', value: 'value1' },
+      { label: 'Label 2', value: 'value2' },
+    ])
   }, [])
 
-  const onChange = (selected: Option | Option[]) => {
-    const options = Array.isArray(selected) ? selected : [selected]
-    setValue(options.map((option) => (typeof option === 'string' ? option : option.value)))
+  const onChange = (val: string | string[]) => {
+    setValue(Array.isArray(val) ? (val[0] ?? '') : val)
   }
 
   return (
@@ -38,12 +27,10 @@ export const CustomSelect: SelectFieldClientComponent = (props) => {
         {...props}
         field={{
           ...props.field,
-          name: path,
-          hasMany: true,
           options,
         }}
         onChange={onChange}
-        value={value}
+        value={value ?? ''}
       />
     </div>
   )

--- a/test/admin/collections/CustomFields/fields/Select/index.tsx
+++ b/test/admin/collections/CustomFields/fields/Select/index.tsx
@@ -11,10 +11,14 @@ export const CustomSelect: SelectFieldClientComponent = (props) => {
   const [options, setOptions] = React.useState<Option[]>([])
 
   React.useEffect(() => {
-    setOptions([
-      { label: 'Label 1', value: 'value1' },
-      { label: 'Label 2', value: 'value2' },
-    ])
+    const fetchOptions = () => {
+      const fetchedOptions: Option[] = [
+        { label: 'Label 1', value: 'value1' },
+        { label: 'Label 2', value: 'value2' },
+      ]
+      setOptions(fetchedOptions)
+    }
+    void fetchOptions()
   }, [])
 
   const onChange = (val: string | string[]) => {

--- a/test/admin/collections/CustomFields/index.ts
+++ b/test/admin/collections/CustomFields/index.ts
@@ -83,6 +83,16 @@ export const CustomFields: CollectionConfig = {
       },
     },
     {
+      name: 'customMultiSelectField',
+      type: 'text',
+      hasMany: true,
+      admin: {
+        components: {
+          Field: '/collections/CustomFields/fields/Select/CustomMultiSelect.js#CustomMultiSelect',
+        },
+      },
+    },
+    {
       name: 'relationshipFieldWithBeforeAfterInputs',
       type: 'relationship',
       admin: {

--- a/test/admin/components/AfterNavLinks/index.tsx
+++ b/test/admin/components/AfterNavLinks/index.tsx
@@ -3,7 +3,7 @@
 import type { PayloadClientReactComponent, SanitizedConfig } from 'payload'
 
 import LinkImport from 'next/link.js'
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 import { useConfig } from '@payloadcms/ui'
 import React from 'react'

--- a/test/admin/components/CustomTabComponent/client.tsx
+++ b/test/admin/components/CustomTabComponent/client.tsx
@@ -7,7 +7,7 @@ import LinkImport from 'next/link.js'
 import { useParams } from 'next/navigation.js'
 import React from 'react'
 
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 type CustomTabComponentClientProps = {
   label: string

--- a/test/admin/components/views/CustomDefault/index.tsx
+++ b/test/admin/components/views/CustomDefault/index.tsx
@@ -3,7 +3,7 @@ import LinkImport from 'next/link.js'
 import { redirect } from 'next/navigation.js'
 import React from 'react'
 
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 import type { AdminViewServerProps } from 'payload'
 

--- a/test/admin/components/views/CustomMinimal/index.tsx
+++ b/test/admin/components/views/CustomMinimal/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 // As this is the demo project, we import our dependencies from the `src` directory.
 
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 // In your projects, you can import as follows:
 // import { MinimalTemplate } from 'payload/components/templates';

--- a/test/admin/components/views/CustomProtectedView/index.tsx
+++ b/test/admin/components/views/CustomProtectedView/index.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import { customNestedViewTitle, customViewPath } from '../../../shared.js'
 import { settingsGlobalSlug } from '../../../slugs.js'
 
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 export async function CustomProtectedView({ initPageResult }: AdminViewServerProps) {
   const {

--- a/test/admin/components/views/CustomView/index.tsx
+++ b/test/admin/components/views/CustomView/index.tsx
@@ -3,7 +3,7 @@ import type { AdminViewServerProps } from 'payload'
 import LinkImport from 'next/link.js'
 import React from 'react'
 
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 import { Button } from '@payloadcms/ui'
 

--- a/test/admin/components/views/CustomViewNested/index.tsx
+++ b/test/admin/components/views/CustomViewNested/index.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 
 import { customNestedViewTitle, customViewPath } from '../../../shared.js'
 
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 export function CustomNestedView({ initPageResult }: AdminViewServerProps) {
   const {

--- a/test/admin/components/views/CustomViewWithParam/index.tsx
+++ b/test/admin/components/views/CustomViewWithParam/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@payloadcms/ui'
 import LinkImport from 'next/link.js'
 import React from 'react'
 
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 import type { AdminViewServerProps } from 'payload'
 

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -649,6 +649,26 @@ describe('Document View', () => {
         await page.locator('#field-customSelectField .rs__control').click()
         await expect(page.locator('#field-customSelectField .rs__option')).toHaveCount(2)
       })
+
+      test('should render custom multi select options', async () => {
+        await page.goto(customFieldsURL.create)
+        await page.locator('#field-customMultiSelectField .rs__control').click()
+        await expect(page.locator('#field-customMultiSelectField .rs__option')).toHaveCount(2)
+      })
+
+      test('should allow selecting multiple values in custom multi select', async () => {
+        await page.goto(customFieldsURL.create)
+
+        const control = page.locator('#field-customMultiSelectField .rs__control')
+
+        await control.click()
+        await page.locator('.rs__option', { hasText: 'Label 1' }).click()
+        await expect(page.locator('#field-customMultiSelectField .rs__multi-value')).toHaveCount(1)
+
+        await control.click()
+        await page.locator('.rs__option', { hasText: 'Label 2' }).click()
+        await expect(page.locator('#field-customMultiSelectField .rs__multi-value')).toHaveCount(2)
+      })
     })
   })
 

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -384,6 +384,7 @@ export interface CustomField {
   descriptionAsComponent?: string | null;
   customSelectField?: string | null;
   customSelectInput?: string | null;
+  customMultiSelectField?: string[] | null;
   relationshipFieldWithBeforeAfterInputs?: (string | null) | Post;
   arrayFieldWithBeforeAfterInputs?:
     | {
@@ -927,6 +928,7 @@ export interface CustomFieldsSelect<T extends boolean = true> {
   descriptionAsComponent?: T;
   customSelectField?: T;
   customSelectInput?: T;
+  customMultiSelectField?: T;
   relationshipFieldWithBeforeAfterInputs?: T;
   arrayFieldWithBeforeAfterInputs?:
     | T

--- a/test/fields/components/AfterNavLinks.tsx
+++ b/test/fields/components/AfterNavLinks.tsx
@@ -4,7 +4,7 @@ import type { PayloadClientReactComponent, SanitizedConfig } from 'payload'
 
 import { NavGroup, useConfig } from '@payloadcms/ui'
 import LinkImport from 'next/link.js'
-const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 import React from 'react'
 
 const baseClass = 'after-nav-links'


### PR DESCRIPTION
### What?

Update `SelectFieldBaseClientProps` type so `value` accepts `string[]` for `hasMany` selects

### Why?

Multi-selects currently error with “Type 'string[]' is not assignable to type 'string'”.

### How?

- Change `value?: string` to `value?: string | string[]`
- Also adds additional multi select custom component to `admin` test suite for testing