### PR TITLE
fix: versions created with incomplete data when using   `select` parameter

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -267,12 +267,14 @@ export const createOperation = async <
         password: data.password as string,
         payload: req.payload,
         req,
+        select,
       })
     } else {
       doc = await payload.db.create({
         collection: collectionConfig.slug,
         data: resultWithLocales,
         req,
+        select,
       })
     }
 

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -267,14 +267,12 @@ export const createOperation = async <
         password: data.password as string,
         payload: req.payload,
         req,
-        select,
       })
     } else {
       doc = await payload.db.create({
         collection: collectionConfig.slug,
         data: resultWithLocales,
         req,
-        select,
       })
     }
 

--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -301,7 +301,6 @@ export const updateDocument = async <
       data: dataToUpdate,
       locale,
       req,
-      select,
     })
   }
 
@@ -321,7 +320,6 @@ export const updateDocument = async <
       payload,
       publishSpecificLocale,
       req,
-      select,
       snapshot: versionSnapshotResult,
     })
   }


### PR DESCRIPTION
### What?

Remove `select` parameter from database operations in update operation during version creation to fix malformed version data.

### Why?

The `select` parameter was being passed to `saveVersion()` in update operations, causing versions to only contain selected fields

### How?

- Removed `select` parameter from `payload.db.updateOne()` calls in update operations
- Removed `select` parameter from `saveVersion()` call in update operation


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211334352350013