### PR TITLE
fix(richtext-lexical): correctly type field property of RenderLexical

### DIFF
--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/field/index.ts
@@ -1,8 +1,8 @@
 import type { SerializedEditorState } from 'lexical'
-import type { Field, RichTextField } from 'payload'
+import type { Field } from 'payload'
 
 import type { SanitizedServerEditorConfig } from '../../../../lexical/config/types.js'
-import type { AdapterProps, LexicalRichTextAdapter } from '../../../../types.js'
+import type { LexicalRichTextAdapter, LexicalRichTextField } from '../../../../types.js'
 import type { HTMLConverter } from '../converter/types.js'
 import type { HTMLConverterFeatureProps } from '../index.js'
 
@@ -125,10 +125,9 @@ export const lexicalHTML: (
             )
           }
 
-          const lexicalField: RichTextField<SerializedEditorState, AdapterProps> =
-            siblingFields.find(
-              (field) => 'name' in field && field.name === lexicalFieldName,
-            ) as RichTextField<SerializedEditorState, AdapterProps>
+          const lexicalField: LexicalRichTextField = siblingFields.find(
+            (field) => 'name' in field && field.name === lexicalFieldName,
+          ) as LexicalRichTextField
 
           const lexicalFieldData: SerializedEditorState = siblingData[lexicalFieldName]
 

--- a/packages/richtext-lexical/src/features/typesServer.ts
+++ b/packages/richtext-lexical/src/features/typesServer.ts
@@ -26,7 +26,7 @@ import type {
 
 import type { ServerEditorConfig } from '../lexical/config/types.js'
 import type { Transformer } from '../packages/@lexical/markdown/index.js'
-import type { AdapterProps } from '../types.js'
+import type { LexicalRichTextField } from '../types.js'
 import type { HTMLConverter } from './converters/lexicalToHtml_deprecated/converter/types.js'
 import type { BaseClientFeatureProps } from './typesClient.js'
 
@@ -39,7 +39,7 @@ export type PopulationPromise<T extends SerializedLexicalNode = SerializedLexica
    * This maps all population promises to the node type
    */
   editorPopulationPromises: Map<string, Array<PopulationPromise>>
-  field: RichTextField<SerializedEditorState, AdapterProps>
+  field: LexicalRichTextField
   /**
    * fieldPromises are used for things like field hooks. They will be awaited before awaiting populationPromises
    */
@@ -305,7 +305,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
        * Current schema which will be modified by this function.
        */
       currentSchema: JSONSchema4
-      field: RichTextField<SerializedEditorState, AdapterProps>
+      field: LexicalRichTextField
       i18n?: I18n
       /**
        * Allows you to define new top-level interfaces that can be re-used in the output schema.
@@ -382,7 +382,7 @@ export type SanitizedServerFeatures = {
          * Current schema which will be modified by this function.
          */
         currentSchema: JSONSchema4
-        field: RichTextField<SerializedEditorState, AdapterProps>
+        field: LexicalRichTextField
         i18n?: I18n
         /**
          * Allows you to define new top-level interfaces that can be re-used in the output schema.

--- a/packages/richtext-lexical/src/field/RenderLexical/index.tsx
+++ b/packages/richtext-lexical/src/field/RenderLexical/index.tsx
@@ -14,6 +14,7 @@ import {
 import React, { useCallback, useEffect, useRef } from 'react'
 
 import type { DefaultTypedEditorState } from '../../nodeTypes.js'
+import type { LexicalRichTextField } from '../../types.js'
 
 /**
  * Utility to render a lexical editor on the client.
@@ -34,7 +35,7 @@ export const RenderLexical: React.FC<
 
     setValue?: FieldType<DefaultTypedEditorState | undefined>['setValue']
     value?: FieldType<DefaultTypedEditorState | undefined>['value']
-  } & RenderFieldServerFnArgs
+  } & RenderFieldServerFnArgs<LexicalRichTextField>
 > = (args) => {
   const { field, initialValue, Loading, path, schemaPath, setValue, value } = args
   const [Component, setComponent] = React.useState<null | React.ReactNode>(null)

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -4,6 +4,7 @@ import type {
   DefaultServerCellComponentProps,
   LabelFunction,
   RichTextAdapter,
+  RichTextField,
   RichTextFieldClient,
   RichTextFieldClientProps,
   SanitizedConfig,
@@ -140,3 +141,5 @@ export type GeneratedFeatureProviderComponent = {
   clientFeature: FeatureProviderProviderClient<any, any>
   clientFeatureProps: BaseClientFeatureProps<object>
 }
+
+export type LexicalRichTextField = RichTextField<SerializedEditorState, AdapterProps>

--- a/packages/ui/src/forms/fieldSchemasToFormState/serverFunctions/renderFieldServerFn.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/serverFunctions/renderFieldServerFn.ts
@@ -5,11 +5,11 @@ import { getClientSchemaMap } from '../../../utilities/getClientSchemaMap.js'
 import { getSchemaMap } from '../../../utilities/getSchemaMap.js'
 import { renderField } from '../renderField.js'
 
-export type RenderFieldServerFnArgs = {
+export type RenderFieldServerFnArgs<TField = Field> = {
   /**
    * Override field config pulled from schemaPath lookup
    */
-  field?: Partial<Field>
+  field?: Partial<TField>
   /**
    * Pass the value this field will receive when rendering it on the server.
    * For richText, this helps provide initial state for sub-fields that are immediately rendered (like blocks)


### PR DESCRIPTION
Previously, the `field` property of `RenderLexical` was loosely typed as `Field`. This PR strengthens the type to `LexicalRichTextField`- that way, people don't accidentally pass properties that do not exist for richtext fields.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211603491809657