### PR TITLE
fix(ui): select dropdown obscured by header in landscape mode

### DIFF
--- a/packages/ui/src/elements/ReactSelect/index.scss
+++ b/packages/ui/src/elements/ReactSelect/index.scss
@@ -36,7 +36,7 @@
     }
 
     .rs__menu {
-      z-index: 4;
+      z-index: var(--z-select-menu);
       border-radius: 0;
       @include shadow-lg;
       background: var(--theme-input-bg);

--- a/packages/ui/src/fields/Select/index.scss
+++ b/packages/ui/src/fields/Select/index.scss
@@ -3,6 +3,8 @@
 @layer payload-default {
   .field-type.select {
     position: relative;
+    // Fixes a bug where the Select field's dropdown menu would be hidden behind the AppHeader in landscape mobile mode
+    z-index: 1;
   }
 
   html[data-theme='light'] {

--- a/packages/ui/src/scss/app.scss
+++ b/packages/ui/src/scss/app.scss
@@ -34,6 +34,7 @@
     --z-popup: 10;
     --z-nav: 20;
     --z-modal: 30;
+    --z-select-menu: 35;
     --z-status: 40;
 
     --accessibility-outline: 2px solid var(--theme-text);


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14073

Select dropdown menus are obscured by the AppHeader when opening upward in landscape mobile mode because the ReactSelect menu has z-index: 4 while the AppHeader has z-index: 30. This PR adds a new CSS variable --z-select-menu: 35 to the global z-index system and applies it to ReactSelect menu styles, placing the dropdown above the header while maintaining the established z-index hierarchy. This follows the existing pattern used in PR #13908 for the SearchBar z-index fix.