### PR TITLE
fix(ui): sidebar missing sticky top offset

### DIFF
--- a/packages/ui/src/elements/DocumentFields/index.scss
+++ b/packages/ui/src/elements/DocumentFields/index.scss
@@ -93,7 +93,7 @@
       }
 
       position: var(--sidebar-wrap-position, sticky);
-      top: var(--sidebar-wrap-top, 0);
+      top: var(--sidebar-wrap-top, var(--doc-controls-height));
       width: var(--sidebar-wrap-width, 33.33%);
       height: var(--sidebar-wrap-height, calc(100vh - var(--doc-controls-height)));
       min-width: var(--sidebar-wrap-min-width, var(--doc-sidebar-width));


### PR DESCRIPTION
Regression from https://github.com/payloadcms/payload/pull/13340. Incorrect fallback value for the `--sidebar-wrap-top` css variable was used.

### Before
<img width="2896" height="1200" alt="CleanShot 2025-09-01 at 10 03 39@2x" src="https://github.com/user-attachments/assets/caf054d2-ac61-4a96-b6a1-3981ce9f528f" />

### After
<img width="2894" height="1194" alt="CleanShot 2025-09-01 at 10 02 59@2x" src="https://github.com/user-attachments/assets/1e13e084-6f62-47bb-88b3-921ba5f3ff10" />

