### PR TITLE
fix: sanitize collection labels to inherit defaults when only a partial config is provided

### DIFF
--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -158,7 +158,12 @@ export const sanitizeCollection = async (
     }
   }
 
-  sanitized.labels = sanitized.labels || formatLabels(sanitized.slug)
+  const defaultLabels = formatLabels(sanitized.slug)
+
+  sanitized.labels = {
+    plural: sanitized.labels?.plural || defaultLabels.plural,
+    singular: sanitized.labels?.singular || defaultLabels.singular,
+  }
 
   if (sanitized.versions) {
     if (sanitized.versions === true) {

--- a/packages/payload/src/utilities/formatLabels.ts
+++ b/packages/payload/src/utilities/formatLabels.ts
@@ -22,6 +22,7 @@ const toWords = (inputString: string, joinWords = false): string => {
 
 const formatLabels = (slug: string): { plural: string; singular: string } => {
   const words = toWords(slug)
+
   return isPlural(slug)
     ? {
         plural: words,

--- a/test/config/config.ts
+++ b/test/config/config.ts
@@ -14,6 +14,10 @@ export default buildConfigWithDefaults({
   collections: [
     {
       slug: 'pages',
+      labels: {
+        // Purposefully exclude `singular` to test default inheritance
+        plural: 'Pages',
+      },
       access: {
         create: () => true,
         delete: () => true,

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -126,6 +126,11 @@ describe('Config', () => {
         description: 'The blockOne of this page',
       })
     })
+
+    it('properly merges collection.labels with defaults', () => {
+      const [collection] = payload.config.collections
+      expect(collection?.labels).toEqual({ plural: 'Pages', singular: 'Pages' })
+    })
   })
 
   describe('global config', () => {

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -129,7 +129,7 @@ describe('Config', () => {
 
     it('properly merges collection.labels with defaults', () => {
       const [collection] = payload.config.collections
-      expect(collection?.labels).toEqual({ plural: 'Pages', singular: 'Pages' })
+      expect(collection?.labels).toEqual({ plural: 'Pages', singular: 'Page' })
     })
   })
 


### PR DESCRIPTION
When only a partial `labels` config is defined on a collection, the collection defaults do not apply as expected. This leads to undefined `singular` or `plural` properties that render as either empty or untranslated strings on the front-end.

For example:

```ts
import type { CollectionConfig } from 'payload'

export MyCollection: CollectionConfig = {
  // ... 
  labels: {
    plural: 'Pages', // Notice that `singular` is excluded here
  },
}
```

This renders empty or untranslated strings throughout the admin panel, here are a couple examples:

<img width="326" height="211" alt="Screenshot 2025-09-26 at 10 27 40 AM" src="https://github.com/user-attachments/assets/3872c4dd-0dac-4c1c-b417-61ddd042bbb8" />

<img width="330" height="267" alt="Screenshot 2025-09-26 at 10 27 51 AM" src="https://github.com/user-attachments/assets/78772405-b5f3-45fa-9bf0-bc078f1ba976" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211478736160147