### PR TITLE
fix(ui): undefined operators for virtual field with unsupported field types

### DIFF
--- a/packages/ui/src/forms/Form/createNestedClientFieldPath.ts
+++ b/packages/ui/src/forms/Form/createNestedClientFieldPath.ts
@@ -5,7 +5,7 @@ import { fieldAffectsData } from 'payload/shared'
 
 export const createNestedClientFieldPath = (parentPath: string, field: ClientField): string => {
   if (parentPath) {
-    if (fieldAffectsData(field)) {
+    if (fieldAffectsData(field) && field.name) {
       return `${parentPath}.${field.name}`
     }
     return parentPath

--- a/packages/ui/src/utilities/reduceFieldsToOptions.tsx
+++ b/packages/ui/src/utilities/reduceFieldsToOptions.tsx
@@ -43,6 +43,11 @@ export const reduceFieldsToOptions = ({
       const baseLabel = ('label' in field && field.label) || ('name' in field && field.name) || ''
       const localizedLabel = getTranslation(baseLabel, i18n)
 
+      // Skip virtual fields with unsupported field types i.e. groups
+      if (!fieldTypes[field.type]) {
+        return reduced
+      }
+
       reduced.push({
         label: localizedLabel,
         plainTextLabel: localizedLabel,


### PR DESCRIPTION
### What?

Fixes crash when virtual fields use field types not supported by the WhereBuilder (e.g. 'group' fields).

<img width="1336" height="459" alt="Screenshot 2025-09-16 at 11 00 30 AM" src="https://github.com/user-attachments/assets/3adbb507-3033-4f52-b7cc-3c5bad74900b" />

### Why?

Users reported a crash with error "Cannot read properties of undefined (reading 'operators')" when entering collection list views with virtual fields that have `type: 'group'`. The issue occurred because:
- Virtual fields can use any field type including 'group'
- The `fieldTypes` object in WhereBuilder only supports specific field types (text, number, select, etc.)
- Code tried to access `fieldTypes[field.type].operators` when `field.type` was 'group', causing undefined access

### How?

- Refactored virtual field handling to use a unified processing flow instead of separate early returns
- Virtual fields now set the `pathPrefix` to their virtual path and continue through normal field validation

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211315667956059