### PR TITLE
fix(db-mongodb): documents not showing in folders with `useJoinAggregations: false`

### DIFF
--- a/packages/db-mongodb/src/utilities/resolveJoins.ts
+++ b/packages/db-mongodb/src/utilities/resolveJoins.ts
@@ -480,11 +480,15 @@ function extractRelationToFilter(where: Record<string, unknown>): null | string[
 
   // Check for relationTo in logical operators
   if (where.and && Array.isArray(where.and)) {
+    const allResults: string[] = []
     for (const condition of where.and) {
       const result = extractRelationToFilter(condition)
       if (result) {
-        return result
+        allResults.push(...result)
       }
+    }
+    if (allResults.length > 0) {
+      return [...new Set(allResults)] // Remove duplicates
     }
   }
 

--- a/packages/db-mongodb/src/utilities/resolveJoins.ts
+++ b/packages/db-mongodb/src/utilities/resolveJoins.ts
@@ -445,6 +445,20 @@ export async function resolveJoins({
 
 /**
  * Extracts relationTo filter values from a WHERE clause
+ *
+ * @purpose When you have a polymorphic join field that can reference multiple collection types (e.g. the documentsAndFolders join field on
+ * folders that points to all folder-enabled collections), Payload needs to decide which collections to actually query. Without filtering,
+ * it would query ALL possible collections even when the WHERE clause clearly indicates it only needs specific ones.
+ *
+ * extractRelationToFilter analyzes the WHERE clause to extract relationTo conditions and returns only the collection slugs that
+ * could possibly match, avoiding unnecessary database queries.
+ *
+ * @description The function recursively traverses a WHERE clause looking for relationTo conditions in these patterns:
+ *
+ * 1. Direct conditions: { relationTo: { equals: 'posts' } }
+ * 2. IN conditions: { relationTo: { in: ['posts', 'media'] } }
+ * 3. Nested in AND/OR: Recursively searches through logical operators
+
  * @param where - The WHERE clause to search
  * @returns Array of collection slugs if relationTo filter found, null otherwise
  */
@@ -475,11 +489,15 @@ function extractRelationToFilter(where: Record<string, unknown>): null | string[
   }
 
   if (where.or && Array.isArray(where.or)) {
+    const allResults: string[] = []
     for (const condition of where.or) {
       const result = extractRelationToFilter(condition)
       if (result) {
-        return result
+        allResults.push(...result)
       }
+    }
+    if (allResults.length > 0) {
+      return [...new Set(allResults)] // Remove duplicates
     }
   }
 


### PR DESCRIPTION
### What?

Documents were not showing in folders in admin views. This has actually not been working since v3.48.0 (#12763), just haven't had the time to fix 😅

### Why?

The admin folder view was generating a join query like the following:

```ts
joins: {
  documentsAndFolders: {
    limit: 100000000,
    sort: 'name',
    where: {
      or: [
        {
          and: [
            { relationTo: { equals: 'payload-folders' } },  // <-- breaking here
            {
              or: [{ folderType: { in: ['posts'] } }, { folderType: { exists: false } }],
            },
          ],
        },
        {
          and: [{ relationTo: { equals: 'posts' } }],
        },
      ],
    },
  },
},
```

The `extractRelationToFilter()` function in `resolveJoins.ts` was not correctly processing  `and` and `or` queries. It was breaking on the first `relationTo` found in the array, thus only returning folders and not other documents.

### Fixes

`extractRelationToFilter()` now handles `and`/`or` where queries in joins correctly


