### PR TITLE
perf(drizzle): 2x faster document deletion

### DIFF
--- a/packages/db-mongodb/src/deleteOne.ts
+++ b/packages/db-mongodb/src/deleteOne.ts
@@ -1,5 +1,5 @@
 import type { MongooseUpdateQueryOptions } from 'mongoose'
-import type { DeleteOne } from 'payload'
+import type { DeleteOne, SelectType } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
@@ -11,9 +11,16 @@ import { transform } from './utilities/transform.js'
 
 export const deleteOne: DeleteOne = async function deleteOne(
   this: MongooseAdapter,
-  { collection: collectionSlug, req, returning, select, where },
+  { collection: collectionSlug, req, returning, select: selectArg, where },
 ) {
   const { collectionConfig, Model } = getCollection({ adapter: this, collectionSlug })
+
+  const select: SelectType | undefined =
+    returning === false
+      ? {
+          id: true,
+        }
+      : selectArg
 
   const options: MongooseUpdateQueryOptions = {
     projection: buildProjectionFromSelect({

--- a/test/database/postgres-logs.int.spec.ts
+++ b/test/database/postgres-logs.int.spec.ts
@@ -92,7 +92,7 @@ describePostgres('database - postgres logs', () => {
     consoleCount.mockRestore()
   })
 
-  it('ensure deleteOne is done in single db query - returning true', async () => {
+  it('ensure deleteOne is done in two db queries - returning true', async () => {
     const post = await payload.create({
       collection: 'posts',
       data: {

--- a/test/database/postgres-logs.int.spec.ts
+++ b/test/database/postgres-logs.int.spec.ts
@@ -92,6 +92,47 @@ describePostgres('database - postgres logs', () => {
     consoleCount.mockRestore()
   })
 
+  it('ensure deleteOne is done in single db query - returning true', async () => {
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        title: 'Some title',
+        number: 5,
+      },
+    })
+    // Count every console log
+    const consoleCount = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    await payload.db.deleteOne({
+      collection: 'posts',
+      where: { id: { equals: post.id } },
+    })
+
+    expect(consoleCount).toHaveBeenCalledTimes(2)
+    consoleCount.mockRestore()
+  })
+
+  it('ensure deleteOne is done in single db query - returning false', async () => {
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        title: 'Some title',
+        number: 5,
+      },
+    })
+    // Count every console log
+    const consoleCount = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    await payload.db.deleteOne({
+      collection: 'posts',
+      where: { id: { equals: post.id } },
+      returning: false,
+    })
+
+    expect(consoleCount).toHaveBeenCalledTimes(1)
+    consoleCount.mockRestore()
+  })
+
   it('ensure deleteMany is done in single db query - no where query', async () => {
     await payload.create({
       collection: 'posts',


### PR DESCRIPTION
Currently, db.deleteOne will always result in 2 db calls: finding the document, then deleting it.

However, if `returning` is `false` and no joins are required for fetching the document we want to delete, we can do this operation in one single db call: delete it while passing the original where query.

If `returning` is `false` but joins are required (e.g. due to complex where query referencing other tables), this also slightly optimizes performance by using a narrower `select`.

Related PR for deleteMany (already merged - simpler, as deleteMany does not return any documents, deleteOne does): https://github.com/payloadcms/payload/pull/13255

In order to improve code readability, this also changes this PR to call `this.findOne` to find the document instead of manually calling drizzle APIs. This does add minimal overhead (`buildQuery` being called twice), but should not introduce additional db calls.

### Local API Performance Impact

The speeds up the `payload.delete()` local API operation, which uses `payload.db.deleteOne` + `returning: false` internally. It does not make use of `payload.db.deleteMany`

=> Unlike the previous PR optimizing `payload.deleteMany()`, this PR will actually have a **noticeable, positive performance impact when deleting documents in the admin panel - especially when using bulk delete**

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211156702717869