### PR TITLE
fix: properly encode url for image sizes

### DIFF
--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -223,7 +223,11 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
                     const sizeFilename = data?.sizes?.[size.name]?.filename
 
                     if (sizeFilename) {
-                      return `${config.serverURL}${config.routes?.api}/${collection.slug}/file/${sizeFilename}`
+                      return generateURL({
+                        collectionSlug: collection.slug,
+                        config,
+                        filename: sizeFilename,
+                      })
                     }
 
                     return null


### PR DESCRIPTION
### What?

Properly encode the additional sizes for uploads. We found that when using images with multiple source, and if the uploaded image has spaces, the generated `<source>` do not properly encode the url, causing it to not working. Below is an example from our blog page https://magichour.ai/blog/top-10-ai-qr-code-generators

<img width="1764" height="564" alt="Screenshot 2025-10-04 at 1 30 39 PM" src="https://github.com/user-attachments/assets/bf9b1b83-d593-4f39-83e4-7f232b089d83" />


### Why?
so we are able to render the smaller size images for better web performance

### How?
updated to using the same `generateURL` as the original image. 

Related to #9698, which was fixed in #10048, but looks like that fix did to complete resolve the issue with source, since the source url generation did not use the `generateURL` function

