### PR TITLE
fix(ui): invalid time value error when document locking with autosave enabled

### DIFF
--- a/packages/ui/src/elements/DocumentLocked/index.tsx
+++ b/packages/ui/src/elements/DocumentLocked/index.tsx
@@ -26,7 +26,7 @@ const formatDate = (date) => {
     minute: 'numeric',
     month: 'short',
     year: 'numeric',
-  }).format(date)
+  }).format(new Date(date))
 }
 
 export const DocumentLocked: React.FC<{

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -500,8 +500,6 @@ export function DefaultEditView({
 
   const isFolderCollection = config.folders && collectionSlug === config.folders?.slug
 
-  console.log('Last update time:', lastUpdateTime)
-
   return (
     <main
       className={[

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -225,9 +225,14 @@ export function DefaultEditView({
           }
           setCurrentEditor(lockedState.user as ClientUser)
         }
+
+        // Update lastUpdateTime when lock state changes
+        if (lockedState.lastEditedAt) {
+          setLastUpdateTime(new Date(lockedState.lastEditedAt).getTime())
+        }
       }
     },
-    [documentLockState, setCurrentEditor, setDocumentIsLocked, user?.id],
+    [documentLockState, setCurrentEditor, setDocumentIsLocked, setLastUpdateTime, user?.id],
   )
 
   const handlePrevent = useCallback((nextHref: null | string) => {
@@ -494,6 +499,8 @@ export function DefaultEditView({
     !isLockExpired
 
   const isFolderCollection = config.folders && collectionSlug === config.folders?.slug
+
+  console.log('Last update time:', lastUpdateTime)
 
   return (
     <main


### PR DESCRIPTION
### What?

Fixes "Invalid time value" error in the DocumentLocked modal when displaying the last edited timestamp.

### Why?

The `formatDate` function was passing a timestamp number directly to `Intl.DateTimeFormat().format()`, which expects a Date object. When `updatedAt` is a number (timestamp), this causes an "Invalid time value" error.

### How?

Wrap the date parameter with `new Date()` before passing it to `Intl.DateTimeFormat().format()` to properly convert the timestamp to a Date object.

Fixes #14016 
