### PR TITLE
fix(plugin-multi-tenant): block references issue

### DIFF
--- a/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
@@ -103,11 +103,13 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
       const newBlocks: Block[] = []
       ;(newField.blockReferences ?? newField.blocks).forEach((_block) => {
         let block: Block | undefined
+        let isReference = false
 
         if (typeof _block === 'string') {
           if (blockReferencesWithFilters.includes(_block)) {
             return
           }
+          isReference = true
           block = config?.blocks?.find((b) => b.slug === _block)
           blockReferencesWithFilters.push(_block)
         } else {
@@ -130,7 +132,7 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
           })
         }
 
-        if (block) {
+        if (block && !isReference) {
           newBlocks.push(block)
         }
       })


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14251

When block references were found they were also being pushed to the field when adding the filter - which is incorrect. The reference is the one that should be mutated and the field should not push blocks onto it since it has references.