### PR TITLE
docs: update folders documentation with the right property

### DIFF
--- a/docs/folders/overview.mdx
+++ b/docs/folders/overview.mdx
@@ -83,7 +83,7 @@ const config = buildConfig({
 
 ## Collection Configuration
 
-To enable folders on a collection, you need to set the `admin.folders` property to `true` on the collection config. This will add a hidden relationship field to the collection that relates to a folder — or no folder.
+To enable folders on a collection, you need to set the `folders` property to `true` on the collection config. This will add a hidden relationship field to the collection that relates to a folder — or no folder.
 
 ```ts
 // Type definition


### PR DESCRIPTION
`admin.folders` does not exist, but `folders` do