### PR TITLE
fix(db-mongodb): bug resolving joins when useJoinAggregations is disabled

### DIFF
--- a/packages/db-mongodb/src/utilities/resolveJoins.ts
+++ b/packages/db-mongodb/src/utilities/resolveJoins.ts
@@ -465,23 +465,21 @@ function extractRelationToFilter(where: Record<string, unknown>): null | string[
   }
 
   // Check for relationTo in logical operators
-  if (where.and && Array.isArray(where.and)) {
-    for (const condition of where.and) {
-      const result = extractRelationToFilter(condition)
-      if (result) {
-        return result
-      }
-    }
-  }
+	const operators = ['and', 'or'];
 
-  if (where.or && Array.isArray(where.or)) {
-    for (const condition of where.or) {
-      const result = extractRelationToFilter(condition)
-      if (result) {
-        return result
-      }
-    }
-  }
+	for (const operator of operators) {
+		if (where[operator] && Array.isArray(where[operator])) {
+			return where[operator].reduce((acc, condition) => {
+				const result: null | string[] = extractRelationToFilter(condition);
+
+        if (result) {
+					acc.push(...result);
+				}
+
+				return acc;
+			}, []);
+		}
+	}
 
   return null
 }


### PR DESCRIPTION
### What?

When using MongoDB adapter, with the option `useJoinAggregations` set to `false`, queries containing multiple joins were only executing the first join

When useJoinAggregations is disabled and a join includes multiple collections, only first was included.

For example, if we have this json query `where` (simplified real use case from the Folders feature), only the `payload-folders` join where processed.

```json
{
  "or": [
    {
      "and": [
        {
          "relationTo": {
            "equals": "payload-folders"
          }
        }
      ]
    },
    {
      "and": [
        {
          "relationTo": {
            "equals": "media"
          }
        }
      ]
    }
  ]
}
```

### Fixes

Go through multiple `or` and `and` operators in a query `where`, looking for the `relationTo` property, instead of keeping the first one found.