### PR TITLE
fix: prevent enabling trash on folders

### DIFF
--- a/packages/payload/src/folders/types.ts
+++ b/packages/payload/src/folders/types.ts
@@ -87,8 +87,8 @@ export type RootFoldersConfiguration = {
   collectionOverrides?: (({
     collection,
   }: {
-    collection: CollectionConfig
-  }) => CollectionConfig | Promise<CollectionConfig>)[]
+    collection: Omit<CollectionConfig, 'trash'>
+  }) => Omit<CollectionConfig, 'trash'> | Promise<Omit<CollectionConfig, 'trash'>>)[]
   /**
    * If true, you can scope folders to specific collections.
    *


### PR DESCRIPTION
### What?

This PR updates the folder configuration types to explicitly omit the `trash` option from `CollectionConfig` when used for folders.

### Why?

Currently, only documents are designed to support trashing. Allowing folders to be trashed introduces inconsistencies, since removing a folder does not properly remove its references from associated documents.

By omitting `trash` from folder configurations, we prevent accidental use of unsupported behavior until proper design and handling for folder trashing is implemented.

### How?

- Updated `RootFoldersConfiguration.collectionOverrides` type to use `Omit<CollectionConfig, 'trash'>`
- Ensures `trash` cannot be enabled on folders
