### PR TITLE
fix(ui): document locked modal blocks interaction after clicking Go Back

### DIFF
--- a/packages/ui/src/elements/DocumentLocked/index.tsx
+++ b/packages/ui/src/elements/DocumentLocked/index.tsx
@@ -78,6 +78,7 @@ export const DocumentLocked: React.FC<{
             buttonStyle="secondary"
             id={`${modalSlug}-go-back`}
             onClick={() => {
+              closeModal(modalSlug)
               startRouteTransition(() => handleGoBack())
             }}
             size="large"

--- a/test/locked-documents/e2e.spec.ts
+++ b/test/locked-documents/e2e.spec.ts
@@ -793,6 +793,35 @@ describe('Locked Documents', () => {
       expect(page.url()).toContain(postsUrl.list)
     })
 
+    test('should properly close modal and allow re-opening after clicking Go Back', async () => {
+      await page.goto(postsUrl.list)
+
+      // eslint-disable-next-line payload/no-wait-function
+      await wait(500)
+
+      // First time: navigate to locked document
+      await page.goto(postsUrl.edit(postDoc.id))
+
+      const modalContainer = page.locator('.payload__modal-container')
+      await expect(modalContainer).toBeVisible()
+
+      // Click Go Back
+      await page.locator('#document-locked-go-back').click()
+
+      // Wait for navigation to complete
+      await page.waitForURL(`**${postsUrl.list}`)
+
+      // Modal should be completely closed
+      await expect(modalContainer).toBeHidden()
+
+      // Second time: navigate to the same locked document again
+      await page.goto(postsUrl.edit(postDoc.id))
+
+      // Modal should appear again (verifies no stuck modal state)
+      await expect(modalContainer).toBeVisible()
+      await expect(page.locator('#document-locked-go-back')).toBeVisible()
+    })
+
     test('should not show Document Locked modal for incoming user when entering expired locked document', async () => {
       await page.goto(testsUrl.list)
 

--- a/test/locked-documents/payload-types.ts
+++ b/test/locked-documents/payload-types.ts
@@ -147,7 +147,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -174,7 +174,7 @@ export interface ServerComponent {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];


### PR DESCRIPTION
### What?

Fixes a bug where clicking "Go Back" in the DocumentLocked modal leaves an invisible overlay that blocks all page interactions, requiring a page refresh.

### Why?

The "Go Back" button was calling `handleGoBack()` to navigate away but wasn't explicitly closing the modal first. This left the modal in a stuck state where the backdrop remained present and blocked user interaction. The other buttons ("View Read Only" and "Take Over") already call `closeModal()` before their actions.

### How?

- Added `closeModal(modalSlug)` before `startRouteTransition(() => handleGoBack())` in the Go Back button handler

Fixes #14285 
