### PR TITLE
fix: add detection for --experimental-https flag

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1120,7 +1120,9 @@ export const getPayload = async (
     ) {
       try {
         const port = process.env.PORT || '3000'
-        const protocol = process.env.USE_HTTPS === 'true' ? 'wss' : 'ws'
+        const hasHTTPS =
+          process.env.USE_HTTPS === 'true' || process.argv.includes('--experimental-https')
+        const protocol = hasHTTPS ? 'wss' : 'ws'
 
         const path = '/_next/webpack-hmr'
         // The __NEXT_ASSET_PREFIX env variable is set for both assetPrefix and basePath (tested in Next.js 15.1.6)


### PR DESCRIPTION
Follow up from https://github.com/payloadcms/payload/pull/14053

Add detection for `--experimental-https` flag based on `process.argv` which may not be reliable so we're keeping the env var toggle in as well