### PR TITLE
chore(eslint): set reportUnusedDisableDirectives to error

### DIFF
--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -181,6 +181,9 @@ export const rootEslintConfig = [
       },
       parser: typescriptParser,
     },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
     plugins: {
       'import-x': importX,
     },

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -81,7 +81,7 @@
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:without_reactcompiler": "rm -rf dist && rm -rf tsconfig.tsbuildinfo && pnpm copyfiles && pnpm build:types && pnpm build:swc && pnpm build:cjs && pnpm build:esbuild",
-    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "clean": "rimraf -g {dist,*.tsbuildinfo,esbuild}",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -350,7 +350,7 @@
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:without_reactcompiler": "rm -rf dist && rm -rf tsconfig.tsbuildinfo && pnpm copyfiles && pnpm build:types && pnpm build:swc && pnpm build:esbuild && pnpm build:esbuild:postproces && rm -rf dist/exports/client && mv dist/exports/client_unoptimized dist/exports/client",
-    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "clean": "rimraf -g {dist,*.tsbuildinfo,esbuild}",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -129,7 +129,7 @@
     "build:swc": "swc ./src -d dist --config-file .swcrc --strip-leading-paths",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:without_reactcompiler": "rm -rf dist && rm -rf tsconfig.tsbuildinfo && pnpm copyfiles && pnpm build:types && pnpm build:swc",
-    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "clean": "rimraf -g {dist,*.tsbuildinfo,esbuild}",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/ui/src/providers/Preferences/index.tsx
+++ b/packages/ui/src/providers/Preferences/index.tsx
@@ -157,11 +157,8 @@ export const PreferencesProvider: React.FC<{ children?: React.ReactNode }> = ({ 
     [api, getPreference, i18n.language, pendingUpdate, serverURL],
   )
 
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
   contextRef.current.getPreference = getPreference
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
   contextRef.current.setPreference = setPreference
-  // eslint-disable-next-line react-compiler/react-compiler -- TODO: fix
   return <Context value={contextRef.current}>{children}</Context>
 }
 

--- a/packages/ui/src/providers/TableColumns/index.tsx
+++ b/packages/ui/src/providers/TableColumns/index.tsx
@@ -100,7 +100,6 @@ export const TableColumnsProvider: React.FC<TableColumnsProviderProps> = ({
         resetColumnsState,
         setActiveColumns,
         toggleColumn,
-        // eslint-disable-next-line react-compiler/react-compiler
         ...contextRef.current,
       }}
     >


### PR DESCRIPTION
Sets `reportUnusedDisableDirectives: 'error'` in our eslint config. This will error when `// eslint-disable-*` directives are unused. It will also auto-fix if possible.