### PR TITLE
fix(ui): pass locale arg in query params for folder operations

### DIFF
--- a/packages/ui/src/providers/Folders/index.tsx
+++ b/packages/ui/src/providers/Folders/index.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 import { useDrawerDepth } from '../../elements/Drawer/index.js'
 import { parseSearchParams } from '../../utilities/parseSearchParams.js'
 import { useConfig } from '../Config/index.js'
+import { useLocale } from '../Locale/index.js'
 import { useRouteTransition } from '../RouteTransition/index.js'
 import { useTranslation } from '../Translation/index.js'
 import { groupItemIDsByRelation } from './groupItemIDsByRelation.js'
@@ -207,6 +208,8 @@ export function FolderProvider({
   const { t } = useTranslation()
   const router = useRouter()
   const { startRouteTransition } = useRouteTransition()
+  const locale = useLocale()
+  const localeCode = locale ? locale.code : undefined
 
   const currentlySelectedIndexes = React.useRef(new Set<number>())
 
@@ -257,6 +260,7 @@ export function FolderProvider({
       const mergedQuery = {
         ...currentQuery,
         ...newQuery,
+        locale: localeCode,
         page,
         relationTo: 'relationTo' in newQuery ? newQuery.relationTo : currentQuery?.relationTo,
         search: 'search' in newQuery ? newQuery.search : currentQuery?.search,
@@ -265,21 +269,21 @@ export function FolderProvider({
 
       return mergedQuery
     },
-    [currentQuery],
+    [currentQuery, localeCode],
   )
 
   const refineFolderData: FolderContextValue['refineFolderData'] = React.useCallback(
     ({ query, updateURL }) => {
       if (updateURL) {
-        const newQuery = mergeQuery(query)
+        const queryParams = mergeQuery(query)
 
         startRouteTransition(() =>
           router.replace(
-            `${qs.stringify({ ...newQuery, relationTo: JSON.stringify(newQuery.relationTo) }, { addQueryPrefix: true })}`,
+            `${qs.stringify({ ...queryParams, relationTo: JSON.stringify(queryParams.relationTo) }, { addQueryPrefix: true })}`,
           ),
         )
 
-        setCurrentQuery(newQuery)
+        setCurrentQuery(queryParams)
       }
     },
     [mergeQuery, router, startRouteTransition],
@@ -287,10 +291,12 @@ export function FolderProvider({
 
   const getFolderRoute: FolderContextValue['getFolderRoute'] = React.useCallback(
     (toFolderID) => {
-      const newQuery = mergeQuery({ page: '1', search: '' })
+      const queryParams = qs.stringify(mergeQuery({ page: '1', search: '' }), {
+        addQueryPrefix: true,
+      })
       return formatAdminURL({
         adminRoute: config.routes.admin,
-        path: `${baseFolderPath}${toFolderID ? `/${toFolderID}` : ''}${qs.stringify(newQuery, { addQueryPrefix: true })}`,
+        path: `${baseFolderPath}${toFolderID ? `/${toFolderID}` : ''}${queryParams}`,
         serverURL: config.serverURL,
       })
     },
@@ -678,8 +684,17 @@ export function FolderProvider({
         items[0].value.id === folderID
 
       if (movingCurrentFolder) {
+        const queryParams = qs.stringify(
+          {
+            depth: 0,
+            locale: localeCode,
+          },
+          {
+            addQueryPrefix: true,
+          },
+        )
         const req = await fetch(
-          `${serverURL}${routes.api}/${folderCollectionSlug}/${folderID}?depth=0`,
+          `${serverURL}${routes.api}/${folderCollectionSlug}/${folderID}${queryParams}`,
           {
             body: JSON.stringify({ [folderFieldName]: toFolderID || null }),
             credentials: 'include',
@@ -694,10 +709,11 @@ export function FolderProvider({
         }
       } else {
         for (const [collectionSlug, ids] of Object.entries(groupItemIDsByRelation(items))) {
-          const query = qs.stringify(
+          const queryParams = qs.stringify(
             {
               depth: 0,
               limit: 0,
+              locale: localeCode,
               where: {
                 id: {
                   in: ids,
@@ -709,7 +725,7 @@ export function FolderProvider({
             },
           )
           try {
-            await fetch(`${serverURL}${routes.api}/${collectionSlug}${query}`, {
+            await fetch(`${serverURL}${routes.api}/${collectionSlug}${queryParams}`, {
               body: JSON.stringify({ [folderFieldName]: toFolderID || null }),
               credentials: 'include',
               headers: {
@@ -728,7 +744,16 @@ export function FolderProvider({
 
       clearSelections()
     },
-    [folderID, clearSelections, folderCollectionSlug, folderFieldName, routes.api, serverURL, t],
+    [
+      folderID,
+      clearSelections,
+      folderCollectionSlug,
+      folderFieldName,
+      routes.api,
+      serverURL,
+      t,
+      localeCode,
+    ],
   )
 
   const checkIfItemIsDisabled: FolderContextValue['checkIfItemIsDisabled'] = React.useCallback(


### PR DESCRIPTION
Fixes #13818 

Folder provider operations were not passing the locale query param, causing issues when moving items into folders that had a required localized field.
