### PR TITLE
fix(ui): custom folder slug in browse-by

### DIFF
--- a/packages/payload/src/folders/createFolderCollection.ts
+++ b/packages/payload/src/folders/createFolderCollection.ts
@@ -3,7 +3,6 @@ import type { Field, Option, SelectField } from '../fields/config/types.js'
 
 import { defaultAccess } from '../auth/defaultAccess.js'
 import { buildFolderField } from './buildFolderField.js'
-import { foldersSlug } from './constants.js'
 import { deleteSubfoldersBeforeDelete } from './hooks/deleteSubfoldersAfterDelete.js'
 import { dissasociateAfterDelete } from './hooks/dissasociateAfterDelete.js'
 import { ensureSafeCollectionsChange } from './hooks/ensureSafeCollectionsChange.js'
@@ -115,7 +114,7 @@ export const createFolderCollection = ({
       ],
       beforeDelete: [deleteSubfoldersBeforeDelete({ folderFieldName, folderSlug: slug })],
       beforeValidate: [
-        ...(collectionSpecific ? [ensureSafeCollectionsChange({ foldersSlug })] : []),
+        ...(collectionSpecific ? [ensureSafeCollectionsChange({ foldersSlug: slug })] : []),
       ],
     },
     labels: {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13887

ensureSafeCollectionsChange was using the `folderSlug` imported from the constants file instead of using the `slug` passed into the createFolderCollection function.