### PR TITLE
fix(richtext-lexical): editor re-mounting on save due to json key order not being preserved in postgres

### DIFF
--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -1,6 +1,5 @@
 'use client'
 import type { EditorState, SerializedEditorState } from 'lexical'
-import type { Validate } from 'payload'
 
 import {
   FieldDescription,
@@ -13,6 +12,7 @@ import {
 } from '@payloadcms/ui'
 import { mergeFieldStyles } from '@payloadcms/ui/shared'
 import { dequal } from 'dequal/lite'
+import { type Validate } from 'payload'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
@@ -145,7 +145,10 @@ const RichTextComponent: React.FC<
       // In postgres, the order of keys in JSON objects is not guaranteed to be preserved,
       // so we need to do a deep equality check here that does not care about key order => we use dequal.
       // If we used JSON.stringify, the editor would re-mount every time you save the document, as the order of keys changes => change detected => re-mount.
-      if (prevValueRef.current !== value && !dequal(prevValueRef.current, value)) {
+      if (
+        prevValueRef.current !== value &&
+        !dequal(JSON.parse(JSON.stringify(prevValueRef.current)), value)
+      ) {
         prevInitialValueRef.current = initialValue
         prevValueRef.current = value
         setRerenderProviderKey(new Date())

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -12,6 +12,7 @@ import {
   useField,
 } from '@payloadcms/ui'
 import { mergeFieldStyles } from '@payloadcms/ui/shared'
+import { dequal } from 'dequal/lite'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
@@ -140,11 +141,11 @@ const RichTextComponent: React.FC<
   const handleInitialValueChange = useEffectEvent(
     (initialValue: SerializedEditorState | undefined) => {
       // Object deep equality check here, as re-mounting the editor if
-      // the new value is the same as the old one is not necessary
-      if (
-        prevValueRef.current !== value &&
-        JSON.stringify(prevValueRef.current) !== JSON.stringify(value)
-      ) {
+      // the new value is the same as the old one is not necessary.
+      // In postgres, the order of keys in JSON objects is not guaranteed to be preserved,
+      // so we need to do a deep equality check here that does not care about key order => we use dequal.
+      // If we used JSON.stringify, the editor would re-mount every time you save the document, as the order of keys changes => change detected => re-mount.
+      if (prevValueRef.current !== value && !dequal(prevValueRef.current, value)) {
         prevInitialValueRef.current = initialValue
         prevValueRef.current = value
         setRerenderProviderKey(new Date())


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13904

When using Postgres, saving a document can cause the editor to re-mount. If the document includes a blocks field, this leads to the editor incorrectly resetting its value to the previous state. The issue occurs because the editor is re-mounted without recalculating the initial Lexical state.

This re-mounting behavior is caused by how Postgres handles JSON storage:
- With `jsonb` columns, unlike `json` columns, object key order is not guaranteed.
- As a result, saving and reloading the Lexical editor state shifts key order, causing `JSON.stringify()` comparisons to fail.

## Solution

To fix this, we now compare the incoming and previous editor state in a way that ignores key order. Specifically, we switched from `JSON.stringify()` to `dequal` for deep equality checks.

## Notes

- This code only runs when external changes occur (e.g. after saving a document or when custom code modifies form fields).
- Because this check is infrequent, performance impact is negligible.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211488746010087