### PR TITLE
fix(ui): prevent infinite redirect if no user

### DIFF
--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -179,15 +179,17 @@ export function AuthProvider({
           return json.user
         }
 
-        setNewUser(null)
-        redirectToInactivityRoute()
+        if (user) {
+          setNewUser(null)
+          redirectToInactivityRoute()
+        }
         return null
       } catch (e) {
         toast.error(`Refreshing token failed: ${e.message}`)
         return null
       }
     },
-    [apiRoute, i18n.language, redirectToInactivityRoute, serverURL, setNewUser, userSlug],
+    [apiRoute, i18n.language, redirectToInactivityRoute, serverURL, setNewUser, userSlug, user],
   )
 
   const logOut = useCallback(async () => {


### PR DESCRIPTION
Conditionally send the user to the inactivity route if there was a user but refresh failed. You can get into an infinite loop if you call this function externally and a redirect is being used in the url. 