### PR TITLE
fix: restore as draft function was passing a published status

### DIFF
--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -260,8 +260,8 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
 
     // Ensure updatedAt date is always updated
     result.updatedAt = new Date().toISOString()
-    // Ensure status respects draft arg
-    result._status = draftArg ? 'draft' : 'published'
+    // Ensure status respects restoreAsDraft arg
+    result._status = draftArg ? 'draft' : result._status
     result = await req.payload.db.updateOne({
       id: parentDocID,
       collection: collectionConfig.slug,

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -260,6 +260,8 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
 
     // Ensure updatedAt date is always updated
     result.updatedAt = new Date().toISOString()
+    // Ensure status respects draft arg
+    result._status = draftArg ? 'draft' : 'published'
     result = await req.payload.db.updateOne({
       id: parentDocID,
       collection: collectionConfig.slug,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -265,7 +265,12 @@ describe('Versions', () => {
 
       await expect(page.locator('#field-title')).toHaveValue('v2')
       await page.goto(`${savedDocURL}/api`)
-      await expect(page.locator('.query-inspector__value')).not.toHaveText(/published/i)
+      const values = page.locator('.query-inspector__value')
+      const count = await values.count()
+
+      for (let i = 0; i < count; i++) {
+        await expect(values.nth(i)).not.toHaveText(/published/i)
+      }
     })
 
     test('should show currently published version status in versions view', async () => {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -241,6 +241,33 @@ describe('Versions', () => {
       await expect(page.locator('#field-title')).toHaveValue('v1')
     })
 
+    test('should restore version as draft', async () => {
+      await page.goto(url.create)
+      await page.locator('#field-title').fill('v1')
+      await saveDocAndAssert(page, '#action-save-draft')
+      await page.locator('#field-title').fill('v2')
+      await page.locator('#field-description').fill('restore me as draft')
+      await saveDocAndAssert(page)
+      await page.locator('#field-title').fill('v3')
+      await page.locator('#field-description').fill('published')
+      await saveDocAndAssert(page)
+
+      const savedDocURL = page.url()
+      await page.goto(`${savedDocURL}/versions`)
+      const row2 = page.locator('tbody .row-2')
+      const versionID = await row2.locator('.cell-id').textContent()
+      await page.goto(`${savedDocURL}/versions/${versionID}`)
+      await expect(page.locator('.render-field-diffs')).toBeVisible()
+      await page.locator('.restore-version .popup__trigger-wrap button').click()
+      await page.getByRole('button', { name: 'Restore as draft' }).click()
+      await page.locator('button:has-text("Confirm")').click()
+      await page.waitForURL(savedDocURL)
+
+      await expect(page.locator('#field-title')).toHaveValue('v2')
+      await page.goto(`${savedDocURL}/api`)
+      await expect(page.locator('.query-inspector__value')).not.toHaveText(/published/i)
+    })
+
     test('should show currently published version status in versions view', async () => {
       const publishedDoc = await payload.create({
         collection: draftCollectionSlug,


### PR DESCRIPTION
### What  
When using the `Restore as draft` action from the version view, the restored document incorrectly appears as `published` in the API. This issue was reported by a client.  

### Why  
In the `restoreVersion` operation, the document is updated via `db.updateOne` (line 265). The update passes along the status stored in the version being restored but does not respect the `draft` query parameter.  

### How  
Ensures that the result status is explicitly set to `draft` when the `draft` argument is `true`.  
