### PR TITLE
fix(plugin-import-export): collectionSlug field regression from hidden field changes

### DIFF
--- a/packages/plugin-import-export/src/export/getFields.ts
+++ b/packages/plugin-import-export/src/export/getFields.ts
@@ -224,7 +224,9 @@ export const getFields = (config: Config, pluginConfig?: ImportExportPluginConfi
             components: {
               Field: '@payloadcms/plugin-import-export/rsc#CollectionField',
             },
-            hidden: true,
+            style: {
+              display: 'none',
+            },
           },
           required: true,
         },

--- a/packages/plugin-import-export/src/export/getFields.ts
+++ b/packages/plugin-import-export/src/export/getFields.ts
@@ -224,9 +224,6 @@ export const getFields = (config: Config, pluginConfig?: ImportExportPluginConfi
             components: {
               Field: '@payloadcms/plugin-import-export/rsc#CollectionField',
             },
-            style: {
-              display: 'none',
-            },
           },
           required: true,
         },

--- a/test/plugin-import-export/payload-types.ts
+++ b/test/plugin-import-export/payload-types.ts
@@ -198,7 +198,7 @@ export interface Page {
               root: {
                 type: string;
                 children: {
-                  type: string;
+                  type: any;
                   version: number;
                   [k: string]: unknown;
                 }[];


### PR DESCRIPTION
### What?

- Fixes collectionSlug field not being populated, breaking export downloads
- Works around recent UI changes that prevent custom components from rendering for `admin.hidden` fields
- Removes `admin.hidden: true` - as the component already ensures a hidden state by returning `null`

### Why?

- This merged [PR](https://github.com/payloadcms/payload/pull/13869) changed how `admin.hidden` fields are rendered, causing them to bypass custom field components entirely. The `collectionSlug` field relied on a custom `CollectionField` component to set its value from the ImportExportProvider context.

### How?

- Removes `admin.hidden: true`
- Field remains visually hidden with `null` return but custom component logic now executes properly

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211439277582333