### PR TITLE
fix(templates): ignore wrangler when bundling to fix template styles

### DIFF
--- a/templates/with-cloudflare-d1/src/payload.config.ts
+++ b/templates/with-cloudflare-d1/src/payload.config.ts
@@ -46,10 +46,11 @@ export default buildConfig({
 
 // Adapted from https://github.com/opennextjs/opennextjs-cloudflare/blob/d00b3a13e42e65aad76fba41774815726422cc39/packages/cloudflare/src/api/cloudflare-context.ts#L328C36-L328C46
 function getCloudflareContextFromWrangler(): Promise<CloudflareContext> {
-  return import(`${'__wrangler'.replaceAll('_', '')}`).then(({ getPlatformProxy }) =>
-    getPlatformProxy({
-      environment: process.env.CLOUDFLARE_ENV,
-      experimental: { remoteBindings: cloudflareRemoteBindings },
-    } satisfies GetPlatformProxyOptions),
+  return import(/* webpackIgnore: true */ `${'__wrangler'.replaceAll('_', '')}`).then(
+    ({ getPlatformProxy }) =>
+      getPlatformProxy({
+        environment: process.env.CLOUDFLARE_ENV,
+        experimental: { remoteBindings: cloudflareRemoteBindings },
+      } satisfies GetPlatformProxyOptions),
   )
 }


### PR DESCRIPTION
### What?
Adds the missing `/* webpackIgnore: true */` annotation when importing wrangler, as in the original OpenNext patch.

### Why?
It looks like Webpack messes up the template styles when bundling the Cloudflare template, which causes some issues such as black text on black background or larger than usual font size.

### How?
By telling Webpack to ignore wrangler when bundling.

This solution was found by @nwong212 in the original issue, I'm just submitting the fix after checking my self that it indeed fixes the bundling.

Fixes #13989