### PR TITLE
test: increase timeout in uploads cors test

### DIFF
--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -1296,7 +1296,7 @@ describe('Uploads', () => {
       const pasteUrlEndpoint = `/api/uploads-1/paste-url?src=${encodedImageURL}`
       const serverSideFetchPromise = page.waitForResponse(
         (response) => response.url().includes(pasteUrlEndpoint) && response.status() === 200,
-        { timeout: 1000 },
+        { timeout: POLL_TOPASS_TIMEOUT },
       )
 
       // Click the "Add File" button


### PR DESCRIPTION
Deflakes the uploads e2e suite. The CORS test was not waiting not long enough for the response and ultimately fails.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211295974585601