### PR TITLE
fix: hide jobs stats global by default

### DIFF
--- a/packages/payload/src/queues/config/global.ts
+++ b/packages/payload/src/queues/config/global.ts
@@ -35,6 +35,10 @@ export type JobStats = {
 export const getJobStatsGlobal: (config: Config) => GlobalConfig = (config) => {
   return {
     slug: jobStatsGlobalSlug,
+    admin: {
+      group: 'System',
+      hidden: true,
+    },
     fields: [
       {
         name: 'stats',


### PR DESCRIPTION
The jobs stats global is used internally to get the scheduling system to work. Currently, if scheduling is enabled, the "Payload Jobs Stats" global is visible in the Payload Admin Panel:

<img width="524" height="252" alt="Screenshot 2025-08-23 at 00 10 13@2x" src="https://github.com/user-attachments/assets/91702c93-4b58-4990-922b-8241ea9aa00e" />

Similarly to how we do it in the Payload Jobs collection, this PR hides the payload jobs stats global from the admin panel by default

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211124797199081