### PR TITLE
fix(next): logout when collection has auth cookies domain set to subdomain

### DIFF
--- a/packages/next/src/auth/logout.ts
+++ b/packages/next/src/auth/logout.ts
@@ -36,10 +36,12 @@ export async function logout({
     return { message: 'Logout failed', success: false }
   }
 
+  const authConfig = collection?.config.auth
+
   const existingCookie = await getExistingAuthToken(payload.config.cookiePrefix)
   if (existingCookie) {
     const cookies = await getCookies()
-    cookies.delete(existingCookie.name)
+    cookies.delete({ name: existingCookie.name, domain: authConfig?.cookies?.domain || undefined })
   }
 
   return { message: 'User logged out successfully', success: true }


### PR DESCRIPTION
### What
Adds support for using the `domain` property from a collection’s auth configuration when deleting cookies.

### Why
When a cookie is set with a specific domain (for example, `test.vercel.app`), the browser will only delete it if the same domain is explicitly provided when calling `cookies.delete`.  
Without this, logout operations can fail because the session token cookie remains undeleted.

There is no problem, when collection auth cookie domain config is standard domain (eg. `vercel.app`).

### How?
Get cookie domain from collection auth config and pass it to "cookies.delete" function (if domain set).

Fixes #
There is no issue corresponding to this fix.
I get this bug when deployed payload to vercel without setting custom domain. Vercel set it's own subdomain, and then logout suddenly stopped working.

I had to add workaround like adding `cookies.delete({name:"payload-token",` domain: <the-same-domain-as-in-collection-auth-config>})` next to payload's logoutAction and it started working.
```typescript
"use server"

import "server-only"
import { logout } from "@payloadcms/next/auth"
import { cookies as getCookies } from "next/headers"
import { env } from "@/lib/env.ts"
import config from "@/payload.config"

export const logoutUserAction = async () => {
	try {
		const result = await logout({
			allSessions: true,
			config,
		})

		const cookies = await getCookies()

		cookies.delete({
			name: "payload-token",
			domain: process.env.NODE_ENV === "production" ? env.NEXT_PUBLIC_DOMAIN : undefined,
		})

		if (!result.success) {
			return {
				success: false,
				message: "user-not-logged-out",
			}
		}

		return { success: true }
	} catch (error) {
		console.error("ERROR", error)

		return {
			success: false,
			message: "user-not-logged-out",
		}
	}
}

```