### PR TITLE
fix: support `hasMany: true` relationships in `findDistinct`

### DIFF
--- a/packages/db-mongodb/src/findDistinct.ts
+++ b/packages/db-mongodb/src/findDistinct.ts
@@ -48,28 +48,56 @@ export const findDistinct: FindDistinct = async function (this: MongooseAdapter,
     fieldPath = fieldPathResult.localizedPath.replace('<locale>', args.locale)
   }
 
+  const isHasManyValue =
+    fieldPathResult && 'hasMany' in fieldPathResult.field && fieldPathResult.field.hasMany
+
   const page = args.page || 1
 
   const sortProperty = Object.keys(sort)[0]! // assert because buildSortParam always returns at least 1 key.
   const sortDirection = sort[sortProperty] === 'asc' ? 1 : -1
+
+  let $unwind: string = ''
+  let $group: any
+  if (
+    isHasManyValue &&
+    sortAggregation.length &&
+    sortAggregation[0] &&
+    '$lookup' in sortAggregation[0]
+  ) {
+    $unwind = `$${sortAggregation[0].$lookup.as}`
+    $group = {
+      _id: {
+        _field: `$${sortAggregation[0].$lookup.as}._id`,
+        _sort: `$${sortProperty}`,
+      },
+    }
+  } else {
+    $group = {
+      _id: {
+        _field: `$${fieldPath}`,
+        ...(sortProperty === fieldPath
+          ? {}
+          : {
+              _sort: `$${sortProperty}`,
+            }),
+      },
+    }
+  }
 
   const pipeline: PipelineStage[] = [
     {
       $match: query,
     },
     ...(sortAggregation.length > 0 ? sortAggregation : []),
-
+    ...($unwind
+      ? [
+          {
+            $unwind,
+          },
+        ]
+      : []),
     {
-      $group: {
-        _id: {
-          _field: `$${fieldPath}`,
-          ...(sortProperty === fieldPath
-            ? {}
-            : {
-                _sort: `$${sortProperty}`,
-              }),
-        },
-      },
+      $group,
     },
     {
       $sort: {

--- a/packages/payload/src/collections/operations/findDistinct.ts
+++ b/packages/payload/src/collections/operations/findDistinct.ts
@@ -155,6 +155,10 @@ export const findDistinctOperation = async (
       args.depth
     ) {
       const populationPromises: Promise<void>[] = []
+      const sanitizedField = { ...fieldResult.field }
+      if (fieldResult.field.hasMany) {
+        sanitizedField.hasMany = false
+      }
       for (const doc of result.values) {
         populationPromises.push(
           relationshipPopulationPromise({
@@ -162,7 +166,7 @@ export const findDistinctOperation = async (
             depth: args.depth,
             draft: false,
             fallbackLocale: req.fallbackLocale || null,
-            field: fieldResult.field,
+            field: sanitizedField,
             locale: req.locale || null,
             overrideAccess: args.overrideAccess ?? true,
             parentIsLocalized: false,

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -128,6 +128,12 @@ export const getConfig: () => Partial<Config> = () => ({
         },
         {
           type: 'relationship',
+          relationTo: 'categories',
+          hasMany: true,
+          name: 'categories',
+        },
+        {
+          type: 'relationship',
           relationTo: 'categories-custom-id',
           name: 'categoryCustomID',
         },

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -197,6 +197,7 @@ export interface Post {
   id: string;
   title: string;
   category?: (string | null) | Category;
+  categories?: (string | Category)[] | null;
   categoryCustomID?: (number | null) | CategoriesCustomId;
   localized?: string | null;
   text?: string | null;
@@ -822,6 +823,7 @@ export interface CategoriesCustomIdSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   category?: T;
+  categories?: T;
   categoryCustomID?: T;
   localized?: T;
   text?: T;


### PR DESCRIPTION
Previously, the `findDistinct` operation didn't work correctly for relationships with `hasMany: true`. This PR fixes it.