### PR TITLE
fix(db-postgres): force pg-cloudflare to be installed when using pnpm

### DIFF
--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -81,6 +81,7 @@
     "drizzle-kit": "0.31.4",
     "drizzle-orm": "0.44.2",
     "pg": "8.16.3",
+    "pg-cloudflare": "1.2.7",
     "prompts": "2.4.2",
     "to-snake-case": "1.0.0",
     "uuid": "10.0.0"

--- a/templates/with-cloudflare-d1/next.config.ts
+++ b/templates/with-cloudflare-d1/next.config.ts
@@ -12,6 +12,8 @@ const nextConfig = {
 
     return webpackConfig
   },
+
+  serverExternalPackages: ['pg-cloudflare'],
 }
 
 export default withPayload(nextConfig, { devBundleServerPackages: false })


### PR DESCRIPTION
### What?
Forces `pg-cloudflare` dependency to be installed, even when using `pnpm install`

### Why?
When using the `db-postgres` adapter inside Cloudflare, it needs the `pg-cloudflare` package to work, which is an optional dependency of `pg`. This is necessary to support connecting to a Postgres database, via Cloudflare's Hyperdrive, when deploying Payload on Cloudflare.

Optional dependencies are installed by default when using npm, but not when using pnpm.

### How?
By declaring `pg-cloudflare` as a dependency of `db-postgres`.
To help with the bundling, it's also necessary to add `pg-cloudflare` to the list of Next.js' external dependencies. More info here: https://opennext.js.org/cloudflare/howtos/workerd#configuration

Discord discussion: https://discordapp.com/channels/967097582721572934/1427199951766552586
