### PR TITLE
docs: clarify JWT token encryption / decryption in configuration docs

### DIFF
--- a/docs/authentication/jwt.mdx
+++ b/docs/authentication/jwt.mdx
@@ -14,6 +14,20 @@ Payload offers the ability to [Authenticate](./overview) via JSON Web Tokens (JW
   the `req.user` argument. [More details](./token-data).
 </Banner>
 
+## External JWT Validation
+
+When validating Payload-generated JWT tokens in external services, use the processed secret rather than your original secret key:
+
+```ts
+import crypto from 'node:crypto'
+
+const secret = crypto.createHash('sha256').update(process.env.PAYLOAD_SECRET).digest('hex').slice(0, 32)
+```
+
+<Banner type="info">
+  **Note:** Payload processes your secret using SHA-256 hash and takes the first 32 characters. This processed value is what's used for JWT operations, not your original secret.
+</Banner>
+
 ### Identifying Users Via The Authorization Header
 
 In addition to authenticating via an HTTP-only cookie, you can also identify users via the `Authorization` header on an HTTP request.

--- a/docs/authentication/jwt.mdx
+++ b/docs/authentication/jwt.mdx
@@ -14,20 +14,6 @@ Payload offers the ability to [Authenticate](./overview) via JSON Web Tokens (JW
   the `req.user` argument. [More details](./token-data).
 </Banner>
 
-## External JWT Validation
-
-When validating Payload-generated JWT tokens in external services, use the processed secret rather than your original secret key:
-
-```ts
-import crypto from 'node:crypto'
-
-const secret = crypto.createHash('sha256').update(process.env.PAYLOAD_SECRET).digest('hex').slice(0, 32)
-```
-
-<Banner type="info">
-  **Note:** Payload processes your secret using SHA-256 hash and takes the first 32 characters. This processed value is what's used for JWT operations, not your original secret.
-</Banner>
-
 ### Identifying Users Via The Authorization Header
 
 In addition to authenticating via an HTTP-only cookie, you can also identify users via the `Authorization` header on an HTTP request.
@@ -67,3 +53,17 @@ export const UsersWithoutJWTs: CollectionConfig = {
   },
 }
 ```
+
+## External JWT Validation
+
+When validating Payload-generated JWT tokens in external services, use the processed secret rather than your original secret key:
+
+```ts
+import crypto from 'node:crypto'
+
+const secret = crypto.createHash('sha256').update(process.env.PAYLOAD_SECRET).digest('hex').slice(0, 32)
+```
+
+<Banner type="info">
+  **Note:** Payload processes your secret using SHA-256 hash and takes the first 32 characters. This processed value is what's used for JWT operations, not your original secret.
+</Banner>

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -111,10 +111,6 @@ _\* An asterisk denotes that a property is required._
   details](../custom-components/overview#accessing-the-payload-config).
 </Banner>
 
-<Banner type="warning">
-  Payload does not use your secret key directly for encryption. Instead, it first processes the secret using the SHA-256 hash function, then reduces the encrypted string to its first 32 characters. This final processed value is what Payload actually uses for encryption and JWT token generation.
-</Banner>
-
 ### TypeScript Config
 
 Payload exposes a variety of TypeScript settings that you can leverage. These settings are used to auto-generate TypeScript interfaces for your [Collections](./collections) and [Globals](./globals), and to ensure that Payload uses your [Generated Types](../typescript/overview) for all [Local API](../local-api/overview) methods.

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -111,6 +111,10 @@ _\* An asterisk denotes that a property is required._
   details](../custom-components/overview#accessing-the-payload-config).
 </Banner>
 
+<Banner type="warning">
+  Payload does not use your secret key directly for encryption. Instead, it first processes the secret using the SHA-256 hash function, then reduces the encrypted string to its first 32 characters. This final processed value is what Payload actually uses for encryption and JWT token generation.
+</Banner>
+
 ### TypeScript Config
 
 Payload exposes a variety of TypeScript settings that you can leverage. These settings are used to auto-generate TypeScript interfaces for your [Collections](./collections) and [Globals](./globals), and to ensure that Payload uses your [Generated Types](../typescript/overview) for all [Local API](../local-api/overview) methods.


### PR DESCRIPTION
### What?

This PR adds back clarification that the `secret` configured in Payload is not used directly to sign JWT tokens, which can cause confusion when attempting to verify tokens in other services.

### Why?

There was previously an issue (#2441) that explained this unexpected behavior, and documentation was added to clarify it. However, that clarification has since been removed from the current docs, which led to confusion when I attempted to validate the JWT in another service and received an "invalid signature" error.

### How?

- Included a brief explanation and a cautionary warning to inform developers of this custom behavior.

Fixes #13814
