### PR TITLE
feat(plugin-multi-tenant): allow overriding filter options

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -319,11 +319,11 @@ export type FilterOptionsProps<TData = any> = {
   user: Partial<PayloadRequest['user']>
 }
 
-export type FilterOptionsFunc<TData = any> = (
+export type FilterOptionsFunction<TData = any> = (
   options: FilterOptionsProps<TData>,
 ) => boolean | Promise<boolean | Where> | Where
 
-export type FilterOptions<TData = any> = FilterOptionsFunc<TData> | null | Where
+export type FilterOptions<TData = any> = FilterOptionsFunction<TData> | null | Where
 
 type BlockSlugOrString = (({} & string) | BlockSlug)[]
 

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1464,6 +1464,7 @@ export type {
   FieldWithSubFields,
   FieldWithSubFieldsClient,
   FilterOptions,
+  FilterOptionsFunction,
   FilterOptionsProps,
   FlattenedArrayField,
   FlattenedBlock,

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -3,6 +3,7 @@ import type {
   ArrayField,
   CollectionSlug,
   Field,
+  FilterOptionsFunction,
   RelationshipField,
   SingleRelationshipField,
   TypedUser,
@@ -246,3 +247,29 @@ export type UserWithTenantsField = {
       }[]
     | null
 } & TypedUser
+
+declare module 'payload' {
+  export interface FieldCustom {
+    'plugin-multi-tenant'?: {
+      /**
+       * Function to override the filterOptions result for the relationship field.
+       * The original filterOptions / filterOptions injected by the multi-tenant plugin will still run,
+       * and the result will be passed as the first argument to this function.
+       *
+       * This allows you to combine your own filtering logic with the multi-tenant filtering logic.
+       *
+       * While passing your own `filterOptions` function to the field config will allow you to add stricter filter options
+       * in addition to the multi-tenant filtering, this property allows you to override the result of the multi-tenant filtering entirely
+       * for cases where you need to make it less strict.
+       *
+       * @param args.filterOptionsResult - The result of the original filterOptions function
+       * @param args.filterOptionsArgs - The arguments that were passed to the original filterOptions function
+       * ```ts
+       */
+      filterOptionsOverride?: (args: {
+        filterOptionsArgs: Parameters<FilterOptionsFunction>[0]
+        filterOptionsResult: Awaited<ReturnType<FilterOptionsFunction>>
+      }) => ReturnType<FilterOptionsFunction>
+    }
+  }
+}

--- a/test/plugin-multi-tenant/collections/Relationships.ts
+++ b/test/plugin-multi-tenant/collections/Relationships.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig } from 'payload'
+import type { CollectionConfig, Where } from 'payload'
 
 export const Relationships: CollectionConfig = {
   slug: 'relationships',
@@ -16,6 +16,27 @@ export const Relationships: CollectionConfig = {
       name: 'relationship',
       type: 'relationship',
       relationTo: 'relationships',
+      custom: {
+        'plugin-multi-tenant': {
+          filterOptionsOverride({ filterOptionsResult }) {
+            if (typeof filterOptionsResult === 'object' && filterOptionsResult !== null) {
+              // Wrap
+              const newResult: Where = {
+                or: [
+                  filterOptionsResult,
+                  {
+                    'tenant.isPublic': {
+                      equals: true,
+                    },
+                  },
+                ],
+              }
+              return newResult
+            }
+            return filterOptionsResult
+          },
+        },
+      },
     },
   ],
 }


### PR DESCRIPTION
By default, relationships fields where relationTo links to a multi-tenant enabled collection will automatically have filterOptions attached by the plugin. These ensure you can only link to documents within the same tenant.

In some cases, you may want to override these filterOptions to allow linking to documents from certain different tenant. 

My use-case:

We have a relationship field that links to documents from the `users` collection. By default, you can only select users from the same tenant as the parent document. However, I would also like to allow selecting admin users that have access to all tenants. To do that, I would do the following:

```ts
{
      name: 'author',
      type: 'relationship',
      relationTo: 'users',
      custom: {
        'plugin-multi-tenant': {
          filterOptionsOverride({ filterOptionsResult }) {
            if (typeof filterOptionsResult === 'object' && filterOptionsResult !== null) {
              return {
                or: [
                  filterOptionsResult,
                  {
                    'isAdmin': {
                      equals: true,
                    },
                  },
                ],
              }
            }
            return filterOptionsResult
          },
        },
      },
}
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211456244666497