### PR TITLE
fix(sdk): incorrect `fetch` initialization on cloudflare

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -130,7 +130,7 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
   fetch: typeof fetch
   constructor(args: Args) {
     this.baseURL = args.baseURL
-    this.fetch = args.fetch ?? globalThis.fetch
+    this.fetch = args.fetch ?? globalThis.fetch.bind(globalThis)
     this.baseInit = args.baseInit ?? {}
   }
 


### PR DESCRIPTION
Fixes
```
TypeError: Illegal invocation: function called with incorrect this reference.
```
error on Cloudflare - https://github.com/payloadcms/payload/pull/9463#discussion_r2230376819