### PR TITLE
docs: fix link to slug-overrides in text.mdx

### DIFF
--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -215,7 +215,7 @@ The slug field exposes a few top-level config options for easy customization:
 | Option         | Description                                                                                                                               |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`         | To be used as the slug field's name. Defaults to `slug`.                                                                                  |
-| `overrides`    | A function that receives the default fields so you can override on a granular level. See example below. [More details](./slug-overrides). |
+| `overrides`    | A function that receives the default fields so you can override on a granular level. See example below. [More details](#slug-overrides).  |
 | `checkboxName` | To be used as the name for the `generateSlug` checkbox field. Defaults to `generateSlug`.                                                 |
 | `fieldToUse`   | The name of the field to use when generating the slug. This field must exist in the same collection. Defaults to `title`.                 |
 | `position`     | The position of the slug field. [More details](./overview#admin-options).                                                                 |


### PR DESCRIPTION
### What?

Broken link in new slug field documentation.

### Why?

Linking to non-existing page `./slug-overrides` instead of reference to `#slug-overrides`.

### How?

Properly links to `#slug-overrides`.