### PR TITLE
fix(ui): double ? in gravatar url

### DIFF
--- a/packages/ui/src/graphics/Account/Gravatar/index.tsx
+++ b/packages/ui/src/graphics/Account/Gravatar/index.tsx
@@ -22,7 +22,7 @@ export const GravatarAccountIcon: React.FC = () => {
       alt="yas"
       className="gravatar-account"
       height={25}
-      src={`https://www.gravatar.com/avatar/${hash}?${query}`}
+      src={`https://www.gravatar.com/avatar/${hash}${query}`}
       style={{ borderRadius: '50%' }}
       width={25}
     />

--- a/packages/ui/src/graphics/Account/index.tsx
+++ b/packages/ui/src/graphics/Account/index.tsx
@@ -3,7 +3,6 @@ import { usePathname } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'
 import React from 'react'
 
-// import { RenderComponent } from '../../elements/RenderComponent/client.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { DefaultAccountIcon } from './Default/index.js'


### PR DESCRIPTION
### What?

Ensure the Gravatar URL appends the query string only once.

### Why?

Previously `src` used `...?${query}` while `query` already began with `?`, producing `??` and causing the avatar URL to be invalid in some cases.

### How?

- Keep `query` as `?${params}` (from `URLSearchParams`).
- Change `src` from `https://www.gravatar.com/avatar/${hash}?${query}` to `https://www.gravatar.com/avatar/${hash}${query}` so only one `?` is present.

Fixes #13325 