### PR TITLE
docs: beforeChange and beforeValidate updates

### DIFF
--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -114,8 +114,19 @@ The following arguments are provided to the `beforeValidate` hook:
 | **`context`**     | Custom context passed between Hooks. [More details](./context).                                                                                       |
 | **`data`**        | The incoming data passed through the operation.                                                                                                       |
 | **`operation`**   | The name of the operation that this hook is running within.                                                                                           |
-| **`originalDoc`** | The Document before changes are applied.                                                                                                              |
+| **`originalDoc`** | The full document before changes are applied. Present on updates; undefined on creates. Use this to read the document id and any unchanged fields.    |
 | **`req`**         | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations. |
+
+**Why isn’t id in data?**
+
+`data` only represents the delta you’re saving. Read `originalDoc.id` during updates, and prefer `afterChange` if you need the `id` during creates
+
+<Banner type="warning">
+  On update operations, data contains only the fields being changed. It may omit
+  id and any unchanged fields. Use originalDoc to read existing values. On
+  create, data is the new submission and the document id is not yet available at
+  this stage.
+</Banner>
 
 ### beforeChange
 
@@ -124,7 +135,19 @@ Immediately before validation, beforeChange hooks will run during create and upd
 ```ts
 import type { CollectionBeforeChangeHook } from 'payload'
 
-const beforeChangeHook: CollectionBeforeChangeHook = async ({ data }) => {
+export const requireTitleOnUpdate: CollectionBeforeChangeHook = async ({
+  data, // Partial<T> — changed fields only
+  originalDoc, // Full doc before changes (defined on update)
+  operation, // 'create' | 'update'
+}) => {
+  // Need the id? Don't expect it in `data`.
+  const id = operation === 'update' ? originalDoc.id : undefined
+
+  // Example: enforce that title cannot be cleared on update
+  if (operation === 'update' && 'title' in (data ?? {}) && !data.title) {
+    throw new Error(`Document ${id} must have a title`)
+  }
+
   return data
 }
 ```
@@ -137,8 +160,19 @@ The following arguments are provided to the `beforeChange` hook:
 | **`context`**     | Custom context passed between hooks. [More details](./context).                                                                                       |
 | **`data`**        | The incoming data passed through the operation.                                                                                                       |
 | **`operation`**   | The name of the operation that this hook is running within.                                                                                           |
-| **`originalDoc`** | The Document before changes are applied.                                                                                                              |
+| **`originalDoc`** | The full document before changes are applied. Present on updates; undefined on creates. Use this to read the document id and any unchanged fields.    |
 | **`req`**         | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations. |
+
+**Why isn’t id in data?**
+
+`data` only represents the delta you’re saving. Read `originalDoc.id` during updates, and prefer `afterChange` if you need the `id` during creates
+
+<Banner type="warning">
+  On update operations, data contains only the fields being changed. It may omit
+  id and any unchanged fields. Use originalDoc to read existing values. On
+  create, data is the new submission and the document id is not yet available at
+  this stage.
+</Banner>
 
 ### afterChange
 

--- a/docs/hooks/globals.mdx
+++ b/docs/hooks/globals.mdx
@@ -103,8 +103,15 @@ The following arguments are provided to the `beforeValidate` hook:
 | **`global`**      | The [Global](../configuration/globals) in which this Hook is running against.                                                                         |
 | **`context`**     | Custom context passed between Hooks. [More details](./context).                                                                                       |
 | **`data`**        | The incoming data passed through the operation.                                                                                                       |
-| **`originalDoc`** | The Document before changes are applied.                                                                                                              |
+| **`originalDoc`** | The full document before changes are applied. Present on updates; undefined on creates. Use this to read the document id and any unchanged fields.    |
 | **`req`**         | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations. |
+
+<Banner type="warning">
+  On update operations, data contains only the fields being changed. It may omit
+  id and any unchanged fields. Use originalDoc to read existing values. On
+  create, data is the new submission and the document id is not yet available at
+  this stage.
+</Banner>
 
 ### beforeChange
 
@@ -129,8 +136,15 @@ The following arguments are provided to the `beforeChange` hook:
 | **`global`**      | The [Global](../configuration/globals) in which this Hook is running against.                                                                         |
 | **`context`**     | Custom context passed between hooks. [More details](./context).                                                                                       |
 | **`data`**        | The incoming data passed through the operation.                                                                                                       |
-| **`originalDoc`** | The Document before changes are applied.                                                                                                              |
+| **`originalDoc`** | The full document before changes are applied. Present on updates; undefined on creates. Use this to read the document id and any unchanged fields.    |
 | **`req`**         | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations. |
+
+<Banner type="warning">
+  On update operations, data contains only the fields being changed. It may omit
+  id and any unchanged fields. Use originalDoc to read existing values. On
+  create, data is the new submission and the document id is not yet available at
+  this stage.
+</Banner>
 
 ### afterChange
 


### PR DESCRIPTION
- updates definition of args for beforeValidate and before change
- updates example for beforeChange
- adds warning regarding partial data
