### PR TITLE
feat(plugin-multi-tenant): allow custom tenant field per collection

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -84,7 +84,7 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
        * Opt out of adding the tenant field and place
        * it manually using the `tenantField` export from the plugin
        */
-      manuallyPlaceTenantField?: boolean
+      customTenantField?: boolean
       /**
        * Overrides for the tenant field, will override the entire tenantField configuration
        */

--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -81,12 +81,17 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
        */
       isGlobal?: boolean
       /**
+       * Opt out of adding the tenant field and place
+       * it manually using the `tenantField` export from the plugin
+       */
+      manuallyPlaceTenantField?: boolean
+      /**
        * Overrides for the tenant field, will override the entire tenantField configuration
        */
       tenantFieldOverrides?: CollectionTenantFieldConfigOverrides
       /**
-       * Set to `false` if you want to manually apply
-       * the baseFilter
+       * Set to `false` if you want to manually apply the baseListFilter
+       * Set to `false` if you want to manually apply the baseFilter
        *
        * @default true
        */

--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -53,7 +53,7 @@ export const TenantField = (args: Props) => {
     }
   }, [args.unique, options, selectedTenantID, setTenant, value, setEntityType, entityType])
 
-  if (options.length > 1 && !args.field.admin?.hidden) {
+  if (options.length > 1 && !args.field.admin?.hidden && !args.field.hidden) {
     return (
       <>
         <div className={baseClass}>

--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -53,7 +53,7 @@ export const TenantField = (args: Props) => {
     }
   }, [args.unique, options, selectedTenantID, setTenant, value, setEntityType, entityType])
 
-  if (options.length > 1) {
+  if (options.length > 1 && !args.field.admin?.hidden) {
     return (
       <>
         <div className={baseClass}>

--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -64,7 +64,7 @@ export const TenantField = (args: Props) => {
                 ...args.field,
                 required: true,
               }}
-              readOnly={args.readOnly || args.unique}
+              readOnly={args.readOnly || args.field.admin?.readOnly || args.unique}
             />
           </div>
         </div>

--- a/packages/plugin-multi-tenant/src/exports/fields.ts
+++ b/packages/plugin-multi-tenant/src/exports/fields.ts
@@ -1,1 +1,2 @@
+export { tenantField } from '../fields/tenantField/index.js'
 export { tenantsArrayField } from '../fields/tenantsArrayField/index.js'

--- a/packages/plugin-multi-tenant/src/exports/utilities.ts
+++ b/packages/plugin-multi-tenant/src/exports/utilities.ts
@@ -1,3 +1,4 @@
+export { defaults } from '../defaults.js'
 export { filterDocumentsByTenants as getTenantListFilter } from '../filters/filterDocumentsByTenants.js'
 export { getGlobalViewRedirect } from '../utilities/getGlobalViewRedirect.js'
 export { getTenantAccess } from '../utilities/getTenantAccess.js'

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -163,20 +163,22 @@ export const multiTenantPlugin =
       incomingConfig.folders = incomingConfig.folders || {}
       incomingConfig.folders.collectionOverrides = incomingConfig.folders.collectionOverrides || []
       incomingConfig.folders.collectionOverrides.push(({ collection }) => {
-        /**
-         * Add tenant field to enabled collections
-         */
-        const folderTenantField = tenantField({
-          ...(pluginConfig?.tenantField || {}),
-          name: tenantFieldName,
-          debug: pluginConfig.debug,
-          overrides,
-          tenantsArrayFieldName,
-          tenantsArrayTenantFieldName,
-          tenantsCollectionSlug,
-          unique: false,
-        })
-        collection.fields.unshift(folderTenantField)
+        if (pluginConfig.collections[foldersSlug]?.manuallyPlaceTenantField !== true) {
+          /**
+           * Add tenant field to enabled collections
+           */
+          const folderTenantField = tenantField({
+            ...(pluginConfig?.tenantField || {}),
+            name: tenantFieldName,
+            debug: pluginConfig.debug,
+            overrides,
+            tenantsArrayFieldName,
+            tenantsArrayTenantFieldName,
+            tenantsCollectionSlug,
+            unique: false,
+          })
+          collection.fields.unshift(folderTenantField)
+        }
 
         if (pluginConfig.collections[foldersSlug]?.useBaseListFilter !== false) {
           /**
@@ -331,22 +333,24 @@ export const multiTenantPlugin =
           ? pluginConfig.collections[collection.slug]?.tenantFieldOverrides
           : pluginConfig.tenantField || {}
 
-        /**
-         * Add tenant field to enabled collections
-         */
-        collection.fields.splice(
-          0,
-          0,
-          tenantField({
-            name: tenantFieldName,
-            debug: pluginConfig.debug,
-            overrides,
-            tenantsArrayFieldName,
-            tenantsArrayTenantFieldName,
-            tenantsCollectionSlug,
-            unique: isGlobal,
-          }),
-        )
+        if (pluginConfig.collections[collection.slug]?.manuallyPlaceTenantField !== true) {
+          /**
+           * Add tenant field to enabled collections
+           */
+          collection.fields.splice(
+            0,
+            0,
+            tenantField({
+              name: tenantFieldName,
+              debug: pluginConfig.debug,
+              overrides,
+              tenantsArrayFieldName,
+              tenantsArrayTenantFieldName,
+              tenantsCollectionSlug,
+              unique: isGlobal,
+            }),
+          )
+        }
 
         const { useBaseFilter, useBaseListFilter } = pluginConfig.collections[collection.slug] || {}
 

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -163,7 +163,7 @@ export const multiTenantPlugin =
       incomingConfig.folders = incomingConfig.folders || {}
       incomingConfig.folders.collectionOverrides = incomingConfig.folders.collectionOverrides || []
       incomingConfig.folders.collectionOverrides.push(({ collection }) => {
-        if (pluginConfig.collections[foldersSlug]?.manuallyPlaceTenantField !== true) {
+        if (pluginConfig.collections[foldersSlug]?.customTenantField !== true) {
           /**
            * Add tenant field to enabled collections
            */
@@ -333,7 +333,7 @@ export const multiTenantPlugin =
           ? pluginConfig.collections[collection.slug]?.tenantFieldOverrides
           : pluginConfig.tenantField || {}
 
-        if (pluginConfig.collections[collection.slug]?.manuallyPlaceTenantField !== true) {
+        if (pluginConfig.collections[collection.slug]?.customTenantField !== true) {
           /**
            * Add tenant field to enabled collections
            */

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -37,6 +37,11 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
        */
       isGlobal?: boolean
       /**
+       * Opt out of adding the tenant field and place
+       * it manually using the `tenantField` export from the plugin
+       */
+      manuallyPlaceTenantField?: boolean
+      /**
        * Overrides for the tenant field, will override the entire tenantField configuration
        */
       tenantFieldOverrides?: CollectionTenantFieldConfigOverrides

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -31,16 +31,16 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   collections: {
     [key in CollectionSlug]?: {
       /**
+       * Opt out of adding the tenant field and place
+       * it manually using the `tenantField` export from the plugin
+       */
+      customTenantField?: boolean
+      /**
        * Set to `true` if you want the collection to behave as a global
        *
        * @default false
        */
       isGlobal?: boolean
-      /**
-       * Opt out of adding the tenant field and place
-       * it manually using the `tenantField` export from the plugin
-       */
-      manuallyPlaceTenantField?: boolean
       /**
        * Overrides for the tenant field, will override the entire tenantField configuration
        */

--- a/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
+++ b/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
@@ -102,39 +102,37 @@ export const FolderTypeField = ({
   const styles = React.useMemo(() => mergeFieldStyles(field), [field])
 
   return (
-    <div>
-      <SelectInput
-        AfterInput={AfterInput}
-        BeforeInput={BeforeInput}
-        className={className}
-        Description={Description}
-        description={t('folder:folderTypeDescription')}
-        Error={Error}
-        filterOption={
-          selectFilterOptions
-            ? ({ value }) =>
-                selectFilterOptions?.some(
-                  (option) => (typeof option === 'string' ? option : option.value) === value,
-                )
-            : undefined
-        }
-        hasMany={hasMany}
-        isClearable={isClearable}
-        isSortable={isSortable}
-        Label={Label}
-        label={label}
-        localized={localized}
-        name={name}
-        onChange={onChange}
-        options={options}
-        path={path}
-        placeholder={placeholder}
-        readOnly={readOnly || disabled}
-        required={required || (Array.isArray(folderType) && folderType.length > 0)}
-        showError={showError}
-        style={styles}
-        value={value as string | string[]}
-      />
-    </div>
+    <SelectInput
+      AfterInput={AfterInput}
+      BeforeInput={BeforeInput}
+      className={className}
+      Description={Description}
+      description={t('folder:folderTypeDescription')}
+      Error={Error}
+      filterOption={
+        selectFilterOptions
+          ? ({ value }) =>
+              selectFilterOptions?.some(
+                (option) => (typeof option === 'string' ? option : option.value) === value,
+              )
+          : undefined
+      }
+      hasMany={hasMany}
+      isClearable={isClearable}
+      isSortable={isSortable}
+      Label={Label}
+      label={label}
+      localized={localized}
+      name={name}
+      onChange={onChange}
+      options={options}
+      path={path}
+      placeholder={placeholder}
+      readOnly={readOnly || disabled}
+      required={required || (Array.isArray(folderType) && folderType.length > 0)}
+      showError={showError}
+      style={styles}
+      value={value as string | string[]}
+    />
   )
 }


### PR DESCRIPTION
Adds the ability to manually place the tenantField on a per collection basis. This means you can add the tenantField where you would like in your own collection.

⚠️  MUST BE TOP LEVEL STILL, i.e. not nested inside a named group/tab.

In the example below, we are turning folders on and then placing the tenantField on the folders collection manually.

```ts
// payload config 

import { tenantField } from '@payloadcms/plugin-multi-tenant/fields'
import { defaults } from '@payloadcms/plugin-multi-tenant/utilities'

export default buildConfig({
  // ... rest of config
  folders: {
    browseByFolder: false,
    collectionOverrides: [
      ({ collection }) => {
        collection.fields.push(
          {
            name: 'scopeByTenant',
            type: 'checkbox',
            required: false,
            admin: {
              position: 'sidebar',
            },
          },
          tenantField({
            name: defaults.tenantFieldName,
            tenantsArrayFieldName: defaults.tenantsArrayFieldName,
            tenantsArrayTenantFieldName: defaults.tenantsArrayTenantFieldName,
            tenantsCollectionSlug: defaults.tenantCollectionSlug,
            unique: false,
            overrides: {
              admin: {
                condition: (data) => {
                  if (data.scopeByTenant) {
                    return true
                  }
                  return false
                },
              },
            },
          }),
        )
        return collection
      },
    ],
  },
  collections: [
    {
      slug: 'posts',
      folders: true,
      fields: [
        {
          name: 'title',
          type: 'text',
        },
    }
  ],
  plugins: [
    multiTenantPlugin<ConfigType>({
      // ... other plugin configurations
      collections: {
        posts: {},
        'payload-folders': {
          customTenantField: true, // <-- New property added
        },
      },
    }),
  ],
})