### PR TITLE
feat(ui): add collection admin config for custom debounce timeout for form updates

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -145,6 +145,7 @@ The following options are available:
 | `enableListViewSelectAPI`    | Performance opt-in. When `true`, uses the Select API in the List View to query only the active columns as opposed to entire documents. [More details](#enable-list-view-select-api).                                         |
 | `pagination`                 | Set pagination-specific options for this Collection in the List View. [More details](#pagination).                                                                                                                           |
 | `baseFilter`                 | Defines a default base filter which will be applied to the List View (along with any other filters applied by the user) and internal links in Lexical Editor,                                                                |
+| `formUpdateDebounceTimeout`  | Performance opt-in. Set custom debounce timeout (ms) for form updates to be sent to server. Defaults to 250ms.                                                                                                               |
 
 <Banner type="warning">
   **Note:** If you set `useAsTitle` to a relationship or join field, it will use

--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -44,6 +44,7 @@ export type ServerOnlyUploadProperties = keyof Pick<
 export type ClientCollectionConfig = {
   admin: {
     description?: StaticDescription
+    formUpdateDebounceTimeout?: number
     livePreview?: Omit<LivePreviewConfig, ServerOnlyLivePreviewProperties>
     preview?: boolean
   } & Omit<
@@ -149,6 +150,14 @@ export const createClientCollectionConfig = ({
                   clientCollection.admin.description = description
                 }
               }
+              break
+
+            case 'formUpdateDebounceTimeout':
+              if (collection.admin.formUpdateDebounceTimeout) {
+                clientCollection.admin.formUpdateDebounceTimeout =
+                  collection.admin.formUpdateDebounceTimeout
+              }
+
               break
 
             case 'livePreview':

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -418,6 +418,10 @@ export type CollectionAdminOptions = {
     viewType?: ViewTypes
   }) => null | string
   /**
+   * Custom debounce timeout for sending form updates to server
+   */
+  formUpdateDebounceTimeout?: number
+  /**
    * Specify a navigational group for collections in the admin sidebar.
    * - Provide a string to place the entity in a custom group.
    * - Provide a record to define localized group names.

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -799,7 +799,7 @@ export const Form: React.FC<FormProps> = (props) => {
       isFirstRenderRef.current = false
     },
     [modified, submitted, formState],
-    250,
+    docConfig.admin?.formUpdateDebounceTimeout || 250,
   )
 
   const DocumentFormContextComponent: React.FC<any> = isDocumentForm


### PR DESCRIPTION
### What and Why?
Every form field change causes a (debounced) request to the server containing the form state, and the returned server state is then reconciled on the client, causing client side re-rendering. 
At AMBOSS, some of our collections are large and contain multiple `text` and `richText` fields. We do not have autoSave enabled and don't have a lot of conditional UI. We'd like to tweak the debounce timeout of these form updates for two reasons.
1. The request size can be very large that puts sufficient load on our Next.js server degrading its performance and thus slowly down the application. 
2. Frequent client reconciliation makes the UI laggy and unresponsive.

### How?
Add a collection admin config to provide a custom debounce timeout for form updates. For example,

```ts
export const PostsCollection: CollectionConfig = {
  slug: postsSlug,
  admin: {
    useAsTitle: 'title',
    enableListViewSelectAPI: true,
    formUpdateDebounceTimeout: 500
  },
 ...
```