### PR TITLE
fix(plugin-ecommerce): ensure `products` set to true by default

### DIFF
--- a/packages/plugin-ecommerce/src/utilities/sanitizePluginConfig.ts
+++ b/packages/plugin-ecommerce/src/utilities/sanitizePluginConfig.ts
@@ -76,6 +76,10 @@ export const sanitizePluginConfig = ({ pluginConfig }: Props): SanitizedEcommerc
     config.payments.paymentMethods = []
   }
 
+  if (typeof config.products === 'undefined') {
+    config.products = true
+  }
+
   if (config.products) {
     if (typeof config.products === 'object' && typeof config.products.variants === 'undefined') {
       config.products.variants = true


### PR DESCRIPTION
### What?

- default the sanitized ecommerce plugin config to set `products` to true when the option is omitted

### Why?

 - the runtime config left `products` undefined, conflicting with the documented default and requiring consumers to opt in manually, will throw error `t('plugin-ecommerce:product') has invalid relationship 'products'.` if not manually set it to true

### How?

- updated `src/utilities/sanitizePluginConfig.ts` to assign `config.products = true` before applying any variant overrides when the property is not provided
