### PR TITLE
fix(db-*): querying joins with `$exists` on mongodb and improve performance when querying multiple times on postgres

### DIFF
--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -114,7 +114,7 @@ export async function buildSearchParam({
 
     const { operator: formattedOperator, rawQuery, val: formattedValue } = sanitizedQueryValue
 
-    if (rawQuery) {
+    if (rawQuery && paths.length === 1) {
       return { value: rawQuery }
     }
 

--- a/packages/drizzle/src/queries/buildQuery.ts
+++ b/packages/drizzle/src/queries/buildQuery.ts
@@ -11,7 +11,7 @@ import { parseParams } from './parseParams.js'
 export type BuildQueryJoinAliases = {
   condition: SQL
   queryPath?: string
-  table: GenericTable | PgTableWithColumns<any>
+  table: GenericTable<any> | PgTableWithColumns<any>
   type?: 'innerJoin' | 'leftJoin' | 'rightJoin'
 }[]
 

--- a/packages/drizzle/src/queries/buildQuery.ts
+++ b/packages/drizzle/src/queries/buildQuery.ts
@@ -11,7 +11,7 @@ import { parseParams } from './parseParams.js'
 export type BuildQueryJoinAliases = {
   condition: SQL
   queryPath?: string
-  table: GenericTable<any> | PgTableWithColumns<any>
+  table: GenericTable | PgTableWithColumns<any>
   type?: 'innerJoin' | 'leftJoin' | 'rightJoin'
 }[]
 

--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -373,12 +373,11 @@ export const getTableColumnFromPath = ({
             (e) => e.queryPath === `${constraintPath}${field.name}._rels`,
           )
 
-          const aliasRelationshipTable =
-            existingTable?.table ??
+          const aliasRelationshipTable = (existingTable?.table ??
             getTableAlias({
               adapter,
               tableName: relationTableName,
-            }).newAliasTable
+            }).newAliasTable) as PgTableWithColumns<any>
 
           const relationshipField = getFieldByPath({
             fields: adapter.payload.collections[field.collection].config.flattenedFields,
@@ -429,12 +428,11 @@ export const getTableColumnFromPath = ({
             (e) => e.queryPath === `${constraintPath}${field.name}`,
           )
 
-          const relationshipTable =
-            existingMainTable?.table ??
+          const relationshipTable = (existingMainTable?.table ??
             getTableAlias({
               adapter,
               tableName: relationshipTableName,
-            }).newAliasTable
+            }).newAliasTable) as PgTableWithColumns<any>
 
           if (!existingMainTable) {
             joins.push({

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -1844,6 +1844,7 @@ describe('Joins Field', () => {
       collection: 'posts',
       data: { group: { category: category.id }, isFiltered: true, title: 'my-category-title' },
     })
+
     const found = await payload.find({
       collection: 'categories',
       where: {

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -1837,6 +1837,60 @@ describe('Joins Field', () => {
     expect(found.docs).toHaveLength(1)
     expect(found.docs[0].id).toBe(category.id)
   })
+
+  it('should support where querying by a join field multiple times', async () => {
+    const category = await payload.create({ collection: 'categories', data: {} })
+    await payload.create({
+      collection: 'posts',
+      data: { group: { category: category.id }, isFiltered: true, title: 'my-category-title' },
+    })
+    const found = await payload.find({
+      collection: 'categories',
+      where: {
+        and: [
+          {
+            'group.relatedPosts.title': { equals: 'my-category-title' },
+          },
+          {
+            'group.relatedPosts.title': { exists: true },
+          },
+          {
+            'group.relatedPosts.isFiltered': { equals: true },
+          },
+        ],
+      },
+    })
+
+    expect(found.docs).toHaveLength(1)
+    expect(found.docs[0].id).toBe(category.id)
+  })
+
+  it('should support where querying by a join field with hasMany relationship multiple times', async () => {
+    const category = await payload.create({ collection: 'categories', data: {} })
+    await payload.create({
+      collection: 'posts',
+      data: { categories: [category.id], title: 'my-title', isFiltered: true },
+    })
+
+    const found = await payload.find({
+      collection: 'categories',
+      where: {
+        and: [
+          {
+            'hasManyPosts.title': { equals: 'my-title' },
+          },
+          {
+            'hasManyPosts.title': { exists: true },
+          },
+          {
+            'hasManyPosts.isFiltered': { equals: true },
+          },
+        ],
+      },
+    })
+    expect(found.docs).toHaveLength(1)
+    expect(found.docs[0].id).toBe(category.id)
+  })
 })
 
 async function createPost(overrides?: Partial<Post>, locale?: Config['locale']) {


### PR DESCRIPTION
1. Fixes handling of `$exists` when querying a field nested to a join field.
2. Avoids adding new SQL joins when querying a join field multiple times
before
```sql
SELECT DISTINCT
    "categories"."id",
    "categories"."created_at",
    "categories"."created_at"
FROM
    "categories"
    LEFT JOIN "posts_rels" AS "c40660ed_b4bf_4644_bbd1_b7225045bb92"
        ON (
            "categories"."id" = "c40660ed_b4bf_4644_bbd1_b7225045bb92"."categories_id"
            AND "c40660ed_b4bf_4644_bbd1_b7225045bb92"."path" LIKE ?
        )
    LEFT JOIN "posts" AS "6702692c_e77e_41b3_ab0c_038d8ca584f6"
        ON "c40660ed_b4bf_4644_bbd1_b7225045bb92"."parent_id" = "6702692c_e77e_41b3_ab0c_038d8ca584f6"."id"
    LEFT JOIN "posts" AS "b8d97c7b_51c7_448e_96dd_567ac0a24ccf"
        ON "c40660ed_b4bf_4644_bbd1_b7225045bb92"."parent_id" = "b8d97c7b_51c7_448e_96dd_567ac0a24ccf"."id"
    LEFT JOIN "posts" AS "89586995_3641_4226_b047_dc3c96b33d9f"
        ON "c40660ed_b4bf_4644_bbd1_b7225045bb92"."parent_id" = "89586995_3641_4226_b047_dc3c96b33d9f"."id"
WHERE
    "6702692c_e77e_41b3_ab0c_038d8ca584f6"."title" = ?
    AND "b8d97c7b_51c7_448e_96dd_567ac0a24ccf"."title" IS NOT NULL
    AND "89586995_3641_4226_b047_dc3c96b33d9f"."is_filtered" = ?
ORDER BY
    "categories"."created_at" DESC
LIMIT ?
-- params: ["categories", "my-title", 1, 10]
```
now
```sql
SELECT DISTINCT
    "categories"."id",
    "categories"."created_at",
    "categories"."created_at"
FROM
    "categories"
    LEFT JOIN "posts_rels" AS "b6ba04a3_a557_4321_abfb_7b58250baa2c"
        ON (
            "categories"."id" = "b6ba04a3_a557_4321_abfb_7b58250baa2c"."categories_id"
            AND "b6ba04a3_a557_4321_abfb_7b58250baa2c"."path" LIKE ?
        )
    LEFT JOIN "posts" AS "86c9090f_c50b_485d_a9bb_1ca8b5ad079d"
        ON "b6ba04a3_a557_4321_abfb_7b58250baa2c"."parent_id" = "86c9090f_c50b_485d_a9bb_1ca8b5ad079d"."id"
WHERE
    "86c9090f_c50b_485d_a9bb_1ca8b5ad079d"."title" = ?
    AND "86c9090f_c50b_485d_a9bb_1ca8b5ad079d"."title" IS NOT NULL
    AND "86c9090f_c50b_485d_a9bb_1ca8b5ad079d"."is_filtered" = ?
ORDER BY
    "categories"."created_at" DESC
LIMIT ?
-- params: ["categories", "my-title", 1, 10]
```