### PR TITLE
fix: pagination returning duplicate results when timestamps: false

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -54,7 +54,7 @@ export const find: Find = async function find(
       locale,
       sort: sortArg || collectionConfig.defaultSort,
       sortAggregation,
-      timestamps: true,
+      timestamps: collectionConfig.timestamps || false,
     })
   }
 

--- a/test/admin/collections/NoTimestamps.ts
+++ b/test/admin/collections/NoTimestamps.ts
@@ -1,0 +1,14 @@
+import type { CollectionConfig } from 'payload'
+
+export const noTimestampsSlug = 'no-timestamps'
+
+export const NoTimestampsCollection: CollectionConfig = {
+  slug: noTimestampsSlug,
+  timestamps: false,
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -21,6 +21,7 @@ import { CollectionHidden } from './collections/Hidden.js'
 import { ListDrawer } from './collections/ListDrawer.js'
 import { ListViewSelectAPI } from './collections/ListViewSelectAPI/index.js'
 import { CollectionNoApiView } from './collections/NoApiView.js'
+import { NoTimestampsCollection } from './collections/NoTimestamps.js'
 import { CollectionNotInView } from './collections/NotInView.js'
 import { Placeholder } from './collections/Placeholder.js'
 import { Posts } from './collections/Posts.js'
@@ -191,6 +192,7 @@ export default buildConfigWithDefaults({
     CustomListDrawer,
     ListViewSelectAPI,
     Virtuals,
+    NoTimestampsCollection,
   ],
   globals: [
     GlobalHidden,

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -96,6 +96,7 @@ export interface Config {
     'custom-list-drawer': CustomListDrawer;
     'list-view-select-api': ListViewSelectApi;
     virtuals: Virtual;
+    'no-timestamps': NoTimestamp;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -131,6 +132,7 @@ export interface Config {
     'custom-list-drawer': CustomListDrawerSelect<false> | CustomListDrawerSelect<true>;
     'list-view-select-api': ListViewSelectApiSelect<false> | ListViewSelectApiSelect<true>;
     virtuals: VirtualsSelect<false> | VirtualsSelect<true>;
+    'no-timestamps': NoTimestampsSelect<false> | NoTimestampsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -614,6 +616,14 @@ export interface Virtual {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "no-timestamps".
+ */
+export interface NoTimestamp {
+  id: string;
+  title?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -734,6 +744,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'virtuals';
         value: string | Virtual;
+      } | null)
+    | ({
+        relationTo: 'no-timestamps';
+        value: string | NoTimestamp;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -1174,6 +1188,13 @@ export interface VirtualsSelect<T extends boolean = true> {
   post?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "no-timestamps_select".
+ */
+export interface NoTimestampsSelect<T extends boolean = true> {
+  title?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What
Fixes a bug where collection docs paginate incorrectly when `timestamps: false` is set — the same docs were appearing across multiple pages.

### Why
The `find` query sanitizes the `sort` parameter.  

- With `timestamps: true`, it defaults to `createdAt`
- With `timestamps: false`, it falls back to `_id`

That logic is correct, but in `find.ts` we always passed `timestamps: true`, ignoring the collection config. With the right sort applied, pagination works as expected.

### How
`find.ts` now passes `collectionConfig.timestamps` to `buildSortParam()`, ensuring the correct sort field is chosen.  

---

Fixes #13888
