### PR TITLE
fix(ui): ensures visible list view thumbnails with enableListViewSelectAPI

### DIFF
--- a/packages/next/src/views/List/appendUploadSelectFields.ts
+++ b/packages/next/src/views/List/appendUploadSelectFields.ts
@@ -1,4 +1,4 @@
-import type { SanitizedCollectionConfig } from 'payload'
+import type { SanitizedCollectionConfig, SelectType } from 'payload'
 
 /**
  * Mutates the incoming select object to append fields required for upload thumbnails
@@ -10,9 +10,9 @@ export const appendUploadSelectFields = ({
   select,
 }: {
   collectionConfig: SanitizedCollectionConfig
-  select: Record<string, unknown>
+  select: SelectType
 }) => {
-  if (!collectionConfig.upload) {
+  if (!collectionConfig.upload || !select) {
     return
   }
 

--- a/packages/next/src/views/List/appendUploadSelectFields.ts
+++ b/packages/next/src/views/List/appendUploadSelectFields.ts
@@ -1,0 +1,49 @@
+import type { SanitizedCollectionConfig } from 'payload'
+
+/**
+ * Mutates the incoming select object to append fields required for upload thumbnails
+ * @param collectionConfig
+ * @param select
+ */
+export const appendUploadSelectFields = ({
+  collectionConfig,
+  select,
+}: {
+  collectionConfig: SanitizedCollectionConfig
+  select: Record<string, unknown>
+}) => {
+  if (!collectionConfig.upload) {
+    return
+  }
+
+  select.mimeType = true
+  select.thumbnailURL = true
+
+  if (collectionConfig.upload.imageSizes && collectionConfig.upload.imageSizes.length > 0) {
+    if (
+      collectionConfig.upload.adminThumbnail &&
+      typeof collectionConfig.upload.adminThumbnail === 'string'
+    ) {
+      /** Only return image size properties that are required to generate the adminThumbnailURL */
+      select.sizes = {
+        [collectionConfig.upload.adminThumbnail]: {
+          filename: true,
+        },
+      }
+    } else {
+      /** Only return image size properties that are required for thumbnails */
+      select.sizes = collectionConfig.upload.imageSizes.reduce((acc, imageSizeConfig) => {
+        return {
+          ...acc,
+          [imageSizeConfig.name]: {
+            filename: true,
+            url: true,
+            width: true,
+          },
+        }
+      }, {})
+    }
+  } else {
+    select.url = true
+  }
+}

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -223,17 +223,40 @@ export const renderListView = async (
       ? transformColumnsToSelect(columns)
       : undefined
 
-    // force select image fields for list view thumbnails
+    /** Force select image fields for list view thumbnails */
     if (collectionConfig.upload && select) {
       select.mimeType = true
-      select.url = true
 
-      if (collectionConfig.upload.imageSizes) {
-        select.sizes = true
+      if (collectionConfig.upload.adminThumbnail) {
+        select.thumbnailURL = true
+      }
 
-        if (collectionConfig.upload.adminThumbnail) {
-          select.thumbnailURL = true
+      if (collectionConfig.upload.imageSizes && collectionConfig.upload.imageSizes.length > 0) {
+        if (
+          collectionConfig.upload.adminThumbnail &&
+          typeof collectionConfig.upload.adminThumbnail === 'string'
+        ) {
+          /** Only return image size properties that are required to generate the adminThumbnailURL */
+          select.sizes = {
+            [collectionConfig.upload.adminThumbnail]: {
+              filename: true,
+            },
+          }
+        } else {
+          /** Only return image size properties that are required for thumbnails */
+          select.sizes = collectionConfig.upload.imageSizes.reduce((acc, imageSizeConfig) => {
+            return {
+              ...acc,
+              [imageSizeConfig.name]: {
+                filename: true,
+                url: true,
+                width: true,
+              },
+            }
+          }, {})
         }
+      } else {
+        select.url = true
       }
     }
 

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -223,6 +223,20 @@ export const renderListView = async (
       ? transformColumnsToSelect(columns)
       : undefined
 
+    // force select image fields for list view thumbnails
+    if (collectionConfig.upload && select) {
+      select.mimeType = true
+      select.url = true
+
+      if (collectionConfig.upload.imageSizes) {
+        select.sizes = true
+
+        if (collectionConfig.upload.adminThumbnail) {
+          select.thumbnailURL = true
+        }
+      }
+    }
+
     try {
       if (collectionConfig.admin.groupBy && query.groupBy) {
         ;({ columnState, data, Table } = await handleGroupBy({

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -1,19 +1,20 @@
+import type {
+  AdminViewServerProps,
+  CollectionPreferences,
+  Column,
+  ColumnPreference,
+  ListQuery,
+  ListViewClientProps,
+  ListViewServerPropsOnly,
+  PaginatedDocs,
+  QueryPreset,
+  SanitizedCollectionPermission,
+} from 'payload'
+
 import { DefaultListView, HydrateAuthProvider, ListQueryProvider } from '@payloadcms/ui'
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
 import { getColumns, renderFilters, renderTable, upsertPreferences } from '@payloadcms/ui/rsc'
 import { notFound } from 'next/navigation.js'
-import {
-  type AdminViewServerProps,
-  type CollectionPreferences,
-  type Column,
-  type ColumnPreference,
-  type ListQuery,
-  type ListViewClientProps,
-  type ListViewServerPropsOnly,
-  type PaginatedDocs,
-  type QueryPreset,
-  type SanitizedCollectionPermission,
-} from 'payload'
 import {
   combineWhereConstraints,
   formatAdminURL,

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -25,6 +25,7 @@ import {
 import React, { Fragment } from 'react'
 
 import { getDocumentPermissions } from '../Document/getDocumentPermissions.js'
+import { appendUploadSelectFields } from './appendUploadSelectFields.js'
 import { handleGroupBy } from './handleGroupBy.js'
 import { renderListViewSlots } from './renderListViewSlots.js'
 import { resolveAllFilterOptions } from './resolveAllFilterOptions.js'
@@ -224,41 +225,10 @@ export const renderListView = async (
       : undefined
 
     /** Force select image fields for list view thumbnails */
-    if (collectionConfig.upload && select) {
-      select.mimeType = true
-
-      if (collectionConfig.upload.adminThumbnail) {
-        select.thumbnailURL = true
-      }
-
-      if (collectionConfig.upload.imageSizes && collectionConfig.upload.imageSizes.length > 0) {
-        if (
-          collectionConfig.upload.adminThumbnail &&
-          typeof collectionConfig.upload.adminThumbnail === 'string'
-        ) {
-          /** Only return image size properties that are required to generate the adminThumbnailURL */
-          select.sizes = {
-            [collectionConfig.upload.adminThumbnail]: {
-              filename: true,
-            },
-          }
-        } else {
-          /** Only return image size properties that are required for thumbnails */
-          select.sizes = collectionConfig.upload.imageSizes.reduce((acc, imageSizeConfig) => {
-            return {
-              ...acc,
-              [imageSizeConfig.name]: {
-                filename: true,
-                url: true,
-                width: true,
-              },
-            }
-          }, {})
-        }
-      } else {
-        select.url = true
-      }
-    }
+    appendUploadSelectFields({
+      collectionConfig,
+      select,
+    })
 
     try {
       if (collectionConfig.admin.groupBy && query.groupBy) {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13856

When using `enableListViewSelectAPI` on upload collections the thumbnail images require data, this PR ensures that the required data is always selected.