### PR TITLE
fix(plugin-search): exclude skipped drafts in reindex handler

### DIFF
--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -1,4 +1,4 @@
-import type { PayloadHandler } from 'payload'
+import type { PayloadHandler, Where } from 'payload'
 
 import {
   addLocalesToRequestFromData,
@@ -82,21 +82,28 @@ export const generateReindexHandler =
     }
 
     const payload = req.payload
-    const batchSize = pluginConfig.reindexBatchSize
+    const { reindexBatchSize: batchSize, syncDrafts } = pluginConfig
 
     const defaultLocalApiProps = {
       overrideAccess: false,
       req,
       user: req.user,
     }
+    const whereStatusPublished: Where = {
+      _status: {
+        equals: 'published',
+      },
+    }
+    let aggregateDocsWithDrafts = 0
     let aggregateErrors = 0
     let aggregateDocs = 0
 
-    const countDocuments = async (collection: string): Promise<number> => {
+    const countDocuments = async (collection: string, drafts?: boolean): Promise<number> => {
       const { totalDocs } = await payload.count({
         collection,
         ...defaultLocalApiProps,
         req: undefined,
+        where: drafts ? undefined : whereStatusPublished,
       })
       return totalDocs
     }
@@ -112,8 +119,16 @@ export const generateReindexHandler =
     }
 
     const reindexCollection = async (collection: string) => {
-      const totalDocs = await countDocuments(collection)
+      const draftsEnabled = Boolean(payload.collections[collection]?.config.versions?.drafts)
+
+      const totalDocsWithDrafts = await countDocuments(collection, true)
+      const totalDocs =
+        syncDrafts || !draftsEnabled
+          ? totalDocsWithDrafts
+          : await countDocuments(collection, !draftsEnabled)
       const totalBatches = Math.ceil(totalDocs / batchSize)
+
+      aggregateDocsWithDrafts += totalDocsWithDrafts
       aggregateDocs += totalDocs
 
       for (let j = 0; j < reindexLocales.length; j++) {
@@ -128,6 +143,7 @@ export const generateReindexHandler =
             limit: batchSize,
             locale: localeToSync,
             page: i + 1,
+            where: syncDrafts || !draftsEnabled ? undefined : whereStatusPublished,
             ...defaultLocalApiProps,
           })
 
@@ -171,7 +187,8 @@ export const generateReindexHandler =
     const message = t('general:successfullyReindexed', {
       collections: collections.join(', '),
       count: aggregateDocs - aggregateErrors,
-      total: aggregateDocs,
+      skips: syncDrafts ? 0 : aggregateDocsWithDrafts - aggregateDocs,
+      total: aggregateDocsWithDrafts,
     })
 
     if (shouldCommit) {

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -406,7 +406,7 @@ export const arTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} تم إنشاؤها بنجاح.',
     successfullyDuplicated: '{{label}} تم استنساخها بنجاح.',
     successfullyReindexed:
-      'تم إعادة فهرسة {{count}} من أصل {{total}} مستندات من {{collections}} مجموعات بنجاح.',
+      'تمت إعادة فهرسة {{count}} من أصل {{total}} مستند من {{collections}} وتخطي {{skips}} مسودة.',
     takeOver: 'تولي',
     thisLanguage: 'العربية',
     time: 'الوقت',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -418,7 +418,7 @@ export const azTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} uğurla yaradıldı.',
     successfullyDuplicated: '{{label}} uğurla dublikatlandı.',
     successfullyReindexed:
-      '{{collections}} kolleksiyalarından {{total}} sənəddən {{count}} sənəd uğurla yenidən indeksləndi.',
+      '"{{collections}}" kolleksiyalarından {{total}} sənəddən {{count}} sənəd uğurla yenidən indeksləndi və {{skips}} qaralama keçildi.',
     takeOver: 'Əvvəl',
     thisLanguage: 'Azərbaycan dili',
     time: 'Vaxt',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -415,7 +415,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} успешно създаден.',
     successfullyDuplicated: '{{label}} успешно дупликиран.',
     successfullyReindexed:
-      'Успешно преиндексирани {{count}} от {{total}} документа от {{collections}} колекции.',
+      'Успешно преиндексирани {{count}} от общо {{total}} документа от {{collections}} и пропуснати {{skips}} чернови.',
     takeOver: 'Поемане',
     thisLanguage: 'Български',
     time: 'Време',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -421,7 +421,7 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} সফলভাবে তৈরি করা হয়েছে।',
     successfullyDuplicated: '{{label}} সফলভাবে ডুপ্লিকেট করা হয়েছে।',
     successfullyReindexed:
-      '{{collections}} থেকে {{total}} ডকুমেন্টের মধ্যে {{count}} টি সফলভাবে পুনরায় সূচিবদ্ধ করা হয়েছে',
+      '{{collections}} থেকে মোট {{total}}টি ডকুমেন্টের মধ্যে {{count}}টি সফলভাবে পুনরায় ইনডেক্স করা হয়েছে এবং {{skips}}টি খসড়া বাদ দেওয়া হয়েছে।',
     takeOver: 'দায়িত্ব নিন',
     thisLanguage: 'বাংলা (বাংলাদেশ)',
     time: 'সময়',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -420,7 +420,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} সফলভাবে তৈরি করা হয়েছে।',
     successfullyDuplicated: '{{label}} সফলভাবে ডুপ্লিকেট করা হয়েছে।',
     successfullyReindexed:
-      '{{collections}} থেকে {{total}} ডকুমেন্টের মধ্যে {{count}} টি সফলভাবে পুনরায় সূচিবদ্ধ করা হয়েছে',
+      '{{collections}} থেকে মোট {{total}}টি নথির মধ্যে {{count}}টি সফলভাবে পুনরায় সূচীকৃত হয়েছে এবং {{skips}}টি খসড়া বাদ দেওয়া হয়েছে।',
     takeOver: 'দায়িত্ব নিন',
     thisLanguage: 'বাংলা (বাংলাদেশ)',
     time: 'সময়',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -418,7 +418,7 @@ export const caTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} creada correctament.',
     successfullyDuplicated: '{{label}} duplicada correctament.',
     successfullyReindexed:
-      'Reindexació correcta de {{count}} de {{total}} documents de {{collections}}',
+      "S'han reindexat correctament {{count}} de {{total}} documents de {{collections}} i s'han omès {{skips}} esborranys.",
     takeOver: 'Prendre el control',
     thisLanguage: 'Catala',
     time: 'Temps',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -414,7 +414,7 @@ export const csTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} úspěšně vytvořeno.',
     successfullyDuplicated: '{{label}} úspěšně duplikováno.',
     successfullyReindexed:
-      'Úspěšně přeindexováno {{count}} z {{total}} dokumentů z {{collections}} kolekcí.',
+      'Úspěšně reindexováno {{count}} z {{total}} dokumentů z {{collections}} a přeskočeno {{skips}} konceptů.',
     takeOver: 'Převzít',
     thisLanguage: 'Čeština',
     time: 'Čas',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -415,7 +415,7 @@ export const daTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} oprettet.',
     successfullyDuplicated: '{{label}} duplikeret.',
     successfullyReindexed:
-      '{{count}} ud af {{total}} dokumenter fra {{collections}} samlinger blev genindekseret med succes.',
+      '{{count}} ud af {{total}} dokumenter fra {{collections}} blev succesfuldt genindekseret, og {{skips}} kladder blev sprunget over.',
     takeOver: 'Overtag',
     thisLanguage: 'Dansk',
     time: 'Tid',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -426,7 +426,7 @@ export const deTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} erfolgreich erstellt.',
     successfullyDuplicated: '{{label}} wurde erfolgreich dupliziert.',
     successfullyReindexed:
-      'Erfolgreich {{count}} von {{total}} Dokumenten aus {{collections}} Sammlungen neu indiziert.',
+      '{{count}} von insgesamt {{total}} Dokumenten aus {{collections}} wurden erfolgreich neu indexiert, {{skips}} Entwürfe wurden übersprungen.',
     takeOver: 'Übernehmen',
     thisLanguage: 'Deutsch',
     time: 'Zeit',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -1,5 +1,3 @@
-import { title } from 'process'
-
 import type { Language } from '../types.js'
 
 export const enTranslations = {
@@ -419,7 +417,7 @@ export const enTranslations = {
     successfullyCreated: '{{label}} successfully created.',
     successfullyDuplicated: '{{label}} successfully duplicated.',
     successfullyReindexed:
-      'Successfully reindexed {{count}} of {{total}} documents from {{collections}}',
+      'Successfully reindexed {{count}} of {{total}} documents from {{collections}} and skipped {{skips}} drafts.',
     takeOver: 'Take over',
     thisLanguage: 'English',
     time: 'Time',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -422,7 +422,7 @@ export const esTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} creado con éxito.',
     successfullyDuplicated: '{{label}} duplicado con éxito.',
     successfullyReindexed:
-      '{{count}} de {{total}} documentos de {{collections}} reindexados con éxito.',
+      'Se reindexaron correctamente {{count}} de {{total}} documentos de {{collections}} y se omitieron {{skips}} borradores.',
     takeOver: 'Tomar el control',
     thisLanguage: 'Español',
     time: 'Hora',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -411,7 +411,7 @@ export const etTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} edukalt loodud.',
     successfullyDuplicated: '{{label}} edukalt dubleeritud.',
     successfullyReindexed:
-      'Edukalt indekseeritud {{count}} {{total}}-st dokumendist kollektsioonides {{collections}}',
+      'Õnnestus ümberindekseerida {{count}} dokumenti {{total}}-st kollektsioonist {{collections}} ja {{skips}} mustandeid jäeti vahele.',
     takeOver: 'Võta üle',
     thisLanguage: 'Eesti',
     time: 'Aeg',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -407,7 +407,7 @@ export const faTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} با موفقیت ایجاد شد.',
     successfullyDuplicated: 'کپی از {{label}} با موفقیت ایجاد شد.',
     successfullyReindexed:
-      '{{count}} از {{total}} صفحه در مجموعه {{collections}} با موفقیت ایندکس مجدد شدند.',
+      'با موفقیت {{count}} از {{total}} سند از {{collections}} بازشاخص‌گذاری شد و {{skips}} پیش‌نویس رد شد.',
     takeOver: 'ادامه ویرایش',
     thisLanguage: 'فارسی',
     time: 'زمان',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -426,7 +426,7 @@ export const frTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} créé(e) avec succès.',
     successfullyDuplicated: '{{label}} dupliqué(e) avec succès.',
     successfullyReindexed:
-      '{{count}} des {{total}} documents des collections {{collections}} ont été réindexés avec succès.',
+      '{{count}} des {{total}} documents de {{collections}} ont été réindexés avec succès, et {{skips}} brouillons ont été ignorés.',
     takeOver: 'Prendre en charge',
     thisLanguage: 'Français',
     time: 'Temps',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -404,7 +404,7 @@ export const heTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} נוצר בהצלחה.',
     successfullyDuplicated: '{{label}} שוכפל בהצלחה.',
     successfullyReindexed:
-      'הוחזרו בהצלחה אינדקס {{count}} מתוך {{total}} מסמכים מ{{collections}} אוספים.',
+      'ביצוע מחדש של אינדקס בוצע בהצלחה על {{count}} מתוך {{total}} מסמכים מתוך {{collections}}, ו-{{skips}} טיוטות הושמטו.',
     takeOver: 'קח פיקוד',
     thisLanguage: 'עברית',
     time: 'זמן',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -416,7 +416,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} uspješno izrađeno.',
     successfullyDuplicated: '{{label}} uspješno duplicirano.',
     successfullyReindexed:
-      'Uspješno ponovno indeksirano {{count}} od {{total}} dokumenata iz {{collections}} kolekcija.',
+      'Uspješno je reindeksirano {{count}} od {{total}} dokumenata iz {{collections}}, a {{skips}} nacrta je preskočeno.',
     takeOver: 'Preuzmi',
     thisLanguage: 'Hrvatski',
     time: 'Vrijeme',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -420,7 +420,7 @@ export const huTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} sikeresen létrehozva.',
     successfullyDuplicated: '{{label}} sikeresen duplikálódott.',
     successfullyReindexed:
-      'Sikeresen újraindexelve {{total}} dokumentumból {{count}} a(z) {{collections}} gyűjteményekből.',
+      'Sikeresen újraindexelésre került {{count}} a {{total}} dokumentumból a {{collections}} gyűjteményből, és {{skips}} vázlat kerül átugrásra.',
     takeOver: 'Átvétel',
     thisLanguage: 'Magyar',
     time: 'Idő',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -418,7 +418,7 @@ export const hyTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} հաջողությամբ ստեղծվել է։',
     successfullyDuplicated: '{{label}} հաջողությամբ կրկնօրինակվել է։',
     successfullyReindexed:
-      'Հաջողությամբ վերաինդեքսավորվել են {{count}}-ը {{total}} փաստաթղթերից {{collections}}-ում',
+      '{{collections}}-ից {{total}} փաստաթղթից {{count}}-ը հաջողությամբ վերաինդեքսավորվեց, և {{skips}} նախագիծ թռիչք դարձան։',
     takeOver: 'Վերցնել վերահսկողությունը',
     thisLanguage: 'Հայերեն',
     time: 'Ժամ',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -417,7 +417,7 @@ export const idTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} berhasil dibuat.',
     successfullyDuplicated: '{{label}} berhasil diduplikasi.',
     successfullyReindexed:
-      'Berhasil mengindeks ulang {{count}} dari {{total}} dokumen dari {{collections}}',
+      'Berhasil mengindeks ulang {{count}} dari {{total}} dokumen dari {{collections}}, dan melewatkan {{skips}} draf.',
     takeOver: 'Ambil alih',
     thisLanguage: 'Bahasa Indonesia',
     time: 'Waktu',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -413,7 +413,7 @@ export const isTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} var nýskráð.',
     successfullyDuplicated: '{{label}} tvöfaldað.',
     successfullyReindexed:
-      'Endursetti leitargrunn fyrir {{count}} af {{total}} færslur í {{collections}}',
+      'Tókst að endurvísa {{count}} af {{total}} skjölum úr {{collections}} og {{skips}} drög voru sleppt.',
     takeOver: 'Taka yfir',
     thisLanguage: 'Íslenska',
     time: 'Tími',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -420,7 +420,7 @@ export const itTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} creato con successo.',
     successfullyDuplicated: '{{label}} duplicato con successo.',
     successfullyReindexed:
-      'Reindicizzati con successo {{count}} di {{total}} documenti da {{collections}} collezioni.',
+      'Sono stati reindicizzati con successo {{count}} dei {{total}} documenti da {{collections}}, e {{skips}} bozze sono state saltate.',
     takeOver: 'Prendi il controllo',
     thisLanguage: 'Italiano',
     time: 'Tempo',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -418,7 +418,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} が作成されました。',
     successfullyDuplicated: '{{label}} が複製されました。',
     successfullyReindexed:
-      '{{collections}} コレクションから {{total}} 件中 {{count}} 件のドキュメントが正常に再インデックスされました。',
+      '{{collections}} から {{total}} 件のうち {{count}} 件を正常に再インデックスし、{{skips}} 件の下書きをスキップしました。',
     takeOver: '引き継ぐ',
     thisLanguage: 'Japanese',
     time: '時間',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -414,7 +414,7 @@ export const koTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}}이(가) 생성되었습니다.',
     successfullyDuplicated: '{{label}}이(가) 복제되었습니다.',
     successfullyReindexed:
-      '{{collections}} 컬렉션에서 {{total}} 문서 중 {{count}} 문서가 성공적으로 재인덱싱되었습니다.',
+      '{{collections}} 의 문서 총 **{{total}}**건 중 **{{count}}**건이 성공적으로 재인덱싱되었으며, **{{skips}}**건의 초안이 건너뛰어졌습니다.',
     takeOver: '인수하기',
     thisLanguage: '한국어',
     time: '시간',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -418,7 +418,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} sėkmingai sukurtas.',
     successfullyDuplicated: '{{label}} sėkmingai dubliuotas.',
     successfullyReindexed:
-      'Sėkmingai perindeksuota {{count}} iš {{total}} dokumentų iš {{collections}}',
+      'Sėkmingai perindeksuota {{count}} iš {{total}} dokumentų iš {{collections}}, praleista {{skips}} juodraščių.',
     takeOver: 'Perimti',
     thisLanguage: 'Lietuvių',
     time: 'Laikas',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -416,7 +416,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} veiksmīgi izveidots.',
     successfullyDuplicated: '{{label}} veiksmīgi dublēts.',
     successfullyReindexed:
-      'Veiksmīgi pārindeksēti {{count}} no {{total}} dokumentiem no {{collections}}',
+      'Veiksmīgi pārindeksēti {{count}} no {{total}} dokumentiem no {{collections}}, izlaisti {{skips}} melnraksti.',
     takeOver: 'Pārņemt',
     thisLanguage: 'Latviešu',
     time: 'Laiks',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -420,7 +420,7 @@ export const myTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} အောင်မြင်စွာဖန်တီးခဲ့သည်။',
     successfullyDuplicated: '{{label}} အောင်မြင်စွာ ပုံတူပွားခဲ့သည်။',
     successfullyReindexed:
-      '{{collections}} စုစည်းမှုများမှ စာရွက်စာတမ်း {{total}} ခုအနက် {{count}} ခုကို အောင်မြင်စွာ ပြန်လည်အညွှန်းပြုလုပ်ခဲ့ပါသည်။',
+      '{{collections}} မှ စုစုပေါင်း {{total}} စာတမ်းထဲမှ {{count}} စာတမ်းကိုအောင်မြင်စွာပြန်လည်ညွှန်းကောက်ခဲ့ပြီး {{skips}} အကြမ်းဖျဉ်ချုပ်ကိုလွဲချခဲ့သည်။',
     takeOver: 'တာဝန်ယူပါ',
     thisLanguage: 'မြန်မာစာ',
     time: 'Masa',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -417,7 +417,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} ble opprettet.',
     successfullyDuplicated: '{{label}} ble duplisert.',
     successfullyReindexed:
-      'Vellykket reindeksering av {{count}} av {{total}} dokumenter fra {{collections}} samlinger.',
+      'Vellykket reindeksering av {{count}} av totalt {{total}} dokumenter fra {{collections}}, og {{skips}} utkast ble hoppet over.',
     takeOver: 'Ta over',
     thisLanguage: 'Norsk',
     time: 'Tid',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -424,7 +424,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} succesvol aangemaakt.',
     successfullyDuplicated: '{{label}} succesvol gedupliceerd.',
     successfullyReindexed:
-      'Succesvol {{count}} van {{total}} documenten uit {{collections}} collecties herindexeerd.',
+      'Succesvol {{count}} van {{total}} documenten uit {{collections}} opnieuw geïndexeerd, en {{skips}} concepten werden overgeslagen.',
     takeOver: 'Overnemen',
     thisLanguage: 'Nederlands',
     time: 'Tijd',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -414,7 +414,7 @@ export const plTranslations: DefaultTranslationsObject = {
     successfullyCreated: 'Pomyślnie utworzono {{label}}.',
     successfullyDuplicated: 'Pomyślnie zduplikowano {{label}}',
     successfullyReindexed:
-      'Pomyślnie ponownie zindeksowano {{count}} z {{total}} dokumentów z kolekcji {{collections}}.',
+      'Pomyślnie ponownie zindeksowano {{count}} z {{total}} dokumentów z {{collections}}, pomijając {{skips}} szkice.',
     takeOver: 'Przejąć',
     thisLanguage: 'Polski',
     time: 'Czas',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -418,7 +418,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} criado com sucesso.',
     successfullyDuplicated: '{{label}} duplicado com sucesso.',
     successfullyReindexed:
-      'Reindexação concluída com sucesso de {{count}} de {{total}} documentos das coleções {{collections}}.',
+      'Reindexação bem‑sucedida de {{count}} de {{total}} documentos de {{collections}}, e {{skips}} rascunhos foram ignorados.',
     takeOver: 'Assumir',
     thisLanguage: 'Português',
     time: 'Tempo',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -421,7 +421,7 @@ export const roTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} creat(ă) cu succes.',
     successfullyDuplicated: '{{label}} duplicat(ă) cu succes.',
     successfullyReindexed:
-      'Reindexare realizată cu succes pentru {{count}} din {{total}} documente din colecțiile {{collections}}.',
+      'Au fost reindexate cu succes {{count}} din {{total}} documente din {{collections}}, iar {{skips}} proiecte au fost omise.',
     takeOver: 'Preia controlul',
     thisLanguage: 'Română',
     time: 'Timp',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -416,7 +416,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} успешно креирано.',
     successfullyDuplicated: '{{label}} успешно дуплицирано.',
     successfullyReindexed:
-      'Успешно је реиндексирано {{count}} од {{total}} докумената из {{collections}} колекција.',
+      'Успешно је реиндексирано {{count}} од укупно {{total}} докумената из {{collections}}, и {{skips}} нацрта је прескочено.',
     takeOver: 'Превузети',
     thisLanguage: 'Српски (ћирилица)',
     time: 'Vreme',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -417,7 +417,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} uspešno kreirano.',
     successfullyDuplicated: '{{label}} uspešno duplicirano.',
     successfullyReindexed:
-      'Uspešno je reindeksirano {{count}} od {{total}} dokumenata iz {{collections}} kolekcija.',
+      'Uspešno je reindeksirano {{count}} od ukupno {{total}} dokumenata iz {{collections}}, i {{skips}} nacrta je preskočeno.',
     takeOver: 'Preuzeti',
     thisLanguage: 'Srpski (latinica)',
     time: 'Vreme',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -417,7 +417,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} успешно создан.',
     successfullyDuplicated: '{{label}} успешно продублирован.',
     successfullyReindexed:
-      'Успешно переиндексировано {{count}} из {{total}} документов из {{collections}} коллекций.',
+      'Успешно переиндексировано {{count}} из {{total}} документов из {{collections}}, пропущено {{skips}} черновиков.',
     takeOver: 'Взять на себя',
     thisLanguage: 'Русский',
     time: 'Время',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -415,7 +415,7 @@ export const skTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} úspešne vytvorené.',
     successfullyDuplicated: '{{label}} úspešne duplikované.',
     successfullyReindexed:
-      'Úspešne bolo reindexovaných {{count}} z {{total}} dokumentov z kolekcií {{collections}}.',
+      'Úspešne bolo preindexovaných {{count}} z {{total}} dokumentov z kolekcie {{collections}}, a {{skips}} konceptov bolo preskočených.',
     takeOver: 'Prevziať',
     thisLanguage: 'Slovenčina',
     time: 'Čas',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -415,7 +415,7 @@ export const slTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} uspešno ustvarjen.',
     successfullyDuplicated: '{{label}} uspešno podvojen.',
     successfullyReindexed:
-      'Uspešno reindeksiranih {{count}} od {{total}} dokumentov iz zbirk {{collections}}.',
+      'Uspešno je bilo ponovo indeksiranih {{count}} od skupno {{total}} dokumentov iz {{collections}}, in {{skips}} osnutkov je bilo preskočenih.',
     takeOver: 'Prevzemi',
     thisLanguage: 'Slovenščina',
     time: 'Čas',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -417,7 +417,7 @@ export const svTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} skapades',
     successfullyDuplicated: '{{label}} duplicerades',
     successfullyReindexed:
-      'Lyckades omindexera {{count}} av {{total}} dokument från {{collections}} samlingar.',
+      'Lyckades med att omin­dexera {{count}} av {{total}} dokument från {{collections}}, och {{skips}} utkast hoppades över.',
     takeOver: 'Ta över',
     thisLanguage: 'Svenska',
     time: 'Tid',

--- a/packages/translations/src/languages/ta.ts
+++ b/packages/translations/src/languages/ta.ts
@@ -414,7 +414,7 @@ export const taTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} வெற்றிகரமாக உருவாக்கப்பட்டது.',
     successfullyDuplicated: '{{label}} வெற்றிகரமாக நகலெடுக்கப்பட்டது.',
     successfullyReindexed:
-      'வெற்றிகரமாக {{collections}}-இல் {{total}} ஆவணங்களில் {{count}} மறுஅட்டவணை செய்யப்பட்டது',
+      '{{collections}} இலிருந்து மொத்த {{total}} ஆவணங்களில் {{count}} ஆவணங்கள் வெற்றிகரமாக மறுஇன்டெக்ஸ் செய்யப்பட்டன, மேலும் {{skips}} வரைவு எடுக்க முடியவில்லை.',
     takeOver: 'கையகப்படுத்து',
     thisLanguage: 'தமிழ்',
     time: 'நேரம்',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -408,7 +408,7 @@ export const thTranslations: DefaultTranslationsObject = {
     successfullyCreated: 'สร้าง {{label}} สำเร็จ',
     successfullyDuplicated: 'สำเนา {{label}} สำเร็จ',
     successfullyReindexed:
-      'จัดทำดัชนีใหม่สำเร็จ {{count}} จาก {{total}} เอกสารจากคอลเลกชัน {{collections}}',
+      'ทำการรีอินเด็กซ์เอกสารจำนวน {{count}} จาก {{total}} เอกสารจาก {{collections}} สำเร็จ และข้ามร่างเอกสาร {{skips}} รายการ',
     takeOver: 'เข้ายึด',
     thisLanguage: 'ไทย',
     time: 'เวลา',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -420,7 +420,7 @@ export const trTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} başarıyla oluşturuldu.',
     successfullyDuplicated: '{{label}} başarıyla kopyalandı.',
     successfullyReindexed:
-      '{{collections}} koleksiyonlarından {{total}} belgenin {{count}} tanesi başarıyla yeniden indekslendi.',
+      '{{collections}}’den toplam {{total}} belge arasından {{count}} belge başarıyla yeniden indekslendi ve {{skips}} taslak atlandı.',
     takeOver: 'Devralmak',
     thisLanguage: 'Türkçe',
     time: 'Zaman',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -414,7 +414,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} успішно створено.',
     successfullyDuplicated: '{{label}} успішно продубльовано.',
     successfullyReindexed:
-      'Успішно повторно індексовано {{count}} з {{total}} документів з колекцій {{collections}}.',
+      'Успішно переіндексовано {{count}} із {{total}} документів із {{collections}}, пропущено {{skips}} чернеток.',
     takeOver: 'Перехопити',
     thisLanguage: 'Українська',
     time: 'Час',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -415,7 +415,7 @@ export const viTranslations: DefaultTranslationsObject = {
     successfullyCreated: '{{label}} đã được tạo thành công.',
     successfullyDuplicated: '{{label}} đã được sao chép thành công.',
     successfullyReindexed:
-      'Tái lập chỉ mục thành công {{count}} trong tổng số {{total}} tài liệu từ {{collections}} bộ sưu tập.',
+      'Đã lập chỉ mục lại thành công {{count}} trên tổng số {{total}} tài liệu từ {{collections}}, và bỏ qua {{skips}} bản nháp.',
     takeOver: 'Tiếp quản',
     thisLanguage: 'Vietnamese (Tiếng Việt)',
     time: 'Thời gian',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -397,7 +397,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     successfullyCreated: '成功创建 {{label}}',
     successfullyDuplicated: '成功复制 {{label}}',
     successfullyReindexed:
-      '成功重新索引了 {{collections}} 集合中 {{total}} 个文档中的 {{count}} 个。',
+      '已成功重新索引 {{count}} 个来自 {{collections}} 的 {{total}} 个文档，并跳过了 {{skips}} 个草稿。',
     takeOver: '接管',
     thisLanguage: '中文 (简体)',
     time: '时间',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -395,7 +395,8 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     success: '成功',
     successfullyCreated: '已成功建立 {{label}}。',
     successfullyDuplicated: '已成功複製 {{label}}。',
-    successfullyReindexed: '已成功重新索引 {{collections}} 中 {{total}} 筆文件中的 {{count}} 筆。',
+    successfullyReindexed:
+      '已成功重新索引 {{count}} 個來自 {{collections}} 的 {{total}} 個文件，並跳過了 {{skips}} 個草稿。',
     takeOver: '接手編輯',
     thisLanguage: '中文（繁體）',
     time: '時間',


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR aims to provide better insight into how many documents were reindexed. Currently, the reindex handler will ignore document status and claim all documents were reindexed even when none were due to being drafts (as per plugin-search default behavior).

This PR takes into consideration `syncDrafts` enabled in the plugin config and whether the collection of the document being reindexed has `drafts` enabled. In this way, we can "skip" attempting to reindex documents that are drafts when syncDrafts is not true _and_ provide a useful count for the end-user of how many draft docs were skipped during reindexing.

### Why?
To provide more insight into how many documents/drafts were reindexed, as well as provide a minor perf improvement when reindexing collections with `syncDrafts: false`.

### How?
 - By tracking document count in collections with drafts enabled via `totalDocsWithDrafts`. 
 - Filtering the find in `reindexCollection` based on if `drafts` & `syncDrafts` are enabled
 
 Before:
 
[Search-Results---Payload--before.webm](https://github.com/user-attachments/assets/bfd7696d-1124-4df5-8f99-d86c282f485c)

 After:
 
[Search-Results---Payload.webm](https://github.com/user-attachments/assets/7b0d5c84-328e-43e9-b0ae-5bcd0a0e9f07)
