### PR TITLE
fix(richtext-lexical): list item not removing curlys in lexical serializer

### DIFF
--- a/packages/plugin-form-builder/src/utilities/lexical/converters/list.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/converters/list.ts
@@ -20,7 +20,7 @@ export const ListHTMLConverter: HTMLConverter<any> = {
 }
 
 export const ListItemHTMLConverter: HTMLConverter<any> = {
-  converter: async ({ converters, node, parent }) => {
+  converter: async ({ converters, node, parent, submissionData }) => {
     const childrenText = await convertLexicalNodesToHTML({
       converters,
       lexicalNodes: node.children,
@@ -28,6 +28,7 @@ export const ListItemHTMLConverter: HTMLConverter<any> = {
         ...node,
         parent,
       },
+      submissionData
     })
 
     if ('listType' in parent && parent?.listType === 'check') {


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

List item converter in lexical serializer was not removing curlys on email send.

### Why?

List item converter was not passing 'submissionData' into 'ListItemHTMLConverter'

### How?

Passing 'submissionData' into 'ListItemHTMLConverter' fixed the issue.

Fixes # relates to https://github.com/payloadcms/payload/pull/4753

-->
