### PR TITLE
docs: db indexes - code example missing const

### DIFF
--- a/docs/database/indexes.mdx
+++ b/docs/database/indexes.mdx
@@ -15,7 +15,7 @@ To index a field, set the `index` option to `true` in your field's config:
 ```ts
 import type { CollectionConfig } from 'payload'
 
-export MyCollection: CollectionConfig = {
+export const MyCollection: CollectionConfig = {
   // ...
   fields: [
     // ...


### PR DESCRIPTION
The first code example was missing `const` when defining the export – the second example on the same page already correctly includes it.