### PR TITLE
fix(ui): show loading state in relationship field during search and pagination

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -359,6 +359,9 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
       updateResultsEffectEvent({
         filterOptions,
         lastLoadedPage: {},
+        onSuccess: () => {
+          setIsLoading(false)
+        },
         search: searchArg,
         sort: true,
         ...(hasManyArg === true
@@ -379,6 +382,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
   const handleInputChange = useCallback(
     (options: { search: string } & HasManyValueUnion) => {
       if (search !== options.search) {
+        setIsLoading(true)
         setLastLoadedPage({})
         updateSearch(options)
       }
@@ -814,10 +818,14 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
                 }
               }}
               onMenuScrollToBottom={() => {
+                setIsLoading(true)
                 updateResultsEffectEvent({
                   filterOptions,
                   lastFullyLoadedRelation,
                   lastLoadedPage,
+                  onSuccess: () => {
+                    setIsLoading(false)
+                  },
                   search,
                   sort: false,
                   ...(hasMany === true


### PR DESCRIPTION
When searching and the data is still being fetched, users see "no options" until the data is populated, this is very confusing especially if the loading time could take more seconds, user would start clearing input and type again.

This PR shows the loading indicator during search and pagination by setting `isLoading` to true immediately when search begins and setting it to false when data fetching completes

**Before**

https://github.com/user-attachments/assets/86367207-31f6-40f0-bd98-c9e885ecd0dd



**After**


https://github.com/user-attachments/assets/202d2c05-61a6-4e3a-9973-65b302b4495a

