### PR TITLE
fix(db-postgres): limit index and foreign key names length

### DIFF
--- a/packages/db-d1-sqlite/src/index.ts
+++ b/packages/db-d1-sqlite/src/index.ts
@@ -102,6 +102,7 @@ export function sqliteD1Adapter(args: Args): DatabaseAdapterObj<SQLiteD1Adapter>
         json: true,
       },
       fieldConstraints: {},
+      foreignKeys: new Set(),
       generateSchema: createSchemaGenerator({
         columnToCodeConverter,
         corePackageSuffix: 'sqlite-core',

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -182,6 +182,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       findGlobalVersions,
       findOne,
       findVersions,
+      foreignKeys: new Set(),
       indexes: new Set<string>(),
       init,
       insert,

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -169,6 +169,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       findGlobalVersions,
       findOne,
       findVersions,
+      foreignKeys: new Set(),
       indexes: new Set<string>(),
       init,
       insert,

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -111,6 +111,7 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
       },
       fieldConstraints: {},
       forceUseVercelPostgres: args.forceUseVercelPostgres ?? false,
+      foreignKeys: new Set(),
       generateSchema: createSchemaGenerator({
         columnToCodeConverter,
         corePackageSuffix: 'pg-core',

--- a/packages/drizzle/src/schema/build.ts
+++ b/packages/drizzle/src/schema/build.ts
@@ -188,6 +188,8 @@ export const buildTable = ({
 
   if (hasLocalizedField || localizedRelations.size) {
     const localeTableName = `${tableName}${adapter.localesSuffix}`
+    adapter.rawTables[localeTableName] = localesTable
+
     localesColumns.id = {
       name: 'id',
       type: 'serial',
@@ -337,6 +339,7 @@ export const buildTable = ({
   if (isRoot) {
     if (hasManyTextField) {
       const textsTableName = `${rootTableName}_texts`
+      adapter.rawTables[textsTableName] = textsTable
 
       const columns: Record<string, RawColumn> = {
         id: {
@@ -442,6 +445,7 @@ export const buildTable = ({
 
     if (hasManyNumberField) {
       const numbersTableName = `${rootTableName}_numbers`
+      adapter.rawTables[numbersTableName] = numbersTable
       const columns: Record<string, RawColumn> = {
         id: {
           name: 'id',

--- a/packages/drizzle/src/schema/build.ts
+++ b/packages/drizzle/src/schema/build.ts
@@ -16,6 +16,7 @@ import type {
 } from '../types.js'
 
 import { createTableName } from '../createTableName.js'
+import { buildForeignKeyName } from '../utilities/buildForeignKeyName.js'
 import { buildIndexName } from '../utilities/buildIndexName.js'
 import { traverseFields } from './traverseFields.js'
 
@@ -207,7 +208,11 @@ export const buildTable = ({
     }
 
     localesIndexes._localeParent = {
-      name: `${localeTableName}_locale_parent_id_unique`,
+      name: buildIndexName({
+        name: `${localeTableName}_locale_parent_id_unique`,
+        adapter,
+        appendSuffix: false,
+      }),
       on: ['_locale', '_parentID'],
       unique: true,
     }
@@ -217,7 +222,7 @@ export const buildTable = ({
       columns: localesColumns,
       foreignKeys: {
         _parentIdFk: {
-          name: `${localeTableName}_parent_id_fk`,
+          name: buildForeignKeyName({ name: `${localeTableName}_parent_id`, adapter }),
           columns: ['_parentID'],
           foreignColumns: [
             {
@@ -371,21 +376,29 @@ export const buildTable = ({
 
       const textsTableIndexes: Record<string, RawIndex> = {
         orderParentIdx: {
-          name: `${textsTableName}_order_parent_idx`,
+          name: buildIndexName({
+            name: `${textsTableName}_order_parent`,
+            adapter,
+            appendSuffix: false,
+          }),
           on: ['order', 'parent'],
         },
       }
 
       if (hasManyTextField === 'index') {
         textsTableIndexes.text_idx = {
-          name: `${textsTableName}_text_idx`,
+          name: buildIndexName({ name: `${textsTableName}_text`, adapter }),
           on: 'text',
         }
       }
 
       if (hasLocalizedManyTextField) {
         textsTableIndexes.localeParent = {
-          name: `${textsTableName}_locale_parent`,
+          name: buildIndexName({
+            name: `${textsTableName}_locale_parent`,
+            adapter,
+            appendSuffix: false,
+          }),
           on: ['locale', 'parent'],
         }
       }
@@ -395,7 +408,7 @@ export const buildTable = ({
         columns,
         foreignKeys: {
           parentFk: {
-            name: `${textsTableName}_parent_fk`,
+            name: buildForeignKeyName({ name: `${textsTableName}_parent`, adapter }),
             columns: ['parent'],
             foreignColumns: [
               {
@@ -465,19 +478,26 @@ export const buildTable = ({
       }
 
       const numbersTableIndexes: Record<string, RawIndex> = {
-        orderParentIdx: { name: `${numbersTableName}_order_parent_idx`, on: ['order', 'parent'] },
+        orderParentIdx: {
+          name: buildIndexName({ name: `${numbersTableName}_order_parent`, adapter }),
+          on: ['order', 'parent'],
+        },
       }
 
       if (hasManyNumberField === 'index') {
         numbersTableIndexes.numberIdx = {
-          name: `${numbersTableName}_number_idx`,
+          name: buildIndexName({ name: `${numbersTableName}_number`, adapter }),
           on: 'number',
         }
       }
 
       if (hasLocalizedManyNumberField) {
         numbersTableIndexes.localeParent = {
-          name: `${numbersTableName}_locale_parent`,
+          name: buildIndexName({
+            name: `${numbersTableName}_locale_parent`,
+            adapter,
+            appendSuffix: false,
+          }),
           on: ['locale', 'parent'],
         }
       }
@@ -487,7 +507,7 @@ export const buildTable = ({
         columns,
         foreignKeys: {
           parentFk: {
-            name: `${numbersTableName}_parent_fk`,
+            name: buildForeignKeyName({ name: `${numbersTableName}_parent`, adapter }),
             columns: ['parent'],
             foreignColumns: [
               {
@@ -554,29 +574,29 @@ export const buildTable = ({
 
       const relationshipIndexes: Record<string, RawIndex> = {
         order: {
-          name: `${relationshipsTableName}_order_idx`,
+          name: buildIndexName({ name: `${relationshipsTableName}_order`, adapter }),
           on: 'order',
         },
         parentIdx: {
-          name: `${relationshipsTableName}_parent_idx`,
+          name: buildIndexName({ name: `${relationshipsTableName}_parent`, adapter }),
           on: 'parent',
         },
         pathIdx: {
-          name: `${relationshipsTableName}_path_idx`,
+          name: buildIndexName({ name: `${relationshipsTableName}_path`, adapter }),
           on: 'path',
         },
       }
 
       if (hasLocalizedRelationshipField) {
         relationshipIndexes.localeIdx = {
-          name: `${relationshipsTableName}_locale_idx`,
+          name: buildIndexName({ name: `${relationshipsTableName}_locale`, adapter }),
           on: 'locale',
         }
       }
 
       const relationshipForeignKeys: Record<string, RawForeignKey> = {
         parentFk: {
-          name: `${relationshipsTableName}_parent_fk`,
+          name: buildIndexName({ name: `${relationshipsTableName}_parent`, adapter }),
           columns: ['parent'],
           foreignColumns: [
             {
@@ -615,7 +635,10 @@ export const buildTable = ({
         }
 
         relationshipForeignKeys[`${relationTo}IdFk`] = {
-          name: `${relationshipsTableName}_${toSnakeCase(relationTo)}_fk`,
+          name: buildForeignKeyName({
+            name: `${relationshipsTableName}_${toSnakeCase(relationTo)}`,
+            adapter,
+          }),
           columns: [colName],
           foreignColumns: [
             {

--- a/packages/drizzle/src/schema/buildRawSchema.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.ts
@@ -22,6 +22,7 @@ export const buildRawSchema = ({
   setColumnID: SetColumnID
 }) => {
   adapter.indexes = new Set()
+  adapter.foreignKeys = new Set()
 
   adapter.payload.config.collections.forEach((collection) => {
     createTableName({

--- a/packages/drizzle/src/schema/buildRawSchema.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.ts
@@ -8,6 +8,7 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter, RawIndex, SetColumnID } from '../types.js'
 
 import { createTableName } from '../createTableName.js'
+import { buildIndexName } from '../utilities/buildIndexName.js'
 import { buildTable } from './build.js'
 
 /**
@@ -45,7 +46,7 @@ export const buildRawSchema = ({
     const baseIndexes: Record<string, RawIndex> = {}
 
     if (collection.upload.filenameCompoundIndex) {
-      const indexName = `${tableName}_filename_compound_idx`
+      const indexName = buildIndexName({ name: `${tableName}_filename_compound_idx`, adapter })
 
       baseIndexes.filename_compound_index = {
         name: indexName,

--- a/packages/drizzle/src/types.ts
+++ b/packages/drizzle/src/types.ts
@@ -354,6 +354,7 @@ export interface DrizzleAdapter extends BaseDatabaseAdapter {
    * Used for returning properly formed errors from unique fields
    */
   fieldConstraints: Record<string, Record<string, string>>
+  foreignKeys: Set<string>
   idType: 'serial' | 'uuid'
   indexes: Set<string>
   initializing: Promise<void>

--- a/packages/drizzle/src/utilities/buildForeignKeyName.ts
+++ b/packages/drizzle/src/utilities/buildForeignKeyName.ts
@@ -1,0 +1,29 @@
+import type { DrizzleAdapter } from '../types.js'
+
+export const buildForeignKeyName = ({
+  name,
+  adapter,
+  number = 0,
+}: {
+  adapter: DrizzleAdapter
+  name: string
+  number?: number
+}): string => {
+  let foreignKeyName = `${name}${number ? `_${number}` : ''}_fk`
+
+  if (foreignKeyName.length > 60) {
+    const suffix = `${number ? `_${number}` : ''}_fk`
+    foreignKeyName = `${name.slice(0, 60 - suffix.length)}${suffix}`
+  }
+
+  if (!adapter.foreignKeys.has(foreignKeyName)) {
+    adapter.foreignKeys.add(foreignKeyName)
+    return foreignKeyName
+  }
+
+  return buildForeignKeyName({
+    name,
+    adapter,
+    number: number + 1,
+  })
+}

--- a/packages/drizzle/src/utilities/buildIndexName.ts
+++ b/packages/drizzle/src/utilities/buildIndexName.ts
@@ -3,16 +3,18 @@ import type { DrizzleAdapter } from '../types.js'
 export const buildIndexName = ({
   name,
   adapter,
+  appendSuffix = true,
   number = 0,
 }: {
   adapter: DrizzleAdapter
+  appendSuffix?: boolean
   name: string
   number?: number
 }): string => {
-  let indexName = `${name}${number ? `_${number}` : ''}_idx`
+  let indexName = `${name}${number ? `_${number}` : ''}${appendSuffix ? '_idx' : ''}`
 
   if (indexName.length > 60) {
-    const suffix = `${number ? `_${number}` : ''}_idx`
+    const suffix = `${number ? `_${number}` : ''}${appendSuffix ? '_idx' : ''}`
     indexName = `${name.slice(0, 60 - suffix.length)}${suffix}`
   }
 
@@ -24,6 +26,7 @@ export const buildIndexName = ({
   return buildIndexName({
     name,
     adapter,
+    appendSuffix,
     number: number + 1,
   })
 }

--- a/packages/drizzle/src/utilities/buildIndexName.ts
+++ b/packages/drizzle/src/utilities/buildIndexName.ts
@@ -18,7 +18,7 @@ export const buildIndexName = ({
     indexName = `${name.slice(0, 60 - suffix.length)}${suffix}`
   }
 
-  if (!adapter.indexes.has(indexName)) {
+  if (!adapter.indexes.has(indexName) && !(indexName in adapter.rawTables)) {
     adapter.indexes.add(indexName)
     return indexName
   }


### PR DESCRIPTION
Continuation of https://github.com/payloadcms/payload/pull/13428.
Ensures `buildIndexName` is used everywhere and adds the same logic for foreign keys