### PR TITLE
fix(db-mongodb): improve check for `ObjectId`

### DIFF
--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -9,6 +9,7 @@ import type { MongooseAdapter } from '../index.js'
 import type { OperatorMapKey } from './operatorMap.js'
 
 import { getCollection } from '../utilities/getEntity.js'
+import { isObjectID } from '../utilities/isObjectID.js'
 import { operatorMap } from './operatorMap.js'
 import { sanitizeQueryValue } from './sanitizeQueryValue.js'
 
@@ -199,11 +200,11 @@ export async function buildSearchParam({
 
               if (Array.isArray(ref)) {
                 for (const item of ref) {
-                  if (item instanceof Types.ObjectId) {
+                  if (isObjectID(item)) {
                     $in.push(item)
                   }
                 }
-              } else if (ref instanceof Types.ObjectId) {
+              } else if (isObjectID(ref)) {
                 $in.push(ref)
               }
             } else {

--- a/packages/db-mongodb/src/utilities/isObjectID.ts
+++ b/packages/db-mongodb/src/utilities/isObjectID.ts
@@ -1,0 +1,16 @@
+import type { Types } from 'mongoose'
+
+export const isObjectID = (value: unknown): value is Types.ObjectId => {
+  if (
+    value &&
+    typeof value === 'object' &&
+    '_bsontype' in value &&
+    value._bsontype === 'ObjectId' &&
+    'toHexString' in value &&
+    typeof value.toHexString === 'function'
+  ) {
+    return true
+  }
+
+  return false
+}

--- a/packages/db-mongodb/src/utilities/transform.ts
+++ b/packages/db-mongodb/src/utilities/transform.ts
@@ -17,6 +17,8 @@ import { fieldAffectsData, fieldShouldBeLocalized } from 'payload/shared'
 
 import type { MongooseAdapter } from '../index.js'
 
+import { isObjectID } from './isObjectID.js'
+
 interface RelationObject {
   relationTo: string
   value: number | string
@@ -88,7 +90,7 @@ const convertRelationshipValue = ({
   )
 
   if (operation === 'read') {
-    if (value instanceof Types.ObjectId) {
+    if (isObjectID(value)) {
       return value.toHexString()
     }
 
@@ -141,7 +143,7 @@ const sanitizeRelationship = ({
       for (let i = 0; i < value.docs.length; i++) {
         const item = value.docs[i]
 
-        if (item instanceof Types.ObjectId) {
+        if (isObjectID(item)) {
           value.docs[i] = item.toHexString()
         } else if (Array.isArray(field.collection) && item) {
           // Fields here for polymorphic joins cannot be determinted, JSON.parse needed
@@ -492,7 +494,7 @@ export const transform = ({
     data.id = data._id || data.id
     delete data['_id']
 
-    if (data.id instanceof Types.ObjectId) {
+    if (isObjectID(data.id)) {
       data.id = data.id.toHexString()
     }
 


### PR DESCRIPTION
`instanceof` may not always work correctly, this PR implements a new function `isObjectID` which checks whether the value is `ObjectId` in a more robust way and replaces `instanceof` usage to this function.