### PR TITLE
templates: fix experimental-build-mode compile generating invalid code

### DIFF
--- a/templates/website/src/utilities/getURL.ts
+++ b/templates/website/src/utilities/getURL.ts
@@ -1,17 +1,12 @@
 import canUseDOM from './canUseDOM'
 
 export const getServerSideURL = () => {
-  let url = process.env.NEXT_PUBLIC_SERVER_URL
-
-  if (!url && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
-    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-  }
-
-  if (!url) {
-    url = 'http://localhost:3000'
-  }
-
-  return url
+  return (
+    process.env.NEXT_PUBLIC_SERVER_URL ||
+    (process.env.VERCEL_PROJECT_PRODUCTION_URL
+      ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+      : 'http://localhost:3000')
+  )
 }
 
 export const getClientSideURL = () => {

--- a/templates/with-vercel-website/src/utilities/getURL.ts
+++ b/templates/with-vercel-website/src/utilities/getURL.ts
@@ -1,17 +1,12 @@
 import canUseDOM from './canUseDOM'
 
 export const getServerSideURL = () => {
-  let url = process.env.NEXT_PUBLIC_SERVER_URL
-
-  if (!url && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
-    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-  }
-
-  if (!url) {
-    url = 'http://localhost:3000'
-  }
-
-  return url
+  return (
+    process.env.NEXT_PUBLIC_SERVER_URL ||
+    (process.env.VERCEL_PROJECT_PRODUCTION_URL
+      ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+      : 'http://localhost:3000')
+  )
 }
 
 export const getClientSideURL = () => {


### PR DESCRIPTION
When using `pnpm next build --experimental-build-mode compile` in our website template, Next.js outputs the following code for the `getServerSideURL` function:

<img width="2322" height="1262" alt="Screenshot 2025-09-16 at 14 39 31@2x" src="https://github.com/user-attachments/assets/bb7dc5c1-ffe7-4ee7-8864-19cb2147c07d" />

If you then run `pnpm next build --experimental-build-mode generate` or `pnpm next build --experimental-build-mode generate-env` which inlines the env variable, it becomes the following code:

<img width="2276" height="1340" alt="Screenshot 2025-09-16 at 14 40 14@2x" src="https://github.com/user-attachments/assets/6fc8cbd4-4df8-4d9b-a3e5-fc299e147537" />

Suddenly, it no longer assigns to a variable but to a string, which is invalid JavaScript syntax, throwing the following error:

<img width="2314" height="320" alt="Screenshot 2025-09-16 at 14 40 53@2x" src="https://github.com/user-attachments/assets/2c3487be-82e3-4043-aa04-0d98f0a05b4b" />

This PR works around this issue changing up the source code in `getServerSideURL`.

I have reported this issue to Next.js: https://github.com/vercel/next.js/issues/83863


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211375615406662