### PR TITLE
feat(richtext-lexical): add disableListColumn to lexicalHTMLField args

### DIFF
--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
@@ -9,6 +9,12 @@ import { convertLexicalToHTMLAsync } from '../index.js'
 type Args = {
   converters?: HTMLConvertersAsync | HTMLConvertersFunctionAsync
   /**
+   * Whether the lexicalHTML field should appear in the list view filter options.
+   *
+   * @default true
+   */
+  disableListColumn?: boolean
+  /**
    * Whether the lexicalHTML field should be hidden in the admin panel
    *
    * @default true
@@ -36,11 +42,19 @@ type Args = {
  * @todo will be renamed to lexicalHTML in 4.0, replacing the deprecated `lexicalHTML` converter
  */
 export const lexicalHTMLField: (args: Args) => Field = (args) => {
-  const { converters, hidden = true, htmlFieldName, lexicalFieldName, storeInDB = false } = args
+  const {
+    converters,
+    disableListColumn = true,
+    hidden = true,
+    htmlFieldName,
+    lexicalFieldName,
+    storeInDB = false,
+  } = args
   const field: Field = {
     name: htmlFieldName,
     type: 'code',
     admin: {
+      disableListColumn,
       editorOptions: {
         language: 'html',
       },


### PR DESCRIPTION
…
Hello there!

### Patch

A small patch that does two things:

1. Hides (by default) the `lexicalHTMLField` from the list columns (the same way `lexicalHTMLField` has `admin.hidden` set to true by default).
2. Allows you to set `admin.disableListColumn` to false (the same way `lexicalHTMLField` allows you to set `admin.hidden` to false).

### Why

- Because having the converted html code in the collecion list on by default can look jarring.
- I am able to set `admin.disableListColumn` for the richtext field but not for the corresponding _html field.

### Suggestion
Suggestion: Adding the whole [`admin: FieldAdmin`](https://github.com/payloadcms/payload/blob/24dad011d64c0f51837a70b4cb32dd6bd26cf361/packages/payload/src/fields/config/types.ts#L343) property to `lexicalHTMLField` sounds like a simple way to reduce redundancy and allow us to do things like show the field on the sidebar. 