### PR TITLE
fix: add graphql dependency to missing templates

### DIFF
--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -25,7 +25,7 @@
     "@payloadcms/ui": "workspace:*",
     "cross-env": "^7.0.3",
     "dotenv": "16.4.7",
-    "graphql": "^16.8.1",
+    "graphql": "^16.11.0",
     "next": "15.4.4",
     "payload": "workspace:*",
     "react": "19.1.0",

--- a/templates/ecommerce/package.json
+++ b/templates/ecommerce/package.json
@@ -49,6 +49,7 @@
     "embla-carousel-auto-scroll": "^8.1.5",
     "embla-carousel-react": "^8.5.2",
     "geist": "^1.3.0",
+    "graphql": "^16.11.0",
     "jsonwebtoken": "9.0.1",
     "lucide-react": "^0.477.0",
     "next": "^15.5.4",

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -43,7 +43,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "16.4.7",
     "geist": "^1.3.0",
-    "graphql": "^16.8.2",
+    "graphql": "^16.11.0",
     "lucide-react": "^0.378.0",
     "next": "15.4.4",
     "next-sitemap": "^4.2.3",


### PR DESCRIPTION
### What? Why? How?
I cloned the ecommerce template and tried starting it. It would not start because the graphql peer dependency was missing. I've added it to that template's package.json. Since I'm here, I also bumped two other template's versions to keep them consistent. 

Now a fresh clone of the ecommerce template should start just fine.


