### PR TITLE
fix: add missed `pagination` property to `findVersions` and `findGlobalVersions` and handle it properly

### DIFF
--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -97,11 +97,15 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
     // Find
     // /////////////////////////////////////
 
+    const usePagination = pagination && limit !== 0
+    const sanitizedLimit = limit ?? (usePagination ? 10 : 0)
+    const sanitizedPage = page || 1
+
     const paginatedDocs = await payload.db.findVersions<TData>({
       collection: collectionConfig.slug,
-      limit: limit ?? 10,
+      limit: sanitizedLimit,
       locale: locale!,
-      page: page || 1,
+      page: sanitizedPage,
       pagination,
       req,
       select,

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -62,6 +62,11 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   page?: number
   /**
+   * Set to `false` to return all documents and avoid querying for document counts which introduces some overhead.
+   * You can also combine that property with a specified `limit` to limit documents but avoid the count query.
+   */
+  pagination?: boolean
+  /**
    * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
    */
   populate?: PopulateType
@@ -114,6 +119,7 @@ export async function findVersionsLocal<TSlug extends CollectionSlug>(
     limit,
     overrideAccess = true,
     page,
+    pagination = true,
     populate,
     select,
     showHiddenFields,
@@ -136,6 +142,7 @@ export async function findVersionsLocal<TSlug extends CollectionSlug>(
     limit,
     overrideAccess,
     page,
+    pagination,
     populate,
     req: await createLocalReq(options as CreateLocalReqOptions, payload),
     select,

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -79,11 +79,15 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
     // Find
     // /////////////////////////////////////
 
+    const usePagination = pagination && limit !== 0
+    const sanitizedLimit = limit ?? (usePagination ? 10 : 0)
+    const sanitizedPage = page || 1
+
     const paginatedDocs = await payload.db.findGlobalVersions<T>({
       global: globalConfig.slug,
-      limit: limit ?? 10,
+      limit: sanitizedLimit,
       locale: locale!,
-      page: page || 1,
+      page: sanitizedPage,
       pagination,
       req,
       select,

--- a/packages/payload/src/globals/operations/local/findVersions.ts
+++ b/packages/payload/src/globals/operations/local/findVersions.ts
@@ -54,6 +54,11 @@ export type Options<TSlug extends GlobalSlug> = {
    */
   page?: number
   /**
+   * Set to `false` to return all documents and avoid querying for document counts which introduces some overhead.
+   * You can also combine that property with a specified `limit` to limit documents but avoid the count query.
+   */
+  pagination?: boolean
+  /**
    * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
    */
   populate?: PopulateType
@@ -101,6 +106,7 @@ export async function findGlobalVersionsLocal<TSlug extends GlobalSlug>(
     limit,
     overrideAccess = true,
     page,
+    pagination = true,
     populate,
     select,
     showHiddenFields,
@@ -120,6 +126,7 @@ export async function findGlobalVersionsLocal<TSlug extends GlobalSlug>(
     limit,
     overrideAccess,
     page,
+    pagination,
     populate,
     req: await createLocalReq(options as CreateLocalReqOptions, payload),
     select,

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -24,6 +24,7 @@ import AutosaveGlobal from './globals/Autosave.js'
 import AutosaveWithDraftButtonGlobal from './globals/AutosaveWithDraftButton.js'
 import DisablePublishGlobal from './globals/DisablePublish.js'
 import DraftGlobal from './globals/Draft.js'
+import DraftUnlimitedGlobal from './globals/DraftUnlimited.js'
 import DraftWithMaxGlobal from './globals/DraftWithMax.js'
 import LocalizedGlobal from './globals/LocalizedGlobal.js'
 import { MaxVersions } from './globals/MaxVersions.js'
@@ -64,6 +65,7 @@ export default buildConfigWithDefaults({
     DisablePublishGlobal,
     LocalizedGlobal,
     MaxVersions,
+    DraftUnlimitedGlobal,
   ],
   indexSortableFields: true,
   localization: {

--- a/test/versions/globals/DraftUnlimited.ts
+++ b/test/versions/globals/DraftUnlimited.ts
@@ -1,0 +1,61 @@
+import type { GlobalConfig } from 'payload'
+
+import { draftUnlimitedGlobalSlug } from '../slugs.js'
+
+const DraftUnlimitedGlobal: GlobalConfig = {
+  slug: draftUnlimitedGlobalSlug,
+  label: 'Draft Unlimited Global',
+  admin: {
+    preview: () => 'https://payloadcms.com',
+    components: {
+      views: {
+        edit: {
+          version: {
+            actions: ['/elements/GlobalVersionButton/index.js'],
+          },
+          versions: {
+            actions: ['/elements/GlobalVersionsButton/index.js'],
+          },
+        },
+      },
+    },
+  },
+  versions: {
+    max: 0,
+    drafts: {
+      schedulePublish: true,
+    },
+  },
+  access: {
+    read: ({ req: { user } }) => {
+      if (user) {
+        return true
+      }
+
+      return {
+        or: [
+          {
+            _status: {
+              equals: 'published',
+            },
+          },
+          {
+            _status: {
+              exists: false,
+            },
+          },
+        ],
+      }
+    },
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+      localized: true,
+    },
+  ],
+}
+
+export default DraftUnlimitedGlobal

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -543,6 +543,44 @@ describe('Versions', () => {
       expect(restoredVersion.title).toStrictEqual('v1')
     })
 
+    it('findVersions - pagination should work correctly', async () => {
+      const post = await payload.create({
+        collection: 'draft-posts',
+        data: { description: 'a', title: 'title' },
+      })
+      for (let i = 0; i < 100; i++) {
+        await payload.update({ collection: 'draft-posts', id: post.id, data: {} })
+      }
+      const res = await payload.findVersions({
+        collection: 'draft-posts',
+        where: { parent: { equals: post.id } },
+      })
+      expect(res.totalDocs).toBe(101)
+      expect(res.docs).toHaveLength(10)
+      const resPaginationFalse = await payload.findVersions({
+        collection: 'draft-posts',
+        where: { parent: { equals: post.id } },
+        pagination: false,
+      })
+      const resPaginationFalse2 = await payload.find({
+        collection: 'draft-posts',
+        // where: { parent: { equals: post.id } },
+        pagination: false,
+      })
+
+      expect(resPaginationFalse.docs).toHaveLength(101)
+      expect(resPaginationFalse.totalDocs).toBe(101)
+
+      const resPaginationFalseLimit0 = await payload.findVersions({
+        collection: 'draft-posts',
+        where: { parent: { equals: post.id } },
+        pagination: false,
+        limit: 0,
+      })
+      expect(resPaginationFalseLimit0.docs).toHaveLength(101)
+      expect(resPaginationFalseLimit0.totalDocs).toBe(101)
+    })
+
     describe('Update', () => {
       it('should allow a draft to be patched', async () => {
         const originalTitle = 'Here is a published post'
@@ -1770,6 +1808,31 @@ describe('Versions', () => {
         disableErrors: true,
       })
       expect(version_1_deleted).toBeFalsy()
+    })
+
+    it('findGlobalVersions - pagination should work correctly', async () => {
+      for (let i = 0; i < 100; i++) {
+        await payload.updateGlobal({ slug: 'draft-unlimited-global', data: { title: 'title' } })
+      }
+      const res = await payload.findGlobalVersions({
+        slug: 'draft-unlimited-global',
+      })
+      expect(res.totalDocs).toBe(100)
+      expect(res.docs).toHaveLength(10)
+      const resPaginationFalse = await payload.findGlobalVersions({
+        slug: 'draft-unlimited-global',
+        pagination: false,
+      })
+      expect(resPaginationFalse.docs).toHaveLength(100)
+      expect(resPaginationFalse.totalDocs).toBe(100)
+
+      const resPaginationFalseLimit0 = await payload.findGlobalVersions({
+        slug: 'draft-unlimited-global',
+        pagination: false,
+        limit: 0,
+      })
+      expect(resPaginationFalseLimit0.docs).toHaveLength(100)
+      expect(resPaginationFalseLimit0.totalDocs).toBe(100)
     })
 
     describe('Read', () => {

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -126,6 +126,7 @@ export interface Config {
     'disable-publish-global': DisablePublishGlobal;
     'localized-global': LocalizedGlobal;
     'max-versions': MaxVersion;
+    'draft-unlimited-global': DraftUnlimitedGlobal;
   };
   globalsSelect: {
     'autosave-global': AutosaveGlobalSelect<false> | AutosaveGlobalSelect<true>;
@@ -135,6 +136,7 @@ export interface Config {
     'disable-publish-global': DisablePublishGlobalSelect<false> | DisablePublishGlobalSelect<true>;
     'localized-global': LocalizedGlobalSelect<false> | LocalizedGlobalSelect<true>;
     'max-versions': MaxVersionsSelect<false> | MaxVersionsSelect<true>;
+    'draft-unlimited-global': DraftUnlimitedGlobalSelect<false> | DraftUnlimitedGlobalSelect<true>;
   };
   locale: 'en' | 'es' | 'de';
   user: User & {
@@ -1292,6 +1294,17 @@ export interface MaxVersion {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "draft-unlimited-global".
+ */
+export interface DraftUnlimitedGlobal {
+  id: string;
+  title: string;
+  _status?: ('draft' | 'published') | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "autosave-global_select".
  */
 export interface AutosaveGlobalSelect<T extends boolean = true> {
@@ -1370,6 +1383,17 @@ export interface MaxVersionsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "draft-unlimited-global_select".
+ */
+export interface DraftUnlimitedGlobalSelect<T extends boolean = true> {
+  title?: T;
+  _status?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "TaskSchedulePublish".
  */
 export interface TaskSchedulePublish {
@@ -1385,7 +1409,7 @@ export interface TaskSchedulePublish {
           relationTo: 'draft-posts';
           value: string | DraftPost;
         } | null);
-    global?: 'draft-global' | null;
+    global?: ('draft-global' | 'draft-unlimited-global') | null;
     user?: (string | null) | User;
   };
   output?: unknown;

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -45,6 +45,8 @@ export const autosaveWithDraftButtonGlobal = 'autosave-with-draft-button-global'
 
 export const draftGlobalSlug = 'draft-global'
 
+export const draftUnlimitedGlobalSlug = 'draft-unlimited-global'
+
 export const draftWithMaxGlobalSlug = 'draft-with-max-global'
 
 export const globalSlugs = [autoSaveGlobalSlug, draftGlobalSlug]


### PR DESCRIPTION
* The `pagination` property was missing in `findVersions` and `findGlobalVersions` Local API operations, although the actual functions did have it - https://github.com/payloadcms/payload/blob/1b93c4becc9f85684bc2d79795615aee101988fd/packages/payload/src/collections/operations/findVersions.ts#L25
* The handling of the `pagination` property in those functions was broken, this PR fixes it.