### PR TITLE
feat(plugin-multi-tenant): allow collection access to be overridden via callback

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -75,16 +75,25 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   collections: {
     [key in CollectionSlug]?: {
       /**
-       * Set to `true` if you want the collection to behave as a global
+       * Override the access result from the collection access control functions
        *
-       * @default false
+       * The function receives:
+       *  - accessResult: the original result from the access control function
+       *  - accessKey: 'read', 'create', 'update', 'delete', 'readVersions', or 'unlock'
+       *  - ...restOfAccessArgs: the original arguments passed to the access control function
        */
-      isGlobal?: boolean
+      accessResultOverride?: CollectionAccessResultOverride
       /**
        * Opt out of adding the tenant field and place
        * it manually using the `tenantField` export from the plugin
        */
       customTenantField?: boolean
+      /**
+       * Set to `true` if you want the collection to behave as a global
+       *
+       * @default false
+       */
+      isGlobal?: boolean
       /**
        * Overrides for the tenant field, will override the entire tenantField configuration
        */
@@ -243,6 +252,15 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
       : TypedUser,
   ) => boolean
   /**
+   * Override the access result on the users collection access control functions
+   *
+   * The function receives:
+   *  - accessResult: the original result from the access control function
+   *  - accessKey: 'read', 'create', 'update', 'delete', 'readVersions', or 'unlock'
+   *  - ...restOfAccessArgs: the original arguments passed to the access control function
+   */
+  usersAccessResultOverride?: CollectionAccessResultOverride
+  /**
    * Opt out of adding access constraints to the tenants collection
    */
   useTenantsCollectionAccess?: boolean
@@ -250,6 +268,7 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
    * Opt out including the baseListFilter to filter tenants by selected tenant
    */
   useTenantsListFilter?: boolean
+
   /**
    * Opt out including the baseListFilter to filter users by selected tenant
    */

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -227,6 +227,7 @@ export const multiTenantPlugin =
            * Add access control constraint to tenant enabled folders collection
            */
           addCollectionAccess({
+            accessResultCallback: pluginConfig.collections[foldersSlug]?.accessResultOverride,
             adminUsersSlug: adminUsersCollection.slug,
             collection,
             fieldName: tenantFieldName,
@@ -412,6 +413,7 @@ export const multiTenantPlugin =
            * Add access control constraint to tenant enabled collection
            */
           addCollectionAccess({
+            accessResultCallback: pluginConfig.collections[collection.slug]?.accessResultOverride,
             adminUsersSlug: adminUsersCollection.slug,
             collection,
             fieldName: tenantFieldName,

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -1,5 +1,6 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
 import type {
+  AccessArgs,
   AccessResult,
   ArrayField,
   CollectionConfig,
@@ -32,6 +33,15 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
    */
   collections: {
     [key in CollectionSlug]?: {
+      /**
+       * Override the access result from the collection access control functions
+       *
+       * The function receives:
+       *  - accessResult: the original result from the access control function
+       *  - accessKey: 'read', 'create', 'update', 'delete', 'readVersions', or 'unlock'
+       *  - ...restOfAccessArgs: the original arguments passed to the access control function
+       */
+      accessResultOverride?: CollectionAccessResultOverride
       /**
        * Opt out of adding the tenant field and place
        * it manually using the `tenantField` export from the plugin
@@ -201,13 +211,7 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   /**
    * Override the result of the admin `users` collection access control functions
    */
-  usersAccessResultOverride?: ({
-    accessKey,
-    result,
-  }: {
-    accessKey: AllAccessKeys[number]
-    result: AccessResult
-  }) => AccessResult
+  usersAccessResultOverride?: CollectionAccessResultOverride
   /**
    * Opt out of adding access constraints to the tenants collection
    */
@@ -271,3 +275,11 @@ type AllAccessKeysT<T extends readonly string[]> = T[number] extends keyof Omit<
 export type AllAccessKeys = AllAccessKeysT<
   ['create', 'read', 'update', 'delete', 'readVersions', 'unlock']
 >
+
+export type CollectionAccessResultOverride = ({
+  accessKey,
+  accessResult,
+}: {
+  accessKey: AllAccessKeys[number]
+  accessResult: AccessResult
+} & AccessArgs) => AccessResult

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -209,7 +209,12 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
     user: ConfigTypes extends { user: unknown } ? ConfigTypes['user'] : TypedUser,
   ) => boolean
   /**
-   * Override the result of the admin `users` collection access control functions
+   * Override the access result on the users collection access control functions
+   *
+   * The function receives:
+   *  - accessResult: the original result from the access control function
+   *  - accessKey: 'read', 'create', 'update', 'delete', 'readVersions', or 'unlock'
+   *  - ...restOfAccessArgs: the original arguments passed to the access control function
    */
   usersAccessResultOverride?: CollectionAccessResultOverride
   /**
@@ -282,4 +287,4 @@ export type CollectionAccessResultOverride = ({
 }: {
   accessKey: AllAccessKeys[number]
   accessResult: AccessResult
-} & AccessArgs) => AccessResult
+} & AccessArgs) => AccessResult | Promise<AccessResult>

--- a/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
@@ -42,10 +42,12 @@ export const withTenantAccess =
       if (accessResultCallback) {
         return accessResultCallback({
           accessKey,
-          result: false,
+          accessResult: false,
+          ...args,
         })
+      } else {
+        return false
       }
-      return false
     } else if (accessResult && typeof accessResult === 'object') {
       constraints.push(accessResult)
     }
@@ -81,17 +83,21 @@ export const withTenantAccess =
       if (accessResultCallback) {
         return accessResultCallback({
           accessKey,
-          result: combineWhereConstraints(constraints),
+          accessResult: combineWhereConstraints(constraints),
+          ...args,
         })
+      } else {
+        return combineWhereConstraints(constraints)
       }
-      return combineWhereConstraints(constraints)
     }
 
     if (accessResultCallback) {
       return accessResultCallback({
         accessKey,
-        result: accessResult,
+        accessResult,
+        ...args,
       })
+    } else {
+      return accessResult
     }
-    return accessResult
   }


### PR DESCRIPTION
This allows users to write a function that can modify the access control results. 

The function args are:
- accessKey: 'read', 'create', 'update', 'delete', 'readVersions', or 'unlock'
- accessResult: the access result that has the multi-tenant constraints on it, `Where` or a `boolean`
- ...args: the rest of the args passed to an access control function

It can be used like so:
```ts
multiTenantPlugin<ConfigType>({
  collections: {
    posts: {
      accessResultOverride: async ({ accessResult, accessKey, req }) => {
        // here is where you can change the access result or return something entirely different
        if (accessKey === 'read') {
          return {
            or: [
              {
                isShared: {
                  equals: true,
                }
              },
              accessResult
            ]
          }
        } else {
          return accessResult
        }
      }
    }
  }
})
```