### PR TITLE
templates: ensure blank template installs matching react-dom version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1708,6 +1708,9 @@ importers:
       react:
         specifier: 19.1.0
         version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
       sharp:
         specifier: 0.34.2
         version: 0.34.2

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -29,6 +29,7 @@
     "next": "15.4.4",
     "payload": "workspace:*",
     "react": "19.1.0",
+    "react-dom": "19.1.0",
     "sharp": "0.34.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, in fresh installations, pnpm may install react-dom version 19.1.1, which will throw an error as it does not match the react version it installs (19.1.0)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211306293437538