### PR TITLE
feat(richtext-lexical): full admin object

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1451,6 +1451,7 @@ export type {
   EmailFieldClient,
   Field,
   FieldAccess,
+  FieldAdmin,
   FieldAffectingData,
   FieldAffectingDataClient,
   FieldBase,

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
@@ -1,5 +1,5 @@
 import type { SerializedEditorState } from 'lexical'
-import type { Field } from 'payload'
+import type { Field, FieldAdmin } from 'payload'
 
 import type { HTMLConvertersAsync, HTMLConvertersFunctionAsync } from '../types.js'
 
@@ -7,9 +7,19 @@ import { getPayloadPopulateFn } from '../../../utilities/payloadPopulateFn.js'
 import { convertLexicalToHTMLAsync } from '../index.js'
 
 type Args = {
+  /**
+   * Admin config for the lexicalHTML field
+   *
+   * The `editorOptions` property will be omitted and set to `{ language: 'html' }` by default.
+   * @since v3.62.0
+   */
+  admin?: Omit<FieldAdmin, 'editorOptions'>
   converters?: HTMLConvertersAsync | HTMLConvertersFunctionAsync
   /**
    * Whether the lexicalHTML field should be hidden in the admin panel
+   *
+   * @deprecated since v3.62.0 - use the `admin` property instead
+   * @todo remove deprecated hidden property in 4.0
    *
    * @default true
    */
@@ -36,15 +46,26 @@ type Args = {
  * @todo will be renamed to lexicalHTML in 4.0, replacing the deprecated `lexicalHTML` converter
  */
 export const lexicalHTMLField: (args: Args) => Field = (args) => {
-  const { converters, hidden = true, htmlFieldName, lexicalFieldName, storeInDB = false } = args
+  const {
+    admin = {},
+    converters,
+    hidden = true, // TODO: remove deprecated `hidden` property in 4.0
+    htmlFieldName,
+    lexicalFieldName,
+    storeInDB = false,
+  } = args
+
   const field: Field = {
     name: htmlFieldName,
     type: 'code',
     admin: {
+      ...{
+        ...admin,
+        hidden, // TODO: remove deprecated `hidden` property in 4.0
+      },
       editorOptions: {
         language: 'html',
       },
-      hidden,
     },
     hooks: {
       afterRead: [

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
@@ -60,8 +60,8 @@ export const lexicalHTMLField: (args: Args) => Field = (args) => {
     type: 'code',
     admin: {
       ...{
+        hidden: hidden ? hidden : false, // TODO: remove deprecated `hidden` property in 4.0
         ...admin,
-        hidden, // TODO: remove deprecated `hidden` property in 4.0
       },
       editorOptions: {
         language: 'html',

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
@@ -60,6 +60,7 @@ export const lexicalHTMLField: (args: Args) => Field = (args) => {
     type: 'code',
     admin: {
       ...{
+        disableListColumn: true, // Disable list column by default for HTML field
         hidden: hidden ? hidden : false, // TODO: remove deprecated `hidden` property in 4.0
         ...admin,
       },

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
@@ -61,7 +61,7 @@ export const lexicalHTMLField: (args: Args) => Field = (args) => {
     admin: {
       ...{
         disableListColumn: true, // Disable list column by default for HTML field
-        hidden: hidden ? hidden : false, // TODO: remove deprecated `hidden` property in 4.0
+        hidden, // TODO: remove deprecated `hidden` property in 4.0
         ...(admin || {}),
       },
       editorOptions: {

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/field/index.ts
@@ -47,7 +47,7 @@ type Args = {
  */
 export const lexicalHTMLField: (args: Args) => Field = (args) => {
   const {
-    admin = {},
+    admin,
     converters,
     hidden = true, // TODO: remove deprecated `hidden` property in 4.0
     htmlFieldName,
@@ -62,7 +62,7 @@ export const lexicalHTMLField: (args: Args) => Field = (args) => {
       ...{
         disableListColumn: true, // Disable list column by default for HTML field
         hidden: hidden ? hidden : false, // TODO: remove deprecated `hidden` property in 4.0
-        ...admin,
+        ...(admin || {}),
       },
       editorOptions: {
         language: 'html',


### PR DESCRIPTION
Hey, this is the full alternative to #14235

To recall this was in order to have `lexicalHTML` fields hidden from the list views by default with `disableListColumn` set to true by default.

### This patch brings the full `admin` object:

- Export `FieldAdmin` type from payload core package for proper typing
- Add `admin` param to lexicalHTML (fixed `editorOptions` properties)
- Deprecate `hidden` parameter in favor of the admin object
- Maintain compatibility by preserving existing `hidden` parameter
- Plan removal of deprecated `hidden` property for v4.0 with notices

### This patch also sets `disableListColumn` to true by default, which can be overriden by specifying it in the optional `admin` property.

> [!NOTE] 
> Please review the modified jsdocs - it uses the `@since` jsdoc tag presuming this patch (ever) makes it to 3.61

I've not actually tested this, tell me if you consider merging this.

Regards,