### PR TITLE
feat: allow overriding ID type for generated types

### DIFF
--- a/packages/payload/src/bin/generateTypes.ts
+++ b/packages/payload/src/bin/generateTypes.ts
@@ -29,7 +29,11 @@ export async function generateTypes(
 
   const i18n = await initI18n({ config: config.i18n, context: 'api', language })
 
-  const jsonSchema = configToJSONSchema(config, config.db.defaultIDType, i18n)
+  const jsonSchema = configToJSONSchema(
+    config,
+    config.typescript?.defaultIDType ?? config.db.defaultIDType,
+    i18n,
+  )
 
   const declare = `declare module 'payload' {\n  export interface GeneratedTypes extends Config {}\n}`
   const declareWithTSIgnoreError = `declare module 'payload' {\n  // @ts-ignore \n  export interface GeneratedTypes extends Config {}\n}`

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1292,7 +1292,6 @@ export type Config = {
      * @default true
      */
     autoGenerate?: boolean
-
     /** Disable declare block in generated types file */
     declare?:
       | {
@@ -1306,6 +1305,13 @@ export type Config = {
           ignoreTSError?: boolean
         }
       | false
+
+    /**
+     * Override the default ID field type set by the database adapter for generated types.
+     * This is useful when switching between database adapters in order to ensure the generated types remain consistent,
+     * for example in the Payload monorepo.
+     */
+    defaultIDType?: 'number' | 'text'
 
     /** Filename to write the generated types to */
     outputFile?: string

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -184,8 +184,9 @@ function generateAuthEntitySchemas(entities: SanitizedCollectionConfig[]): JSONS
  * @example { db: idType: string }
  */
 function generateDbEntitySchema(config: SanitizedConfig): JSONSchema4 {
+  const defaultIDTypeConfig = config.typescript?.defaultIDType || config.db.defaultIDType
   const defaultIDType: JSONSchema4 =
-    config.db?.defaultIDType === 'number' ? { type: 'number' } : { type: 'string' }
+    defaultIDTypeConfig === 'number' ? { type: 'number' } : { type: 'string' }
 
   return {
     type: 'object',

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -184,7 +184,7 @@ function generateAuthEntitySchemas(entities: SanitizedCollectionConfig[]): JSONS
  * @example { db: idType: string }
  */
 function generateDbEntitySchema(config: SanitizedConfig): JSONSchema4 {
-  const defaultIDTypeConfig = config.typescript?.defaultIDType || config.db.defaultIDType
+  const defaultIDTypeConfig = config.typescript?.defaultIDType || config.db?.defaultIDType
   const defaultIDType: JSONSchema4 =
     defaultIDTypeConfig === 'number' ? { type: 'number' } : { type: 'string' }
 

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -130,7 +130,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -420,6 +420,7 @@ export interface HiddenField {
       }[]
     | null;
   hidden?: boolean | null;
+  hiddenWithDefault?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -490,7 +491,7 @@ export interface RichText {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -520,7 +521,7 @@ export interface Regression1 {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -538,7 +539,7 @@ export interface Regression1 {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -555,7 +556,7 @@ export interface Regression1 {
             root: {
               type: string;
               children: {
-                type: string;
+                type: any;
                 version: number;
                 [k: string]: unknown;
               }[];
@@ -576,7 +577,7 @@ export interface Regression1 {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -593,7 +594,7 @@ export interface Regression1 {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -615,7 +616,7 @@ export interface Regression1 {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -635,7 +636,7 @@ export interface Regression1 {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -655,7 +656,7 @@ export interface Regression1 {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -685,7 +686,7 @@ export interface Regression2 {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -704,7 +705,7 @@ export interface Regression2 {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -1116,6 +1117,7 @@ export interface HiddenFieldsSelect<T extends boolean = true> {
         id?: T;
       };
   hidden?: T;
+  hiddenWithDefault?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/admin-bar/payload-types.ts
+++ b/test/admin-bar/payload-types.ts
@@ -185,6 +185,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -323,6 +330,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/admin-root/payload-types.ts
+++ b/test/admin-root/payload-types.ts
@@ -143,6 +143,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -226,6 +233,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/array-update/payload-types.ts
+++ b/test/array-update/payload-types.ts
@@ -151,6 +151,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -246,6 +253,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/auth-basic/payload-types.ts
+++ b/test/auth-basic/payload-types.ts
@@ -126,6 +126,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -194,6 +201,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -247,7 +247,7 @@ export interface User {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -275,6 +275,7 @@ export interface User {
   unnamedTabSaveToJWTString?: string | null;
   unnamedTabSaveToJWTFalse?: string | null;
   custom?: string | null;
+  shouldNotShowInClientConfigUnlessAuthenticated?: string | null;
   updatedAt: string;
   createdAt: string;
   enableAPIKey?: boolean | null;
@@ -348,7 +349,6 @@ export interface ApiKey {
  */
 export interface PublicUser {
   id: string;
-  shouldNotShowInClientConfigUnlessAuthenticated?: string | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -545,6 +545,7 @@ export interface UsersSelect<T extends boolean = true> {
   unnamedTabSaveToJWTString?: T;
   unnamedTabSaveToJWTFalse?: T;
   custom?: T;
+  shouldNotShowInClientConfigUnlessAuthenticated?: T;
   updatedAt?: T;
   createdAt?: T;
   enableAPIKey?: T;
@@ -612,7 +613,6 @@ export interface ApiKeysSelect<T extends boolean = true> {
  * via the `definition` "public-users_select".
  */
 export interface PublicUsersSelect<T extends boolean = true> {
-  shouldNotShowInClientConfigUnlessAuthenticated?: T;
   updatedAt?: T;
   createdAt?: T;
   email?: T;

--- a/test/benchmark-blocks/payload-types.ts
+++ b/test/benchmark-blocks/payload-types.ts
@@ -8529,7 +8529,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -35012,6 +35012,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -35763,6 +35770,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -145,6 +145,8 @@ export async function buildConfigWithDefaults(
       ...(testConfig?.i18n || {}),
     },
     typescript: {
+      // Set defaultIDType to 'text' to ensure consistent generated types when switching db adapters
+      defaultIDType: 'text',
       declare: {
         ignoreTSError: true,
       },

--- a/test/collections-graphql/payload-types.ts
+++ b/test/collections-graphql/payload-types.ts
@@ -148,6 +148,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -435,6 +442,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/config/payload-types.ts
+++ b/test/config/payload-types.ts
@@ -151,6 +151,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -245,6 +252,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/custom-graphql/payload-types.ts
+++ b/test/custom-graphql/payload-types.ts
@@ -126,6 +126,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -194,6 +201,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/dataloader/payload-types.ts
+++ b/test/dataloader/payload-types.ts
@@ -149,6 +149,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -363,6 +370,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/email-nodemailer/payload-types.ts
+++ b/test/email-nodemailer/payload-types.ts
@@ -126,6 +126,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -194,6 +201,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/email-resend/payload-types.ts
+++ b/test/email-resend/payload-types.ts
@@ -126,6 +126,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -194,6 +201,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/email/payload-types.ts
+++ b/test/email/payload-types.ts
@@ -190,6 +190,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -329,6 +336,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/endpoints/payload-types.ts
+++ b/test/endpoints/payload-types.ts
@@ -156,6 +156,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -251,6 +258,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/field-error-states/payload-types.ts
+++ b/test/field-error-states/payload-types.ts
@@ -179,7 +179,7 @@ export interface ErrorField {
             root: {
               type: string;
               children: {
-                type: string;
+                type: any;
                 version: number;
                 [k: string]: unknown;
               }[];
@@ -232,7 +232,7 @@ export interface ErrorField {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -286,7 +286,7 @@ export interface ErrorField {
                 root: {
                   type: string;
                   children: {
-                    type: string;
+                    type: any;
                     version: number;
                     [k: string]: unknown;
                   }[];
@@ -351,7 +351,7 @@ export interface Upload {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];

--- a/test/field-perf/payload-types.ts
+++ b/test/field-perf/payload-types.ts
@@ -125,7 +125,7 @@ export interface BlocksCollection {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -168,6 +168,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -269,6 +276,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/fields-relationship/payload-types.ts
+++ b/test/fields-relationship/payload-types.ts
@@ -181,7 +181,16 @@ export interface FieldsRelationship {
   /**
    * This will filter the relationship options if the filter field in this document is set to "Include me"
    */
-  nestedRelationshipFilteredByField?: (string | null) | FieldsRelationship;
+  filteredByFieldInCollapsible?: (string | null) | FieldsRelationship;
+  array?:
+    | {
+        /**
+         * This will filter the relationship options if the filter field in this document is set to "Include me"
+         */
+        filteredByFieldInArray?: (string | null) | FieldsRelationship;
+        id?: string | null;
+      }[]
+    | null;
   relationshipFilteredAsync?: (string | null) | RelationOne;
   relationshipManyFiltered?:
     | (
@@ -518,7 +527,13 @@ export interface FieldsRelationshipSelect<T extends boolean = true> {
   relationshipWithTitle?: T;
   relationshipFilteredByID?: T;
   relationshipFilteredByField?: T;
-  nestedRelationshipFilteredByField?: T;
+  filteredByFieldInCollapsible?: T;
+  array?:
+    | T
+    | {
+        filteredByFieldInArray?: T;
+        id?: T;
+      };
   relationshipFilteredAsync?: T;
   relationshipManyFiltered?: T;
   filter?: T;

--- a/test/folders-browse-by-disabled/payload-types.ts
+++ b/test/folders-browse-by-disabled/payload-types.ts
@@ -156,6 +156,7 @@ export interface FolderInterface {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  folderType?: 'posts'[] | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -174,6 +175,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -261,6 +269,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -270,6 +285,7 @@ export interface PayloadFoldersSelect<T extends boolean = true> {
   name?: T;
   folder?: T;
   documentsAndFolders?: T;
+  folderType?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/folders/payload-types.ts
+++ b/test/folders/payload-types.ts
@@ -150,6 +150,7 @@ export interface Post {
  */
 export interface Media {
   id: string;
+  testAdminThumbnail?: string | null;
   folder?: (string | null) | FolderInterface;
   updatedAt: string;
   createdAt: string;
@@ -359,6 +360,7 @@ export interface PostsSelect<T extends boolean = true> {
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
+  testAdminThumbnail?: T;
   folder?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/test/globals/payload-types.ts
+++ b/test/globals/payload-types.ts
@@ -138,6 +138,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -206,6 +213,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/graphql-schema-gen/payload-types.ts
+++ b/test/graphql-schema-gen/payload-types.ts
@@ -174,6 +174,8 @@ export interface Collection2 {
   nestedGroup?: {
     meta?: SharedMeta;
   };
+  'some[text]'?: string | null;
+  spaceBottom?: ('mb-0' | 'mb-8' | 'mb-16' | 'mb-24' | 'mb-[150px]') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -210,6 +212,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -335,6 +344,8 @@ export interface Collection2Select<T extends boolean = true> {
     | {
         meta?: T | SharedMetaSelect<T>;
       };
+  'some[text]'?: T;
+  spaceBottom?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -369,6 +380,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/graphql/payload-types.ts
+++ b/test/graphql/payload-types.ts
@@ -140,6 +140,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -224,6 +231,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/hooks/payload-types.ts
+++ b/test/hooks/payload-types.ts
@@ -278,6 +278,13 @@ export interface HooksUser {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -851,6 +858,13 @@ export interface HooksUsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/lexical-mdx/payload-types.ts
+++ b/test/lexical-mdx/payload-types.ts
@@ -135,7 +135,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -150,7 +150,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -234,6 +234,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -394,6 +401,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/lexical/payload-types.ts
+++ b/test/lexical/payload-types.ts
@@ -132,7 +132,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     tabsWithRichText: TabsWithRichText;
@@ -172,7 +172,7 @@ export interface UserAuthOperations {
  * via the `definition` "lexical-fully-featured".
  */
 export interface LexicalFullyFeatured {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -196,7 +196,7 @@ export interface LexicalFullyFeatured {
  * via the `definition` "lexical-link-feature".
  */
 export interface LexicalLinkFeature {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -225,7 +225,7 @@ export interface LexicalHeadingFeature {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -244,7 +244,7 @@ export interface LexicalHeadingFeature {
  * via the `definition` "lexical-jsx-converter".
  */
 export interface LexicalJsxConverter {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -268,7 +268,7 @@ export interface LexicalJsxConverter {
  * via the `definition` "lexical-fields".
  */
 export interface LexicalField {
-  id: number;
+  id: string;
   title: string;
   lexicalRootEditor?: {
     root: {
@@ -285,6 +285,9 @@ export interface LexicalField {
     };
     [k: string]: unknown;
   } | null;
+  /**
+   * A simple lexical field
+   */
   lexicalSimple?: {
     root: {
       type: string;
@@ -300,6 +303,9 @@ export interface LexicalField {
     };
     [k: string]: unknown;
   } | null;
+  /**
+   * Should not be rendered
+   */
   lexicalWithBlocks: {
     root: {
       type: string;
@@ -324,7 +330,7 @@ export interface LexicalField {
  * via the `definition` "lexical-migrate-fields".
  */
 export interface LexicalMigrateField {
-  id: number;
+  id: string;
   title: string;
   lexicalWithLexicalPluginData?: {
     root: {
@@ -419,7 +425,7 @@ export interface LexicalMigrateField {
  * via the `definition` "lexical-localized-fields".
  */
 export interface LexicalLocalizedField {
-  id: number;
+  id: string;
   title: string;
   /**
    * Non-localized field with localized block subfields
@@ -465,7 +471,7 @@ export interface LexicalLocalizedField {
  * via the `definition` "lexicalObjectReferenceBug".
  */
 export interface LexicalObjectReferenceBug {
-  id: number;
+  id: string;
   lexicalDefault?: {
     root: {
       type: string;
@@ -504,7 +510,7 @@ export interface LexicalObjectReferenceBug {
  * via the `definition` "LexicalInBlock".
  */
 export interface LexicalInBlock {
-  id: number;
+  id: string;
   content?: {
     root: {
       type: string;
@@ -550,7 +556,7 @@ export interface LexicalInBlock {
  * via the `definition` "lexical-access-control".
  */
 export interface LexicalAccessControl {
-  id: number;
+  id: string;
   title?: string | null;
   richText?: {
     root: {
@@ -575,7 +581,7 @@ export interface LexicalAccessControl {
  * via the `definition` "lexical-relationship-fields".
  */
 export interface LexicalRelationshipField {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -614,7 +620,7 @@ export interface LexicalRelationshipField {
  * via the `definition` "rich-text-fields".
  */
 export interface RichTextField {
-  id: number;
+  id: string;
   title: string;
   lexicalCustomFields: {
     root: {
@@ -695,7 +701,7 @@ export interface RichTextField {
  * via the `definition` "text-fields".
  */
 export interface TextField {
-  id: number;
+  id: string;
   text: string;
   hiddenTextField?: string | null;
   /**
@@ -747,9 +753,9 @@ export interface TextField {
  * via the `definition` "uploads".
  */
 export interface Upload {
-  id: number;
+  id: string;
   text?: string | null;
-  media?: (number | null) | Upload;
+  media?: (string | null) | Upload;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -788,7 +794,7 @@ export interface Uploads2 {
  * via the `definition` "array-fields".
  */
 export interface ArrayField {
-  id: number;
+  id: string;
   title?: string | null;
   items: {
     text: string;
@@ -886,7 +892,7 @@ export interface ArrayField {
  * via the `definition` "OnDemandForm".
  */
 export interface OnDemandForm {
-  id: number;
+  id: string;
   json?:
     | {
         [k: string]: unknown;
@@ -904,7 +910,7 @@ export interface OnDemandForm {
  * via the `definition` "OnDemandOutsideForm".
  */
 export interface OnDemandOutsideForm {
-  id: number;
+  id: string;
   json?:
     | {
         [k: string]: unknown;
@@ -937,7 +943,7 @@ export interface OnDemandOutsideForm {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -961,15 +967,15 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'lexical-fully-featured';
-        value: number | LexicalFullyFeatured;
+        value: string | LexicalFullyFeatured;
       } | null)
     | ({
         relationTo: 'lexical-link-feature';
-        value: number | LexicalLinkFeature;
+        value: string | LexicalLinkFeature;
       } | null)
     | ({
         relationTo: 'lexical-heading-feature';
@@ -977,47 +983,47 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'lexical-jsx-converter';
-        value: number | LexicalJsxConverter;
+        value: string | LexicalJsxConverter;
       } | null)
     | ({
         relationTo: 'lexical-fields';
-        value: number | LexicalField;
+        value: string | LexicalField;
       } | null)
     | ({
         relationTo: 'lexical-migrate-fields';
-        value: number | LexicalMigrateField;
+        value: string | LexicalMigrateField;
       } | null)
     | ({
         relationTo: 'lexical-localized-fields';
-        value: number | LexicalLocalizedField;
+        value: string | LexicalLocalizedField;
       } | null)
     | ({
         relationTo: 'lexicalObjectReferenceBug';
-        value: number | LexicalObjectReferenceBug;
+        value: string | LexicalObjectReferenceBug;
       } | null)
     | ({
         relationTo: 'LexicalInBlock';
-        value: number | LexicalInBlock;
+        value: string | LexicalInBlock;
       } | null)
     | ({
         relationTo: 'lexical-access-control';
-        value: number | LexicalAccessControl;
+        value: string | LexicalAccessControl;
       } | null)
     | ({
         relationTo: 'lexical-relationship-fields';
-        value: number | LexicalRelationshipField;
+        value: string | LexicalRelationshipField;
       } | null)
     | ({
         relationTo: 'rich-text-fields';
-        value: number | RichTextField;
+        value: string | RichTextField;
       } | null)
     | ({
         relationTo: 'text-fields';
-        value: number | TextField;
+        value: string | TextField;
       } | null)
     | ({
         relationTo: 'uploads';
-        value: number | Upload;
+        value: string | Upload;
       } | null)
     | ({
         relationTo: 'uploads2';
@@ -1025,24 +1031,24 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'array-fields';
-        value: number | ArrayField;
+        value: string | ArrayField;
       } | null)
     | ({
         relationTo: 'OnDemandForm';
-        value: number | OnDemandForm;
+        value: string | OnDemandForm;
       } | null)
     | ({
         relationTo: 'OnDemandOutsideForm';
-        value: number | OnDemandOutsideForm;
+        value: string | OnDemandOutsideForm;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -1052,10 +1058,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -1075,7 +1081,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -1513,7 +1519,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "tabsWithRichText".
  */
 export interface TabsWithRichText {
-  id: number;
+  id: string;
   tab1?: {
     rt1?: {
       root: {
@@ -1587,7 +1593,7 @@ export interface LexicalBlocksRadioButtonsBlock {
 export interface AvatarGroupBlock {
   avatars?:
     | {
-        image?: (number | null) | Upload;
+        image?: (string | null) | Upload;
         id?: string | null;
       }[]
     | null;

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -336,7 +336,7 @@ export interface Page {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -351,7 +351,7 @@ export interface Page {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -382,7 +382,7 @@ export interface Page {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];

--- a/test/localization-rtl/payload-types.ts
+++ b/test/localization-rtl/payload-types.ts
@@ -128,6 +128,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -144,7 +151,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -229,6 +236,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -172,7 +172,7 @@ export interface RichText {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -390,6 +390,7 @@ export interface NoLocalizedField {
   text?: string | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1086,6 +1087,7 @@ export interface NoLocalizedFieldsSelect<T extends boolean = true> {
   text?: T;
   updatedAt?: T;
   createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/locked-documents/payload-types.ts
+++ b/test/locked-documents/payload-types.ts
@@ -147,7 +147,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -174,7 +174,7 @@ export interface ServerComponent {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];

--- a/test/login-with-username/payload-types.ts
+++ b/test/login-with-username/payload-types.ts
@@ -185,6 +185,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -203,6 +210,13 @@ export interface LoginWithEither {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -221,6 +235,13 @@ export interface RequireEmail {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -317,6 +338,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -333,6 +361,13 @@ export interface LoginWithEitherSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -349,6 +384,13 @@ export interface RequireEmailSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/migrations-cli/payload-types.ts
+++ b/test/migrations-cli/payload-types.ts
@@ -126,6 +126,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -194,6 +201,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/nested-fields/payload-types.ts
+++ b/test/nested-fields/payload-types.ts
@@ -214,6 +214,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -385,6 +392,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/payload-cloud/payload-types.ts
+++ b/test/payload-cloud/payload-types.ts
@@ -165,6 +165,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -280,6 +287,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-cloud-storage/payload-types.ts
+++ b/test/plugin-cloud-storage/payload-types.ts
@@ -186,6 +186,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -323,6 +330,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-redirects/payload-types.ts
+++ b/test/plugin-redirects/payload-types.ts
@@ -130,6 +130,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -239,6 +246,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-sentry/payload-types.ts
+++ b/test/plugin-sentry/payload-types.ts
@@ -138,6 +138,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -220,6 +227,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-seo/payload-types.ts
+++ b/test/plugin-seo/payload-types.ts
@@ -132,6 +132,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -167,7 +174,7 @@ export interface Media {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -294,6 +301,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-stripe/payload-types.ts
+++ b/test/plugin-stripe/payload-types.ts
@@ -154,6 +154,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -210,6 +217,13 @@ export interface Customer {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -298,6 +312,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -345,6 +366,13 @@ export interface CustomersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugins/payload-types.ts
+++ b/test/plugins/payload-types.ts
@@ -128,6 +128,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -211,6 +218,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/query-presets/payload-types.ts
+++ b/test/query-presets/payload-types.ts
@@ -268,7 +268,7 @@ export interface PayloadQueryPreset {
     | null;
   relatedCollection: 'pages' | 'posts';
   /**
-   * This is a tempoary field used to determine if updating the preset would remove the user's access to it. When `true`, this record will be deleted after running the preset's `validate` function.
+   * This is a temporary field used to determine if updating the preset would remove the user's access to it. When `true`, this record will be deleted after running the preset's `validate` function.
    */
   isTemp?: boolean | null;
   updatedAt: string;

--- a/test/queues/payload-types.ts
+++ b/test/queues/payload-types.ts
@@ -165,7 +165,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -100,7 +100,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     'global-post': GlobalPost;
@@ -142,7 +142,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: number;
+  id: string;
   text?: string | null;
   number?: number | null;
   select?: ('a' | 'b') | null;
@@ -182,17 +182,17 @@ export interface Post {
   };
   unnamedTabText?: string | null;
   unnamedTabNumber?: number | null;
-  hasOne?: (number | null) | Rel;
-  hasMany?: (number | Rel)[] | null;
-  hasManyUpload?: (number | Upload)[] | null;
+  hasOne?: (string | null) | Rel;
+  hasMany?: (string | Rel)[] | null;
+  hasManyUpload?: (string | Upload)[] | null;
   hasOnePoly?: {
     relationTo: 'rels';
-    value: number | Rel;
+    value: string | Rel;
   } | null;
   hasManyPoly?:
     | {
         relationTo: 'rels';
-        value: number | Rel;
+        value: string | Rel;
       }[]
     | null;
   updatedAt: string;
@@ -203,7 +203,7 @@ export interface Post {
  * via the `definition` "rels".
  */
 export interface Rel {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
 }
@@ -212,7 +212,7 @@ export interface Rel {
  * via the `definition` "upload".
  */
 export interface Upload {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -230,7 +230,7 @@ export interface Upload {
  * via the `definition` "localized-posts".
  */
 export interface LocalizedPost {
-  id: number;
+  id: string;
   text?: string | null;
   number?: number | null;
   select?: ('a' | 'b') | null;
@@ -301,7 +301,7 @@ export interface LocalizedPost {
  * via the `definition` "versioned-posts".
  */
 export interface VersionedPost {
-  id: number;
+  id: string;
   text?: string | null;
   number?: number | null;
   array?:
@@ -327,7 +327,7 @@ export interface VersionedPost {
  * via the `definition` "deep-posts".
  */
 export interface DeepPost {
-  id: number;
+  id: string;
   group?: {
     array?:
       | {
@@ -369,22 +369,22 @@ export interface DeepPost {
  * via the `definition` "pages".
  */
 export interface Page {
-  id: number;
-  relatedPage?: (number | null) | Page;
+  id: string;
+  relatedPage?: (string | null) | Page;
   content?:
     | {
         title: string;
         link: {
           docPoly?: {
             relationTo: 'pages';
-            value: number | Page;
+            value: string | Page;
           } | null;
-          doc?: (number | null) | Page;
-          docMany?: (number | Page)[] | null;
+          doc?: (string | null) | Page;
+          docMany?: (string | Page)[] | null;
           docHasManyPoly?:
             | {
                 relationTo: 'pages';
-                value: number | Page;
+                value: string | Page;
               }[]
             | null;
           label: string;
@@ -393,7 +393,7 @@ export interface Page {
           root: {
             type: string;
             children: {
-              type: string;
+              type: any;
               version: number;
               [k: string]: unknown;
             }[];
@@ -440,7 +440,7 @@ export interface Page {
  * via the `definition` "points".
  */
 export interface Point {
-  id: number;
+  id: string;
   text?: string | null;
   /**
    * @minItems 2
@@ -455,7 +455,7 @@ export interface Point {
  * via the `definition` "force-select".
  */
 export interface ForceSelect {
-  id: number;
+  id: string;
   text?: string | null;
   forceSelected?: string | null;
   array?:
@@ -482,7 +482,7 @@ export interface CustomId {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   name?: string | null;
   number?: number | null;
   updatedAt: string;
@@ -508,43 +508,43 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'posts';
-        value: number | Post;
+        value: string | Post;
       } | null)
     | ({
         relationTo: 'localized-posts';
-        value: number | LocalizedPost;
+        value: string | LocalizedPost;
       } | null)
     | ({
         relationTo: 'versioned-posts';
-        value: number | VersionedPost;
+        value: string | VersionedPost;
       } | null)
     | ({
         relationTo: 'deep-posts';
-        value: number | DeepPost;
+        value: string | DeepPost;
       } | null)
     | ({
         relationTo: 'pages';
-        value: number | Page;
+        value: string | Page;
       } | null)
     | ({
         relationTo: 'points';
-        value: number | Point;
+        value: string | Point;
       } | null)
     | ({
         relationTo: 'force-select';
-        value: number | ForceSelect;
+        value: string | ForceSelect;
       } | null)
     | ({
         relationTo: 'upload';
-        value: number | Upload;
+        value: string | Upload;
       } | null)
     | ({
         relationTo: 'rels';
-        value: number | Rel;
+        value: string | Rel;
       } | null)
     | ({
         relationTo: 'custom-ids';
@@ -552,12 +552,12 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -567,10 +567,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -590,7 +590,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -982,7 +982,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "global-post".
  */
 export interface GlobalPost {
-  id: number;
+  id: string;
   text?: string | null;
   number?: number | null;
   updatedAt?: string | null;
@@ -993,7 +993,7 @@ export interface GlobalPost {
  * via the `definition` "force-select-global".
  */
 export interface ForceSelectGlobal {
-  id: number;
+  id: string;
   text?: string | null;
   forceSelected?: string | null;
   array?:

--- a/test/server-functions/payload-types.ts
+++ b/test/server-functions/payload-types.ts
@@ -126,6 +126,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -194,6 +201,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/storage-azure/payload-types.ts
+++ b/test/storage-azure/payload-types.ts
@@ -84,7 +84,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {};
   globalsSelect: {};
@@ -120,7 +120,7 @@ export interface UserAuthOperations {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   alt?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -157,7 +157,7 @@ export interface Media {
  * via the `definition` "media-with-prefix".
  */
 export interface MediaWithPrefix {
-  id: number;
+  id: string;
   prefix?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -176,7 +176,7 @@ export interface MediaWithPrefix {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -200,24 +200,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'media-with-prefix';
-        value: number | MediaWithPrefix;
+        value: string | MediaWithPrefix;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -227,10 +227,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -250,7 +250,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;

--- a/test/storage-gcs/payload-types.ts
+++ b/test/storage-gcs/payload-types.ts
@@ -186,6 +186,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -323,6 +330,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/storage-s3/payload-types.ts
+++ b/test/storage-s3/payload-types.ts
@@ -206,6 +206,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -364,6 +371,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/storage-uploadthing/payload-types.ts
+++ b/test/storage-uploadthing/payload-types.ts
@@ -84,7 +84,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {};
   globalsSelect: {};
@@ -120,7 +120,7 @@ export interface UserAuthOperations {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   alt?: string | null;
   _key?: string | null;
   updatedAt: string;
@@ -160,7 +160,7 @@ export interface Media {
  * via the `definition` "media-with-prefix".
  */
 export interface MediaWithPrefix {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -178,7 +178,7 @@ export interface MediaWithPrefix {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -202,24 +202,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'media-with-prefix';
-        value: number | MediaWithPrefix;
+        value: string | MediaWithPrefix;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -229,10 +229,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -252,7 +252,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;

--- a/test/storage-vercel-blob/payload-types.ts
+++ b/test/storage-vercel-blob/payload-types.ts
@@ -84,7 +84,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {};
   globalsSelect: {};
@@ -120,7 +120,7 @@ export interface UserAuthOperations {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   alt?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -157,8 +157,7 @@ export interface Media {
  * via the `definition` "media-with-prefix".
  */
 export interface MediaWithPrefix {
-  id: number;
-  prefix?: string | null;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -176,7 +175,7 @@ export interface MediaWithPrefix {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -200,24 +199,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'media-with-prefix';
-        value: number | MediaWithPrefix;
+        value: string | MediaWithPrefix;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -227,10 +226,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -250,7 +249,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -303,7 +302,6 @@ export interface MediaSelect<T extends boolean = true> {
  * via the `definition` "media-with-prefix_select".
  */
 export interface MediaWithPrefixSelect<T extends boolean = true> {
-  prefix?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;

--- a/test/types/payload-types.ts
+++ b/test/types/payload-types.ts
@@ -405,6 +405,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -190,7 +190,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {};
   globalsSelect: {};
@@ -226,14 +226,14 @@ export interface UserAuthOperations {
  * via the `definition` "relation".
  */
 export interface Relation {
-  id: number;
-  image?: (number | null) | Media;
-  versionedImage?: (number | null) | Version;
-  hideFileInputOnCreate?: (number | null) | HideFileInputOnCreate;
+  id: string;
+  image?: (string | null) | Media;
+  versionedImage?: (string | null) | Version;
+  hideFileInputOnCreate?: (string | null) | HideFileInputOnCreate;
   blocks?:
     | {
-        media: number | Media;
-        relatedMedia?: (number | Media)[] | null;
+        media: string | Media;
+        relatedMedia?: (string | Media)[] | null;
         id?: string | null;
         blockName?: string | null;
         blockType: 'localizedMediaBlock';
@@ -248,7 +248,7 @@ export interface Relation {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   alt?: string | null;
   localized?: string | null;
   updatedAt: string;
@@ -398,7 +398,7 @@ export interface Media {
  * via the `definition` "versions".
  */
 export interface Version {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -418,7 +418,7 @@ export interface Version {
  * via the `definition` "hide-file-input-on-create".
  */
 export interface HideFileInputOnCreate {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -437,8 +437,8 @@ export interface HideFileInputOnCreate {
  * via the `definition` "audio".
  */
 export interface Audio {
-  id: number;
-  audio?: (number | null) | Media;
+  id: string;
+  audio?: (string | null) | Media;
   updatedAt: string;
   createdAt: string;
 }
@@ -447,7 +447,7 @@ export interface Audio {
  * via the `definition` "gif-resize".
  */
 export interface GifResize {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -483,7 +483,7 @@ export interface GifResize {
  * via the `definition` "filename-compound-index".
  */
 export interface FilenameCompoundIndex {
-  id: number;
+  id: string;
   /**
    * Alt text to be used for compound index
    */
@@ -523,7 +523,7 @@ export interface FilenameCompoundIndex {
  * via the `definition` "no-image-sizes".
  */
 export interface NoImageSize {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -541,7 +541,7 @@ export interface NoImageSize {
  * via the `definition` "object-fit".
  */
 export interface ObjectFit {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -593,7 +593,7 @@ export interface ObjectFit {
  * via the `definition` "with-meta-data".
  */
 export interface WithMetaDatum {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -621,7 +621,7 @@ export interface WithMetaDatum {
  * via the `definition` "without-meta-data".
  */
 export interface WithoutMetaDatum {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -649,7 +649,7 @@ export interface WithoutMetaDatum {
  * via the `definition` "with-only-jpeg-meta-data".
  */
 export interface WithOnlyJpegMetaDatum {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -677,7 +677,7 @@ export interface WithOnlyJpegMetaDatum {
  * via the `definition` "crop-only".
  */
 export interface CropOnly {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -721,7 +721,7 @@ export interface CropOnly {
  * via the `definition` "focal-only".
  */
 export interface FocalOnly {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -765,7 +765,7 @@ export interface FocalOnly {
  * via the `definition` "image-sizes-only".
  */
 export interface ImageSizesOnly {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -801,7 +801,7 @@ export interface ImageSizesOnly {
  * via the `definition` "focal-no-sizes".
  */
 export interface FocalNoSize {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -819,7 +819,7 @@ export interface FocalNoSize {
  * via the `definition` "allow-list-media".
  */
 export interface AllowListMedia {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -837,7 +837,7 @@ export interface AllowListMedia {
  * via the `definition` "skip-safe-fetch-media".
  */
 export interface SkipSafeFetchMedia {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -855,7 +855,7 @@ export interface SkipSafeFetchMedia {
  * via the `definition` "skip-safe-fetch-header-filter".
  */
 export interface SkipSafeFetchHeaderFilter {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -873,7 +873,7 @@ export interface SkipSafeFetchHeaderFilter {
  * via the `definition` "skip-allow-list-safe-fetch-media".
  */
 export interface SkipAllowListSafeFetchMedia {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -891,7 +891,7 @@ export interface SkipAllowListSafeFetchMedia {
  * via the `definition` "restrict-file-types".
  */
 export interface RestrictFileType {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -909,7 +909,7 @@ export interface RestrictFileType {
  * via the `definition` "no-restrict-file-types".
  */
 export interface NoRestrictFileType {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -927,7 +927,7 @@ export interface NoRestrictFileType {
  * via the `definition` "no-restrict-file-mime-types".
  */
 export interface NoRestrictFileMimeType {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -945,7 +945,7 @@ export interface NoRestrictFileMimeType {
  * via the `definition` "animated-type-media".
  */
 export interface AnimatedTypeMedia {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -997,7 +997,7 @@ export interface AnimatedTypeMedia {
  * via the `definition` "enlarge".
  */
 export interface Enlarge {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1065,7 +1065,7 @@ export interface Enlarge {
  * via the `definition` "without-enlarge".
  */
 export interface WithoutEnlarge {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1083,7 +1083,7 @@ export interface WithoutEnlarge {
  * via the `definition` "reduce".
  */
 export interface Reduce {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1135,7 +1135,7 @@ export interface Reduce {
  * via the `definition` "media-trim".
  */
 export interface MediaTrim {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1179,7 +1179,7 @@ export interface MediaTrim {
  * via the `definition` "custom-file-name-media".
  */
 export interface CustomFileNameMedia {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1207,7 +1207,7 @@ export interface CustomFileNameMedia {
  * via the `definition` "unstored-media".
  */
 export interface UnstoredMedia {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1225,7 +1225,7 @@ export interface UnstoredMedia {
  * via the `definition` "externally-served-media".
  */
 export interface ExternallyServedMedia {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1243,16 +1243,16 @@ export interface ExternallyServedMedia {
  * via the `definition` "uploads-1".
  */
 export interface Uploads1 {
-  id: number;
-  hasManyUpload?: (number | Uploads2)[] | null;
-  singleUpload?: (number | null) | Uploads2;
-  hasManyThumbnailUpload?: (number | AdminThumbnailSize)[] | null;
-  singleThumbnailUpload?: (number | null) | AdminThumbnailSize;
+  id: string;
+  hasManyUpload?: (string | Uploads2)[] | null;
+  singleUpload?: (string | null) | Uploads2;
+  hasManyThumbnailUpload?: (string | AdminThumbnailSize)[] | null;
+  singleThumbnailUpload?: (string | null) | AdminThumbnailSize;
   richText?: {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1280,7 +1280,7 @@ export interface Uploads1 {
  * via the `definition` "uploads-2".
  */
 export interface Uploads2 {
-  id: number;
+  id: string;
   prefix: string;
   title?: string | null;
   updatedAt: string;
@@ -1300,7 +1300,7 @@ export interface Uploads2 {
  * via the `definition` "admin-thumbnail-size".
  */
 export interface AdminThumbnailSize {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1336,7 +1336,7 @@ export interface AdminThumbnailSize {
  * via the `definition` "any-images".
  */
 export interface AnyImage {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1354,7 +1354,7 @@ export interface AnyImage {
  * via the `definition` "admin-thumbnail-function".
  */
 export interface AdminThumbnailFunction {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1372,7 +1372,7 @@ export interface AdminThumbnailFunction {
  * via the `definition` "admin-thumbnail-with-search-queries".
  */
 export interface AdminThumbnailWithSearchQuery {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1390,7 +1390,7 @@ export interface AdminThumbnailWithSearchQuery {
  * via the `definition` "admin-upload-control".
  */
 export interface AdminUploadControl {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1408,7 +1408,7 @@ export interface AdminUploadControl {
  * via the `definition` "optional-file".
  */
 export interface OptionalFile {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1426,7 +1426,7 @@ export interface OptionalFile {
  * via the `definition` "required-file".
  */
 export interface RequiredFile {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1444,7 +1444,7 @@ export interface RequiredFile {
  * via the `definition` "custom-upload-field".
  */
 export interface CustomUploadField {
-  id: number;
+  id: string;
   alt?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1463,7 +1463,7 @@ export interface CustomUploadField {
  * via the `definition` "media-with-relation-preview".
  */
 export interface MediaWithRelationPreview {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1482,7 +1482,7 @@ export interface MediaWithRelationPreview {
  * via the `definition` "media-without-cache-tags".
  */
 export interface MediaWithoutCacheTag {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1501,7 +1501,7 @@ export interface MediaWithoutCacheTag {
  * via the `definition` "media-without-relation-preview".
  */
 export interface MediaWithoutRelationPreview {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1520,13 +1520,13 @@ export interface MediaWithoutRelationPreview {
  * via the `definition` "relation-preview".
  */
 export interface RelationPreview {
-  id: number;
-  imageWithPreview1?: (number | null) | MediaWithRelationPreview;
-  imageWithPreview2?: (number | null) | MediaWithRelationPreview;
-  imageWithoutPreview1?: (number | null) | MediaWithRelationPreview;
-  imageWithoutPreview2?: (number | null) | MediaWithoutRelationPreview;
-  imageWithPreview3?: (number | null) | MediaWithoutRelationPreview;
-  imageWithoutPreview3?: (number | null) | MediaWithoutRelationPreview;
+  id: string;
+  imageWithPreview1?: (string | null) | MediaWithRelationPreview;
+  imageWithPreview2?: (string | null) | MediaWithRelationPreview;
+  imageWithoutPreview1?: (string | null) | MediaWithRelationPreview;
+  imageWithoutPreview2?: (string | null) | MediaWithoutRelationPreview;
+  imageWithPreview3?: (string | null) | MediaWithoutRelationPreview;
+  imageWithoutPreview3?: (string | null) | MediaWithoutRelationPreview;
   updatedAt: string;
   createdAt: string;
 }
@@ -1535,11 +1535,11 @@ export interface RelationPreview {
  * via the `definition` "best-fit".
  */
 export interface BestFit {
-  id: number;
-  withAdminThumbnail?: (number | null) | AdminThumbnailFunction;
-  withinRange?: (number | null) | Enlarge;
-  nextSmallestOutOfRange?: (number | null) | FocalOnly;
-  original?: (number | null) | FocalOnly;
+  id: string;
+  withAdminThumbnail?: (string | null) | AdminThumbnailFunction;
+  withinRange?: (string | null) | Enlarge;
+  nextSmallestOutOfRange?: (string | null) | FocalOnly;
+  original?: (string | null) | FocalOnly;
   updatedAt: string;
   createdAt: string;
 }
@@ -1548,10 +1548,10 @@ export interface BestFit {
  * via the `definition` "list-view-preview".
  */
 export interface ListViewPreview {
-  id: number;
+  id: string;
   title?: string | null;
-  imageUpload?: (number | null) | MediaWithRelationPreview;
-  imageRelationship?: (number | null) | MediaWithRelationPreview;
+  imageUpload?: (string | null) | MediaWithRelationPreview;
+  imageRelationship?: (string | null) | MediaWithRelationPreview;
   updatedAt: string;
   createdAt: string;
 }
@@ -1560,7 +1560,7 @@ export interface ListViewPreview {
  * via the `definition` "three-dimensional".
  */
 export interface ThreeDimensional {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1576,7 +1576,7 @@ export interface ThreeDimensional {
  * via the `definition` "constructor-options".
  */
 export interface ConstructorOption {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1594,11 +1594,11 @@ export interface ConstructorOption {
  * via the `definition` "bulk-uploads".
  */
 export interface BulkUpload {
-  id: number;
+  id: string;
   title: string;
   relationship?: {
     relationTo: 'simple-relationship';
-    value: number | SimpleRelationship;
+    value: string | SimpleRelationship;
   } | null;
   updatedAt: string;
   createdAt: string;
@@ -1617,7 +1617,7 @@ export interface BulkUpload {
  * via the `definition` "simple-relationship".
  */
 export interface SimpleRelationship {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1627,7 +1627,7 @@ export interface SimpleRelationship {
  * via the `definition` "file-mime-type".
  */
 export interface FileMimeType {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1646,7 +1646,7 @@ export interface FileMimeType {
  * via the `definition` "svg-only".
  */
 export interface SvgOnly {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1664,7 +1664,7 @@ export interface SvgOnly {
  * via the `definition` "media-without-delete-access".
  */
 export interface MediaWithoutDeleteAccess {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1682,7 +1682,7 @@ export interface MediaWithoutDeleteAccess {
  * via the `definition` "media-with-image-size-admin-props".
  */
 export interface MediaWithImageSizeAdminProp {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1734,7 +1734,7 @@ export interface MediaWithImageSizeAdminProp {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -1758,236 +1758,236 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'relation';
-        value: number | Relation;
+        value: string | Relation;
       } | null)
     | ({
         relationTo: 'audio';
-        value: number | Audio;
+        value: string | Audio;
       } | null)
     | ({
         relationTo: 'gif-resize';
-        value: number | GifResize;
+        value: string | GifResize;
       } | null)
     | ({
         relationTo: 'filename-compound-index';
-        value: number | FilenameCompoundIndex;
+        value: string | FilenameCompoundIndex;
       } | null)
     | ({
         relationTo: 'no-image-sizes';
-        value: number | NoImageSize;
+        value: string | NoImageSize;
       } | null)
     | ({
         relationTo: 'object-fit';
-        value: number | ObjectFit;
+        value: string | ObjectFit;
       } | null)
     | ({
         relationTo: 'with-meta-data';
-        value: number | WithMetaDatum;
+        value: string | WithMetaDatum;
       } | null)
     | ({
         relationTo: 'without-meta-data';
-        value: number | WithoutMetaDatum;
+        value: string | WithoutMetaDatum;
       } | null)
     | ({
         relationTo: 'with-only-jpeg-meta-data';
-        value: number | WithOnlyJpegMetaDatum;
+        value: string | WithOnlyJpegMetaDatum;
       } | null)
     | ({
         relationTo: 'crop-only';
-        value: number | CropOnly;
+        value: string | CropOnly;
       } | null)
     | ({
         relationTo: 'focal-only';
-        value: number | FocalOnly;
+        value: string | FocalOnly;
       } | null)
     | ({
         relationTo: 'image-sizes-only';
-        value: number | ImageSizesOnly;
+        value: string | ImageSizesOnly;
       } | null)
     | ({
         relationTo: 'focal-no-sizes';
-        value: number | FocalNoSize;
+        value: string | FocalNoSize;
       } | null)
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'allow-list-media';
-        value: number | AllowListMedia;
+        value: string | AllowListMedia;
       } | null)
     | ({
         relationTo: 'skip-safe-fetch-media';
-        value: number | SkipSafeFetchMedia;
+        value: string | SkipSafeFetchMedia;
       } | null)
     | ({
         relationTo: 'skip-safe-fetch-header-filter';
-        value: number | SkipSafeFetchHeaderFilter;
+        value: string | SkipSafeFetchHeaderFilter;
       } | null)
     | ({
         relationTo: 'skip-allow-list-safe-fetch-media';
-        value: number | SkipAllowListSafeFetchMedia;
+        value: string | SkipAllowListSafeFetchMedia;
       } | null)
     | ({
         relationTo: 'restrict-file-types';
-        value: number | RestrictFileType;
+        value: string | RestrictFileType;
       } | null)
     | ({
         relationTo: 'no-restrict-file-types';
-        value: number | NoRestrictFileType;
+        value: string | NoRestrictFileType;
       } | null)
     | ({
         relationTo: 'no-restrict-file-mime-types';
-        value: number | NoRestrictFileMimeType;
+        value: string | NoRestrictFileMimeType;
       } | null)
     | ({
         relationTo: 'animated-type-media';
-        value: number | AnimatedTypeMedia;
+        value: string | AnimatedTypeMedia;
       } | null)
     | ({
         relationTo: 'enlarge';
-        value: number | Enlarge;
+        value: string | Enlarge;
       } | null)
     | ({
         relationTo: 'without-enlarge';
-        value: number | WithoutEnlarge;
+        value: string | WithoutEnlarge;
       } | null)
     | ({
         relationTo: 'reduce';
-        value: number | Reduce;
+        value: string | Reduce;
       } | null)
     | ({
         relationTo: 'media-trim';
-        value: number | MediaTrim;
+        value: string | MediaTrim;
       } | null)
     | ({
         relationTo: 'custom-file-name-media';
-        value: number | CustomFileNameMedia;
+        value: string | CustomFileNameMedia;
       } | null)
     | ({
         relationTo: 'unstored-media';
-        value: number | UnstoredMedia;
+        value: string | UnstoredMedia;
       } | null)
     | ({
         relationTo: 'externally-served-media';
-        value: number | ExternallyServedMedia;
+        value: string | ExternallyServedMedia;
       } | null)
     | ({
         relationTo: 'uploads-1';
-        value: number | Uploads1;
+        value: string | Uploads1;
       } | null)
     | ({
         relationTo: 'uploads-2';
-        value: number | Uploads2;
+        value: string | Uploads2;
       } | null)
     | ({
         relationTo: 'any-images';
-        value: number | AnyImage;
+        value: string | AnyImage;
       } | null)
     | ({
         relationTo: 'admin-thumbnail-function';
-        value: number | AdminThumbnailFunction;
+        value: string | AdminThumbnailFunction;
       } | null)
     | ({
         relationTo: 'admin-thumbnail-with-search-queries';
-        value: number | AdminThumbnailWithSearchQuery;
+        value: string | AdminThumbnailWithSearchQuery;
       } | null)
     | ({
         relationTo: 'admin-thumbnail-size';
-        value: number | AdminThumbnailSize;
+        value: string | AdminThumbnailSize;
       } | null)
     | ({
         relationTo: 'admin-upload-control';
-        value: number | AdminUploadControl;
+        value: string | AdminUploadControl;
       } | null)
     | ({
         relationTo: 'optional-file';
-        value: number | OptionalFile;
+        value: string | OptionalFile;
       } | null)
     | ({
         relationTo: 'required-file';
-        value: number | RequiredFile;
+        value: string | RequiredFile;
       } | null)
     | ({
         relationTo: 'versions';
-        value: number | Version;
+        value: string | Version;
       } | null)
     | ({
         relationTo: 'custom-upload-field';
-        value: number | CustomUploadField;
+        value: string | CustomUploadField;
       } | null)
     | ({
         relationTo: 'media-with-relation-preview';
-        value: number | MediaWithRelationPreview;
+        value: string | MediaWithRelationPreview;
       } | null)
     | ({
         relationTo: 'media-without-cache-tags';
-        value: number | MediaWithoutCacheTag;
+        value: string | MediaWithoutCacheTag;
       } | null)
     | ({
         relationTo: 'media-without-relation-preview';
-        value: number | MediaWithoutRelationPreview;
+        value: string | MediaWithoutRelationPreview;
       } | null)
     | ({
         relationTo: 'relation-preview';
-        value: number | RelationPreview;
+        value: string | RelationPreview;
       } | null)
     | ({
         relationTo: 'hide-file-input-on-create';
-        value: number | HideFileInputOnCreate;
+        value: string | HideFileInputOnCreate;
       } | null)
     | ({
         relationTo: 'best-fit';
-        value: number | BestFit;
+        value: string | BestFit;
       } | null)
     | ({
         relationTo: 'list-view-preview';
-        value: number | ListViewPreview;
+        value: string | ListViewPreview;
       } | null)
     | ({
         relationTo: 'three-dimensional';
-        value: number | ThreeDimensional;
+        value: string | ThreeDimensional;
       } | null)
     | ({
         relationTo: 'constructor-options';
-        value: number | ConstructorOption;
+        value: string | ConstructorOption;
       } | null)
     | ({
         relationTo: 'bulk-uploads';
-        value: number | BulkUpload;
+        value: string | BulkUpload;
       } | null)
     | ({
         relationTo: 'simple-relationship';
-        value: number | SimpleRelationship;
+        value: string | SimpleRelationship;
       } | null)
     | ({
         relationTo: 'file-mime-type';
-        value: number | FileMimeType;
+        value: string | FileMimeType;
       } | null)
     | ({
         relationTo: 'svg-only';
-        value: number | SvgOnly;
+        value: string | SvgOnly;
       } | null)
     | ({
         relationTo: 'media-without-delete-access';
-        value: number | MediaWithoutDeleteAccess;
+        value: string | MediaWithoutDeleteAccess;
       } | null)
     | ({
         relationTo: 'media-with-image-size-admin-props';
-        value: number | MediaWithImageSizeAdminProp;
+        value: string | MediaWithImageSizeAdminProp;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -1997,10 +1997,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -2020,7 +2020,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -209,7 +209,7 @@ export interface AutosavePost {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -514,7 +514,7 @@ export interface Diff {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -529,7 +529,7 @@ export interface Diff {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];


### PR DESCRIPTION
This PR introduces a new `config.typescript.defaultIDType` property that allows overriding the ID type (string or number) defined by the database adapter.

In our monorepo, this helps address a recurring issue: previously, the generated types would switch between string and number depending on whether tests were run with Postgres or MongoDB. By explicitly setting defaultIDType, we can enforce consistency (e.g., always generating string IDs), reducing unnecessary diffs in payload-types.ts and avoiding noisy commits.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211456244666489