### PR TITLE
fix(plugin-multi-tenant): object reference mutations in addFilterOptionsToFields

### DIFF
--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -169,7 +169,7 @@ export const multiTenantPlugin =
         /**
          * Add filter options to all relationship fields
          */
-        addFilterOptionsToFields({
+        collection.fields = addFilterOptionsToFields({
           blockReferencesWithFilters,
           config: incomingConfig,
           fields: collection.fields,
@@ -355,7 +355,7 @@ export const multiTenantPlugin =
         /**
          * Add filter options to all relationship fields
          */
-        addFilterOptionsToFields({
+        collection.fields = addFilterOptionsToFields({
           blockReferencesWithFilters,
           config: incomingConfig,
           fields: collection.fields,

--- a/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
@@ -58,7 +58,7 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
           })
         }
       } else {
-        newField.relationTo.map((relationTo) => {
+        for (const relationTo of newField.relationTo) {
           if (tenantEnabledGlobalSlugs.includes(relationTo)) {
             throw new Error(
               `The collection ${relationTo} is a global collection and cannot be related to a tenant enabled collection.`,
@@ -75,7 +75,7 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
               userHasAccessToAllTenants,
             })
           }
-        })
+        }
       }
     }
 

--- a/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
@@ -88,7 +88,7 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
       newField.fields = addFilterOptionsToFields({
         blockReferencesWithFilters,
         config,
-        fields: [...newField.fields],
+        fields: newField.fields,
         tenantEnabledCollectionSlugs,
         tenantEnabledGlobalSlugs,
         tenantFieldName,
@@ -119,7 +119,7 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
           block.fields = addFilterOptionsToFields({
             blockReferencesWithFilters,
             config,
-            fields: [...block.fields],
+            fields: block.fields,
             tenantEnabledCollectionSlugs,
             tenantEnabledGlobalSlugs,
             tenantFieldName,
@@ -143,7 +143,7 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
         newTab.fields = addFilterOptionsToFields({
           blockReferencesWithFilters,
           config,
-          fields: [...tab.fields],
+          fields: tab.fields,
           tenantEnabledCollectionSlugs,
           tenantEnabledGlobalSlugs,
           tenantFieldName,


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14075


## Fix object reference mutations in `addFilterOptionsToFields`

Refactored `addFilterOptionsToFields` to return new arrays with copied objects instead of mutating the original config in place.

This fixes issues where shared block and tab configurations would break when reused across multiple collections.

### Problem
When field, block, or tab configs were reused across multiple collections (e.g., a `BlockFields` constant referenced in multiple places), the plugin would mutate the original shared objects. This caused filters to be applied multiple times or break entirely on subsequent uses.

**Example that failed:**
```typescript
// Shared block config
export const BlockFields: Field[] = [
    {
      name: 'image',
      relationTo: ['images', 'documents'],
      type: 'relationship',
    }
]

// example fields config definition
fields: [
  {
    name: 'blocksExample',
    blocks: [
      {
        fields: BlockFields,
        slug: 'blockSet1',
        type: 'blocks',
      },
      {
        fields: BlockFields,
        slug: 'blockSet2',
        type: 'blocks',
      }
    ]
  }
]
```

### Root cause
The original implementation mutated config objects in place without creating copies, directly modifying user-provided configuration that might be reused elsewhere.

### Solution
Changed addFilterOptionsToFields from a void function that mutates in place to one that returns new arrays with copied objects:
- Fields: Create shallow copy of each field ({ ...field }) before modification
- Blocks: Create shallow copy of each block ({ ..._block }) before modifying fields
- Tabs: Map to create new tab objects ({ ...tab }) instead of mutating in-place
- Return new arrays: Build and return newFields array instead of mutating the input
- Update callers: Assign the returned value back (e.g., collection.fields = addFilterOptionsToFields(...))

This ensures the plugin can safely handle reused config objects without side effects.