### PR TITLE
fix(ui): auth-fields container renders despite no visible auth/API key/verify content

### DIFF
--- a/packages/ui/src/views/Edit/Auth/index.tsx
+++ b/packages/ui/src/views/Edit/Auth/index.tsx
@@ -191,7 +191,12 @@ export const Auth: React.FC<Props> = (props) => {
     }
   }, [modified])
 
-  if (disableLocalStrategy && !enableFields && !useAPIKey) {
+  const showAuthBlock = enableFields
+  const showAPIKeyBlock = useAPIKey && canReadApiKey
+  const showVerifyBlock = verify && isEditing
+  const hasVisibleContent = showAuthBlock || showAPIKeyBlock || showVerifyBlock
+
+  if (!hasVisibleContent) {
     return null
   }
 

--- a/packages/ui/src/views/Edit/Auth/index.tsx
+++ b/packages/ui/src/views/Edit/Auth/index.tsx
@@ -194,9 +194,8 @@ export const Auth: React.FC<Props> = (props) => {
   const showAuthBlock = enableFields
   const showAPIKeyBlock = useAPIKey && canReadApiKey
   const showVerifyBlock = verify && isEditing
-  const hasVisibleContent = showAuthBlock || showAPIKeyBlock || showVerifyBlock
 
-  if (!hasVisibleContent) {
+  if (!(showAuthBlock || showAPIKeyBlock || showVerifyBlock)) {
     return null
   }
 

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -261,6 +261,33 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      slug: 'api-keys-with-field-read-access',
+      auth: {
+        disableLocalStrategy: true,
+        useAPIKey: true,
+      },
+      fields: [
+        {
+          name: 'enableAPIKey',
+          type: 'checkbox',
+          access: {
+            read: () => false,
+          },
+        },
+        {
+          name: 'apiKey',
+          type: 'text',
+          access: {
+            read: () => false,
+          },
+        },
+      ],
+      labels: {
+        plural: 'API Keys With Field Read Access',
+        singular: 'API Key With Field Read Access',
+      },
+    },
   ],
   onInit: seed,
   typescript: {

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -335,5 +335,30 @@ describe('Auth', () => {
         })
       })
     })
+
+    describe('api-keys-with-field-read-access', () => {
+      let user
+
+      beforeAll(async () => {
+        url = new AdminUrlUtil(serverURL, 'api-keys-with-field-read-access')
+
+        user = await payload.create({
+          collection: apiKeysSlug,
+          data: {
+            apiKey: uuid(),
+            enableAPIKey: true,
+          },
+        })
+      })
+
+      test('should hide auth parent container if api keys enabled but no read access', async () => {
+        await page.goto(url.create)
+
+        // assert that the auth parent container is hidden
+        await expect(page.locator('.auth-fields')).toBeHidden()
+
+        await saveDocAndAssert(page)
+      })
+    })
   })
 })

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -68,6 +68,7 @@ export interface Config {
     'disable-local-strategy-password': DisableLocalStrategyPasswordAuthOperations;
     'api-keys': ApiKeyAuthOperations;
     'public-users': PublicUserAuthOperations;
+    'api-keys-with-field-read-access': ApiKeysWithFieldReadAccessAuthOperations;
   };
   blocks: {};
   collections: {
@@ -77,6 +78,7 @@ export interface Config {
     'api-keys': ApiKey;
     'public-users': PublicUser;
     relationsCollection: RelationsCollection;
+    'api-keys-with-field-read-access': ApiKeysWithFieldReadAccess;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -89,6 +91,7 @@ export interface Config {
     'api-keys': ApiKeysSelect<false> | ApiKeysSelect<true>;
     'public-users': PublicUsersSelect<false> | PublicUsersSelect<true>;
     relationsCollection: RelationsCollectionSelect<false> | RelationsCollectionSelect<true>;
+    'api-keys-with-field-read-access': ApiKeysWithFieldReadAccessSelect<false> | ApiKeysWithFieldReadAccessSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -114,6 +117,9 @@ export interface Config {
       })
     | (PublicUser & {
         collection: 'public-users';
+      })
+    | (ApiKeysWithFieldReadAccess & {
+        collection: 'api-keys-with-field-read-access';
       });
   jobs: {
     tasks: unknown;
@@ -193,6 +199,24 @@ export interface ApiKeyAuthOperations {
   };
 }
 export interface PublicUserAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface ApiKeysWithFieldReadAccessAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -342,6 +366,18 @@ export interface RelationsCollection {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "api-keys-with-field-read-access".
+ */
+export interface ApiKeysWithFieldReadAccess {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -370,6 +406,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'relationsCollection';
         value: string | RelationsCollection;
+      } | null)
+    | ({
+        relationTo: 'api-keys-with-field-read-access';
+        value: string | ApiKeysWithFieldReadAccess;
       } | null);
   globalSlug?: string | null;
   user:
@@ -392,6 +432,10 @@ export interface PayloadLockedDocument {
     | {
         relationTo: 'public-users';
         value: string | PublicUser;
+      }
+    | {
+        relationTo: 'api-keys-with-field-read-access';
+        value: string | ApiKeysWithFieldReadAccess;
       };
   updatedAt: string;
   createdAt: string;
@@ -422,6 +466,10 @@ export interface PayloadPreference {
     | {
         relationTo: 'public-users';
         value: string | PublicUser;
+      }
+    | {
+        relationTo: 'api-keys-with-field-read-access';
+        value: string | ApiKeysWithFieldReadAccess;
       };
   key?: string | null;
   value?:
@@ -575,6 +623,17 @@ export interface RelationsCollectionSelect<T extends boolean = true> {
   text?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "api-keys-with-field-read-access_select".
+ */
+export interface ApiKeysWithFieldReadAccessSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?

Prevents the Auth component from rendering an empty `.auth-fields` wrapper.

### Why?

When `disableLocalStrategy` is true and `enableFields` is false, but `useAPIKey` is true while
read access to API key fields is denied, the component still rendered the parent wrapper with a
background—showing a blank box.

### How?

Introduce `!(showAuthBlock || showAPIKeyBlock || showVerifyBlock)`:

- `showAuthBlock = enableFields`
- `showAPIKeyBlock = useAPIKey && canReadApiKey`
- `showVerifyBlock = verify && isEditing`

If none are true, return `null`. (`disableLocalStrategy` is already accounted for via `enableFields`.)

Fixes #12089 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211117270523574