### PR TITLE
fix(ui): upload dropzone error when collectionConfig is undefined

### DIFF
--- a/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
+++ b/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
@@ -89,7 +89,7 @@ export function RelationshipContent(props: Props) {
   }
 
   const metaText = withMeta ? generateMetaText(mimeType, byteSize) : ''
-  const previewAllowed = displayPreview ?? collectionConfig.upload?.displayPreview ?? true
+  const previewAllowed = displayPreview ?? collectionConfig?.upload?.displayPreview ?? true
 
   return (
     <div className={[baseClass, className].filter(Boolean).join(' ')}>


### PR DESCRIPTION
### What?

Fixes a bug where dragging a file into an upload dropzone when the drawer is closed throws an error: "Cannot read properties of undefined".

### Why?

The `collectionConfig` variable can be undefined when the drawer is not opened, causing the code to fail when trying to access `collectionConfig.upload?.displayPreview`.

### How?

Added optional chaining (`?.`) to safely access `collectionConfig`, changing `collectionConfig.upload?.displayPreview` to `collectionConfig?.upload?.displayPreview`.

Fixes #13999 

