### PR TITLE
fix(ui): safely access preferences when loading list view

### DIFF
--- a/packages/next/src/views/Root/index.tsx
+++ b/packages/next/src/views/Root/index.tsx
@@ -166,7 +166,9 @@ export const RootPage = async ({
         req.user.id,
         config.admin.user,
       ).then((res) => {
-        collectionPreferences = res.value
+        if (res && res.value) {
+          collectionPreferences = res.value
+        }
       })
     }
   }


### PR DESCRIPTION
Fixes an issue when user has no collection preferences saved. When no collection level preferences are saved, the result is `undefined`. This change ensures there is a result before accessing `res.value`.

<img width="720" height="387" alt="image" src="https://github.com/user-attachments/assets/fa222928-88ca-43ca-bf85-f0cd94d63f1b" />
