### PR TITLE
chore(templates): update vercel-website template for shadcn/ui compatibility

### DIFF
--- a/templates/with-vercel-website/components.json
+++ b/templates/with-vercel-website/components.json
@@ -4,7 +4,7 @@
   "rsc": true,
   "tsx": true,
   "tailwind": {
-    "config": "tailwind.config.js",
+    "config": "tailwind.config.mjs",
     "css": "src/app/(frontend)/globals.css",
     "baseColor": "slate",
     "cssVariables": true,

--- a/templates/with-vercel-website/tailwind.config.mjs
+++ b/templates/with-vercel-website/tailwind.config.mjs
@@ -107,7 +107,8 @@ const config = {
           to: { height: '0' },
         },
       },
-      typography: () => ({
+
+      typography: {
         DEFAULT: {
           css: [
             {
@@ -145,7 +146,7 @@ const config = {
             },
           ],
         },
-      }),
+      },
     },
   },
 }


### PR DESCRIPTION
### What?
This PR updates the vercel-website template configuration to be compatible with the latest shadcn/ui tooling requirements.

### Why?
The latest version of shadcn/ui requires specific configuration formats that the current template doesn't support, causing `pnpm dlx shadcn@latest add [component]` commands to fail.

### How?
- Updated `components.json` to reference `tailwind.config.mjs` instead of `tailwind.config.js`
- Converted typography configuration from function format `typography: () => ({...})` to object format `typography: {...}` in `tailwind.config.mjs`