### PR TITLE
perf: added inline relationships (use JOINs instead of SELECTs)

### DIFF
--- a/packages/drizzle/src/transform/read/index.ts
+++ b/packages/drizzle/src/transform/read/index.ts
@@ -6,7 +6,7 @@ import { createBlocksMap } from '../../utilities/createBlocksMap.js'
 import { createPathMap } from '../../utilities/createRelationshipMap.js'
 import { traverseFields } from './traverseFields.js'
 
-type TransformArgs = {
+export type TransformArgs = {
   adapter: DrizzleAdapter
   config: SanitizedConfig
   data: Record<string, unknown>

--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -49,7 +49,7 @@ import { GraphQLJSON } from '../packages/graphql-type-json/index.js'
 import { combineParentName } from '../utilities/combineParentName.js'
 import { formatName } from '../utilities/formatName.js'
 import { formatOptions } from '../utilities/formatOptions.js'
-import { resolveSelect} from '../utilities/select.js'
+import { resolveSelect } from '../utilities/select.js'
 import { buildObjectType, type ObjectTypeConfig } from './buildObjectType.js'
 import { isFieldNullable } from './isFieldNullable.js'
 import { withNullableType } from './withNullableType.js'
@@ -57,7 +57,11 @@ import { withNullableType } from './withNullableType.js'
 function formattedNameResolver({
   field,
   ...rest
-}: { field: Field } & GraphQLFieldConfig<any, Context, any>): GraphQLFieldConfig<any, Context, any> {
+}: { field: Field } & GraphQLFieldConfig<any, Context, any>): GraphQLFieldConfig<
+  any,
+  Context,
+  any
+> {
   if ('name' in field) {
     if (formatName(field.name) !== field.name) {
       return {
@@ -669,21 +673,24 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
                 id = relatedDoc.value
               }
 
-              const result = await context.req.payloadDataLoader.load(
-                createDataloaderCacheKey({
-                  collectionSlug: collectionSlug as string,
-                  currentDepth: 0,
-                  depth: 0,
-                  docID: id,
-                  draft,
-                  fallbackLocale,
-                  locale,
-                  overrideAccess: false,
-                  select,
-                  showHiddenFields: false,
-                  transactionID: context.req.transactionID,
-                }),
-              )
+              const inline = field.inline && typeof id === 'object'
+              const result = inline
+                ? id
+                : await context.req.payloadDataLoader.load(
+                    createDataloaderCacheKey({
+                      collectionSlug: collectionSlug as string,
+                      currentDepth: 0,
+                      depth: 0,
+                      docID: id,
+                      draft,
+                      fallbackLocale,
+                      locale,
+                      overrideAccess: false,
+                      select,
+                      showHiddenFields: false,
+                      transactionID: context.req.transactionID,
+                    }),
+                  )
 
               if (result) {
                 if (isRelatedToManyCollections) {
@@ -719,21 +726,24 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
 
         if (id) {
           if (graphQLCollections.some((collection) => collection.slug === relatedCollectionSlug)) {
-            const relatedDocument = await context.req.payloadDataLoader.load(
-              createDataloaderCacheKey({
-                collectionSlug: relatedCollectionSlug as string,
-                currentDepth: 0,
-                depth: 0,
-                docID: id,
-                draft,
-                fallbackLocale,
-                locale,
-                overrideAccess: false,
-                select,
-                showHiddenFields: false,
-                transactionID: context.req.transactionID,
-              }),
-            )
+            const inline = field.inline && typeof id === 'object'
+            const relatedDocument = inline
+              ? id
+              : await context.req.payloadDataLoader.load(
+                  createDataloaderCacheKey({
+                    collectionSlug: relatedCollectionSlug as string,
+                    currentDepth: 0,
+                    depth: 0,
+                    docID: id,
+                    draft,
+                    fallbackLocale,
+                    locale,
+                    overrideAccess: false,
+                    select,
+                    showHiddenFields: false,
+                    transactionID: context.req.transactionID,
+                  }),
+                )
 
             if (relatedDocument) {
               if (isRelatedToManyCollections) {
@@ -970,7 +980,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
     const hasManyValues = field.hasMany
     const relationshipName = combineParentName(parentName, toWords(field.name, true))
 
-    let type
+    let type: GraphQLOutputType
     let relationToType = null
 
     if (Array.isArray(relationTo)) {
@@ -1079,21 +1089,24 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
               id = relatedDoc.value
             }
 
-            const result = await context.req.payloadDataLoader.load(
-              createDataloaderCacheKey({
-                collectionSlug,
-                currentDepth: 0,
-                depth: 0,
-                docID: id,
-                draft,
-                fallbackLocale,
-                locale,
-                overrideAccess: false,
-                select,
-                showHiddenFields: false,
-                transactionID: context.req.transactionID,
-              }),
-            )
+            const inline = field.inline && typeof id === 'object'
+            const result = inline
+              ? id
+              : await context.req.payloadDataLoader.load(
+                  createDataloaderCacheKey({
+                    collectionSlug,
+                    currentDepth: 0,
+                    depth: 0,
+                    docID: id,
+                    draft,
+                    fallbackLocale,
+                    locale,
+                    overrideAccess: false,
+                    select,
+                    showHiddenFields: false,
+                    transactionID: context.req.transactionID,
+                  }),
+                )
 
             if (result) {
               if (isRelatedToManyCollections) {
@@ -1127,21 +1140,24 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         }
 
         if (id) {
-          const relatedDocument = await context.req.payloadDataLoader.load(
-            createDataloaderCacheKey({
-              collectionSlug: relatedCollectionSlug,
-              currentDepth: 0,
-              depth: 0,
-              docID: id,
-              draft,
-              fallbackLocale,
-              locale,
-              overrideAccess: false,
-              select,
-              showHiddenFields: false,
-              transactionID: context.req.transactionID,
-            }),
-          )
+          const inline = field.inline && typeof id === 'object'
+          const relatedDocument = inline
+            ? id
+            : await context.req.payloadDataLoader.load(
+                createDataloaderCacheKey({
+                  collectionSlug: relatedCollectionSlug,
+                  currentDepth: 0,
+                  depth: 0,
+                  docID: id,
+                  draft,
+                  fallbackLocale,
+                  locale,
+                  overrideAccess: false,
+                  select,
+                  showHiddenFields: false,
+                  transactionID: context.req.transactionID,
+                }),
+              )
 
           if (relatedDocument) {
             if (isRelatedToManyCollections) {

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -959,6 +959,7 @@ type SharedUploadProperties = {
    */
   displayPreview?: boolean
   filterOptions?: FilterOptions
+  inline?: boolean
   /**
    * Sets a maximum population depth for this field, regardless of the remaining depth when this field is reached.
    *
@@ -1165,6 +1166,7 @@ export type SelectFieldClient = {
 
 type SharedRelationshipProperties = {
   filterOptions?: FilterOptions
+  inline?: boolean
   /**
    * Sets a maximum population depth for this field, regardless of the remaining depth when this field is reached.
    *

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -39,6 +39,10 @@ const populate = async ({
   showHiddenFields,
 }: PopulateArgs) => {
   const dataToUpdate = dataReference
+  const inline =
+    typeof data === 'object' &&
+    (field.type === 'relationship' || field.type === 'upload') &&
+    field.inline
   let relation
   if (field.type === 'join') {
     relation = Array.isArray(field.collection) ? data.relationTo : field.collection
@@ -56,12 +60,14 @@ const populate = async ({
       id = data.value
     } else if (field.type !== 'join' && Array.isArray(field.relationTo)) {
       id = data.value
+    } else if (inline != true && data.id) {
+      id = data.id
     } else {
       id = data
     }
 
     let relationshipValue
-    const shouldPopulate = depth && currentDepth <= depth
+    const shouldPopulate = depth && currentDepth <= depth && !inline
 
     if (
       typeof id !== 'string' &&
@@ -208,10 +214,7 @@ export const relationshipPopulationPromise = async ({
           if (relatedDoc) {
             await populate({
               currentDepth,
-              data:
-                !(field.type === 'join' && Array.isArray(field.collection)) && relatedDoc?.id
-                  ? relatedDoc.id
-                  : relatedDoc,
+              data: relatedDoc,
               dataReference: resultingDoc,
               depth: populateDepth!,
               draft,

--- a/packages/payload/src/fields/hooks/afterRead/virtualFieldPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/virtualFieldPopulationPromise.ts
@@ -127,26 +127,28 @@ export const virtualFieldPopulationPromise = async ({
       }
 
       const collectionSlug = currentField.relationTo
-
-      const populatedDocs = await Promise.all(
-        docIDs.map((docID) => {
-          return req.payloadDataLoader.load(
-            createDataloaderCacheKey({
-              collectionSlug,
-              currentDepth: 0,
-              depth: 0,
-              docID,
-              draft,
-              fallbackLocale,
-              locale,
-              overrideAccess,
-              select,
-              showHiddenFields,
-              transactionID: req.transactionID as number,
+      const inline = currentField.inline && typeof currentValue[0] === 'object'
+      const populatedDocs = inline
+        ? currentValue
+        : await Promise.all(
+            docIDs.map((docID) => {
+              return req.payloadDataLoader.load(
+                createDataloaderCacheKey({
+                  collectionSlug,
+                  currentDepth: 0,
+                  depth: 0,
+                  docID,
+                  draft,
+                  fallbackLocale,
+                  locale,
+                  overrideAccess,
+                  select,
+                  showHiddenFields,
+                  transactionID: req.transactionID as number,
+                }),
+              )
             }),
           )
-        }),
-      )
 
       for (const doc of populatedDocs) {
         if (!doc) {
@@ -189,21 +191,24 @@ export const virtualFieldPopulationPromise = async ({
       return
     }
 
-    const populatedDoc = await req.payloadDataLoader.load(
-      createDataloaderCacheKey({
-        collectionSlug: currentField.relationTo,
-        currentDepth: 0,
-        depth: 0,
-        docID,
-        draft,
-        fallbackLocale,
-        locale,
-        overrideAccess,
-        select,
-        showHiddenFields,
-        transactionID: req.transactionID as number,
-      }),
-    )
+    const inline = currentField.inline && typeof currentValue === 'object'
+    const populatedDoc = inline
+      ? currentValue
+      : await req.payloadDataLoader.load(
+          createDataloaderCacheKey({
+            collectionSlug: currentField.relationTo,
+            currentDepth: 0,
+            depth: 0,
+            docID,
+            draft,
+            fallbackLocale,
+            locale,
+            overrideAccess,
+            select,
+            showHiddenFields,
+            transactionID: req.transactionID as number,
+          }),
+        )
 
     if (!populatedDoc) {
       return

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -769,6 +769,7 @@ export type UploadFieldSingleValidation = Validate<unknown, unknown, unknown, Up
 export const upload: UploadFieldValidation = async (value, options) => {
   const {
     event,
+    inline,
     maxRows,
     minRows,
     relationTo,
@@ -812,7 +813,9 @@ export const upload: UploadFieldValidation = async (value, options) => {
         collectionSlug = relationTo
 
         // custom id
-        if (val || typeof val === 'number') {
+        if (inline && typeof val === 'object') {
+          requestedID = val.id
+        } else if (val || typeof val === 'number') {
           requestedID = val
         }
       }


### PR DESCRIPTION
### What?
Adds the ability to inline relationships (i.e. use JOINs instead of separate SELECTs when fetching from the database).
This is controlled by a new `inline` flag that can be enabled when defining a relationship/upload field.
This feature works particularly well when used alongside the `select` parameter.

### Why?
To reduce the total number of database queries that are generated when fetching, saving or updating collections. This is particularly impactful on collections with multiple relationship/upload fields. I've seen it reduce from 15-30 queries to the database in a single operation to just 5-10.

### How?
By configuring Drizzle to join with the related collection, via the `with` parameter.
