### PR TITLE
fix: blocks access control not respecting update access whether on collection or on a per field basis

### DIFF
--- a/packages/payload/src/utilities/getFieldPermissions.spec.ts
+++ b/packages/payload/src/utilities/getFieldPermissions.spec.ts
@@ -1,0 +1,86 @@
+import type { SanitizedDocumentPermissions } from '../auth/types.js'
+
+import { getFieldPermissions } from './getFieldPermissions.js'
+
+describe('getFieldPermissions with collection fallback', () => {
+  const mockField = {
+    name: 'testField',
+    type: 'text' as const,
+  }
+
+  describe('fallback to collection permissions', () => {
+    it('should enable read-only mode when field permissions are missing but collection has read access', () => {
+      const fieldPermissions = {} // Empty/sanitized field permissions
+      const collectionPermissions: SanitizedDocumentPermissions = {
+        read: true,
+        fields: {},
+      }
+
+      const result = getFieldPermissions({
+        field: mockField,
+        operation: 'update',
+        parentName: '',
+        permissions: fieldPermissions,
+        collectionPermissions,
+      })
+
+      expect(result.read).toBe(true)
+      expect(result.operation).toBe(false) // Should be read-only
+      expect(result.permissions).toEqual({ read: true })
+    })
+
+    it('should respect existing field permissions when they exist', () => {
+      const fieldPermissions = true // All permissions are true
+      const collectionPermissions: SanitizedDocumentPermissions = {
+        read: true,
+        fields: {},
+      }
+
+      const result = getFieldPermissions({
+        field: mockField,
+        operation: 'update',
+        parentName: '',
+        permissions: fieldPermissions,
+      })
+
+      expect(result.read).toBe(true)
+      expect(result.operation).toBe(true) // Should have operation permission
+      expect(result.permissions).toBe(true)
+    })
+
+    it('should not provide access when neither field nor collection has read permission', () => {
+      const fieldPermissions = {}
+      const collectionPermissions: SanitizedDocumentPermissions = {
+        // No read permission at collection level
+        fields: {},
+      }
+
+      const result = getFieldPermissions({
+        field: mockField,
+        operation: 'update',
+        parentName: '',
+        permissions: fieldPermissions,
+        collectionPermissions,
+      })
+
+      expect(result.read).toBe(false)
+      expect(result.operation).toBe(false)
+    })
+
+    it('should work without collection permissions (backward compatibility)', () => {
+      const fieldPermissions = true // All permissions
+
+      const result = getFieldPermissions({
+        field: mockField,
+        operation: 'update',
+        parentName: '',
+        permissions: fieldPermissions,
+        // No collectionPermissions provided
+      })
+
+      expect(result.read).toBe(true)
+      expect(result.operation).toBe(true)
+      expect(result.permissions).toBe(true)
+    })
+  })
+})

--- a/packages/payload/src/utilities/getFieldPermissions.ts
+++ b/packages/payload/src/utilities/getFieldPermissions.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { SanitizedFieldPermissions, SanitizedFieldsPermissions } from '../auth/types.js'
+import type {
+  SanitizedDocumentPermissions,
+  SanitizedFieldPermissions,
+  SanitizedFieldsPermissions,
+} from '../auth/types.js'
 import type { ClientField, Field } from '../fields/config/types.js'
 import type { Operation } from '../types/index.js'
 
@@ -11,11 +15,13 @@ import type { Operation } from '../types/index.js'
  * - `read`: Whether the user has permission to read the field.
  */
 export const getFieldPermissions = ({
+  collectionPermissions,
   field,
   operation,
   parentName,
   permissions,
 }: {
+  readonly collectionPermissions?: SanitizedDocumentPermissions
   readonly field: ClientField | Field
   readonly operation: Operation
   readonly parentName: string
@@ -28,8 +34,9 @@ export const getFieldPermissions = ({
    */
   permissions: SanitizedFieldPermissions | SanitizedFieldsPermissions
   read: boolean
-} => ({
-  operation:
+} => {
+  // First, calculate permissions using the existing logic
+  const fieldOperation =
     permissions === true ||
     permissions?.[operation as keyof typeof permissions] === true ||
     permissions?.[parentName as keyof typeof permissions] === true ||
@@ -38,15 +45,16 @@ export const getFieldPermissions = ({
       permissions?.[field.name as keyof typeof permissions] &&
       (permissions[field.name as keyof typeof permissions] === true ||
         (operation in (permissions as any)[field.name] &&
-          (permissions as any)[field.name][operation]))),
+          (permissions as any)[field.name][operation])))
 
-  permissions:
+  const fieldPermissions =
     permissions === undefined || permissions === null || permissions === true
       ? true
       : 'name' in field
         ? (permissions as any)[field.name]
-        : permissions,
-  read:
+        : permissions
+
+  const fieldRead =
     permissions === true ||
     permissions?.read === true ||
     permissions?.[parentName as keyof typeof permissions] === true ||
@@ -54,5 +62,36 @@ export const getFieldPermissions = ({
       typeof permissions === 'object' &&
       permissions?.[field.name as keyof typeof permissions] &&
       ((permissions as any)[field.name] === true ||
-        ('read' in (permissions as any)[field.name] && (permissions as any)[field.name].read))),
-})
+        ('read' in (permissions as any)[field.name] && (permissions as any)[field.name].read)))
+
+  // Check if field permissions are effectively empty/missing
+  const hasFieldPermissions =
+    permissions === true ||
+    (typeof permissions === 'object' && permissions !== null && Object.keys(permissions).length > 0)
+
+  // If no field permissions are defined, fallback to collection permissions
+  if (!hasFieldPermissions && collectionPermissions) {
+    const collectionRead = Boolean(collectionPermissions.read)
+    let collectionOperation = false
+
+    // Check operation-specific permission on collection
+    if (operation === 'create' && 'create' in collectionPermissions) {
+      collectionOperation = Boolean(collectionPermissions.create)
+    } else if (operation === 'update') {
+      collectionOperation = Boolean(collectionPermissions.update)
+    }
+
+    return {
+      operation: collectionOperation,
+      permissions: { read: collectionRead } as SanitizedFieldPermissions,
+      read: collectionRead,
+    }
+  }
+
+  // Return the calculated permissions
+  return {
+    operation: Boolean(fieldOperation),
+    permissions: fieldPermissions,
+    read: Boolean(fieldRead),
+  }
+}

--- a/test/access-control/collections/BlocksFieldAccess/index.ts
+++ b/test/access-control/collections/BlocksFieldAccess/index.ts
@@ -1,0 +1,133 @@
+import type { CollectionConfig } from 'payload'
+
+import { blocksFieldAccessSlug } from '../../shared.js'
+
+export const BlocksFieldAccess: CollectionConfig = {
+  slug: blocksFieldAccessSlug,
+  access: {
+    create: () => true,
+    delete: () => true,
+    read: () => true,
+    update: () => true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    // Block field with normal blocks - NO access control (should be fully editable)
+    {
+      type: 'blocks',
+      name: 'editableBlocks',
+      blocks: [
+        {
+          slug: 'testBlock',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'content',
+              type: 'textarea',
+            },
+          ],
+        },
+      ],
+    },
+    // Block field with normal blocks - WITH access control (should be read-only)
+    {
+      type: 'blocks',
+      name: 'readOnlyBlocks',
+      access: {
+        read: () => true,
+        create: () => false,
+        update: () => false,
+      },
+      blocks: [
+        {
+          slug: 'testBlock2',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'content',
+              type: 'textarea',
+            },
+          ],
+        },
+      ],
+    },
+    // Block field with block references - NO access control (should be fully editable)
+    {
+      type: 'blocks',
+      name: 'editableBlockRefs',
+      blocks: [],
+      blockReferences: ['titleblock'],
+    },
+    // Block field with block references - WITH access control (should be read-only)
+    {
+      type: 'blocks',
+      name: 'readOnlyBlockRefs',
+      access: {
+        read: () => true,
+        create: () => false,
+        update: () => false,
+      },
+      blocks: [],
+      blockReferences: ['titleblock'],
+    },
+    // Test tab with read-only blocks fields
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Tab Read-Only Test',
+          name: 'tabReadOnlyTest',
+          fields: [
+            // Block field with normal blocks - WITH access control (should be read-only) - IN TAB
+            {
+              type: 'blocks',
+              name: 'tabReadOnlyBlocks',
+              access: {
+                read: () => true,
+                create: () => false,
+                update: () => false,
+              },
+              blocks: [
+                {
+                  slug: 'testBlock3',
+                  fields: [
+                    {
+                      name: 'title',
+                      type: 'text',
+                    },
+                    {
+                      name: 'content',
+                      type: 'textarea',
+                    },
+                  ],
+                },
+              ],
+            },
+            // Block field with block references - WITH access control (should be read-only) - IN TAB
+            {
+              type: 'blocks',
+              name: 'tabReadOnlyBlockRefs',
+              access: {
+                read: () => true,
+                create: () => false,
+                update: () => false,
+              },
+              blocks: [],
+              blockReferences: ['titleblock'],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -67,7 +67,9 @@ export interface Config {
     'public-users': PublicUserAuthOperations;
     'auth-collection': AuthCollectionAuthOperations;
   };
-  blocks: {};
+  blocks: {
+    titleblock: Titleblock;
+  };
   collections: {
     users: User;
     'public-users': PublicUser;
@@ -87,6 +89,7 @@ export interface Config {
     'hidden-access': HiddenAccess;
     'hidden-access-count': HiddenAccessCount;
     'fields-and-top-access': FieldsAndTopAccess;
+    'blocks-field-access': BlocksFieldAccess;
     disabled: Disabled;
     'rich-text': RichText;
     regression1: Regression1;
@@ -118,6 +121,7 @@ export interface Config {
     'hidden-access': HiddenAccessSelect<false> | HiddenAccessSelect<true>;
     'hidden-access-count': HiddenAccessCountSelect<false> | HiddenAccessCountSelect<true>;
     'fields-and-top-access': FieldsAndTopAccessSelect<false> | FieldsAndTopAccessSelect<true>;
+    'blocks-field-access': BlocksFieldAccessSelect<false> | BlocksFieldAccessSelect<true>;
     disabled: DisabledSelect<false> | DisabledSelect<true>;
     'rich-text': RichTextSelect<false> | RichTextSelect<true>;
     regression1: Regression1Select<false> | Regression1Select<true>;
@@ -215,6 +219,16 @@ export interface AuthCollectionAuthOperations {
     email: string;
     password: string;
   };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "titleblock".
+ */
+export interface Titleblock {
+  title?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'titleblock';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -458,6 +472,48 @@ export interface FieldsAndTopAccess {
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "blocks-field-access".
+ */
+export interface BlocksFieldAccess {
+  id: string;
+  title: string;
+  editableBlocks?:
+    | {
+        title?: string | null;
+        content?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'testBlock';
+      }[]
+    | null;
+  readOnlyBlocks?:
+    | {
+        title?: string | null;
+        content?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'testBlock2';
+      }[]
+    | null;
+  editableBlockRefs?: Titleblock[] | null;
+  readOnlyBlockRefs?: Titleblock[] | null;
+  tabReadOnlyTest?: {
+    tabReadOnlyBlocks?:
+      | {
+          title?: string | null;
+          content?: string | null;
+          id?: string | null;
+          blockName?: string | null;
+          blockType: 'testBlock3';
+        }[]
+      | null;
+    tabReadOnlyBlockRefs?: Titleblock[] | null;
+  };
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -892,6 +948,10 @@ export interface PayloadLockedDocument {
         value: string | FieldsAndTopAccess;
       } | null)
     | ({
+        relationTo: 'blocks-field-access';
+        value: string | BlocksFieldAccess;
+      } | null)
+    | ({
         relationTo: 'disabled';
         value: string | Disabled;
       } | null)
@@ -1205,6 +1265,58 @@ export interface FieldsAndTopAccessSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "blocks-field-access_select".
+ */
+export interface BlocksFieldAccessSelect<T extends boolean = true> {
+  title?: T;
+  editableBlocks?:
+    | T
+    | {
+        testBlock?:
+          | T
+          | {
+              title?: T;
+              content?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  readOnlyBlocks?:
+    | T
+    | {
+        testBlock2?:
+          | T
+          | {
+              title?: T;
+              content?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  editableBlockRefs?: T | {};
+  readOnlyBlockRefs?: T | {};
+  tabReadOnlyTest?:
+    | T
+    | {
+        tabReadOnlyBlocks?:
+          | T
+          | {
+              testBlock3?:
+                | T
+                | {
+                    title?: T;
+                    content?: T;
+                    id?: T;
+                    blockName?: T;
+                  };
+            };
+        tabReadOnlyBlockRefs?: T | {};
+      };
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/access-control/shared.ts
+++ b/test/access-control/shared.ts
@@ -6,6 +6,7 @@ export const unrestrictedSlug = 'unrestricted'
 export const readOnlySlug = 'read-only-collection'
 export const readOnlyGlobalSlug = 'read-only-global'
 export const hooksSlug = 'hooks'
+export const blocksFieldAccessSlug = 'blocks-field-access'
 
 export const userRestrictedCollectionSlug = 'user-restricted-collection'
 export const fullyRestrictedSlug = 'fully-restricted'


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14221
Fixes https://github.com/payloadcms/payload/issues/13569

Fixes a problem where blocks would have their fields disappear entirely if update permissions were false on the collection or on the blocks field itself.

This fixes that and makes sure that fields are always visible and that the blocks fields are correctly being set to readOnly mode if you have permissions to read but not update