### PR TITLE
feat(plugin-multi-tenant): re-enable global selector on all views

### DIFF
--- a/packages/plugin-multi-tenant/src/components/TenantSelector/index.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantSelector/index.tsx
@@ -9,14 +9,7 @@ type Props = {
   label: MultiTenantPluginConfig['tenantSelectorLabel']
 } & ServerProps
 export const TenantSelector = (props: Props) => {
-  const { enabledSlugs, label, params, viewType } = props
-  const enabled = Boolean(
-    params?.segments &&
-      Array.isArray(params.segments) &&
-      params.segments[0] === 'collections' &&
-      params.segments[1] &&
-      enabledSlugs.includes(params.segments[1]),
-  )
+  const { label, viewType } = props
 
-  return <TenantSelectorClient disabled={!enabled} label={label} viewType={viewType} />
+  return <TenantSelectorClient label={label} viewType={viewType} />
 }


### PR DESCRIPTION
Fixes #13559

Re-enable the global tenant selector on all views. In the last release the global tenant filter was only enabled on tenant enabled collection list views. This change allows the global tenant filter to be selected on all non-document views. This is useful on custom views or custom components on views that may not be tenant-enabled. 
