### PR TITLE
fix(richtext-lexical): ensure block node form displays up-to-date value when editor remounts

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
@@ -98,17 +98,26 @@ export const BlockComponent: React.FC<Props> = (props) => {
   const schemaFieldsPath = `${schemaPath}.lexical_internal_feature.blocks.lexical_blocks.${blockType}.fields`
 
   const [initialState, setInitialState] = React.useState<false | FormState | undefined>(() => {
-    return initialLexicalFormState?.[formData.id]?.formState
-      ? {
-          ...initialLexicalFormState?.[formData.id]?.formState,
-          blockName: {
-            initialValue: formData.blockName,
-            passesCondition: true,
-            valid: true,
-            value: formData.blockName,
-          },
-        }
-      : false
+    // Initial form state that was calculated server-side. May have stale values
+    const cachedFormState = initialLexicalFormState?.[formData.id]?.formState
+    if (!cachedFormState) {
+      return false
+    }
+
+    // Merge current formData values into the cached form state
+    // This ensures that when the component remounts (e.g., due to view changes), we don't lose user edits
+    return Object.fromEntries(
+      Object.entries(cachedFormState).map(([fieldName, fieldState]) => [
+        fieldName,
+        fieldName in formData
+          ? {
+              ...fieldState,
+              initialValue: formData[fieldName],
+              value: formData[fieldName],
+            }
+          : fieldState,
+      ]),
+    )
   })
 
   const hasMounted = useRef(false)


### PR DESCRIPTION
The richText editor may remount if the value is changed externally, or when changing the editor view (https://github.com/payloadcms/payload/pull/14244).

This is fine for most nodes. But for the block node, this will cause it to fall-back to `initialState`. This initialState may be stale though, as it's calculated on the server. If the richText editor remounts, we do not guarantee that the initialState is refreshed.

Thus, an action such as changing the editor value externally or updating the editor view will discard unsaved value changes for block nodes.

The solution is to merge in value from the up-to-date `formData` object (= editor state for this node) into the initialState object. We already do this for the `blockName` field. Now, we do this for all fields.

https://linear.app/figma-trial/issue/PAYL-243/fixrichtext-lexical-ensure-block-node-form-displays-up-to-date-value