### PR TITLE
fix: replace skip with pagination to use allowed API

### DIFF
--- a/packages/payload/src/versions/enforceMaxVersions.ts
+++ b/packages/payload/src/versions/enforceMaxVersions.ts
@@ -35,9 +35,9 @@ export const enforceMaxVersions = async ({
       const query = await payload.db.findVersions({
         collection: collection.slug,
         limit: 1,
-        pagination: false,
+        page: max,
+        pagination: true,
         req,
-        skip: max,
         sort: '-updatedAt',
         where,
       })
@@ -47,9 +47,9 @@ export const enforceMaxVersions = async ({
       const query = await payload.db.findGlobalVersions({
         global: globalConfig.slug,
         limit: 1,
-        pagination: false,
+        page: max,
+        pagination: true,
         req,
-        skip: max,
         sort: '-updatedAt',
         where,
       })


### PR DESCRIPTION
`skip` isn't part of the API, it's part of `db.*`.
I lost almost a day of work tracking down why my new db adapter wasn't working, and the cause was this.