### PR TITLE
fix(ui): searchbar dropdown covered by table rows

### DIFF
--- a/packages/ui/src/elements/SearchBar/index.scss
+++ b/packages/ui/src/elements/SearchBar/index.scss
@@ -19,7 +19,7 @@
     }
 
     &:has(.popup--active) {
-      z-index: 1;
+      z-index: 2;
     }
 
     .icon--search {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14101

The fix in PR #13908 set `z-index: 1` for the SearchBar, but table cells also have `z-index: 1`, causing the dropdown to still be covered by table rows due to DOM order.

This PR completes the fix by changing the z-index from `1` to `2`, placing the SearchBar dropdown above table cells. This value is already safely used by other UI components (Card, Drawer, ReactSelect) without conflicts.