### PR TITLE
build: add README sync for top-level -> packages/payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Jumpstart your next project with a ready-to-go template. These are **production-
 
 #### 🛍️ [Ecommerce](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) 🎉 _**NEW**_ 🎉
 
-We're constantly adding more templates to our [**Templates Directory**](https://github.com/payloadcms/payload/tree/main/templates).  
+We're constantly adding more templates to our [**Templates Directory**](https://github.com/payloadcms/payload/tree/main/templates).
 If you maintain your own, add the `payload-template` topic to your GitHub repo so others can discover it.
 
 **🔗 Explore more:**

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
       "eslint --cache --fix"
     ],
     "templates/**/pnpm-lock.yaml": "pnpm runts scripts/remove-template-lock-files.ts",
-    "tsconfig.base.json": "node scripts/reset-tsconfig.js"
+    "tsconfig.base.json": "node scripts/reset-tsconfig.js",
+    "README.md": "sh -c 'cp ./README.md ./packages/payload/README.md'"
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",

--- a/packages/payload/README.md
+++ b/packages/payload/README.md
@@ -9,6 +9,8 @@
   &nbsp;
   <a href="https://www.npmjs.com/package/payload"><img alt="npm" src="https://img.shields.io/npm/dw/payload?style=flat-square" /></a>
   &nbsp;
+  <a href="https://github.com/payloadcms/payload/graphs/contributors"><img alt="npm" src="https://img.shields.io/github/contributors-anon/payloadcms/payload?color=yellow&style=flat-square" /></a>
+  &nbsp;
   <a href="https://www.npmjs.com/package/payload"><img alt="npm" src="https://img.shields.io/npm/v/payload?style=flat-square" /></a>
   &nbsp;
   <a href="https://twitter.com/payloadcms"><img src="https://img.shields.io/badge/follow-payloadcms-1DA1F2?logo=twitter&style=flat-square" alt="Payload Twitter" /></a>
@@ -20,12 +22,13 @@
 <hr/>
 
 > [!IMPORTANT]
-> 🎉 <strong>We've released 3.0!</strong> Star this repo or keep an eye on it to follow along.
+> Star this repo or keep an eye on it to follow along.
 
 Payload is the first-ever Next.js native CMS that can install directly in your existing `/app` folder. It's the start of a new era for headless CMS.
 
 <h3>Benefits over a regular CMS</h3>
 <ul>
+   <li>It's both an app framework & headless CMS</li>
   <li>Deploy anywhere, including serverless on Vercel for free</li>
   <li>Combine your front+backend in the same <code>/app</code> folder if you want</li>
   <li>Don't sign up for yet another SaaS - Payload is open source</li>
@@ -46,20 +49,39 @@ pnpx create-payload-app@latest
 
 **If you're new to Payload, you should start with the website template** (`pnpx create-payload-app@latest -t website`). It shows how to do _everything_ - including custom Rich Text blocks, on-demand revalidation, live preview, and more. It comes with a frontend built with Tailwind all in one `/app` folder.
 
+## One-click deployment options
+
+You can deploy Payload serverlessly in one-click via Vercel and Cloudflare—giving everything you need without the hassle of the plumbing.
+
+### Deploy on Cloudflare
+
+Fully self-contained — one click to deploy Payload with **Workers**, **R2** for uploads, and **D1** for a globally replicated database.
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://dub.sh/payload-cloudflare)
+
+### Deploy on Vercel
+
+All-in-one on Vercel — one click to deploy Payload with a **Next.js** front end, **Neon** database, and **Vercel Blob** for media storage.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://dub.sh/payload-vercel)
+
 ## One-click templates
 
-Jumpstart your next project by starting with a pre-made template. These are production-ready, end-to-end solutions designed to get you to market as fast as possible.
+Jumpstart your next project with a ready-to-go template. These are **production-ready, end-to-end solutions** designed to get you to market fast. Build any kind of **website**, **ecommerce store**, **blog**, or **portfolio** — complete with a modern front end built using **React Server Components** and **Tailwind**.
 
-### [🌐 Website](https://github.com/payloadcms/payload/tree/main/templates/website)
+#### 🌐 [Website](https://github.com/payloadcms/payload/tree/main/templates/website)
 
-Build any kind of website, blog, or portfolio from small to enterprise. Comes with a fully functional front-end built with RSCs and Tailwind.
+#### 🛍️ [Ecommerce](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) 🎉 _**NEW**_ 🎉
 
-We're constantly adding more templates to our [Templates Directory](https://github.com/payloadcms/payload/tree/main/templates). If you maintain your own template, consider adding the `payload-template` topic to your GitHub repository for others to find.
+We're constantly adding more templates to our [**Templates Directory**](https://github.com/payloadcms/payload/tree/main/templates).
+If you maintain your own, add the `payload-template` topic to your GitHub repo so others can discover it.
+
+**🔗 Explore more:**
 
 - [Official Templates](https://github.com/payloadcms/payload/tree/main/templates)
 - [Community Templates](https://github.com/topics/payload-template)
 
-## ✨ Features
+## ✨ Payload Features
 
 - Completely free and open-source
 - Next.js native, built to run inside _your_ `/app` folder
@@ -94,7 +116,11 @@ If you want to add contributions to this repository, please follow the instructi
 
 The [Examples Directory](./examples) is a great resource for learning how to setup Payload in a variety of different ways, but you can also find great examples in our blog and throughout our social media.
 
-If you'd like to run the examples, you can either copy them to a folder outside this repo or run them directly by (1) navigating to the example's subfolder (`cd examples/your-example-folder`) and (2) using the `--ignore-workspace` flag to bypass workspace restrictions (e.g., `pnpm --ignore-workspace install` or `pnpm --ignore-workspace dev`).
+If you'd like to run the examples, you can use `create-payload-app` to create a project from one:
+
+```sh
+npx create-payload-app --example example_name
+```
 
 You can see more examples at:
 
@@ -119,8 +145,6 @@ There are lots of good conversations and resources in our Github Discussions boa
 - [Community Help](https://payloadcms.com/community-help)
 
 ## ⭐ Like what we're doing? Give us a star
-
-![payload-github-star](https://cms.payloadcms.com/media/payload-github-star.gif)
 
 ## 👏 Thanks to all our contributors
 


### PR DESCRIPTION
Adds check in `lint-staged` to see if the top-level README.md has been modified, if so, it will copy it to `packages/payload/README.md`. This is to ensure the README shown on the [npm package page](https://www.npmjs.com/package/payload) is proper.

✅  This PR also performs the sync