### PR TITLE
fix: hasMany / polymorphic relationships to custom number IDs

### DIFF
--- a/packages/db-mongodb/src/utilities/transform.ts
+++ b/packages/db-mongodb/src/utilities/transform.ts
@@ -99,7 +99,11 @@ const convertRelationshipValue = ({
       return value.toHexString()
     }
 
-    if (customIDField?.type === 'number' && adapter.useBigIntForNumberIDs) {
+    if (
+      customIDField?.type === 'number' &&
+      typeof value === 'bigint' &&
+      adapter.useBigIntForNumberIDs
+    ) {
       return Number(value)
     }
 

--- a/packages/drizzle/src/postgres/columnToCodeConverter.ts
+++ b/packages/drizzle/src/postgres/columnToCodeConverter.ts
@@ -34,6 +34,10 @@ export const columnToCodeConverter: ColumnToCodeConverter = ({
       }
       break
     }
+    case 'numeric': {
+      columnBuilderArgsArray.push("mode: 'number'")
+      break
+    }
     case 'timestamp': {
       columnBuilderArgsArray.push(`mode: '${column.mode}'`)
       if (column.withTimezone) {

--- a/packages/drizzle/src/postgres/schema/buildDrizzleTable.ts
+++ b/packages/drizzle/src/postgres/schema/buildDrizzleTable.ts
@@ -74,6 +74,11 @@ export const buildDrizzleTable = ({
         break
       }
 
+      case 'numeric': {
+        columns[key] = numeric(column.name, { mode: 'number' })
+        break
+      }
+
       case 'sparsevec': {
         const builder = sparsevec(column.name, { dimensions: column.dimensions })
 

--- a/packages/drizzle/src/sqlite/columnToCodeConverter.ts
+++ b/packages/drizzle/src/sqlite/columnToCodeConverter.ts
@@ -44,6 +44,11 @@ export const columnToCodeConverter: ColumnToCodeConverter = ({
       break
     }
 
+    case 'numeric': {
+      columnBuilderArgsArray.push("mode: 'number'")
+      break
+    }
+
     case 'serial': {
       columnBuilderFn = 'integer'
       break

--- a/packages/drizzle/src/sqlite/schema/buildDrizzleTable.ts
+++ b/packages/drizzle/src/sqlite/schema/buildDrizzleTable.ts
@@ -44,6 +44,11 @@ export const buildDrizzleTable: BuildDrizzleTable = ({ adapter, locales, rawTabl
         break
       }
 
+      case 'numeric': {
+        columns[key] = numeric(column.name, { mode: 'number' })
+        break
+      }
+
       case 'serial': {
         columns[key] = integer(column.name)
         break

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -149,6 +149,12 @@ export const getConfig: () => Partial<Config> = () => ({
         },
         {
           type: 'relationship',
+          relationTo: 'categories-custom-id',
+          hasMany: true,
+          name: 'categoriesCustomID',
+        },
+        {
+          type: 'relationship',
           relationTo: ['categories'],
           name: 'categoryPoly',
         },

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -212,6 +212,18 @@ describe('database', () => {
       expect(duplicate.arrayWithIDs[0].id).not.toStrictEqual(arrayRowID)
       expect(duplicate.blocksWithIDs[0].id).not.toStrictEqual(blockID)
     })
+
+    it('should properly give the result with hasMany relationships with custom numeric IDs', async () => {
+      await payload.create({ collection: 'categories-custom-id', data: { id: 9999 } })
+      const res = await payload.create({
+        collection: 'posts',
+        data: { title: 'post', categoriesCustomID: [9999] },
+        depth: 0,
+      })
+      expect(res.categoriesCustomID[0]).toBe(9999)
+      const resFind = await payload.findByID({ collection: 'posts', id: res.id, depth: 0 })
+      expect(resFind.categoriesCustomID[0]).toBe(9999)
+    })
   })
 
   describe('timestamps', () => {

--- a/test/database/payload-generated-schema.ts
+++ b/test/database/payload-generated-schema.ts
@@ -28,6 +28,9 @@ export const categories = sqliteTable(
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     title: text('title'),
+    simple: integer('simple_id').references(() => simple.id, {
+      onDelete: 'set null',
+    }),
     hideout_camera1_time1Image: integer('hideout_camera1_time1_image_id').references(
       () => posts.id,
       {
@@ -43,6 +46,7 @@ export const categories = sqliteTable(
     _status: text('_status', { enum: ['draft', 'published'] }).default('draft'),
   },
   (columns) => [
+    index('categories_simple_idx').on(columns.simple),
     uniqueIndex('categories_hideout_camera1_hideout_camera1_time1_image_idx').on(
       columns.hideout_camera1_time1Image,
     ),
@@ -60,6 +64,9 @@ export const _categories_v = sqliteTable(
       onDelete: 'set null',
     }),
     version_title: text('version_title'),
+    version_simple: integer('version_simple_id').references(() => simple.id, {
+      onDelete: 'set null',
+    }),
     version_hideout_camera1_time1Image: integer(
       'version_hideout_camera1_time1_image_id',
     ).references(() => posts.id, {
@@ -84,6 +91,7 @@ export const _categories_v = sqliteTable(
   },
   (columns) => [
     index('_categories_v_parent_idx').on(columns.parent),
+    index('_categories_v_version_version_simple_idx').on(columns.version_simple),
     index('_categories_v_version_hideout_camera1_version_hideout_ca_idx').on(
       columns.version_hideout_camera1_time1Image,
     ),
@@ -103,7 +111,7 @@ export const simple = sqliteTable(
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     text: text('text'),
-    number: numeric('number'),
+    number: numeric('number', { mode: 'number' }),
     updatedAt: text('updated_at')
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
@@ -120,7 +128,7 @@ export const simple = sqliteTable(
 export const categories_custom_id = sqliteTable(
   'categories_custom_id',
   {
-    id: numeric('id').primaryKey(),
+    id: numeric('id', { mode: 'number' }).primaryKey(),
     updatedAt: text('updated_at')
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
@@ -140,7 +148,7 @@ export const _categories_custom_id_v = sqliteTable(
   '_categories_custom_id_v',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
-    parent: numeric('parent_id').references(() => categories_custom_id.id, {
+    parent: numeric('parent_id', { mode: 'number' }).references(() => categories_custom_id.id, {
       onDelete: 'set null',
     }),
     version_updatedAt: text('version_updated_at').default(
@@ -306,11 +314,14 @@ export const posts = sqliteTable(
     category: integer('category_id').references(() => categories.id, {
       onDelete: 'set null',
     }),
-    categoryCustomID: numeric('category_custom_i_d_id').references(() => categories_custom_id.id, {
-      onDelete: 'set null',
-    }),
+    categoryCustomID: numeric('category_custom_i_d_id', { mode: 'number' }).references(
+      () => categories_custom_id.id,
+      {
+        onDelete: 'set null',
+      },
+    ),
     text: text('text'),
-    number: numeric('number'),
+    number: numeric('number', { mode: 'number' }),
     testNestedGroup_nestedText1: text('test_nested_group_nested_text1'),
     testNestedGroup_nestedText2: text('test_nested_group_nested_text2'),
     D1_D2_D3_D4: text('d1_d2_d3_d4'),
@@ -361,6 +372,7 @@ export const posts_rels = sqliteTable(
     path: text('path').notNull(),
     locale: text('locale', { enum: ['en', 'es'] }),
     categoriesID: integer('categories_id'),
+    'categories-custom-idID': numeric('categories_custom_id_id', { mode: 'number' }),
     simpleID: integer('simple_id'),
   },
   (columns) => [
@@ -369,6 +381,10 @@ export const posts_rels = sqliteTable(
     index('posts_rels_path_idx').on(columns.path),
     index('posts_rels_locale_idx').on(columns.locale),
     index('posts_rels_categories_id_idx').on(columns.categoriesID, columns.locale),
+    index('posts_rels_categories_custom_id_id_idx').on(
+      columns['categories-custom-idID'],
+      columns.locale,
+    ),
     index('posts_rels_simple_id_idx').on(columns.simpleID, columns.locale),
     foreignKey({
       columns: [columns['parent']],
@@ -379,6 +395,11 @@ export const posts_rels = sqliteTable(
       columns: [columns['categoriesID']],
       foreignColumns: [categories.id],
       name: 'posts_rels_categories_fk',
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [columns['categories-custom-idID']],
+      foreignColumns: [categories_custom_id.id],
+      name: 'posts_rels_categories_custom_id_fk',
     }).onDelete('cascade'),
     foreignKey({
       columns: [columns['simpleID']],
@@ -1744,7 +1765,7 @@ export const users = sqliteTable(
     ),
     salt: text('salt'),
     hash: text('hash'),
-    loginAttempts: numeric('login_attempts').default('0'),
+    loginAttempts: numeric('login_attempts', { mode: 'number' }).default('0'),
     lockUntil: text('lock_until').default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   },
   (columns) => [
@@ -1783,7 +1804,7 @@ export const payload_locked_documents_rels = sqliteTable(
     noTimeStampsID: integer('no_time_stamps_id'),
     categoriesID: integer('categories_id'),
     simpleID: integer('simple_id'),
-    'categories-custom-idID': numeric('categories_custom_id_id'),
+    'categories-custom-idID': numeric('categories_custom_id_id', { mode: 'number' }),
     postsID: integer('posts_id'),
     'error-on-unnamed-fieldsID': integer('error_on_unnamed_fields_id'),
     'default-valuesID': integer('default_values_id'),
@@ -2011,7 +2032,7 @@ export const payload_migrations = sqliteTable(
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     name: text('name'),
-    batch: numeric('batch'),
+    batch: numeric('batch', { mode: 'number' }),
     updatedAt: text('updated_at')
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
@@ -2167,6 +2188,11 @@ export const virtual_relation_global = sqliteTable(
 
 export const relations_no_time_stamps = relations(no_time_stamps, () => ({}))
 export const relations_categories = relations(categories, ({ one }) => ({
+  simple: one(simple, {
+    fields: [categories.simple],
+    references: [simple.id],
+    relationName: 'simple',
+  }),
   hideout_camera1_time1Image: one(posts, {
     fields: [categories.hideout_camera1_time1Image],
     references: [posts.id],
@@ -2178,6 +2204,11 @@ export const relations__categories_v = relations(_categories_v, ({ one }) => ({
     fields: [_categories_v.parent],
     references: [categories.id],
     relationName: 'parent',
+  }),
+  version_simple: one(simple, {
+    fields: [_categories_v.version_simple],
+    references: [simple.id],
+    relationName: 'version_simple',
   }),
   version_hideout_camera1_time1Image: one(posts, {
     fields: [_categories_v.version_hideout_camera1_time1Image],
@@ -2274,6 +2305,11 @@ export const relations_posts_rels = relations(posts_rels, ({ one }) => ({
     fields: [posts_rels.categoriesID],
     references: [categories.id],
     relationName: 'categories',
+  }),
+  'categories-custom-idID': one(categories_custom_id, {
+    fields: [posts_rels['categories-custom-idID']],
+    references: [categories_custom_id.id],
+    relationName: 'categories-custom-id',
   }),
   simpleID: one(simple, {
     fields: [posts_rels.simpleID],

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -212,6 +212,7 @@ export interface Post {
   categoryTitle?: string | null;
   categorySimpleText?: string | null;
   categories?: (string | Category)[] | null;
+  categoriesCustomID?: (number | CategoriesCustomId)[] | null;
   categoryPoly?: {
     relationTo: 'categories';
     value: string | Category;
@@ -884,6 +885,7 @@ export interface PostsSelect<T extends boolean = true> {
   categoryTitle?: T;
   categorySimpleText?: T;
   categories?: T;
+  categoriesCustomID?: T;
   categoryPoly?: T;
   categoryPolyMany?: T;
   categoryCustomID?: T;


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14197
Ensures that any numeric column is sanitized to a number JS type on Drizzle side
Properly converts `BigInt` relationship values if `useBigIntForNumberIDs: true` is passed to the mongodb adapter (e.g `compatibilityOptions.firestore`)