### PR TITLE
feat(sdk): add logout helper and SDK method

### DIFF
--- a/packages/payload/src/auth/operations/logout.ts
+++ b/packages/payload/src/auth/operations/logout.ts
@@ -74,7 +74,7 @@ export const logoutOperation = async (incomingArgs: Arguments): Promise<boolean>
     }
 
     // Ensure updatedAt date is always updated
-    ;(userWithSessions as any).updatedAt = new Date().toISOString()
+    ; (userWithSessions as any).updatedAt = new Date().toISOString()
 
     await req.payload.db.updateOne({
       id: user.id,

--- a/packages/sdk/src/auth/logout.ts
+++ b/packages/sdk/src/auth/logout.ts
@@ -1,0 +1,36 @@
+import type { PayloadSDK } from '../index.js'
+import type {
+  AuthCollectionSlug,
+  PayloadGeneratedTypes,
+} from '../types.js'
+
+export type LogoutOptions<
+  T extends PayloadGeneratedTypes,
+  TSlug extends AuthCollectionSlug<T>
+> = {
+  collection: TSlug
+  allSessions?: boolean
+}
+
+export type LogoutResult = {
+  message: string
+}
+
+export async function logout<
+  T extends PayloadGeneratedTypes,
+  TSlug extends AuthCollectionSlug<T>
+>(
+  sdk: PayloadSDK<T>,
+  options: LogoutOptions<T, TSlug>,
+  init?: RequestInit,
+): Promise<LogoutResult> {
+  const url = `/${options.collection}/logout?allSessions=${options.allSessions ?? false}`
+
+  const response = await sdk.request({
+    init,
+    method: 'POST',
+    path: url,
+  })
+
+  return response.json()
+}

--- a/packages/sdk/src/auth/logout.ts
+++ b/packages/sdk/src/auth/logout.ts
@@ -13,7 +13,9 @@ export type LogoutOptions<
 }
 
 export type LogoutResult = {
+  headers: Headers
   message: string
+  status: number
 }
 
 export async function logout<
@@ -29,6 +31,10 @@ export async function logout<
     method: 'POST',
     path: `/${options.collection}/logout?allSessions=${options.allSessions ?? false}`,
   })
-
-  return response.json()
+  const data = await response.json()
+  return {
+    headers: response.headers,
+    message: data.message,
+    status: response.status,
+  }
 }

--- a/packages/sdk/src/auth/logout.ts
+++ b/packages/sdk/src/auth/logout.ts
@@ -8,8 +8,8 @@ export type LogoutOptions<
   T extends PayloadGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>
 > = {
-  collection: TSlug
   allSessions?: boolean
+  collection: TSlug
 }
 
 export type LogoutResult = {

--- a/packages/sdk/src/auth/logout.ts
+++ b/packages/sdk/src/auth/logout.ts
@@ -24,12 +24,10 @@ export async function logout<
   options: LogoutOptions<T, TSlug>,
   init?: RequestInit,
 ): Promise<LogoutResult> {
-  const url = `/${options.collection}/logout?allSessions=${options.allSessions ?? false}`
-
   const response = await sdk.request({
     init,
     method: 'POST',
-    path: url,
+    path: `/${options.collection}/logout?allSessions=${options.allSessions ?? false}`,
   })
 
   return response.json()

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -57,6 +57,7 @@ import { findGlobalVersions } from './globals/findVersions.js'
 import { restoreGlobalVersion } from './globals/restoreVersion.js'
 import { updateGlobal } from './globals/update.js'
 import { buildSearchParams } from './utilities/buildSearchParams.js'
+import { logout, LogoutOptions, LogoutResult } from './auth/logout.js'
 
 type Args = {
   /** Base passed `RequestInit` to `fetch`. For base headers / credentials include etc. */
@@ -371,4 +372,12 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
   ): Promise<{ message: string }> {
     return verifyEmail(this, options, init)
   }
+
+  logout<TSlug extends AuthCollectionSlug<T>>(
+    options: LogoutOptions<T, TSlug>,
+    init?: RequestInit,
+  ): Promise<LogoutResult> {
+    return logout(this, options, init)
+  }
+
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@ import type { ApplyDisableErrors, PaginatedDocs, SelectType, TypeWithVersion } f
 
 import type { ForgotPasswordOptions } from './auth/forgotPassword.js'
 import type { LoginOptions, LoginResult } from './auth/login.js'
+import type { LogoutOptions, LogoutResult } from './auth/logout.js';
 import type { MeOptions, MeResult } from './auth/me.js'
 import type { ResetPasswordOptions, ResetPasswordResult } from './auth/resetPassword.js'
 import type { CountOptions } from './collections/count.js'
@@ -33,6 +34,7 @@ import type { OperationArgs } from './utilities/buildSearchParams.js'
 
 import { forgotPassword } from './auth/forgotPassword.js'
 import { login } from './auth/login.js'
+import { logout } from './auth/logout.js'
 import { me } from './auth/me.js'
 import { type RefreshOptions, type RefreshResult, refreshToken } from './auth/refreshToken.js'
 import { resetPassword } from './auth/resetPassword.js'
@@ -57,7 +59,6 @@ import { findGlobalVersions } from './globals/findVersions.js'
 import { restoreGlobalVersion } from './globals/restoreVersion.js'
 import { updateGlobal } from './globals/update.js'
 import { buildSearchParams } from './utilities/buildSearchParams.js'
-import { logout, LogoutOptions, LogoutResult } from './auth/logout.js'
 
 type Args = {
   /** Base passed `RequestInit` to `fetch`. For base headers / credentials include etc. */
@@ -259,6 +260,13 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
     return login(this, options, init)
   }
 
+  logout<TSlug extends AuthCollectionSlug<T>>(
+    options: LogoutOptions<T, TSlug>,
+    init?: RequestInit,
+  ): Promise<LogoutResult> {
+    return logout(this, options, init)
+  }
+
   me<TSlug extends AuthCollectionSlug<T>>(
     options: MeOptions<T, TSlug>,
     init?: RequestInit,
@@ -364,13 +372,6 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
     init?: RequestInit,
   ): Promise<TransformGlobalWithSelect<T, TSlug, TSelect>> {
     return updateGlobal(this, options, init)
-  }
-
-  logout<TSlug extends AuthCollectionSlug<T>>(
-    options: LogoutOptions<T, TSlug>,
-    init?: RequestInit,
-  ): Promise<LogoutResult> {
-    return logout(this, options, init)
   }
 
   verifyEmail<TSlug extends AuthCollectionSlug<T>>(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -366,18 +366,18 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
     return updateGlobal(this, options, init)
   }
 
-  verifyEmail<TSlug extends AuthCollectionSlug<T>>(
-    options: VerifyEmailOptions<T, TSlug>,
-    init?: RequestInit,
-  ): Promise<{ message: string }> {
-    return verifyEmail(this, options, init)
-  }
-
   logout<TSlug extends AuthCollectionSlug<T>>(
     options: LogoutOptions<T, TSlug>,
     init?: RequestInit,
   ): Promise<LogoutResult> {
     return logout(this, options, init)
+  }
+
+  verifyEmail<TSlug extends AuthCollectionSlug<T>>(
+    options: VerifyEmailOptions<T, TSlug>,
+    init?: RequestInit,
+  ): Promise<{ message: string }> {
+    return verifyEmail(this, options, init)
   }
 
 }

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -306,4 +306,28 @@ describe('@payloadcms/sdk', () => {
 
     expect(email).toBe(user.email)
   })
+
+  it('should execute logout', async () => {
+    const loginRes = await sdk.login({
+      collection: 'users',
+      data: { email: testUserCredentials.email, password: testUserCredentials.password },
+    })
+
+    expect(loginRes.user.email).toBe(testUserCredentials.email)
+
+    const logoutRes = await sdk.logout({
+      collection: 'users',
+      allSessions: false,
+    })
+
+    expect(logoutRes.message).toBeDefined()
+
+    await expect(
+      sdk.request({
+        method: 'GET',
+        path: '/users/me',
+      }),
+    ).rejects.toThrow()
+  })
+
 })

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -24,7 +24,7 @@ const testUserCredentials = {
 
 describe('@payloadcms/sdk', () => {
   beforeAll(async () => {
-    ;({ payload, sdk } = await initPayloadInt(dirname))
+    ; ({ payload, sdk } = await initPayloadInt(dirname))
 
     post = await payload.create({ collection: 'posts', data: { number: 1, number2: 3 } })
     await payload.create({
@@ -320,14 +320,15 @@ describe('@payloadcms/sdk', () => {
       allSessions: false,
     })
 
-    expect(logoutRes.message).toBeDefined()
+    expect(logoutRes.headers).toBeDefined()
 
-    await expect(
-      sdk.request({
-        method: 'GET',
-        path: '/users/me',
-      }),
-    ).rejects.toThrow()
+    const { token } = await sdk.me({ collection: "users" },
+      { headers: logoutRes.headers },
+    )
+
+    expect(
+      token
+    ).toBeUndefined()
   })
 
 })


### PR DESCRIPTION
## What?

This PR introduces a new `logout` helper and corresponding SDK method for authentication collections.  
It mirrors the existing `login` helper, allowing developers to easily call the Payload logout endpoint with proper typing.

## Why?

Currently, the SDK provides a typed `login` method but lacks a counterpart for logging out.  
By adding this method, SDK users can:

- Log out from the current session
- Optionally log out from all sessions (`allSessions=true`)
- Rely on fully typed options and results, improving DX

## How?

- Added `LogoutOptions` and `LogoutResult` types
- Implemented `logout` helper function using `sdk.request`
- Extended the SDK class with `logout` method, mirroring the `login` method’s pattern

### Example usage

```ts
const result = await sdk.logout({
  collection: 'users',
  allSessions: false,
})

console.log(result.message)
// -> "You have been logged out"
