### PR TITLE
docs(db-mongodb): fix note on indexing localized fields

### DIFF
--- a/docs/database/indexes.mdx
+++ b/docs/database/indexes.mdx
@@ -67,18 +67,4 @@ export const MyCollection: CollectionConfig = {
 
 When you set `index: true` or `unique: true` on a localized field, MongoDB creates one index **per locale path** (e.g., `slug.en`, `slug.da-dk`, etc.). With many locales and indexed fields, this can quickly approach MongoDB's per-collection index limit.
 
-If you know you'll query specifically by a locale, index only those locale paths using the collection-level `indexes` option instead of setting `index: true` on the localized field. This approach gives you more control and helps avoid unnecessary indexes.
-
-```ts
-import type { CollectionConfig } from 'payload'
-
-export const Pages: CollectionConfig = {
-  fields: [{ name: 'slug', type: 'text', localized: true }],
-  indexes: [
-    // Index English slug only (rather than all locales)
-    { fields: ['slug.en'] },
-    // You could also make it unique:
-    // { fields: ['slug.en'], unique: true },
-  ],
-}
-```
+If you know you'll query specifically by a locale, you can insert a custom MongoDB index for the locale path manually or with a migration script.


### PR DESCRIPTION
It was explained in #14025 that defining indexes via collection-level `indexes` for locale paths is not actually supported.

This removes the recommendation and configuration example, and replaces them with workarounds provided in #14025.

Fixes: 379ef87d8457f49c5b5375f9802ef78e0fc91de0