### PR TITLE
fix(richtext-lexical): improve type autocomplete and assignability for lexical nodes

### DIFF
--- a/docs/rich-text/rendering-on-demand.mdx
+++ b/docs/rich-text/rendering-on-demand.mdx
@@ -37,7 +37,9 @@ export const Component: JSONFieldClientComponent = (args) => {
       field={{
         name: 'myFieldName' /* Make sure this matches the field name present in your form */,
       }}
-      initialValue={buildEditorState({ text: 'default value' })}
+      initialValue={buildEditorState<DefaultNodeTypes>({
+        text: 'default value',
+      })}
       schemaPath={`collection.${lexicalFullyFeaturedSlug}.richText`}
     />
   )
@@ -63,18 +65,20 @@ import { lexicalFullyFeaturedSlug } from '../../slugs.js'
 export const Component: JSONFieldClientComponent = (args) => {
   // Manually manage the editor state
   const [value, setValue] = useState<DefaultTypedEditorState | undefined>(() =>
-    buildEditorState({ text: 'state default' }),
+    buildEditorState<DefaultNodeTypes>({ text: 'state default' }),
   )
 
   const handleReset = React.useCallback(() => {
-    setValue(buildEditorState({ text: 'state default' }))
+    setValue(buildEditorState<DefaultNodeTypes>({ text: 'state default' }))
   }, [])
 
   return (
     <div>
       <RenderLexical
         field={{ name: 'myField' }}
-        initialValue={buildEditorState({ text: 'default value' })}
+        initialValue={buildEditorState<DefaultNodeTypes>({
+          text: 'default value',
+        })}
         schemaPath={`collection.${lexicalFullyFeaturedSlug}.richText`}
         setValue={setValue as any}
         value={value}

--- a/packages/richtext-lexical/src/exports/client/index.ts
+++ b/packages/richtext-lexical/src/exports/client/index.ts
@@ -155,4 +155,4 @@ export { CodeComponent } from '../../features/blocks/premade/CodeBlock/Component
 export { CodeBlockBlockComponent } from '../../features/blocks/premade/CodeBlock/Component/Block.js'
 
 export { RenderLexical } from '../../field/RenderLexical/index.js'
-export { buildEditorState } from '../../utilities/buildEditorState.js'
+export { buildDefaultEditorState, buildEditorState } from '../../utilities/buildEditorState.js'

--- a/packages/richtext-lexical/src/features/blockquote/server/index.ts
+++ b/packages/richtext-lexical/src/features/blockquote/server/index.ts
@@ -1,7 +1,9 @@
 import type { SerializedQuoteNode as _SerializedQuoteNode } from '@lexical/rich-text'
-import type { Spread } from 'lexical'
+import type { SerializedLexicalNode } from 'lexical'
 
 import { QuoteNode } from '@lexical/rich-text'
+
+import type { StronglyTypedNode } from '../../../nodeTypes.js'
 
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/lexicalToHtml_deprecated/converter/index.js'
@@ -9,12 +11,8 @@ import { createNode } from '../../typeUtilities.js'
 import { MarkdownTransformer } from '../markdownTransformer.js'
 import { i18n } from './i18n.js'
 
-export type SerializedQuoteNode = Spread<
-  {
-    type: 'quote'
-  },
-  _SerializedQuoteNode
->
+export type SerializedQuoteNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
+  StronglyTypedNode<_SerializedQuoteNode, 'quote', T>
 
 export const BlockquoteFeature = createServerFeature({
   feature: {

--- a/packages/richtext-lexical/src/features/blockquote/server/index.ts
+++ b/packages/richtext-lexical/src/features/blockquote/server/index.ts
@@ -3,7 +3,7 @@ import type { SerializedLexicalNode } from 'lexical'
 
 import { QuoteNode } from '@lexical/rich-text'
 
-import type { StronglyTypedNode } from '../../../nodeTypes.js'
+import type { StronglyTypedElementNode } from '../../../nodeTypes.js'
 
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/lexicalToHtml_deprecated/converter/index.js'
@@ -12,7 +12,7 @@ import { MarkdownTransformer } from '../markdownTransformer.js'
 import { i18n } from './i18n.js'
 
 export type SerializedQuoteNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
-  StronglyTypedNode<_SerializedQuoteNode, 'quote', T>
+  StronglyTypedElementNode<_SerializedQuoteNode, 'quote', T>
 
 export const BlockquoteFeature = createServerFeature({
   feature: {

--- a/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/index.ts
+++ b/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/index.ts
@@ -8,7 +8,12 @@ import { codeConverter } from './converter.js'
 /**
  * @experimental - this API may change in future, minor releases
  */
-export const CodeBlock: (args?: AdditionalCodeComponentProps) => Block = (args) => {
+export const CodeBlock: (
+  args?: {
+    fieldOverrides?: Partial<Block>
+  } & AdditionalCodeComponentProps,
+) => Block = (_args) => {
+  const { fieldOverrides, ...args } = _args || {}
   const languages = args?.languages || defaultLanguages
 
   return {
@@ -54,5 +59,6 @@ export const CodeBlock: (args?: AdditionalCodeComponentProps) => Block = (args) 
       },
     ],
     jsx: codeConverter,
+    ...(fieldOverrides || {}),
   }
 }

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
@@ -7,13 +7,14 @@ import type {
   LexicalEditor,
   LexicalNode,
   NodeKey,
-  Spread,
 } from 'lexical'
 import type { JsonObject } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
 import ObjectID from 'bson-objectid'
+
+import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
 
 type BaseBlockFields<TBlockFields extends JsonObject = JsonObject> = {
   /** Block form data */
@@ -29,16 +30,9 @@ export type BlockFieldsOptionalID<TBlockFields extends JsonObject = JsonObject> 
   id?: string
 } & BaseBlockFields<TBlockFields>
 
-export type SerializedBlockNode<TBlockFields extends JsonObject = JsonObject> = Omit<
-  Spread<
-    {
-      fields: BlockFields<TBlockFields>
-      type: 'block'
-    },
-    Omit<SerializedDecoratorBlockNode, 'type'>
-  >,
-  'children'
->
+export type SerializedBlockNode<TBlockFields extends JsonObject = JsonObject> = {
+  fields: BlockFields<TBlockFields>
+} & StronglyTypedLeafNode<SerializedDecoratorBlockNode, 'block'>
 
 export class ServerBlockNode extends DecoratorBlockNode {
   __cacheBuster: number

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
@@ -29,13 +29,15 @@ export type BlockFieldsOptionalID<TBlockFields extends JsonObject = JsonObject> 
   id?: string
 } & BaseBlockFields<TBlockFields>
 
-export type SerializedBlockNode<TBlockFields extends JsonObject = JsonObject> = Spread<
-  {
-    children?: never // required so that our typed editor state doesn't automatically add children
-    fields: BlockFields<TBlockFields>
-    type: 'block'
-  },
-  SerializedDecoratorBlockNode
+export type SerializedBlockNode<TBlockFields extends JsonObject = JsonObject> = Omit<
+  Spread<
+    {
+      fields: BlockFields<TBlockFields>
+      type: 'block'
+    },
+    Omit<SerializedDecoratorBlockNode, 'type'>
+  >,
+  'children'
 >
 
 export class ServerBlockNode extends DecoratorBlockNode {

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
@@ -6,7 +6,6 @@ import type {
   LexicalNode,
   NodeKey,
   SerializedLexicalNode,
-  Spread,
 } from 'lexical'
 import type { JsonObject } from 'payload'
 import type React from 'react'
@@ -15,21 +14,16 @@ import type { JSX } from 'react'
 import ObjectID from 'bson-objectid'
 import { DecoratorNode } from 'lexical'
 
+import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
+
 export type InlineBlockFields<TInlineBlockFields extends JsonObject = JsonObject> = {
   blockType: string
   id: string
 } & TInlineBlockFields
 
-export type SerializedInlineBlockNode<TBlockFields extends JsonObject = JsonObject> = Omit<
-  Spread<
-    {
-      fields: InlineBlockFields<TBlockFields>
-      type: 'inlineBlock'
-    },
-    Omit<SerializedLexicalNode, 'type'>
-  >,
-  'children'
->
+export type SerializedInlineBlockNode<TBlockFields extends JsonObject = JsonObject> = {
+  fields: InlineBlockFields<TBlockFields>
+} & StronglyTypedLeafNode<SerializedLexicalNode, 'inlineBlock'>
 
 export class ServerInlineBlockNode extends DecoratorNode<null | React.ReactElement> {
   __cacheBuster: number

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
@@ -20,13 +20,15 @@ export type InlineBlockFields<TInlineBlockFields extends JsonObject = JsonObject
   id: string
 } & TInlineBlockFields
 
-export type SerializedInlineBlockNode<TBlockFields extends JsonObject = JsonObject> = Spread<
-  {
-    children?: never // required so that our typed editor state doesn't automatically add children
-    fields: InlineBlockFields<TBlockFields>
-    type: 'inlineBlock'
-  },
-  SerializedLexicalNode
+export type SerializedInlineBlockNode<TBlockFields extends JsonObject = JsonObject> = Omit<
+  Spread<
+    {
+      fields: InlineBlockFields<TBlockFields>
+      type: 'inlineBlock'
+    },
+    Omit<SerializedLexicalNode, 'type'>
+  >,
+  'children'
 >
 
 export class ServerInlineBlockNode extends DecoratorNode<null | React.ReactElement> {

--- a/packages/richtext-lexical/src/features/experimental_table/server/index.ts
+++ b/packages/richtext-lexical/src/features/experimental_table/server/index.ts
@@ -3,11 +3,13 @@ import type {
   SerializedTableNode as _SerializedTableNode,
   SerializedTableRowNode as _SerializedTableRowNode,
 } from '@lexical/table'
-import type { Spread } from 'lexical'
+import type { SerializedLexicalNode } from 'lexical'
 import type { Config, Field, FieldSchemaMap } from 'payload'
 
 import { TableCellNode, TableNode, TableRowNode } from '@lexical/table'
 import { sanitizeFields } from 'payload'
+
+import type { StronglyTypedNode } from '../../../nodeTypes.js'
 
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/lexicalToHtml_deprecated/converter/index.js'
@@ -29,26 +31,14 @@ const fields: Field[] = [
   },
 ]
 
-export type SerializedTableCellNode = Spread<
-  {
-    type: 'tablecell'
-  },
-  _SerializedTableCellNode
->
+export type SerializedTableCellNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
+  StronglyTypedNode<_SerializedTableCellNode, 'tablecell', T>
 
-export type SerializedTableNode = Spread<
-  {
-    type: 'table'
-  },
-  _SerializedTableNode
->
+export type SerializedTableNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
+  StronglyTypedNode<_SerializedTableNode, 'table', T>
 
-export type SerializedTableRowNode = Spread<
-  {
-    type: 'tablerow'
-  },
-  _SerializedTableRowNode
->
+export type SerializedTableRowNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
+  StronglyTypedNode<_SerializedTableRowNode, 'tablerow', T>
 export const EXPERIMENTAL_TableFeature = createServerFeature({
   feature: async ({ config, isRoot, parentIsLocalized }) => {
     const validRelationships = config.collections.map((c) => c.slug) || []

--- a/packages/richtext-lexical/src/features/experimental_table/server/index.ts
+++ b/packages/richtext-lexical/src/features/experimental_table/server/index.ts
@@ -9,7 +9,7 @@ import type { Config, Field, FieldSchemaMap } from 'payload'
 import { TableCellNode, TableNode, TableRowNode } from '@lexical/table'
 import { sanitizeFields } from 'payload'
 
-import type { StronglyTypedNode } from '../../../nodeTypes.js'
+import type { StronglyTypedElementNode } from '../../../nodeTypes.js'
 
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/lexicalToHtml_deprecated/converter/index.js'
@@ -32,13 +32,13 @@ const fields: Field[] = [
 ]
 
 export type SerializedTableCellNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
-  StronglyTypedNode<_SerializedTableCellNode, 'tablecell', T>
+  StronglyTypedElementNode<_SerializedTableCellNode, 'tablecell', T>
 
 export type SerializedTableNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
-  StronglyTypedNode<_SerializedTableNode, 'table', T>
+  StronglyTypedElementNode<_SerializedTableNode, 'table', T>
 
 export type SerializedTableRowNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
-  StronglyTypedNode<_SerializedTableRowNode, 'tablerow', T>
+  StronglyTypedElementNode<_SerializedTableRowNode, 'tablerow', T>
 export const EXPERIMENTAL_TableFeature = createServerFeature({
   feature: async ({ config, isRoot, parentIsLocalized }) => {
     const validRelationships = config.collections.map((c) => c.slug) || []

--- a/packages/richtext-lexical/src/features/heading/server/index.ts
+++ b/packages/richtext-lexical/src/features/heading/server/index.ts
@@ -16,7 +16,7 @@ export type SerializedHeadingNode = Spread<
   {
     type: 'heading'
   },
-  _SerializedHeadingNode
+  Omit<_SerializedHeadingNode, 'type'>
 >
 
 export type HeadingFeatureProps = {

--- a/packages/richtext-lexical/src/features/heading/server/index.ts
+++ b/packages/richtext-lexical/src/features/heading/server/index.ts
@@ -2,9 +2,11 @@ import type {
   SerializedHeadingNode as _SerializedHeadingNode,
   HeadingTagType,
 } from '@lexical/rich-text'
-import type { SerializedLexicalNode, Spread } from 'lexical'
+import type { SerializedLexicalNode } from 'lexical'
 
 import { HeadingNode } from '@lexical/rich-text'
+
+import type { StronglyTypedNode } from '../../../nodeTypes.js'
 
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/lexicalToHtml_deprecated/converter/index.js'
@@ -12,17 +14,8 @@ import { createNode } from '../../typeUtilities.js'
 import { MarkdownTransformer } from '../markdownTransformer.js'
 import { i18n } from './i18n.js'
 
-export type SerializedHeadingNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
-  children?: T[]
-} & Omit<
-  Spread<
-    {
-      type: 'heading'
-    },
-    _SerializedHeadingNode
-  >,
-  'children'
->
+export type SerializedHeadingNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
+  StronglyTypedNode<_SerializedHeadingNode, 'heading', T>
 
 export type HeadingFeatureProps = {
   enabledHeadingSizes?: HeadingTagType[]

--- a/packages/richtext-lexical/src/features/heading/server/index.ts
+++ b/packages/richtext-lexical/src/features/heading/server/index.ts
@@ -2,7 +2,7 @@ import type {
   SerializedHeadingNode as _SerializedHeadingNode,
   HeadingTagType,
 } from '@lexical/rich-text'
-import type { Spread } from 'lexical'
+import type { SerializedLexicalNode, Spread } from 'lexical'
 
 import { HeadingNode } from '@lexical/rich-text'
 
@@ -12,11 +12,16 @@ import { createNode } from '../../typeUtilities.js'
 import { MarkdownTransformer } from '../markdownTransformer.js'
 import { i18n } from './i18n.js'
 
-export type SerializedHeadingNode = Spread<
-  {
-    type: 'heading'
-  },
-  Omit<_SerializedHeadingNode, 'type'>
+export type SerializedHeadingNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
+  children?: T[]
+} & Omit<
+  Spread<
+    {
+      type: 'heading'
+    },
+    _SerializedHeadingNode
+  >,
+  'children'
 >
 
 export type HeadingFeatureProps = {

--- a/packages/richtext-lexical/src/features/heading/server/index.ts
+++ b/packages/richtext-lexical/src/features/heading/server/index.ts
@@ -6,7 +6,7 @@ import type { SerializedLexicalNode } from 'lexical'
 
 import { HeadingNode } from '@lexical/rich-text'
 
-import type { StronglyTypedNode } from '../../../nodeTypes.js'
+import type { StronglyTypedElementNode } from '../../../nodeTypes.js'
 
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/lexicalToHtml_deprecated/converter/index.js'
@@ -15,7 +15,7 @@ import { MarkdownTransformer } from '../markdownTransformer.js'
 import { i18n } from './i18n.js'
 
 export type SerializedHeadingNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
-  StronglyTypedNode<_SerializedHeadingNode, 'heading', T>
+  StronglyTypedElementNode<_SerializedHeadingNode, 'heading', T>
 
 export type HeadingFeatureProps = {
   enabledHeadingSizes?: HeadingTagType[]

--- a/packages/richtext-lexical/src/features/horizontalRule/server/nodes/HorizontalRuleNode.tsx
+++ b/packages/richtext-lexical/src/features/horizontalRule/server/nodes/HorizontalRuleNode.tsx
@@ -6,24 +6,20 @@ import type {
   LexicalCommand,
   LexicalNode,
   SerializedLexicalNode,
-  Spread,
 } from 'lexical'
 import type * as React from 'react'
 
 import { addClassNamesToElement } from '@lexical/utils'
 import { $applyNodeReplacement, createCommand, DecoratorNode } from 'lexical'
 
+import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
+
 /**
  * Serialized representation of a horizontal rule node. Serialized = converted to JSON. This is what is stored in the database / in the lexical editor state.
  */
-export type SerializedHorizontalRuleNode = Omit<
-  Spread<
-    {
-      type: 'horizontalrule'
-    },
-    Omit<SerializedLexicalNode, 'type'>
-  >,
-  'children'
+export type SerializedHorizontalRuleNode = StronglyTypedLeafNode<
+  SerializedLexicalNode,
+  'horizontalrule'
 >
 
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> = createCommand(

--- a/packages/richtext-lexical/src/features/horizontalRule/server/nodes/HorizontalRuleNode.tsx
+++ b/packages/richtext-lexical/src/features/horizontalRule/server/nodes/HorizontalRuleNode.tsx
@@ -16,12 +16,14 @@ import { $applyNodeReplacement, createCommand, DecoratorNode } from 'lexical'
 /**
  * Serialized representation of a horizontal rule node. Serialized = converted to JSON. This is what is stored in the database / in the lexical editor state.
  */
-export type SerializedHorizontalRuleNode = Spread<
-  {
-    children?: never // required so that our typed editor state doesn't automatically add children
-    type: 'horizontalrule'
-  },
-  SerializedLexicalNode
+export type SerializedHorizontalRuleNode = Omit<
+  Spread<
+    {
+      type: 'horizontalrule'
+    },
+    Omit<SerializedLexicalNode, 'type'>
+  >,
+  'children'
 >
 
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> = createCommand(

--- a/packages/richtext-lexical/src/features/link/nodes/types.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/types.ts
@@ -1,5 +1,7 @@
-import type { SerializedElementNode, SerializedLexicalNode, Spread } from 'lexical'
+import type { SerializedElementNode, SerializedLexicalNode } from 'lexical'
 import type { DefaultDocumentIDType, JsonValue } from 'payload'
+
+import type { StronglyTypedNode } from '../../../nodeTypes.js'
 
 export type LinkFields = {
   [key: string]: JsonValue
@@ -18,17 +20,14 @@ export type LinkFields = {
   url?: string
 }
 
-export type SerializedLinkNode<T extends SerializedLexicalNode = SerializedLexicalNode> = Spread<
-  {
-    fields: LinkFields
-    /**
-     * @todo make required in 4.0 and type AutoLinkNode differently
-     */
-    id?: string // optional if AutoLinkNode
-    type: 'link'
-  },
-  SerializedElementNode<T>
->
+export type SerializedLinkNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
+  fields: LinkFields
+  /**
+   * @todo make required in 4.0 and type AutoLinkNode differently
+   */
+  id?: string // optional if AutoLinkNode
+} & StronglyTypedNode<SerializedElementNode, 'link', T>
+
 export type SerializedAutoLinkNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
-  type: 'autolink'
-} & Omit<SerializedLinkNode<T>, 'id' | 'type'>
+  fields: LinkFields
+} & StronglyTypedNode<SerializedElementNode, 'autolink', T>

--- a/packages/richtext-lexical/src/features/link/nodes/types.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/types.ts
@@ -1,7 +1,7 @@
 import type { SerializedElementNode, SerializedLexicalNode } from 'lexical'
 import type { DefaultDocumentIDType, JsonValue } from 'payload'
 
-import type { StronglyTypedNode } from '../../../nodeTypes.js'
+import type { StronglyTypedElementNode } from '../../../nodeTypes.js'
 
 export type LinkFields = {
   [key: string]: JsonValue
@@ -26,8 +26,8 @@ export type SerializedLinkNode<T extends SerializedLexicalNode = SerializedLexic
    * @todo make required in 4.0 and type AutoLinkNode differently
    */
   id?: string // optional if AutoLinkNode
-} & StronglyTypedNode<SerializedElementNode, 'link', T>
+} & StronglyTypedElementNode<SerializedElementNode, 'link', T>
 
 export type SerializedAutoLinkNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
   fields: LinkFields
-} & StronglyTypedNode<SerializedElementNode, 'autolink', T>
+} & StronglyTypedElementNode<SerializedElementNode, 'autolink', T>

--- a/packages/richtext-lexical/src/features/lists/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/lists/plugin/index.tsx
@@ -8,16 +8,16 @@ import type { SerializedLexicalNode } from 'lexical'
 import { ListPlugin } from '@lexical/react/LexicalListPlugin.js'
 import React from 'react'
 
-import type { StronglyTypedNode } from '../../../nodeTypes.js'
+import type { StronglyTypedElementNode } from '../../../nodeTypes.js'
 import type { PluginComponent } from '../../typesClient.js'
 
 export type SerializedListItemNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
   checked?: boolean
-} & StronglyTypedNode<_SerializedListItemNode, 'listitem', T>
+} & StronglyTypedElementNode<_SerializedListItemNode, 'listitem', T>
 
 export type SerializedListNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
   checked?: boolean
-} & StronglyTypedNode<_SerializedListNode, 'list', T>
+} & StronglyTypedElementNode<_SerializedListNode, 'list', T>
 
 export const LexicalListPlugin: PluginComponent<undefined> = () => {
   return <ListPlugin />

--- a/packages/richtext-lexical/src/features/lists/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/lists/plugin/index.tsx
@@ -3,28 +3,21 @@ import type {
   SerializedListItemNode as _SerializedListItemNode,
   SerializedListNode as _SerializedListNode,
 } from '@lexical/list'
-import type { Spread } from 'lexical'
+import type { SerializedLexicalNode } from 'lexical'
 
 import { ListPlugin } from '@lexical/react/LexicalListPlugin.js'
 import React from 'react'
 
+import type { StronglyTypedNode } from '../../../nodeTypes.js'
 import type { PluginComponent } from '../../typesClient.js'
 
-export type SerializedListItemNode = Spread<
-  {
-    checked?: boolean
-    type: 'listitem'
-  },
-  _SerializedListItemNode
->
+export type SerializedListItemNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
+  checked?: boolean
+} & StronglyTypedNode<_SerializedListItemNode, 'listitem', T>
 
-export type SerializedListNode = Spread<
-  {
-    checked?: boolean
-    type: 'list'
-  },
-  _SerializedListNode
->
+export type SerializedListNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
+  checked?: boolean
+} & StronglyTypedNode<_SerializedListNode, 'list', T>
 
 export const LexicalListPlugin: PluginComponent<undefined> = () => {
   return <ListPlugin />

--- a/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
@@ -8,12 +8,13 @@ import type {
   LexicalEditor,
   LexicalNode,
   NodeKey,
-  Spread,
 } from 'lexical'
 import type { CollectionSlug, DataFromCollectionSlug } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
+
+import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
 
 export type RelationshipData = {
   [TCollectionSlug in CollectionSlug]: {
@@ -22,12 +23,8 @@ export type RelationshipData = {
   }
 }[CollectionSlug]
 
-export type SerializedRelationshipNode = Omit<
-  {
-    type: 'relationship'
-  } & Spread<RelationshipData, Omit<SerializedDecoratorBlockNode, 'type'>>,
-  'children'
->
+export type SerializedRelationshipNode = RelationshipData &
+  StronglyTypedLeafNode<SerializedDecoratorBlockNode, 'relationship'>
 
 function $relationshipElementToServerNode(domNode: HTMLDivElement): DOMConversionOutput | null {
   const id = domNode.getAttribute('data-lexical-relationship-id')

--- a/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
@@ -22,10 +22,12 @@ export type RelationshipData = {
   }
 }[CollectionSlug]
 
-export type SerializedRelationshipNode = {
-  children?: never // required so that our typed editor state doesn't automatically add children
-  type: 'relationship'
-} & Spread<RelationshipData, SerializedDecoratorBlockNode>
+export type SerializedRelationshipNode = Omit<
+  {
+    type: 'relationship'
+  } & Spread<RelationshipData, Omit<SerializedDecoratorBlockNode, 'type'>>,
+  'children'
+>
 
 function $relationshipElementToServerNode(domNode: HTMLDivElement): DOMConversionOutput | null {
   const id = domNode.getAttribute('data-lexical-relationship-id')

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -5,7 +5,6 @@ import type {
   ElementFormatType,
   LexicalNode,
   NodeKey,
-  Spread,
 } from 'lexical'
 import type {
   CollectionSlug,
@@ -19,6 +18,8 @@ import type { JSX } from 'react'
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
 import ObjectID from 'bson-objectid'
 import { $applyNodeReplacement } from 'lexical'
+
+import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
 
 import { $convertUploadElement } from './conversions.js'
 
@@ -76,12 +77,8 @@ export type UploadDataImproved<TUploadExtraFieldsData extends JsonObject = JsonO
   }
 }[UploadCollectionSlug]
 
-export type SerializedUploadNode = Omit<
-  {
-    type: 'upload'
-  } & Spread<UploadData, Omit<SerializedDecoratorBlockNode, 'type'>>,
-  'children'
->
+export type SerializedUploadNode = StronglyTypedLeafNode<SerializedDecoratorBlockNode, 'upload'> &
+  UploadData
 
 export class UploadServerNode extends DecoratorBlockNode {
   __data: UploadData

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -76,10 +76,12 @@ export type UploadDataImproved<TUploadExtraFieldsData extends JsonObject = JsonO
   }
 }[UploadCollectionSlug]
 
-export type SerializedUploadNode = {
-  children?: never // required so that our typed editor state doesn't automatically add children
-  type: 'upload'
-} & Spread<UploadData, SerializedDecoratorBlockNode>
+export type SerializedUploadNode = Omit<
+  {
+    type: 'upload'
+  } & Spread<UploadData, Omit<SerializedDecoratorBlockNode, 'type'>>,
+  'children'
+>
 
 export class UploadServerNode extends DecoratorBlockNode {
   __data: UploadData

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -1058,7 +1058,7 @@ export { populate } from './populateGraphQL/populate.js'
 
 export type { LexicalEditorProps, LexicalFieldAdminProps, LexicalRichTextAdapter } from './types.js'
 
-export { buildEditorState } from './utilities/buildEditorState.js'
+export { buildDefaultEditorState, buildEditorState } from './utilities/buildEditorState.js'
 export { createServerFeature } from './utilities/createServerFeature.js'
 
 export { editorConfigFactory } from './utilities/editorConfigFactory.js'

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -23,6 +23,8 @@ import type { SerializedListItemNode, SerializedListNode } from './features/list
 import type { SerializedRelationshipNode } from './features/relationship/server/nodes/RelationshipNode.js'
 import type { SerializedUploadNode } from './features/upload/server/nodes/UploadNode.js'
 
+import { buildEditorState } from './utilities/buildEditorState.js'
+
 export type {
   SerializedAutoLinkNode,
   SerializedBlockNode,
@@ -139,3 +141,62 @@ export type DefaultTypedEditorState<
 > = [TAdditionalNodeTypes] extends null
   ? TypedEditorState<DefaultNodeTypes>
   : TypedEditorState<DefaultNodeTypes | NonNullable<TAdditionalNodeTypes>>
+
+const a: DefaultNodeTypes = {
+  type: 'text',
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  style: '',
+  version: 0,
+  // Has text type suggestion
+}
+
+const b: DefaultTypedEditorState['root']['children'][number] = {
+  type: 'text',
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  style: '',
+  version: 1,
+  // Has text type suggestion
+}
+
+const c = buildEditorState({
+  nodes: [
+    {
+      type: 'text',
+      detail: 0,
+      format: 0,
+      mode: 'normal',
+      style: '',
+      version: 1,
+      // Does not have text type suggestion unless I remove version property
+    },
+  ],
+})
+
+const d = buildEditorState<DefaultNodeTypes | SerializedBlockNode>({
+  nodes: [
+    {
+      type: 'text',
+      detail: 0,
+      format: 0,
+      mode: 'normal',
+      style: '',
+      text: 'hello',
+      version: 1,
+      // Does not have text type suggestion unless I remove version property
+    },
+    {
+      type: 'block',
+      fields: {
+        id: 'id',
+        blockName: 'Cool block',
+        blockType: 'myBlock',
+      },
+      format: 'left',
+      version: 1,
+    },
+  ],
+})

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -83,8 +83,9 @@ type DecrementDepth<N extends number> = [0, 0, 1, 2, 3, 4][N]
  * more strictly, narrowing down nodes based on the `type` without having to manually
  * type-cast.
  */
-export type TypedEditorState<T extends SerializedLexicalNode = SerializedLexicalNode> =
-  SerializedEditorState<RecursiveNodes<T>>
+export type TypedEditorState<T extends SerializedLexicalNode = SerializedLexicalNode> = {
+  [k: string]: unknown
+} & SerializedEditorState<RecursiveNodes<T>>
 
 /**
  * All node types included by default in a lexical editor without configuration.

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -5,7 +5,6 @@ import type {
   SerializedEditorState,
   SerializedElementNode,
   SerializedLexicalNode,
-  Spread,
 } from 'lexical'
 
 import type { SerializedQuoteNode } from './features/blockquote/server/index.js'
@@ -22,6 +21,34 @@ import type { SerializedAutoLinkNode, SerializedLinkNode } from './features/link
 import type { SerializedListItemNode, SerializedListNode } from './features/lists/plugin/index.js'
 import type { SerializedRelationshipNode } from './features/relationship/server/nodes/RelationshipNode.js'
 import type { SerializedUploadNode } from './features/upload/server/nodes/UploadNode.js'
+
+/**
+ * Helper type to create strongly typed serialized nodes with flexible children types.
+ * Omits 'children' and 'type' from the base node type and redeclares them with proper typing.
+ *
+ * @param TBase - The base Lexical node type (e.g., _SerializedHeadingNode)
+ * @param TType - The node type string (e.g., 'heading')
+ * @param TChildren - The type for children (defaults to SerializedLexicalNode)
+ */
+export type StronglyTypedNode<
+  TBase,
+  TType extends string,
+  TChildren extends SerializedLexicalNode = SerializedLexicalNode,
+> = {
+  children?: TChildren[]
+  type: TType
+} & Omit<TBase, 'children' | 'type'>
+
+/**
+ * Helper type to create strongly typed leaf nodes (nodes without children).
+ * Omits 'children' and 'type' from the base node type and redeclares 'type' with a literal.
+ *
+ * @param TBase - The base Lexical node type (e.g., _SerializedTextNode)
+ * @param TType - The node type string (e.g., 'text')
+ */
+export type StronglyTypedLeafNode<TBase, TType extends string> = {
+  type: TType
+} & Omit<TBase, 'children' | 'type'>
 
 export type {
   SerializedAutoLinkNode,
@@ -40,43 +67,15 @@ export type {
   SerializedUploadNode,
 }
 
-export type SerializedParagraphNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
-  Spread<
-    {
-      textFormat: number
-      type: 'paragraph'
-    },
-    Omit<SerializedElementNode<T>, 'type'>
-  >
-export type SerializedTextNode = Omit<
-  Spread<
-    {
-      type: 'text'
-    },
-    Omit<_SerializedTextNode, 'type'>
-  >,
-  'children'
->
+export type SerializedParagraphNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
+  textFormat: number
+} & StronglyTypedNode<SerializedElementNode, 'paragraph', T>
 
-export type SerializedTabNode = Omit<
-  Spread<
-    {
-      type: 'tab'
-    },
-    Omit<_SerializedTabNode, 'type'>
-  >,
-  'children'
->
+export type SerializedTextNode = StronglyTypedLeafNode<_SerializedTextNode, 'text'>
 
-export type SerializedLineBreakNode = Omit<
-  Spread<
-    {
-      type: 'linebreak'
-    },
-    Omit<_SerializedLineBreakNode, 'type'>
-  >,
-  'children'
->
+export type SerializedTabNode = StronglyTypedLeafNode<_SerializedTabNode, 'tab'>
+
+export type SerializedLineBreakNode = StronglyTypedLeafNode<_SerializedLineBreakNode, 'linebreak'>
 
 /**
  * Recursively adds typed children to nodes up to a specified depth.

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -23,8 +23,6 @@ import type { SerializedListItemNode, SerializedListNode } from './features/list
 import type { SerializedRelationshipNode } from './features/relationship/server/nodes/RelationshipNode.js'
 import type { SerializedUploadNode } from './features/upload/server/nodes/UploadNode.js'
 
-import { buildEditorState } from './utilities/buildEditorState.js'
-
 export type {
   SerializedAutoLinkNode,
   SerializedBlockNode,
@@ -141,62 +139,3 @@ export type DefaultTypedEditorState<
 > = [TAdditionalNodeTypes] extends null
   ? TypedEditorState<DefaultNodeTypes>
   : TypedEditorState<DefaultNodeTypes | NonNullable<TAdditionalNodeTypes>>
-
-const a: DefaultNodeTypes = {
-  type: 'text',
-  detail: 0,
-  format: 0,
-  mode: 'normal',
-  style: '',
-  version: 0,
-  // Has text type suggestion
-}
-
-const b: DefaultTypedEditorState['root']['children'][number] = {
-  type: 'text',
-  detail: 0,
-  format: 0,
-  mode: 'normal',
-  style: '',
-  version: 1,
-  // Has text type suggestion
-}
-
-const c = buildEditorState({
-  nodes: [
-    {
-      type: 'text',
-      detail: 0,
-      format: 0,
-      mode: 'normal',
-      style: '',
-      version: 1,
-      // Does not have text type suggestion unless I remove version property
-    },
-  ],
-})
-
-const d = buildEditorState<DefaultNodeTypes | SerializedBlockNode>({
-  nodes: [
-    {
-      type: 'text',
-      detail: 0,
-      format: 0,
-      mode: 'normal',
-      style: '',
-      text: 'hello',
-      version: 1,
-      // Does not have text type suggestion unless I remove version property
-    },
-    {
-      type: 'block',
-      fields: {
-        id: 'id',
-        blockName: 'Cool block',
-        blockType: 'myBlock',
-      },
-      format: 'left',
-      version: 1,
-    },
-  ],
-})

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -85,8 +85,10 @@ export type SerializedLineBreakNode = StronglyTypedLeafNode<_SerializedLineBreak
  * - `OriginalUnion`: Preserves full union so nested children accept all node types, not just parent's type. If we just used `T`, the type would be narrowed to the parent's type and the children would only consist of the parent's type.
  * - `'children' extends keyof T`: Only adds children to container nodes; respects leaf nodes that use `Omit<_, 'children'>`
  * - `Depth`: Limits recursion to prevent infinite types (default: 4 levels)
+ *
+ * @internal - this type may change or be removed in a minor release
  */
-type RecursiveNodes<
+export type RecursiveNodes<
   T extends SerializedLexicalNode,
   Depth extends number = 4,
   OriginalUnion extends SerializedLexicalNode = T,

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -91,6 +91,7 @@ type RecursiveNodes<
   T extends SerializedLexicalNode,
   Depth extends number = 4,
   OriginalUnion extends SerializedLexicalNode = T,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 > = T extends any // Make distributive over unions
   ? Depth extends 0
     ? T

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -35,7 +35,7 @@ export type StronglyTypedNode<
   TType extends string,
   TChildren extends SerializedLexicalNode = SerializedLexicalNode,
 > = {
-  children?: TChildren[]
+  children: TChildren[]
   type: TType
 } & Omit<TBase, 'children' | 'type'>
 

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -30,7 +30,7 @@ import type { SerializedUploadNode } from './features/upload/server/nodes/Upload
  * @param TType - The node type string (e.g., 'heading')
  * @param TChildren - The type for children (defaults to SerializedLexicalNode)
  */
-export type StronglyTypedNode<
+export type StronglyTypedElementNode<
   TBase,
   TType extends string,
   TChildren extends SerializedLexicalNode = SerializedLexicalNode,
@@ -69,7 +69,7 @@ export type {
 
 export type SerializedParagraphNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
   textFormat: number
-} & StronglyTypedNode<SerializedElementNode, 'paragraph', T>
+} & StronglyTypedElementNode<SerializedElementNode, 'paragraph', T>
 
 export type SerializedTextNode = StronglyTypedLeafNode<_SerializedTextNode, 'text'>
 

--- a/packages/richtext-lexical/src/utilities/buildEditorState.ts
+++ b/packages/richtext-lexical/src/utilities/buildEditorState.ts
@@ -1,6 +1,6 @@
 import type { SerializedLexicalNode } from 'lexical'
 
-import type { DefaultTypedEditorState, TypedEditorState } from '../nodeTypes.js'
+import type { DefaultNodeTypes, DefaultTypedEditorState, TypedEditorState } from '../nodeTypes.js'
 
 /**
  * Helper to build lexical editor state JSON from text and/or nodes.
@@ -86,3 +86,13 @@ export function buildEditorState<T extends SerializedLexicalNode>({
 
   return editorJSON as TypedEditorState<T>
 }
+
+/**
+ *
+ * Alias for `buildEditorState<DefaultNodeTypes>`
+ *
+ * @experimental this API may change or be removed in a minor release
+ * @internal
+ */
+export const buildDefaultEditorState: typeof buildEditorState<DefaultNodeTypes> =
+  buildEditorState<DefaultNodeTypes>

--- a/packages/richtext-lexical/src/utilities/buildEditorState.ts
+++ b/packages/richtext-lexical/src/utilities/buildEditorState.ts
@@ -2,14 +2,16 @@ import type { SerializedLexicalNode } from 'lexical'
 
 import type { DefaultTypedEditorState, TypedEditorState } from '../nodeTypes.js'
 
+// Non-generic overload: when no type is specified, return DefaultTypedEditorState
 export function buildEditorState(args: {
   nodes?: DefaultTypedEditorState['root']['children']
   text?: string
 }): DefaultTypedEditorState
 
+// Generic overload: when explicit type T is provided, return TypedEditorState<T>
+// Note: NoInfer prevents TypeScript from inferring T from the argument, forcing explicit type parameters
 export function buildEditorState<T extends SerializedLexicalNode>(args: {
-  // If you pass children typed for a specific schema T, the return is TypedEditorState<T>
-  nodes?: TypedEditorState<T>['root']['children']
+  nodes?: TypedEditorState<NoInfer<T>>['root']['children']
   text?: string
 }): TypedEditorState<T>
 

--- a/packages/richtext-lexical/src/utilities/buildEditorState.ts
+++ b/packages/richtext-lexical/src/utilities/buildEditorState.ts
@@ -2,19 +2,6 @@ import type { SerializedLexicalNode } from 'lexical'
 
 import type { DefaultTypedEditorState, TypedEditorState } from '../nodeTypes.js'
 
-// Non-generic overload: when no type is specified, return DefaultTypedEditorState
-export function buildEditorState(args: {
-  nodes?: DefaultTypedEditorState['root']['children']
-  text?: string
-}): DefaultTypedEditorState
-
-// Generic overload: when explicit type T is provided, return TypedEditorState<T>
-// Note: NoInfer prevents TypeScript from inferring T from the argument, forcing explicit type parameters
-export function buildEditorState<T extends SerializedLexicalNode>(args: {
-  nodes?: TypedEditorState<NoInfer<T>>['root']['children']
-  text?: string
-}): TypedEditorState<T>
-
 /**
  * Helper to build lexical editor state JSON from text and/or nodes.
  *
@@ -27,7 +14,7 @@ export function buildEditorState<T extends SerializedLexicalNode>(args: {
  * just passing text:
  *
  * ```ts
- * const editorState = buildEditorState({ text: 'Hello world' }) // result typed as DefaultTypedEditorState
+ * const editorState = buildEditorState<DefaultNodeTypes>({ text: 'Hello world' }) // result typed as DefaultTypedEditorState
  * ```
  *
  * @example
@@ -56,9 +43,9 @@ export function buildEditorState<T extends SerializedLexicalNode>({
   nodes,
   text,
 }: {
-  nodes?: DefaultTypedEditorState['root']['children'] | TypedEditorState<T>['root']['children']
+  nodes?: TypedEditorState<T>['root']['children']
   text?: string
-}): DefaultTypedEditorState | TypedEditorState<T> {
+}): TypedEditorState<T> {
   const editorJSON: DefaultTypedEditorState = {
     root: {
       type: 'root',
@@ -97,5 +84,5 @@ export function buildEditorState<T extends SerializedLexicalNode>({
     editorJSON.root.children.push(...(nodes as any))
   }
 
-  return editorJSON
+  return editorJSON as TypedEditorState<T>
 }

--- a/packages/richtext-lexical/src/utilities/buildEditorState.ts
+++ b/packages/richtext-lexical/src/utilities/buildEditorState.ts
@@ -81,6 +81,7 @@ export function buildEditorState<T extends SerializedLexicalNode>({
   }
 
   if (nodes?.length) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     editorJSON.root.children.push(...(nodes as any))
   }
 

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -4,7 +4,7 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import type { FieldAccess } from 'payload'
 
-import { buildEditorState } from '@payloadcms/richtext-lexical'
+import { buildEditorState, type DefaultNodeTypes } from '@payloadcms/richtext-lexical'
 
 import type { Config, User } from './payload-types.js'
 
@@ -719,33 +719,35 @@ export default buildConfigWithDefaults(
       await payload.create({
         collection: 'regression1',
         data: {
-          richText4: buildEditorState({ text: 'Text1' }),
-          array: [{ art: buildEditorState({ text: 'Text2' }) }],
-          arrayWithAccessFalse: [{ richText6: buildEditorState({ text: 'Text3' }) }],
+          richText4: buildEditorState<DefaultNodeTypes>({ text: 'Text1' }),
+          array: [{ art: buildEditorState<DefaultNodeTypes>({ text: 'Text2' }) }],
+          arrayWithAccessFalse: [
+            { richText6: buildEditorState<DefaultNodeTypes>({ text: 'Text3' }) },
+          ],
           group1: {
             text: 'Text4',
-            richText1: buildEditorState({ text: 'Text5' }),
+            richText1: buildEditorState<DefaultNodeTypes>({ text: 'Text5' }),
           },
           blocks: [
             {
               blockType: 'myBlock3',
-              richText7: buildEditorState({ text: 'Text6' }),
+              richText7: buildEditorState<DefaultNodeTypes>({ text: 'Text6' }),
               blockName: 'My Block 1',
             },
           ],
           blocks3: [
             {
               blockType: 'myBlock2',
-              richText5: buildEditorState({ text: 'Text7' }),
+              richText5: buildEditorState<DefaultNodeTypes>({ text: 'Text7' }),
               blockName: 'My Block 2',
             },
           ],
           tab1: {
-            richText2: buildEditorState({ text: 'Text8' }),
+            richText2: buildEditorState<DefaultNodeTypes>({ text: 'Text8' }),
             blocks2: [
               {
                 blockType: 'myBlock',
-                richText3: buildEditorState({ text: 'Text9' }),
+                richText3: buildEditorState<DefaultNodeTypes>({ text: 'Text9' }),
                 blockName: 'My Block 3',
               },
             ],
@@ -758,12 +760,12 @@ export default buildConfigWithDefaults(
         data: {
           array: [
             {
-              richText2: buildEditorState({ text: 'Text1' }),
+              richText2: buildEditorState<DefaultNodeTypes>({ text: 'Text1' }),
             },
           ],
           group: {
             text: 'Text2',
-            richText1: buildEditorState({ text: 'Text3' }),
+            richText1: buildEditorState<DefaultNodeTypes>({ text: 'Text3' }),
           },
         },
       })

--- a/test/lexical/collections/OnDemandForm/Component.tsx
+++ b/test/lexical/collections/OnDemandForm/Component.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { DefaultNodeTypes } from '@payloadcms/richtext-lexical'
 import type { JSONFieldClientComponent } from 'payload'
 
 import { buildEditorState, RenderLexical } from '@payloadcms/richtext-lexical/client'
@@ -12,7 +13,7 @@ export const Component: JSONFieldClientComponent = () => {
       Fully-Featured Component:
       <RenderLexical
         field={{ name: 'json' }}
-        initialValue={buildEditorState({ text: 'defaultValue' })}
+        initialValue={buildEditorState<DefaultNodeTypes>({ text: 'defaultValue' })}
         schemaPath={`collection.${lexicalFullyFeaturedSlug}.richText`}
       />
     </div>

--- a/test/lexical/collections/OnDemandOutsideForm/Component.tsx
+++ b/test/lexical/collections/OnDemandOutsideForm/Component.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
+import type { DefaultNodeTypes, DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
 import type { JSONFieldClientComponent } from 'payload'
 
 import { buildEditorState, RenderLexical } from '@payloadcms/richtext-lexical/client'
@@ -8,11 +8,11 @@ import React, { useState } from 'react'
 
 export const Component: JSONFieldClientComponent = () => {
   const [value, setValue] = useState<DefaultTypedEditorState | undefined>(() =>
-    buildEditorState({ text: 'state default' }),
+    buildEditorState<DefaultNodeTypes>({ text: 'state default' }),
   )
 
   const handleReset = React.useCallback(() => {
-    setValue(buildEditorState({ text: 'state default' }))
+    setValue(buildEditorState<DefaultNodeTypes>({ text: 'state default' }))
   }, [])
 
   return (
@@ -20,7 +20,7 @@ export const Component: JSONFieldClientComponent = () => {
       Default Component:
       <RenderLexical
         field={{ name: 'myField', label: 'My Label' }}
-        initialValue={buildEditorState({ text: 'defaultValue' })}
+        initialValue={buildEditorState<DefaultNodeTypes>({ text: 'defaultValue' })}
         schemaPath={`collection.OnDemandOutsideForm.hiddenAnchor`}
         setValue={setValue as any}
         value={value}

--- a/test/lexical/lexical.int.spec.ts
+++ b/test/lexical/lexical.int.spec.ts
@@ -7,6 +7,7 @@ import type { PaginatedDocs, Payload } from 'payload'
 /* eslint-disable jest/no-conditional-in-test */
 import {
   buildEditorState,
+  type DefaultNodeTypes,
   type SerializedBlockNode,
   type SerializedLinkNode,
   type SerializedRelationshipNode,
@@ -655,7 +656,7 @@ describe('Lexical', () => {
         locale: 'en',
         data: {
           title: 'Localized Lexical hooks',
-          lexicalBlocksLocalized: buildEditorState({ text: 'some text' }),
+          lexicalBlocksLocalized: buildEditorState<DefaultNodeTypes>({ text: 'some text' }),
           lexicalBlocksSubLocalized: generateLexicalLocalizedRichText(
             'Shared text',
             'English text in block',

--- a/test/lexical/seed.ts
+++ b/test/lexical/seed.ts
@@ -23,7 +23,7 @@ import {
 
 // import type { Payload } from 'payload'
 
-import { buildEditorState } from '@payloadcms/richtext-lexical'
+import { buildEditorState, type DefaultNodeTypes } from '@payloadcms/richtext-lexical'
 import { getFileByPath } from 'payload'
 
 import { devUser } from '../credentials.js'
@@ -223,7 +223,7 @@ export const seed = async (_payload: Payload) => {
     collection: lexicalLocalizedFieldsSlug,
     data: {
       title: 'Localized Lexical en',
-      lexicalBlocksLocalized: buildEditorState({ text: 'English text' }),
+      lexicalBlocksLocalized: buildEditorState<DefaultNodeTypes>({ text: 'English text' }),
       lexicalBlocksSubLocalized: generateLexicalLocalizedRichText(
         'Shared text',
         'English text in block',
@@ -237,7 +237,7 @@ export const seed = async (_payload: Payload) => {
   await _payload.create({
     collection: lexicalRelationshipFieldsSlug,
     data: {
-      richText: buildEditorState({ text: 'English text' }),
+      richText: buildEditorState<DefaultNodeTypes>({ text: 'English text' }),
     },
     depth: 0,
     overrideAccess: true,
@@ -248,7 +248,7 @@ export const seed = async (_payload: Payload) => {
     id: lexicalLocalizedDoc1.id,
     data: {
       title: 'Localized Lexical es',
-      lexicalBlocksLocalized: buildEditorState({ text: 'Spanish text' }),
+      lexicalBlocksLocalized: buildEditorState<DefaultNodeTypes>({ text: 'Spanish text' }),
       lexicalBlocksSubLocalized: generateLexicalLocalizedRichText(
         'Shared text',
         'Spanish text in block',
@@ -265,7 +265,7 @@ export const seed = async (_payload: Payload) => {
     data: {
       title: 'Localized Lexical en 2',
 
-      lexicalBlocksLocalized: buildEditorState({
+      lexicalBlocksLocalized: buildEditorState<DefaultNodeTypes>({
         text: 'English text 2',
         nodes: [
           {
@@ -277,7 +277,7 @@ export const seed = async (_payload: Payload) => {
           },
         ],
       }),
-      lexicalBlocksSubLocalized: buildEditorState({
+      lexicalBlocksSubLocalized: buildEditorState<DefaultNodeTypes>({
         text: 'English text 2',
         nodes: [
           {
@@ -301,7 +301,7 @@ export const seed = async (_payload: Payload) => {
     data: {
       title: 'Localized Lexical es 2',
 
-      lexicalBlocksLocalized: buildEditorState({
+      lexicalBlocksLocalized: buildEditorState<DefaultNodeTypes>({
         text: 'Spanish text 2',
         nodes: [
           {
@@ -349,7 +349,7 @@ export const seed = async (_payload: Payload) => {
               version: 2,
               fields: {
                 id: '6773773284be8978db7a498d',
-                lexicalInBlock: buildEditorState({ text: 'text' }),
+                lexicalInBlock: buildEditorState<DefaultNodeTypes>({ text: 'text' }),
                 blockName: '',
                 blockType: 'blockInLexical',
               },
@@ -366,12 +366,12 @@ export const seed = async (_payload: Payload) => {
         {
           blockType: 'lexicalInBlock2',
           blockName: '1',
-          lexical: buildEditorState({ text: '1' }),
+          lexical: buildEditorState<DefaultNodeTypes>({ text: '1' }),
         },
         {
           blockType: 'lexicalInBlock2',
           blockName: '2',
-          lexical: buildEditorState({ text: '2' }),
+          lexical: buildEditorState<DefaultNodeTypes>({ text: '2' }),
         },
         {
           blockType: 'lexicalInBlock2',

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -448,7 +448,7 @@ describe('Types testing', () => {
       expect<'children' extends keyof TabNode ? true : false>().type.toBe<false>()
     })
 
-    test('aa', () => {
+    test('accepts complete heading node as part of DefaultNodeTypes if heading node is explicitly typed', () => {
       const headingNode: SerializedHeadingNode = {
         type: 'heading',
         tag: 'h1',

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -447,7 +447,7 @@ describe('Types testing', () => {
     })
 
     describe('buildEditorState', () => {
-      test('buildEditorState without generic returns DefaultTypedEditorState', () => {
+      test('buildEditorState returns DefaultTypedEditorState', () => {
         const result = buildEditorState<DefaultNodeTypes>({ text: 'hello' })
         expect(result).type.toBe<DefaultTypedEditorState>()
       })
@@ -551,10 +551,7 @@ describe('Types testing', () => {
         expect(result).type.toBe<DefaultTypedEditorState>()
       })
 
-      test('buildEditorState without generic parameter correctly validates incomplete text node (missing text property)', () => {
-        // This test verifies the NoInfer fix works correctly
-        // Before NoInfer: TypeScript would infer a narrow type from the incomplete object, preventing autocomplete
-        // After NoInfer: TypeScript uses DefaultTypedEditorState['root']['children'], catching the missing property
+      test('buildEditorState correctly validates incomplete text node (missing text property)', () => {
         expect(
           buildEditorState<DefaultNodeTypes>({
             nodes: [
@@ -572,7 +569,7 @@ describe('Types testing', () => {
         ).type.toRaiseError()
       })
 
-      test('buildEditorState without generic parameter validates complete text node correctly', () => {
+      test('buildEditorState validates complete text node correctly', () => {
         const result = buildEditorState<DefaultNodeTypes>({
           nodes: [
             {
@@ -587,9 +584,10 @@ describe('Types testing', () => {
           ],
         })
         expect(result).type.toBe<DefaultTypedEditorState>()
+        expect(result).type.toBe<TypedEditorState<DefaultNodeTypes>>()
       })
 
-      test('buildEditorState without generic parameter correctly validates incomplete heading node (missing tag property)', () => {
+      test('buildEditorState correctly validates incomplete heading node (missing tag property)', () => {
         expect(
           buildEditorState<DefaultNodeTypes>({
             nodes: [
@@ -626,9 +624,6 @@ describe('Types testing', () => {
       })
 
       test('buildEditorState returns DefaultTypedEditorState even with incomplete nodes (though nodes cause errors)', () => {
-        // This verifies that the return type is DefaultTypedEditorState (first overload)
-        // and not a narrowed TypedEditorState<T> (second overload)
-        // The incomplete node will cause an error, but the return type should still be correct
         const _result = buildEditorState<DefaultNodeTypes>({
           nodes: [
             {
@@ -640,6 +635,33 @@ describe('Types testing', () => {
         })
         type ResultType = typeof _result
         expect<ResultType>().type.toBe<DefaultTypedEditorState>()
+      })
+
+      test('accepts complete heading node with DefaultNodeTypes', () => {
+        const result = buildEditorState<DefaultNodeTypes>({
+          nodes: [
+            {
+              type: 'heading',
+              tag: 'h1',
+              children: [
+                {
+                  type: 'text',
+                  detail: 0,
+                  format: 0,
+                  mode: 'normal',
+                  style: '',
+                  text: 'Title',
+                  version: 1,
+                },
+              ],
+              direction: 'ltr',
+              format: '',
+              indent: 0,
+              version: 1,
+            },
+          ],
+        })
+        expect(result).type.toBe<TypedEditorState<DefaultNodeTypes>>()
       })
     })
   })

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -486,6 +486,126 @@ describe('Types testing', () => {
       expect(editorState).type.toBe<TypedEditorState<DefaultNodeTypes>>()
     })
 
+    test('accepts complete heading node as part of nested children within DefaultNodeTypes if heading node is explicitly typed', () => {
+      // Extract the correct children type from DefaultTypedEditorState
+      type DefaultChildren = DefaultTypedEditorState['root']['children'][number]
+
+      const headingNode: SerializedHeadingNode<DefaultChildren> = {
+        type: 'heading',
+        tag: 'h1',
+        children: [
+          {
+            type: 'text',
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'Title',
+            version: 1,
+          } as SerializedTextNode,
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        version: 1,
+      }
+
+      const editorState: DefaultTypedEditorState = {
+        root: {
+          type: 'root',
+          children: [
+            {
+              type: 'paragraph',
+              children: [headingNode],
+              direction: 'ltr',
+              format: 'left',
+              indent: 0,
+              version: 0,
+              textFormat: 0,
+            },
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          version: 1,
+        },
+      }
+
+      expect(editorState).type.toBe<TypedEditorState<DefaultNodeTypes>>()
+    })
+
+    test('accepts complete heading node as part of nested, nested children within DefaultNodeTypes if heading node is explicitly typed', () => {
+      // Extract the correct children type from DefaultTypedEditorState
+      type DefaultChildren = DefaultTypedEditorState['root']['children'][number]
+
+      const headingNode: SerializedHeadingNode<DefaultChildren> = {
+        type: 'heading',
+        tag: 'h1',
+        children: [
+          {
+            type: 'text',
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'Title',
+            version: 1,
+          } as SerializedTextNode,
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        version: 1,
+      }
+
+      const editorState: DefaultTypedEditorState = {
+        root: {
+          type: 'root',
+          children: [
+            {
+              type: 'paragraph',
+              children: [],
+              direction: 'ltr',
+              format: 'left',
+              indent: 0,
+              version: 0,
+              textFormat: 0,
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'link',
+                  children: [headingNode],
+                  direction: 'ltr',
+                  format: 'left',
+                  indent: 0,
+                  version: 0,
+                  textFormat: 0,
+                  fields: {
+                    linkType: 'custom',
+                    newTab: false,
+                    url: 'https://www.payloadcms.com',
+                  },
+                },
+              ],
+              direction: 'ltr',
+              format: 'left',
+              indent: 0,
+              version: 0,
+              textFormat: 0,
+            },
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          version: 1,
+        },
+      }
+
+      expect(editorState).type.toBe<TypedEditorState<DefaultNodeTypes>>()
+    })
+
     describe('buildEditorState', () => {
       test('buildEditorState returns DefaultTypedEditorState', () => {
         const result = buildEditorState<DefaultNodeTypes>({ text: 'hello' })

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -448,6 +448,41 @@ describe('Types testing', () => {
       expect<'children' extends keyof TabNode ? true : false>().type.toBe<false>()
     })
 
+    test('aa', () => {
+      const headingNode: SerializedHeadingNode = {
+        type: 'heading',
+        tag: 'h1',
+        children: [
+          {
+            type: 'text',
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'Title',
+            version: 1,
+          } as SerializedTextNode,
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        version: 1,
+      }
+
+      const editorState: DefaultTypedEditorState = {
+        root: {
+          type: 'root',
+          children: [headingNode],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          version: 1,
+        },
+      }
+
+      expect(editorState).type.toBe<TypedEditorState<DefaultNodeTypes>>()
+    })
+
     describe('buildEditorState', () => {
       test('buildEditorState returns DefaultTypedEditorState', () => {
         const result = buildEditorState<DefaultNodeTypes>({ text: 'hello' })

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -666,6 +666,38 @@ describe('Types testing', () => {
         expect(result).type.toBe<TypedEditorState<DefaultNodeTypes>>()
       })
 
+      test('throws error for invalid children of non-explicit typed heading node', () => {
+        expect(
+          buildEditorState<DefaultNodeTypes>({
+            nodes: [
+              {
+                type: 'heading',
+                tag: 'h1',
+                children: [
+                  {
+                    type: 'text',
+                    detail: 0,
+                    format: 0,
+                    mode: 'normal',
+                    style: '',
+                    text: 'Title',
+                    version: 1,
+                  },
+                  {
+                    type: 'invalid',
+                    test: 'test',
+                  },
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                version: 1,
+              },
+            ],
+          }),
+        ).type.toRaiseError()
+      })
+
       test('accepts complete heading node with DefaultNodeTypes if heading node is explicitly typed', () => {
         const headingNode: SerializedHeadingNode = {
           type: 'heading',

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -289,7 +289,7 @@ describe('Types testing', () => {
        *
        * const mySeedData: RequiredDataFromCollectionSlug<'posts'> = {
        *   title: 'hello',
-       *   richText: buildEditorState({text: 'hello'}) // <= DefaultTypedEditorState
+       *   richText: buildEditorState<DefaultNodeTypes>({text: 'hello'}) // <= DefaultTypedEditorState
        * }
        */
       type GeneratedRichTextType = Post['richText']
@@ -448,17 +448,17 @@ describe('Types testing', () => {
 
     describe('buildEditorState', () => {
       test('buildEditorState without generic returns DefaultTypedEditorState', () => {
-        const result = buildEditorState({ text: 'hello' })
+        const result = buildEditorState<DefaultNodeTypes>({ text: 'hello' })
         expect(result).type.toBe<DefaultTypedEditorState>()
       })
 
       test('buildEditorState with text parameter returns DefaultTypedEditorState', () => {
-        const result = buildEditorState({ text: 'Hello world' })
+        const result = buildEditorState<DefaultNodeTypes>({ text: 'Hello world' })
         expect(result).type.toBe<DefaultTypedEditorState>()
       })
 
       test('buildEditorState with nodes parameter returns DefaultTypedEditorState', () => {
-        const result = buildEditorState({
+        const result = buildEditorState<DefaultNodeTypes>({
           nodes: [
             {
               type: 'text',
@@ -510,7 +510,7 @@ describe('Types testing', () => {
       })
 
       test('buildEditorState return type includes correct node types in children', () => {
-        const _result = buildEditorState({ text: 'hello' })
+        const _result = buildEditorState<DefaultNodeTypes>({ text: 'hello' })
         type NodeType = (typeof _result)['root']['children'][number]['type']
         expect<NodeType>().type.toBe<_Hardcoded_DefaultNodeTypes>()
       })
@@ -522,13 +522,13 @@ describe('Types testing', () => {
       })
 
       test('buildEditorState result can be assigned to Post richText field', () => {
-        const _result = buildEditorState({ text: 'hello' })
+        const _result = buildEditorState<DefaultNodeTypes>({ text: 'hello' })
         type GeneratedRichTextType = Post['richText']
         expect<GeneratedRichTextType>().type.toBeAssignableWith<typeof _result>()
       })
 
       test('buildEditorState allows pushing typed nodes to children', () => {
-        const result = buildEditorState({ text: 'hello' })
+        const result = buildEditorState<DefaultNodeTypes>({ text: 'hello' })
         result.root.children.push({
           type: 'heading',
           tag: 'h1',
@@ -556,7 +556,7 @@ describe('Types testing', () => {
         // Before NoInfer: TypeScript would infer a narrow type from the incomplete object, preventing autocomplete
         // After NoInfer: TypeScript uses DefaultTypedEditorState['root']['children'], catching the missing property
         expect(
-          buildEditorState({
+          buildEditorState<DefaultNodeTypes>({
             nodes: [
               {
                 type: 'text',
@@ -573,7 +573,7 @@ describe('Types testing', () => {
       })
 
       test('buildEditorState without generic parameter validates complete text node correctly', () => {
-        const result = buildEditorState({
+        const result = buildEditorState<DefaultNodeTypes>({
           nodes: [
             {
               type: 'text',
@@ -591,7 +591,7 @@ describe('Types testing', () => {
 
       test('buildEditorState without generic parameter correctly validates incomplete heading node (missing tag property)', () => {
         expect(
-          buildEditorState({
+          buildEditorState<DefaultNodeTypes>({
             nodes: [
               {
                 type: 'heading',
@@ -629,7 +629,7 @@ describe('Types testing', () => {
         // This verifies that the return type is DefaultTypedEditorState (first overload)
         // and not a narrowed TypedEditorState<T> (second overload)
         // The incomplete node will cause an error, but the return type should still be correct
-        const _result = buildEditorState({
+        const _result = buildEditorState<DefaultNodeTypes>({
           nodes: [
             {
               type: 'text',

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -449,7 +449,10 @@ describe('Types testing', () => {
     })
 
     test('accepts complete heading node as part of DefaultNodeTypes if heading node is explicitly typed', () => {
-      const headingNode: SerializedHeadingNode = {
+      // Extract the correct children type from DefaultTypedEditorState
+      type DefaultChildren = DefaultTypedEditorState['root']['children'][number]
+
+      const headingNode: SerializedHeadingNode<DefaultChildren> = {
         type: 'heading',
         tag: 'h1',
         children: [
@@ -734,7 +737,10 @@ describe('Types testing', () => {
       })
 
       test('accepts complete heading node with DefaultNodeTypes if heading node is explicitly typed', () => {
-        const headingNode: SerializedHeadingNode = {
+        // Extract the correct children type for the heading node
+        type DefaultChildren = TypedEditorState<DefaultNodeTypes>['root']['children'][number]
+
+        const headingNode: SerializedHeadingNode<DefaultChildren> = {
           type: 'heading',
           tag: 'h1',
           children: [

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -13,6 +13,7 @@ import {
   buildEditorState,
   type DefaultNodeTypes,
   type DefaultTypedEditorState,
+  type RecursiveNodes,
   type SerializedBlockNode,
   type SerializedHeadingNode,
   type SerializedTextNode,
@@ -449,10 +450,7 @@ describe('Types testing', () => {
     })
 
     test('accepts complete heading node as part of DefaultNodeTypes if heading node is explicitly typed', () => {
-      // Extract the correct children type from DefaultTypedEditorState
-      type DefaultChildren = DefaultTypedEditorState['root']['children'][number]
-
-      const headingNode: SerializedHeadingNode<DefaultChildren> = {
+      const headingNode: SerializedHeadingNode<RecursiveNodes<DefaultNodeTypes>> = {
         type: 'heading',
         tag: 'h1',
         children: [
@@ -487,10 +485,7 @@ describe('Types testing', () => {
     })
 
     test('accepts complete heading node as part of nested children within DefaultNodeTypes if heading node is explicitly typed', () => {
-      // Extract the correct children type from DefaultTypedEditorState
-      type DefaultChildren = DefaultTypedEditorState['root']['children'][number]
-
-      const headingNode: SerializedHeadingNode<DefaultChildren> = {
+      const headingNode: SerializedHeadingNode<RecursiveNodes<DefaultNodeTypes>> = {
         type: 'heading',
         tag: 'h1',
         children: [

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -14,6 +14,8 @@ import {
   type DefaultNodeTypes,
   type DefaultTypedEditorState,
   type SerializedBlockNode,
+  type SerializedHeadingNode,
+  type SerializedTextNode,
   type TypedEditorState,
 } from '@payloadcms/richtext-lexical'
 import payload from 'payload'
@@ -660,6 +662,32 @@ describe('Types testing', () => {
               version: 1,
             },
           ],
+        })
+        expect(result).type.toBe<TypedEditorState<DefaultNodeTypes>>()
+      })
+
+      test('accepts complete heading node with DefaultNodeTypes if heading node is explicitly typed', () => {
+        const headingNode: SerializedHeadingNode = {
+          type: 'heading',
+          tag: 'h1',
+          children: [
+            {
+              type: 'text',
+              detail: 0,
+              format: 0,
+              mode: 'normal',
+              style: '',
+              text: 'Title',
+              version: 1,
+            } as SerializedTextNode,
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          version: 1,
+        }
+        const result = buildEditorState<DefaultNodeTypes>({
+          nodes: [headingNode],
         })
         expect(result).type.toBe<TypedEditorState<DefaultNodeTypes>>()
       })

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -1,9 +1,4 @@
 import type {
-  DefaultNodeTypes,
-  DefaultTypedEditorState,
-  TypedEditorState,
-} from '@payloadcms/richtext-lexical'
-import type {
   BulkOperationResult,
   CustomDocumentViewConfig,
   DefaultDocumentViewConfig,
@@ -14,6 +9,11 @@ import type {
   Where,
 } from 'payload'
 
+import {
+  type DefaultNodeTypes,
+  type DefaultTypedEditorState,
+  type TypedEditorState,
+} from '@payloadcms/richtext-lexical'
 import payload from 'payload'
 import { describe, expect, test } from 'tstyche'
 
@@ -279,6 +279,29 @@ describe('Types testing', () => {
       type GeneratedRichTextType = Post['richText']
 
       expect<DefaultTypedEditorState>().type.toBeAssignableWith<GeneratedRichTextType>()
+    })
+
+    test('ensure DefaultTypedEditorState type can be assigned to GeneratedRichTextType type', () => {
+      /**
+       * Example:
+       *
+       * const mySeedData: RequiredDataFromCollectionSlug<'posts'> = {
+       *   title: 'hello',
+       *   richText: buildEditorState({text: 'hello'}) // <= DefaultTypedEditorState
+       * }
+       */
+      type GeneratedRichTextType = Post['richText']
+
+      expect<GeneratedRichTextType>().type.toBeAssignableWith<DefaultTypedEditorState>()
+    })
+
+    test('ensure type property in editorState.root.children.push() is correctly typed as union of all node types', () => {
+      const _editorState: DefaultTypedEditorState = null as unknown as DefaultTypedEditorState
+
+      // Test that the type parameter is correctly typed
+      type PushParameterType = Parameters<typeof _editorState.root.children.push>[0]
+
+      expect<PushParameterType['type']>().type.toBe<_Hardcoded_DefaultNodeTypes>()
     })
   })
 })

--- a/test/versions/seed.ts
+++ b/test/versions/seed.ts
@@ -1,4 +1,4 @@
-import { buildEditorState } from '@payloadcms/richtext-lexical'
+import { buildEditorState, type DefaultNodeTypes } from '@payloadcms/richtext-lexical'
 import path from 'path'
 import { getFileByPath, type Payload } from 'payload'
 import { fileURLToPath } from 'url'
@@ -273,7 +273,9 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
         textID: doc1ID,
         updated: false,
       }) as any,
-      richtextWithCustomDiff: buildEditorState({ text: 'richtextWithCustomDiff' }),
+      richtextWithCustomDiff: buildEditorState<DefaultNodeTypes>({
+        text: 'richtextWithCustomDiff',
+      }),
       select: 'option1',
       text: 'text',
       textArea: 'textArea',
@@ -442,7 +444,9 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
         textID: doc2ID,
         updated: true,
       }) as any,
-      richtextWithCustomDiff: buildEditorState({ text: 'richtextWithCustomDiff2' }),
+      richtextWithCustomDiff: buildEditorState<DefaultNodeTypes>({
+        text: 'richtextWithCustomDiff2',
+      }),
       select: 'option2',
       text: 'text2',
       textArea: 'textArea2',


### PR DESCRIPTION
# What This Fixes

## **1. VS Code Autocomplete**
When typing `type: ''` in lexical nodes, the IDE now suggests all node types (`'heading'`, `'paragraph'`, `'linebreak'`, etc.) instead of only leaf nodes (e.g. `linebreak`).

#### Before

<img width="1290" height="486" alt="Screenshot 2025-10-07 at 17 12 59@2x" src="https://github.com/user-attachments/assets/eb1ed8f5-6a3b-462b-b8e0-401bdf8bd9a3" />


#### After

<img width="1192" height="734" alt="Screenshot 2025-10-07 at 17 12 03@2x" src="https://github.com/user-attachments/assets/184479fe-8743-4706-83f3-f56967d74d21" />


## **2. Type Assignability**
`DefaultTypedEditorState` is now compatible with generated Payload types, enabling patterns like:
```ts
// Seed data with buildEditorState
const post: RequiredDataFromCollectionSlug<'posts'> = {
  title: 'Hello',
  richText: buildEditorState({ text: 'Welcome!' }) // ✅ Now works
}
```

## **3. buildEditorState Autocomplete**
When creating nodes with `buildEditorState({ nodes: [...] })`, TypeScript now provides autocomplete for all node properties as you type, instead of inferring a narrow type from incomplete objects.

```ts
// Before: TypeScript infers narrow type, no autocomplete for 'text' property
const state = buildEditorState({
  nodes: [{
    type: 'text',
    version: 1,
    // ❌ No suggestion for 'text' property
  }]
})

// After: Full autocomplete and validation
const state = buildEditorState<DefaultNodeTypes>({
  nodes: [{
    type: 'text',
    version: 1,
    text: // ✅ Autocomplete works, missing properties are caught
  }]
})
```

It is not possible to reliably get this to work without passing a generic, even if we fall back to `DefaultNodeTypes` automatically. This is because TypeScript still tries to infer the type based on what you pass through, and using NoInfer<> has other drawbacks that break types in other scenarios. Thus, passing a generic is now required in order for proper type completion.


# Technical Changes

**Node type definitions:**
- Replaced `children?: never` with `Omit<_, 'children'>` on leaf nodes (fixes autocomplete)
- Added `Omit<_, 'type'>` to preserve literal types like `'heading'` instead of `string`

**TypedEditorState:**
- Added index signature `{ [k: string]: unknown }` for compatibility with generated types

**RecursiveNodes type:**
These changes are required to ensure types for nested nodes still work correctly despite removing `children?: never` to fix type suggestions:
- Made distributive over unions to process each node type individually
- Preserves full union type at all nesting depths (children can be any node type, not just parent's type)
- Respects leaf nodes that shouldn't have `children`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211573102751778