### PR TITLE
fix(ui): folder filters hidden behind results

### DIFF
--- a/packages/ui/src/elements/SearchBar/index.scss
+++ b/packages/ui/src/elements/SearchBar/index.scss
@@ -18,6 +18,10 @@
       grid-template-columns: auto 1fr auto;
     }
 
+    &:has(.popup--active) {
+      z-index: 1;
+    }
+
     .icon--search {
       grid-column: 1/2;
       grid-row: 1/2;


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13886

Search filters would be hidden behind the table results. This PR adds css to adjust the z-index of the searchbar when it has an active popup.