### PR TITLE
fix(templates): correct typo in footer text

### DIFF
--- a/templates/ecommerce/src/components/Footer/index.tsx
+++ b/templates/ecommerce/src/components/Footer/index.tsx
@@ -57,7 +57,7 @@ export async function Footer() {
           <p>Designed in Michigan</p>
           <p className="md:ml-auto">
             <a className="text-black dark:text-white" href="https://payloadcms.com">
-              Crafted by Prayload
+              Crafted by Payload
             </a>
           </p>
         </div>


### PR DESCRIPTION
### What?
Fixed a typo in the ecommerce template footer component.  
Changed "Crafted by Prayload" → "Crafted by Payload" in `templates/ecommerce/src/components/Footer/index.tsx`.

### Why?
Ensures correct branding and improves professionalism of the template.

### How?
Updated the footer text string directly.

Before:
  Crafted by Prayload  
After:
  Crafted by Payload
