### PR TITLE
feat: add --check flag to migrate:create on Postgres

### DIFF
--- a/docs/database/migrations.mdx
+++ b/docs/database/migrations.mdx
@@ -132,6 +132,7 @@ npm run payload migrate:create optional-name-here
 Flags:
 
 - `--skip-empty`: with Postgres, it skips the "no schema changes detected. Would you like to create a blank migration file?" prompt which can be useful for generating migration in CI.
+- `--check`: with Postgres, it only checks if new migrations are needed (exits with code 1 if needed and 0 if up-to-date) without writing any files. Useful for CI checks.
 - `--force-accept-warning`: accepts any command prompts, creates a blank migration even if there weren't any changes to the schema.
 
 ### Status

--- a/packages/drizzle/src/utilities/buildCreateMigration.ts
+++ b/packages/drizzle/src/utilities/buildCreateMigration.ts
@@ -22,7 +22,7 @@ export const buildCreateMigration = ({
   const dirname = path.dirname(filename)
   return async function createMigration(
     this: DrizzleAdapter,
-    { file, forceAcceptWarning, migrationName, payload, skipEmpty },
+    { check, file, forceAcceptWarning, migrationName, payload, skipEmpty },
   ) {
     const dir = payload.db.migrationDir
     if (!fs.existsSync(dir)) {
@@ -89,7 +89,7 @@ export const buildCreateMigration = ({
       }
 
       if (!upSQL?.length && !downSQL?.length && !forceAcceptWarning) {
-        if (skipEmpty) {
+        if (skipEmpty || check) {
           process.exit(0)
         }
 
@@ -110,6 +110,12 @@ export const buildCreateMigration = ({
         if (!shouldCreateBlankMigration) {
           process.exit(0)
         }
+      }
+
+      // abort if only checking for changes
+      if (check) {
+        payload.logger.error({ msg: 'Schema changes detected, a new migration is needed' })
+        process.exit(1)
       }
 
       // write schema

--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -52,6 +52,7 @@ export const migrate = async ({ config, parsedArgs }: Args): Promise<void> => {
 
   const forceAcceptWarning = forceAcceptFromProps || formattedArgs.includes('forceAcceptWarning')
   const skipEmpty = formattedArgs.includes('skipEmpty')
+  const check = formattedArgs.includes('check')
 
   if (help) {
     // eslint-disable-next-line no-console
@@ -89,6 +90,7 @@ export const migrate = async ({ config, parsedArgs }: Args): Promise<void> => {
     case 'migrate:create':
       try {
         await adapter.createMigration({
+          check,
           file,
           forceAcceptWarning,
           migrationName: args[1],

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -172,6 +172,10 @@ export type Connect = (args?: ConnectArgs) => Promise<void>
 export type Destroy = () => Promise<void>
 
 export type CreateMigration = (args: {
+  /**
+   * Only checks if new migrations are needed, doesn't create a new migration file
+   */
+  check?: boolean
   file?: string
   forceAcceptWarning?: boolean
   migrationName?: string


### PR DESCRIPTION
### What
Add `--check` flag to `migrate:create` on Postgres adapter. When the flag is applied, the command only checks if migrations are needed without actually creating new migrations.

- If schema is up-to-date and migrations are not needed, the command exits with code 0.
- If new migrations are needed, the command prints "Schema changes detected, a new migration is needed" and exits with code 1.

### Why
This is useful for creating CI checks. There has been discussion about this at least in #10978.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
