### PR TITLE
fix(db-postgres): prevent autorun job duplication due to MVCC race condition

### DIFF
--- a/packages/drizzle/src/updateJobs.ts
+++ b/packages/drizzle/src/updateJobs.ts
@@ -1,5 +1,7 @@
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import type { UpdateJobs, Where } from 'payload'
 
+import { and, eq, inArray } from 'drizzle-orm'
 import toSnakeCase from 'to-snake-case'
 
 import type { DrizzleAdapter } from './types.js'
@@ -63,6 +65,34 @@ export const updateJobs: UpdateJobs = async function updateMany(
   const results = []
 
   // TODO: We need to batch this to reduce the amount of db calls. This can get very slow if we are updating a lot of rows.
+  // PostgreSQL MVCC fix: prevent multiple workers from claiming the same jobs
+  // Uses atomic UPDATE ... WHERE processing = false to ensure exclusivity
+  if (this.name === 'postgres' && data.processing === true && !id && jobs.docs.length > 0) {
+    const jobIds = jobs.docs.map((job: any) => job.id)
+    const table = this.tables[tableName]
+    const pgDb = db as NodePgDatabase
+
+    try {
+      // Atomic update with WHERE clause ensures only unclaimed jobs are updated
+      const atomicResults = await pgDb
+        .update(table)
+        .set(data)
+        .where(and(inArray(table.id, jobIds), eq(table.processing, false)))
+        .returning()
+
+      if (atomicResults && atomicResults.length > 0) {
+        // Preserve original ordering
+        const resultMap = new Map(atomicResults.map((r: any) => [r.id, r]))
+        const orderedResults = jobIds.map((id: any) => resultMap.get(id)).filter(Boolean)
+        return orderedResults
+      }
+      return []
+    } catch (_error) {
+      // Fall back to original logic
+    }
+  }
+
+  // Original logic for non-PostgreSQL or non-processing updates
   for (const job of jobs.docs) {
     const updateData = useOptimizedUpsertRow
       ? data

--- a/test/queues/getConfig.ts
+++ b/test/queues/getConfig.ts
@@ -49,15 +49,25 @@ export const getConfig: () => Partial<Config> = () => ({
       },
       hooks: {
         afterChange: [
-          async ({ req, doc, context }) => {
-            await req.payload.jobs.queue({
-              workflow: context.useJSONWorkflow ? 'updatePostJSONWorkflow' : 'updatePost',
-              input: {
-                post: doc.id,
-                message: 'hello',
-              },
-              req,
-            })
+          async ({ req, doc, context, operation, previousDoc }) => {
+            // Prevent infinite loop: skip if update is from job execution
+            const isJobUpdate =
+              previousDoc &&
+              (doc.jobStep1Ran !== previousDoc.jobStep1Ran ||
+                doc.jobStep2Ran !== previousDoc.jobStep2Ran) &&
+              doc.title === previousDoc.title
+
+            if (operation === 'create' || (operation === 'update' && !isJobUpdate)) {
+              await req.payload.jobs.queue({
+                workflow: context.useJSONWorkflow ? 'updatePostJSONWorkflow' : 'updatePost',
+                input: {
+                  post: doc.id,
+                  message: 'hello',
+                },
+                queue: 'autorunSecond',
+                req,
+              })
+            }
           },
         ],
       },


### PR DESCRIPTION
WIP

### What?

  Adds atomic UPDATE operation for PostgreSQL when claiming jobs to prevent duplicate execution in high-frequency autorun scenarios.

  ### Why?

  PostgreSQL's MVCC (Multi-Version Concurrency Control) allows multiple concurrent transactions to see the same job with `processing: false` before any transaction commits. When autorun crons execute
  frequently (e.g., every second), multiple workers can claim and process the same job, causing duplication.

  **Important:** Prior to this fix, PostgreSQL autorun jobs weren't executing at all in many cases. The non-atomic update pattern was causing jobs to get stuck or lost between concurrent cron executions,
  effectively breaking autorun functionality entirely for PostgreSQL users.

  The issue manifests as:
  - Jobs not being processed at all (stuck in queue indefinitely)
  - When partially working: single job being executed multiple times
  - Job count growing exponentially in high-frequency autoruns
  - Tests expecting 1 result getting 2+ results

  ### How?

  - Added atomic `UPDATE ... WHERE processing = false RETURNING` in `updateJobs.ts` specifically for PostgreSQL when setting `processing: true`
  - The WHERE clause ensures only unclaimed jobs are updated, preventing race conditions
  - Returns jobs in original order to preserve FIFO/LIFO processing but likely needs a different implementation to cover uuid
  - Falls back to original logic for non-PostgreSQL databases

  Also fixed infinite loop in test config where job execution would trigger new job creation.

  **Note:** This is a proof-of-concept demonstrating the race condition and providing a working solution. Further testing and better best-practices is likely necessary.
  You guys may want to explore alternatives like PostgreSQL advisory locks or different transaction isolation levels.

  Related to #13433