### PR TITLE
fix(ui): show correct error when bulk uploads exceed NGINX size limit

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -92,6 +92,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'error:unPublishingDocument',
   'error:problemUploadingFile',
   'error:restoringTitle',
+  'error:fileTooLarge',
 
   'fields:addLabel',
   'fields:addLink',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -92,6 +92,7 @@ export const enTranslations = {
     documentNotFound:
       'The document with ID {{id}} could not be found. It may have been deleted or never existed, or you may not have access to it.',
     emailOrPasswordIncorrect: 'The email or password provided is incorrect.',
+    fileTooLarge: 'File size limit exceeded',
     followingFieldsInvalid_one: 'The following field is invalid:',
     followingFieldsInvalid_other: 'The following fields are invalid:',
     incorrectCollection: 'Incorrect Collection',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -92,7 +92,7 @@ export const enTranslations = {
     documentNotFound:
       'The document with ID {{id}} could not be found. It may have been deleted or never existed, or you may not have access to it.',
     emailOrPasswordIncorrect: 'The email or password provided is incorrect.',
-    fileTooLarge: 'File size limit exceeded',
+    fileTooLarge: 'File size limit exceeded of 70MB',
     followingFieldsInvalid_one: 'The following field is invalid:',
     followingFieldsInvalid_other: 'The following fields are invalid:',
     incorrectCollection: 'Incorrect Collection',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -92,7 +92,7 @@ export const enTranslations = {
     documentNotFound:
       'The document with ID {{id}} could not be found. It may have been deleted or never existed, or you may not have access to it.',
     emailOrPasswordIncorrect: 'The email or password provided is incorrect.',
-    fileTooLarge: 'File size limit exceeded of 70MB',
+    fileTooLarge: 'File size limit exceeded',
     followingFieldsInvalid_one: 'The following field is invalid:',
     followingFieldsInvalid_other: 'The following fields are invalid:',
     incorrectCollection: 'Incorrect Collection',

--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -305,57 +305,84 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
             method: 'POST',
           })
 
-          const json = await req.json()
+          if (req.status === 413) {
+            const { name } = (currentForms[i].formState.file as any).value as File
 
-          if (req.status === 201 && json?.doc) {
-            newDocs.push(json.doc)
-          }
+            const message = t('error:fileTooLarge', {
+              fileName: name,
+            })
 
-          // should expose some sort of helper for this
-          const [fieldErrors, nonFieldErrors] = (json?.errors || []).reduce(
-            ([fieldErrs, nonFieldErrs], err) => {
-              const newFieldErrs: any[] = []
-              const newNonFieldErrs: any[] = []
-
-              if (err?.message) {
-                newNonFieldErrs.push(err)
-              }
-
-              if (Array.isArray(err?.data?.errors)) {
-                err.data?.errors.forEach((dataError) => {
-                  if (dataError?.path) {
-                    newFieldErrs.push(dataError)
-                  } else {
-                    newNonFieldErrs.push(dataError)
-                  }
-                })
-              }
-
-              return [
-                [...fieldErrs, ...newFieldErrs],
-                [...nonFieldErrs, ...newNonFieldErrs],
-              ]
-            },
-            [[], []],
-          )
-
-          currentForms[i] = {
-            errorCount: fieldErrors.length,
-            formID: currentForms[i].formID,
-            formState: fieldReducer(currentForms[i].formState, {
-              type: 'ADD_SERVER_ERRORS',
-              errors: fieldErrors,
-            }),
-          }
-
-          if (req.status === 413 || req.status === 400) {
-            // file too large
             currentForms[i] = {
               ...currentForms[i],
-              errorCount: currentForms[i].errorCount + 1,
+              errorCount: (currentForms[i].errorCount || 0) + 1,
+              formState: fieldReducer(currentForms[i].formState, {
+                type: 'ADD_SERVER_ERRORS',
+                errors: [
+                  {
+                    message,
+                    path: 'file',
+                  },
+                ],
+              }),
             }
 
-            toast.error(nonFieldErrors[0]?.message)
+            toast.error(message)
+          } else {
+            const json = await req.json()
+
+            if (req.status < 400) {
+              if (json?.doc) {
+                newDocs.push(json.doc)
+              }
+            } else {
+              // should expose some sort of helper for this
+              const [fieldErrors, nonFieldErrors] = (json?.errors || []).reduce(
+                ([fieldErrs, nonFieldErrs], err) => {
+                  const newFieldErrs: any[] = []
+                  const newNonFieldErrs: any[] = []
+
+                  if (err?.message) {
+                    newNonFieldErrs.push(err)
+                  }
+
+                  if (Array.isArray(err?.data?.errors)) {
+                    err.data?.errors.forEach((dataError) => {
+                      if (dataError?.path) {
+                        newFieldErrs.push(dataError)
+                      } else {
+                        newNonFieldErrs.push(dataError)
+                      }
+                    })
+                  }
+
+                  return [
+                    [...fieldErrs, ...newFieldErrs],
+                    [...nonFieldErrs, ...newNonFieldErrs],
+                  ]
+                },
+                [[], []],
+              )
+
+              currentForms[i] = {
+                errorCount: fieldErrors.length,
+                formID: currentForms[i].formID,
+                formState: fieldReducer(currentForms[i].formState, {
+                  type: 'ADD_SERVER_ERRORS',
+                  errors: fieldErrors,
+                }),
+              }
+
+              if (nonFieldErrors.length > 0) {
+                currentForms[i] = {
+                  ...currentForms[i],
+                  errorCount: currentForms[i].errorCount + nonFieldErrors.length,
+                }
+
+                nonFieldErrors.forEach((error) => {
+                  toast.error(error.message)
+                })
+              }
+            }
           }
         } catch (_) {
           // swallow


### PR DESCRIPTION
## What?
This PR fixes misleading success messaging in the Admin UI when bulk file uploads contain one or more files that exceed the `client_max_body_size` (70 MB) enforced by NGINX. Previously, the oversized file(s) would be rejected with HTTP 413 at the proxy layer, but the UI still displayed a success state for the whole batch. After refresh, the file was absent (correct server behavior), but the messaging was incorrect.

## Why?
Without this fix, Admin users receive false-positive success feedback, creating confusion and the impression that oversized files were uploaded when they were not. Accurate per-file error handling is critical for trust and usability in the media upload flow.

## How?
- Updated bulk upload handler to properly detect and surface 413 responses from NGINX.  
- When a file is rejected, the UI now shows a clear per-file error message:  
  > `File size limit exceeded`  
- For mixed batches, success/error counts are summarized (e.g., `Failed to upload 1 file.`,  `Successfully uploaded 4 files `).  
- Single-file uploads remain unaffected (already correctly handled).  

## Before
- Bulk upload including oversized file → success message for the batch.  
- Oversized file absent after refresh.  

## After
- Bulk upload including oversized file → per-file error message + accurate summary.  
- Only valid files are marked success.  
- Watch [this](https://siddharth-kumar-gope2.neetorecord.com/watch/b8960addec591c0dabae)

---

Fixes https://github.com/payloadcms/payload/issues/13650