### PR TITLE
feat(ui): colorize boolean cell span for better clarity

### DIFF
--- a/packages/ui/src/elements/Table/DefaultCell/fields/Checkbox/index.scss
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Checkbox/index.scss
@@ -20,5 +20,15 @@
 
     background: var(--theme-elevation-100);
     color: var(--theme-elevation-800);
+
+    &[data-checked='true'] {
+      background: var(--theme-success-100);
+      color: var(--theme-success-600);
+    }
+
+    &[data-checked='false'] {
+      background: var(--theme-error-100);
+      color: var(--theme-error-600);
+    }
   }
 }

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Checkbox/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Checkbox/index.tsx
@@ -10,9 +10,8 @@ export const CheckboxCell: React.FC<DefaultCellComponentProps<CheckboxFieldClien
   cellData,
 }) => {
   const { t } = useTranslation()
-
   return (
-    <code className="bool-cell">
+    <code className="bool-cell" data-checked={cellData}>
       <span>{t(`general:${cellData}`).toLowerCase()}</span>
     </code>
   )


### PR DESCRIPTION
## What / Why
I've always felt that boolean cells could be more readable if they used standard colors to better differentiate true and false values.

## Changes introduced
- Added a `data-checked` attribute to the `<code />` element to store corresponding boolean value.
- Added `data-checked` scoped styles to color its badge accordingly.

## Behavior after the fix
- `true` badges use `--theme-success` color (blue) 
- `false` badges use `--theme--error` color (red).

## How to test manually
1. Run `pnpm dev fields` or similar
2. Navigate to any collection list view where a checkbox field is used (with either true or false value).

## Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/788e4423-d222-487a-b27f-39015cf31dbf" />
