### PR TITLE
perf(richtext-lexical): decrease size of field schema, minor perf optimizations

### DIFF
--- a/packages/richtext-lexical/src/cell/rscEntry.tsx
+++ b/packages/richtext-lexical/src/cell/rscEntry.tsx
@@ -1,13 +1,11 @@
 import type { SerializedLexicalNode } from 'lexical'
-import type { Payload } from 'payload'
 
-import { getTranslation, type I18nClient } from '@payloadcms/translations'
+import { getTranslation } from '@payloadcms/translations'
 import { Link } from '@payloadcms/ui'
 import { formatAdminURL } from 'payload/shared'
 import React from 'react'
 
-import type { SanitizedServerEditorConfig } from '../lexical/config/types.js'
-import type { LexicalFieldAdminProps, LexicalRichTextCellProps } from '../types.js'
+import type { LexicalRichTextCellProps } from '../types.js'
 
 function recurseEditorState(
   editorState: SerializedLexicalNode[],
@@ -30,14 +28,7 @@ function recurseEditorState(
   return textContent
 }
 
-export const RscEntryLexicalCell: React.FC<
-  {
-    admin: LexicalFieldAdminProps
-    i18n: I18nClient
-    payload: Payload
-    sanitizedEditorConfig: SanitizedServerEditorConfig
-  } & LexicalRichTextCellProps
-> = (props) => {
+export const RscEntryLexicalCell: React.FC<LexicalRichTextCellProps> = (props) => {
   const {
     cellData,
     className: classNameFromProps,
@@ -49,7 +40,6 @@ export const RscEntryLexicalCell: React.FC<
     onClick: onClickFromProps,
     payload,
     rowData,
-    sanitizedEditorConfig,
   } = props
 
   const classNameFromConfigContext = admin && 'className' in admin ? admin.className : undefined

--- a/packages/richtext-lexical/src/features/typesServer.ts
+++ b/packages/richtext-lexical/src/features/typesServer.ts
@@ -8,9 +8,9 @@ import type {
   SerializedLexicalNode,
 } from 'lexical'
 import type {
-  Config,
   Field,
   FieldSchemaMap,
+  ImportMapGenerators,
   JsonObject,
   PayloadComponent,
   PayloadRequest,
@@ -294,8 +294,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
     | {
         [key: string]: PayloadComponent
       }
-    // @ts-expect-error - TODO: fix this
-    | Config['admin']['importMap']['generators'][0]
+    | ImportMapGenerators[0]
     | PayloadComponent[]
   generatedTypes?: {
     modifyOutputSchema: (args: {

--- a/packages/richtext-lexical/src/field/index.tsx
+++ b/packages/richtext-lexical/src/field/index.tsx
@@ -21,7 +21,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
   const {
     admin = {},
     clientFeatures,
-    featureClientImportMap,
+    featureClientImportMap = {},
     featureClientSchemaMap,
     field,
     lexicalEditorConfig = defaultEditorLexicalConfig,
@@ -39,7 +39,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
     }
 
     const featureProvidersLocal: FeatureProviderClient<any, any>[] = []
-    for (const [_featureKey, clientFeature] of Object.entries(clientFeatures)) {
+    for (const clientFeature of Object.values(clientFeatures)) {
       if (!clientFeature.clientFeatureProvider) {
         continue
       }
@@ -47,10 +47,6 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
         clientFeature.clientFeatureProvider(clientFeature.clientFeatureProps),
       ) // Execute the clientFeatureProvider function here, as the server cannot execute functions imported from use client files
     }
-
-    const finalLexicalEditorConfig = lexicalEditorConfig
-      ? lexicalEditorConfig
-      : defaultEditorLexicalConfig
 
     const resolvedClientFeatures = loadClientFeatures({
       config,
@@ -60,22 +56,22 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
       schemaPath: schemaPath ?? field.name,
       unSanitizedEditorConfig: {
         features: featureProvidersLocal,
-        lexical: finalLexicalEditorConfig,
+        lexical: lexicalEditorConfig,
       },
     })
 
     setFinalSanitizedEditorConfig(
-      sanitizeClientEditorConfig(resolvedClientFeatures, finalLexicalEditorConfig, admin),
+      sanitizeClientEditorConfig(resolvedClientFeatures, lexicalEditorConfig, admin),
     )
   }, [
-    lexicalEditorConfig,
     admin,
-    finalSanitizedEditorConfig,
     clientFeatures,
+    config,
     featureClientImportMap,
     featureClientSchemaMap,
     field,
-    config,
+    finalSanitizedEditorConfig,
+    lexicalEditorConfig,
     schemaPath,
   ]) // TODO: Optimize this and use useMemo for this in the future. This might break sub-richtext-blocks from the blocks feature. Need to investigate
 

--- a/packages/richtext-lexical/src/field/rscEntry.tsx
+++ b/packages/richtext-lexical/src/field/rscEntry.tsx
@@ -13,8 +13,8 @@ import React from 'react'
 
 import type { SanitizedServerEditorConfig } from '../lexical/config/types.js'
 import type {
+  LexicalEditorProps,
   LexicalFieldAdminClientProps,
-  LexicalFieldAdminProps,
   LexicalRichTextFieldProps,
 } from '../types.js'
 
@@ -25,10 +25,10 @@ import { initLexicalFeatures } from '../utilities/initLexicalFeatures.js'
 
 export const RscEntryLexicalField: React.FC<
   {
-    admin: LexicalFieldAdminProps
     sanitizedEditorConfig: SanitizedServerEditorConfig
   } & ClientComponentProps &
     Pick<FieldPaths, 'path'> &
+    Pick<LexicalEditorProps, 'admin'> &
     ServerComponentProps
 > = async (args) => {
   const field: RichTextFieldType = args.field as RichTextFieldType
@@ -97,7 +97,6 @@ export const RscEntryLexicalField: React.FC<
 
   const props: LexicalRichTextFieldProps = {
     clientFeatures,
-    featureClientImportMap,
     featureClientSchemaMap, // TODO: Does client need this? Why cant this just live in the server
     field: args.clientField as RichTextFieldClient,
     forceRender: args.forceRender,
@@ -111,6 +110,9 @@ export const RscEntryLexicalField: React.FC<
   }
   if (Object.keys(admin).length) {
     props.admin = admin
+  }
+  if (Object.keys(featureClientImportMap).length) {
+    props.featureClientImportMap = featureClientImportMap
   }
 
   for (const key in props) {

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -1,3 +1,4 @@
+import type { GenericLanguages, GenericTranslationsObject } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 import type { SerializedEditorState, SerializedLexicalNode } from 'lexical'
 
@@ -8,6 +9,7 @@ import {
   beforeValidateTraverseFields,
   checkDependencies,
   deepMergeSimple,
+  type RichTextAdapter,
   withNullableJSONSchemaType,
 } from 'payload'
 
@@ -15,13 +17,13 @@ import type { FeatureProviderServer, ResolvedServerFeatureMap } from './features
 import type { SanitizedServerEditorConfig } from './lexical/config/types.js'
 import type { AdapterProps, LexicalEditorProps, LexicalRichTextAdapterProvider } from './types.js'
 
-import { getDefaultSanitizedEditorConfig } from './getDefaultSanitizedEditorConfig.js'
 import { i18n } from './i18n.js'
 import { defaultEditorFeatures } from './lexical/config/server/default.js'
 import { populateLexicalPopulationPromises } from './populateGraphQL/populateLexicalPopulationPromises.js'
 import { featuresInputToEditorConfig } from './utilities/editorConfigFactory.js'
 import { getGenerateImportMap } from './utilities/generateImportMap.js'
 import { getGenerateSchemaMap } from './utilities/generateSchemaMap.js'
+import { getDefaultSanitizedEditorConfig } from './utilities/getDefaultSanitizedEditorConfig.js'
 import { recurseNodeTree } from './utilities/recurseNodeTree.js'
 import { richTextValidateHOC } from './validate/index.js'
 
@@ -83,41 +85,28 @@ export function lexicalEditor(args?: LexicalEditorProps): LexicalRichTextAdapter
       resolvedFeatureMap = result.resolvedFeatureMap
     }
 
-    const featureI18n = finalSanitizedEditorConfig.features.i18n
-    for (const lang in i18n) {
-      if (!featureI18n[lang as keyof typeof featureI18n]) {
-        featureI18n[lang as keyof typeof featureI18n] = {
-          lexical: {},
-        }
-      }
-      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
-      featureI18n[lang].lexical.general = i18n[lang]
+    const featureI18n: Partial<GenericLanguages> = finalSanitizedEditorConfig.features.i18n
+    for (const _lang in i18n) {
+      const lang = _lang as keyof typeof i18n
+      const lexicalI18nForLang = ((featureI18n[lang] ??= {}).lexical ??=
+        {}) as GenericTranslationsObject
+
+      lexicalI18nForLang.general = i18n[lang] ?? {}
     }
 
     config.i18n.translations = deepMergeSimple(config.i18n.translations, featureI18n)
 
     return {
-      CellComponent: {
-        path: '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell',
-        serverProps: {
-          admin: args?.admin,
-          sanitizedEditorConfig: finalSanitizedEditorConfig,
-        },
-      },
-      DiffComponent: {
-        path: '@payloadcms/richtext-lexical/rsc#LexicalDiffComponent',
-        serverProps: {
-          admin: args?.admin,
-          sanitizedEditorConfig: finalSanitizedEditorConfig,
-        },
-      },
+      CellComponent: '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell',
+      DiffComponent: '@payloadcms/richtext-lexical/rsc#LexicalDiffComponent',
       editorConfig: finalSanitizedEditorConfig,
       features,
       FieldComponent: {
         path: '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField',
         serverProps: {
           admin: args?.admin,
-          sanitizedEditorConfig: finalSanitizedEditorConfig,
+          // SanitizedEditorConfig is manually passed by `renderField` in `fieldSchemasToFormState/renderField.tsx`
+          // in order to reduce the size of the field schema
         },
       },
       generateImportMap: getGenerateImportMap({

--- a/packages/richtext-lexical/src/lexical/config/client/loader.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/loader.ts
@@ -29,6 +29,8 @@ export function loadClientFeatures({
   schemaPath: string
   unSanitizedEditorConfig: ClientEditorConfig
 }): ResolvedClientFeatureMap {
+  const featureProviderMap: ClientFeatureProviderMap = new Map()
+
   for (const featureProvider of unSanitizedEditorConfig.features) {
     if (
       !featureProvider?.clientFeatureProps?.featureKey ||
@@ -39,17 +41,13 @@ export function loadClientFeatures({
         'A Feature you have installed does not return the client props as clientFeatureProps. Please make sure to always return those props, even if they are null, as other important props like order and featureKey are later on injected.',
       )
     }
+    featureProviderMap.set(featureProvider.clientFeatureProps.featureKey, featureProvider)
   }
 
   // sort unSanitizedEditorConfig.features by order
   unSanitizedEditorConfig.features = unSanitizedEditorConfig.features.sort(
     (a, b) => a.clientFeatureProps.order - b.clientFeatureProps.order,
   )
-
-  const featureProviderMap: ClientFeatureProviderMap = new Map()
-  for (const feature of unSanitizedEditorConfig.features) {
-    featureProviderMap.set(feature.clientFeatureProps.featureKey, feature)
-  }
 
   const resolvedFeatures: ResolvedClientFeatureMap = new Map()
 

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -117,11 +117,15 @@ export type LexicalRichTextFieldProps = {
   // clientFeatures is added through the rsc field
   clientFeatures: {
     [featureKey: string]: {
-      clientFeatureProps?: object
+      clientFeatureProps?: BaseClientFeatureProps<Record<string, any>>
       clientFeatureProvider?: FeatureProviderProviderClient<any, any>
     }
   }
-  featureClientImportMap: Record<string, any>
+  /**
+   * Part of the import map that contains client components for all lexical features of this field that
+   * have been added through `feature.componentImports`.
+   */
+  featureClientImportMap?: Record<string, any>
   featureClientSchemaMap: FeatureClientSchemaMap
   initialLexicalFormState: InitialLexicalFormState
   lexicalEditorConfig: LexicalEditorConfig | undefined // Undefined if default lexical editor config should be used

--- a/packages/richtext-lexical/src/utilities/editorConfigFactory.ts
+++ b/packages/richtext-lexical/src/utilities/editorConfigFactory.ts
@@ -9,10 +9,10 @@ import type {
   LexicalRichTextAdapterProvider,
 } from '../types.js'
 
-import { getDefaultSanitizedEditorConfig } from '../getDefaultSanitizedEditorConfig.js'
 import { defaultEditorConfig, defaultEditorFeatures } from '../lexical/config/server/default.js'
 import { loadFeatures } from '../lexical/config/server/loader.js'
 import { sanitizeServerFeatures } from '../lexical/config/server/sanitize.js'
+import { getDefaultSanitizedEditorConfig } from './getDefaultSanitizedEditorConfig.js'
 
 export const editorConfigFactory = {
   default: async (args: {

--- a/packages/richtext-lexical/src/utilities/generateImportMap.tsx
+++ b/packages/richtext-lexical/src/utilities/generateImportMap.tsx
@@ -1,17 +1,20 @@
-import type { PayloadComponent, RichTextAdapter } from 'payload'
+import type { RichTextAdapter } from 'payload'
 
 import { genImportMapIterateFields } from 'payload'
 
 import type { ResolvedServerFeatureMap } from '../features/typesServer.js'
+import type { LexicalEditorProps } from '../types.js'
 
 export const getGenerateImportMap =
-  (args: { resolvedFeatureMap: ResolvedServerFeatureMap }): RichTextAdapter['generateImportMap'] =>
+  (args: {
+    lexicalEditorArgs?: LexicalEditorProps
+    resolvedFeatureMap: ResolvedServerFeatureMap
+  }): RichTextAdapter['generateImportMap'] =>
   ({ addToImportMap, baseDir, config, importMap, imports }) => {
     addToImportMap('@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell')
     addToImportMap('@payloadcms/richtext-lexical/rsc#RscEntryLexicalField')
     addToImportMap('@payloadcms/richtext-lexical/rsc#LexicalDiffComponent')
 
-    // iterate just through args.resolvedFeatureMap.values()
     for (const resolvedFeature of args.resolvedFeatureMap.values()) {
       if ('componentImports' in resolvedFeature) {
         if (typeof resolvedFeature.componentImports === 'function') {
@@ -22,27 +25,17 @@ export const getGenerateImportMap =
             importMap,
             imports,
           })
-        } else if (
-          Array.isArray(resolvedFeature.componentImports) &&
-          resolvedFeature.componentImports?.length
-        ) {
-          resolvedFeature.componentImports.forEach((component) => {
-            addToImportMap(component)
-          })
+        } else if (Array.isArray(resolvedFeature.componentImports)) {
+          addToImportMap(resolvedFeature.componentImports)
         } else if (typeof resolvedFeature.componentImports === 'object') {
-          for (const component of Object.values(resolvedFeature.componentImports)) {
-            addToImportMap(component as PayloadComponent)
-          }
+          addToImportMap(Object.values(resolvedFeature.componentImports))
         }
       }
 
-      const ClientComponent = resolvedFeature.ClientFeature
-      if (ClientComponent) {
-        addToImportMap(ClientComponent)
-      }
+      addToImportMap(resolvedFeature.ClientFeature)
 
       /*
-        Now run for all possible sub-fields
+       * Now run for all possible sub-fields
        */
       if (resolvedFeature.nodes?.length) {
         for (const node of resolvedFeature.nodes) {

--- a/packages/richtext-lexical/src/utilities/getDefaultSanitizedEditorConfig.ts
+++ b/packages/richtext-lexical/src/utilities/getDefaultSanitizedEditorConfig.ts
@@ -1,8 +1,8 @@
 import type { SanitizedConfig } from 'payload'
 
-import { type SanitizedServerEditorConfig } from './index.js'
-import { defaultEditorConfig } from './lexical/config/server/default.js'
-import { sanitizeServerEditorConfig } from './lexical/config/server/sanitize.js'
+import { type SanitizedServerEditorConfig } from '../index.js'
+import { defaultEditorConfig } from '../lexical/config/server/default.js'
+import { sanitizeServerEditorConfig } from '../lexical/config/server/sanitize.js'
 
 let cachedDefaultSanitizedServerEditorConfig:
   | null

--- a/packages/richtext-lexical/src/utilities/initLexicalFeatures.ts
+++ b/packages/richtext-lexical/src/utilities/initLexicalFeatures.ts
@@ -3,7 +3,10 @@ import type { I18nClient } from '@payloadcms/translations'
 import { type ClientFieldSchemaMap, type FieldSchemaMap, type Payload } from 'payload'
 import { getFromImportMap } from 'payload/shared'
 
-import type { FeatureProviderProviderClient } from '../features/typesClient.js'
+import type {
+  BaseClientFeatureProps,
+  FeatureProviderProviderClient,
+} from '../features/typesClient.js'
 import type { SanitizedServerEditorConfig } from '../lexical/config/types.js'
 import type { FeatureClientSchemaMap, LexicalRichTextFieldProps } from '../types.js'
 type Args = {
@@ -24,16 +27,16 @@ export function initLexicalFeatures(args: Args): {
   const clientFeatures: LexicalRichTextFieldProps['clientFeatures'] = {}
 
   // turn args.resolvedFeatureMap into an array of [key, value] pairs, ordered by value.order, lowest order first:
-  const resolvedFeatureMapArray = Array.from(
-    args.sanitizedEditorConfig.resolvedFeatureMap.entries(),
-  ).sort((a, b) => a[1].order - b[1].order)
+  const resolvedFeatureMapArray = [...args.sanitizedEditorConfig.resolvedFeatureMap].sort(
+    (a, b) => a[1].order - b[1].order,
+  )
 
   const featureClientSchemaMap: FeatureClientSchemaMap = {}
 
   /**
    * All modules added to the import map, keyed by the provided key, if feature.componentImports with type object is used
    */
-  const featureClientImportMap: Record<string, any> = {}
+  const featureClientImportMap: Record<string, any> | undefined = {}
 
   for (const [featureKey, resolvedFeature] of resolvedFeatureMapArray) {
     clientFeatures[featureKey] = {}
@@ -55,7 +58,8 @@ export function initLexicalFeatures(args: Args): {
         continue
       }
 
-      const clientFeatureProps = resolvedFeature.clientFeatureProps ?? {}
+      const clientFeatureProps: BaseClientFeatureProps<Record<string, any>> =
+        resolvedFeature.clientFeatureProps ?? {}
       clientFeatureProps.featureKey = resolvedFeature.key
       clientFeatureProps.order = resolvedFeature.order
       if (
@@ -64,7 +68,6 @@ export function initLexicalFeatures(args: Args): {
       ) {
         clientFeatureProps.clientProps = ClientFeaturePayloadComponent.clientProps
       }
-
       // As clientFeatureProvider is a client function, we cannot execute it on the server here. Thus, the client will have to execute clientFeatureProvider with its props
       clientFeatures[featureKey] = { clientFeatureProps, clientFeatureProvider }
     }
@@ -76,11 +79,7 @@ export function initLexicalFeatures(args: Args): {
     // as well, as it already called feature.generateSchemaMap for each feature.
     // We will check for the existance resolvedFeature.generateSchemaMap to skip unnecessary loops for constructing featureSchemaMap, but we don't run it here
     if (resolvedFeature.generateSchemaMap) {
-      const featureSchemaPath = [
-        ...args.schemaPath.split('.'),
-        'lexical_internal_feature',
-        featureKey,
-      ].join('.')
+      const featureSchemaPath = `${args.schemaPath}.lexical_internal_feature.${featureKey}`
 
       featureClientSchemaMap[featureKey] = {}
 
@@ -90,22 +89,22 @@ export function initLexicalFeatures(args: Args): {
           featureClientSchemaMap[featureKey][key] = 'fields' in entry ? entry.fields : [entry]
         }
       }
-      if (
-        resolvedFeature.componentImports &&
-        typeof resolvedFeature.componentImports === 'object'
-      ) {
-        for (const key in resolvedFeature.componentImports) {
-          const payloadComponent = resolvedFeature.componentImports[key]
+    }
 
-          const resolvedComponent = getFromImportMap({
-            importMap: args.payload.importMap,
-            PayloadComponent: payloadComponent,
-            schemaPath: 'lexical-clientComponent',
-            silent: true,
-          })
+    if (
+      resolvedFeature.componentImports &&
+      typeof resolvedFeature.componentImports === 'object' &&
+      !Array.isArray(resolvedFeature.componentImports)
+    ) {
+      for (const [key, payloadComponent] of Object.entries(resolvedFeature.componentImports)) {
+        const resolvedComponent = getFromImportMap({
+          importMap: args.payload.importMap,
+          PayloadComponent: payloadComponent,
+          schemaPath: 'lexical-clientComponent',
+          silent: true,
+        })
 
-          featureClientImportMap[`${resolvedFeature.key}.${key}`] = resolvedComponent
-        }
+        featureClientImportMap[`${resolvedFeature.key}.${key}`] = resolvedComponent
       }
     }
   }

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -257,7 +257,13 @@ export const renderField: RenderFieldMethod = ({
             clientProps,
             Component: fieldConfig.editor.FieldComponent,
             importMap: req.payload.importMap,
-            serverProps,
+            serverProps: {
+              ...serverProps,
+              // Manually inject lexical-specific `sanitizedEditorConfig` server prop, in order to reduce the size of the field schema.
+              // Otherwise, the editorConfig would be included twice - once on the top-level, and once as part of the `FieldComponent` server props.
+              sanitizedEditorConfig:
+                'editorConfig' in fieldConfig.editor ? fieldConfig.editor.editorConfig : undefined,
+            },
           })}
         </WatchCondition>
       ) : (


### PR DESCRIPTION
Following up on https://github.com/payloadcms/payload/pull/14228, this PR further reduces the size of the lexical field schema. Reasoning can be found in that PR.

Additionally, this PR includes a bunch of random TypeScript/JSDocs/Performance improvements, extracted from https://github.com/payloadcms/payload/pull/14244 to keep the PR diff small. Not worth making separate PRs for each individual change.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211668728617851