### PR TITLE
feat: configurable toast notifications

### DIFF
--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -107,6 +107,7 @@ The following options are available:
 | `suppressHydrationWarning` | If set to `true`, suppresses React hydration mismatch warnings during the hydration of the root `<html>` tag. Defaults to `false`.              |
 | `theme`                    | Restrict the Admin Panel theme to use only one of your choice. Default is `all`.                                                                |
 | `timezones`                | Configure the timezone settings for the admin panel. [More details](#timezones)                                                                 |
+| `toast`                    | Customize the handling of toast messages within the Admin Panel. [More details](#toasts)                                                        |
 | `user`                     | The `slug` of the Collection that you want to allow to login to the Admin Panel. [More details](#the-admin-user-collection).                    |
 
 <Banner type="success">
@@ -298,3 +299,20 @@ We validate the supported timezones array by checking the value against the list
   `timezone: true`. See [Date Fields](../fields/overview#date) for more
   information.
 </Banner>
+
+## Toast
+
+The `admin.toast` configuration allows you to customize the handling of toast messages within the Admin Panel, such as increasing the duration they are displayed and limiting the number of visible toasts at once.
+
+<Banner type="info">
+  **Note:** The Admin Panel currently uses the
+  [Sonner](https://sonner.emilkowal.ski) library for toast notifications.
+</Banner>
+
+The following options are available for the `admin.toast` configuration:
+
+| Option     | Description                                                                                                      | Default |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- | ------- |
+| `duration` | The length of time (in milliseconds) that a toast message is displayed.                                          | `4000`  |
+| `expand`   | If `true`, will expand the message stack so that all messages are shown simultaneously without user interaction. | `false` |
+| `limit`    | The maximum number of toasts that can be visible on the screen at once.                                          | `5`     |

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -116,6 +116,7 @@ export const createClientConfig = ({
           routes: config.admin.routes,
           theme: config.admin.theme,
           timezones: config.admin.timezones,
+          toast: config.admin.toast,
           user: config.admin.user,
         }
 

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -959,7 +959,7 @@ export type Config = {
        * The maximum number of toasts that can be visible on the screen at once.
        * @default 5
        */
-      visibleToasts?: number
+      limit?: number
     }
     /** The slug of a Collection that you want to be used to log in to the Admin dashboard. */
     user?: string

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -752,7 +752,6 @@ export type Config = {
           username?: string
         }
       | false
-
     /** Set account profile picture. Options: gravatar, default or a custom React component. */
     avatar?:
       | 'default'
@@ -760,6 +759,7 @@ export type Config = {
       | {
           Component: PayloadComponent
         }
+
     /**
      * Add extra and/or replace built-in components with custom components
      *
@@ -939,6 +939,26 @@ export type Config = {
      * Configure timezone related settings for the admin panel.
      */
     timezones?: TimezonesConfig
+    /**
+     * Toast Config
+     */
+    toast?: {
+      /**
+       * Time in milliseconds until the toast automatically closes.
+       * @default 4000
+       */
+      duration?: number
+      /**
+       * Control whether toasts are expanded by default (not collapsed).
+       * @default false
+       */
+      expand?: boolean
+      /**
+       * The maximum number of toasts that can be visible on the screen at once.
+       * @default 5
+       */
+      visibleToasts?: number
+    }
     /** The slug of a Collection that you want to be used to log in to the Admin dashboard. */
     user?: string
   }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -951,7 +951,8 @@ export type Config = {
        */
       duration?: number
       /**
-       * Control whether toasts are expanded by default (not collapsed).
+       * If `true`, will expand the message stack so that all messages are shown simultaneously without user interaction.
+       * Otherwise only the latest notification can be read until the user hovers the stack.
        * @default false
        */
       expand?: boolean

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -940,7 +940,9 @@ export type Config = {
      */
     timezones?: TimezonesConfig
     /**
-     * Toast Config
+     * @experimental
+     * Configure toast message behavior and appearance in the admin panel.
+     * Currently using [Sonner](https://sonner.emilkowal.ski) for toast notifications.
      */
     toast?: {
       /**

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -139,11 +139,7 @@ export const RootProvider: React.FC<Props> = ({
           </RouteCache>
         </RouteTransitionProvider>
       </ServerFunctionsProvider>
-      <ToastContainer
-        duration={config.admin.toast?.duration}
-        expand={config.admin.toast?.expand}
-        visibleToasts={config.admin.toast?.visibleToasts}
-      />
+      <ToastContainer config={config} />
     </ClickOutsideProvider>
   )
 }

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -139,7 +139,11 @@ export const RootProvider: React.FC<Props> = ({
           </RouteCache>
         </RouteTransitionProvider>
       </ServerFunctionsProvider>
-      <ToastContainer />
+      <ToastContainer
+        duration={config.admin.toast?.duration}
+        expand={config.admin.toast?.expand}
+        visibleToasts={config.admin.toast?.visibleToasts}
+      />
     </ClickOutsideProvider>
   )
 }

--- a/packages/ui/src/providers/ToastContainer/index.tsx
+++ b/packages/ui/src/providers/ToastContainer/index.tsx
@@ -2,18 +2,27 @@
 import React from 'react'
 import { Toaster } from 'sonner'
 
+import { useConfig } from '../Config/index.js'
 import { Error } from './icons/Error.js'
 import { Info } from './icons/Info.js'
 import { Success } from './icons/Success.js'
 import { Warning } from './icons/Warning.js'
 
 export const ToastContainer: React.FC = () => {
+  const {
+    config: {
+      admin: { toast },
+    },
+  } = useConfig()
+
   return (
     <Toaster
       className="payload-toast-container"
       closeButton
       // @ts-expect-error
       dir="undefined"
+      duration={toast?.duration ?? 4000}
+      expand={toast?.expand ?? false}
       gap={8}
       icons={{
         error: <Error />,
@@ -36,7 +45,7 @@ export const ToastContainer: React.FC = () => {
         },
         unstyled: true,
       }}
-      visibleToasts={5}
+      visibleToasts={toast?.visibleToasts ?? 5}
     />
   )
 }

--- a/packages/ui/src/providers/ToastContainer/index.tsx
+++ b/packages/ui/src/providers/ToastContainer/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { Config } from 'payload'
+import type { ClientConfig } from 'payload'
 
 import React from 'react'
 import { Toaster } from 'sonner'
@@ -9,9 +9,11 @@ import { Info } from './icons/Info.js'
 import { Success } from './icons/Success.js'
 import { Warning } from './icons/Warning.js'
 
-export const ToastContainer: React.FC<
-  Pick<Config['admin']['toast'], 'duration' | 'expand' | 'visibleToasts'>
-> = ({ duration, expand, visibleToasts }) => {
+export const ToastContainer: React.FC<{
+  config: ClientConfig
+}> = ({ config }) => {
+  const { admin: { toast: { duration, expand, visibleToasts } = {} } = {} } = config
+
   return (
     <Toaster
       className="payload-toast-container"

--- a/packages/ui/src/providers/ToastContainer/index.tsx
+++ b/packages/ui/src/providers/ToastContainer/index.tsx
@@ -1,28 +1,25 @@
 'use client'
+import type { Config } from 'payload'
+
 import React from 'react'
 import { Toaster } from 'sonner'
 
-import { useConfig } from '../Config/index.js'
 import { Error } from './icons/Error.js'
 import { Info } from './icons/Info.js'
 import { Success } from './icons/Success.js'
 import { Warning } from './icons/Warning.js'
 
-export const ToastContainer: React.FC = () => {
-  const {
-    config: {
-      admin: { toast },
-    },
-  } = useConfig()
-
+export const ToastContainer: React.FC<
+  Pick<Config['admin']['toast'], 'duration' | 'expand' | 'visibleToasts'>
+> = ({ duration, expand, visibleToasts }) => {
   return (
     <Toaster
       className="payload-toast-container"
       closeButton
       // @ts-expect-error
       dir="undefined"
-      duration={toast?.duration ?? 4000}
-      expand={toast?.expand ?? false}
+      duration={duration ?? 4000}
+      expand={expand ?? false}
       gap={8}
       icons={{
         error: <Error />,
@@ -45,7 +42,7 @@ export const ToastContainer: React.FC = () => {
         },
         unstyled: true,
       }}
-      visibleToasts={toast?.visibleToasts ?? 5}
+      visibleToasts={visibleToasts ?? 5}
     />
   )
 }

--- a/packages/ui/src/providers/ToastContainer/index.tsx
+++ b/packages/ui/src/providers/ToastContainer/index.tsx
@@ -12,7 +12,7 @@ import { Warning } from './icons/Warning.js'
 export const ToastContainer: React.FC<{
   config: ClientConfig
 }> = ({ config }) => {
-  const { admin: { toast: { duration, expand, visibleToasts } = {} } = {} } = config
+  const { admin: { toast: { duration, expand, limit } = {} } = {} } = config
 
   return (
     <Toaster
@@ -44,7 +44,7 @@ export const ToastContainer: React.FC<{
         },
         unstyled: true,
       }}
-      visibleToasts={visibleToasts ?? 5}
+      visibleToasts={limit ?? 5}
     />
   )
 }


### PR DESCRIPTION
Follow up to #12119.

You can now configure the toast notifications used in the admin panel through the Payload config:

```ts
import { buildConfig } from 'payload'

export default buildConfig({
  // ...
  admin: {
    // ...
    toast: {
      duration: 8000,
      limit: 1,
      // ...
    }
  }
})
```

_Note: the toast config is temporarily labeled as experimental to allow for changes to the API, if necessary._

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211139422639711