### PR TITLE
fix(ui): set prefetch false on Link buttons

### DIFF
--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -130,7 +130,6 @@ export const Button: React.FC<Props> = (props) => {
   }
 
   let buttonElement
-  let prefetch
 
   switch (el) {
     case 'anchor':
@@ -159,7 +158,7 @@ export const Button: React.FC<Props> = (props) => {
       }
 
       buttonElement = (
-        <Link {...buttonProps} href={to || url} prefetch={prefetch}>
+        <Link {...buttonProps} href={to || url} prefetch={false}>
           <ButtonContents icon={icon} showTooltip={showTooltip} tooltip={tooltip}>
             {children}
           </ButtonContents>


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13834

Brings back `prefetch={false}` from https://github.com/payloadcms/payload/pull/9020/files#diff-a2b1253ad6d1c9dde331641afc52893d73be7d3449c25e44b81066a839fef85dR152

I believe the prop was mistakenly removed, this PR adds it back.