### PR TITLE
fix: prevent outdated documents being shown

### DIFF
--- a/packages/next/src/layouts/Root/RouteRefreshProvider.client.tsx
+++ b/packages/next/src/layouts/Root/RouteRefreshProvider.client.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { usePathname, useRouter } from 'next/navigation.js'
+import React, { useEffect, useRef } from 'react'
+
+/**
+ * Centralized route refresh provider that calls `router.refresh()`
+ * when navigating to specific views to prevent stale data issues with browser back/forward navigation
+ * due to the Next.js client side caching similar to BF-cache, see:
+ * https://nextjs.org/docs/app/guides/caching#client-side-router-cache
+ */
+export const RouteRefreshProvider: React.FC<{
+  children: React.ReactNode
+}> = ({ children }) => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const prevPathnameRef = useRef<string>()
+
+  useEffect(() => {
+    const prevPathname = prevPathnameRef.current
+    prevPathnameRef.current = pathname
+
+    // Check if we're navigating to routes that need refresh
+    const needsRefresh =
+      // Document edit routes: /collections/{slug}/{id} or /globals/{slug}
+      /^\/admin\/collections\/[^/]+\/[^/]+(?:\/[^/]*)?$/.test(pathname) ||
+      /^\/admin\/globals\/[^/]+(?:\/[^/]*)?$/.test(pathname) ||
+      // Versions routes: /collections/{slug}/{id}/versions or /globals/{slug}/versions
+      pathname.includes('/versions') ||
+      // List routes: /collections/{slug}
+      /^\/admin\/collections\/[^/]+\/?$/.test(pathname)
+
+    if (needsRefresh && prevPathname && prevPathname !== pathname) {
+      router.refresh()
+    }
+  }, [pathname, router])
+
+  return <>{children}</>
+}

--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -12,6 +12,7 @@ import { getRequestTheme } from '../../utilities/getRequestTheme.js'
 import { initReq } from '../../utilities/initReq.js'
 import { checkDependencies } from './checkDependencies.js'
 import { NestProviders } from './NestProviders.js'
+import { RouteRefreshProvider } from './RouteRefreshProvider.client.js'
 
 import '@payloadcms/ui/scss/app.scss'
 
@@ -130,23 +131,25 @@ export const RootLayout = async ({
           user={req.user}
         >
           <ProgressBar />
-          {Array.isArray(config.admin?.components?.providers) &&
-          config.admin?.components?.providers.length > 0 ? (
-            <NestProviders
-              importMap={req.payload.importMap}
-              providers={config.admin?.components?.providers}
-              serverProps={{
-                i18n: req.i18n,
-                payload: req.payload,
-                permissions,
-                user: req.user,
-              }}
-            >
-              {children}
-            </NestProviders>
-          ) : (
-            children
-          )}
+          <RouteRefreshProvider>
+            {Array.isArray(config.admin?.components?.providers) &&
+            config.admin?.components?.providers.length > 0 ? (
+              <NestProviders
+                importMap={req.payload.importMap}
+                providers={config.admin?.components?.providers}
+                serverProps={{
+                  i18n: req.i18n,
+                  payload: req.payload,
+                  permissions,
+                  user: req.user,
+                }}
+              >
+                {children}
+              </NestProviders>
+            ) : (
+              children
+            )}
+          </RouteRefreshProvider>
         </RootProvider>
         <div id="portal" />
       </body>


### PR DESCRIPTION
Explicitly calls `router.refresh()` to invalidate a Next.js client side cache that acts as BF-cache replacement, when opening a route where a view is shown that might be outdated if the cache is not invalidated. The issue of showing outdated documents was consistently reproducible when using the browser back / forward buttons to open the document edit view.

The implementation uses route matching to only invalidate the cache for some routes. More testing might be required to see whether more / all routes should have this behavior, or whether applying it only to the edit view would be sufficient.

FIxes https://github.com/payloadcms/payload/issues/12914.

Before:


https://github.com/user-attachments/assets/99945ac4-1423-43c2-980e-8c97f0e23175

After:

https://github.com/user-attachments/assets/af6b9f64-fa60-4265-bd2d-8c17cce7e370
