### PR TITLE
fix: exit payload generate:importmap and generate:types after completion

### DIFF
--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -99,11 +99,11 @@ export const bin = async () => {
   }
 
   if (script === 'generate:types') {
-    return generateTypes(config)
+    return generateTypes(config).then(() => process.exit(0))
   }
 
   if (script === 'generate:importmap') {
-    return generateImportMap(config)
+    return generateImportMap(config).then(() => process.exit(0))
   }
 
   if (script === 'jobs:run') {


### PR DESCRIPTION
### What?

Exit the process after running generate:importmap and generate:types bin scripts.

### Why?

In some configurations the process hangs after the importmap and types has been generated.

### How?

Execute process.exit(0) after generation has completed.


Fixes #13744

