### PR TITLE
feat(ui): allow label prop to be string or ReactNode

### DIFF
--- a/packages/ui/src/elements/NavGroup/index.tsx
+++ b/packages/ui/src/elements/NavGroup/index.tsx
@@ -14,7 +14,7 @@ const baseClass = 'nav-group'
 type Props = {
   children: React.ReactNode
   isOpen?: boolean
-  label: string
+  label: string | React.ReactNode
 }
 
 const preferencesKey = 'nav'


### PR DESCRIPTION
### What?
This update enables menu label props within the Payload admin interface to accept both string and ReactNode types. It allows developers to use icons, styled text, or JSX components directly in admin menu labels, improving flexibility and branding consistency in the UI.

### Why?
```
          <NavGroup
            key={key}
            // @ts-expect-error - intentionally passing ReactNode
            label={
              <span className="text-base font-semibold text-(--theme-elevation-600) transition-all duration-300 hover:text-(--font-body)">
                {label}
              </span>
            }
            isOpen={navPreferences?.groups?.[label]?.open}
          >
```

Currently throws ts error when passing non-string items into the label field.