### PR TITLE
fix(plugin-form-builder): display full textarea content in form submissions

### DIFF
--- a/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
@@ -55,7 +55,7 @@ export const generateSubmissionCollection = (
         },
         {
           name: 'value',
-          type: 'text',
+          type: 'textarea',
           required: true,
           validate: (value: unknown) => {
             // TODO:


### PR DESCRIPTION
Fixes #14102

Changed `submissionData.value` field type from `text` to `textarea` to properly display multi-line content in the Form Submissions admin view.

The `text` field type was rendering content in single-line inputs with 40px fixed height, truncating textarea values. Using `textarea` field type leverages Payload's existing multi-line rendering.