### PR TITLE
feat: allow multiple, different payload instances using getPayload in same process

### DIFF
--- a/packages/db-mongodb/src/destroy.ts
+++ b/packages/db-mongodb/src/destroy.ts
@@ -1,11 +1,11 @@
 import type { Destroy } from 'payload'
 
-import mongoose from 'mongoose'
-
 import type { MongooseAdapter } from './index.js'
 
 export const destroy: Destroy = async function destroy(this: MongooseAdapter) {
-  await mongoose.disconnect()
+  await this.connection.close()
 
-  Object.keys(mongoose.models).map((model) => mongoose.deleteModel(model))
+  for (const name of Object.keys(this.connection.models)) {
+    this.connection.deleteModel(name)
+  }
 }

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -999,8 +999,8 @@ export const reload = async (
   ;(global as any)._payload_doNotCacheClientSchemaMap = true
 }
 
-let _cached: WeakMap<
-  object,
+let _cached: Map<
+  string,
   Map<
     string,
     {
@@ -1013,11 +1013,19 @@ let _cached: WeakMap<
 > = (global as any)._payload
 
 if (!_cached) {
-  _cached = (global as any)._payload = new WeakMap()
+  _cached = (global as any)._payload = new Map()
 }
 
 export const getPayload = async (
-  options: Pick<InitOptions, 'config' | 'cron' | 'disableOnInit' | 'importMap'>,
+  options: {
+    /**
+     * A unique key to identify the payload instance. You can pass your own key if you want to cache this payload instance separately.
+     * This is useful if you pass a different payload config for each instance.
+     *
+     * @default 'default'
+     */
+    key?: string
+  } & Pick<InitOptions, 'config' | 'cron' | 'disableOnInit' | 'importMap'>,
 ): Promise<Payload> => {
   if (!options?.config) {
     throw new Error('Error: the payload config is required for getPayload to work.')
@@ -1025,10 +1033,10 @@ export const getPayload = async (
 
   let alreadyCachedSameConfig = false
 
-  let cachedByConfig = _cached.get(options.config)
+  let cachedByConfig = _cached.get(options.key ?? 'default')
   if (!cachedByConfig) {
     cachedByConfig = new Map()
-    _cached.set(options.config, cachedByConfig)
+    _cached.set(options.key ?? 'default', cachedByConfig)
   } else {
     alreadyCachedSameConfig = true
   }

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1020,6 +1020,14 @@ if (!_cached) {
   _cached = (global as any)._payload = new Map()
 }
 
+/**
+ * Get a payload instance.
+ * This function is a wrapper around new BasePayload().init() that adds the following functionality on top of that:
+ *
+ * - smartly caches Payload instance on the module scope. That way, we prevent unnecessarily initializing Payload over and over again
+ * when calling getPayload multiple times or from multiple locations.
+ * - adds HMR support and reloads the payload instance when the config changes.
+ */
 export const getPayload = async (
   options: {
     /**
@@ -1059,6 +1067,7 @@ export const getPayload = async (
 
   if (cached.payload) {
     if (options.cron && !cached.initializedCrons) {
+      // getPayload called with crons enabled, but existing cached version does not have crons initialized. => Initialize crons in existing cached version
       cached.initializedCrons = true
       await cached.payload._initializeCrons()
     }

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -1,12 +1,12 @@
-import type { BlockField, Payload } from 'payload'
-
 import { execSync } from 'child_process'
 import { existsSync, readFileSync, rmSync } from 'fs'
 import path from 'path'
+import { type BlocksField, getPayload, type Payload } from 'payload'
 import { fileURLToPath } from 'url'
 
 import type { NextRESTClient } from '../helpers/NextRESTClient.js'
 
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
 import { testFilePath } from './testFilePath.js'
 
@@ -40,6 +40,54 @@ describe('Config', () => {
         description: 'Get the sanitized payload config',
       })
     })
+
+    it('should allow multiple getPayload calls using different configs in same process', async () => {
+      const payload2 = await getPayload({
+        config: await buildConfigWithDefaults({
+          collections: [
+            {
+              slug: 'payload2',
+              fields: [{ name: 'title2', type: 'text' }],
+            },
+          ],
+        }),
+      })
+
+      // Use payload2 instance before creating payload3 instance, as we share the same db connection => each instance
+      // creation will reset the db schema.
+      const result2: any = await payload2.create({
+        collection: 'payload2',
+        data: {
+          title2: 'Payload 2',
+        },
+      } as any)
+
+      expect(result2.title2).toBe('Payload 2')
+
+      const payload3 = await getPayload({
+        config: await buildConfigWithDefaults({
+          collections: [
+            {
+              slug: 'payload3',
+              fields: [{ name: 'title3', type: 'text' }],
+            },
+          ],
+        }),
+      })
+
+      // If payload was still incorrectly cached, this would fail, as the old payload config would still be used
+      const result3: any = await payload3.create({
+        collection: 'payload3',
+        data: {
+          title3: 'Payload 3',
+        },
+      } as any)
+
+      expect(result3.title3).toBe('Payload 3')
+
+      await payload2.destroy()
+      await payload3.destroy()
+    })
   })
 
   describe('collection config', () => {
@@ -72,7 +120,7 @@ describe('Config', () => {
       const [collection] = payload.config.collections
       const [, blocksField] = collection.fields
 
-      expect((blocksField as BlockField).blocks[0].custom).toEqual({
+      expect((blocksField as BlocksField).blocks[0].custom).toEqual({
         description: 'The blockOne of this page',
       })
     })

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -43,6 +43,7 @@ describe('Config', () => {
 
     it('should allow multiple getPayload calls using different configs in same process', async () => {
       const payload2 = await getPayload({
+        key: 'payload2',
         config: await buildConfigWithDefaults({
           collections: [
             {
@@ -65,6 +66,7 @@ describe('Config', () => {
       expect(result2.title2).toBe('Payload 2')
 
       const payload3 = await getPayload({
+        key: 'payload3',
         config: await buildConfigWithDefaults({
           collections: [
             {

--- a/test/queues/cli.int.spec.ts
+++ b/test/queues/cli.int.spec.ts
@@ -1,0 +1,85 @@
+import path from 'path'
+import {
+  _internal_jobSystemGlobals,
+  _internal_resetJobSystemGlobals,
+  getPayload,
+  migrateCLI,
+  type SanitizedConfig,
+} from 'payload'
+import { wait } from 'payload/shared'
+import { fileURLToPath } from 'url'
+
+import { initPayloadInt } from '../helpers/initPayloadInt.js'
+import { waitUntilAutorunIsDone } from './utilities.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+describe('Queues - CLI', () => {
+  let config: SanitizedConfig
+  beforeAll(async () => {
+    ;({ config } = await initPayloadInt(dirname, undefined, false))
+  })
+
+  it('ensure consecutive getPayload call with cron: true will autorun jobs', async () => {
+    const payload = await getPayload({
+      config,
+    })
+
+    await payload.jobs.queue({
+      workflow: 'inlineTaskTest',
+      queue: 'autorunSecond',
+      input: {
+        message: 'hello!',
+      },
+    })
+
+    process.env.PAYLOAD_DROP_DATABASE = 'false'
+
+    // Second instance of payload with the only purpose of running cron jobs
+    const _payload2 = await getPayload({
+      config,
+      cron: true,
+    })
+
+    await waitUntilAutorunIsDone({
+      payload,
+      queue: 'autorunSecond',
+    })
+
+    const allSimples = await payload.find({
+      collection: 'simple',
+      limit: 100,
+    })
+
+    expect(allSimples.totalDocs).toBe(1)
+    expect(allSimples?.docs?.[0]?.title).toBe('hello!')
+
+    // Shut down safely:
+    // Ensure no new crons are scheduled
+    _internal_jobSystemGlobals.shouldAutoRun = false
+    _internal_jobSystemGlobals.shouldAutoSchedule = false
+    // Wait 3 seconds to ensure all currently-running crons are done. If we shut down the db while a function is running, it can cause issues
+    // Cron function runs may persist after a test has finished
+    await wait(3000)
+    // Now we can destroy the payload instance
+    await _payload2.destroy()
+    await payload.destroy()
+    _internal_resetJobSystemGlobals()
+  })
+
+  it('can run migrate CLI without jobs attempting to run', async () => {
+    await migrateCLI({
+      config,
+      parsedArgs: {
+        _: ['migrate'],
+      },
+    })
+
+    // Wait 3 seconds to let potential autorun crons trigger
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+
+    // Expect no errors. Previously, this would throw an "error: relation "payload_jobs" does not exist" error
+    expect(true).toBe(true)
+  })
+})

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -1475,8 +1475,6 @@ describe('Queues - CLI', () => {
   })
 
   it('ensure consecutive getPayload call with cron: true will autorun jobs', async () => {
-    ;({ config } = await initPayloadInt(dirname, undefined, false))
-
     const payload = await getPayload({
       config,
     })


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13433. Testing release: `3.54.0-internal.90cf7d5`

Previously, when calling `getPayload`, you would always use the same, cached payload instance within a single process, regardless of the arguments passed to the `getPayload` function. This resulted in the following issues - both are fixed by this PR:

- If, in your frontend you're calling `getPayload` without `cron: true`, and you're hosting the Payload Admin Panel in the same process, crons will not be enabled even if you visit the admin panel which calls `getPayload` with `cron: true`. This will break jobs autorun depending on which page you visit first - admin panel or frontend
- Within the same process, you are unable to use `getPayload` twice for different instances of payload with different Payload Configs.
On postgres, you can get around this by manually calling new `BasePayload()` which skips the cache. This did not work on mongoose though, as mongoose was caching the models on a global singleton (this PR addresses this).
In order to bust the cache for different Payload Config, this PR introduces a new, optional `key` property to `getPayload`.


## Mongoose - disable using global singleton

This PR refactors the Payload Mongoose adapter to stop relying on the global mongoose singleton. Instead, each adapter instance now creates and manages its own scoped Connection object.

### Motivation

Previously, calling `getPayload()` more than once in the same process would throw `Cannot overwrite model` errors because models were compiled into the global singleton. This prevented running multiple Payload instances side-by-side, even when pointing at different databases.

### Changes
- Replace usage of `mongoose.connect()` / `mongoose.model()` with instance-scoped `createConnection()` and `connection.model()`.
- Ensure models, globals, and versions are compiled per connection, not globally.
- Added proper `close()` handling on `this.connection` instead of `mongoose.disconnect()`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211114366468745