### PR TITLE
fix: exits handlers loop if response is returned

### DIFF
--- a/packages/payload/src/uploads/endpoints/getFile.ts
+++ b/packages/payload/src/uploads/endpoints/getFile.ts
@@ -49,6 +49,9 @@ export const getFileHandler: PayloadHandler = async (req) => {
           filename,
         },
       })
+      if (customResponse && customResponse instanceof Response) {
+        break
+      }
     }
 
     if (customResponse instanceof Response) {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13762

Adjusts custom upload handlers for loop to match the documentation, exiting the loop if a response is returned.