### PR TITLE
feat: support any depth for relationships in `findDistinct`

### DIFF
--- a/packages/db-mongodb/src/findDistinct.ts
+++ b/packages/db-mongodb/src/findDistinct.ts
@@ -93,9 +93,8 @@ export const findDistinct: FindDistinct = async function (this: MongooseAdapter,
         if ('$lookup' in each && each.$lookup.as.replace(/^_+/, '') === tempPath) {
           return false
         }
-        {
-          return true
-        }
+
+        return true
       })
       currentFields = this.payload.collections[field.relationTo]?.config
         .flattenedFields as FlattenedField[]

--- a/packages/db-mongodb/src/findDistinct.ts
+++ b/packages/db-mongodb/src/findDistinct.ts
@@ -41,7 +41,9 @@ export const findDistinct: FindDistinct = async function (this: MongooseAdapter,
   })
 
   const fieldPathResult = getFieldByPath({
+    config: this.payload.config,
     fields: collectionConfig.flattenedFields,
+    includeRelationships: true,
     path: args.field,
   })
   let fieldPath = args.field

--- a/packages/drizzle/src/findDistinct.ts
+++ b/packages/drizzle/src/findDistinct.ts
@@ -64,7 +64,9 @@ export const findDistinct: FindDistinct = async function (this: DrizzleAdapter, 
   })
 
   const field = getFieldByPath({
+    config: this.payload.config,
     fields: collectionConfig.flattenedFields,
+    includeRelationships: true,
     path: args.field,
   })?.field
 

--- a/packages/payload/src/collections/operations/findDistinct.ts
+++ b/packages/payload/src/collections/operations/findDistinct.ts
@@ -118,7 +118,9 @@ export const findDistinctOperation = async (
     })
 
     const fieldResult = getFieldByPath({
+      config: payload.config,
       fields: collectionConfig.flattenedFields,
+      includeRelationships: true,
       path: args.field,
     })
 

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -55,6 +55,11 @@ export const getConfig: () => Partial<Config> = () => ({
           name: 'title',
         },
         {
+          name: 'simple',
+          type: 'relationship',
+          relationTo: 'simple',
+        },
+        {
           type: 'tabs',
           tabs: [
             {

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -137,6 +137,11 @@ export const getConfig: () => Partial<Config> = () => ({
           virtual: 'category.title',
         },
         {
+          type: 'text',
+          name: 'categorySimpleText',
+          virtual: 'category.simple.text',
+        },
+        {
           type: 'relationship',
           relationTo: 'categories',
           hasMany: true,

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1190,6 +1190,60 @@ describe('database', () => {
     ])
   })
 
+  it('should find distinct values with virtual field linked to a 2x relationship', async () => {
+    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'simple', where: {} })
+
+    const simple_1 = await payload.create({ collection: 'simple', data: { text: 'simple_1' } })
+    const simple_2 = await payload.create({ collection: 'simple', data: { text: 'simple_2' } })
+    const simple_3 = await payload.create({ collection: 'simple', data: { text: 'simple_3' } })
+
+    const category_1 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_1', simple: simple_1 },
+    })
+    const category_2 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_2', simple: simple_2 },
+    })
+    const category_3 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_3', simple: simple_3 },
+    })
+    const category_4 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_4', simple: simple_3 },
+    })
+
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_1 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_2 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_2 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_2 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_4 } })
+
+    const res = await payload.findDistinct({
+      collection: 'posts',
+      field: 'category.simple.text',
+    })
+
+    expect(res.values).toEqual([
+      {
+        'category.simple.text': 'simple_1',
+      },
+      {
+        'category.simple.text': 'simple_2',
+      },
+      {
+        'category.simple.text': 'simple_3',
+      },
+    ])
+  })
+
   describe('Compound Indexes', () => {
     beforeEach(async () => {
       await payload.delete({ collection: 'compound-indexes', where: {} })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1190,7 +1190,7 @@ describe('database', () => {
     ])
   })
 
-  it('should find distinct values with virtual field linked to a 2x relationship', async () => {
+  it('should find distinct values with field nested to a 2x relationship', async () => {
     await payload.delete({ collection: 'posts', where: {} })
     await payload.delete({ collection: 'categories', where: {} })
     await payload.delete({ collection: 'simple', where: {} })
@@ -1240,6 +1240,60 @@ describe('database', () => {
       },
       {
         'category.simple.text': 'simple_3',
+      },
+    ])
+  })
+
+  it('should find distinct values with virtual field linked to a 2x relationship', async () => {
+    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'simple', where: {} })
+
+    const simple_1 = await payload.create({ collection: 'simple', data: { text: 'simple_1' } })
+    const simple_2 = await payload.create({ collection: 'simple', data: { text: 'simple_2' } })
+    const simple_3 = await payload.create({ collection: 'simple', data: { text: 'simple_3' } })
+
+    const category_1 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_1', simple: simple_1 },
+    })
+    const category_2 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_2', simple: simple_2 },
+    })
+    const category_3 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_3', simple: simple_3 },
+    })
+    const category_4 = await payload.create({
+      collection: 'categories',
+      data: { title: 'category_4', simple: simple_3 },
+    })
+
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_1 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_2 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_2 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_2 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_3 } })
+    await payload.create({ collection: 'posts', data: { title: 'post', category: category_4 } })
+
+    const res = await payload.findDistinct({
+      collection: 'posts',
+      field: 'categorySimpleText',
+    })
+
+    expect(res.values).toEqual([
+      {
+        categorySimpleText: 'simple_1',
+      },
+      {
+        categorySimpleText: 'simple_2',
+      },
+      {
+        categorySimpleText: 'simple_3',
       },
     ])
   })

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -210,6 +210,7 @@ export interface Post {
   title: string;
   category?: (string | null) | Category;
   categoryTitle?: string | null;
+  categorySimpleText?: string | null;
   categories?: (string | Category)[] | null;
   categoryPoly?: {
     relationTo: 'categories';
@@ -881,6 +882,7 @@ export interface PostsSelect<T extends boolean = true> {
   title?: T;
   category?: T;
   categoryTitle?: T;
+  categorySimpleText?: T;
   categories?: T;
   categoryPoly?: T;
   categoryPolyMany?: T;

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -180,6 +180,7 @@ export interface NoTimeStamp {
 export interface Category {
   id: string;
   title?: string | null;
+  simple?: (string | null) | Simple;
   hideout?: {
     camera1?: {
       time1Image?: (string | null) | Post;
@@ -188,6 +189,17 @@ export interface Category {
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "simple".
+ */
+export interface Simple {
+  id: string;
+  text?: string | null;
+  number?: number | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -317,17 +329,6 @@ export interface CategoriesCustomId {
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "simple".
- */
-export interface Simple {
-  id: string;
-  text?: string | null;
-  number?: number | null;
-  updatedAt: string;
-  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -838,6 +839,7 @@ export interface NoTimeStampsSelect<T extends boolean = true> {
  */
 export interface CategoriesSelect<T extends boolean = true> {
   title?: T;
+  simple?: T;
   hideout?:
     | T
     | {


### PR DESCRIPTION
Follow up to https://github.com/payloadcms/payload/pull/14026

```ts
// Supported before
const relationResult = await payload.findDistinct({ collection: 'posts', field: 'relation1.title' })
// Supported now
const relationResult = await payload.findDistinct({ collection: 'posts', field: 'relation1.relation2.title' })
const relationResult = await payload.findDistinct({ collection: 'posts', field: 'relation1.relation2.relation3.title' })
```