### PR TITLE
docs: improvements and fixes to blocks documentation

### DIFF
--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -2,7 +2,7 @@
 title: Blocks Field
 label: Blocks
 order: 30
-desc: The Blocks Field is a great layout build and can be used to construct any flexible content model. Learn how to use Block Fields, see examples and options.
+desc: The Blocks Field is a great layout builder and can be used to construct any flexible content model. Learn how to use Block Fields, see examples and options.
 keywords: blocks, fields, config, configuration, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -6,20 +6,19 @@ desc: The Blocks Field is a great layout build and can be used to construct any 
 keywords: blocks, fields, config, configuration, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 
-The Blocks Field is **incredibly powerful**, storing an array of objects based on the fields that you define, where each item in the array is a "block" with its own unique schema.
+The Blocks Field is one of the most flexible tools in Payload. It stores an array of objects, where each object is a “block” with its own schema. Unlike a simple array (where every item looks the same), blocks let you mix and match different content types in any order.
 
-Blocks are a great way to create a flexible content model that can be used to build a wide variety of content types, including:
+This makes Blocks perfect for building dynamic, editor-friendly experiences, such as:
 
-- A layout builder tool that grants editors to design highly customizable page or post layouts. Blocks could include configs such as `Quote`, `CallToAction`, `Slider`, `Content`, `Gallery`, or others.
-- A form builder tool where available block configs might be `Text`, `Select`, or `Checkbox`.
-- Virtual event agenda "timeslots" where a timeslot could either be a `Break`, a `Presentation`, or a `BreakoutSession`.
-
-<LightDarkImage
-  srcLight="https://payloadcms.com/images/docs/fields/blocks.png"
-  srcDark="https://payloadcms.com/images/docs/fields/blocks-dark.png"
-  alt="Admin Panel screenshot of add Blocks drawer view"
-  caption="Admin Panel screenshot of add Blocks drawer view"
-/>
+- A page builder with blocks like `Quote`, `CallToAction`, `Slider`, or `Gallery`.
+- A form builder with block types like `Text`, `Select`, or `Checkbox`.
+- An event agenda where each timeslot could be a `Break`, `Presentation`, or `BreakoutSession`.
+  <LightDarkImage
+    srcLight="https://payloadcms.com/images/docs/fields/blocks.png"
+    srcDark="https://payloadcms.com/images/docs/fields/blocks-dark.png"
+    alt="Admin Panel screenshot of add Blocks drawer view"
+    caption="Admin Panel screenshot of add Blocks drawer view"
+  />
 
 To add a Blocks Field, set the `type` to `blocks` in your [Field Config](./overview):
 
@@ -37,7 +36,11 @@ export const MyBlocksField: Field = {
 }
 ```
 
-## Config Options
+This page is divided into two parts: first, the settings of the Blocks Field, and then the settings of the blocks inside it.
+
+## Block Field
+
+### Config Options
 
 | Option                 | Description                                                                                                                                                                                                                                                                                             |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -62,7 +65,7 @@ export const MyBlocksField: Field = {
 
 _\* An asterisk denotes that a property is required._
 
-## Admin Options
+### Admin Options
 
 To customize the appearance and behavior of the Blocks Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
@@ -80,12 +83,10 @@ export const MyBlocksField: Field = {
 
 The Blocks Field inherits all of the default admin options from the base [Field Admin Config](./overview#admin-options), plus the following additional options:
 
-| Option                 | Description                                                                |
-| ---------------------- | -------------------------------------------------------------------------- |
-| **`group`**            | Text or localization object used to group this Block in the Blocks Drawer. |
-| **`initCollapsed`**    | Set the initial collapsed state                                            |
-| **`isSortable`**       | Disable order sorting by setting this value to `false`                     |
-| **`disableBlockName`** | Hide the blockName field by setting this value to `true`                   |
+| Option              | Description                                            |
+| ------------------- | ------------------------------------------------------ |
+| **`initCollapsed`** | Set the initial collapsed state                        |
+| **`isSortable`**    | Disable order sorting by setting this value to `false` |
 
 #### Customizing the way your block is rendered in Lexical
 
@@ -132,7 +133,9 @@ import {
 } from '@payloadcms/richtext-lexical/client'
 ```
 
-## Block Configs
+## Blocks Items
+
+### Config Options
 
 Blocks are defined as separate configs of their own.
 
@@ -149,7 +152,7 @@ Blocks are defined as separate configs of their own.
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`slug`** \*              | Identifier for this block type. Will be saved on each block as the `blockType` property.                                                                                            |
 | **`fields`** \*            | Array of fields to be stored in this block.                                                                                                                                         |
-| **`labels`**               | Customize the block labels that appear in the Admin dashboard. Auto-generated from slug if not defined.                                                                             |
+| **`labels`**               | Customize the block labels that appear in the Admin dashboard. Auto-generated from slug if not defined. Alternatively you can use `admin.components.Label` for greater control.     |
 | **`imageURL`**             | Provide a custom image thumbnail to help editors identify this block in the Admin UI.                                                                                               |
 | **`imageAltText`**         | Customize this block's image thumbnail alt text.                                                                                                                                    |
 | **`interfaceName`**        | Create a top level, reusable [Typescript interface](/docs/typescript/generating-types#custom-field-interfaces) & [GraphQL type](/docs/graphql/graphql-schema#custom-field-schemas). |
@@ -157,17 +160,118 @@ Blocks are defined as separate configs of their own.
 | **`dbName`**               | Custom table name for this block type when using SQL Database Adapter ([Postgres](/docs/database/postgres)). Auto-generated from slug if not defined.                               |
 | **`custom`**               | Extension point for adding custom data (e.g. for plugins)                                                                                                                           |
 
-### Auto-generated data per block
+### Admin Options
 
-In addition to the field data that you define on each block, Payload will store two additional properties on each block:
+Blocks are not fields, so they don’t inherit the base properties shared by all fields (not to be confused with the Blocks Field, documented above, which does). Here are their available admin options:
 
-**`blockType`**
+| Option                 | Description                                                                |
+| ---------------------- | -------------------------------------------------------------------------- |
+| **`components.Block`** | Custom component for replacing the Block, including the header.            |
+| **`components.Label`** | Custom component for replacing the Block Label.                            |
+| **`disableBlockName`** | Hide the blockName field by setting this value to `true`.                  |
+| **`group`**            | Text or localization object used to group this Block in the Blocks Drawer. |
+| **`custom`**           | Extension point for adding custom data (e.g. for plugins)                  |
 
-The `blockType` is saved as the slug of the block that has been selected.
+### blockType, blockName, and block.label
 
-**`blockName`**
+Each block stores two pieces of data alongside your fields. The `blockType` identifies which schema to use and it is exactly the block’s `slug`. The `blockName` is an optional label you can give to a block to make editing and scanning easier.
 
-The Admin Panel provides each block with a `blockName` field which optionally allows editors to label their blocks for better editability and readability. This can be visually hidden via `admin.disableBlockName`.
+The **label** is shared by all blocks of the same type and is defined in the block config via `label` with a fallback to `slug`. On the other hand, the **blockName** is specific to each block individually. You can hide the editable name with `admin.disableBlockName`.
+
+If you provide `admin.components.Label`, that component replaces both the name and the label in the Admin UI.
+
+| Property      | Scope      | Source                                     | Visible in UI | Notes                                                                                              |
+| ------------- | ---------- | ------------------------------------------ | ------------- | -------------------------------------------------------------------------------------------------- |
+| `blockType`   | Each block | The block’s `slug`                         | Not a header  | Used to resolve which block schema to render                                                       |
+| `blockName`   | Each block | Editor input in the Admin                  | Yes           | Optional label; hide with `admin.disableBlockName` or replace with custom `admin.components.Label` |
+| `block.label` | Block type | `label` in block config or `slug` fallback | Yes           | Shared by all blocks of that type. Can be replaced with custom `admin.components.Label`            |
+
+### Custom Components
+
+#### Field
+
+##### Server Component
+
+```tsx
+import type React from 'react'
+import { BlocksField } from '@payloadcms/ui'
+import type { BlocksFieldServerComponent } from 'payload'
+
+export const CustomBlocksFieldServer: BlocksFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <BlocksField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+##### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { BlocksField } from '@payloadcms/ui'
+import type { BlocksFieldClientComponent } from 'payload'
+
+export const CustomBlocksFieldClient: BlocksFieldClientComponent = (props) => {
+  return <BlocksField {...props} />
+}
+```
+
+#### Label
+
+##### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { BlocksFieldLabelServerComponent } from 'payload'
+
+export const CustomBlocksFieldLabelServer: BlocksFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+##### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { BlocksFieldLabelClientComponent } from 'payload'
+
+export const CustomBlocksFieldLabelClient: BlocksFieldLabelClientComponent = ({
+  label,
+  path,
+  required,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```
 
 ## Example
 
@@ -209,109 +313,6 @@ export const ExampleCollection: CollectionConfig = {
       ],
     },
   ],
-}
-```
-
-## Custom Components
-
-### Field
-
-#### Server Component
-
-```tsx
-import type React from 'react'
-import { BlocksField } from '@payloadcms/ui'
-import type { BlocksFieldServerComponent } from 'payload'
-
-export const CustomBlocksFieldServer: BlocksFieldServerComponent = ({
-  clientField,
-  path,
-  schemaPath,
-  permissions,
-}) => {
-  return (
-    <BlocksField
-      field={clientField}
-      path={path}
-      schemaPath={schemaPath}
-      permissions={permissions}
-    />
-  )
-}
-```
-
-#### Client Component
-
-```tsx
-'use client'
-import React from 'react'
-import { BlocksField } from '@payloadcms/ui'
-import type { BlocksFieldClientComponent } from 'payload'
-
-export const CustomBlocksFieldClient: BlocksFieldClientComponent = (props) => {
-  return <BlocksField {...props} />
-}
-```
-
-### Label
-
-#### Server Component
-
-```tsx
-import React from 'react'
-import { FieldLabel } from '@payloadcms/ui'
-import type { BlocksFieldLabelServerComponent } from 'payload'
-
-export const CustomBlocksFieldLabelServer: BlocksFieldLabelServerComponent = ({
-  clientField,
-  path,
-}) => {
-  return (
-    <FieldLabel
-      label={clientField?.label || clientField?.name}
-      path={path}
-      required={clientField?.required}
-    />
-  )
-}
-```
-
-#### Client Component
-
-```tsx
-'use client'
-import React from 'react'
-import { FieldLabel } from '@payloadcms/ui'
-import type { BlocksFieldLabelClientComponent } from 'payload'
-
-export const CustomBlocksFieldLabelClient: BlocksFieldLabelClientComponent = ({
-  label,
-  path,
-  required,
-}) => {
-  return (
-    <FieldLabel
-      label={field?.label || field?.name}
-      path={path}
-      required={field?.required}
-    />
-  )
-}
-```
-
-### Row Label
-
-```tsx
-'use client'
-
-import { useRowLabel } from '@payloadcms/ui'
-
-export const BlockRowLabel = () => {
-  const { data, rowNumber } = useRowLabel<{ title?: string }>()
-
-  const customLabel = `${data.type} ${String(rowNumber).padStart(2, '0')} `
-
-  return <div>Custom Label: {customLabel}</div>
 }
 ```
 


### PR DESCRIPTION
The information about the block field and the blocks themselves wasn't separated in the documentation, and in fact, there were times when they were confused and incorrectly mixed.

This caused confusion among our users.

This PR closes an issue, a discussion, and another PR that arose because it wasn't clear that the `blockName` could be programmatically modified with the block's content. This is possible through `admin.components.Label`, which isn't the best name, as it changes the `label` and the `name` of the block, two different concepts.

I've added a section to the documentation that I think will make all of this much clearer.

Before:

<img width="266" height="362" alt="image" src="https://github.com/user-attachments/assets/3b5c95f0-2cdb-4995-a25d-9984f9ab54cb" />

After:

<img width="266" height="383" alt="image" src="https://github.com/user-attachments/assets/99936f64-326f-4d69-a464-626d7f53fa08" />


Replaces https://github.com/payloadcms/payload/pull/12135
Fixes https://github.com/payloadcms/payload/issues/12112 & addresses https://github.com/payloadcms/payload/discussions/4648