### PR TITLE
ci: add cron to activity notifications [skip ci]

### DIFF
--- a/.github/workflows/activity-notifications.yml
+++ b/.github/workflows/activity-notifications.yml
@@ -1,6 +1,8 @@
 name: activity-notifications
 
 on:
+  schedule:
+    - cron: '0 11 * * 1'
   workflow_dispatch:
     inputs:
       debug:


### PR DESCRIPTION
Set GitHub activity notifications to run on Monday mornings