### PR TITLE
fix(templates): don't use remote bindings in cloudflare when developing locally

### DIFF
--- a/templates/with-cloudflare-d1/next.config.ts
+++ b/templates/with-cloudflare-d1/next.config.ts
@@ -1,7 +1,4 @@
 import { withPayload } from '@payloadcms/next/withPayload'
-import { initOpenNextCloudflareForDev } from '@opennextjs/cloudflare'
-
-initOpenNextCloudflareForDev({ environment: process.env.CLOUDFLARE_ENV })
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/templates/with-cloudflare-d1/package.json
+++ b/templates/with-cloudflare-d1/package.json
@@ -56,7 +56,7 @@
     "typescript": "5.7.3",
     "vite-tsconfig-paths": "5.1.4",
     "vitest": "3.2.3",
-    "wrangler": "^4.26.1"
+    "wrangler": "~4.42.0"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
@@ -74,11 +74,6 @@
       "PAYLOAD_SECRET": {
         "description": "Generate a random string using `openssl rand -hex 32`"
       }
-    }
-  },
-  "overrides": {
-    "@payloadcms/db-d1-sqlite": {
-      "drizzle-kit": "0.30.6"
     }
   }
 }

--- a/templates/with-cloudflare-d1/wrangler.jsonc
+++ b/templates/with-cloudflare-d1/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "main": ".open-next/worker.js",
   "name": "my-app",
-  "compatibility_date": "2025-05-05",
+  "compatibility_date": "2025-08-15",
   "compatibility_flags": [
     // Enable Node.js API
     // see https://developers.cloudflare.com/workers/configuration/compatibility-flags/#nodejs-compatibility-flag
@@ -10,8 +10,6 @@
     // Allow to fetch URLs in your app
     // see https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public
     "global_fetch_strictly_public",
-    // Enable MessagePort, used by undici
-    "expose_global_message_channel",
   ],
   "assets": {
     "directory": ".open-next/assets",
@@ -45,7 +43,7 @@
   ],
 
   // Here's how to configure an additional environment
-  // It can be deployed with `CLOUDFLARE_ENV=staging npm run deploy`
+  // It can be deployed with `CLOUDFLARE_ENV=staging pnpm run deploy`
   // "env": {
   //   "staging": {
   //     "name": "my-app-staging",
@@ -54,7 +52,7 @@
   //         "binding": "D1",
   //         "database_id": "DATABASE_ID",
   //         "database_name": "my-app-staging",
-  //         "experimental_remote": true
+  //         "remote": true
   //       }
   //     ],
   //     "services": [


### PR DESCRIPTION
### What?
Fixes the remote binding behavior so that they're only used when deployed or when applying the database migrations.
I've also pinned the Wrangler version to prevent it breaking due to behavior changes in minor versions.
And I took the opportunity to update the compatibility date, to one that already includes the MessagePort by default.

### Why?
It turns out the remote binding behavior slightly changed since the beta until the final release.
As a result, when developing locally, wrangler would connect to the remote database, which is a big nono

### How?
By making sure the getCloudflareContext() method is not invoked outside of NODE_ENV === 'production', as the wrangler.jsonc has the "remote" flag as true for the D1 database and therefore will always point to the remote database.

Fixes #14041
