### PR TITLE
fix(richtext-lexical): state key collisions when multiple TextStateFeatures are registered

### DIFF
--- a/packages/richtext-lexical/src/features/textState/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/textState/feature.client.tsx
@@ -5,9 +5,9 @@ import type { TextStateFeatureProps } from './feature.server.js'
 
 import { TextStateIcon } from '../../lexical/ui/icons/TextState/index.js'
 import { createClientFeature } from '../../utilities/createClientFeature.js'
-import { registerTextStates, setTextState, StatePlugin } from './textState.js'
+import { registerTextStates, setTextState, type StateMap, StatePlugin } from './textState.js'
 
-const toolbarGroups = (props: TextStateFeatureProps): ToolbarGroup[] => {
+const toolbarGroups = (props: TextStateFeatureProps, stateMap: StateMap): ToolbarGroup[] => {
   const items: ToolbarDropdownGroup['items'] = []
 
   for (const stateKey in props.state) {
@@ -19,7 +19,7 @@ const toolbarGroups = (props: TextStateFeatureProps): ToolbarGroup[] => {
         key: stateValue,
         label: meta.label,
         onSelect: ({ editor }) => {
-          setTextState(editor, stateKey, stateValue)
+          setTextState(editor, stateMap, stateKey, stateValue)
         },
       })
     }
@@ -32,7 +32,7 @@ const toolbarGroups = (props: TextStateFeatureProps): ToolbarGroup[] => {
       label: ({ i18n }) => i18n.t('lexical:textState:defaultStyle'),
       onSelect: ({ editor }) => {
         for (const stateKey in props.state) {
-          setTextState(editor, stateKey, undefined)
+          setTextState(editor, stateMap, stateKey, undefined)
         }
       },
       order: 1,
@@ -51,19 +51,19 @@ const toolbarGroups = (props: TextStateFeatureProps): ToolbarGroup[] => {
 }
 
 export const TextStateFeatureClient = createClientFeature<TextStateFeatureProps>(({ props }) => {
-  registerTextStates(props.state)
+  const stateMap = registerTextStates(props.state)
   return {
     plugins: [
       {
-        Component: StatePlugin,
+        Component: () => StatePlugin({ stateMap }),
         position: 'normal',
       },
     ],
     toolbarFixed: {
-      groups: toolbarGroups(props),
+      groups: toolbarGroups(props, stateMap),
     },
     toolbarInline: {
-      groups: toolbarGroups(props),
+      groups: toolbarGroups(props, stateMap),
     },
   }
 })

--- a/packages/richtext-lexical/src/features/textState/textState.ts
+++ b/packages/richtext-lexical/src/features/textState/textState.ts
@@ -7,15 +7,17 @@ import { useEffect } from 'react'
 
 import { type StateValues, type TextStateFeatureProps } from './feature.server.js'
 
-const stateMap = new Map<
+export type StateMap = Map<
   string,
   {
     stateConfig: StateConfig<string, string | undefined>
     stateValues: StateValues
   }
->()
+>
 
 export function registerTextStates(state: TextStateFeatureProps['state']) {
+  const stateMap: StateMap = new Map()
+
   for (const stateKey in state) {
     const stateValues = state[stateKey]!
     const stateConfig = createState(stateKey, {
@@ -24,9 +26,15 @@ export function registerTextStates(state: TextStateFeatureProps['state']) {
     })
     stateMap.set(stateKey, { stateConfig, stateValues })
   }
+  return stateMap
 }
 
-export function setTextState(editor: LexicalEditor, stateKey: string, value: string | undefined) {
+export function setTextState(
+  editor: LexicalEditor,
+  stateMap: StateMap,
+  stateKey: string,
+  value: string | undefined,
+) {
   editor.update(() => {
     $forEachSelectedTextNode((textNode) => {
       const stateMapEntry = stateMap.get(stateKey)
@@ -38,7 +46,7 @@ export function setTextState(editor: LexicalEditor, stateKey: string, value: str
   })
 }
 
-export function StatePlugin() {
+export function StatePlugin({ stateMap }: { stateMap: StateMap }) {
   const [editor] = useLexicalComposerContext()
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #13723

The problem was that `stateMap` was a global variable, shared by all instances of `TextStateFeature`. This PR solves the problem by making the variable local, isolated to the scope of each Feature.