### PR TITLE
chore(eslint): update to typescript-eslint v8 recommendations

### DIFF
--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -190,7 +190,7 @@ export const rootEslintConfig = [
     // has 3 entries: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-eslint/src/configs/recommended-type-checked.ts
     ...deepMerge(
       baseExtends,
-      tseslint.configs.recommendedTypeChecked,
+      ...tseslint.configs.recommendedTypeChecked,
       eslintConfigPrettier,
       {
         plugins: {
@@ -208,7 +208,7 @@ export const rootEslintConfig = [
     name: 'TypeScript-React',
     ...deepMerge(
       baseExtends,
-      tseslint.configs.recommendedTypeChecked,
+      ...tseslint.configs.recommendedTypeChecked,
       reactExtends,
       eslintConfigPrettier,
       {

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -190,9 +190,7 @@ export const rootEslintConfig = [
     // has 3 entries: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-eslint/src/configs/recommended-type-checked.ts
     ...deepMerge(
       baseExtends,
-      tseslint.configs.recommendedTypeChecked[0],
-      tseslint.configs.recommendedTypeChecked[1],
-      tseslint.configs.recommendedTypeChecked[2],
+      tseslint.configs.recommendedTypeChecked,
       eslintConfigPrettier,
       {
         plugins: {
@@ -210,9 +208,7 @@ export const rootEslintConfig = [
     name: 'TypeScript-React',
     ...deepMerge(
       baseExtends,
-      tseslint.configs.recommendedTypeChecked[0],
-      tseslint.configs.recommendedTypeChecked[1],
-      tseslint.configs.recommendedTypeChecked[2],
+      tseslint.configs.recommendedTypeChecked,
       reactExtends,
       eslintConfigPrettier,
       {


### PR DESCRIPTION
- Replaced manual indexing of recommendedTypeChecked[0-2] with direct spread of recommendedTypeChecked.
- Ensured compatibility with the new flat config array shape introduced in @typescript-eslint v8.
- Simplified config merging for TypeScript and React rules.

## What?

This PR updates our ESLint configuration to align with the new recommendations from `@typescript-eslint` v8. It removes legacy array indexing and ensures future compatibility.

## Why?

- Reduces maintenance overhead by removing fragile [0], [1], [2] references.
- Aligns with upstream changes in typescript-eslint.
- Prevents errors related to internal subpath exports (use-at-your-own-risk).

## How?

- Updated ESLint config to spread tseslint.configs.recommendedTypeChecked directly.
- Verified compatibility across TypeScript and React rule sets.