### PR TITLE
fix(ui): correct field path in inline create drawer for auth fields

### DIFF
--- a/packages/ui/src/elements/EmailAndUsername/index.tsx
+++ b/packages/ui/src/elements/EmailAndUsername/index.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import { EmailField } from '../../fields/Email/index.js'
 import { TextField } from '../../fields/Text/index.js'
 import './index.scss'
+import { FieldPathContext } from '../../forms/RenderFields/context.js'
 
 const baseClass = 'login-fields'
 type RenderEmailAndUsernameFieldsProps = {
@@ -79,36 +80,41 @@ export function EmailAndUsernameFields(props: RenderEmailAndUsernameFieldsProps)
     return (
       <div className={[baseClass, className && className].filter(Boolean).join(' ')}>
         {showEmailField ? (
-          <EmailField
-            field={{
-              name: 'email',
-              admin: {
-                autoComplete: 'off',
-              },
-              label: t('general:email'),
-              required: !loginWithUsername || (loginWithUsername && loginWithUsername.requireEmail),
-            }}
-            path="email"
-            readOnly={readOnly || !emailPermissions.update}
-            schemaPath="email"
-            validate={email}
-          />
+          <FieldPathContext value="email">
+            <EmailField
+              field={{
+                name: 'email',
+                admin: {
+                  autoComplete: 'off',
+                },
+                label: t('general:email'),
+                required:
+                  !loginWithUsername || (loginWithUsername && loginWithUsername.requireEmail),
+              }}
+              path="email"
+              readOnly={readOnly || !emailPermissions.update}
+              schemaPath="email"
+              validate={email}
+            />
+          </FieldPathContext>
         ) : null}
         {showUsernameField && (
-          <TextField
-            field={{
-              name: 'username',
-              admin: {
-                autoComplete: 'off',
-              },
-              label: t('authentication:username'),
-              required: loginWithUsername && loginWithUsername.requireUsername,
-            }}
-            path="username"
-            readOnly={readOnly || !usernamePermissions.update}
-            schemaPath="username"
-            validate={username}
-          />
+          <FieldPathContext value="username">
+            <TextField
+              field={{
+                name: 'username',
+                admin: {
+                  autoComplete: 'off',
+                },
+                label: t('authentication:username'),
+                required: loginWithUsername && loginWithUsername.requireUsername,
+              }}
+              path="username"
+              readOnly={readOnly || !usernamePermissions.update}
+              schemaPath="username"
+              validate={username}
+            />
+          </FieldPathContext>
         )}
       </div>
     )

--- a/packages/ui/src/forms/RenderFields/context.ts
+++ b/packages/ui/src/forms/RenderFields/context.ts
@@ -14,7 +14,7 @@ import React from 'react'
  *
  * export const MyCustomField: TextFieldClientComponent = (props) => {
  *   return (
- *     <FieldPathContext path="path.to.some.other.field">
+ *     <FieldPathContext value="path.to.some.other.field">
  *       <TextField {...props} />
  *     </FieldPathContext>
  *   )


### PR DESCRIPTION
Wrap `EmailField` and `TextField` with `FieldPathContext` to ensure the inputs bind to their own paths (`"email"`, `"username"`) instead of inheriting the relationship field name (e.g., `"author"`).
This restores correct `name` / `schemaPath` binding and fixes form submission.

Regression introduced in #11973.
Fixes #13764.

This approach is consistent with the discussion in [#13806](https://github.com/payloadcms/payload/pull/13806), where it was suggested that enforcing field paths explicitly is the right direction.

**What?**
Fixes regression where inline create drawer fields (`EmailField`, `TextField`) incorrectly inherited the parent relationship field name, breaking form submission.

**Why?**
Without this fix, the email input in inline create forms was bound to the relationship field name (e.g., `"author"`) instead of `"email"`, causing authentication-enabled collections to fail when creating users inline.

**How?**

* Wrap `EmailField` with `FieldPathContext value="email"`
* Wrap `TextField` with `FieldPathContext value="username"`
* Ensures inputs register under the correct paths in form state.

Fixes #13764.
