### PR TITLE
fix(plugin-multi-tenant): improve Norwegian translation for "tenant"

### DIFF
--- a/packages/plugin-multi-tenant/src/translations/languages/nb.ts
+++ b/packages/plugin-multi-tenant/src/translations/languages/nb.ts
@@ -2,10 +2,10 @@ import type { PluginDefaultTranslationsObject, PluginLanguage } from '../types.j
 
 export const nbTranslations: PluginDefaultTranslationsObject = {
   'plugin-multi-tenant': {
-    'assign-tenant-button-label': 'Tildel Leietaker',
+    'assign-tenant-button-label': 'Tildel organisasjon',
     'assign-tenant-modal-title': 'Tildel "{{title}}"',
-    'field-assignedTenant-label': 'Tildelt leietaker',
-    'nav-tenantSelector-label': 'Leietaker',
+    'field-assignedTenant-label': 'Tildelt organisasjon',
+    'nav-tenantSelector-label': 'Filtrer etter organisasjon',
   },
 }
 


### PR DESCRIPTION
### What?

Replaced the Norwegian translation of “tenant” from **leietaker** (literal but misleading in context) to **organisasjon**. 

### Why?

The previous translation “leietaker” works for property rentals, but does not make sense in a SaaS or CMS context. “Organisasjon” is more natural and communicates the concept of a tenant more clearly to users.

### How?

Updated `nbTranslations` in `plugin-multi-tenant` to replace “leietaker” with “organisasjon”.
