### PR TITLE
refactor(richtext-lexical): add jsdoc to deprecated HTMLConverterFeature

### DIFF
--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/converter/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/converter/index.ts
@@ -48,7 +48,16 @@ export type ConvertLexicalToHTMLArgs = {
 )
 
 /**
- * @deprecated - will be removed in 4.0
+ * @deprecated - will be removed in 4.0. Use the function exported from `@payloadcms/richtext-lexical/html` instead.
+ * @example
+ * ```ts
+ * // old (deprecated)
+ * import { convertLexicalToHTML } from '@payloadcms/richtext-lexical'
+ * // new (recommended)
+ * import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html'
+ * ```
+ * For more details, you can refer to https://payloadcms.com/docs/rich-text/converting-html to see all the
+ * ways to convert lexical to HTML.
  */
 export async function convertLexicalToHTML({
   converters,

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml_deprecated/index.ts
@@ -10,7 +10,8 @@ export type HTMLConverterFeatureProps = {
 
 // This is just used to save the props on the richText field
 /**
- * @deprecated - will be removed in 4.0
+ * @deprecated - will be removed in 4.0. Please refer to https://payloadcms.com/docs/rich-text/converting-html
+ * to see all the ways to convert lexical to HTML.
  */
 export const HTMLConverterFeature = createServerFeature<HTMLConverterFeatureProps>({
   feature: {},


### PR DESCRIPTION
Small clarification in response to user questions.