### PR TITLE
fix(sdk): fix package sdk types error

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,4 @@
-import type { ApplyDisableErrors, PaginatedDocs, SelectType, TypeWithVersion } from 'payload'
+import type { ApplyDisableErrors, PaginatedDocs, TypedCollectionSelect, TypeWithVersion } from 'payload'
 
 import type { ForgotPasswordOptions } from './auth/forgotPassword.js'
 import type { LoginOptions, LoginResult } from './auth/login.js'
@@ -151,7 +151,7 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
    * @param options
    * @returns created document
    */
-  create<TSlug extends CollectionSlug<T>, TSelect extends SelectType>(
+  create<TSlug extends CollectionSlug<T>, TSelect extends TypedCollectionSelect<T>>(
     options: CreateOptions<T, TSlug, TSelect>,
     init?: RequestInit,
   ): Promise<TransformCollectionWithSelect<T, TSlug, TSelect>> {
@@ -186,7 +186,7 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
    * @param options
    * @returns documents satisfying query
    */
-  find<TSlug extends CollectionSlug<T>, TSelect extends SelectType>(
+  find<TSlug extends CollectionSlug<T>, TSelect extends TypedCollectionSelect<T>>(
     options: FindOptions<T, TSlug, TSelect>,
     init?: RequestInit,
   ): Promise<PaginatedDocs<TransformCollectionWithSelect<T, TSlug, TSelect>>> {
@@ -201,7 +201,7 @@ export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes>
   findByID<
     TSlug extends CollectionSlug<T>,
     TDisableErrors extends boolean,
-    TSelect extends SelectType,
+    TSelect extends TypedCollectionSelect<T>,
   >(
     options: FindByIDOptions<T, TSlug, TDisableErrors, TSelect>,
     init?: RequestInit,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -12,20 +12,39 @@ import type { MarkOptional, NonNever } from 'ts-essentials'
 export interface PayloadGeneratedTypes {
   auth: {
     [slug: string]: {
-      forgotPassword: {
-        email: string
-      }
-      login: {
-        email: string
-        password: string
-      }
-      registerFirstUser: {
-        email: string
-        password: string
-      }
-      unlock: {
-        email: string
-      }
+      forgotPassword:
+        | {
+            email: string
+          }
+        | {
+          username: string
+          };
+      login:
+        | {
+            email: string
+            password: string
+          }
+        | {
+            password: string
+            username: string
+          }
+      registerFirstUser:
+        | {
+            email: string
+            password: string
+          }
+        | {
+            password: string
+            username: string
+            email?: string
+          }
+      unlock:
+        | {
+            email: string
+          }
+        | {
+            username: string
+          }
     }
   }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -14,37 +14,37 @@ export interface PayloadGeneratedTypes {
     [slug: string]: {
       forgotPassword:
         | {
-            email: string
+            email: string;
           }
         | {
-          username: string
+          username: string;
           };
       login:
         | {
-            email: string
-            password: string
+            email: string;
+            password: string;
           }
         | {
-            password: string
-            username: string
-          }
+            password: string;
+            username: string;
+          };
       registerFirstUser:
         | {
-            email: string
-            password: string
+            email: string;
+            password: string;
           }
         | {
-            password: string
-            username: string
-            email?: string
-          }
+            password: string;
+            username: string;
+            email?: string;
+          };
       unlock:
         | {
-            email: string
+            email: string;
           }
         | {
-            username: string
-          }
+            username: string;
+          };
     }
   }
 


### PR DESCRIPTION
error1:
When i use this config.
_File: `collections.Users.index.ts`_
```typescript
...
export const Users: CollectionConfig = {
  slug: "users",
  auth: {
    loginWithUsername: {
      allowEmailLogin: true,
    },
  },
...
}
```
The `payload-config.ts` is
```typescript
...
export interface AdminAuthOperations {
  forgotPassword:
    | {
        email: string;
      }
    | {
      username: string;
      };
  login:
    | {
        email: string;
        password: string;
      }
    | {
        password: string;
        username: string;
      }
  registerFirstUser: {
      password: string;
      username: string;
      email?: string;
    };
  unlock:
    | {
        email: string;
      }
    | {
        username: string;
      };
}
...
```

So `new PayloadSDK<Config>` got error: `not satisfy the constraint`

error2:

When i use `select` condition:

```typescripts
const sdk = new PayloadSDK<Config>({ baseURL: "http://localhost:3000" });
const result = await sdk.find({
  collection: "entries",
  select: {
    path: true,
    updatedAt: true,
  },
});

// this line got error `Property 'path' does not exists`
console.log(result.docs[0].path);
```
