### PR TITLE
fix: ensure unique IDs for new array rows in bulk updates

### DIFF
--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -244,7 +244,26 @@ export const updateOperation = async <
           autosave: false,
           collectionConfig,
           config,
-          data: deepCopyObjectSimple(data),
+          data: (() => {
+            const dataForDoc = deepCopyObjectSimple(data)
+
+            collectionConfig.fields.forEach((field) => {
+              if (
+                field.type === 'array' &&
+                dataForDoc[field.name] &&
+                Array.isArray(dataForDoc[field.name])
+              ) {
+                dataForDoc[field.name].forEach((row: Record<string, any>) => {
+                  if (row.id && typeof row.id === 'string') {
+                    delete row.id
+                  }
+                })
+              }
+            })
+
+            return dataForDoc
+          })(),
+
           depth: depth!,
           docWithLocales,
           draftArg,


### PR DESCRIPTION
## What?

This PR addresses a bug where bulk updating documents that include array fields with newly added rows would fail. Specifically:

- When attempting to add a new row to an array field (e.g., `store_statuses` in the **Users** collection) across multiple documents in a single bulk update operation:
  - The update would succeed for the **first document**.
  - The update would fail for **subsequent documents**.

---

## Why?

The root cause was that **Payload's bulk update operation reused the same temporary client-generated ID** for new array rows across all documents being updated.

- When the first document’s array row was inserted, it used this temporary ID.
- On subsequent documents, trying to insert another row with the **same ID** triggered a **unique constraint violation**, causing the entire bulk update to fail.

---

## How?

The fix is implemented within the `updateOperation` for collections:

1. Before the data for each document is passed to `updateDocument`, a **deep copy** of the data is made.  
2. For any array fields within this copied data:
   - New rows (identified by their **temporary string-based IDs**) have their `id` property **removed**.  
3. This ensures the database adapter generates **fresh, unique IDs** for each new array row in every document, preventing unique constraint violations.

---

## Link to reproduction

https://github.com/JesperWe/bulk-update-array.git

Fixes https://github.com/payloadcms/payload/issues/13736

Watch [this](https://siddharth-kumar-gope2.neetorecord.com/watch/8bc4fe79738632ffa086)
