### PR TITLE
fix(next): richtext fields not read-only for locked documents

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -208,7 +208,7 @@ export const renderDocument = async ({
       globalSlug,
       locale: locale?.code,
       operation,
-      readOnly: isTrashedDoc,
+      readOnly: isTrashedDoc || isLocked,
       renderAllFields: true,
       req,
       schemaPath: collectionSlug || globalSlug,

--- a/test/locked-documents/collections/Posts/index.ts
+++ b/test/locked-documents/collections/Posts/index.ts
@@ -17,6 +17,10 @@ export const PostsCollection: CollectionConfig = {
       type: 'text',
     },
     {
+      name: 'richText',
+      type: 'richText',
+    },
+    {
       name: 'documentLoaded',
       label: 'Document loaded',
       type: 'date',

--- a/test/locked-documents/e2e.spec.ts
+++ b/test/locked-documents/e2e.spec.ts
@@ -755,6 +755,22 @@ describe('Locked Documents', () => {
 
       // fields should be readOnly / disabled
       await expect(page.locator('#field-text')).toBeDisabled()
+
+      const richTextRoot = page
+        .locator('.rich-text-lexical .ContentEditable__root[data-lexical-editor="true"]')
+        .first()
+
+      // ensure editor is present
+      await expect(richTextRoot).toBeVisible()
+
+      // core read-only checks
+      await expect(richTextRoot).toHaveAttribute('contenteditable', 'false')
+      await expect(richTextRoot).toHaveAttribute('aria-readonly', 'true')
+
+      // wrapper has read-only class (nice-to-have)
+      await expect(page.locator('.rich-text-lexical').first()).toHaveClass(
+        /rich-text-lexical--read-only/,
+      )
     })
   })
 

--- a/test/locked-documents/payload-types.ts
+++ b/test/locked-documents/payload-types.ts
@@ -141,6 +141,21 @@ export interface Page {
 export interface Post {
   id: string;
   text?: string | null;
+  richText?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   documentLoaded?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -264,6 +279,7 @@ export interface PagesSelect<T extends boolean = true> {
  */
 export interface PostsSelect<T extends boolean = true> {
   text?: T;
+  richText?: T;
   documentLoaded?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
### What?

Ensure the Rich Text field is read-only when viewing a locked document.

### Why?

When opening a locked doc in read-only mode, the Rich Text field could still appear editable. This is inconsistent with other fields and allows users to try typing into a locked document.

### How?

- Pass `readOnly={isTrashedDoc || isLocked}` into `buildFormState` in the edit view renderer.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211141396953189