### PR TITLE
fix(next): error after logging in and navigating to different page in production

### DIFF
--- a/packages/next/src/views/Root/SyncClientConfig.tsx
+++ b/packages/next/src/views/Root/SyncClientConfig.tsx
@@ -2,7 +2,7 @@
 import type { ClientConfig } from 'payload'
 
 import { useConfig } from '@payloadcms/ui'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 /**
  * This component is required in order for the _page_ to be able to refresh the client config,
@@ -12,15 +12,8 @@ import { useEffect, useRef } from 'react'
  */
 export const SyncClientConfig = ({ clientConfig }: { clientConfig: ClientConfig }) => {
   const { setConfig } = useConfig()
-  const initialRender = useRef(true)
 
   useEffect(() => {
-    // Can skip the initial render, as the config will already be set by the layout
-    if (initialRender.current) {
-      initialRender.current = false
-      return
-    }
-
     setConfig(clientConfig)
   }, [clientConfig, setConfig])
 


### PR DESCRIPTION
Since https://github.com/payloadcms/payload/pull/13714, if you open payload, log in, then client-side navigate to any page (e.g. clicking on any collection), the following error will appear and crash the page:

<img width="2046" height="460" alt="Screenshot 2025-09-09 at 18 35 46@2x" src="https://github.com/user-attachments/assets/26762b4c-55de-4e8c-b09c-ef7e9a16b9c2" />

This only happens in production. It does not happen during development, because the `SyncClientConfig` `useEffect` runs twice due to react strict mode.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211306293437542