### PR TITLE
fix(richtext-lexical): field.admin overrides were ignored in RenderLexical helper

### DIFF
--- a/packages/richtext-lexical/src/field/RenderLexical/index.tsx
+++ b/packages/richtext-lexical/src/field/RenderLexical/index.tsx
@@ -53,7 +53,7 @@ export const RenderLexical: React.FC<
           type: 'richText',
           admin: {
             ...((field as RichTextField)?.admin || {}),
-
+            // When using "fake" anchor fields, hidden is often set to true. We need to override that here to ensure the field is rendered.
             hidden: false,
           },
         },

--- a/packages/richtext-lexical/src/field/RenderLexical/index.tsx
+++ b/packages/richtext-lexical/src/field/RenderLexical/index.tsx
@@ -52,7 +52,7 @@ export const RenderLexical: React.FC<
           ...((field as RichTextField) || {}),
           type: 'richText',
           admin: {
-            ...((field?.admin as RichTextField) || {}),
+            ...((field as RichTextField)?.admin || {}),
 
             hidden: false,
           },

--- a/packages/richtext-lexical/src/field/RenderLexical/index.tsx
+++ b/packages/richtext-lexical/src/field/RenderLexical/index.tsx
@@ -52,6 +52,8 @@ export const RenderLexical: React.FC<
           ...((field as RichTextField) || {}),
           type: 'richText',
           admin: {
+            ...((field?.admin as RichTextField) || {}),
+
             hidden: false,
           },
         },


### PR DESCRIPTION
We forgot to spread field.admin, thus you were not able to override this when using `RenderLexical`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211524241290888