### PR TITLE
fix(plugin-search): add locale to key in syncedDocsSet

### DIFF
--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -84,7 +84,7 @@ export type SanitizedSearchPluginConfig = {
 
 export type SyncWithSearchArgs = {
   collection: string
-  pluginConfig: SearchPluginConfig
+  pluginConfig: SanitizedSearchPluginConfig
 } & Omit<Parameters<CollectionAfterChangeHook>[0], 'collection'>
 
 export type SyncDocArgs = {

--- a/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
+++ b/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
@@ -24,7 +24,8 @@ export const syncDocAsSearchIndex = async ({
     },
     title,
   }
-  const docKey = `${collection}:${id}`
+  const docKeyPrefix = `${collection}:${id}`
+  const docKey = pluginConfig.locales?.length ? `${docKeyPrefix}:${syncLocale}` : docKeyPrefix
   const syncedDocsSet = (req.context?.syncedDocsSet as Set<string>) || new Set<string>()
 
   if (syncedDocsSet.has(docKey)) {


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR adjusts the `docKey` used in `syncDocAsSearchIndex` to consider configured locales. The existing behavior prevents reindexing from saving locales outside of the default locale. With this PR, the plugin successfully reindexes all configured locales.

### Why?
To allow all configured locales to be reindexed as expected.

### How?
- Checking if the pluginConfig includes locales and, if so, sets the `docKey` to include the `syncLocale` being used
- Correcting type for `pluginConfig` in `SyncWithSearchArgs` to be `SanitizedSearchPluginConfig`
- Adding an int test to demonstrate reindexing all configured locales as default behavior

Fixes #14276

Before:

[before.mp4](https://private-user-images.githubusercontent.com/20878653/503591671-d7d9ccbf-7e9d-4d98-bbc4-0e5729bb2505.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjEwNTk4NjMsIm5iZiI6MTc2MTA1OTU2MywicGF0aCI6Ii8yMDg3ODY1My81MDM1OTE2NzEtZDdkOWNjYmYtN2U5ZC00ZDk4LWJiYzQtMGU1NzI5YmIyNTA1Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEwMjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMDIxVDE1MTI0M1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTlmZGYxYTZmNDBlMTJhMDlkZGQ4ZTg3ZGU4Njk1ZThiZDk0ODc3MzllNTE1YTA3NDgyNGE5YWJmZmVmYWI4ZTcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.93C6OWecb34l8JeAtAc2AdOFh6aVoIDfcSxJ247FO1k)

After:

[Search-Results---Payload--after.webm](https://github.com/user-attachments/assets/57bb689d-4cfb-40f0-be8d-08c6787c7bec)
