### PR TITLE
fix(plugin-search): returns doc instead of empty return

### DIFF
--- a/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
+++ b/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
@@ -33,7 +33,7 @@ export const syncDocAsSearchIndex = async ({
      * this can happen when hooks call `payload.update` within the create lifecycle
      * like the nested-docs plugin does
      */
-    return
+    return doc
   } else {
     syncedDocsSet.add(docKey)
   }


### PR DESCRIPTION
Returns doc instead of nothing/undefined inside the syncDocAsSearchIndex function when the plugin encounters a document it has already synced. 