### PR TITLE
fix(richtext-lexical): richtext field duplicates description custom component

### DIFF
--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -184,7 +184,6 @@ const RichTextComponent: React.FC<
           />
           {AfterInput}
         </ErrorBoundary>
-        {Description}
         <RenderCustomComponent
           CustomComponent={Description}
           Fallback={<FieldDescription description={description} path={path} />}

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -104,7 +104,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const { startRouteTransition } = useRouteTransition()
   const { getUploadHandler } = useUploadHandlers()
 
-  const { config, getEntityConfig } = useConfig()
+  const { config } = useConfig()
 
   const [disabled, setDisabled] = useState(disabledFromProps || false)
   const [isMounted, setIsMounted] = useState(false)

--- a/test/lexical/collections/Lexical/components/Description.tsx
+++ b/test/lexical/collections/Lexical/components/Description.tsx
@@ -1,0 +1,7 @@
+export const Description = () => {
+  return (
+    <div className="lexical-blocks-custom-description" style={{ color: 'red' }}>
+      My Custom Lexical Description
+    </div>
+  )
+}

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -1446,6 +1446,27 @@ describe('lexicalMain', () => {
     page.getByText('Creating new User')
   })
 
+  test('ensure custom Description component is rendered only once', async () => {
+    await navigateToLexicalFields()
+    const lexicalWithBlocks = page.locator('.rich-text-lexical').nth(2)
+    await lexicalWithBlocks.scrollIntoViewIfNeeded()
+    await expect(lexicalWithBlocks).toBeVisible()
+
+    await expect(lexicalWithBlocks.locator('.lexical-blocks-custom-description')).toHaveCount(1)
+    await expect(lexicalWithBlocks.locator('.lexical-blocks-custom-description')).toBeVisible()
+  })
+
+  test('ensure admin.description property is rendered', async () => {
+    await navigateToLexicalFields()
+    const lexicalSimple = page.locator('.rich-text-lexical').nth(1)
+    await lexicalSimple.scrollIntoViewIfNeeded()
+    await expect(lexicalSimple).toBeVisible()
+
+    await expect(lexicalSimple.locator('.field-description')).toHaveCount(1)
+    await expect(lexicalSimple.locator('.field-description')).toBeVisible()
+    await expect(lexicalSimple.locator('.field-description')).toHaveText('A simple lexical field')
+  })
+
   test('ensure links can created from clipboard and deleted', async () => {
     await navigateToLexicalFields()
     const richTextField = page.locator('.rich-text-lexical').first()

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -1454,6 +1454,8 @@ describe('lexicalMain', () => {
 
     await expect(lexicalWithBlocks.locator('.lexical-blocks-custom-description')).toHaveCount(1)
     await expect(lexicalWithBlocks.locator('.lexical-blocks-custom-description')).toBeVisible()
+
+    await expect(lexicalWithBlocks.locator('.field-description')).toHaveCount(0)
   })
 
   test('ensure admin.description property is rendered', async () => {

--- a/test/lexical/collections/Lexical/index.ts
+++ b/test/lexical/collections/Lexical/index.ts
@@ -354,6 +354,7 @@ export const getLexicalFieldsCollection: (args: {
           components: {
             Description: '/collections/Lexical/components/Description.js#Description',
           },
+          description: 'Should not be rendered',
         },
         editor: lexicalEditor({
           admin: {

--- a/test/lexical/collections/Lexical/index.ts
+++ b/test/lexical/collections/Lexical/index.ts
@@ -309,6 +309,9 @@ export const getLexicalFieldsCollection: (args: {
       {
         name: 'lexicalSimple',
         type: 'richText',
+        admin: {
+          description: 'A simple lexical field',
+        },
         editor: lexicalEditor({
           features: ({ defaultFeatures }) => [
             //TestRecorderFeature(),
@@ -347,6 +350,11 @@ export const getLexicalFieldsCollection: (args: {
       {
         name: 'lexicalWithBlocks',
         type: 'richText',
+        admin: {
+          components: {
+            Description: '/collections/Lexical/components/Description.js#Description',
+          },
+        },
         editor: lexicalEditor({
           admin: {
             hideGutter: false,


### PR DESCRIPTION
The lexical field component was accidentally rendering the description component twice.

Fixes https://github.com/payloadcms/payload/issues/13644

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211402009345669