### PR TITLE
docs: revert sentry docs change

### DIFF
--- a/docs/plugins/sentry.mdx
+++ b/docs/plugins/sentry.mdx
@@ -94,9 +94,8 @@ import pg from 'pg'
 export default buildConfig({
   db: postgresAdapter({
     pool: { connectionString: process.env.DATABASE_URL },
-  },
-  pg, // Inject the patched pg driver for Sentry instrumentation
-  ),
+    pg, // Inject the patched pg driver for Sentry instrumentation
+  }),
   plugins: [sentryPlugin({ Sentry })],
 })
 ```


### PR DESCRIPTION
I merged https://github.com/payloadcms/payload/pull/14088, but on a second look, according to the PR that added this feature https://github.com/payloadcms/payload/pull/11478 there wasn't anything wrong before that change