### PR TITLE
fix: unable to query versions on latest key

### DIFF
--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -162,7 +162,12 @@ export async function validateSearchParam({
         if (versionFields) {
           fieldAccess = policies[entityType]![entitySlug]!.fields
 
-          if (segments[0] === 'parent' || segments[0] === 'version' || segments[0] === 'snapshot') {
+          if (
+            segments[0] === 'parent' ||
+            segments[0] === 'version' ||
+            segments[0] === 'snapshot' ||
+            segments[0] === 'latest'
+          ) {
             segments.shift()
           }
         } else {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -4,6 +4,7 @@ import { schedulePublishHandler } from '@payloadcms/ui/utilities/schedulePublish
 import path from 'path'
 import { createLocalReq, ValidationError } from 'payload'
 import { wait } from 'payload/shared'
+import * as qs from 'qs-esm'
 import { fileURLToPath } from 'url'
 
 import type { NextRESTClient } from '../helpers/NextRESTClient.js'
@@ -1549,9 +1550,32 @@ describe('Versions', () => {
         },
       })
 
-      const response = await restClient.GET(`/${collection}/versions?where[latest]=true`)
+      const query = qs.stringify(
+        {
+          where: {
+            and: [
+              {
+                latest: {
+                  equals: true,
+                },
+              },
+              {
+                parent: {
+                  equals: version1.id,
+                },
+              },
+            ],
+          },
+        },
+        {
+          addQueryPrefix: true,
+        },
+      )
+
+      const response = await restClient.GET(`/${draftCollectionSlug}/versions${query}`)
       expect(response.status).toBe(200)
       const json = await response.json()
+      expect(json.docs).toHaveLength(1)
 
       expect(json.docs[0].version.title).toBe(newestVersion.title)
     })


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13455

https://github.com/payloadcms/payload/pull/13297 Fixed a scoping issue, but exposed a new issue where querying versioned documents by the `latest` key would fail. This PR fixes the newly discoverable issue.