### PR TITLE
fix: restoring trashed drafts with empty required fields fails validation

### DIFF
--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -241,7 +241,11 @@ export const updateDocument = async <
         collectionConfig.versions.drafts &&
         !collectionConfig.versions.drafts.validate) ||
       // Skip validation for trash operations since they're just metadata updates
-      Boolean(data?.deletedAt),
+      (collectionConfig.trash &&
+        (Boolean(data?.deletedAt) ||
+          // Skip validation when restoring from trash, but only if not publishing
+          // (if publishing, we need full validation)
+          (Boolean(originalDoc?.deletedAt) && data._status !== 'published'))),
   }
 
   if (publishSpecificLocale) {

--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -245,7 +245,7 @@ export const updateDocument = async <
         (Boolean(data?.deletedAt) ||
           // Skip validation when restoring from trash, but only if not publishing
           // (if publishing, we need full validation)
-          (Boolean(originalDoc?.deletedAt) && data._status !== 'published'))),
+          (Boolean(originalDoc?.deletedAt) && data?._status !== 'published'))),
   }
 
   if (publishSpecificLocale) {


### PR DESCRIPTION
### What?

This PR fixes the validation logic for restoring documents from trash. Previously, restoring a trashed draft with empty required fields would fail with "The following fields are invalid" errors, even when restoring as a draft.

### Why?

When a draft document with empty required fields is trashed and then restored:
- Trashing works correctly (skips validation since it's just setting `deletedAt`)
- Restoring as draft should also work (it's just metadata, clearing `deletedAt`)
- Restoring as published should require validation (content is being published)

The previous fix only handled trashing (when `deletedAt` is set), but didn't handle the restore case (when `deletedAt` is set to `null`).

### How?

Extended the `skipValidation` logic in `updateDocument()` to detect restore operations.

Fixes #14180
