### PR TITLE
fix(db-sqlite): `exists` operator in `createJSONQuery`

### DIFF
--- a/packages/ui/src/utilities/getFolderResultsComponentAndData.tsx
+++ b/packages/ui/src/utilities/getFolderResultsComponentAndData.tsx
@@ -120,11 +120,6 @@ export const getFolderResultsComponentAndData = async ({
                     exists: false,
                   },
                 },
-                {
-                  folderType: {
-                    equals: null,
-                  },
-                },
               ],
             }
           : undefined,

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -406,7 +406,7 @@ describe('Joins Field', () => {
     expect(findFolder?.docs[0]?.documentsAndFolders?.docs).toHaveLength(1)
   })
 
-  it('should not throw an error with where query using EXISTS / EQUALS operators on hasMany select fields', async () => {
+  it('should query where with exists for hasMany select fields', async () => {
     await payload.delete({ collection: 'payload-folders', where: {} })
     const folderDoc = await payload.create({
       collection: 'payload-folders',
@@ -453,11 +453,6 @@ describe('Joins Field', () => {
                   {
                     folderType: {
                       exists: false,
-                    },
-                  },
-                  {
-                    folderType: {
-                      equals: null,
                     },
                   },
                 ],

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -406,6 +406,71 @@ describe('Joins Field', () => {
     expect(findFolder?.docs[0]?.documentsAndFolders?.docs).toHaveLength(1)
   })
 
+  it('should not throw an error with where query using EXISTS / EQUALS operators on hasMany select fields', async () => {
+    await payload.delete({ collection: 'payload-folders', where: {} })
+    const folderDoc = await payload.create({
+      collection: 'payload-folders',
+      data: {
+        name: 'scopedFolder',
+        folderType: ['folderPoly1', 'folderPoly2'],
+      },
+    })
+
+    await payload.create({
+      collection: 'payload-folders',
+      data: {
+        name: 'childFolder',
+        folderType: ['folderPoly1'],
+        folder: folderDoc.id,
+      },
+    })
+
+    const findFolder = await payload.find({
+      collection: 'payload-folders',
+      where: {
+        id: {
+          equals: folderDoc.id,
+        },
+      },
+      joins: {
+        documentsAndFolders: {
+          limit: 100_000,
+          sort: 'name',
+          where: {
+            and: [
+              {
+                relationTo: {
+                  equals: 'payload-folders',
+                },
+              },
+              {
+                or: [
+                  {
+                    folderType: {
+                      in: ['folderPoly1'],
+                    },
+                  },
+                  {
+                    folderType: {
+                      exists: false,
+                    },
+                  },
+                  {
+                    folderType: {
+                      equals: null,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    expect(findFolder?.docs[0]?.documentsAndFolders?.docs).toHaveLength(1)
+  })
+
   it('should filter joins using where query', async () => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13882