### PR TITLE
fix(ui): revert-to-published button showing on new drafts

### DIFF
--- a/packages/ui/src/elements/Status/index.tsx
+++ b/packages/ui/src/elements/Status/index.tsx
@@ -198,27 +198,29 @@ export const Status: React.FC = () => {
               />
             </React.Fragment>
           )}
-          {((!isTrashed && canUpdate && statusToRender === 'changed') ||
-            statusToRender === 'draft') && (
-            <React.Fragment>
-              &nbsp;&mdash;&nbsp;
-              <Button
-                buttonStyle="none"
-                className={`${baseClass}__action`}
-                id="action-revert-to-published"
-                onClick={() => toggleModal(revertModalSlug)}
-              >
-                {t('version:revertToPublished')}
-              </Button>
-              <ConfirmationModal
-                body={t('version:aboutToRevertToPublished')}
-                confirmingLabel={t('version:reverting')}
-                heading={t('version:confirmRevertToSaved')}
-                modalSlug={revertModalSlug}
-                onConfirm={() => performAction('revert')}
-              />
-            </React.Fragment>
-          )}
+          {!isTrashed &&
+            canUpdate &&
+            hasPublishedDoc &&
+            (statusToRender === 'changed' || statusToRender === 'draft') && (
+              <React.Fragment>
+                &nbsp;&mdash;&nbsp;
+                <Button
+                  buttonStyle="none"
+                  className={`${baseClass}__action`}
+                  id="action-revert-to-published"
+                  onClick={() => toggleModal(revertModalSlug)}
+                >
+                  {t('version:revertToPublished')}
+                </Button>
+                <ConfirmationModal
+                  body={t('version:aboutToRevertToPublished')}
+                  confirmingLabel={t('version:reverting')}
+                  heading={t('version:confirmRevertToSaved')}
+                  modalSlug={revertModalSlug}
+                  onConfirm={() => performAction('revert')}
+                />
+              </React.Fragment>
+            )}
         </div>
       </div>
     )


### PR DESCRIPTION
### What?

Hide the "**Revert to published**" button when creating a new draft that has never been published.

### Why?

Previously, the button was visible on new drafts, which was confusing because there was no published version to revert to.

### How?

Updated the revert button condition to also require `hasPublishedDoc`.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211363361462143