### PR TITLE
templates: add missing @eslint/eslintrc to blank template

### DIFF
--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -33,6 +33,7 @@
     "sharp": "0.34.2"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.2.0",
     "@playwright/test": "1.54.1",
     "@testing-library/react": "16.3.0",
     "@types/node": "^22.5.4",


### PR DESCRIPTION
### What?
Adds the missing `@eslint/eslintrc` dependency to the blank template's devDependencies to standardize ESLint configurations across all template projects.

### Why?
The blank template was missing the `@eslint/eslintrc` dependency that is present in other templates like website and ecommerce. This caused linting to fail with the error:

```
PS F:\data\dev\payloadcms> pnpm lint

> r-store@1.0.0 lint F:\data\dev\payloadcms

Cannot find package '@eslint/eslintrc' imported from F:\data\dev\payloadcms\eslint.config.mjs
Did you mean to import "@eslint/eslintrc/dist/eslintrc.cjs"?
ELIFECYCLE  Command failed with exit code 1.
```

### How?
Added `"@eslint/eslintrc": "^3.2.0"` to the devDependencies in the blank template's package.json, matching the version used in other templates.