### PR TITLE
feat: fail migrations immediately when dev push encountered in prod

### DIFF
--- a/packages/db-mongodb/src/connect.ts
+++ b/packages/db-mongodb/src/connect.ts
@@ -95,7 +95,7 @@ export const connect: Connect = async function connect(
     }
 
     if (process.env.NODE_ENV === 'production' && this.prodMigrations) {
-      await this.migrate({ migrations: this.prodMigrations })
+      await this.migrate({ failOnDev: true, migrations: this.prodMigrations })
     }
   } catch (err) {
     let msg = `Error: cannot connect to MongoDB.`

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -127,6 +127,6 @@ export const connect: Connect = async function connect(
   }
 
   if (process.env.NODE_ENV === 'production' && this.prodMigrations) {
-    await this.migrate({ migrations: this.prodMigrations as unknown as Migration[] })
+    await this.migrate({ failOnDev: true, migrations: this.prodMigrations as unknown as Migration[] })
   }
 }

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -53,6 +53,6 @@ export const connect: Connect = async function connect(
   }
 
   if (process.env.NODE_ENV === 'production' && this.prodMigrations) {
-    await this.migrate({ migrations: this.prodMigrations as Migration[] })
+    await this.migrate({ failOnDev: true, migrations: this.prodMigrations as Migration[] })
   }
 }

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -109,6 +109,6 @@ export const connect: Connect = async function connect(
   }
 
   if (process.env.NODE_ENV === 'production' && this.prodMigrations) {
-    await this.migrate({ migrations: this.prodMigrations as Migration[] })
+    await this.migrate({ failOnDev: true, migrations: this.prodMigrations as Migration[] })
   }
 }

--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -44,6 +44,9 @@ export const migrate: DrizzleAdapter['migrate'] = async function migrate(
     }))
 
     if (migrationsInDB.find((m) => m.batch === -1)) {
+      if (args?.failOnDev) {
+        payload.logger.fatal("It looks like you've run Payload in dev mode, meaning you've dynamically pushed changes to your database. Running migrations will cause data loss.")
+      }
       const { confirm: runMigrations } = await prompts(
         {
           name: 'confirm',

--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -52,6 +52,7 @@ export const migrate = async ({ config, parsedArgs }: Args): Promise<void> => {
 
   const forceAcceptWarning = forceAcceptFromProps || formattedArgs.includes('forceAcceptWarning')
   const skipEmpty = formattedArgs.includes('skipEmpty')
+  const failMigrationOnDev = formattedArgs.includes('failMigrationOnDev')
 
   if (help) {
     // eslint-disable-next-line no-console
@@ -84,7 +85,7 @@ export const migrate = async ({ config, parsedArgs }: Args): Promise<void> => {
 
   switch (args[0]) {
     case 'migrate':
-      await adapter.migrate()
+      await adapter.migrate({failOnDev: failMigrationOnDev})
       break
     case 'migrate:create':
       try {

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -83,7 +83,7 @@ export interface BaseDatabaseAdapter {
   /**
    * Run any migration up functions that have not yet been performed and update the status
    */
-  migrate: (args?: { migrations?: Migration[] }) => Promise<void>
+  migrate: (args?: { failOnDev: boolean, migrations?: Migration[] }) => Promise<void>
   /**
    * Run any migration down functions that have been performed
    */


### PR DESCRIPTION
Today, the behavior of `payload migrate` against production is farily terrifying - in CI, where there's no TTY/interactive input, the CLI will notice that someone's mucked with the database, ask politely if we want to incur data loss, exit without getting an input (since there is no user session to do inputs) and exit cleanly with a 0 exit code. Anyone using a pipeline to do migrations during deployment will have their migration step silently fail. At minimum, we should prefer to have a flag that allows users to opt into the CLI crashing out immediately in such a case, so that the pipeline fails and this data corruption is noticed. In any scenario where we know we're in production (the `connect.ts` cases in this diff), it's not clear what the code would have done today, since this would presumably be called in the `getPayload()` chain, where no user input is possible either... but the likely best behavior here is to fail immediately as well.

---

Note to reviewers: I am new to the codebase and I don't know that I've implemented this well. Any and all feedback welcome, happy to rework this as needed. I do not like the name I came up with for the option.