### PR TITLE
feat(plugin-multi-tenant): user collection access overrides

### DIFF
--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -99,6 +99,7 @@ export const multiTenantPlugin =
     }
 
     addCollectionAccess({
+      accessResultCallback: pluginConfig.usersAccessResultOverride,
       adminUsersSlug: adminUsersCollection.slug,
       collection: adminUsersCollection,
       fieldName: `${tenantsArrayFieldName}.${tenantsArrayTenantFieldName}`,

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -1,6 +1,8 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
 import type {
+  AccessResult,
   ArrayField,
+  CollectionConfig,
   CollectionSlug,
   Field,
   RelationshipField,
@@ -197,6 +199,16 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
     user: ConfigTypes extends { user: unknown } ? ConfigTypes['user'] : TypedUser,
   ) => boolean
   /**
+   * Override the result of the admin `users` collection access control functions
+   */
+  usersAccessResultOverride?: ({
+    accessKey,
+    result,
+  }: {
+    accessKey: AllAccessKeys[number]
+    result: AccessResult
+  }) => AccessResult
+  /**
    * Opt out of adding access constraints to the tenants collection
    */
   useTenantsCollectionAccess?: boolean
@@ -204,6 +216,7 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
    * Opt out including the baseListFilter to filter tenants by selected tenant
    */
   useTenantsListFilter?: boolean
+
   /**
    * Opt out including the baseListFilter to filter users by selected tenant
    */
@@ -246,3 +259,16 @@ export type UserWithTenantsField = {
       }[]
     | null
 } & TypedUser
+
+type AllAccessKeysT<T extends readonly string[]> = T[number] extends keyof Omit<
+  Required<CollectionConfig>['access'],
+  'admin'
+>
+  ? keyof Omit<Required<CollectionConfig>['access'], 'admin'> extends T[number]
+    ? T
+    : never
+  : never
+
+export type AllAccessKeys = AllAccessKeysT<
+  ['create', 'read', 'update', 'delete', 'readVersions', 'unlock']
+>

--- a/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
@@ -1,23 +1,20 @@
 import type { CollectionConfig } from 'payload'
 
-import type { MultiTenantPluginConfig } from '../types.js'
+import type { AllAccessKeys, MultiTenantPluginConfig } from '../types.js'
 
 import { withTenantAccess } from './withTenantAccess.js'
 
-type AllAccessKeys<T extends readonly string[]> = T[number] extends keyof Omit<
-  Required<CollectionConfig>['access'],
-  'admin'
->
-  ? keyof Omit<Required<CollectionConfig>['access'], 'admin'> extends T[number]
-    ? T
-    : never
-  : never
-
-const collectionAccessKeys: AllAccessKeys<
-  ['create', 'read', 'update', 'delete', 'readVersions', 'unlock']
-> = ['create', 'read', 'update', 'delete', 'readVersions', 'unlock'] as const
+export const collectionAccessKeys: AllAccessKeys = [
+  'create',
+  'read',
+  'update',
+  'delete',
+  'readVersions',
+  'unlock',
+] as const
 
 type Args<ConfigType> = {
+  accessResultCallback?: MultiTenantPluginConfig<ConfigType>['usersAccessResultOverride']
   adminUsersSlug: string
   collection: CollectionConfig
   fieldName: string
@@ -33,6 +30,7 @@ type Args<ConfigType> = {
  * - constrains access a users assigned tenants
  */
 export const addCollectionAccess = <ConfigType>({
+  accessResultCallback,
   adminUsersSlug,
   collection,
   fieldName,
@@ -46,6 +44,8 @@ export const addCollectionAccess = <ConfigType>({
     }
     collection.access[key] = withTenantAccess<ConfigType>({
       accessFunction: collection.access?.[key],
+      accessKey: key,
+      accessResultCallback,
       adminUsersSlug,
       collection,
       fieldName: key === 'readVersions' ? `version.${fieldName}` : fieldName,


### PR DESCRIPTION
Allows users to override the access control functions on the users collection. By default the users collection adds tenant privacy, but you may want to override that for some users.

You can now add this property to the config
```ts
usersAccessResultOverride: ({
  accessKey: 'read', // 'create', 'read', 'update', 'delete', 'readVersions', 'unlock'
  accessResult: AccessResult, // the `AccessResult` type
  ...args, // AccessArgs
}) => {
  // this is where you could adjust what gets returned here.
  if (accessKey === 'read') {
    return true // over simplified example
  }

  // default to returning the result from the plugin
  return accessResult
}
```
