### PR TITLE
feat(ui): convert relationship cell texts into links

### DIFF
--- a/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.tsx
@@ -13,7 +13,9 @@ import { useIntersect } from '../../../../../hooks/useIntersect.js'
 import { useConfig } from '../../../../../providers/Config/index.js'
 import { useTranslation } from '../../../../../providers/Translation/index.js'
 import { canUseDOM } from '../../../../../utilities/canUseDOM.js'
+import { formatAdminURL } from '../../../../../utilities/formatAdminURL.js'
 import { formatDocTitle } from '../../../../../utilities/formatDocTitle/index.js'
+import { Link } from '../../../../Link/index.js'
 import { useListRelationships } from '../../../RelationshipProvider/index.js'
 import { FileCell } from '../File/index.js'
 import './index.scss'
@@ -43,6 +45,7 @@ export const RelationshipCell: React.FC<RelationshipCellProps> = ({
 
   const { config, getEntityConfig } = useConfig()
   const { collections, routes } = config
+  const { admin: adminRoute } = routes
   const [intersectionRef, entry] = useIntersect()
   const [values, setValues] = useState<Value[]>([])
   const { documents, getRelationships } = useListRelationships()
@@ -128,11 +131,22 @@ export const RelationshipCell: React.FC<RelationshipCellProps> = ({
           }
         }
 
+        const documentHref = formatAdminURL({
+          adminRoute,
+          path: `/collections/${relationTo}/${encodeURIComponent(value)}`,
+        })
+
         return (
           <React.Fragment key={i}>
             {document === false && `${t('general:untitled')} - ID: ${value}`}
             {document === null && `${t('general:loading')}...`}
-            {document ? fileField || label : null}
+            {document
+              ? fileField || (
+                  <Link href={documentHref} prefetch={false}>
+                    {label}
+                  </Link>
+                )
+              : null}
             {values.length > i + 1 && ', '}
           </React.Fragment>
         )


### PR DESCRIPTION
## What / Why
 Some clients have told me this before and I also think it's something useful that improves document navigation overall.

 It makes it easier to check related documents from list view, otherwise, you'd need to either:

- Navigate to that related collection and find that particular document
- Open the document and then click on the edit button inside of the relationship field (kind of unnecesary most of the time).

## Changes introduced
- Added `Link` component import to the Relationship field component
- Added `formatAdminURL` utility import for proper admin route construction
- Modified the render logic to wrap document labels with `<Link>` components that navigate to the related document's edit page.
- Added href generation using `formatAdminURL()` (after all, needed information was already there, no need for extra API calls or anything).
- Maintained existing behavior for upload fields (FileCell) and edge cases (loading/untitled states)

## Behavior after the fix
- Related documents in table cells now appear as clickable links instead of plain text
- Links navigate directly to the related document's edit page in the admin panel
- Multiple related documents each have their own individual clickable link, separated by commas
- Upload field relationships continue to show file previews with existing functionality
- Loading and untitled states remain as plain text (non-clickable)

## Concern
I'm not sure if it would be better to make this "configurable" in some way so that developers can enable/disable this or even choose if they want to navigate to that document or open a drawer instead.

## How to test manually
1. Run `pnpm dev fields` or similar
2. Navigate to any collection list view where a relationship field is used (test both single relationships or hasMany relationships)

## Video
https://github.com/user-attachments/assets/41aae833-71dc-40ab-be89-90625b420978


