### PR TITLE
test: allows running Jest tests through Test Explorer in VSCode and other improvements

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "firsttris.vscode-jest-runner",
-    "ms-playwright.playwright"
+    "ms-playwright.playwright",
+    "orta.vscode-jest"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,9 @@
   "bun.test.filePattern": "bun.test.ts",
   "playwright.env": {
     "NODE_OPTIONS": "--no-deprecation --no-experimental-strip-types"
-  }
+  },
+  "jest.virtualFolders": [
+    { "name": "root", "rootPath": "." },
+    { "name": "test", "rootPath": "test" }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,19 @@
     "NODE_OPTIONS": "--no-deprecation --no-experimental-strip-types"
   },
   "jest.virtualFolders": [
-    { "name": "root", "rootPath": "." },
-    { "name": "test", "rootPath": "test" }
+    {
+      "name": "root",
+      "rootPath": ".",
+      "runMode": {
+        "type": "on-demand"
+      }
+    },
+    {
+      "name": "test",
+      "rootPath": "test",
+      "runMode": {
+        "type": "on-demand"
+      }
+    }
   ]
 }


### PR DESCRIPTION
VSCode has 2 popular extensions for Jest:

<img width="403" height="150" alt="image" src="https://github.com/user-attachments/assets/9c774e06-64f1-46c0-a662-79a51b893b5d" />


Although the `firsttris` one has more downloads (I'm not sure if that's accurate), the `Orta` one is way more maintained, has more stars, contributors, and many more features.

The `firsttris` one displays a couple of small buttons above each test:

<img width="184" height="53" alt="image" src="https://github.com/user-attachments/assets/42c1e31e-8214-4f02-b473-7c934a3e183c" />

The `Orta` one leverages the official VSCode APIs for running and viewing tests. This includes the Test Explorer with its handy tree view, as well as the green buttons next to each test:

<img width="1426" height="932" alt="image" src="https://github.com/user-attachments/assets/3e62e8c3-2878-4268-8e16-2192c646492d" />

With a couple of lines of configuration, I got it to detect all our tests. There are also many nice additional options that can be configured, such as watchMode, snapshots, coverage, etc.

In this PR I'm changing the extension from `firsttris` to `Orta` in our suggestion list, and setting it correctly in our `.vscode/settings.json`

