### PR TITLE
docs: add mention of the useUploadHandlers error and steps to remedy it with a mention to monorepos

### DIFF
--- a/docs/troubleshooting/troubleshooting.mdx
+++ b/docs/troubleshooting/troubleshooting.mdx
@@ -119,7 +119,7 @@ Another error you might see is the following or similarly related to hooks, in p
 useUploadHandlers must be used within UploadHandlersProvider
 ```
 
-This is a common pitfall when using a monorepo setup with multiple packages. In this case, ensure that all packages in the monorepo use the same version of `payload`, `@payloadcms/*`, `next`, `react`, and `react-dom`. You can use pnpm with workspaces to manage dependencies across packages in a monorepo effectively. Unfortunately this error becomes harder to debug inside a monnorepo due to how package managers hoist dependencies as well as resolve them.
+This is a common pitfall when using a monorepo setup with multiple packages. In this case, ensure that all packages in the monorepo use the same version of `payload`, `@payloadcms/*`, `next`, `react`, and `react-dom`. You can use pnpm with workspaces to manage dependencies across packages in a monorepo effectively. Unfortunately this error becomes harder to debug inside a monorepo due to how package managers hoist dependencies as well as resolve them.
 
 If you've pinned the versions and the error persists we recommend removing `.next/`, `node_modules/` and if possible deleting the lockfile and re-generating it to ensure that all packages in the monorepo are using the same version of the dependencies mentioned above.
 

--- a/docs/troubleshooting/troubleshooting.mdx
+++ b/docs/troubleshooting/troubleshooting.mdx
@@ -111,6 +111,18 @@ pnpm dedupe
 
 Absolute last resort: add Webpack aliases so that all imports of a given package resolve to the same path (e.g. `resolve.alias['react'] = path.resolve('./node_modules/react')`). Keep this only until you can fix the underlying version skew.
 
+### Monorepos
+
+Another error you might see is the following or similarly related to hooks, in particular when `next` versions are mismatched:
+
+```bash
+useUploadHandlers must be used within UploadHandlersProvider
+```
+
+This is a common pitfall when using a monorepo setup with multiple packages. In this case, ensure that all packages in the monorepo use the same version of `payload`, `@payloadcms/*`, `next`, `react`, and `react-dom`. You can use pnpm with workspaces to manage dependencies across packages in a monorepo effectively. Unfortunately this error becomes harder to debug inside a monnorepo due to how package managers hoist dependencies as well as resolve them.
+
+If you've pinned the versions and the error persists we recommend removing `.next/`, `node_modules/` and if possible deleting the lockfile and re-generating it to ensure that all packages in the monorepo are using the same version of the dependencies mentioned above.
+
 ## "Unauthorized, you must be logged in to make this request" when attempting to log in
 
 This means that your auth cookie is not being set or accepted correctly upon logging in. To resolve check the following settings in your Payload Config:


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/13353

Updated documentation to mention the `useUploadHandlers` error, most commonly triggered in monorepos where different apps end up resolving to different dependencies in particular of nextjs or react