### PR TITLE
chore(sdk): move payload to dev dependencies

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,12 +41,12 @@
     "prepublishOnly": "pnpm clean && pnpm turbo build"
   },
   "dependencies": {
-    "payload": "workspace:*",
     "qs-esm": "7.0.2",
     "ts-essentials": "10.0.3"
   },
   "devDependencies": {
-    "@payloadcms/eslint-config": "workspace:*"
+    "@payloadcms/eslint-config": "workspace:*",
+    "payload": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1532,9 +1532,6 @@ importers:
 
   packages/sdk:
     dependencies:
-      payload:
-        specifier: workspace:*
-        version: link:../payload
       qs-esm:
         specifier: 7.0.2
         version: 7.0.2
@@ -1545,6 +1542,9 @@ importers:
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      payload:
+        specifier: workspace:*
+        version: link:../payload
 
   packages/storage-azure:
     dependencies:


### PR DESCRIPTION
Move `payload` to dev dependencies so it doesn't bloat production builds when installing production dependencies recursively, as only sdk only imports types.