### PR TITLE
fix(ui): autosave in document drawer overwrites local changes

### DIFF
--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientCollectionConfig, DefaultDocumentIDType } from 'payload'
+import type { ClientCollectionConfig } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import React, { Fragment, useCallback, useEffect, useState } from 'react'
@@ -33,7 +33,6 @@ export const AddNewRelation: React.FC<Props> = ({
   const { permissions } = useAuth()
   const [show, setShow] = useState(false)
   const [selectedCollection, setSelectedCollection] = useState<string>()
-  const [docID, setDocID] = useState<DefaultDocumentIDType>(undefined)
 
   const relatedToMany = relatedCollections.length > 1
 
@@ -47,9 +46,7 @@ export const AddNewRelation: React.FC<Props> = ({
 
   const [DocumentDrawer, DocumentDrawerToggler, { isDrawerOpen, toggleDrawer }] = useDocumentDrawer(
     {
-      id: docID,
       collectionSlug: collectionConfig?.slug,
-      keepUUIDAfterCreate: true,
     },
   )
 
@@ -90,7 +87,6 @@ export const AddNewRelation: React.FC<Props> = ({
         }
 
         setSelectedCollection(undefined)
-        setDocID(doc.id)
       }
     },
     [collectionConfig, hasMany, onChange, value, relatedCollections],
@@ -157,7 +153,6 @@ export const AddNewRelation: React.FC<Props> = ({
               .filter(Boolean)
               .join(' ')}
             onClick={() => {
-              setDocID(undefined)
               setShowTooltip(false)
             }}
             onMouseEnter={() => setShowTooltip(true)}
@@ -206,7 +201,6 @@ export const AddNewRelation: React.FC<Props> = ({
                         key={relatedCollection?.slug}
                         onClick={() => {
                           closePopup()
-                          setDocID(undefined)
                           setSelectedCollection(relatedCollection?.slug)
                         }}
                       >

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -52,9 +52,15 @@ export const AddNewRelation: React.FC<Props> = ({
 
   const onSave: DocumentDrawerContextType['onSave'] = useCallback(
     ({ doc, operation }) => {
-      if (operation === 'create') {
-        let isNewValue = false
+      // if autosave is enabled, the operation will be 'update'
+      const isAutosaveEnabled =
+        typeof collectionConfig?.versions?.drafts === 'object'
+          ? collectionConfig.versions.drafts.autosave
+          : false
 
+      if (operation === 'create' || (operation === 'update' && isAutosaveEnabled)) {
+        // ensure the value is not already in the array
+        let isNewValue = false
         if (!value) {
           isNewValue = true
         } else {

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -52,15 +52,9 @@ export const AddNewRelation: React.FC<Props> = ({
 
   const onSave: DocumentDrawerContextType['onSave'] = useCallback(
     ({ doc, operation }) => {
-      // if autosave is enabled, the operation will be 'update'
-      const isAutosaveEnabled =
-        typeof collectionConfig?.versions?.drafts === 'object'
-          ? collectionConfig.versions.drafts.autosave
-          : false
-
-      if (operation === 'create' || (operation === 'update' && isAutosaveEnabled)) {
-        // ensure the value is not already in the array
+      if (operation === 'create') {
         let isNewValue = false
+
         if (!value) {
           isNewValue = true
         } else {
@@ -70,17 +64,6 @@ export const AddNewRelation: React.FC<Props> = ({
         }
 
         if (isNewValue) {
-          // dispatchOptions({
-          //   collection: collectionConfig,
-          //   // TODO: fix this
-          //   // @ts-expect-error-next-line
-          //   type: 'ADD',
-          //   config,
-          //   docs: [doc],
-          //   i18n,
-          //   sort: true,
-          // })
-
           if (hasMany === true) {
             onChange([
               ...(Array.isArray(value) ? value : []),

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -105,8 +105,6 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>(
     (args) => {
-      getDocumentView(args.doc.id)
-
       if (typeof onSaveFromProps === 'function') {
         void onSaveFromProps({
           ...args,
@@ -114,13 +112,11 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
         })
       }
     },
-    [onSaveFromProps, collectionConfig, getDocumentView],
+    [onSaveFromProps, collectionConfig],
   )
 
   const onDuplicate = useCallback<DocumentDrawerProps['onDuplicate']>(
     (args) => {
-      getDocumentView(args.doc.id)
-
       if (typeof onDuplicateFromProps === 'function') {
         void onDuplicateFromProps({
           ...args,
@@ -128,7 +124,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
         })
       }
     },
-    [onDuplicateFromProps, collectionConfig, getDocumentView],
+    [onDuplicateFromProps, collectionConfig],
   )
 
   const onDelete = useCallback<DocumentDrawerProps['onDelete']>(

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -15,7 +15,7 @@ import { abortAndIgnore, handleAbortRef } from '../../utilities/abortAndIgnore.j
 import { DocumentDrawerContextProvider } from './Provider.js'
 
 export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
-  id: existingDocID,
+  id: docID,
   collectionSlug,
   disableActions,
   drawerSlug,
@@ -43,10 +43,12 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
 
   const [DocumentView, setDocumentView] = useState<React.ReactNode>(undefined)
   const [isLoading, setIsLoading] = useState(true)
+
   const hasInitialized = useRef(false)
+  const prevDocID = useRef(docID)
 
   const getDocumentView = useCallback(
-    (docID?: number | string, showLoadingIndicator: boolean = false) => {
+    (docID?: DocumentDrawerProps['id'], showLoadingIndicator: boolean = false) => {
       const controller = handleAbortRef(abortGetDocumentViewRef)
 
       const fetchDocumentView = async () => {
@@ -78,7 +80,6 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
         } catch (error) {
           toast.error(error?.message || t('error:unspecific'))
           closeModal(drawerSlug)
-          // toast.error(data?.errors?.[0].message || t('error:unspecific'))
         }
 
         abortGetDocumentViewRef.current = null
@@ -146,11 +147,15 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   }, [getDocumentView])
 
   useEffect(() => {
-    if (!DocumentView && !hasInitialized.current) {
-      getDocumentView(existingDocID, true)
+    if (!DocumentView && (!hasInitialized.current || prevDocID.current !== docID)) {
+      getDocumentView(docID, true)
       hasInitialized.current = true
     }
-  }, [DocumentView, getDocumentView, existingDocID])
+
+    if (prevDocID.current !== docID) {
+      prevDocID.current = docID
+    }
+  }, [DocumentView, getDocumentView, docID])
 
   // Cleanup any pending requests when the component unmounts
   useEffect(() => {

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -45,7 +45,6 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const [isLoading, setIsLoading] = useState(true)
 
   const hasInitialized = useRef(false)
-  const prevDocID = useRef(docID)
 
   const getDocumentView = useCallback(
     (docID?: DocumentDrawerProps['id'], showLoadingIndicator: boolean = false) => {
@@ -106,6 +105,10 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>(
     (args) => {
+      if (args.operation === 'create') {
+        getDocumentView(args.doc.id, false)
+      }
+
       if (typeof onSaveFromProps === 'function') {
         void onSaveFromProps({
           ...args,
@@ -113,11 +116,13 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
         })
       }
     },
-    [onSaveFromProps, collectionConfig],
+    [onSaveFromProps, collectionConfig, getDocumentView],
   )
 
   const onDuplicate = useCallback<DocumentDrawerProps['onDuplicate']>(
     (args) => {
+      getDocumentView(args.doc.id, false)
+
       if (typeof onDuplicateFromProps === 'function') {
         void onDuplicateFromProps({
           ...args,
@@ -125,7 +130,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
         })
       }
     },
-    [onDuplicateFromProps, collectionConfig],
+    [onDuplicateFromProps, collectionConfig, getDocumentView],
   )
 
   const onDelete = useCallback<DocumentDrawerProps['onDelete']>(
@@ -147,13 +152,9 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   }, [getDocumentView])
 
   useEffect(() => {
-    if (!DocumentView && (!hasInitialized.current || prevDocID.current !== docID)) {
+    if (!DocumentView && !hasInitialized.current) {
       getDocumentView(docID, true)
       hasInitialized.current = true
-    }
-
-    if (prevDocID.current !== docID) {
-      prevDocID.current = docID
     }
   }, [DocumentView, getDocumentView, docID])
 

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -106,7 +106,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const onSave = useCallback<DocumentDrawerProps['onSave']>(
     (args) => {
       if (args.operation === 'create') {
-        getDocumentView(args.doc.id, false)
+        getDocumentView(args.doc.id)
       }
 
       if (typeof onSaveFromProps === 'function') {
@@ -121,7 +121,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
 
   const onDuplicate = useCallback<DocumentDrawerProps['onDuplicate']>(
     (args) => {
-      getDocumentView(args.doc.id, false)
+      getDocumentView(args.doc.id)
 
       if (typeof onDuplicateFromProps === 'function') {
         void onDuplicateFromProps({

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -22,13 +22,15 @@ const formatDocumentDrawerSlug = ({
   id,
   collectionSlug,
   depth,
+  keepUUIDAfterCreate,
   uuid,
 }: {
   collectionSlug: string
   depth: number
   id: number | string
+  keepUUIDAfterCreate?: boolean
   uuid: string // supply when creating a new document and no id is available
-}) => `doc-drawer_${collectionSlug}_${depth}${id ? `_${id}` : ''}_${uuid}`
+}) => `doc-drawer_${collectionSlug}_${depth}${id && !keepUUIDAfterCreate ? `_${id}` : ''}_${uuid}`
 
 export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
   children,
@@ -91,6 +93,7 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = (props) => {
 export const useDocumentDrawer: UseDocumentDrawer = ({
   id,
   collectionSlug,
+  keepUUIDAfterCreate,
   overrideEntityVisibility,
 }) => {
   const editDepth = useEditDepth()
@@ -102,6 +105,7 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
     id,
     collectionSlug,
     depth: editDepth,
+    keepUUIDAfterCreate,
     uuid,
   })
 
@@ -128,11 +132,12 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
         collectionSlug={collectionSlug}
         drawerSlug={drawerSlug}
         id={id}
+        keepUUIDAfterCreate={keepUUIDAfterCreate}
         key={drawerSlug}
         overrideEntityVisibility={overrideEntityVisibility}
       />
     )
-  }, [id, drawerSlug, collectionSlug, overrideEntityVisibility])
+  }, [id, drawerSlug, collectionSlug, overrideEntityVisibility, keepUUIDAfterCreate])
 
   const MemoizedDrawerToggler = useMemo<React.FC<DocumentTogglerProps>>(() => {
     return (props) => (

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useModal } from '@faceless-ui/modal'
-import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
 
 import type {
   DocumentDrawerProps,
@@ -22,11 +22,13 @@ const formatDocumentDrawerSlug = ({
   id,
   collectionSlug,
   depth,
+  uuid,
 }: {
   collectionSlug: string
   depth: number
-  id: number | string
-}) => `doc-drawer_${collectionSlug}_${depth}_${id}`
+  id?: number | string
+  uuid: string
+}) => `doc-drawer_${collectionSlug}_${depth}${id ? `_${id}` : ''}_${uuid}`
 
 export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
   children,
@@ -96,16 +98,11 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
   const { closeModal, modalState, openModal, toggleModal } = useModal()
   const [isOpen, setIsOpen] = useState(false)
 
-  const initializedWithoutID = useRef(!id)
-
   const drawerSlug = formatDocumentDrawerSlug({
-    /**
-     * This pattern will maintain the same drawer slug across the create and update operations.
-     * Otherwise the drawer would be treated as a different instance and close unexpectedly.
-     */
-    id: initializedWithoutID.current ? uuid : id,
+    id,
     collectionSlug,
     depth: editDepth,
+    uuid,
   })
 
   useEffect(() => {

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useModal } from '@faceless-ui/modal'
-import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import type {
   DocumentDrawerProps,
@@ -22,15 +22,11 @@ const formatDocumentDrawerSlug = ({
   id,
   collectionSlug,
   depth,
-  keepUUIDAfterCreate,
-  uuid,
 }: {
   collectionSlug: string
   depth: number
   id: number | string
-  keepUUIDAfterCreate?: boolean
-  uuid: string // supply when creating a new document and no id is available
-}) => `doc-drawer_${collectionSlug}_${depth}${id && !keepUUIDAfterCreate ? `_${id}` : ''}_${uuid}`
+}) => `doc-drawer_${collectionSlug}_${depth}_${id}`
 
 export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
   children,
@@ -93,7 +89,6 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = (props) => {
 export const useDocumentDrawer: UseDocumentDrawer = ({
   id,
   collectionSlug,
-  keepUUIDAfterCreate,
   overrideEntityVisibility,
 }) => {
   const editDepth = useEditDepth()
@@ -101,12 +96,12 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
   const { closeModal, modalState, openModal, toggleModal } = useModal()
   const [isOpen, setIsOpen] = useState(false)
 
+  const preferUUID = useRef(!id)
+
   const drawerSlug = formatDocumentDrawerSlug({
-    id,
+    id: preferUUID.current ? uuid : id,
     collectionSlug,
     depth: editDepth,
-    keepUUIDAfterCreate,
-    uuid,
   })
 
   useEffect(() => {
@@ -132,12 +127,11 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
         collectionSlug={collectionSlug}
         drawerSlug={drawerSlug}
         id={id}
-        keepUUIDAfterCreate={keepUUIDAfterCreate}
         key={drawerSlug}
         overrideEntityVisibility={overrideEntityVisibility}
       />
     )
-  }, [id, drawerSlug, collectionSlug, overrideEntityVisibility, keepUUIDAfterCreate])
+  }, [id, drawerSlug, collectionSlug, overrideEntityVisibility])
 
   const MemoizedDrawerToggler = useMemo<React.FC<DocumentTogglerProps>>(() => {
     return (props) => (

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -96,10 +96,14 @@ export const useDocumentDrawer: UseDocumentDrawer = ({
   const { closeModal, modalState, openModal, toggleModal } = useModal()
   const [isOpen, setIsOpen] = useState(false)
 
-  const preferUUID = useRef(!id)
+  const initializedWithoutID = useRef(!id)
 
   const drawerSlug = formatDocumentDrawerSlug({
-    id: preferUUID.current ? uuid : id,
+    /**
+     * This pattern will maintain the same drawer slug across the create and update operations.
+     * Otherwise the drawer would be treated as a different instance and close unexpectedly.
+     */
+    id: initializedWithoutID.current ? uuid : id,
     collectionSlug,
     depth: editDepth,
   })

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -1,4 +1,4 @@
-import type { Data, FormState, Operation } from 'payload'
+import type { Data, DefaultDocumentIDType, FormState, Operation } from 'payload'
 import type React from 'react'
 import type { HTMLAttributes } from 'react'
 
@@ -7,15 +7,29 @@ import type { DocumentDrawerContextProps } from './Provider.js'
 
 export type DocumentDrawerProps = {
   readonly AfterFields?: React.ReactNode
+  /**
+   * The slug of the collection to which the document belongs.
+   */
   readonly collectionSlug: string
   readonly disableActions?: boolean
   readonly drawerSlug?: string
-  readonly id?: null | number | string
+  /**
+   * The ID of the document to be edited.
+   * When provided, will be fetched and displayed in the drawer.
+   * If omitted, will render the "create new" view for the given collection.
+   */
+  readonly id?: DefaultDocumentIDType | null
   readonly initialData?: Data
   /**
    * @deprecated
    */
   readonly initialState?: FormState
+  /**
+   * If true, the drawer will keep the same UUID it generated for the "create new" document.
+   * This is useful for keeping the drawer open when creating a new document, as it
+   * prevents the drawer from generating a new modal slug after the document ID is created.
+   */
+  readonly keepUUIDAfterCreate?: boolean
   readonly overrideEntityVisibility?: boolean
   readonly redirectAfterCreate?: boolean
   readonly redirectAfterDelete?: boolean
@@ -43,19 +57,12 @@ export type UseDocumentDrawerContext = {
   toggleDrawer: () => void
 }
 
-export type UseDocumentDrawer = (args: {
-  /**
-   * The slug of the collection to which the document belongs.
-   */
-  collectionSlug: string
-  /**
-   * The ID of the document to be edited.
-   * When provided, will be fetched and displayed in the drawer.
-   * If omitted, will render the "create new" view for the given collection.
-   */
-  id?: number | string
-  overrideEntityVisibility?: boolean
-}) => [
+export type UseDocumentDrawer = (
+  args: Pick<
+    DocumentDrawerProps,
+    'collectionSlug' | 'id' | 'keepUUIDAfterCreate' | 'overrideEntityVisibility'
+  >,
+) => [
   // drawer
   React.FC<
     {

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -24,12 +24,6 @@ export type DocumentDrawerProps = {
    * @deprecated
    */
   readonly initialState?: FormState
-  /**
-   * If true, the drawer will keep the same UUID it generated for the "create new" document.
-   * This is useful for keeping the drawer open when creating a new document, as it
-   * prevents the drawer from generating a new modal slug after the document ID is created.
-   */
-  readonly keepUUIDAfterCreate?: boolean
   readonly overrideEntityVisibility?: boolean
   readonly redirectAfterCreate?: boolean
   readonly redirectAfterDelete?: boolean
@@ -58,10 +52,7 @@ export type UseDocumentDrawerContext = {
 }
 
 export type UseDocumentDrawer = (
-  args: Pick<
-    DocumentDrawerProps,
-    'collectionSlug' | 'id' | 'keepUUIDAfterCreate' | 'overrideEntityVisibility'
-  >,
+  args: Pick<DocumentDrawerProps, 'collectionSlug' | 'id' | 'overrideEntityVisibility'>,
 ) => [
   // drawer
   React.FC<

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-compiler/react-compiler -- TODO: fix */
 'use client'
 
-import type { ClientUser, DocumentViewClientProps, FormState } from 'payload'
+import type { ClientUser, DocumentViewClientProps } from 'payload'
 
 import { useRouter, useSearchParams } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -568,7 +568,9 @@ describe('Relationship Field', () => {
     ).toHaveCount(1)
     await drawerField.fill('Updated document')
     await saveButton.click()
-    await expect(page.locator('.payload-toast-container')).toContainText('Updated successfully')
+    await expect(page.locator('.payload-toast-container').first()).toContainText(
+      'Updated successfully',
+    )
     await page.locator('.doc-drawer__header-close').click()
     await expect(
       page.locator('#field-relationshipHasMany .value-container .rs__multi-value'),

--- a/test/fields-relationship/payload-types.ts
+++ b/test/fields-relationship/payload-types.ts
@@ -387,6 +387,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -661,6 +668,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -71,8 +71,8 @@ export interface Config {
     posts: Post;
     'autosave-posts': AutosavePost;
     'autosave-with-draft-button-posts': AutosaveWithDraftButtonPost;
-    'autosave-with-validate-posts': AutosaveWithValidatePost;
     'autosave-multi-select-posts': AutosaveMultiSelectPost;
+    'autosave-with-validate-posts': AutosaveWithValidatePost;
     'draft-posts': DraftPost;
     'draft-with-max-posts': DraftWithMaxPost;
     'draft-with-validate-posts': DraftWithValidatePost;
@@ -96,8 +96,8 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     'autosave-posts': AutosavePostsSelect<false> | AutosavePostsSelect<true>;
     'autosave-with-draft-button-posts': AutosaveWithDraftButtonPostsSelect<false> | AutosaveWithDraftButtonPostsSelect<true>;
-    'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'autosave-multi-select-posts': AutosaveMultiSelectPostsSelect<false> | AutosaveMultiSelectPostsSelect<true>;
+    'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'draft-posts': DraftPostsSelect<false> | DraftPostsSelect<true>;
     'draft-with-max-posts': DraftWithMaxPostsSelect<false> | DraftWithMaxPostsSelect<true>;
     'draft-with-validate-posts': DraftWithValidatePostsSelect<false> | DraftWithValidatePostsSelect<true>;
@@ -284,23 +284,23 @@ export interface AutosaveWithDraftButtonPost {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "autosave-with-validate-posts".
- */
-export interface AutosaveWithValidatePost {
-  id: string;
-  title: string;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "autosave-multi-select-posts".
  */
 export interface AutosaveMultiSelectPost {
   id: string;
   title: string;
   tag?: ('blog' | 'essay' | 'portfolio')[] | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-validate-posts".
+ */
+export interface AutosaveWithValidatePost {
+  id: string;
+  title: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -411,6 +411,7 @@ export interface Diff {
               textInNamedTab1InBlock?: string | null;
             };
             textInUnnamedTab2InBlock?: string | null;
+            textInRowInUnnamedTab2InBlock?: string | null;
             id?: string | null;
             blockName?: string | null;
             blockType: 'TabsBlock';
@@ -706,12 +707,12 @@ export interface PayloadLockedDocument {
         value: string | AutosaveWithDraftButtonPost;
       } | null)
     | ({
-        relationTo: 'autosave-with-validate-posts';
-        value: string | AutosaveWithValidatePost;
-      } | null)
-    | ({
         relationTo: 'autosave-multi-select-posts';
         value: string | AutosaveMultiSelectPost;
+      } | null)
+    | ({
+        relationTo: 'autosave-with-validate-posts';
+        value: string | AutosaveWithValidatePost;
       } | null)
     | ({
         relationTo: 'draft-posts';
@@ -860,21 +861,21 @@ export interface AutosaveWithDraftButtonPostsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "autosave-with-validate-posts_select".
+ * via the `definition` "autosave-multi-select-posts_select".
  */
-export interface AutosaveWithValidatePostsSelect<T extends boolean = true> {
+export interface AutosaveMultiSelectPostsSelect<T extends boolean = true> {
   title?: T;
+  tag?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "autosave-multi-select-posts_select".
+ * via the `definition` "autosave-with-validate-posts_select".
  */
-export interface AutosaveMultiSelectPostsSelect<T extends boolean = true> {
+export interface AutosaveWithValidatePostsSelect<T extends boolean = true> {
   title?: T;
-  tag?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1027,6 +1028,7 @@ export interface DiffSelect<T extends boolean = true> {
                     textInNamedTab1InBlock?: T;
                   };
               textInUnnamedTab2InBlock?: T;
+              textInRowInUnnamedTab2InBlock?: T;
               id?: T;
               blockName?: T;
             };
@@ -1384,6 +1386,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,15 +21,8 @@
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "sourceMap": true,
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
-    "types": [
-      "node",
-      "jest"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["node", "jest"],
     "incremental": true,
     "isolatedModules": true,
     "plugins": [
@@ -38,72 +31,36 @@
       }
     ],
     "paths": {
-      "@payload-config": [
-        "./test/form-state/config.ts"
-      ],
-      "@payloadcms/admin-bar": [
-        "./packages/admin-bar/src"
-      ],
-      "@payloadcms/live-preview": [
-        "./packages/live-preview/src"
-      ],
-      "@payloadcms/live-preview-react": [
-        "./packages/live-preview-react/src/index.ts"
-      ],
-      "@payloadcms/live-preview-vue": [
-        "./packages/live-preview-vue/src/index.ts"
-      ],
-      "@payloadcms/ui": [
-        "./packages/ui/src/exports/client/index.ts"
-      ],
-      "@payloadcms/ui/shared": [
-        "./packages/ui/src/exports/shared/index.ts"
-      ],
-      "@payloadcms/ui/rsc": [
-        "./packages/ui/src/exports/rsc/index.ts"
-      ],
-      "@payloadcms/ui/scss": [
-        "./packages/ui/src/scss.scss"
-      ],
-      "@payloadcms/ui/scss/app.scss": [
-        "./packages/ui/src/scss/app.scss"
-      ],
-      "@payloadcms/next/*": [
-        "./packages/next/src/exports/*.ts"
-      ],
+      "@payload-config": ["./test/_community/config.ts"],
+      "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
+      "@payloadcms/live-preview": ["./packages/live-preview/src"],
+      "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
+      "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],
+      "@payloadcms/ui": ["./packages/ui/src/exports/client/index.ts"],
+      "@payloadcms/ui/shared": ["./packages/ui/src/exports/shared/index.ts"],
+      "@payloadcms/ui/rsc": ["./packages/ui/src/exports/rsc/index.ts"],
+      "@payloadcms/ui/scss": ["./packages/ui/src/scss.scss"],
+      "@payloadcms/ui/scss/app.scss": ["./packages/ui/src/scss/app.scss"],
+      "@payloadcms/next/*": ["./packages/next/src/exports/*.ts"],
       "@payloadcms/richtext-lexical/client": [
         "./packages/richtext-lexical/src/exports/client/index.ts"
       ],
-      "@payloadcms/richtext-lexical/rsc": [
-        "./packages/richtext-lexical/src/exports/server/rsc.ts"
-      ],
-      "@payloadcms/richtext-slate/rsc": [
-        "./packages/richtext-slate/src/exports/server/rsc.ts"
-      ],
+      "@payloadcms/richtext-lexical/rsc": ["./packages/richtext-lexical/src/exports/server/rsc.ts"],
+      "@payloadcms/richtext-slate/rsc": ["./packages/richtext-slate/src/exports/server/rsc.ts"],
       "@payloadcms/richtext-slate/client": [
         "./packages/richtext-slate/src/exports/client/index.ts"
       ],
-      "@payloadcms/plugin-seo/client": [
-        "./packages/plugin-seo/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-sentry/client": [
-        "./packages/plugin-sentry/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-stripe/client": [
-        "./packages/plugin-stripe/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-search/client": [
-        "./packages/plugin-search/src/exports/client.ts"
-      ],
+      "@payloadcms/plugin-seo/client": ["./packages/plugin-seo/src/exports/client.ts"],
+      "@payloadcms/plugin-sentry/client": ["./packages/plugin-sentry/src/exports/client.ts"],
+      "@payloadcms/plugin-stripe/client": ["./packages/plugin-stripe/src/exports/client.ts"],
+      "@payloadcms/plugin-search/client": ["./packages/plugin-search/src/exports/client.ts"],
       "@payloadcms/plugin-form-builder/client": [
         "./packages/plugin-form-builder/src/exports/client.ts"
       ],
       "@payloadcms/plugin-import-export/rsc": [
         "./packages/plugin-import-export/src/exports/rsc.ts"
       ],
-      "@payloadcms/plugin-multi-tenant/rsc": [
-        "./packages/plugin-multi-tenant/src/exports/rsc.ts"
-      ],
+      "@payloadcms/plugin-multi-tenant/rsc": ["./packages/plugin-multi-tenant/src/exports/rsc.ts"],
       "@payloadcms/plugin-multi-tenant/utilities": [
         "./packages/plugin-multi-tenant/src/exports/utilities.ts"
       ],
@@ -113,42 +70,25 @@
       "@payloadcms/plugin-multi-tenant/client": [
         "./packages/plugin-multi-tenant/src/exports/client.ts"
       ],
-      "@payloadcms/plugin-multi-tenant": [
-        "./packages/plugin-multi-tenant/src/index.ts"
-      ],
+      "@payloadcms/plugin-multi-tenant": ["./packages/plugin-multi-tenant/src/index.ts"],
       "@payloadcms/plugin-multi-tenant/translations/languages/all": [
         "./packages/plugin-multi-tenant/src/translations/index.ts"
       ],
       "@payloadcms/plugin-multi-tenant/translations/languages/*": [
         "./packages/plugin-multi-tenant/src/translations/languages/*.ts"
       ],
-      "@payloadcms/next": [
-        "./packages/next/src/exports/*"
-      ],
-      "@payloadcms/storage-azure/client": [
-        "./packages/storage-azure/src/exports/client.ts"
-      ],
-      "@payloadcms/storage-s3/client": [
-        "./packages/storage-s3/src/exports/client.ts"
-      ],
+      "@payloadcms/next": ["./packages/next/src/exports/*"],
+      "@payloadcms/storage-azure/client": ["./packages/storage-azure/src/exports/client.ts"],
+      "@payloadcms/storage-s3/client": ["./packages/storage-s3/src/exports/client.ts"],
       "@payloadcms/storage-vercel-blob/client": [
         "./packages/storage-vercel-blob/src/exports/client.ts"
       ],
-      "@payloadcms/storage-gcs/client": [
-        "./packages/storage-gcs/src/exports/client.ts"
-      ],
+      "@payloadcms/storage-gcs/client": ["./packages/storage-gcs/src/exports/client.ts"],
       "@payloadcms/storage-uploadthing/client": [
         "./packages/storage-uploadthing/src/exports/client.ts"
       ]
     }
   },
-  "include": [
-    "${configDir}/src"
-  ],
-  "exclude": [
-    "${configDir}/dist",
-    "${configDir}/build",
-    "${configDir}/temp",
-    "**/*.spec.ts"
-  ]
+  "include": ["${configDir}/src"],
+  "exclude": ["${configDir}/dist", "${configDir}/build", "${configDir}/temp", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Fixes #13574.

When editing an autosave-enabled document within a document drawer, any changes made will while the autosave is processing are ultimately discarded from local form state. This makes is difficult or even impossible to edit fields.

This is because we server-render, then replace, the entire document on every save. This includes form state, which is stale because it was rendered while new changes were still being made. We don't need to re-render the entire view on every save, though, only on create. We don't do this on the top-level edit view, for example. Instead, we only need to replace form state.

This change is also a performance improvement because we are no longer rendering all components unnecessarily, especially on every autosave interval.

Before:

https://github.com/user-attachments/assets/e9c221bf-4800-4153-af55-8b82e93b3c26

After:

https://github.com/user-attachments/assets/d77ef2f3-b98b-41d6-ba6c-b502b9bb99cc

Note: ignore the flashing autosave status and doc controls. This is horrible and we're actively fixing it, but is outside the scope of this PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211139422639700