### PR TITLE
fix: revert sharp to 0.32.6 for Vercel templates

### DIFF
--- a/templates/with-vercel-website/package.json
+++ b/templates/with-vercel-website/package.json
@@ -54,7 +54,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "7.45.4",
-    "sharp": "0.34.2",
+    "sharp": "0.32.6",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
Discussed here:
https://github.com/vercel/next.js/discussions/83230

---

a simple create-next-app with sharp being used in simple example: https://github.com/rgbjoy/vercel-nextjs-turbopack-sharp

Deployed: https://vercel-nextjs-turbopack-sharp.vercel.app/

Building this locally and on a vercel deployment is fine. VIsiting one of the sharp examples shows the 500 error: https://vercel-nextjs-turbopack-sharp.vercel.app/api/thumbnail?w=240&format=webp

---

Discord community help post: https://discord.com/channels/967097582721572934/1425735616913477683

Downgrading sharp from 0.34.4 to 0.32.6 resolves Vercel deployment issues caused by incompatible native binaries in newer sharp releases. Version 0.32.6 includes prebuilt binaries that match Vercel’s current Node runtime, making it the stable choice until Vercel updates its build image.