### PR TITLE
perf(templates): added cloudflare cache headers for static files

### DIFF
--- a/templates/with-cloudflare-d1/public/_headers
+++ b/templates/with-cloudflare-d1/public/_headers
@@ -1,0 +1,2 @@
+/_next/static/*
+  Cache-Control: public,max-age=31536000,immutable


### PR DESCRIPTION
### What?
Adds Cache-Control headers for the static files generated by Next.js (e.g. .js files).
This follows a recommendation by the OpenNext team: https://opennext.js.org/cloudflare/caching#static-assets-caching

### Why?
To avoid avoiding unnecessary revalidation requests caused by Workers Static Assets' default headers.

### How?
By caching the static files for up to an year.