### PR TITLE
fix(translations): stale version.versionCreatedOn key in translation

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -501,7 +501,6 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'version:type',
   'version:unpublish',
   'version:unpublishing',
-  'version:versionCreatedOn',
   'version:versionID',
   'version:version',
   'version:versions',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -587,7 +587,6 @@ export const arTranslations: DefaultTranslationsObject = {
     versionCount_none: 'لم يتمّ العثور على أيّ من النّسخ',
     versionCount_one: 'تمّ العثور على {{count}} من النّسخ',
     versionCount_other: 'تمّ العثور على {{count}} نُسخ',
-    versionCreatedOn: 'تمّ ﻹنشاء النّسخة في {{version}}:',
     versionID: 'مُعرّف النّسخة',
     versions: 'النُّسَخ',
     viewingVersion: 'يتمّ استعراض نسخة ل {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -605,7 +605,6 @@ export const azTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Versiya tapılmadı',
     versionCount_one: '{{count}} versiya tapıldı',
     versionCount_other: '{{count}} versiya tapıldı',
-    versionCreatedOn: '{{version}} tarixində yaradıldı:',
     versionID: 'Versiyanın ID-si',
     versions: 'Versiyalar',
     viewingVersion: '{{entityLabel}} {{documentTitle}} üçün versiyanı göstərir',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -601,7 +601,6 @@ export const bgTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Няма открити версии',
     versionCount_one: '{{count}} открита версия',
     versionCount_other: '{{count}} открити версии',
-    versionCreatedOn: '{{version}} създадена на:',
     versionID: 'Идентификатор на версията',
     versions: 'Версии',
     viewingVersion: 'Гледане на версия за {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -607,7 +607,6 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     versionCount_none: 'কোনো সংস্করণ পাওয়া যায়নি',
     versionCount_one: '{{count}}টি সংস্করণ পাওয়া গেছে',
     versionCount_other: '{{count}}টি সংস্করণ পাওয়া গেছে',
-    versionCreatedOn: '{{version}} তৈরি হয়েছে:',
     versionID: 'সংস্করণ আইডি',
     versions: 'সংস্করণসমূহ',
     viewingVersion: '{{entityLabel}} {{documentTitle}}-এর সংস্করণ দেখানো হচ্ছে',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -606,7 +606,6 @@ export const bnInTranslations: DefaultTranslationsObject = {
     versionCount_none: 'কোনো সংস্করণ পাওয়া যায়নি',
     versionCount_one: '{{count}}টি সংস্করণ পাওয়া গেছে',
     versionCount_other: '{{count}}টি সংস্করণ পাওয়া গেছে',
-    versionCreatedOn: '{{version}} তৈরি হয়েছে:',
     versionID: 'সংস্করণ আইডি',
     versions: 'সংস্করণসমূহ',
     viewingVersion: '{{entityLabel}} {{documentTitle}}-এর সংস্করণ দেখানো হচ্ছে',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -606,7 +606,6 @@ export const caTranslations: DefaultTranslationsObject = {
     versionCount_none: "No s'han trobat versions",
     versionCount_one: '{{count}} versió trobada',
     versionCount_other: '{{count}} versions trobades',
-    versionCreatedOn: '{{version}} creada el:',
     versionID: 'ID de versió',
     versions: 'Versions',
     viewingVersion: 'Veient versió per al {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -599,7 +599,6 @@ export const csTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Žádné verze nenalezeny',
     versionCount_one: '{{count}} verze nalezena',
     versionCount_other: '{{count}} verzí nalezeno',
-    versionCreatedOn: '{{version}} vytvořena:',
     versionID: 'ID verze',
     versions: 'Verze',
     viewingVersion: 'Zobrazuji verzi pro {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -601,7 +601,6 @@ export const daTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Ingen versioner fundet',
     versionCount_one: '{{count}} version fundet',
     versionCount_other: '{{count}} version fundet',
-    versionCreatedOn: '{{version}} oprettet den:',
     versionID: 'Versions-ID',
     versions: 'Versioner',
     viewingVersion: 'Se versionen for {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -613,7 +613,6 @@ export const deTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Keine Versionen gefunden',
     versionCount_one: '{{count}} Version gefunden',
     versionCount_other: '{{count}} Versionen gefunden',
-    versionCreatedOn: '{{version}} erstellt am:',
     versionID: 'Version-ID',
     versions: 'Versionen',
     viewingVersion: 'Version für {{entityLabel}} {{documentTitle}} ansehen',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -605,7 +605,6 @@ export const enTranslations = {
     versionCount_none: 'No versions found',
     versionCount_one: '{{count}} version found',
     versionCount_other: '{{count}} versions found',
-    versionCreatedOn: '{{version}} created on:',
     versionID: 'Version ID',
     versions: 'Versions',
     viewingVersion: 'Viewing version for the {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -608,7 +608,6 @@ export const esTranslations: DefaultTranslationsObject = {
     versionCount_none: 'No se encontraron versiones',
     versionCount_one: '{{count}} versión encontrada',
     versionCount_other: '{{count}} versiones encontradas',
-    versionCreatedOn: '{{version}} creada el:',
     versionID: 'ID de la versión',
     versions: 'Versiones',
     viewingVersion: 'Viendo versión para {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -594,7 +594,6 @@ export const etTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Versioone ei leitud',
     versionCount_one: '{{count}} versioon leitud',
     versionCount_other: '{{count}} versiooni leitud',
-    versionCreatedOn: '{{version}} loodud:',
     versionID: 'Versiooni ID',
     versions: 'Versioonid',
     viewingVersion: 'Vaatan versiooni {{entityLabel}} {{documentTitle}} jaoks',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -596,7 +596,6 @@ export const faTranslations: DefaultTranslationsObject = {
     versionCount_none: 'هیچ نگارشی یافت نشد',
     versionCount_one: '{{count}} نگارش یافت شد',
     versionCount_other: '{{count}} نگارش یافت شد',
-    versionCreatedOn: '{{version}} ساخته شده در:',
     versionID: 'شناسه نگارش',
     versions: 'نگارش‌ها',
     viewingVersion: 'در حال مشاهده نگارش برای {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -617,7 +617,6 @@ export const frTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Aucune version trouvée',
     versionCount_one: '{{count}} version trouvée',
     versionCount_other: '{{count}} versions trouvées',
-    versionCreatedOn: '{{version}} créé(e) le :',
     versionID: 'Identifiant de la version',
     versions: 'Versions',
     viewingVersion: 'Affichage de la version de ou du {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -583,7 +583,6 @@ export const heTranslations: DefaultTranslationsObject = {
     versionCount_none: 'לא נמצאו גרסאות',
     versionCount_one: 'נמצאה גרסה אחת',
     versionCount_other: '{{count}} גרסאות נמצאו',
-    versionCreatedOn: '{{version}} נוצר בתאריך:',
     versionID: 'מזהה גרסה',
     versions: 'גרסאות',
     viewingVersion: 'צופה בגרסה עבור {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -599,7 +599,6 @@ export const hrTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nema pronađenih verzija',
     versionCount_one: '{{count}} pronađena verzija',
     versionCount_other: '{{count}} pronađenih verzija',
-    versionCreatedOn: '{{version}} izrađenih:',
     versionID: 'ID verzije',
     versions: 'Verzije',
     viewingVersion: 'Pregled verzije za {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -608,7 +608,6 @@ export const huTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nem található verzió',
     versionCount_one: '{{count}} verzió található',
     versionCount_other: '{{count}} verzió található',
-    versionCreatedOn: '{{version}} létrehozva:',
     versionID: 'Verzióazonosító',
     versions: 'Verziók',
     viewingVersion: 'A(z) {{entityLabel}} {{documentTitle}} verziójának megtekintése',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -610,7 +610,6 @@ export const hyTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Ոչ մի տարբերակ չի գտնվել',
     versionCount_one: '{{count}} տարբերակ է գտնվել',
     versionCount_other: '{{count}} տարբերակ է գտնվել',
-    versionCreatedOn: '{{version}}-ը ստեղծվել է՝',
     versionID: 'Տարբերակի ID',
     versions: 'Տարբերակներ',
     viewingVersion: 'Ցույց է տրված {{entityLabel}} {{documentTitle}}-ի տարբերակը',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -606,7 +606,6 @@ export const idTranslations = {
     versionCount_none: 'Tidak ada versi yang ditemukan',
     versionCount_one: '{{count}} versi ditemukan',
     versionCount_other: '{{count}} versi ditemukan',
-    versionCreatedOn: '{{version}} dibuat pada:',
     versionID: 'ID Versi',
     versions: 'Versi',
     viewingVersion: 'Melihat versi untuk {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -607,7 +607,6 @@ export const itTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nessuna versione trovata',
     versionCount_one: '{{count}} versione trovata',
     versionCount_other: '{{count}} versioni trovate',
-    versionCreatedOn: '{{version}} creata il:',
     versionID: 'ID Versione',
     versions: 'Versioni',
     viewingVersion: 'Visualizzazione della versione per {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -602,7 +602,6 @@ export const jaTranslations: DefaultTranslationsObject = {
     versionCount_none: 'バージョンがありません',
     versionCount_one: '{{count}} バージョンがあります',
     versionCount_other: '{{count}}バージョンが見つかりました',
-    versionCreatedOn: '{{version}} 作成日時:',
     versionID: 'バージョンID',
     versions: 'バージョン',
     viewingVersion: '表示バージョン: {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -595,7 +595,6 @@ export const koTranslations: DefaultTranslationsObject = {
     versionCount_none: '버전을 찾을 수 없습니다',
     versionCount_one: '{{count}}개의 버전을 찾았습니다',
     versionCount_other: '{{count}}개의 버전을 찾았습니다',
-    versionCreatedOn: '{{version}} 생성 날짜:',
     versionID: '버전 ID',
     versions: '버전',
     viewingVersion: '{{entityLabel}} {{documentTitle}}의 버전 보기',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -606,7 +606,6 @@ export const ltTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nerasta jokių versijų',
     versionCount_one: 'Rasta {{count}} versija',
     versionCount_other: 'Rasta {{count}} versijų',
-    versionCreatedOn: '{{version}} sukurtas:',
     versionID: 'Versijos ID',
     versions: 'Versijos',
     viewingVersion: 'Peržiūrėkite versiją {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -602,7 +602,6 @@ export const lvTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nav atrastu versiju',
     versionCount_one: 'Atrasta {{count}} versija',
     versionCount_other: 'Atrastas {{count}} versijas',
-    versionCreatedOn: '{{version}} izveidota:',
     versionID: 'Versijas ID',
     versions: 'Versijas',
     viewingVersion: 'Skatās versiju priekš {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -611,7 +611,6 @@ export const myTranslations: DefaultTranslationsObject = {
     versionCount_none: 'ဗားရှင်းရှာဖွေ့ပါ။',
     versionCount_one: '{{count}} ဗားရှင်အား တွေ့ပါသည်။',
     versionCount_other: 'ဗားရှင်း {{count}} ခု တွေ့ရှိပါသည်။',
-    versionCreatedOn: '{{version}} အား ဖန်တီးခဲ့သည်။',
     versionID: 'ဗားရှင်း ID',
     versions: 'ဗားရှင်းများ',
     viewingVersion: '{{entityLabel}} {{documentTitle}} အတွက် ဗားရှင်းကို ကြည့်ရှုနေသည်',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -602,7 +602,6 @@ export const nbTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Ingen versjoner funnet',
     versionCount_one: '{{count}} versjon funnet',
     versionCount_other: '{{count}} versjoner funnet',
-    versionCreatedOn: '{{version}} opprettet:',
     versionID: 'Versjons-ID',
     versions: 'Versjoner',
     viewingVersion: 'Viser versjon for {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -611,7 +611,6 @@ export const nlTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Geen versies gevonden',
     versionCount_one: '{{count}} versie gevonden',
     versionCount_other: '{{count}} versies gevonden',
-    versionCreatedOn: '{{version}} aangemaakt op:',
     versionID: 'Versie-ID',
     versions: 'Versies',
     viewingVersion: 'Bekijk versie voor {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -600,7 +600,6 @@ export const plTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nie znaleziono wersji',
     versionCount_one: 'Znaleziono {{count}} wersję',
     versionCount_other: 'Znaleziono {{count}} wersji',
-    versionCreatedOn: 'Wersja {{version}} utworzona:',
     versionID: 'ID wersji',
     versions: 'Wersje',
     viewingVersion: 'Przeglądanie wersji dla {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -604,7 +604,6 @@ export const ptTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nenhuma versão encontrada',
     versionCount_one: '{{count}} versão encontrada',
     versionCount_other: '{{count}} versões encontradas',
-    versionCreatedOn: '{{version}} criada em:',
     versionID: 'ID da versão',
     versions: 'Versões',
     viewingVersion: 'Visualizando versão para o/a {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -611,7 +611,6 @@ export const roTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nici o versiune găsită',
     versionCount_one: '{{count}} versiune găsită',
     versionCount_other: '{{count}} versiuni găsite',
-    versionCreatedOn: '{{version}} creată pe:',
     versionID: 'ID-ul versiunii',
     versions: 'Versiuni',
     viewingVersion: 'Vizualizarea versiunii pentru {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -598,7 +598,6 @@ export const rsTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Нема пронађених верзија',
     versionCount_one: '{{count}} пронађена верзија',
     versionCount_other: '{{count}} пронађених верзија',
-    versionCreatedOn: '{{version}} креираних:',
     versionID: 'Идентификатор верзије',
     versions: 'Верзије',
     viewingVersion: 'Преглед верзије за {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -600,7 +600,6 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Nema pronađenih verzija',
     versionCount_one: '{{count}} pronađena verzija',
     versionCount_other: '{{count}} pronađenih verzija',
-    versionCreatedOn: '{{version}} kreiranih:',
     versionID: 'ID verzije',
     versions: 'Verzije',
     viewingVersion: 'Pregled verzije za {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -604,7 +604,6 @@ export const ruTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Версий не найдено',
     versionCount_one: '{{count}} версия найдена',
     versionCount_other: 'Найдено {{count}} версий',
-    versionCreatedOn: '{{version}} создана:',
     versionID: 'ID версии',
     versions: 'Версии',
     viewingVersion: 'Просмотр версии для {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -600,7 +600,6 @@ export const skTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Žiadne verzie nenájdené',
     versionCount_one: '{{count}} verzia nájdená',
     versionCount_other: '{{count}} verzií nájdených',
-    versionCreatedOn: '{{version}} vytvorená:',
     versionID: 'ID verzie',
     versions: 'Verzie',
     viewingVersion: 'Zobrazujem verziu pre {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -599,7 +599,6 @@ export const slTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Ni najdenih različic',
     versionCount_one: 'Najdena {{count}} različica',
     versionCount_other: 'Najdene {{count}} različice',
-    versionCreatedOn: '{{version}} ustvarjena:',
     versionID: 'ID različice',
     versions: 'Različice',
     viewingVersion: 'Ogled različice za {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -602,7 +602,6 @@ export const svTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Inga versioner hittades',
     versionCount_one: '{{count}} version hittades',
     versionCount_other: '{{count}} versioner hittades',
-    versionCreatedOn: '{{version}} skapad den:',
     versionID: 'Versions-ID',
     versions: 'Versioner',
     viewingVersion: 'Visar version för {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -589,7 +589,6 @@ export const thTranslations: DefaultTranslationsObject = {
     versionCount_none: 'ไม่พบเวอร์ชันอื่น',
     versionCount_one: 'พบ {{count}} เวอร์ชัน',
     versionCount_other: 'พบ {{count}} เวอร์ชัน',
-    versionCreatedOn: '{{version}} ถูกสร้างเมื่อ:',
     versionID: 'ID ของเวอร์ชัน',
     versions: 'เวอร์ชัน',
     viewingVersion: 'กำลังดูเวอร์ชันของ {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -604,7 +604,6 @@ export const trTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Sürüm bulunamadı',
     versionCount_one: '{{count}} sürüm bulundu',
     versionCount_other: '{{count}} sürüm bulundu',
-    versionCreatedOn: '{{version}} oluşturma tarihi:',
     versionID: 'Sürüm ID',
     versions: 'Sürümler',
     viewingVersion: '{{entityLabel}} {{documentTitle}} için sürümler gösteriliyor',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -600,7 +600,6 @@ export const ukTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Версій не знайдено',
     versionCount_one: '{{count}} версія знайдена',
     versionCount_other: '{{count}} версій знайдено',
-    versionCreatedOn: '{{version}} створена:',
     versionID: 'ID версії',
     versions: 'Версії',
     viewingVersion: 'Перенляд версії для {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -597,7 +597,6 @@ export const viTranslations: DefaultTranslationsObject = {
     versionCount_none: 'Không có phiên bản nào được tìm thấy',
     versionCount_one: '{{count}} phiên bản được tìm thấy',
     versionCount_other: 'Đã tìm thấy {{count}} phiên bản',
-    versionCreatedOn: 'Phiên bản {{version}} được tạo vào lúc:',
     versionID: 'ID của phiên bản',
     versions: 'Danh sách phiên bản',
     viewingVersion: 'Xem phiên bản của {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -573,7 +573,6 @@ export const zhTranslations: DefaultTranslationsObject = {
     versionCount_none: '没有发现任何版本',
     versionCount_one: '找到{{count}}版本',
     versionCount_other: '找到{{count}}版本',
-    versionCreatedOn: '{{version}}创建于：',
     versionID: '版本ID',
     versions: '版本',
     viewingVersion: '正在查看{{entityLabel}} {{documentTitle}}的版本',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -573,7 +573,6 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     versionCount_none: '找不到版本',
     versionCount_one: '找到 {{count}} 個版本',
     versionCount_other: '找到 {{count}} 個版本',
-    versionCreatedOn: '{{version}} 建立於：',
     versionID: '版本 ID',
     versions: '版本記錄',
     viewingVersion: '正在檢視 {{entityLabel}}「{{documentTitle}}」的版本',


### PR DESCRIPTION
### What?

Remove `versionCreatedOn` from translations.

### Why?

The key is no longer referenced anywhere in the admin/UI code.

Fixes #13188 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211105332940662