### PR TITLE
fix(graphql): pass collectionSlug to nested join fields in tabs, collapsible and group resolvers

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -248,6 +248,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
     }),
   }),
   collapsible: ({
+    collectionSlug,
     config,
     field,
     forceNullable,
@@ -261,6 +262,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       const addSubField: GenericFieldToSchemaMap = fieldToSchemaMap[subField.type]
       if (addSubField) {
         return addSubField({
+          collectionSlug,
           config,
           field: subField,
           forceNullable,
@@ -298,6 +300,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
     }),
   }),
   group: ({
+    collectionSlug,
     config,
     field,
     forceNullable,
@@ -348,6 +351,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         const addSubField: GenericFieldToSchemaMap = fieldToSchemaMap[subField.type]
         if (addSubField) {
           return addSubField({
+            collectionSlug,
             config,
             field: subField,
             forceNullable,
@@ -840,9 +844,9 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
     }
   },
   tabs: ({
+    collectionSlug,
     config,
     field,
-    collectionSlug,
     forceNullable,
     graphqlResult,
     newlyCreatedBlockType,
@@ -858,10 +862,10 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         if (!graphqlResult.types.groupTypes[interfaceName]) {
           const objectType = buildObjectType({
             name: interfaceName,
+            collectionSlug,
             config,
             fields: tab.fields,
             forceNullable,
-            collectionSlug,
             graphqlResult,
             parentIsLocalized: tab.localized || parentIsLocalized,
             parentName: interfaceName,
@@ -896,10 +900,10 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           const addSubField: GenericFieldToSchemaMap = fieldToSchemaMap[subField.type]
           if (addSubField) {
             return addSubField({
+              collectionSlug,
               config,
               field: subField,
               forceNullable,
-              collectionSlug,
               graphqlResult,
               newlyCreatedBlockType,
               objectTypeConfig: subFieldSchema,

--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -842,6 +842,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
   tabs: ({
     config,
     field,
+    collectionSlug,
     forceNullable,
     graphqlResult,
     newlyCreatedBlockType,
@@ -860,6 +861,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
             config,
             fields: tab.fields,
             forceNullable,
+            collectionSlug,
             graphqlResult,
             parentIsLocalized: tab.localized || parentIsLocalized,
             parentName: interfaceName,
@@ -897,6 +899,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
               config,
               field: subField,
               forceNullable,
+              collectionSlug,
               graphqlResult,
               newlyCreatedBlockType,
               objectTypeConfig: subFieldSchema,


### PR DESCRIPTION
## Problem
GraphQL join fields nested inside tabs and collapsibles return empty results due to missing `collectionSlug` parameter propagation in the tabs and collapsible resolver.

## Root Cause
The `tabs` resolver in `fieldToSchemaMap.ts` doesn't pass `collectionSlug` to nested field resolvers, causing polymorphic relationship queries to fail when constructing MongoDB filters.

## Solution
- Added `collectionSlug` parameter to tabs resolver function signature
- Pass `collectionSlug` to `buildObjectType` for named tabs
- Pass `collectionSlug` to `addSubField` for unnamed tabs

## Testing
- [x] Verified join fields work correctly in tab-nested scenarios
- [x] Tested with multiple collection types
- [x] Confirmed no breaking changes to existing functionality

Fixes #13345  

We have got this running successfully in production and are looking forward for this to get merged so we do not have to patch the core anymore :) 