### PR TITLE
fix(next): richtext field is read-only for expired lock

### DIFF
--- a/packages/next/src/views/Document/getIsLocked.ts
+++ b/packages/next/src/views/Document/getIsLocked.ts
@@ -42,10 +42,28 @@ export const getIsLocked = async ({
 
   const where: Where = {}
 
+  const lockDurationDefault = 300 // Default 5 minutes in seconds
+  const lockDuration =
+    typeof entityConfig.lockDocuments === 'object'
+      ? entityConfig.lockDocuments.duration
+      : lockDurationDefault
+  const lockDurationInMilliseconds = lockDuration * 1000
+
+  const now = new Date().getTime()
+
   if (globalConfig) {
-    where.globalSlug = {
-      equals: globalConfig.slug,
-    }
+    where.and = [
+      {
+        globalSlug: {
+          equals: globalConfig.slug,
+        },
+      },
+      {
+        updatedAt: {
+          greater_than: new Date(now - lockDurationInMilliseconds),
+        },
+      },
+    ]
   } else {
     where.and = [
       {
@@ -56,6 +74,11 @@ export const getIsLocked = async ({
       {
         'document.relationTo': {
           equals: collectionConfig.slug,
+        },
+      },
+      {
+        updatedAt: {
+          greater_than: new Date(now - lockDurationInMilliseconds),
         },
       },
     ]


### PR DESCRIPTION
### What?

Opening a document with an expired lock and richtext caused the richtext to be read-only.

### Why?

The changes in #13579 made the richtext read only if isLocked is set. But the server side implementation of isLocked did not consider expired locks.

### How?

Update the server-side getIsLocked to also consider expired locks by not loading them.