### PR TITLE
fix(sdk): `pagination` is not passed to search params

### DIFF
--- a/packages/sdk/src/utilities/buildSearchParams.ts
+++ b/packages/sdk/src/utilities/buildSearchParams.ts
@@ -10,6 +10,7 @@ export type OperationArgs = {
   limit?: number
   locale?: string
   page?: number
+  pagination?: boolean
   populate?: Record<string, unknown>
   select?: SelectType
   sort?: Sort
@@ -33,6 +34,10 @@ export const buildSearchParams = (args: OperationArgs): string => {
 
   if (typeof args.draft === 'boolean') {
     search.draft = String(args.draft)
+  }
+
+  if (typeof args.pagination === 'boolean') {
+    search.pagination = String(args.pagination)
   }
 
   if (args.fallbackLocale) {

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -44,6 +44,17 @@ describe('@payloadcms/sdk', () => {
     const result = await sdk.find({ collection: 'posts', where: { id: { equals: post.id } } })
 
     expect(result.docs[0].id).toBe(post.id)
+
+    const ids = []
+    for (let i = 0; i < 40; i++) {
+      const post = await payload.create({ collection: 'posts', data: {} })
+      ids.push(post.id)
+    }
+
+    const resultPaginationFalse = await sdk.find({ collection: 'posts', pagination: false })
+    expect(resultPaginationFalse.docs).toHaveLength(41)
+    expect(resultPaginationFalse.totalDocs).toBe(41)
+    await payload.delete({ collection: 'posts', where: { id: { in: ids } } })
   })
 
   it('should execute findVersions', async () => {


### PR DESCRIPTION
Previously, the `pagination` argument didn't work because it wasn't passed to the search params, this PR fixes it and adds a test assertion.