### PR TITLE
chore: cleanup, short-circuit .split calls

### DIFF
--- a/packages/next/src/utilities/handleAuthRedirect.ts
+++ b/packages/next/src/utilities/handleAuthRedirect.ts
@@ -43,5 +43,5 @@ export const handleAuthRedirect = ({ config, route, searchParams, user }: Args):
     { addQueryPrefix: true },
   )}`
 
-  return `${redirectTo.split('?')[0]}${searchParamsWithRedirect}`
+  return `${redirectTo.split('?', 1)[0]}${searchParamsWithRedirect}`
 }

--- a/packages/payload/src/bin/generateImportMap/utilities/parsePayloadComponent.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/parsePayloadComponent.ts
@@ -11,18 +11,19 @@ export function parsePayloadComponent(PayloadComponent: PayloadComponent): {
   const pathAndMaybeExport =
     typeof PayloadComponent === 'string' ? PayloadComponent : PayloadComponent.path
 
-  let path: string | undefined = ''
-  let exportName: string | undefined = 'default'
+  let path: string
+  let exportName: string
 
-  if (pathAndMaybeExport?.includes('#')) {
-    ;[path, exportName] = pathAndMaybeExport.split('#')
+  if (pathAndMaybeExport.includes('#')) {
+    ;[path, exportName] = pathAndMaybeExport.split('#', 2) as [string, string]
   } else {
     path = pathAndMaybeExport
+    exportName = 'default'
   }
 
   if (typeof PayloadComponent === 'object' && PayloadComponent.exportName) {
     exportName = PayloadComponent.exportName
   }
 
-  return { exportName: exportName!, path: path! }
+  return { exportName, path }
 }

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -12,7 +12,7 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
   const { body, headers, method, payload } = req
 
   if (method && ['PATCH', 'POST', 'PUT'].includes(method.toUpperCase()) && body) {
-    const [contentType] = (headers.get('Content-Type') || '').split(';')
+    const [contentType] = (headers.get('Content-Type') || '').split(';', 1)
     const bodyByteSize = parseInt(req.headers.get('Content-Length') || '0', 10)
 
     if (contentType === 'application/json') {

--- a/packages/payload/src/utilities/createArrayFromCommaDelineated.ts
+++ b/packages/payload/src/utilities/createArrayFromCommaDelineated.ts
@@ -2,8 +2,6 @@ export function createArrayFromCommaDelineated(input: string): string[] {
   if (Array.isArray(input)) {
     return input
   }
-  if (input.indexOf(',') > -1) {
-    return input.split(',')
-  }
-  return [input]
+
+  return input.split(',')
 }

--- a/packages/payload/src/utilities/dependencies/getDependencies.ts
+++ b/packages/payload/src/utilities/dependencies/getDependencies.ts
@@ -25,10 +25,7 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 const payloadPkgDirname = path.resolve(dirname, '../../../') // pkg dir (outside src)
-// if node_modules is in payloadPkgDirname, go to parent dir which contains node_modules
-if (payloadPkgDirname.includes('node_modules')) {
-  payloadPkgDirname.split('node_modules').slice(0, -1)
-}
+
 const resolvedCwd = path.resolve(process.cwd())
 
 export type NecessaryDependencies = {

--- a/packages/richtext-lexical/src/features/upload/client/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/plugin/index.tsx
@@ -199,7 +199,7 @@ export const UploadPlugin: PluginComponent<UploadFeaturePropsClient> = ({ client
               byteNumbers[i] = byteCharacters.charCodeAt(i)
             }
             const byteArray = new Uint8Array(byteNumbers)
-            const file = new File([byteArray], 'pasted-image.' + mimeType?.split('/')[1], {
+            const file = new File([byteArray], 'pasted-image.' + mimeType?.split('/', 2)[1], {
               type: mimeType,
             })
             transformedImage = { alt: undefined, file, formID }
@@ -208,7 +208,7 @@ export const UploadPlugin: PluginComponent<UploadFeaturePropsClient> = ({ client
             const res = await fetch(src)
             const blob = await res.blob()
             const inferredFileName =
-              src.split('/').pop() || 'pasted-image' + blob.type.split('/')[1]
+              src.split('/').pop() || 'pasted-image' + blob.type.split('/', 2)[1]
             const file = new File([blob], inferredFileName, {
               type: blob.type,
             })

--- a/packages/richtext-lexical/src/field/Diff/index.tsx
+++ b/packages/richtext-lexical/src/field/Diff/index.tsx
@@ -27,6 +27,7 @@ export const LexicalDiffComponent: RichTextFieldDiffServerComponent = async (arg
     i18n,
     locale,
     nestingLevel,
+    req,
     versionValue: valueTo,
   } = args
 
@@ -34,15 +35,15 @@ export const LexicalDiffComponent: RichTextFieldDiffServerComponent = async (arg
     ...defaultConverters,
     ...LinkDiffHTMLConverterAsync({}),
     ...ListItemDiffHTMLConverterAsync,
-    ...UploadDiffHTMLConverterAsync({ i18n: args.i18n, req: args.req }),
-    ...RelationshipDiffHTMLConverterAsync({ i18n: args.i18n, req: args.req }),
-    ...UnknownDiffHTMLConverterAsync({ i18n: args.i18n, req: args.req }),
+    ...UploadDiffHTMLConverterAsync({ i18n, req }),
+    ...RelationshipDiffHTMLConverterAsync({ i18n, req }),
+    ...UnknownDiffHTMLConverterAsync({ i18n, req }),
   })
 
   const payloadPopulateFn = await getPayloadPopulateFn({
     currentDepth: 0,
     depth: 1,
-    req: args.req,
+    req,
   })
   const fromHTML = await convertLexicalToHTMLAsync({
     converters,

--- a/packages/richtext-lexical/src/field/RenderLexical/index.tsx
+++ b/packages/richtext-lexical/src/field/RenderLexical/index.tsx
@@ -42,7 +42,7 @@ export const RenderLexical: React.FC<
   const serverFunctionContext = useServerFunctions()
   const { _internal_renderField } = serverFunctionContext
 
-  const [entityType, entitySlug] = schemaPath.split('.')
+  const [entityType, entitySlug] = schemaPath.split('.', 2)
 
   const fieldPath = path ?? (field && 'name' in field ? field?.name : '') ?? ''
 


### PR DESCRIPTION
Just some small optimizations, extracted from https://github.com/payloadcms/payload/pull/14244 to make the diff easier to read:

- short circuit .split() calls => faster
- remove unused code and clean up code