### PR TITLE
feat: expose multipart/form-data parsing options

### DIFF
--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -14,7 +14,7 @@ const handlerBuilder =
   ): Promise<Response> => {
     const awaitedConfig = await config
 
-    // Add this endpoint only when using Next.js, still can be overriden.
+    // Add this endpoint only when using Next.js, still can be overridden.
     if (
       initedOGEndpoint === false &&
       !awaitedConfig.endpoints.some(

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -275,6 +275,7 @@ export type InitOptions = {
   disableOnInit?: boolean
 
   importMap?: ImportMap
+
   /**
    * A function that is called immediately following startup that receives the Payload instance as it's only argument.
    */
@@ -980,6 +981,7 @@ export type Config = {
     /** The slug of a Collection that you want to be used to log in to the Admin dashboard. */
     user?: string
   }
+
   /**
    * Configure authentication-related Payload-wide settings.
    */
@@ -1024,10 +1026,8 @@ export type Config = {
   cors?: '*' | CORSConfig | string[]
   /** A whitelist array of URLs to allow Payload cookies to be accepted from as a form of CSRF protection. */
   csrf?: string[]
-
   /** Extension point to add your custom data. Server only. */
   custom?: Record<string, any>
-
   /** Pass in a database adapter for use on this project. */
   db: DatabaseAdapterResult
   /** Enable to expose more detailed error information. */
@@ -1165,7 +1165,6 @@ export type Config = {
    * ```
    */
   logger?: 'sync' | { destination?: DestinationStream; options: pino.LoggerOptions } | PayloadLogger
-
   /**
    * Override the log level of errors for Payload's error handler or disable logging with `false`.
    * Levels can be any of the following: 'trace', 'debug', 'info', 'warn', 'error', 'fatal' or false.
@@ -1196,6 +1195,16 @@ export type Config = {
    * @default 10
    */
   maxDepth?: number
+
+  /**
+   * Pass additional options to the parser used to process `multipart/form-data` requests.
+   * For example, a PATCH request containing HTML form data.
+   * For example, you may want to increase the `limits` imposed by the parser.
+   * Currently using @link {https://www.npmjs.com/package/busboy|busboy} under the hood.
+   *
+   * @experimental This property is experimental and may change in future releases. Use at your own discretion.
+   */
+  multipartFormdataOptions?: Partial<BusboyConfig>
 
   /** A function that is called immediately following startup that receives the Payload instance as its only argument. */
   onInit?: (payload: Payload) => Promise<void> | void

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -996,6 +996,15 @@ export type Config = {
   bin?: BinScriptConfig[]
   blocks?: Block[]
   /**
+   * Pass additional options to the parser used to process `multipart/form-data` requests.
+   * For example, a PATCH request containing HTML form data.
+   * For example, you may want to increase the `limits` imposed by the parser.
+   * Currently using @link {https://www.npmjs.com/package/busboy|busboy} under the hood.
+   *
+   * @experimental This property is experimental and may change in future releases. Use at your own discretion.
+   */
+  bodyParser?: Partial<BusboyConfig>
+  /**
    * Manage the datamodel of your application
    *
    * @see https://payloadcms.com/docs/configuration/collections#collection-configs
@@ -1165,6 +1174,7 @@ export type Config = {
    * ```
    */
   logger?: 'sync' | { destination?: DestinationStream; options: pino.LoggerOptions } | PayloadLogger
+
   /**
    * Override the log level of errors for Payload's error handler or disable logging with `false`.
    * Levels can be any of the following: 'trace', 'debug', 'info', 'warn', 'error', 'fatal' or false.
@@ -1195,16 +1205,6 @@ export type Config = {
    * @default 10
    */
   maxDepth?: number
-
-  /**
-   * Pass additional options to the parser used to process `multipart/form-data` requests.
-   * For example, a PATCH request containing HTML form data.
-   * For example, you may want to increase the `limits` imposed by the parser.
-   * Currently using @link {https://www.npmjs.com/package/busboy|busboy} under the hood.
-   *
-   * @experimental This property is experimental and may change in future releases. Use at your own discretion.
-   */
-  multipartFormdataOptions?: Partial<BusboyConfig>
 
   /** A function that is called immediately following startup that receives the Payload instance as its only argument. */
   onInit?: (payload: Payload) => Promise<void> | void

--- a/packages/payload/src/uploads/fetchAPI-multipart/index.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/index.ts
@@ -7,7 +7,7 @@ import { isEligibleRequest } from './isEligibleRequest.js'
 import { processMultipart } from './processMultipart.js'
 import { debugLog } from './utilities.js'
 
-const DEFAULT_OPTIONS: FetchAPIFileUploadOptions = {
+const DEFAULT_UPLOAD_OPTIONS: FetchAPIFileUploadOptions = {
   abortOnLimit: false,
   createParentPath: false,
   debug: false,
@@ -53,16 +53,22 @@ type FetchAPIFileUpload = (args: {
   options?: FetchAPIFileUploadOptions
   request: Request
 }) => Promise<FetchAPIFileUploadResponse>
-export const fetchAPIFileUpload: FetchAPIFileUpload = async ({ options, request }) => {
-  const uploadOptions: FetchAPIFileUploadOptions = { ...DEFAULT_OPTIONS, ...options }
+
+export const processMultipartFormdata: FetchAPIFileUpload = async ({
+  options: incomingOptions,
+  request,
+}) => {
+  const options: FetchAPIFileUploadOptions = { ...DEFAULT_UPLOAD_OPTIONS, ...incomingOptions }
+
   if (!isEligibleRequest(request)) {
-    debugLog(uploadOptions, 'Request is not eligible for file upload!')
+    debugLog(options, 'Request is not eligible for file upload!')
+
     return {
       error: new APIError('Request is not eligible for file upload', 500),
       fields: undefined!,
       files: undefined!,
     }
   } else {
-    return processMultipart({ options: uploadOptions, request })
+    return processMultipart({ options, request })
   }
 }

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -30,7 +30,7 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
     } else if (bodyByteSize && contentType?.includes('multipart/')) {
       const { error, fields, files } = await processMultipartFormdata({
         options: {
-          ...(payload.config.multipartFormdataOptions || {}),
+          ...(payload.config.bodyParser || {}),
           ...(payload.config.upload || {}),
         },
         request: req as Request,

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -1,7 +1,7 @@
 import type { PayloadRequest } from '../types/index.js'
 
 import { APIError } from '../errors/APIError.js'
-import { fetchAPIFileUpload } from '../uploads/fetchAPI-multipart/index.js'
+import { processMultipartFormdata } from '../uploads/fetchAPI-multipart/index.js'
 
 type AddDataAndFileToRequest = (req: PayloadRequest) => Promise<void>
 
@@ -24,12 +24,15 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
         req.payload.logger.error(error)
       } finally {
         req.data = data
-        // @ts-expect-error
+        // @ts-expect-error attach json method to request
         req.json = () => Promise.resolve(data)
       }
     } else if (bodyByteSize && contentType?.includes('multipart/')) {
-      const { error, fields, files } = await fetchAPIFileUpload({
-        options: payload.config.upload,
+      const { error, fields, files } = await processMultipartFormdata({
+        options: {
+          ...(payload.config.multipartFormdataOptions || {}),
+          ...(payload.config.upload || {}),
+        },
         request: req as Request,
       })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2112,6 +2112,9 @@ importers:
       nodemailer:
         specifier: 6.9.16
         version: 6.9.16
+      object-to-formdata:
+        specifier: 4.5.1
+        version: 4.5.1
       payload:
         specifier: workspace:*
         version: link:../packages/payload

--- a/test/collections-rest/collections/LargeDocuments.ts
+++ b/test/collections-rest/collections/LargeDocuments.ts
@@ -1,0 +1,19 @@
+import type { CollectionConfig } from 'payload'
+
+export const largeDocumentsCollectionSlug = 'large-documents'
+
+export const LargeDocuments: CollectionConfig = {
+  slug: largeDocumentsCollectionSlug,
+  fields: [
+    {
+      name: 'array',
+      type: 'array',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+}

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -6,6 +6,7 @@ import { APIError, type CollectionConfig, type Endpoint } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
+import { LargeDocuments } from './collections/LargeDocuments.js'
 
 export interface Relation {
   id: string
@@ -280,6 +281,7 @@ export default buildConfigWithDefaults({
       ],
       disableBulkEdit: true,
     },
+    LargeDocuments,
   ],
   endpoints: [
     {

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -285,7 +285,7 @@ export default buildConfigWithDefaults({
   ],
   multipartFormdataOptions: {
     limits: {
-      fieldSize: 4 * 1024 * 1024, // 2MB
+      fieldSize: 2 * 1024 * 1024, // 2MB
     },
   },
   endpoints: [

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -283,7 +283,7 @@ export default buildConfigWithDefaults({
     },
     LargeDocuments,
   ],
-  multipartFormdataOptions: {
+  bodyParser: {
     limits: {
       fieldSize: 2 * 1024 * 1024, // 2MB
     },

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -283,6 +283,11 @@ export default buildConfigWithDefaults({
     },
     LargeDocuments,
   ],
+  multipartFormdataOptions: {
+    limits: {
+      fieldSize: 4 * 1024 * 1024, // 2MB
+    },
+  },
   endpoints: [
     {
       handler: async ({ payload }) => {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -141,18 +141,20 @@ describe('collections-rest', () => {
         nullsAsUndefineds: false,
       })
 
-      // Ensure the form data we are about to send is actually over 1mb
+      // Ensure the form data we are about to send is actually over 1mb which is the default limit
       const docSize = getFormDataSize(formData)
       expect(docSize).toBeGreaterThan(1 * 1024 * 1024)
 
       // This request should not fail with error: "Unterminated string in JSON at position..."
-      const data = await restClient
-        .PATCH(`/${postsSlug}/${doc.id}?limit=1`, {
+      // This is because we set `multipartFormdataOptions.limits.fieldSize` to 2mb in the root config
+      const { doc: updatedDoc } = await restClient
+        .PATCH(`/${largeDocumentsCollectionSlug}/${doc.id}?limit=1`, {
           body: formData,
         })
         .then((res) => res.json())
 
-      expect(data.array?.[0]?.text).toEqual('Hello, world!')
+      expect(updatedDoc.id).toEqual(doc.id)
+      expect(updatedDoc.array[0].text).toEqual('Hello, world!')
     })
 
     describe('Bulk operations', () => {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -151,7 +151,7 @@ describe('collections-rest', () => {
       expect(docSize).toBeLessThan(2 * 1024 * 1024)
 
       // This request should not fail with error: "Unterminated string in JSON at position..."
-      // This is because we set `multipartFormdataOptions.limits.fieldSize` to 2mb in the root config
+      // This is because we set `bodyParser.limits.fieldSize` to 2mb in the root config
       const res = await restClient
         .PATCH(`/${largeDocumentsCollectionSlug}/${doc.id}?limit=1`, {
           body: formData,

--- a/test/collections-rest/payload-types.ts
+++ b/test/collections-rest/payload-types.ts
@@ -76,6 +76,7 @@ export interface Config {
     'error-on-hooks': ErrorOnHook;
     endpoints: Endpoint;
     'disabled-bulk-edit-docs': DisabledBulkEditDoc;
+    'large-documents': LargeDocument;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -92,6 +93,7 @@ export interface Config {
     'error-on-hooks': ErrorOnHooksSelect<false> | ErrorOnHooksSelect<true>;
     endpoints: EndpointsSelect<false> | EndpointsSelect<true>;
     'disabled-bulk-edit-docs': DisabledBulkEditDocsSelect<false> | DisabledBulkEditDocsSelect<true>;
+    'large-documents': LargeDocumentsSelect<false> | LargeDocumentsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -261,6 +263,21 @@ export interface DisabledBulkEditDoc {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "large-documents".
+ */
+export interface LargeDocument {
+  id: string;
+  array?:
+    | {
+        text?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -274,6 +291,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -318,6 +342,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'disabled-bulk-edit-docs';
         value: string | DisabledBulkEditDoc;
+      } | null)
+    | ({
+        relationTo: 'large-documents';
+        value: string | LargeDocument;
       } | null)
     | ({
         relationTo: 'users';
@@ -473,6 +501,20 @@ export interface DisabledBulkEditDocsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "large-documents_select".
+ */
+export interface LargeDocumentsSelect<T extends boolean = true> {
+  array?:
+    | T
+    | {
+        text?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
@@ -485,6 +527,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/helpers/NextRESTClient.ts
+++ b/test/helpers/NextRESTClient.ts
@@ -12,6 +12,7 @@ import {
 import * as qs from 'qs-esm'
 
 import { devUser } from '../credentials.js'
+import { getFormDataSize } from './getFormDataSize.js'
 
 type ValidPath = `/${string}`
 type RequestOptions = {
@@ -94,17 +95,26 @@ export class NextRESTClient {
   }
 
   private buildHeaders(options: FileArg & RequestInit & RequestOptions): Headers {
-    const defaultHeaders = {
-      'Content-Type': 'application/json',
+    // Only set `Content-Type` to `application/json` if body is not `FormData`
+    const isFormData =
+      options &&
+      typeof options.body !== 'undefined' &&
+      typeof FormData !== 'undefined' &&
+      options.body instanceof FormData
+
+    const headers = new Headers(options.headers || {})
+
+    if (options?.file) {
+      headers.set('Content-Length', options.file.size.toString())
     }
-    const headers = new Headers({
-      ...(options?.file
-        ? {
-            'Content-Length': options.file.size.toString(),
-          }
-        : defaultHeaders),
-      ...(options?.headers || {}),
-    })
+
+    if (isFormData) {
+      headers.set('Content-Length', getFormDataSize(options.body as FormData).toString())
+    }
+
+    if (!isFormData && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json')
+    }
 
     if (options.auth !== false && this.token) {
       headers.set('Authorization', `JWT ${this.token}`)
@@ -213,6 +223,7 @@ export class NextRESTClient {
       headers: this.buildHeaders(options),
       method: 'PATCH',
     })
+
     return this._PATCH(request, { params: Promise.resolve({ slug }) })
   }
 

--- a/test/helpers/getFormDataSize.ts
+++ b/test/helpers/getFormDataSize.ts
@@ -1,0 +1,16 @@
+export function getFormDataSize(formData: FormData) {
+  const blob = new Blob(formDataToArray(formData))
+  return blob.size
+}
+
+function formDataToArray(formData: FormData) {
+  const parts = []
+  for (const [key, value] of formData.entries()) {
+    if (value instanceof File) {
+      parts.push(value)
+    } else {
+      parts.push(new Blob([value], { type: 'text/plain' }))
+    }
+  }
+  return parts
+}

--- a/test/package.json
+++ b/test/package.json
@@ -83,6 +83,7 @@
     "mongoose": "8.15.1",
     "next": "15.4.4",
     "nodemailer": "6.9.16",
+    "object-to-formdata": "4.5.1",
     "payload": "workspace:*",
     "pg": "8.16.3",
     "qs-esm": "7.0.2",


### PR DESCRIPTION
When sending REST API requests with multipart/form-data, e.g. PATCH or POST within the admin panel, a request body larger than 1MB throws the following error:

```
Unterminated string in JSON at position...
```

This is because there are sensible defaults imposed by the HTML form data parser (currently using [busboy](https://github.com/fastify/busboy)). If your documents exceed this limit, you may run into this error when editing them within the admin panel.

To support large documents over 1MB, use the new `bodyParser` property on the root config:

```ts
import { buildConfig } from 'payload'

const config = buildConfig({
  // ...
  bodyParser: {
    limits: {
      fieldSize: 2 * 1024 * 1024, // This will allow requests containing up to 2MB of multipart/form-data
    }
  }
}
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211317005907885