### PR TITLE
fix(storage-uploadthing): hide key field from filters and columns

### DIFF
--- a/packages/storage-uploadthing/src/index.ts
+++ b/packages/storage-uploadthing/src/index.ts
@@ -145,6 +145,9 @@ function uploadthingInternal(options: UploadthingStorageOptions): Adapter {
       name: '_key',
       type: 'text',
       admin: {
+        disableBulkEdit: true,
+        disableListColumn: true,
+        disableListFilter: true,
         hidden: true,
       },
     },


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13992

Hides the key field from filters and columns for the uploadthing plugin.