### PR TITLE
fix(ui): update memory user when autoLogin enabled

### DIFF
--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -59,6 +59,7 @@ export function AuthProvider({
 
   const {
     admin: {
+      autoLogin,
       autoRefresh,
       routes: { inactivity: logoutInactivityRoute },
       user: userSlug,
@@ -302,6 +303,12 @@ export function AuthProvider({
 
     void fetchUserOnMount()
   }, [])
+
+  useEffect(() => {
+    if (!user && autoLogin && !autoLogin.prefillOnly) {
+      void fetchFullUserEvent()
+    }
+  }, [user, autoLogin])
 
   useEffect(
     () => () => {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14005

When `autoLogin` is enabled, the Auth Provider's user in memory becomes stale. This change ensures the user in memory stays up to date if `autoLogin && !autoLogin.prefillOnly` is set.
