### PR TITLE
fix(richtext-lexical): slash menu arrows keys not respected when block nearby

### DIFF
--- a/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
@@ -8,6 +8,7 @@ import {
   $getSelection,
   $isRangeSelection,
   $setSelection,
+  COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
   createCommand,
   KEY_ARROW_DOWN_COMMAND,
@@ -350,7 +351,7 @@ export function LexicalMenu({
           }
           return true
         },
-        COMMAND_PRIORITY_LOW,
+        COMMAND_PRIORITY_HIGH,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_UP_COMMAND,
@@ -376,7 +377,7 @@ export function LexicalMenu({
           }
           return true
         },
-        COMMAND_PRIORITY_LOW,
+        COMMAND_PRIORITY_HIGH,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ESCAPE_COMMAND,
@@ -408,7 +409,7 @@ export function LexicalMenu({
           selectItemAndCleanUp(selectedItem)
           return true
         },
-        COMMAND_PRIORITY_LOW,
+        COMMAND_PRIORITY_HIGH,
       ),
       editor.registerCommand(
         KEY_ENTER_COMMAND,
@@ -429,7 +430,7 @@ export function LexicalMenu({
           selectItemAndCleanUp(selectedItem)
           return true
         },
-        COMMAND_PRIORITY_LOW,
+        COMMAND_PRIORITY_HIGH,
       ),
     )
   }, [selectItemAndCleanUp, close, editor, groups, selectedItemKey, updateSelectedItem])

--- a/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
@@ -8,8 +8,8 @@ import {
   $getSelection,
   $isRangeSelection,
   $setSelection,
-  COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
+  COMMAND_PRIORITY_NORMAL,
   createCommand,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
@@ -351,7 +351,7 @@ export function LexicalMenu({
           }
           return true
         },
-        COMMAND_PRIORITY_HIGH,
+        COMMAND_PRIORITY_NORMAL,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_UP_COMMAND,
@@ -377,7 +377,7 @@ export function LexicalMenu({
           }
           return true
         },
-        COMMAND_PRIORITY_HIGH,
+        COMMAND_PRIORITY_NORMAL,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ESCAPE_COMMAND,
@@ -409,7 +409,7 @@ export function LexicalMenu({
           selectItemAndCleanUp(selectedItem)
           return true
         },
-        COMMAND_PRIORITY_HIGH,
+        COMMAND_PRIORITY_NORMAL,
       ),
       editor.registerCommand(
         KEY_ENTER_COMMAND,
@@ -430,7 +430,7 @@ export function LexicalMenu({
           selectItemAndCleanUp(selectedItem)
           return true
         },
-        COMMAND_PRIORITY_HIGH,
+        COMMAND_PRIORITY_NORMAL,
       ),
     )
   }, [selectItemAndCleanUp, close, editor, groups, selectedItemKey, updateSelectedItem])


### PR DESCRIPTION
This PR fixes an issue where the Decorator plugin intercepted arrow keys, preventing navigation while the slash menu was open. By increasing the command priority of the slash menu plugin, arrow keys now work correctly when the menu is active.

## Before

https://github.com/user-attachments/assets/0bffb174-6943-4ef5-9f4a-0d6ea87ce199

## After

https://github.com/user-attachments/assets/99323fb1-dfc7-4b52-8902-efbf7f83ba4d


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211524241290880