### PR TITLE
fix: ensure client-side live preview correctly updates for globals

### DIFF
--- a/packages/live-preview/src/mergeData.ts
+++ b/packages/live-preview/src/mergeData.ts
@@ -51,7 +51,7 @@ export const mergeData = async <T extends Record<string, any>>(args: {
       locale,
     },
     endpoint: encodeURI(
-      `${collectionSlug ?? globalSlug}${collectionSlug ? `/${initialData.id}` : ''}`,
+      `${globalSlug ? 'globals/' : ''}${collectionSlug ?? globalSlug}${collectionSlug ? `/${initialData.id}` : ''}`,
     ),
     serverURL,
   }).then((res) => res.json())

--- a/packages/payload/src/globals/endpoints/findOne.ts
+++ b/packages/payload/src/globals/endpoints/findOne.ts
@@ -11,13 +11,18 @@ import { findOneOperation } from '../operations/findOne.js'
 
 export const findOneHandler: PayloadHandler = async (req) => {
   const globalConfig = getRequestGlobal(req)
-  const { searchParams } = req
-  const depth = searchParams.get('depth')
+  const { data, searchParams } = req
+  const depth = data ? data.depth : searchParams.get('depth')
 
   const result = await findOneOperation({
     slug: globalConfig.slug,
+    data: data
+      ? data?.data
+      : searchParams.get('data')
+        ? JSON.parse(searchParams.get('data') as string)
+        : undefined,
     depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: searchParams.get('draft') === 'true',
+    draft: data ? data.draft : searchParams.get('draft') === 'true',
     globalConfig,
     populate: sanitizePopulateParam(req.query.populate),
     req,

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -17,6 +17,11 @@ import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { replaceWithDraftIfAvailable } from '../../versions/drafts/replaceWithDraftIfAvailable.js'
 
 type Args = {
+  /**
+   * You may pass the document data directly which will skip the `db.findOne` database query.
+   * This is useful if you want to use this endpoint solely for running hooks and populating data.
+   */
+  data?: Record<string, unknown>
   depth?: number
   draft?: boolean
   globalConfig: SanitizedGlobalConfig
@@ -67,13 +72,15 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
     // Perform database operation
     // /////////////////////////////////////
 
-    let doc = await req.payload.db.findGlobal({
-      slug,
-      locale: locale!,
-      req,
-      select,
-      where: overrideAccess ? undefined : (accessResult as Where),
-    })
+    let doc =
+      (args.data as any) ??
+      (await req.payload.db.findGlobal({
+        slug,
+        locale: locale!,
+        req,
+        select,
+        where: overrideAccess ? undefined : (accessResult as Where),
+      }))
     if (!doc) {
       doc = {}
     }

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -22,6 +22,11 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    */
   context?: RequestContext
   /**
+   * You may pass the document data directly which will skip the `db.findOne` database query.
+   * This is useful if you want to use this endpoint solely for running hooks and populating data.
+   */
+  data?: Record<string, unknown>
+  /**
    * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
    */
   depth?: number
@@ -84,6 +89,7 @@ export async function findOneGlobalLocal<
 ): Promise<TransformGlobalWithSelect<TSlug, TSelect>> {
   const {
     slug: globalSlug,
+    data,
     depth,
     draft = false,
     includeLockStatus,
@@ -101,6 +107,7 @@ export async function findOneGlobalLocal<
 
   return findOneOperation({
     slug: globalSlug as string,
+    data,
     depth,
     draft,
     globalConfig,


### PR DESCRIPTION
Previously, we were sending incorrect API requests for globals. Additionally, the global findOne endpoint did not respect the data attribute.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211249618316704