### PR TITLE
docs: incorrect pg driver injection example in Sentry integration docs

### DIFF
--- a/docs/plugins/sentry.mdx
+++ b/docs/plugins/sentry.mdx
@@ -94,8 +94,9 @@ import pg from 'pg'
 export default buildConfig({
   db: postgresAdapter({
     pool: { connectionString: process.env.DATABASE_URL },
-    pg, // Inject the patched pg driver for Sentry instrumentation
-  }),
+  },
+  pg, // Inject the patched pg driver for Sentry instrumentation
+  ),
   plugins: [sentryPlugin({ Sentry })],
 })
 ```


### PR DESCRIPTION
This change fixes an error in the Sentry documentation where the patched pg driver for Sentry instrumentation was shown being injected inside the pool object instead of the db object.

The correct placement is to pass pg as a separate argument to postgresAdapter, not nested inside the pool configuration.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
