### PR TITLE
fix: `findDistinct` by explicit ID paths in relationships and virtual fields

### DIFF
--- a/packages/db-mongodb/src/findDistinct.ts
+++ b/packages/db-mongodb/src/findDistinct.ts
@@ -67,7 +67,10 @@ export const findDistinct: FindDistinct = async function (this: MongooseAdapter,
   let tempPath = ''
   let insideRelation = false
 
-  for (const segment of args.field.split('.')) {
+  const segments = args.field.split('.')
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
     const field = currentFields.find((e) => e.name === segment)
     if (rels.length) {
       insideRelation = true
@@ -92,6 +95,11 @@ export const findDistinct: FindDistinct = async function (this: MongooseAdapter,
       (field.type === 'relationship' || field.type === 'upload') &&
       typeof field.relationTo === 'string'
     ) {
+      if (i === segments.length - 2 && segments[i + 1] === 'id') {
+        foundField = field
+        fieldPath = tempPath
+        break
+      }
       rels.push({ fieldPath: tempPath, relationTo: field.relationTo })
       currentFields = this.payload.collections[field.relationTo]?.config
         .flattenedFields as FlattenedField[]

--- a/packages/payload/src/utilities/getFieldByPath.ts
+++ b/packages/payload/src/utilities/getFieldByPath.ts
@@ -62,6 +62,10 @@ export const getFieldByPath = ({
       if (flattenedFields) {
         currentFields = flattenedFields
       }
+
+      if (segments.length === 1 && segments[0] === 'id') {
+        return { field, localizedPath, pathHasLocalized }
+      }
     }
 
     if ('blocks' in field) {

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -132,6 +132,11 @@ export const getConfig: () => Partial<Config> = () => ({
           name: 'category',
         },
         {
+          type: 'json',
+          name: 'categoryID',
+          virtual: 'category.id',
+        },
+        {
           type: 'text',
           name: 'categoryTitle',
           virtual: 'category.title',

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1298,6 +1298,29 @@ describe('database', () => {
     ])
   })
 
+  it('should find distinct values when the virtual field is linked to ID', async () => {
+    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'categories', where: {} })
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title: 'category' },
+    })
+    await payload.create({ collection: 'posts', data: { title: 'post', category } })
+    const distinct = await payload.findDistinct({ collection: 'posts', field: 'categoryID' })
+    expect(distinct.values).toStrictEqual([{ categoryID: category.id }])
+  })
+
+  it('should find distinct values by the explicit ID field path', async () => {
+    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'categories', where: {} })
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title: 'category' },
+    })
+    await payload.create({ collection: 'posts', data: { title: 'post', category } })
+    const distinct = await payload.findDistinct({ collection: 'posts', field: 'category.id' })
+    expect(distinct.values).toStrictEqual([{ 'category.id': category.id }])
+  })
   describe('Compound Indexes', () => {
     beforeEach(async () => {
       await payload.delete({ collection: 'compound-indexes', where: {} })

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -209,6 +209,15 @@ export interface Post {
   id: string;
   title: string;
   category?: (string | null) | Category;
+  categoryID?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
   categoryTitle?: string | null;
   categorySimpleText?: string | null;
   categories?: (string | Category)[] | null;
@@ -881,6 +890,7 @@ export interface CategoriesCustomIdSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   category?: T;
+  categoryID?: T;
   categoryTitle?: T;
   categorySimpleText?: T;
   categories?: T;


### PR DESCRIPTION
Fixes `findDistinct` operation when the `field` argument is:
* an eplicit ID path inside a relationship like:
```ts
const distinct = await payload.findDistinct({ collection: 'posts', field: 'category.id' })
```
* A virtual field linked to a relationship ID field
```ts
[
  {
    type: 'relationship',
    relationTo: 'categories',
    name: 'category',
  },
  {
    type: 'number',
    name: 'categoryID',
    virtual: 'category.id',
  },
]

const distinct = await payload.findDistinct({ collection: 'posts', field: 'categoryID' })
```