### PR TITLE
chore: ignore agent local files [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ dist
 /.idea/runConfigurations/_template*
 !/.idea/payload.iml
 
+# Local AI Agent files
+AGENTS.local.md
+CLAUDE.local.md
+
 # Custom actions
 !.github/actions/**/dist
 


### PR DESCRIPTION
Ignore both `AGENTS.local.md` and `CLAUDE.local.md` files