### PR TITLE
perf(richtext-lexical): do not return i18n from editor adapter

### DIFF
--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -235,6 +235,10 @@ type RichTextAdapterBase<
     siblingDoc: JsonObject
   }) => void
   hooks?: RichTextHooks
+  /**
+   * @deprecated - manually merge i18n translations into the config.i18n.translations object within the adapter provider instead.
+   * This property will be removed in v4.
+   */
   i18n?: Partial<GenericLanguages>
   outputSchema?: (args: {
     collectionIDFieldTypes: { [key: string]: 'number' | 'string' }

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -7,6 +7,7 @@ import {
   beforeChangeTraverseFields,
   beforeValidateTraverseFields,
   checkDependencies,
+  deepMergeSimple,
   withNullableJSONSchemaType,
 } from 'payload'
 
@@ -92,6 +93,8 @@ export function lexicalEditor(args?: LexicalEditorProps): LexicalRichTextAdapter
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       featureI18n[lang].lexical.general = i18n[lang]
     }
+
+    config.i18n.translations = deepMergeSimple(config.i18n.translations, featureI18n)
 
     return {
       CellComponent: {
@@ -783,7 +786,6 @@ export function lexicalEditor(args?: LexicalEditorProps): LexicalRichTextAdapter
           },
         ],
       },
-      i18n: featureI18n,
       outputSchema: ({
         collectionIDFieldTypes,
         config,


### PR DESCRIPTION
This PR deprecates the `i18n` property returned from the editor adapter. Instead, we now merge `i18n` directly into the `config`, since the config is already available in the richtext adapter provider. This simplifies the logic (only one line of code) and eliminates the need to manually read and merge i18n from the adapter.

Benefits:
- **Simpler implementation**: Merging i18n into the config is straightforward
- **Reduced memory usage**: Each editor no longer maintains its own i18n object - only a single, merged `config.i18n` is kept.
- **Improved developer experience**: The sanitized field config is now smaller and easier to inspect. Console logging the config no longer floods the output with hundreds of translation lines.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211668727538425