### PR TITLE
refactor(examples): replace Express with native HTTP server

### DIFF
--- a/examples/custom-server/package.json
+++ b/examples/custom-server/package.json
@@ -15,7 +15,6 @@
     "@payloadcms/payload-cloud": "latest",
     "@payloadcms/richtext-lexical": "latest",
     "cross-env": "^7.0.3",
-    "express": "^4.21.1",
     "graphql": "^16.8.1",
     "next": "15.2.3",
     "payload": "latest",
@@ -23,7 +22,6 @@
     "react-dom": "19.0.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
     "@types/node": "^18.11.5",
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",

--- a/examples/custom-server/src/server.ts
+++ b/examples/custom-server/src/server.ts
@@ -1,4 +1,5 @@
-import express from 'express'
+// https://nextjs.org/docs/pages/guides/custom-server
+import { createServer } from 'http'
 import { parse } from 'url'
 import next from 'next'
 
@@ -8,18 +9,14 @@ const app = next({ dev })
 const handle = app.getRequestHandler()
 
 app.prepare().then(() => {
-  const server = express()
-
-  server.all('*', (req, res) => {
+  createServer((req, res) => {
     const parsedUrl = parse(req.url!, true)
     handle(req, res, parsedUrl)
-  })
+  }).listen(port)
 
-  server.listen(port, () => {
-    console.log(
-      `> Server listening at http://localhost:${port} as ${
-        dev ? 'development' : process.env.NODE_ENV
-      }`,
-    )
-  })
+  console.log(
+    `> Server listening at http://localhost:${port} as ${
+      dev ? 'development' : process.env.NODE_ENV
+    }`,
+  )
 })


### PR DESCRIPTION
### What?
Replace Express with native HTTP server in `examples/custom-server` to match the official NextJS document.
https://nextjs.org/docs/pages/guides/custom-server
### Why?
Speed up and reduce build size

### How?
Remove express from package.json and patse the code from NextJS document to `examples/custom-server/src/server.ts`
