### PR TITLE
fix(next): unnamed, unlabeled groups displayed without label in version view

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Group/index.scss
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Group/index.scss
@@ -1,4 +1,9 @@
 @layer payload-default {
   .group-diff {
+    &__locale-label {
+      &--no-label {
+        color: var(--theme-elevation-600);
+      }
+    }
   }
 }

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Group/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Group/index.tsx
@@ -30,12 +30,14 @@ export const Group: GroupFieldDiffClientComponent = ({
       <DiffCollapser
         fields={field.fields}
         Label={
-          'label' in field &&
-          field.label &&
-          typeof field.label !== 'function' && (
+          'label' in field && field.label && typeof field.label !== 'function' ? (
             <span>
               {locale && <span className={`${baseClass}__locale-label`}>{locale}</span>}
               {getTranslation(field.label, i18n)}
+            </span>
+          ) : (
+            <span className={`${baseClass}__locale-label ${baseClass}__locale-label--no-label`}>
+              &lt;{i18n.t('version:noLabelGroup')}&gt;
             </span>
           )
         }

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -757,19 +757,14 @@ export type UnnamedGroupField = {
 
 export type GroupField = NamedGroupField | UnnamedGroupField
 
-export type NamedGroupFieldClient = {
-  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
-  admin?: AdminClient & Pick<NamedGroupField['admin'], 'hideGutter'>
-  fields: ClientField[]
-} & Omit<FieldBaseClient, 'required'> &
-  Pick<NamedGroupField, 'interfaceName' | 'type'>
-
 export type UnnamedGroupFieldClient = {
   // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
   admin?: AdminClient & Pick<UnnamedGroupField['admin'], 'hideGutter'>
   fields: ClientField[]
 } & Omit<FieldBaseClient, 'name' | 'required'> &
   Pick<UnnamedGroupField, 'label' | 'type'>
+
+export type NamedGroupFieldClient = Pick<NamedGroupField, 'name'> & UnnamedGroupFieldClient
 
 export type GroupFieldClient = NamedGroupFieldClient | UnnamedGroupFieldClient
 

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -14,7 +14,10 @@ import { getFieldPathsModified as getFieldPaths } from '../../getFieldPaths.js'
 import { getExistingRowDoc } from './getExistingRowDoc.js'
 import { traverseFields } from './traverseFields.js'
 
-function buildFieldLabel(parentLabel: string, label: string): string {
+function buildFieldLabel(parentLabel: string, label: string | undefined): string {
+  if (!label) {
+    return parentLabel
+  }
   const capitalizedLabel = label.charAt(0).toUpperCase() + label.slice(1)
   return parentLabel && capitalizedLabel
     ? `${parentLabel} > ${capitalizedLabel}`
@@ -570,7 +573,7 @@ export const promise = async ({
             ? fieldLabelPath
             : buildFieldLabel(
                 fieldLabelPath,
-                getTranslatedLabel(field?.label || field.name!, req.i18n),
+                getTranslatedLabel(field?.label || field.name, req.i18n),
               ),
         fields: field.fields,
         global,

--- a/packages/payload/src/utilities/getTranslatedLabel.ts
+++ b/packages/payload/src/utilities/getTranslatedLabel.ts
@@ -2,7 +2,10 @@ import { getTranslation, type I18n } from '@payloadcms/translations'
 
 import type { LabelFunction, StaticLabel } from '../config/types.js'
 
-export const getTranslatedLabel = (label: LabelFunction | StaticLabel, i18n?: I18n): string => {
+export const getTranslatedLabel = (
+  label: LabelFunction | StaticLabel | undefined,
+  i18n?: I18n,
+): string | undefined => {
   if (typeof label === 'function') {
     return label({ i18n: i18n!, t: i18n!.t })
   }

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -471,6 +471,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'version:lastSavedAgo',
   'version:modifiedOnly',
   'version:noFurtherVersionsFound',
+  'version:noLabelGroup',
   'version:noRowsFound',
   'version:noRowsSelected',
   'version:preview',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -551,6 +551,7 @@ export const arTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'تم التعديل فقط',
     moreVersions: 'المزيد من الإصدارات...',
     noFurtherVersionsFound: 'لم يتمّ العثور على نسخات أخرى',
+    noLabelGroup: 'المجموعة غير المسماة',
     noRowsFound: 'لم يتمّ العثور على {{label}}',
     noRowsSelected: 'لم يتم اختيار {{label}}',
     preview: 'معاينة',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -569,6 +569,7 @@ export const azTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Yalnızca dəyişdirilmişdir',
     moreVersions: 'Daha çox versiyalar...',
     noFurtherVersionsFound: 'Başqa versiyalar tapılmadı',
+    noLabelGroup: 'Adlandırılmamış Qrup',
     noRowsFound: 'Heç bir {{label}} tapılmadı',
     noRowsSelected: 'Heç bir {{label}} seçilməyib',
     preview: 'Öncədən baxış',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -565,6 +565,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Само променени',
     moreVersions: 'Още версии...',
     noFurtherVersionsFound: 'Не са открити повече версии',
+    noLabelGroup: 'Неименувана група',
     noRowsFound: 'Не е открит {{label}}',
     noRowsSelected: 'Не е избран {{label}}',
     preview: 'Предварителен преглед',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -571,6 +571,8 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'শুধুমাত্র পরিবর্তিত',
     moreVersions: 'আরও সংস্করণ...',
     noFurtherVersionsFound: 'আর কোনো সংস্করণ পাওয়া যায়নি',
+    noLabelGroup:
+      'মূল বাক্যের অর্থ প্রেিত্ষ্যে সম্মান রাখুন। নিম্নে পেলোডের কিছু সাধারণ শর্তাবলীর তালিকা প্রদান করেছে যা খুব নির্দিষ্ট অর্থ বহন করে:',
     noRowsFound: 'কোনো {{label}} পাওয়া যায়নি',
     noRowsSelected: 'কোনো {{label}} নির্বাচিত হয়নি',
     preview: 'প্রাকদর্শন',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -570,6 +570,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'শুধুমাত্র পরিবর্তিত',
     moreVersions: 'আরও সংস্করণ...',
     noFurtherVersionsFound: 'আর কোনো সংস্করণ পাওয়া যায়নি',
+    noLabelGroup: 'অনামকো দল',
     noRowsFound: 'কোনো {{label}} পাওয়া যায়নি',
     noRowsSelected: 'কোনো {{label}} নির্বাচিত হয়নি',
     preview: 'প্রাকদর্শন',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -570,6 +570,7 @@ export const caTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Només modificat',
     moreVersions: 'Més versions...',
     noFurtherVersionsFound: "No s'han trobat més versions",
+    noLabelGroup: 'Grup sense nom',
     noRowsFound: "No s'han trobat {{label}}",
     noRowsSelected: "No s'han seleccionat {{label}}",
     preview: 'Vista prèvia',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -563,6 +563,7 @@ export const csTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Pouze upraveno',
     moreVersions: 'Více verzí...',
     noFurtherVersionsFound: 'Nenalezeny další verze',
+    noLabelGroup: 'Nepojmenovaná skupina',
     noRowsFound: 'Nenalezen {{label}}',
     noRowsSelected: 'Nebyl vybrán žádný {{label}}',
     preview: 'Náhled',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -565,6 +565,7 @@ export const daTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Kun ændret',
     moreVersions: 'Flere versioner...',
     noFurtherVersionsFound: 'Ingen yderligere versioner fundet',
+    noLabelGroup: 'Unavngivet Gruppe',
     noRowsFound: 'Ingen {{label}} fundet',
     noRowsSelected: 'Ingen {{label}} valgt',
     preview: 'Forhåndsvisning',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -577,6 +577,7 @@ export const deTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Nur modifiziert',
     moreVersions: 'Mehr Versionen...',
     noFurtherVersionsFound: 'Keine weiteren Versionen vorhanden',
+    noLabelGroup: 'Unbenannte Gruppe',
     noRowsFound: 'Kein {{label}} gefunden',
     noRowsSelected: 'Kein {{label}} ausgewählt',
     preview: 'Vorschau',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -569,6 +569,7 @@ export const enTranslations = {
     modifiedOnly: 'Modified only',
     moreVersions: 'More versions...',
     noFurtherVersionsFound: 'No further versions found',
+    noLabelGroup: 'Unnamed Group',
     noRowsFound: 'No {{label}} found',
     noRowsSelected: 'No {{label}} selected',
     preview: 'Preview',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -572,6 +572,7 @@ export const esTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Modificado solamente',
     moreVersions: 'Más versiones...',
     noFurtherVersionsFound: 'No se encontraron más versiones',
+    noLabelGroup: 'Grupo sin nombre',
     noRowsFound: 'No se encontraron {{label}}.',
     noRowsSelected: 'No se ha seleccionado ningún {{label}}.',
     preview: 'Vista previa',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -558,6 +558,7 @@ export const etTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Muudetud ainult',
     moreVersions: 'Rohkem versioone...',
     noFurtherVersionsFound: 'Rohkem versioone ei leitud',
+    noLabelGroup: 'Nimetamata rühm',
     noRowsFound: '{{label}} ei leitud',
     noRowsSelected: '{{label}} pole valitud',
     preview: 'Eelvaade',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -560,6 +560,7 @@ export const faTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'تنها تغییر یافته',
     moreVersions: 'نسخه های بیشتر...',
     noFurtherVersionsFound: 'نگارش دیگری یافت نشد',
+    noLabelGroup: 'گروه نام‌گذاری نشده',
     noRowsFound: 'هیچ {{label}} یافت نشد',
     noRowsSelected: 'هیچ {{label}} ای انتخاب نشده است',
     preview: 'پیش‌نمایش',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -581,6 +581,7 @@ export const frTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Modifié uniquement',
     moreVersions: 'Plus de versions...',
     noFurtherVersionsFound: 'Aucune autre version trouvée',
+    noLabelGroup: 'Groupe sans nom',
     noRowsFound: 'Aucun(e) {{label}} trouvé(e)',
     noRowsSelected: 'Aucune {{étiquette}} sélectionnée',
     preview: 'Aperçu',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -547,6 +547,7 @@ export const heTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'מותאם בלבד',
     moreVersions: 'עוד גרסאות...',
     noFurtherVersionsFound: 'לא נמצאו עוד גרסאות',
+    noLabelGroup: 'קבוצה ללא שם',
     noRowsFound: 'לא נמצאו {{label}}',
     noRowsSelected: 'לא נבחר {{תווית}}',
     preview: 'תצוגה מקדימה',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -563,6 +563,8 @@ export const hrTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Samo modificirano',
     moreVersions: 'Više verzija...',
     noFurtherVersionsFound: 'Nisu pronađene daljnje verzije',
+    noLabelGroup:
+      'Poštujte značenje izvornog teksta unutar konteksta Payloada. Evo popisa uobičajenih Payload izraza koji nose vrlo specifična značenja:\n    - Zbirka: Zbirka je skupina dokumenata koji dijele zajedničku strukturu i svrhu. Zbirke se koriste za organiziranje i upravljanje sadržajem u Payloadu.\n    - Polje: Polje je specifičan dio podataka unutar dokumenta u zbirci. Polja definiraju strukturu i vrstu podataka koji se mogu p',
     noRowsFound: '{{label}} nije pronađeno',
     noRowsSelected: 'Nije odabrana {{oznaka}}',
     preview: 'Pregled',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -572,6 +572,7 @@ export const huTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Módosítva csak',
     moreVersions: 'További verziók...',
     noFurtherVersionsFound: 'További verziók nem találhatók',
+    noLabelGroup: 'Névtelen Csoport',
     noRowsFound: 'Nem található {{label}}',
     noRowsSelected: 'Nincs {{címke}} kiválasztva',
     preview: 'Előnézet',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -574,6 +574,7 @@ export const hyTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Միայն փոփոխված',
     moreVersions: 'Ավելի շատ տարբերակներ...',
     noFurtherVersionsFound: 'Այլ տարբերակներ չեն գտնվել',
+    noLabelGroup: 'Անանուն խումբ',
     noRowsFound: ' Ոչ մի {{label}} չի գտնվել',
     noRowsSelected: 'Ոչ մի {{label}} ընտրված չէ',
     preview: 'Նախադիտում',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -1,8 +1,6 @@
-import { title } from 'process'
+import type { DefaultTranslationsObject, Language } from '../types.js'
 
-import type { Language } from '../types.js'
-
-export const idTranslations = {
+export const idTranslations: DefaultTranslationsObject = {
   authentication: {
     account: 'Akun',
     accountOfCurrentUser: 'Akun pengguna saat ini',
@@ -29,11 +27,9 @@ export const idTranslations = {
     forgotPassword: 'Lupa Kata Sandi',
     forgotPasswordEmailInstructions:
       'Silakan masukkan email Anda di bawah ini. Anda akan menerima pesan email dengan instruksi tentang cara mengatur ulang kata sandi Anda.',
+    forgotPasswordQuestion: 'Lupa kata sandi?',
     forgotPasswordUsernameInstructions:
       'Silakan masukkan nama pengguna Anda di bawah ini. Instruksi tentang cara mengatur ulang kata sandi Anda akan dikirim ke alamat email yang terkait dengan nama pengguna Anda.',
-    usernameNotValid: 'Nama pengguna yang diberikan tidak valid',
-
-    forgotPasswordQuestion: 'Lupa kata sandi?',
     generate: 'Buat',
     generateNewAPIKey: 'Buat kunci API baru',
     generatingNewAPIKeyWillInvalidate:
@@ -71,6 +67,7 @@ export const idTranslations = {
     tokenRefreshSuccessful: 'Penyegaran token berhasil.',
     unableToVerify: 'Tidak Dapat Memverifikasi',
     username: 'Nama Pengguna',
+    usernameNotValid: 'Nama pengguna yang diberikan tidak valid',
     verified: 'Terverifikasi',
     verifiedSuccessfully: 'Berhasil Diverifikasi',
     verify: 'Verifikasi',
@@ -570,6 +567,7 @@ export const idTranslations = {
     modifiedOnly: 'Hanya yang diubah',
     moreVersions: 'Versi lainnya...',
     noFurtherVersionsFound: 'Tidak ada versi lebih lanjut yang ditemukan',
+    noLabelGroup: 'Grup Tanpa Nama',
     noRowsFound: 'Tidak ada {{label}} yang ditemukan',
     noRowsSelected: 'Tidak ada {{label}} yang dipilih',
     preview: 'Pratinjau',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -1,6 +1,6 @@
-import type { Language } from '../types.js'
+import type { DefaultTranslationsObject, Language } from '../types.js'
 
-export const isTranslations = {
+export const isTranslations: DefaultTranslationsObject = {
   authentication: {
     account: 'Aðgangur',
     accountOfCurrentUser: 'Aðgangur núverandi notanda',
@@ -27,11 +27,9 @@ export const isTranslations = {
     forgotPassword: 'Gleymdist lykilorð',
     forgotPasswordEmailInstructions:
       'Vinsamlegast sláðu inn netfangið þitt hér að neðan. Þú munt fá tölvupóst með leiðbeiningum um hvernig á að endurstilla lykilorðið þitt.',
+    forgotPasswordQuestion: 'Gleymdist lykilorðið?',
     forgotPasswordUsernameInstructions:
       'Vinsamlegast sláðu inn notandanafnið þitt hér að neðan. Leiðbeiningar um hvernig á að endurstilla lykilorðið þitt verða sendar á netfangið sem tengt er notandanafninu þínu.',
-    usernameNotValid: 'Notandanafnið sem gefið var upp er ekki gilt',
-
-    forgotPasswordQuestion: 'Gleymdist lykilorðið?',
     generate: 'Búa til',
     generateNewAPIKey: 'Búa til nýjan API lykil',
     generatingNewAPIKeyWillInvalidate:
@@ -69,6 +67,7 @@ export const isTranslations = {
     tokenRefreshSuccessful: 'Endurnýjun tokens tókst.',
     unableToVerify: 'Ekki hægt að staðfesta',
     username: 'Notandanafn',
+    usernameNotValid: 'Notandanafnið sem gefið var upp er ekki gilt',
     verified: 'Staðfest',
     verifiedSuccessfully: 'Staðfest',
     verify: 'Staðfesta',
@@ -565,6 +564,7 @@ export const isTranslations = {
     modifiedOnly: 'Aðeins breytt',
     moreVersions: 'Fleiri útgáfur...',
     noFurtherVersionsFound: 'Engar fleiri útgáfur fundust',
+    noLabelGroup: 'Ónefnd hópur',
     noRowsFound: 'Ekkert {{label}} fannst',
     noRowsSelected: 'Ekkert {{label}} valið',
     preview: 'Forskoðun',
@@ -601,7 +601,6 @@ export const isTranslations = {
     versionCount_none: 'Engar útgáfur fundust',
     versionCount_one: '{{count}} útgáfa fannst',
     versionCount_other: '{{count}} útgáfur fundust',
-    versionCreatedOn: '{{version}} búin til þann:',
     versionID: 'Útgáfuauðkenni',
     versions: 'Útgáfur',
     viewingVersion: 'Skoða útgáfu fyrir {{entityLabel}} {{documentTitle}}',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -571,6 +571,7 @@ export const itTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Modificato solo',
     moreVersions: 'Altre versioni...',
     noFurtherVersionsFound: 'Non sono state trovate ulteriori versioni',
+    noLabelGroup: 'Gruppo Senza Nome',
     noRowsFound: 'Nessun {{label}} trovato',
     noRowsSelected: 'Nessuna {{etichetta}} selezionata',
     preview: 'Anteprima',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -566,6 +566,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     modifiedOnly: '変更済みのみ',
     moreVersions: 'さらに多くのバージョン...',
     noFurtherVersionsFound: 'その他のバージョンは見つかりませんでした。',
+    noLabelGroup: '名前のないグループ',
     noRowsFound: '{{label}} は未設定です',
     noRowsSelected: '選択された{{label}}はありません',
     preview: 'プレビュー',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -559,6 +559,7 @@ export const koTranslations: DefaultTranslationsObject = {
     modifiedOnly: '수정된 것만',
     moreVersions: '더 많은 버전...',
     noFurtherVersionsFound: '더 이상의 버전을 찾을 수 없습니다.',
+    noLabelGroup: '이름이 없는 그룹',
     noRowsFound: '{{label}}을(를) 찾을 수 없음',
     noRowsSelected: '선택된 {{label}} 없음',
     preview: '미리보기',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -570,6 +570,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Tik modifikuotas',
     moreVersions: 'Daugiau versijų...',
     noFurtherVersionsFound: 'Nerasta daugiau versijų',
+    noLabelGroup: 'Nepavadintas grupė',
     noRowsFound: 'Nerasta {{label}}',
     noRowsSelected: 'Pasirinkta ne viena {{label}}',
     preview: 'Peržiūra',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -566,6 +566,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Tikai modificētie',
     moreVersions: 'Vairāk versijas...',
     noFurtherVersionsFound: 'Papildu versijas nav atrastas',
+    noLabelGroup: 'Nenosaukta grupa',
     noRowsFound: 'Nav atrasts neviens {{label}}',
     noRowsSelected: 'Nav atlasīts neviens {{label}}',
     preview: 'Priekšskatījums',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -575,6 +575,7 @@ export const myTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Hanya diubah',
     moreVersions: 'ပိုမိုများသော ဗားရှင်းများ...',
     noFurtherVersionsFound: 'နောက်ထပ်ဗားရှင်းများ မတွေ့ပါ။',
+    noLabelGroup: 'Tumpuan yang Bernama',
     noRowsFound: '{{label}} အားမတွေ့ပါ။',
     noRowsSelected: 'Tiada {{label}} yang dipilih',
     preview: 'နမူနာပြရန်',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -566,6 +566,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Endret kun',
     moreVersions: 'Flere versjoner...',
     noFurtherVersionsFound: 'Ingen flere versjoner funnet',
+    noLabelGroup: 'Uten navn Gruppe',
     noRowsFound: 'Ingen {{label}} funnet',
     noRowsSelected: 'Ingen {{label}} valgt',
     preview: 'Forhåndsvisning',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -575,6 +575,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Alleen gewijzigd',
     moreVersions: 'Meer versies...',
     noFurtherVersionsFound: 'Geen verdere versies gevonden',
+    noLabelGroup: 'Naamloze Groep',
     noRowsFound: 'Geen {{label}} gevonden',
     noRowsSelected: 'Geen {{label}} geselecteerd',
     preview: 'Voorbeeld',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -564,6 +564,7 @@ export const plTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Tylko zmodyfikowany',
     moreVersions: 'Więcej wersji...',
     noFurtherVersionsFound: 'Nie znaleziono dalszych wersji',
+    noLabelGroup: 'Nienazwana grupa',
     noRowsFound: 'Nie znaleziono {{label}}',
     noRowsSelected: 'Nie wybrano {{etykieta}}',
     preview: 'Podgląd',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -568,6 +568,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Modificado apenas',
     moreVersions: 'Mais versões...',
     noFurtherVersionsFound: 'Nenhuma outra versão encontrada',
+    noLabelGroup: 'Grupo Sem Nome',
     noRowsFound: 'Nenhum(a) {{label}} encontrado(a)',
     noRowsSelected: 'Nenhum {{rótulo}} selecionado',
     preview: 'Pré-visualização',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -575,6 +575,7 @@ export const roTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Modificat doar',
     moreVersions: 'Mai multe versiuni...',
     noFurtherVersionsFound: 'Nu s-au găsit alte versiuni',
+    noLabelGroup: 'Grup Fără Nume',
     noRowsFound: 'Nu s-a găsit niciun {{label}}',
     noRowsSelected: 'Niciun {{etichetă}} selectat',
     preview: 'Previzualizare',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -562,6 +562,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Samo izmenjen',
     moreVersions: 'Više verzija...',
     noFurtherVersionsFound: 'Нису пронађене наредне верзије',
+    noLabelGroup: 'Nepomenuta Grupa',
     noRowsFound: '{{label}} није пронађено',
     noRowsSelected: 'Nije odabrana {{label}}',
     preview: 'Преглед',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -564,6 +564,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Samo izmenjen',
     moreVersions: 'Više verzija...',
     noFurtherVersionsFound: 'Nisu pronađene naredne verzije',
+    noLabelGroup: 'Nepomenuta Grupa',
     noRowsFound: '{{label}} nije pronađeno',
     noRowsSelected: 'Nije odabrana {{label}}',
     preview: 'Pregled',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -568,6 +568,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Модифицирован только',
     moreVersions: 'Больше версий...',
     noFurtherVersionsFound: 'Другие версии не найдены',
+    noLabelGroup: 'Неименованная Группа',
     noRowsFound: 'Не найдено {{label}}',
     noRowsSelected: 'Не выбран {{label}}',
     preview: 'Предпросмотр',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -564,6 +564,7 @@ export const skTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Iba upravené',
     moreVersions: 'Viac verzií...',
     noFurtherVersionsFound: 'Nenájdené ďalšie verzie',
+    noLabelGroup: 'Nepomenovaná skupina',
     noRowsFound: 'Nenájdené {{label}}',
     noRowsSelected: 'Nie je vybraté žiadne {{označenie}}',
     preview: 'Náhľad',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -563,6 +563,7 @@ export const slTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Samo spremenjeno',
     moreVersions: 'Več različic...',
     noFurtherVersionsFound: 'Ni najdenih nadaljnjih različic',
+    noLabelGroup: 'Neimenovana skupina',
     noRowsFound: 'Ni najdenih {{label}}',
     noRowsSelected: 'Ni izbranih {{label}}',
     preview: 'Predogled',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -566,6 +566,7 @@ export const svTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Endast modifierad',
     moreVersions: 'Fler versioner...',
     noFurtherVersionsFound: 'Inga fler versioner hittades',
+    noLabelGroup: 'Onämnd grupp',
     noRowsFound: 'Inga {{label}} hittades',
     noRowsSelected: 'Inget {{etikett}} valt',
     preview: 'Förhandsgranska',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -553,6 +553,8 @@ export const thTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'แก้ไขเท่านั้น',
     moreVersions: 'เพิ่มเวอร์ชั่น...',
     noFurtherVersionsFound: 'ไม่พบเวอร์ชันอื่น ๆ',
+    noLabelGroup:
+      'ร่วมให้ความหมายของข้อความต้นฉบับภายในบริบทของ Payload นี่คือรายการของคำศัพท์ Payload ทั่วไปที่มีความหมายที่แน่นอนมาก :\n    - Collection: Collection คือกลุ่มของเอกสารที่มีโครงสร้างและจุดประสงค์ที่เหม',
     noRowsFound: 'ไม่พบ {{label}}',
     noRowsSelected: 'ไม่มี {{label}} ที่ถูกเลือก',
     preview: 'ตัวอย่าง',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -568,6 +568,7 @@ export const trTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Yalnızca değiştirilmiş',
     moreVersions: 'Daha fazla versiyon...',
     noFurtherVersionsFound: 'Başka sürüm bulunamadı.',
+    noLabelGroup: 'İsimsiz Grup',
     noRowsFound: '{{label}} bulunamadı',
     noRowsSelected: 'Seçilen {{label}} yok',
     preview: 'Önizleme',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -564,6 +564,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Модифіковано тільки',
     moreVersions: 'Більше версій...',
     noFurtherVersionsFound: 'Інших версій не знайдено',
+    noLabelGroup: 'Незатверджена група',
     noRowsFound: 'Не знайдено {{label}}',
     noRowsSelected: 'Не вибрано {{label}}',
     preview: 'Попередній перегляд',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -561,6 +561,7 @@ export const viTranslations: DefaultTranslationsObject = {
     modifiedOnly: 'Chỉ được sửa đổi',
     moreVersions: 'Thêm phiên bản...',
     noFurtherVersionsFound: 'Không tìm thấy phiên bản cũ hơn',
+    noLabelGroup: 'Nhóm Chưa có tên',
     noRowsFound: 'Không tìm thấy: {{label}}',
     noRowsSelected: 'Không có {{label}} được chọn',
     preview: 'Bản xem trước',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -537,6 +537,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     modifiedOnly: '仅修改过的',
     moreVersions: '更多版本...',
     noFurtherVersionsFound: '没有发现其他版本',
+    noLabelGroup: '未命名组',
     noRowsFound: '没有发现{{label}}',
     noRowsSelected: '未选择{{label}}',
     preview: '预览',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -537,6 +537,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     modifiedOnly: '僅顯示已變更的內容',
     moreVersions: '更多版本…',
     noFurtherVersionsFound: '找不到更多版本',
+    noLabelGroup: '未命名群組',
     noRowsFound: '找不到 {{label}}',
     noRowsSelected: '尚未選取任何 {{label}}',
     preview: '預覽',

--- a/test/versions/collections/Diff/index.ts
+++ b/test/versions/collections/Diff/index.ts
@@ -152,6 +152,25 @@ export const Diff: CollectionConfig = {
       ],
     },
     {
+      type: 'group',
+      fields: [
+        {
+          name: 'textInUnnamedGroup',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      type: 'group',
+      label: 'Unnamed Labeled Group',
+      fields: [
+        {
+          name: 'textInUnnamedLabeledGroup',
+          type: 'text',
+        },
+      ],
+    },
+    {
       type: 'number',
       name: 'number',
     },

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1864,13 +1864,43 @@ describe('Versions', () => {
       await expect(email.locator('.html-diff__diff-new')).toHaveText('email2@email.com')
     })
 
-    test('correctly renders diff for group fields', async () => {
+    test('correctly renders diff for named group fields', async () => {
       await navigateToDiffVersionView()
+
+      await expect(
+        page.locator('[data-field-path="group"] .diff-collapser__label').first(),
+      ).toHaveText('Group')
 
       const group = page.locator('[data-field-path="group.textInGroup"]')
 
       await expect(group.locator('.html-diff__diff-old')).toHaveText('textInGroup')
       await expect(group.locator('.html-diff__diff-new')).toHaveText('textInGroup2')
+    })
+
+    test('correctly renders diff for unnamed, unlabeled group fields', async () => {
+      await navigateToDiffVersionView()
+
+      await expect(
+        page.locator('[data-field-path="_index-9"] .diff-collapser__label').first(),
+      ).toHaveText('<Unnamed Group>')
+
+      const group = page.locator('[data-field-path="textInUnnamedGroup"]')
+
+      await expect(group.locator('.html-diff__diff-old')).toHaveText('textInUnnamedGroup')
+      await expect(group.locator('.html-diff__diff-new')).toHaveText('textInUnnamedGroup2')
+    })
+
+    test('correctly renders diff for unnamed, labeled group fields', async () => {
+      await navigateToDiffVersionView()
+
+      await expect(
+        page.locator('[data-field-path="_index-10"] .diff-collapser__label').first(),
+      ).toHaveText('Unnamed Labeled Group')
+
+      const group = page.locator('[data-field-path="textInUnnamedLabeledGroup"]')
+
+      await expect(group.locator('.html-diff__diff-old')).toHaveText('textInUnnamedLabeledGroup')
+      await expect(group.locator('.html-diff__diff-new')).toHaveText('textInUnnamedLabeledGroup2')
     })
 
     test('correctly renders diff for number fields', async () => {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -93,7 +93,6 @@ describe('Versions', () => {
   let customIDURL: AdminUrlUtil
   let postURL: AdminUrlUtil
   let errorOnUnpublishURL: AdminUrlUtil
-  let id: string
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
@@ -1118,7 +1117,7 @@ describe('Versions', () => {
         timeout: POLL_TOPASS_TIMEOUT,
       })
 
-      id = await page.locator('.id-label').getAttribute('title')
+      const id = await page.locator('.id-label').getAttribute('title')
 
       const data = await payload.find({
         collection: localizedCollectionSlug,

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -457,6 +457,8 @@ export interface Diff {
   group?: {
     textInGroup?: string | null;
   };
+  textInUnnamedGroup?: string | null;
+  textInUnnamedLabeledGroup?: string | null;
   number?: number | null;
   /**
    * @minItems 2
@@ -1112,6 +1114,8 @@ export interface DiffSelect<T extends boolean = true> {
     | {
         textInGroup?: T;
       };
+  textInUnnamedGroup?: T;
+  textInUnnamedLabeledGroup?: T;
   number?: T;
   point?: T;
   json?: T;

--- a/test/versions/seed.ts
+++ b/test/versions/seed.ts
@@ -243,6 +243,8 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
       code: 'code',
       date: '2021-04-01T00:00:00.000Z',
       email: 'email@email.com',
+      textInUnnamedGroup: 'textInUnnamedGroup',
+      textInUnnamedLabeledGroup: 'textInUnnamedLabeledGroup',
       group: {
         textInGroup: 'textInGroup',
       },
@@ -386,6 +388,8 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
       code: 'code2',
       date: '2023-04-01T00:00:00.000Z',
       email: 'email2@email.com',
+      textInUnnamedGroup: 'textInUnnamedGroup2',
+      textInUnnamedLabeledGroup: 'textInUnnamedLabeledGroup2',
       group: {
         textInGroup: 'textInGroup2',
       },


### PR DESCRIPTION
Before, unnamed, unlabelled group were part of an unlabeled collapsible in the version diff view. This means, all it displayed was a clickable, empty rectangle. This looks like a bug rather than intended.

This PR displays a new <Unnamed Group> label in these cases.

It also fixes the incorrect `NamedGroupFieldClient` type. Previously, that type did not include the `name` property, even though it was available on the client.

Before:
<img width="2372" height="688" alt="Screenshot 2025-09-16 at 18 57 45@2x" src="https://github.com/user-attachments/assets/0f351f84-a00f-4067-aa40-d0e8fbfd5f0b" />


After:

<img width="2326" height="598" alt="Screenshot 2025-09-16 at 18 56 14@2x" src="https://github.com/user-attachments/assets/bddee841-8218-4a90-a052-9875c5f252c0" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211375615406676