### PR TITLE
fix(richtext-lexical): correctly display checklists in RTL

### DIFF
--- a/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
+++ b/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
@@ -2,11 +2,11 @@
 
 @layer payload-default {
   .LexicalEditorTheme {
-    &__ltr {
+    &[dir='ltr'] {
       text-align: left;
     }
 
-    &__rtl {
+    &[dir='rtl'] {
       text-align: right;
     }
 
@@ -296,7 +296,7 @@
       font-size: var(--listitem-marker-font-size);
     }
 
-    &__listItem[dir='rtl'] {
+    [dir='rtl'] &__listItem {
       margin: 0 40px 0.4em 0;
     }
 
@@ -313,8 +313,8 @@
     }
 
     // See comment above for why we need this
-    &__listItemUnchecked[dir='rtl'],
-    &__listItemChecked[dir='rtl'] {
+    [dir='rtl'] &__listItemUnchecked,
+    [dir='rtl'] &__listItemChecked {
       margin-left: 0;
       padding-left: 0;
       padding-right: 25px;
@@ -338,8 +338,8 @@
       position: absolute;
     }
 
-    &__listItemUnchecked[dir='rtl']:before,
-    &__listItemChecked[dir='rtl']:before {
+    [dir='rtl'] &__listItemUnchecked:before,
+    [dir='rtl'] &__listItemChecked:before {
       left: auto;
       right: 0;
     }


### PR DESCRIPTION
Fixes #14162 (partially)

There was a breaking change regarding RTL in [Lexical 0.35.0](https://github.com/facebook/lexical/releases/tag/v0.35.0) that we did not migrate correctly.

Status: The current changes follow the migration guidelines and result in the checkbox being displayed on the right side. However, the `CheckListPlugin` is not working correctly in Lexical as it keeps waiting for the left-side click to activate or deactivate the checklist. This is a bug in Lexical and is reproducible at https://playground.lexical.dev/.



