### PR TITLE
fix(storage-*): update the client cache to use a map instead with cache keys per bucket config

### DIFF
--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -32,6 +32,12 @@ export type AzureStorageOptions = {
   baseURL: string
 
   /**
+   * Optional cache key to identify the Azure Blob storage client instance.
+   * If not provided, a default key of `azure:containerName` will be used.
+   */
+  clientCacheKey?: string
+
+  /**
    * Do uploads directly on the client to bypass limits on Vercel. You must allow CORS PUT method to your website.
    */
   clientUploads?: ClientUploadsConfig

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -33,7 +33,9 @@ export type AzureStorageOptions = {
 
   /**
    * Optional cache key to identify the Azure Blob storage client instance.
-   * If not provided, a default key of `azure:containerName` will be used.
+   * If not provided, a default key will be used.
+   *
+   * @defaultValue `azure:containerName`
    */
   clientCacheKey?: string
 

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -35,7 +35,7 @@ export type AzureStorageOptions = {
    * Optional cache key to identify the Azure Blob storage client instance.
    * If not provided, a default key will be used.
    *
-   * @defaultValue `azure:containerName`
+   * @default `azure:containerName`
    */
   clientCacheKey?: string
 

--- a/packages/storage-azure/src/utils/getStorageClient.ts
+++ b/packages/storage-azure/src/utils/getStorageClient.ts
@@ -4,18 +4,23 @@ import { BlobServiceClient } from '@azure/storage-blob'
 
 import type { AzureStorageOptions } from '../index.js'
 
-let storageClient: ContainerClient | null = null
+// Cache the Azure Blob storage clients in a map so that multiple instances are not overriding each other in the case of different configurations used per collection
+const azureClients = new Map<string, ContainerClient>()
 
 export function getStorageClient(
-  options: Pick<AzureStorageOptions, 'connectionString' | 'containerName'>,
+  options: Pick<AzureStorageOptions, 'clientCacheKey' | 'connectionString' | 'containerName'>,
 ): ContainerClient {
-  if (storageClient) {
-    return storageClient
+  const cacheKey = options.clientCacheKey || `azure:${options.containerName}`
+
+  if (azureClients.has(cacheKey)) {
+    return azureClients.get(cacheKey)!
   }
 
   const { connectionString, containerName } = options
 
   const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
-  storageClient = blobServiceClient.getContainerClient(containerName)
-  return storageClient
+
+  azureClients.set(cacheKey, blobServiceClient.getContainerClient(containerName))
+
+  return azureClients.get(cacheKey)!
 }

--- a/packages/storage-gcs/src/index.ts
+++ b/packages/storage-gcs/src/index.ts
@@ -26,8 +26,10 @@ export interface GcsStorageOptions {
    */
   bucket: string
   /**
-   * Optional cache key to identify the Azure Blob storage client instance.
-   * If not provided, a default key of `azure:containerName` will be used.
+   * Optional cache key to identify the GCS storage client instance.
+   * If not provided, a default key will be used.
+   *
+   * @defaultValue `gcs:containerName`
    */
   clientCacheKey?: string
   /**

--- a/packages/storage-gcs/src/index.ts
+++ b/packages/storage-gcs/src/index.ts
@@ -29,7 +29,7 @@ export interface GcsStorageOptions {
    * Optional cache key to identify the GCS storage client instance.
    * If not provided, a default key will be used.
    *
-   * @defaultValue `gcs:containerName`
+   * @default `gcs:containerName`
    */
   clientCacheKey?: string
   /**

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -39,7 +39,7 @@ export type S3StorageOptions = {
    * Optional cache key to identify the S3 storage client instance.
    * If not provided, a default key will be used.
    *
-   * @defaultValue `s3:containerName`
+   * @default `s3:containerName`
    */
   clientCacheKey?: string
 

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -36,6 +36,12 @@ export type S3StorageOptions = {
   bucket: string
 
   /**
+   * Optional cache key to identify the Azure Blob storage client instance.
+   * If not provided, a default key of `azure:containerName` will be used.
+   */
+  clientCacheKey?: string
+
+  /**
    * Do uploads directly on the client to bypass limits on Vercel. You must allow CORS PUT method for the bucket to your website.
    */
   clientUploads?: ClientUploadsConfig
@@ -79,7 +85,7 @@ export type S3StorageOptions = {
 
 type S3StoragePlugin = (storageS3Args: S3StorageOptions) => Plugin
 
-let storageClient: AWS.S3 | null = null
+const s3Clients = new Map<string, AWS.S3>()
 
 const defaultRequestHandlerOpts: NodeHttpHandlerOptions = {
   httpAgent: {
@@ -95,16 +101,22 @@ const defaultRequestHandlerOpts: NodeHttpHandlerOptions = {
 export const s3Storage: S3StoragePlugin =
   (s3StorageOptions: S3StorageOptions) =>
   (incomingConfig: Config): Config => {
+    const cacheKey = s3StorageOptions.clientCacheKey || `s3:${s3StorageOptions.bucket}`
+
     const getStorageClient: () => AWS.S3 = () => {
-      if (storageClient) {
-        return storageClient
+      if (s3Clients.has(cacheKey)) {
+        return s3Clients.get(cacheKey)!
       }
 
-      storageClient = new AWS.S3({
-        requestHandler: defaultRequestHandlerOpts,
-        ...(s3StorageOptions.config ?? {}),
-      })
-      return storageClient
+      s3Clients.set(
+        cacheKey,
+        new AWS.S3({
+          requestHandler: defaultRequestHandlerOpts,
+          ...(s3StorageOptions.config ?? {}),
+        }),
+      )
+
+      return s3Clients.get(cacheKey)!
     }
 
     const isPluginDisabled = s3StorageOptions.enabled === false

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -36,8 +36,10 @@ export type S3StorageOptions = {
   bucket: string
 
   /**
-   * Optional cache key to identify the Azure Blob storage client instance.
-   * If not provided, a default key of `azure:containerName` will be used.
+   * Optional cache key to identify the S3 storage client instance.
+   * If not provided, a default key will be used.
+   *
+   * @defaultValue `s3:containerName`
    */
   clientCacheKey?: string
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14175

Updates the client caches to use a map with cache keys per bucket, this key is overridable using `cacheKey` but it defaults to `'adapter:bucketName'` string format eg. `'s3:primary-us'`.

Currently because we use a single variable it means that if you were to instantiate the client multiple times in order to store different collections in different buckets it would all get sent to the last instantiated client as it would be overridden, this makes sure that it's correctly using the client instantiated per bucket.
