### PR TITLE
refactor: deprecate job queue runHooks property

### DIFF
--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -157,6 +157,7 @@ export type JobsConfig = {
    * drastically affect performance.
    *
    * @default false
+   * @deprecated - this will be removed in 4.0
    */
   runHooks?: boolean
   /**


### PR DESCRIPTION
Setting `runHooks: true` is already discouraged and will make the job queue system a lot slower and less reliable. We have no test coverage for this and it's additional code we need to maintain.

To further discourage using this property, this PR marks it as deprecated and for removal in 4.0.