### PR TITLE
fix(examples): secure mt example users collection

### DIFF
--- a/examples/multi-tenant/src/collections/Users/index.ts
+++ b/examples/multi-tenant/src/collections/Users/index.ts
@@ -23,6 +23,20 @@ const defaultTenantArrayField = tenantsArrayField({
       hasMany: true,
       options: ['tenant-admin', 'tenant-viewer'],
       required: true,
+      access: {
+        update: ({ req }) => {
+          const { user } = req
+          if (!user) {
+            return false
+          }
+
+          if (isSuperAdmin(user)) {
+            return true
+          }
+
+          return true
+        },
+      },
     },
   ],
 })
@@ -41,6 +55,27 @@ const Users: CollectionConfig = {
   auth: true,
   endpoints: [externalUsersLogin],
   fields: [
+    {
+      type: 'text',
+      name: 'password',
+      hidden: true,
+      access: {
+        read: () => false, // Hide password field from read access
+        update: ({ req, id }) => {
+          const { user } = req
+          if (!user) {
+            return false
+          }
+
+          if (id === user.id) {
+            // Allow user to update their own password
+            return true
+          }
+
+          return isSuperAdmin(user)
+        },
+      },
+    },
     {
       admin: {
         position: 'sidebar',


### PR DESCRIPTION
Adds custom password field to the multi-tenant example to add security by default. Preventing users from another tenant from being able to update other tenant user passwords. 

⚠️ This has nothing to do with the plugin or payload itself. You should always understand how payload works and how its access control works. But this is a good change for people looking at the multi-tenant example.