### PR TITLE
docs: adds default populate video

### DIFF
--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -148,6 +148,12 @@ export const Pages: CollectionConfig<'pages'> = {
 }
 ```
 
+<VideoDrawer
+  id="Snqjng_w-QU"
+  label="Watch default populate in action"
+  drawerTitle="How to easily optimize Payload CMS requests with defaultPopulate"
+/>
+
 <Banner type="warning">
   **Important:** When using `defaultPopulate` on a collection with
   [Uploads](/docs/fields/upload) enabled and you want to select the `url` field,


### PR DESCRIPTION
Uses the VideoDrawer block to link relevant YouTube video at the bottom of defaultPopulate section