### PR TITLE
fix(ui): query folder children with depth and select

### DIFF
--- a/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
+++ b/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
@@ -39,6 +39,7 @@ export async function queryDocumentsAndFoldersFromJoin({
 
   const subfolderDoc = (await payload.find({
     collection: payload.config.folders.slug,
+    depth: 1,
     joins: {
       documentsAndFolders: {
         limit: 100_000_000,
@@ -49,6 +50,9 @@ export async function queryDocumentsAndFoldersFromJoin({
     limit: 1,
     overrideAccess: false,
     req,
+    select: {
+      documentsAndFolders: true,
+    },
     user,
     where: {
       id: {

--- a/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
+++ b/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
@@ -52,6 +52,7 @@ export async function queryDocumentsAndFoldersFromJoin({
     req,
     select: {
       documentsAndFolders: true,
+      folderType: true,
     },
     user,
     where: {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13890

Query folder children with depth to ensure that the data needed to display the result items is returned.
