### PR TITLE
fix(db-vercel-postgres): use createPool for EdgeRuntime compatibility

### DIFF
--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -1,8 +1,9 @@
 import type { DrizzleAdapter } from '@payloadcms/drizzle/types'
+import type { VercelPool } from '@vercel/postgres'
 import type { Connect, Migration } from 'payload'
 
 import { pushDevSchema } from '@payloadcms/drizzle'
-import { sql, VercelPool } from '@vercel/postgres'
+import { createPool, sql } from '@vercel/postgres'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { withReplicas } from 'drizzle-orm/pg-core'
 import pg from 'pg'
@@ -36,7 +37,7 @@ export const connect: Connect = async function connect(
         },
       )
     } else {
-      client = this.poolOptions ? new VercelPool(this.poolOptions) : sql
+      client = this.poolOptions ? createPool(this.poolOptions) : sql
     }
 
     // Passed the poolOptions if provided,
@@ -53,7 +54,7 @@ export const connect: Connect = async function connect(
           ...this.poolOptions,
           connectionString,
         }
-        const pool = new VercelPool(options)
+        const pool = createPool(options)
         return drizzle({ client: pool, logger, schema: this.schema })
       })
       const myReplicas = withReplicas(this.drizzle, readReplicas as any)


### PR DESCRIPTION
### What?
Fix `vercelPostgresAdapter` to properly handle EdgeRuntime pool configuration by using `createPool()` instead of directly instantiating `VercelPool`.

### Why?
The current implementation bypasses critical EdgeRuntime-specific configuration overrides that prevent connection pool issues. When running on EdgeRuntime:

- Client reuse is not supported, requiring `maxUses: 1`
- A higher `max` connection limit (10,000) is needed to handle concurrent connections
- The `createPool` function contains proper EdgeRuntime detection and applies these overrides
- `vercelPostgresAdapter` was creating `VercelPool` directly, skipping this logic entirely

With wrong EdgeRuntime configuration the connection pool reuses connection which isn't allowed and causes database queries to return `undefined` instead of data, leading to TypeError in `upsertRow`.

### How?
- Modified `vercelPostgresAdapter` to call `createPool(config)` instead of `new VercelPool(config)`
- This ensures the EdgeRuntime detection logic runs and applies the necessary configuration overrides
- No breaking changes - the function signature and behavior remain the same for non-EdgeRuntime environments
