### PR TITLE
fix(ui): saving empty code editor throw error

### DIFF
--- a/packages/ui/src/elements/CodeEditor/CodeEditor.tsx
+++ b/packages/ui/src/elements/CodeEditor/CodeEditor.tsx
@@ -47,7 +47,11 @@ const CodeEditor: React.FC<Props> = (props) => {
 
   React.useEffect(() => {
     if (recalculatedHeightAt && recalculatedHeightAt > prevCalculatedHeightAt.current) {
-      setDynamicHeight(Math.max(MIN_HEIGHT, value.split('\n').length * 18 + 2 + paddingFromProps))
+      setDynamicHeight(
+        value
+          ? Math.max(MIN_HEIGHT, value.split('\n').length * 18 + 2 + paddingFromProps)
+          : MIN_HEIGHT,
+      )
       prevCalculatedHeightAt.current = recalculatedHeightAt
     }
   }, [value, MIN_HEIGHT, paddingFromProps, recalculatedHeightAt])
@@ -81,7 +85,11 @@ const CodeEditor: React.FC<Props> = (props) => {
       height={maxHeight ? Math.min(dynamicHeight, maxHeight) : dynamicHeight}
       onChange={(value, ev) => {
         rest.onChange?.(value, ev)
-        setDynamicHeight(Math.max(MIN_HEIGHT, value.split('\n').length * 18 + 2 + paddingFromProps))
+        setDynamicHeight(
+          value
+            ? Math.max(MIN_HEIGHT, value.split('\n').length * 18 + 2 + paddingFromProps)
+            : MIN_HEIGHT,
+        )
       }}
       onMount={(editor, monaco) => {
         rest.onMount?.(editor, monaco)


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14006

When attempting to save an empty code editor an error would throw because `value` was undefined.