### PR TITLE
chore(examples): fix package.json name

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-payload-monorepo",
+  "name": "astro-payload-monorepo",
   "version": "1.0.0",
   "description": "",
   "keywords": [],


### PR DESCRIPTION
Renames Astro example root package.json name from `remix-payload-monorepo` to `astro-payload-monorepo`