### PR TITLE
fix: add spread operator on categories

### DIFF
--- a/templates/ecommerce/src/endpoints/seed/index.ts
+++ b/templates/ecommerce/src/endpoints/seed/index.ts
@@ -179,7 +179,7 @@ export const seed = async ({
       data: imageHero1Data,
       file: heroBuffer,
     }),
-    categories.map((category) =>
+    ...categories.map((category) =>
       payload.create({
         collection: 'categories',
         data: {


### PR DESCRIPTION
### What?

Fixes seeding script that came with `create-payload-app`.

### Why?

 Because seeding doesn't run on fresh install.

### How?

By adding a spread operator on an array map in the script.

Fixes #14172