### PR TITLE
feat: allow custom bin scripts to return payload instance and exit code

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -284,19 +284,24 @@ Example for `pnpm payload seed`:
 Step 1: create `seed.ts` file in the same folder with `payload.config.ts` with:
 
 ```ts
-import type { SanitizedConfig } from 'payload'
+import type { BinScript } from 'payload'
 
-import payload from 'payload'
+import { getPayload } from 'payload'
 
 // Script must define a "script" function export that accepts the sanitized config
-export const script = async (config: SanitizedConfig) => {
-  await payload.init({ config })
+export const script: BinScript = async (config) => {
+  const payload = await getPayload({ config })
+
   await payload.create({
     collection: 'pages',
     data: { title: 'my title' },
   })
+
   payload.logger.info('Successfully seeded!')
-  process.exit(0)
+
+  // Return the Payload instance so cleanup can be done, e.g. close database connections
+  // Can also include an 'exitCode' property to set the process exit code
+  return { payload }
 }
 ```
 

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -132,7 +132,12 @@ export type BinScriptConfig = {
   scriptPath: string
 }
 
-export type BinScript = (config: SanitizedConfig) => Promise<void> | void
+export type BinScriptResult = {
+  exitCode?: number
+  payload?: Payload
+} | void
+
+export type BinScript = (config: SanitizedConfig) => BinScriptResult | Promise<BinScriptResult>
 
 type Prettify<T> = {
   [K in keyof T]: T[K]


### PR DESCRIPTION
This allows custom bin scripts to return:

* A payload instance, so it can be handled as part of the centralized payload instance cleanup for all bin scripts
* An exit code, so it can be passed to `process.exit()` after the payload instance cleanup

This also updates the custom bin script example in the documentation to illustrate this usage