### PR TITLE
fix: set X-Payload-HTTP-Method-Override as allowed cross origin header

### DIFF
--- a/packages/payload/src/utilities/headersWithCors.ts
+++ b/packages/payload/src/utilities/headersWithCors.ts
@@ -17,6 +17,7 @@ export const headersWithCors = ({ headers, req }: CorsArgs): Headers => {
       'Authorization',
       'Content-Encoding',
       'x-apollo-tracing',
+      'X-Payload-HTTP-Method-Override',
     ]
 
     headers.set('Access-Control-Allow-Methods', 'PUT, PATCH, POST, GET, DELETE, OPTIONS')


### PR DESCRIPTION
### What?

Set  X-Payload-HTTP-Method-Override as allowed cross origin header

### Why?

As of #13619 the live preview uses POST method to retrieve updated data. When running cms and website on different origins, the cross origin requires X-Payload-HTTP-Method-Override header to be allowed

### How?

Adding X-Payload-HTTP-Method-Override as a default allowed header
