### PR TITLE
fix(richtext-lexical): node replacements ignored for block, inline block, upload, unknown and relationship nodes

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/nodes/BlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/nodes/BlocksNode.tsx
@@ -1,7 +1,11 @@
 'use client'
-import type { EditorConfig, LexicalEditor, LexicalNode } from 'lexical'
-
 import ObjectID from 'bson-objectid'
+import {
+  $applyNodeReplacement,
+  type EditorConfig,
+  type LexicalEditor,
+  type LexicalNode,
+} from 'lexical'
 import React, { type JSX } from 'react'
 
 import type { BlockFieldsOptionalID, SerializedBlockNode } from '../../server/nodes/BlocksNode.js'
@@ -50,12 +54,14 @@ export class BlockNode extends ServerBlockNode {
 }
 
 export function $createBlockNode(fields: BlockFieldsOptionalID): BlockNode {
-  return new BlockNode({
-    fields: {
-      ...fields,
-      id: fields?.id || new ObjectID.default().toHexString(),
-    },
-  })
+  return $applyNodeReplacement(
+    new BlockNode({
+      fields: {
+        ...fields,
+        id: fields?.id || new ObjectID.default().toHexString(),
+      },
+    }),
+  )
 }
 
 export function $isBlockNode(node: BlockNode | LexicalNode | null | undefined): node is BlockNode {

--- a/packages/richtext-lexical/src/features/blocks/client/nodes/InlineBlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/nodes/InlineBlocksNode.tsx
@@ -1,7 +1,11 @@
 'use client'
-import type { EditorConfig, LexicalEditor, LexicalNode } from 'lexical'
-
 import ObjectID from 'bson-objectid'
+import {
+  $applyNodeReplacement,
+  type EditorConfig,
+  type LexicalEditor,
+  type LexicalNode,
+} from 'lexical'
 import React, { type JSX } from 'react'
 
 import type {
@@ -47,12 +51,14 @@ export class InlineBlockNode extends ServerInlineBlockNode {
 }
 
 export function $createInlineBlockNode(fields: Exclude<InlineBlockFields, 'id'>): InlineBlockNode {
-  return new InlineBlockNode({
-    fields: {
-      ...fields,
-      id: fields?.id || new ObjectID.default().toHexString(),
-    },
-  })
+  return $applyNodeReplacement(
+    new InlineBlockNode({
+      fields: {
+        ...fields,
+        id: fields?.id || new ObjectID.default().toHexString(),
+      },
+    }),
+  )
 }
 
 export function $isInlineBlockNode(

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
@@ -1,18 +1,19 @@
 import type { SerializedDecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
-import type {
-  DOMConversionMap,
-  DOMExportOutput,
-  EditorConfig,
-  ElementFormatType,
-  LexicalEditor,
-  LexicalNode,
-  NodeKey,
-} from 'lexical'
 import type { JsonObject } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
 import ObjectID from 'bson-objectid'
+import {
+  $applyNodeReplacement,
+  type DOMConversionMap,
+  type DOMExportOutput,
+  type EditorConfig,
+  type ElementFormatType,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+} from 'lexical'
 
 import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
 
@@ -134,12 +135,14 @@ export class ServerBlockNode extends DecoratorBlockNode {
 }
 
 export function $createServerBlockNode(fields: BlockFieldsOptionalID): ServerBlockNode {
-  return new ServerBlockNode({
-    fields: {
-      ...fields,
-      id: fields?.id || new ObjectID.default().toHexString(),
-    },
-  })
+  return $applyNodeReplacement(
+    new ServerBlockNode({
+      fields: {
+        ...fields,
+        id: fields?.id || new ObjectID.default().toHexString(),
+      },
+    }),
+  )
 }
 
 export function $isServerBlockNode(

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
@@ -12,7 +12,7 @@ import type React from 'react'
 import type { JSX } from 'react'
 
 import ObjectID from 'bson-objectid'
-import { DecoratorNode } from 'lexical'
+import { $applyNodeReplacement, DecoratorNode } from 'lexical'
 
 import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
 
@@ -131,12 +131,14 @@ export class ServerInlineBlockNode extends DecoratorNode<null | React.ReactEleme
 export function $createServerInlineBlockNode(
   fields: Exclude<InlineBlockFields, 'id'>,
 ): ServerInlineBlockNode {
-  return new ServerInlineBlockNode({
-    fields: {
-      ...fields,
-      id: fields?.id || new ObjectID.default().toHexString(),
-    },
-  })
+  return $applyNodeReplacement(
+    new ServerInlineBlockNode({
+      fields: {
+        ...fields,
+        id: fields?.id || new ObjectID.default().toHexString(),
+      },
+    }),
+  )
 }
 
 export function $isServerInlineBlockNode(

--- a/packages/richtext-lexical/src/features/link/nodes/AutoLinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/AutoLinkNode.ts
@@ -11,7 +11,7 @@ import { LinkNode } from './LinkNode.js'
 
 export class AutoLinkNode extends LinkNode {
   static override clone(node: AutoLinkNode): AutoLinkNode {
-    return new AutoLinkNode({ id: '', fields: node.__fields, key: node.__key })
+    return new this({ id: '', fields: node.__fields, key: node.__key })
   }
 
   static override getType(): string {

--- a/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
@@ -51,7 +51,7 @@ export class LinkNode extends ElementNode {
   }
 
   static override clone(node: LinkNode): LinkNode {
-    return new LinkNode({
+    return new this({
       id: node.__id,
       fields: node.__fields,
       key: node.__key,

--- a/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/nodes/unknownConvertedNode/index.tsx
+++ b/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/nodes/unknownConvertedNode/index.tsx
@@ -2,7 +2,7 @@ import type { EditorConfig, LexicalNode, NodeKey, SerializedLexicalNode, Spread 
 import type { JSX } from 'react'
 
 import { addClassNamesToElement } from '@lexical/utils'
-import { DecoratorNode } from 'lexical'
+import { $applyNodeReplacement, DecoratorNode } from 'lexical'
 import * as React from 'react'
 
 export type UnknownConvertedNodeData = {
@@ -33,7 +33,7 @@ export class UnknownConvertedNode extends DecoratorNode<JSX.Element> {
   }
 
   static override clone(node: UnknownConvertedNode): UnknownConvertedNode {
-    return new UnknownConvertedNode({
+    return new this({
       data: node.__data,
       key: node.__key,
     })
@@ -90,9 +90,11 @@ export function $createUnknownConvertedNode({
 }: {
   data: UnknownConvertedNodeData
 }): UnknownConvertedNode {
-  return new UnknownConvertedNode({
-    data,
-  })
+  return $applyNodeReplacement(
+    new UnknownConvertedNode({
+      data,
+    }),
+  )
 }
 
 export function $isUnknownConvertedNode(

--- a/packages/richtext-lexical/src/features/migrations/slateToLexical/nodes/unknownConvertedNode/index.tsx
+++ b/packages/richtext-lexical/src/features/migrations/slateToLexical/nodes/unknownConvertedNode/index.tsx
@@ -2,7 +2,7 @@ import type { EditorConfig, LexicalNode, NodeKey, SerializedLexicalNode, Spread 
 import type { JSX } from 'react'
 
 import { addClassNamesToElement } from '@lexical/utils'
-import { DecoratorNode } from 'lexical'
+import { $applyNodeReplacement, DecoratorNode } from 'lexical'
 import * as React from 'react'
 
 export type UnknownConvertedNodeData = {
@@ -33,7 +33,7 @@ export class UnknownConvertedNode extends DecoratorNode<JSX.Element> {
   }
 
   static override clone(node: UnknownConvertedNode): UnknownConvertedNode {
-    return new UnknownConvertedNode({
+    return new this({
       data: node.__data,
       key: node.__key,
     })
@@ -90,9 +90,11 @@ export function $createUnknownConvertedNode({
 }: {
   data: UnknownConvertedNodeData
 }): UnknownConvertedNode {
-  return new UnknownConvertedNode({
-    data,
-  })
+  return $applyNodeReplacement(
+    new UnknownConvertedNode({
+      data,
+    }),
+  )
 }
 
 export function $isUnknownConvertedNode(

--- a/packages/richtext-lexical/src/features/relationship/client/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/client/nodes/RelationshipNode.tsx
@@ -1,13 +1,14 @@
 'use client'
-import type {
-  DOMConversionMap,
-  DOMConversionOutput,
-  EditorConfig,
-  LexicalEditor,
-  LexicalNode,
-} from 'lexical'
 import type { JSX } from 'react'
 
+import {
+  $applyNodeReplacement,
+  type DOMConversionMap,
+  type DOMConversionOutput,
+  type EditorConfig,
+  type LexicalEditor,
+  type LexicalNode,
+} from 'lexical'
 import * as React from 'react'
 
 import type {
@@ -94,9 +95,11 @@ export class RelationshipNode extends RelationshipServerNode {
 }
 
 export function $createRelationshipNode(data: RelationshipData): RelationshipNode {
-  return new RelationshipNode({
-    data,
-  })
+  return $applyNodeReplacement(
+    new RelationshipNode({
+      data,
+    }),
+  )
 }
 
 export function $isRelationshipNode(

--- a/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
@@ -1,18 +1,19 @@
 import type { SerializedDecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
-import type {
-  DOMConversionMap,
-  DOMConversionOutput,
-  DOMExportOutput,
-  EditorConfig,
-  ElementFormatType,
-  LexicalEditor,
-  LexicalNode,
-  NodeKey,
-} from 'lexical'
 import type { CollectionSlug, DataFromCollectionSlug } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
+import {
+  $applyNodeReplacement,
+  type DOMConversionMap,
+  type DOMConversionOutput,
+  type DOMExportOutput,
+  type EditorConfig,
+  type ElementFormatType,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+} from 'lexical'
 
 import type { StronglyTypedLeafNode } from '../../../../nodeTypes.js'
 
@@ -144,9 +145,11 @@ export class RelationshipServerNode extends DecoratorBlockNode {
 }
 
 export function $createServerRelationshipNode(data: RelationshipData): RelationshipServerNode {
-  return new RelationshipServerNode({
-    data,
-  })
+  return $applyNodeReplacement(
+    new RelationshipServerNode({
+      data,
+    }),
+  )
 }
 
 export function $isServerRelationshipNode(

--- a/packages/richtext-lexical/src/features/upload/client/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/plugin/index.tsx
@@ -290,7 +290,7 @@ export const UploadPlugin: PluginComponent<UploadFeaturePropsClient> = ({ client
 
               if ($isRangeSelection(selection)) {
                 for (const file of files) {
-                  const pendingUploadNode = new UploadNode({
+                  const pendingUploadNode = $createUploadNode({
                     data: {
                       pending: {
                         formID: file.formID,
@@ -363,7 +363,7 @@ export const UploadPlugin: PluginComponent<UploadFeaturePropsClient> = ({ client
                 $setSelection(selection)
 
                 for (const file of files) {
-                  const pendingUploadNode = new UploadNode({
+                  const pendingUploadNode = $createUploadNode({
                     data: {
                       pending: {
                         formID: file.formID,


### PR DESCRIPTION
Currently, you are unable to replace block, inline block, upload, unknown and relationship nodes using [lexical node replacement](https://lexical.dev/docs/concepts/node-replacement), because we forgot to call `$applyNodeReplacement` for those nodes.

This PR inserts the missing `$applyNodeReplacement` calls. This concept is not new - we already do this for all the remaining nodes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211668728617855