### PR TITLE
fix(plugin-multi-tenant): hide watchTenant column field

### DIFF
--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -316,6 +316,8 @@ export const multiTenantPlugin =
                 path: '@payloadcms/plugin-multi-tenant/client#WatchTenantCollection',
               },
             },
+            disableBulkEdit: true,
+            disableListColumn: true,
           },
         })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13731

The watch tenant field is just a ui field used to sync updates to the selector, should not appear in the columns selector on the list view.
