### PR TITLE
docs: add dev note about auth strategy hot-reload requirement

### DIFF
--- a/docs/authentication/custom-strategies.mdx
+++ b/docs/authentication/custom-strategies.mdx
@@ -10,6 +10,8 @@ keywords: authentication, config, configuration, overview, documentation, Conten
   This is an advanced feature, so only attempt this if you are an experienced
   developer. Otherwise, just let Payload's built-in authentication handle user
   auth for you.
+
+  **Development Note:** Changes to custom authentication strategies require a full server restart to take effect. Auth strategies are not hot-reloaded during development. Consider using tools like `nodemon` for auto-restart functionality.
 </Banner>
 
 ### Creating a strategy


### PR DESCRIPTION
### What?
Added a documentation note informing developers that custom authentication strategies require a full server restart and are not hot-reloaded during development.

### Why?
During development, developers may expect auth strategies to hot-reload like other code changes in Payload. When changes don't take effect immediately, it leads to confusion and wasted debugging time trying to figure out why their strategy modifications aren't working.

This small documentation addition can save developers significant time and frustration.

### How?
- Added an informational `<Banner>` component in `docs/authentication/custom-strategies.mdx`
- Placed it immediately after the existing warning banner at the top of the page
- Includes a clear note about the restart requirement and suggests using `nodemon` for auto-restart

**Before:**
Only had the warning banner about this being an advanced feature.

**After:**
Now includes an additional info banner that explicitly states auth strategies require restart and are not hot-reloaded.

Fixes: N/A (proactive documentation improvement)