### PR TITLE
fix: document header text clipping

### DIFF
--- a/packages/next/src/elements/DocumentHeader/index.scss
+++ b/packages/next/src/elements/DocumentHeader/index.scss
@@ -3,7 +3,7 @@
 @layer payload-default {
   .doc-header {
     width: 100%;
-    margin-top: base(0.4);
+    margin-top: calc(var(--base) * 0.4);
     padding-bottom: calc(var(--base) * 1.2);
     position: relative;
 
@@ -30,18 +30,17 @@
       overflow: hidden;
       text-overflow: ellipsis;
       margin: 0;
-      padding-bottom: base(0.4);
-      line-height: 1;
+      padding-bottom: calc(var(--base) * 0.4);
       vertical-align: top;
       padding-bottom: 0;
     }
 
     &__after-header {
-      padding-top: var(--base);
+      padding-top: calc(var(--base) * 0.8);
     }
 
     @include mid-break {
-      margin-top: base(0.25);
+      margin-top: calc(var(--base) * 0.25);
       padding-bottom: calc(var(--base) / 1.5);
 
       &__header {


### PR DESCRIPTION
### What?

Fix header text being cut off in the document header.

### Why?

Letters with descenders (like “g” and “y”) were getting clipped due to an overly tight line height.

### How?

Removed the line-height: 1 rule from the header CSS to allow text to render naturally.

#### Before
<img width="579" height="174" alt="Screenshot 2025-10-21 at 12 55 27 PM" src="https://github.com/user-attachments/assets/a455d2c4-825a-47c2-a7be-d72d9c1675bc" />

#### After
<img width="462" height="176" alt="Screenshot 2025-10-21 at 12 55 45 PM" src="https://github.com/user-attachments/assets/8bd58d6e-d22d-485c-ad36-8b5eb388ae93" />

