### PR TITLE
feat(plugin-nested-docs): pass collection config as an arg to generateURL and generateLabel

### DIFF
--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -129,10 +129,11 @@ nestedDocsPlugin({
 
 The function takes two arguments and returns a string:
 
-| Argument | Type     | Description                                  |
-| -------- | -------- | -------------------------------------------- |
-| `docs`   | `Array`  | An array of the breadcrumbs up to that point |
-| `doc`    | `Object` | The current document being edited            |
+| Argument     | Type     | Description                                   |
+| ------------ | -------- | --------------------------------------------- |
+| `docs`       | `Array`  | An array of the breadcrumbs up to that point  |
+| `doc`        | `Object` | The current document being edited             |
+| `collection` | `Object` | The collection config of the current document |
 
 #### `generateURL`
 
@@ -148,10 +149,11 @@ nestedDocsPlugin({
 })
 ```
 
-| Argument | Type     | Description                                  |
-| -------- | -------- | -------------------------------------------- |
-| `docs`   | `Array`  | An array of the breadcrumbs up to that point |
-| `doc`    | `Object` | The current document being edited            |
+| Argument     | Type     | Description                                   |
+| ------------ | -------- | --------------------------------------------- |
+| `docs`       | `Array`  | An array of the breadcrumbs up to that point  |
+| `doc`        | `Object` | The current document being edited             |
+| `collection` | `Object` | The collection config of the current document |
 
 #### `parentFieldSlug`
 

--- a/packages/plugin-nested-docs/src/types.ts
+++ b/packages/plugin-nested-docs/src/types.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug } from 'payload'
+import type { CollectionSlug, SanitizedCollectionConfig } from 'payload'
 
 export type Breadcrumb = {
   doc: string
@@ -9,11 +9,13 @@ export type Breadcrumb = {
 export type GenerateURL = (
   docs: Array<Record<string, unknown>>,
   currentDoc: Record<string, unknown>,
+  collection: SanitizedCollectionConfig,
 ) => string
 
 export type GenerateLabel = (
   docs: Array<Record<string, unknown>>,
   currentDoc: Record<string, unknown>,
+  collection: SanitizedCollectionConfig,
 ) => string
 
 export type NestedDocsPluginConfig = {

--- a/packages/plugin-nested-docs/src/utilities/formatBreadcrumb.ts
+++ b/packages/plugin-nested-docs/src/utilities/formatBreadcrumb.ts
@@ -27,11 +27,11 @@ export const formatBreadcrumb = ({
   const lastDoc = docs[docs.length - 1]!
 
   if (typeof generateURL === 'function') {
-    url = generateURL(docs, lastDoc)
+    url = generateURL(docs, lastDoc, collection)
   }
 
   if (typeof generateLabel === 'function') {
-    label = generateLabel(docs, lastDoc)
+    label = generateLabel(docs, lastDoc, collection)
   } else {
     const title = collection.admin?.useAsTitle ? lastDoc[collection.admin.useAsTitle] : ''
 


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/10378

We now pass `collection` containing the current collection's config into the `generateURL` and `generateLabel` as a third parameter.

In the future we should change this into an object so we can more easily insert new params.