### PR TITLE
perf(graphql): select only the requested columns

### DIFF
--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -293,7 +293,7 @@ export const traverseFields = ({
             ) {
               blockSelect = {}
               blockSelectMode = 'include'
-            } else if (selectMode === 'include' && blocksSelect[block.slug] === true) {
+            } else if (selectMode === 'include' && Boolean(blocksSelect[block.slug])) {
               blockSelect = true
             }
           }
@@ -783,7 +783,7 @@ export const traverseFields = ({
         if (select || selectAllOnCurrentLevel) {
           if (
             selectAllOnCurrentLevel ||
-            (selectMode === 'include' && select[field.name] === true) ||
+            (selectMode === 'include' && Boolean(select[field.name])) ||
             (selectMode === 'exclude' && typeof select[field.name] === 'undefined')
           ) {
             shouldSelect = true
@@ -847,7 +847,7 @@ export const traverseFields = ({
 
         if (
           selectAllOnCurrentLevel ||
-          (selectMode === 'include' && select[field.name] === true) ||
+          (selectMode === 'include' && Boolean(select[field.name])) ||
           (selectMode === 'exclude' && typeof select[field.name] === 'undefined')
         ) {
           const fieldPath = `${path}${field.name}`

--- a/packages/graphql/src/resolvers/collections/find.ts
+++ b/packages/graphql/src/resolvers/collections/find.ts
@@ -1,8 +1,11 @@
-import type { Collection, PaginatedDocs, PayloadRequest, Where } from 'payload'
+import type { GraphQLResolveInfo } from 'graphql'
+import type { Collection, PaginatedDocs, Where } from 'payload'
 
 import { findOperation, isolateObjectProperty } from 'payload'
 
 import type { Context } from '../types.js'
+
+import { buildSelectForCollectionMany } from '../../utilities/select.js'
 
 export type Resolver = (
   _: unknown,
@@ -14,28 +17,24 @@ export type Resolver = (
     locale?: string
     page?: number
     pagination?: boolean
+    select?: boolean
     sort?: string
     trash?: boolean
     where?: Where
   },
-  context: {
-    req: PayloadRequest
-  },
+  context: Context,
+  info: GraphQLResolveInfo,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ) => Promise<PaginatedDocs<any>>
 
 export function findResolver(collection: Collection): Resolver {
-  return async function resolver(_, args, context: Context) {
-    let { req } = context
-    const locale = req.locale
-    const fallbackLocale = req.fallbackLocale
+  return async function resolver(_, args, context, info) {
+    const req = context.req = isolateObjectProperty(context.req, ['locale', 'fallbackLocale', 'transactionID'])
+    const select = context.select = args.select ? buildSelectForCollectionMany(info) : undefined
 
-    req = isolateObjectProperty(req, ['locale', 'fallbackLocale', 'transactionID'])
-    req.locale = args.locale || locale
-    req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) {
-      req.query = {}
-    }
+    req.locale = args.locale || req.locale
+    req.fallbackLocale = args.fallbackLocale || req.fallbackLocale
+    req.query = req.query || {}
 
     const draft: boolean =
       (args.draft ?? req.query?.draft === 'false')
@@ -47,8 +46,6 @@ export function findResolver(collection: Collection): Resolver {
       req.query.draft = String(draft)
     }
 
-    context.req = req
-
     const options = {
       collection,
       depth: 0,
@@ -57,12 +54,13 @@ export function findResolver(collection: Collection): Resolver {
       page: args.page,
       pagination: args.pagination,
       req,
+      select,
       sort: args.sort,
       trash: args.trash,
       where: args.where,
     }
 
-    const results = await findOperation(options)
-    return results
+    const result = await findOperation(options)
+    return result
   }
 }

--- a/packages/graphql/src/resolvers/collections/findByID.ts
+++ b/packages/graphql/src/resolvers/collections/findByID.ts
@@ -1,8 +1,11 @@
-import type { Collection, CollectionSlug, DataFromCollectionSlug, PayloadRequest } from 'payload'
+import type { GraphQLResolveInfo } from 'graphql'
+import type { Collection, CollectionSlug, DataFromCollectionSlug } from 'payload'
 
 import { findByIDOperation, isolateObjectProperty } from 'payload'
 
 import type { Context } from '../types.js'
+
+import { buildSelectForCollection } from '../../utilities/select.js'
 
 export type Resolver<TData> = (
   _: unknown,
@@ -11,27 +14,23 @@ export type Resolver<TData> = (
     fallbackLocale?: string
     id: string
     locale?: string
+    select?: boolean
     trash?: boolean
   },
-  context: {
-    req: PayloadRequest
-  },
+  context: Context,
+  info: GraphQLResolveInfo,
 ) => Promise<TData>
 
 export function findByIDResolver<TSlug extends CollectionSlug>(
   collection: Collection,
 ): Resolver<DataFromCollectionSlug<TSlug>> {
-  return async function resolver(_, args, context: Context) {
-    let { req } = context
-    const locale = req.locale
-    const fallbackLocale = req.fallbackLocale
-    req = isolateObjectProperty(req, 'locale')
-    req = isolateObjectProperty(req, 'fallbackLocale')
-    req.locale = args.locale || locale
-    req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) {
-      req.query = {}
-    }
+  return async function resolver(_, args, context, info) {
+    const req = context.req = isolateObjectProperty(context.req, ['locale', 'fallbackLocale', 'transactionID'])
+    const select = context.select = args.select ? buildSelectForCollection(info) : undefined
+
+    req.locale = args.locale || req.locale
+    req.fallbackLocale = args.fallbackLocale || req.fallbackLocale
+    req.query = req.query || {}
 
     const draft: boolean =
       (args.draft ?? req.query?.draft === 'false')
@@ -43,19 +42,17 @@ export function findByIDResolver<TSlug extends CollectionSlug>(
       req.query.draft = String(draft)
     }
 
-    context.req = req
-
     const options = {
       id: args.id,
       collection,
       depth: 0,
       draft: args.draft,
-      req: isolateObjectProperty(req, 'transactionID'),
+      req,
+      select,
       trash: args.trash,
     }
 
     const result = await findByIDOperation(options)
-
     return result
   }
 }

--- a/packages/graphql/src/resolvers/collections/findVersions.ts
+++ b/packages/graphql/src/resolvers/collections/findVersions.ts
@@ -1,8 +1,11 @@
-import type { Collection, PaginatedDocs, PayloadRequest, Where } from 'payload'
+import type { GraphQLResolveInfo } from 'graphql'
+import type { Collection, PaginatedDocs, Where } from 'payload'
 
 import { findVersionsOperation, isolateObjectProperty } from 'payload'
 
 import type { Context } from '../types.js'
+
+import { buildSelectForCollectionMany } from '../../utilities/select.js'
 
 export type Resolver = (
   _: unknown,
@@ -13,27 +16,23 @@ export type Resolver = (
     locale?: string
     page?: number
     pagination?: boolean
+    select?: boolean
     sort?: string
     trash?: boolean
     where: Where
   },
-  context: {
-    req: PayloadRequest
-  },
+  context: Context,
+  info: GraphQLResolveInfo,
 ) => Promise<PaginatedDocs<any>>
 
 export function findVersionsResolver(collection: Collection): Resolver {
-  return async function resolver(_, args, context: Context) {
-    let { req } = context
-    const locale = req.locale
-    const fallbackLocale = req.fallbackLocale
-    req = isolateObjectProperty(req, 'locale')
-    req = isolateObjectProperty(req, 'fallbackLocale')
-    req.locale = args.locale || locale
-    req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) {
-      req.query = {}
-    }
+  return async function resolver(_, args, context, info) {
+    const req = context.req = isolateObjectProperty(context.req, ['locale', 'fallbackLocale', 'transactionID'])
+    const select = context.select = args.select ? buildSelectForCollectionMany(info) : undefined
+
+    req.locale = args.locale || req.locale
+    req.fallbackLocale = args.fallbackLocale || req.fallbackLocale
+    req.query = req.query || {}
 
     const draft: boolean =
       (args.draft ?? req.query?.draft === 'false')
@@ -45,22 +44,20 @@ export function findVersionsResolver(collection: Collection): Resolver {
       req.query.draft = String(draft)
     }
 
-    context.req = req
-
     const options = {
       collection,
       depth: 0,
       limit: args.limit,
       page: args.page,
       pagination: args.pagination,
-      req: isolateObjectProperty(req, 'transactionID'),
+      req,
+      select,
       sort: args.sort,
       trash: args.trash,
       where: args.where,
     }
 
     const result = await findVersionsOperation(options)
-
     return result
   }
 }

--- a/packages/graphql/src/resolvers/globals/findOne.ts
+++ b/packages/graphql/src/resolvers/globals/findOne.ts
@@ -1,26 +1,42 @@
+import type { GraphQLResolveInfo } from 'graphql'
 import type { Document, SanitizedGlobalConfig } from 'payload'
 
 import { findOneOperation, isolateObjectProperty } from 'payload'
 
 import type { Context } from '../types.js'
 
-export function findOne(globalConfig: SanitizedGlobalConfig): Document {
-  return async function resolver(_, args, context: Context) {
-    if (args.locale) {
-      context.req.locale = args.locale
-    }
-    if (args.fallbackLocale) {
-      context.req.fallbackLocale = args.fallbackLocale
-    }
+import { buildSelectForCollection } from '../../utilities/select.js'
 
+export type Resolver = (
+  _: unknown,
+  args: {
+    draft?: boolean
+    fallbackLocale?: string
+    id: number | string
+    locale?: string
+    select?: boolean
+  },
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<Document>
+
+export function findOne(globalConfig: SanitizedGlobalConfig): Resolver {
+  return async function resolver(_, args, context, info) {
+    const req = context.req = isolateObjectProperty(context.req, ['locale', 'fallbackLocale', 'transactionID'])
+    const select = context.select = args.select ? buildSelectForCollection(info) : undefined
     const { slug } = globalConfig
+
+    req.locale = args.locale || req.locale
+    req.fallbackLocale = args.fallbackLocale || req.fallbackLocale
+    req.query = req.query || {}
 
     const options = {
       slug,
       depth: 0,
       draft: args.draft,
       globalConfig,
-      req: isolateObjectProperty(context.req, 'transactionID'),
+      req,
+      select,
     }
 
     const result = await findOneOperation(options)

--- a/packages/graphql/src/resolvers/globals/findVersions.ts
+++ b/packages/graphql/src/resolvers/globals/findVersions.ts
@@ -1,8 +1,11 @@
-import type { Document, PayloadRequest, SanitizedGlobalConfig, Where } from 'payload'
+import type { GraphQLResolveInfo } from 'graphql'
+import type { Document, SanitizedGlobalConfig, Where } from 'payload'
 
 import { findVersionsOperationGlobal, isolateObjectProperty } from 'payload'
 
 import type { Context } from '../types.js'
+
+import { buildSelectForCollectionMany } from '../../utilities/select.js'
 
 export type Resolver = (
   _: unknown,
@@ -12,29 +15,36 @@ export type Resolver = (
     locale?: string
     page?: number
     pagination?: boolean
+    select?: boolean
     sort?: string
     where: Where
   },
-  context: {
-    req: PayloadRequest
-  },
+  context: Context,
+  info: GraphQLResolveInfo
 ) => Promise<Document>
 
 export function findVersions(globalConfig: SanitizedGlobalConfig): Resolver {
-  return async function resolver(_, args, context: Context) {
+  return async function resolver(_, args, context, info) {
+    const req = context.req = isolateObjectProperty(context.req, ['locale', 'fallbackLocale', 'transactionID'])
+    const select = context.select = args.select ? buildSelectForCollectionMany(info) : undefined
+
+    req.locale = args.locale || req.locale
+    req.fallbackLocale = args.fallbackLocale || req.fallbackLocale
+    req.query = req.query || {}
+
     const options = {
       depth: 0,
       globalConfig,
       limit: args.limit,
       page: args.page,
       pagination: args.pagination,
-      req: isolateObjectProperty(context.req, 'transactionID'),
+      req,
+      select,
       sort: args.sort,
       where: args.where,
     }
 
     const result = await findVersionsOperationGlobal(options)
-
     return result
   }
 }

--- a/packages/graphql/src/resolvers/types.ts
+++ b/packages/graphql/src/resolvers/types.ts
@@ -1,8 +1,9 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest, SelectType } from 'payload'
 
 export type Context = {
   headers: {
     [key: string]: string
   }
   req: PayloadRequest
+  select: SelectType
 }

--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -49,6 +49,7 @@ import { GraphQLJSON } from '../packages/graphql-type-json/index.js'
 import { combineParentName } from '../utilities/combineParentName.js'
 import { formatName } from '../utilities/formatName.js'
 import { formatOptions } from '../utilities/formatOptions.js'
+import { resolveSelect} from '../utilities/select.js'
 import { buildObjectType, type ObjectTypeConfig } from './buildObjectType.js'
 import { isFieldNullable } from './isFieldNullable.js'
 import { withNullableType } from './withNullableType.js'
@@ -56,11 +57,12 @@ import { withNullableType } from './withNullableType.js'
 function formattedNameResolver({
   field,
   ...rest
-}: { field: Field } & GraphQLFieldConfig<any, any, any>): GraphQLFieldConfig<any, any, any> {
+}: { field: Field } & GraphQLFieldConfig<any, Context, any>): GraphQLFieldConfig<any, Context, any> {
   if ('name' in field) {
     if (formatName(field.name) !== field.name) {
       return {
         ...rest,
+        extensions: { ...rest.extensions, field },
         resolve: (parent) => parent[field.name],
       }
     }
@@ -338,13 +340,14 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         ...objectTypeConfig,
         [formatName(field.name)]: {
           type: graphqlResult.types.groupTypes[interfaceName],
-          resolve: (parent, args, context: Context) => {
+          extensions: { field },
+          resolve: (parent, args, context) => {
             return {
               ...parent[field.name],
               _id: parent._id ?? parent.id,
             }
           },
-        },
+        } satisfies GraphQLFieldConfig<any, Context, any>,
       }
     } else {
       return field.fields.reduce((objectTypeConfigWithCollapsibleFields, subField) => {
@@ -369,7 +372,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
   join: ({ collectionSlug, field, graphqlResult, objectTypeConfig, parentName }) => {
     const joinName = combineParentName(parentName, toWords(field.name, true))
 
-    const joinType = {
+    const joinType: GraphQLFieldConfig<any, Context, any> = {
       type: new GraphQLObjectType({
         name: joinName,
         fields: {
@@ -405,13 +408,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       },
       extensions: {
         complexity: typeof field?.graphQL?.complexity === 'number' ? field.graphQL.complexity : 10,
+        field,
       },
-      async resolve(parent, args, context: Context) {
+      async resolve(parent, args, context, info) {
         const { collection } = field
         const { count = false, limit, page, sort, where } = args
         const { req } = context
 
         const draft = Boolean(args.draft ?? context.req.query?.draft)
+        const select = resolveSelect(info, context.select)
 
         const targetField = (field as FlattenedJoinField).targetField
 
@@ -447,6 +452,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           page,
           pagination: count ? true : false,
           req,
+          select,
           sort,
           where: fullWhere,
         })
@@ -626,7 +632,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       }
     }
 
-    const relationship: GraphQLFieldConfig<any, any, any> = {
+    const relationship: GraphQLFieldConfig<any, Context, any> = {
       type: withNullableType({
         type: hasManyValues ? new GraphQLList(new GraphQLNonNull(type)) : type,
         field,
@@ -636,13 +642,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       args: relationshipArgs,
       extensions: {
         complexity: typeof field?.graphQL?.complexity === 'number' ? field.graphQL.complexity : 10,
+        field,
       },
-      async resolve(parent, args, context: Context) {
+      async resolve(parent, args, context, info) {
         const value = parent[field.name]
         const locale = args.locale || context.req.locale
         const fallbackLocale = args.fallbackLocale || context.req.fallbackLocale
         let relatedCollectionSlug = field.relationTo
         const draft = Boolean(args.draft ?? context.req.query?.draft)
+        const select = resolveSelect(info, context.select)
 
         if (hasManyValues) {
           const results = []
@@ -671,6 +679,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
                   fallbackLocale,
                   locale,
                   overrideAccess: false,
+                  select,
                   showHiddenFields: false,
                   transactionID: context.req.transactionID,
                 }),
@@ -720,6 +729,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
                 fallbackLocale,
                 locale,
                 overrideAccess: false,
+                select,
                 showHiddenFields: false,
                 transactionID: context.req.transactionID,
               }),
@@ -765,6 +775,9 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         depth: {
           type: GraphQLInt,
         },
+      },
+      extensions: {
+        field,
       },
       async resolve(parent, args, context: Context) {
         let depth = config.defaultDepth
@@ -1033,7 +1046,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       }
     }
 
-    const relationship = {
+    const relationship: GraphQLFieldConfig<any, Context, any> = {
       type: withNullableType({
         type: hasManyValues ? new GraphQLList(new GraphQLNonNull(type)) : type,
         field,
@@ -1043,13 +1056,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       args: relationshipArgs,
       extensions: {
         complexity: typeof field?.graphQL?.complexity === 'number' ? field.graphQL.complexity : 10,
+        field,
       },
-      async resolve(parent, args, context: Context) {
+      async resolve(parent, args, context, info) {
         const value = parent[field.name]
         const locale = args.locale || context.req.locale
         const fallbackLocale = args.fallbackLocale || context.req.fallbackLocale
         let relatedCollectionSlug = field.relationTo
         const draft = Boolean(args.draft ?? context.req.query?.draft)
+        const select = resolveSelect(info, context.select)
 
         if (hasManyValues) {
           const results = []
@@ -1074,6 +1089,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
                 fallbackLocale,
                 locale,
                 overrideAccess: false,
+                select,
                 showHiddenFields: false,
                 transactionID: context.req.transactionID,
               }),
@@ -1121,6 +1137,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
               fallbackLocale,
               locale,
               overrideAccess: false,
+              select,
               showHiddenFields: false,
               transactionID: context.req.transactionID,
             }),

--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -205,6 +205,7 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
                 locale: { type: graphqlResult.types.localeInputType },
               }
             : {}),
+          select: { type: GraphQLBoolean },
           trash: { type: GraphQLBoolean },
         },
         resolve: findByIDResolver(collection),
@@ -224,6 +225,7 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
           limit: { type: GraphQLInt },
           page: { type: GraphQLInt },
           pagination: { type: GraphQLBoolean },
+          select: { type: GraphQLBoolean },
           sort: { type: GraphQLString },
           trash: { type: GraphQLBoolean },
         },
@@ -390,6 +392,7 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
             limit: { type: GraphQLInt },
             page: { type: GraphQLInt },
             pagination: { type: GraphQLBoolean },
+            select: { type: GraphQLBoolean },
             sort: { type: GraphQLString },
             trash: { type: GraphQLBoolean },
           },

--- a/packages/graphql/src/schema/initGlobals.ts
+++ b/packages/graphql/src/schema/initGlobals.ts
@@ -76,6 +76,7 @@ export function initGlobals({ config, graphqlResult }: InitGlobalsGraphQLArgs): 
                 locale: { type: graphqlResult.types.localeInputType },
               }
             : {}),
+          select: { type: GraphQLBoolean },
         },
         resolve: findOne(global),
       }
@@ -151,6 +152,7 @@ export function initGlobals({ config, graphqlResult }: InitGlobalsGraphQLArgs): 
                   locale: { type: graphqlResult.types.localeInputType },
                 }
               : {}),
+            select: { type: GraphQLBoolean },
           },
           resolve: findVersionByID(global),
         }
@@ -176,6 +178,7 @@ export function initGlobals({ config, graphqlResult }: InitGlobalsGraphQLArgs): 
             limit: { type: GraphQLInt },
             page: { type: GraphQLInt },
             pagination: { type: GraphQLBoolean },
+            select: { type: GraphQLBoolean },
             sort: { type: GraphQLString },
           },
           resolve: findVersions(global),

--- a/packages/graphql/src/utilities/select.ts
+++ b/packages/graphql/src/utilities/select.ts
@@ -1,0 +1,117 @@
+import type { GraphQLObjectType, GraphQLResolveInfo, SelectionSetNode} from 'graphql'
+import type { FieldBase, JoinField, RelationshipField, TypedCollectionSelect } from 'payload'
+
+import { getNamedType, isInterfaceType, isObjectType, isUnionType, Kind } from 'graphql'
+
+export function buildSelectForCollection(info: GraphQLResolveInfo): SelectType {
+  return buildSelect(info)
+}
+export function buildSelectForCollectionMany(info: GraphQLResolveInfo): SelectType {
+  return buildSelect(info).docs as SelectType
+}
+
+export function resolveSelect(info: GraphQLResolveInfo, select: SelectType): SelectType {
+  if (select) {
+    const traversePath: string[] = []
+    const traverseTree = (path: GraphQLResolveInfo['path']) => {
+      const pathKey = path.key
+      const pathType = info.schema.getType(path.typename) as GraphQLObjectType
+
+      if (pathType) {
+        const field = pathType?.getFields()?.[pathKey]?.extensions?.field as JoinField | RelationshipField
+
+        if (field?.type === 'join') {
+          path = path.prev
+          traversePath.unshift('docs')
+        }
+        if (field?.type === 'relationship' && Array.isArray(field.relationTo)) {
+          path = path.prev
+          traversePath.unshift('value')
+        }
+        if (field) {
+          traversePath.unshift(field.name)
+        }
+      }
+
+      if (path.prev) {
+        traverseTree(path.prev)
+      }
+    }
+
+    traverseTree(info.path)
+    traversePath.forEach(key => { select = select?.[key] as SelectType })
+  }
+
+  return select
+}
+
+function buildSelect(info: GraphQLResolveInfo) {
+  const returnType = getNamedType(info.returnType) as GraphQLObjectType
+  const selectionSet = info.fieldNodes[0].selectionSet
+
+  if (!returnType) return
+
+  return buildSelectTree(info, selectionSet, returnType)
+}
+function buildSelectTree(
+  info: GraphQLResolveInfo,
+  selectionSet: SelectionSetNode,
+  type: GraphQLObjectType
+): SelectType {
+  const fieldMap = type.getFields?.()
+  const fieldTree: SelectType = {}
+
+  for (const selection of selectionSet.selections) {
+    switch (selection.kind) {
+      case Kind.FIELD: {
+        const fieldName = selection.name.value
+        const fieldSchema = fieldMap?.[fieldName]
+
+        const field = fieldSchema?.extensions?.field as FieldBase
+        const fieldNameOriginal = field?.name || fieldName
+
+        if (fieldName === '__typename') continue
+        if (fieldSchema == undefined) continue
+
+        if (selection.selectionSet) {
+          const type = getNamedType(fieldSchema.type) as GraphQLObjectType
+
+          if (isObjectType(type) || isInterfaceType(type) || isUnionType(type)) {
+            fieldTree[fieldNameOriginal] = buildSelectTree(info, selection.selectionSet, type)
+            continue
+          }
+        }
+
+        fieldTree[fieldNameOriginal] = true
+        break
+      }
+
+      case Kind.FRAGMENT_SPREAD: {
+        const fragmentName = selection.name.value
+        const fragment = info.fragments[fragmentName]
+        const fragmentType = fragment && info.schema.getType(fragment.typeCondition.name.value) as GraphQLObjectType
+
+        if (fragmentType) {
+          Object.assign(fieldTree, buildSelectTree(info, fragment.selectionSet, fragmentType))
+        }
+        break
+      }
+
+      case Kind.INLINE_FRAGMENT: {
+        const fragmentType = selection.typeCondition
+          ? info.schema.getType(selection.typeCondition.name.value) as GraphQLObjectType
+          : type
+
+
+        if (fragmentType) {
+          Object.assign(fieldTree, buildSelectTree(info, selection.selectionSet, fragmentType))
+        }
+        break
+      }
+    }
+  }
+
+  return fieldTree
+}
+
+type SelectType = TypedCollectionSelect['any']


### PR DESCRIPTION
Optimized database queries generated by graphQL by only selecting the fields that have been requested. This is particularly useful for collections with fields of type "join" and "relationship"
