### PR TITLE
fix(storage-r2): upload with the correct contentType

### DIFF
--- a/packages/storage-r2/src/handleUpload.ts
+++ b/packages/storage-r2/src/handleUpload.ts
@@ -15,7 +15,10 @@ export const getHandleUpload = ({ bucket, prefix = '' }: Args): HandleUpload => 
   return async ({ data, file }) => {
     // Read more: https://github.com/cloudflare/workers-sdk/issues/6047#issuecomment-2691217843
     const buffer = process.env.NODE_ENV === 'development' ? new Blob([file.buffer]) : file.buffer
-    await bucket.put(path.posix.join(prefix, file.filename), buffer)
+    await bucket.put(path.posix.join(prefix, file.filename), buffer, {
+      httpMetadata: { contentType: file.mimeType },
+    })
+
     return data
   }
 }

--- a/packages/storage-r2/src/types.ts
+++ b/packages/storage-r2/src/types.ts
@@ -14,6 +14,7 @@ export interface R2Bucket {
     key: string,
     value: ArrayBuffer | ArrayBufferView | Blob | null | ReadableStream | string,
     options?: {
+      httpMetadata?: any | Headers
       onlyIf: any
     } & any,
   ): Promise<any | null>


### PR DESCRIPTION
### What?
Use the correct Content-Type when uploading files to R2.

### Why?
While R2 can infer the Content-Type of most uploads, in some scenarios it will fail (e.g. when uploading an SVG image).

### How?
By passing the file's MIME type as the Content-Type header.

Bug report: https://discord.com/channels/967097582721572934/1422639568808841329/1422645245534797914
