### PR TITLE
perf(plugin-search): reindex collections in parallel, up to 80% faster

### DIFF
--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -164,8 +164,8 @@ export const generateReindexHandler =
       })
 
       await Promise.all(promises)
-    } catch (msg) {
-      return Response.json({ message: msg }, { headers, status: 500 })
+    } catch (err: any) {
+      return Response.json({ message: err.message }, { headers, status: 500 })
     }
 
     const message = t('general:successfullyReindexed', {

--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -149,22 +149,6 @@ export const generateReindexHandler =
 
     await initTransaction(req)
 
-    // log start time to measure performance
-    const t0 = performance.now()
-
-    // for (const collection of collections) {
-    //   try {
-    //     await deleteIndexes(collection)
-    //     await reindexCollection(collection)
-    //   } catch (err) {
-    //     const message = t('error:unableToReindexCollection', { collection })
-    //     payload.logger.error({ err, msg: message })
-
-    //     await killTransaction(req)
-    //     return Response.json({ message }, { headers, status: 500 })
-    //   }
-    // }
-
     try {
       const promises = collections.map(async (collection) => {
         try {
@@ -183,9 +167,6 @@ export const generateReindexHandler =
     } catch (msg) {
       return Response.json({ message: msg }, { headers, status: 500 })
     }
-
-    const t1 = performance.now()
-    console.log(`Call to reindex took ${t1 - t0} milliseconds.`)
 
     const message = t('general:successfullyReindexed', {
       collections: collections.join(', '),

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -494,20 +494,22 @@ describe('@payloadcms/plugin-search', () => {
   })
 
   it('should reindex whole collections', async () => {
-    await payload.create({
-      collection: pagesSlug,
-      data: {
-        title: 'Test page title',
-        _status: 'published',
-      },
-    })
-    await payload.create({
-      collection: postsSlug,
-      data: {
-        title: 'Test page title',
-        _status: 'published',
-      },
-    })
+    await Promise.all([
+      payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Test page title',
+          _status: 'published',
+        },
+      }),
+      payload.create({
+        collection: postsSlug,
+        data: {
+          title: 'Test page title',
+          _status: 'published',
+        },
+      }),
+    ])
 
     await wait(200)
 

--- a/test/plugin-search/payload-types.ts
+++ b/test/plugin-search/payload-types.ts
@@ -136,6 +136,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -300,6 +307,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-search/seed/index.ts
+++ b/test/plugin-search/seed/index.ts
@@ -14,6 +14,30 @@ export const seed = async (payload: Payload): Promise<boolean> => {
       req,
     })
 
+    // seed 1000 pages
+    for (let i = 0; i < 1000; i++) {
+      await payload.create({
+        collection: 'pages',
+        data: {
+          title: `Test page title ${i}`,
+          _status: 'published',
+        },
+        req,
+      })
+    }
+
+    // seed 1000 posts
+    for (let i = 0; i < 1000; i++) {
+      await payload.create({
+        collection: 'posts',
+        data: {
+          title: `Test post title ${i}`,
+          _status: 'published',
+        },
+        req,
+      })
+    }
+
     return true
   } catch (err) {
     console.error(err)

--- a/test/plugin-search/seed/index.ts
+++ b/test/plugin-search/seed/index.ts
@@ -14,30 +14,6 @@ export const seed = async (payload: Payload): Promise<boolean> => {
       req,
     })
 
-    // seed 1000 pages
-    for (let i = 0; i < 1000; i++) {
-      await payload.create({
-        collection: 'pages',
-        data: {
-          title: `Test page title ${i}`,
-          _status: 'published',
-        },
-        req,
-      })
-    }
-
-    // seed 1000 posts
-    for (let i = 0; i < 1000; i++) {
-      await payload.create({
-        collection: 'posts',
-        data: {
-          title: `Test post title ${i}`,
-          _status: 'published',
-        },
-        req,
-      })
-    }
-
     return true
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
Reindexing all collections in the search plugin was previously done in sequence which is slow and risks timing out under certain network conditions. By running these requests in parallel we are able to save **on average ~80%** in compute time.

This test includes reindexing 2000 documents in total across 2 collections, 3 times over. The indexes themselves are relatively simple, containing only a couple simple fields each, so the savings would only increase with more complexity and/or more documents.

Before:
Attempt 1: 38434.87ms
Attempt 2: 47852.61ms
Attempt 3: 28407.79ms
Avg: 38231.75ms

After:
Attempt 1: 7834.29ms
Attempt 2: 7744.40ms
Attempt 3: 7918.58ms
Avg: 7832.42ms

Total savings: ~79.51%

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211162504205343