### PR TITLE
feat: field path builder

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1718,6 +1718,12 @@ export { defaultLoggerOptions } from './utilities/logger.js'
 export { mapAsync } from './utilities/mapAsync.js'
 export { mergeHeaders } from './utilities/mergeHeaders.js'
 export { parseDocumentID } from './utilities/parseDocumentID.js'
+export {
+  type FieldBuilder,
+  getPathBuilder,
+  narrowBuilder,
+  type RootBuilder,
+} from './utilities/pathBuilder/index.js'
 export { sanitizeFallbackLocale } from './utilities/sanitizeFallbackLocale.js'
 export { sanitizeJoinParams } from './utilities/sanitizeJoinParams.js'
 export { sanitizePopulateParam } from './utilities/sanitizePopulateParam.js'
@@ -1731,8 +1737,8 @@ export { buildVersionCompoundIndexes } from './versions/buildVersionCompoundInde
 export { versionDefaults } from './versions/defaults.js'
 export { deleteCollectionVersions } from './versions/deleteCollectionVersions.js'
 export { appendVersionToQueryKey } from './versions/drafts/appendVersionToQueryKey.js'
-export { getQueryDraftsSort } from './versions/drafts/getQueryDraftsSort.js'
 
+export { getQueryDraftsSort } from './versions/drafts/getQueryDraftsSort.js'
 export { enforceMaxVersions } from './versions/enforceMaxVersions.js'
 export { getLatestCollectionVersion } from './versions/getLatestCollectionVersion.js'
 export { getLatestGlobalVersion } from './versions/getLatestGlobalVersion.js'

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1722,6 +1722,7 @@ export {
   type FieldBuilder,
   getPathBuilder,
   narrowBuilder,
+  type PathResult,
   type RootBuilder,
 } from './utilities/pathBuilder/index.js'
 export { sanitizeFallbackLocale } from './utilities/sanitizeFallbackLocale.js'

--- a/packages/payload/src/utilities/pathBuilder/README.md
+++ b/packages/payload/src/utilities/pathBuilder/README.md
@@ -1,0 +1,395 @@
+# Path Builder Utility
+
+A fluent, type-safe API for building field paths in Payload CMS.
+
+## Overview
+
+Payload uses two types of paths:
+
+- **Data Path (`path`)**: Accesses actual data values, includes array indices (e.g., `content.0.title`)
+- **Schema Path (`schemaPath`)**: Accesses field schemas, uses block slugs and `_index-` notation for unnamed layout fields (e.g., `content.heroBlock.title` or `_index-0-1.field`)
+
+## Installation
+
+```ts
+import { getPathBuilder } from 'payload'
+```
+
+## Basic Usage
+
+### Simple Fields
+
+```ts
+const { path, schemaPath } = getPathBuilder().text('title').build()
+// Result: { path: 'title', schemaPath: 'title' }
+```
+
+### Nested Fields
+
+```ts
+const { path, schemaPath } = getPathBuilder().group('hero').richText('description').build()
+// Result: { path: 'hero.description', schemaPath: 'hero.description' }
+```
+
+### Terminal vs Nesting Fields
+
+Only certain fields allow nesting:
+
+```ts
+// ✅ Valid: group, tabs/tab, collapsible, row, array, blocks allow nesting
+getPathBuilder().group('hero').text('title').build()
+
+// ❌ Invalid: text, number, etc. are terminal - only .build() allowed
+getPathBuilder().text('hero').text('title') // TypeScript error!
+```
+
+**Nesting-capable fields**: `group`, `tabs`/`tab`, `collapsible`, `row`, `array`, `blocks`
+
+**Terminal fields**: `text`, `textarea`, `richText`, `number`, `date`, `checkbox`, `select`, `radio`, `code`, `json`, `point`, `relationship`, `upload`
+
+## Entity Context (Optional)
+
+Use `withEntity: true` to include collection/global context:
+
+```ts
+const { path, schemaPath } = getPathBuilder({ withEntity: true })
+  .collections('pages')
+  .id(123) // or .noId()
+  .text('title')
+  .build()
+// Result: { path: 'title', schemaPath: 'title' }
+```
+
+```ts
+const { path, schemaPath } = getPathBuilder({ withEntity: true })
+  .globals('settings')
+  .text('siteName')
+  .build()
+// Result: { path: 'siteName', schemaPath: 'siteName' }
+```
+
+Without `withEntity`, start directly with fields:
+
+```ts
+const { path, schemaPath } = getPathBuilder().group('hero').text('title').build()
+```
+
+## Array Fields
+
+### With Index
+
+```ts
+const { path, schemaPath } = getPathBuilder().array('items').index(2).text('name').build()
+// Result:
+// {
+//   path: 'items.2.name',      // includes index
+//   schemaPath: 'items.name'   // no index
+// }
+```
+
+### Without Index (Schema Only)
+
+```ts
+const { path, schemaPath } = getPathBuilder().array('items').noIndex().text('name').build()
+// Result: { path: 'items.name', schemaPath: 'items.name' }
+```
+
+## Blocks Fields
+
+Blocks use slugs in schema paths but numeric indices in data paths.
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .blocks('content')
+  .block('heroBlock')
+  .index(0)
+  .text('title')
+  .build()
+// Result:
+// {
+//   path: 'content.0.title',              // numeric index
+//   schemaPath: 'content.heroBlock.title' // block slug
+// }
+```
+
+### Without Index
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .blocks('content')
+  .block('heroBlock')
+  .noIndex()
+  .richText('body')
+  .build()
+// Result:
+// {
+//   path: 'content.body',
+//   schemaPath: 'content.heroBlock.body'
+// }
+```
+
+## Layout Fields with Schema Indices
+
+Unnamed layout fields (tabs, rows, collapsibles, unnamed groups) use schema indices and generate `_index-` notation in schema paths.
+
+### Tabs
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .tabs(0) // schema index of tabs field
+  .tab('general') // named tab
+  .text('title')
+  .build()
+// Result: { path: 'general.title', schemaPath: 'general.title' }
+```
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .tabs(3) // schema index of tabs field
+  .tab(0) // unnamed tab, also by schema index
+  .text('field')
+  .build()
+// Result: { path: 'field', schemaPath: '_index-3-0.field' }
+```
+
+### Nested Unnamed Tabs
+
+Indices accumulate into a single `_index-` segment:
+
+```ts
+const { path, schemaPath } = getPathBuilder().tabs(3).tab(0).tabs(1).tab(0).text('field').build()
+// Result: { path: 'field', schemaPath: '_index-3-0-1-0.field' }
+```
+
+### Groups
+
+```ts
+// Named group
+getPathBuilder().group('hero').text('title').build()
+// Result: { path: 'hero.title', schemaPath: 'hero.title' }
+
+// Unnamed group (by schema index)
+getPathBuilder().group(0).text('field').build()
+// Result: { path: 'field', schemaPath: '_index-0.field' }
+```
+
+### Rows
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .row(0) // schema index
+  .group('column1')
+  .text('content')
+  .build()
+// Result: { path: 'column1.content', schemaPath: '_index-0.column1.content' }
+```
+
+### Collapsibles
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .collapsible(2) // schema index (collapsibles have no names)
+  .text('hidden')
+  .build()
+// Result: { path: 'hidden', schemaPath: '_index-2.hidden' }
+```
+
+## Complex Examples
+
+### Nested Blocks and Arrays
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .blocks('sections')
+  .block('featureList')
+  .index(0)
+  .array('features')
+  .index(2)
+  .text('title')
+  .build()
+// Result:
+// {
+//   path: 'sections.0.features.2.title',
+//   schemaPath: 'sections.featureList.features.title'
+// }
+```
+
+### Row Within Array
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .array('items')
+  .index(0)
+  .row(1) // schema index of row within array item
+  .text('field')
+  .build()
+// Result:
+// {
+//   path: 'items.0.field',
+//   schemaPath: 'items._index-1.field'
+// }
+```
+
+### Mix of Named and Unnamed Groups
+
+```ts
+const { path, schemaPath } = getPathBuilder()
+  .group(0) // unnamed group
+  .group('named')
+  .group(2) // another unnamed group
+  .text('field')
+  .build()
+// Result:
+// {
+//   path: 'named.field',
+//   schemaPath: '_index-0.named._index-2.field'
+// }
+```
+
+## Field Type Methods
+
+### Nesting-Capable Fields
+
+```ts
+.group(nameOrSchemaIndex: string | number)  // named or unnamed group
+.tabs(schemaIndex: number)                   // tabs container
+.tab(nameOrIndex: string | number)           // named or unnamed tab
+.collapsible(schemaIndex: number)            // collapsible (no names)
+.row(schemaIndex: number)                    // row (no names)
+.array(name: string)                         // array field
+.blocks(name: string)                        // blocks field
+```
+
+### Terminal Fields
+
+```ts
+.text(name)         .textarea(name)      .richText(name)
+.number(name)       .date(name)          .checkbox(name)
+.select(name)       .radio(name)         .code(name)
+.json(name)         .point(name)         .relationship(name)
+.upload(name)
+```
+
+## Type Safety
+
+The builder enforces correct chaining at compile time:
+
+```ts
+// ✅ After array, must call .index() or .noIndex()
+getPathBuilder().array('items').index(0).text('name')
+
+// ❌ Cannot access fields without index/noIndex
+getPathBuilder().array('items').text('name') // TypeScript error!
+
+// ✅ After blocks, must call .block()
+getPathBuilder().blocks('content').block('hero').index(0)
+
+// ✅ After block, must call .index(), .noIndex(), or .build()
+getPathBuilder().blocks('content').block('hero').index(0).text('title')
+
+// ❌ Terminal fields can only call .build()
+getPathBuilder().text('title').text('subtitle') // TypeScript error!
+```
+
+## API Reference
+
+### Core Methods
+
+#### `getPathBuilder(options?)`
+
+Create a new path builder instance.
+
+**Options:**
+
+- `withEntity?: boolean` - Enable `.collections()` and `.globals()` methods
+
+#### `.build()`
+
+Returns `{ path: string, schemaPath: string }`
+
+### Array/Blocks Methods
+
+#### `.array(name: string)`
+
+Add an array field (must be followed by `.index()` or `.noIndex()`).
+
+#### `.blocks(name: string)`
+
+Add a blocks field (must be followed by `.block()`).
+
+#### `.block(slug: string)`
+
+Specify a block type (must be followed by `.index()`, `.noIndex()`, or `.build()`).
+
+#### `.index(i: number)`
+
+Add array/block index to data path only.
+
+#### `.noIndex()`
+
+Skip array/block index (useful for schema-only paths).
+
+### Entity Methods (with `withEntity: true`)
+
+#### `.collections(slug: string)`
+
+Start with a collection context (must be followed by `.id()` or `.noId()`).
+
+#### `.globals(slug: string)`
+
+Start with a global context.
+
+#### `.id(id: number | string)` / `.noId()`
+
+Provide or skip document ID context (doesn't modify paths).
+
+## Use Cases
+
+### Form State Building
+
+```ts
+const pathInfo = getPathBuilder()
+  .blocks('content')
+  .block('heroBlock')
+  .index(blockIndex)
+  .richText('title')
+  .build()
+
+const fieldState = formState[pathInfo.path]
+const fieldSchema = fieldSchemaMap[pathInfo.schemaPath]
+```
+
+### Validation Error Paths
+
+```ts
+const errorPath = getPathBuilder()
+  .array('variants')
+  .index(variantIndex)
+  .number('price')
+  .build().path
+```
+
+### Schema Lookup
+
+```ts
+const { schemaPath } = getPathBuilder()
+  .array('items')
+  .noIndex() // skip index for schema lookup
+  .text('name')
+  .build()
+
+const fieldSchema = fieldSchemaMap[schemaPath]
+```
+
+## Testing
+
+```bash
+pnpm test:unit pathBuilder.spec
+```
+
+## Tips
+
+1. **Use specific field methods** for better clarity: `.richText('title')` over generic field access
+2. **Store the result** if you need both paths: `const paths = builder.build()`
+3. **Use `.noIndex()`** for schema-only lookups
+4. **Terminal fields** can only call `.build()` - this prevents invalid nesting at compile time

--- a/packages/payload/src/utilities/pathBuilder/README.md
+++ b/packages/payload/src/utilities/pathBuilder/README.md
@@ -1,6 +1,6 @@
 # Path Builder Utility
 
-A fluent, type-safe API for building field paths in Payload CMS.
+A fluent, type-safe API for building field paths in Payload.
 
 ## Overview
 
@@ -9,13 +9,11 @@ Payload uses two types of paths:
 - **Data Path (`path`)**: Accesses actual data values, includes array indices (e.g., `content.0.title`)
 - **Schema Path (`schemaPath`)**: Accesses field schemas, uses block slugs and `_index-` notation for unnamed layout fields (e.g., `content.heroBlock.title` or `_index-0-1.field`)
 
-## Installation
+## Basic Usage
 
 ```ts
 import { getPathBuilder } from 'payload'
 ```
-
-## Basic Usage
 
 ### Simple Fields
 
@@ -262,30 +260,6 @@ const { path, schemaPath } = getPathBuilder()
 // }
 ```
 
-## Field Type Methods
-
-### Nesting-Capable Fields
-
-```ts
-.group(nameOrSchemaIndex: string | number)  // named or unnamed group
-.tabs(schemaIndex: number)                   // tabs container
-.tab(nameOrIndex: string | number)           // named or unnamed tab
-.collapsible(schemaIndex: number)            // collapsible (no names)
-.row(schemaIndex: number)                    // row (no names)
-.array(name: string)                         // array field
-.blocks(name: string)                        // blocks field
-```
-
-### Terminal Fields
-
-```ts
-.text(name)         .textarea(name)      .richText(name)
-.number(name)       .date(name)          .checkbox(name)
-.select(name)       .radio(name)         .code(name)
-.json(name)         .point(name)         .relationship(name)
-.upload(name)
-```
-
 ## Type Safety
 
 The builder enforces correct chaining at compile time:
@@ -306,113 +280,3 @@ getPathBuilder().blocks('content').block('hero').index(0).text('title')
 // ❌ Terminal fields can only call .build()
 getPathBuilder().text('title').text('subtitle') // TypeScript error!
 ```
-
-## API Reference
-
-### Core Methods
-
-#### `getPathBuilder(options?)`
-
-Create a new path builder instance.
-
-**Options:**
-
-- `prefix?: false | 'entity' | 'entityType.entity'` - Control entity context prefix
-  - `false` (default): No prefix, direct field access
-  - `'entity'`: Prefix with entity slug only (e.g., `'pages.title'`)
-  - `'entityType.entity'`: Prefix with entity type and slug (e.g., `'collection.pages.title'`)
-
-#### `.build()`
-
-Returns `{ indexPath: string, path: string | null, schemaPath: string | null }`
-
-- `indexPath`: The accumulated index path at the end (e.g., `'_index-0-1'`), or empty string
-- `path`: The data access path, or `null` when `noIndex()` is used
-- `schemaPath`: The schema definition path, or `null` when `noSchemaIndex()` is used
-
-### Array/Blocks Methods
-
-#### `.array(name: string)`
-
-Add an array field (must be followed by `.index()` or `.noIndex()`).
-
-#### `.blocks(name: string)`
-
-Add a blocks field (must be followed by `.block()`).
-
-#### `.block(slug: string)`
-
-Specify a block type (must be followed by `.index()`, `.noIndex()`, or `.build()`).
-
-#### `.index(i: number)`
-
-Add array/block index to data path only.
-
-#### `.noIndex()`
-
-Skip array/block index (useful for schema-only paths).
-
-### Entity Methods (with `prefix: 'entity'` or `prefix: 'entityType.entity'`)
-
-#### `.collections(slug: string)`
-
-Start with a collection context (must be followed by `.id()` or `.noId()`).
-
-#### `.globals(slug: string)`
-
-Start with a global context.
-
-#### `.id(id: number | string)` / `.noId()`
-
-Provide or skip document ID context (doesn't modify paths).
-
-## Use Cases
-
-### Form State Building
-
-```ts
-const pathInfo = getPathBuilder()
-  .blocks('content')
-  .block('heroBlock')
-  .index(blockIndex)
-  .richText('title')
-  .build()
-
-const fieldState = formState[pathInfo.path]
-const fieldSchema = fieldSchemaMap[pathInfo.schemaPath]
-```
-
-### Validation Error Paths
-
-```ts
-const errorPath = getPathBuilder()
-  .array('variants')
-  .index(variantIndex)
-  .number('price')
-  .build().path
-```
-
-### Schema Lookup
-
-```ts
-const { schemaPath } = getPathBuilder()
-  .array('items')
-  .noIndex() // skip index for schema lookup
-  .text('name')
-  .build()
-
-const fieldSchema = fieldSchemaMap[schemaPath]
-```
-
-## Testing
-
-```bash
-pnpm test:unit pathBuilder.spec
-```
-
-## Tips
-
-1. **Use specific field methods** for better clarity: `.richText('title')` over generic field access
-2. **Store the result** if you need both paths: `const paths = builder.build()`
-3. **Use `.noIndex()`** for schema-only lookups
-4. **Terminal fields** can only call `.build()` - this prevents invalid nesting at compile time

--- a/packages/payload/src/utilities/pathBuilder/README.md
+++ b/packages/payload/src/utilities/pathBuilder/README.md
@@ -88,6 +88,30 @@ const { indexPath, path, schemaPath } = getPathBuilder().group('hero').text('tit
 // Result: { indexPath: '', path: 'hero.title', schemaPath: 'hero.title' }
 ```
 
+## Legacy Schema Paths (Deprecated)
+
+The `legacySchemaPaths` option exists for compatibility with an old bug in Payload's field schema map where `_index-` notation was omitted from schema paths unless at the end.
+
+**⚠️ This option is deprecated and should only be used for backwards compatibility.**
+
+```ts
+// Normal behavior
+const result = getPathBuilder().group().schemaIndex(0).text('field').build()
+// Result: { indexPath: '', path: 'field', schemaPath: '_index-0.field' }
+
+// Legacy behavior (omits _index- when not at end)
+const result = getPathBuilder({ legacySchemaPaths: true })
+  .group()
+  .schemaIndex(0)
+  .text('field')
+  .build()
+// Result: { indexPath: '', path: 'field', schemaPath: 'field' }
+
+// But preserves _index- at the end
+const result = getPathBuilder({ legacySchemaPaths: true }).group().schemaIndex(0).build()
+// Result: { indexPath: '_index-0', path: '_index-0', schemaPath: '_index-0' }
+```
+
 ## Array Fields
 
 ### With Index

--- a/packages/payload/src/utilities/pathBuilder/README.md
+++ b/packages/payload/src/utilities/pathBuilder/README.md
@@ -49,29 +49,45 @@ getPathBuilder().text('hero').text('title') // TypeScript error!
 
 ## Entity Context (Optional)
 
-Use `withEntity: true` to include collection/global context:
+Use the `prefix` option to include collection/global context:
+
+### `prefix: 'entityType.entity'` - Full prefix with type
 
 ```ts
-const { path, schemaPath } = getPathBuilder({ withEntity: true })
+const { indexPath, path, schemaPath } = getPathBuilder({ prefix: 'entityType.entity' })
   .collections('pages')
   .id(123) // or .noId()
   .text('title')
   .build()
-// Result: { path: 'title', schemaPath: 'title' }
+// Result: { indexPath: '', path: 'collection.pages.123.title', schemaPath: 'collection.pages.title' }
 ```
 
 ```ts
-const { path, schemaPath } = getPathBuilder({ withEntity: true })
+const { indexPath, path, schemaPath } = getPathBuilder({ prefix: 'entityType.entity' })
   .globals('settings')
   .text('siteName')
   .build()
-// Result: { path: 'siteName', schemaPath: 'siteName' }
+// Result: { indexPath: '', path: 'global.settings.siteName', schemaPath: 'global.settings.siteName' }
 ```
 
-Without `withEntity`, start directly with fields:
+### `prefix: 'entity'` - Entity slug only
 
 ```ts
-const { path, schemaPath } = getPathBuilder().group('hero').text('title').build()
+const { indexPath, path, schemaPath } = getPathBuilder({ prefix: 'entity' })
+  .collections('pages')
+  .id(123)
+  .text('title')
+  .build()
+// Result: { indexPath: '', path: 'pages.123.title', schemaPath: 'pages.title' }
+```
+
+### `prefix: false` (default) - No prefix
+
+Without prefix, start directly with fields:
+
+```ts
+const { indexPath, path, schemaPath } = getPathBuilder().group('hero').text('title').build()
+// Result: { indexPath: '', path: 'hero.title', schemaPath: 'hero.title' }
 ```
 
 ## Array Fields
@@ -301,11 +317,18 @@ Create a new path builder instance.
 
 **Options:**
 
-- `withEntity?: boolean` - Enable `.collections()` and `.globals()` methods
+- `prefix?: false | 'entity' | 'entityType.entity'` - Control entity context prefix
+  - `false` (default): No prefix, direct field access
+  - `'entity'`: Prefix with entity slug only (e.g., `'pages.title'`)
+  - `'entityType.entity'`: Prefix with entity type and slug (e.g., `'collection.pages.title'`)
 
 #### `.build()`
 
-Returns `{ path: string, schemaPath: string }`
+Returns `{ indexPath: string, path: string | null, schemaPath: string | null }`
+
+- `indexPath`: The accumulated index path at the end (e.g., `'_index-0-1'`), or empty string
+- `path`: The data access path, or `null` when `noIndex()` is used
+- `schemaPath`: The schema definition path, or `null` when `noSchemaIndex()` is used
 
 ### Array/Blocks Methods
 
@@ -329,7 +352,7 @@ Add array/block index to data path only.
 
 Skip array/block index (useful for schema-only paths).
 
-### Entity Methods (with `withEntity: true`)
+### Entity Methods (with `prefix: 'entity'` or `prefix: 'entityType.entity'`)
 
 #### `.collections(slug: string)`
 

--- a/packages/payload/src/utilities/pathBuilder/index.ts
+++ b/packages/payload/src/utilities/pathBuilder/index.ts
@@ -831,6 +831,31 @@ export function getPathBuilder(_options?: {
 }
 
 /**
+ * Assertion function to narrow the builder type based on an already-narrowed field type.
+ * Use this after you've narrowed the field type to also narrow the builder.
+ *
+ * @example
+ * ```ts
+ * const field: Field = getFieldFromSomewhere()
+ * const builder = getPathBuilder().field(field)
+ *
+ * if (field.type === 'array') {
+ *   // field is now ArrayField, but builder is still a union
+ *   narrowBuilder(field, builder)
+ *   // Now builder is narrowed to ArrayFieldBuilder!
+ *   builder.index(0).text('label')
+ * }
+ * ```
+ */
+export function narrowBuilder<T extends Field>(
+  field: T,
+  builder: FieldTypeToBuilder<Field>,
+): asserts builder is FieldTypeToBuilder<T> {
+  // This is purely for type narrowing - no runtime logic needed
+  // TypeScript will use the field's already-narrowed type to narrow the builder
+}
+
+/**
  * @experimental may change in a minor release
  * @internal
  */

--- a/packages/payload/src/utilities/pathBuilder/index.ts
+++ b/packages/payload/src/utilities/pathBuilder/index.ts
@@ -2,6 +2,11 @@ import type { ClientField, Field } from '../../index.js'
 
 type PathResult = {
   /**
+   * The accumulated index path at the end of the path (e.g., '_index-0-1')
+   * Empty string if the path does not end with an index path
+   */
+  indexPath: string
+  /**
    * Path for accessing data (e.g., 'blocks.0.content.title')
    * Can be null when noIndex() is used
    */
@@ -483,6 +488,10 @@ const methods = {
   },
 
   build(this: PathBuilderState): PathResult {
+    // Calculate indexPath from accumulated indices before flushing
+    const indexPath =
+      this.accumulatedIndices.length > 0 ? `_index-${this.accumulatedIndices.join('-')}` : ''
+
     // Flush any remaining accumulated indices before building
     // Include in path since we're at the end (no named field follows)
     flushAccumulatedIndices(this, true)
@@ -499,6 +508,7 @@ const methods = {
     }
 
     return {
+      indexPath,
       path: this.hasNoIndex ? null : path,
       schemaPath: this.hasNoSchemaIndex ? null : schemaPath,
     }

--- a/packages/payload/src/utilities/pathBuilder/index.ts
+++ b/packages/payload/src/utilities/pathBuilder/index.ts
@@ -380,9 +380,12 @@ const appendSchemaPath = (state: PathBuilderState, segment: string): void => {
 /**
  * Flush accumulated indices as a single _index-X-Y-Z segment in schema path
  */
-const flushAccumulatedIndices = (state: PathBuilderState): void => {
+const flushAccumulatedIndices = (state: PathBuilderState, includeInPath = false): void => {
   if (state.accumulatedIndices.length > 0) {
     const indexMarker = `_index-${state.accumulatedIndices.join('-')}`
+    if (includeInPath) {
+      appendPath(state, indexMarker)
+    }
     appendSchemaPath(state, indexMarker)
     state.accumulatedIndices = []
   }
@@ -422,7 +425,8 @@ const methods = {
 
   build(this: PathBuilderState): PathResult {
     // Flush any remaining accumulated indices before building
-    flushAccumulatedIndices(this)
+    // Include in path since we're at the end (no named field follows)
+    flushAccumulatedIndices(this, true)
 
     // Build the base paths
     let path = this.pathSegments.join('.')

--- a/packages/payload/src/utilities/pathBuilder/index.ts
+++ b/packages/payload/src/utilities/pathBuilder/index.ts
@@ -364,6 +364,20 @@ type PathBuilderState = {
   skipNextIndex: boolean
 }
 
+// Helper function to create a new builder with copied state
+const cloneBuilder = (state: PathBuilderState): PathBuilderState => {
+  return Object.create(methods, {
+    accumulatedIndices: { value: [...state.accumulatedIndices], writable: true },
+    entitySlug: { value: state.entitySlug, writable: true },
+    entityType: { value: state.entityType, writable: true },
+    hasNoIndex: { value: state.hasNoIndex, writable: true },
+    hasNoSchemaIndex: { value: state.hasNoSchemaIndex, writable: true },
+    pathSegments: { value: [...state.pathSegments], writable: false },
+    schemaPathSegments: { value: [...state.schemaPathSegments], writable: false },
+    skipNextIndex: { value: state.skipNextIndex, writable: true },
+  })
+}
+
 // Helper functions that operate on state
 const appendPath = (state: PathBuilderState, segment: string): void => {
   if (segment) {
@@ -403,24 +417,26 @@ const addField = (state: PathBuilderState, name: string): void => {
 // Shared builder methods object (created once, reused for all builders)
 const methods = {
   array(this: PathBuilderState, name: string): ArrayFieldBuilder<string> {
-    this.skipNextIndex = false // Reset flag when entering a new array
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    newState.skipNextIndex = false // Reset flag when entering a new array
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   block(this: PathBuilderState, blockSlug: string): BlockBuilder<string> {
-    // Block slug is only added to schema path, not data path
-    appendSchemaPath(this, blockSlug)
+    const newState = cloneBuilder(this)
+    appendSchemaPath(newState, blockSlug)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   blocks(this: PathBuilderState, name: string): BlocksFieldBuilder<string> {
-    this.skipNextIndex = false // Reset flag when entering a new blocks field
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    newState.skipNextIndex = false // Reset flag when entering a new blocks field
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   build(this: PathBuilderState): PathResult {
@@ -446,183 +462,195 @@ const methods = {
   },
 
   checkbox(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   code(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   collapsible(this: PathBuilderState): CollapsibleAfterCallBuilder {
-    // Collapsibles are unnamed layout fields, no args needed
+    const newState = cloneBuilder(this)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   collections(this: PathBuilderState, slug: string): CollectionAfterSlugBuilder<string> {
-    // Set entity context
-    this.entityType = 'collection'
-    this.entitySlug = slug
+    const newState = cloneBuilder(this)
+    newState.entityType = 'collection'
+    newState.entitySlug = slug
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   date(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   globals(this: PathBuilderState, slug: string): GlobalBuilder<string> {
-    // Set entity context
-    this.entityType = 'global'
-    this.entitySlug = slug
+    const newState = cloneBuilder(this)
+    newState.entityType = 'global'
+    newState.entitySlug = slug
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   group(this: PathBuilderState, name?: string): FieldBuilder<string> | GroupAfterCallBuilder {
+    const newState = cloneBuilder(this)
     if (name !== undefined) {
-      // Named group: add to both paths
-      addField(this, name)
+      addField(newState, name)
     }
-    // Unnamed group or named group both return the same object
-    // but with different type constraints enforced by TypeScript
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   id(this: PathBuilderState, id: number | string): CollectionBuilder<string> {
-    // ID is added to data path but not schema path
-    appendPath(this, String(id))
+    const newState = cloneBuilder(this)
+    appendPath(newState, String(id))
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   noId(this: PathBuilderState): CollectionBuilder<string> {
-    // Explicitly state no ID context
+    const newState = cloneBuilder(this)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   index(this: PathBuilderState, i: number): FieldBuilder<string> {
-    if (!this.skipNextIndex) {
-      appendPath(this, String(i))
+    const newState = cloneBuilder(this)
+    if (!newState.skipNextIndex) {
+      appendPath(newState, String(i))
     }
-    this.skipNextIndex = false
+    newState.skipNextIndex = false
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   json(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   noIndex(this: PathBuilderState): FieldBuilder<string> {
-    this.skipNextIndex = true
-    this.hasNoIndex = true
+    const newState = cloneBuilder(this)
+    newState.skipNextIndex = true
+    newState.hasNoIndex = true
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   number(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   point(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   radio(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   relationship(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   richText(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   row(this: PathBuilderState): RowAfterCallBuilder {
-    // Rows are unnamed layout fields, no args needed
+    const newState = cloneBuilder(this)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   select(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   tab(this: PathBuilderState, name?: string): FieldBuilder<string> | TabAfterCallBuilder {
+    const newState = cloneBuilder(this)
     if (name !== undefined) {
-      // Named tab: flush accumulated indices, then add tab name as a named field
-      flushAccumulatedIndices(this)
-      appendPath(this, name)
-      appendSchemaPath(this, name)
+      flushAccumulatedIndices(newState)
+      appendPath(newState, name)
+      appendSchemaPath(newState, name)
     }
-    // Unnamed tab or named tab both return the same object
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   tabs(this: PathBuilderState): TabsAfterCallBuilder {
-    // Tabs are unnamed layout fields, no args needed
+    const newState = cloneBuilder(this)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   text(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   textarea(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   upload(this: PathBuilderState, name: string): TerminalFieldBuilder {
-    addField(this, name)
+    const newState = cloneBuilder(this)
+    addField(newState, name)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   schemaIndex(this: PathBuilderState, index: number): FieldBuilder<string> | TabsFieldBuilder {
-    // Add schema index to accumulator for unnamed layout fields
-    this.accumulatedIndices.push(index)
+    const newState = cloneBuilder(this)
+    newState.accumulatedIndices.push(index)
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 
   noSchemaIndex(
     this: PathBuilderState,
   ): FieldBuilder<string> | TabAfterCallBuilder | TabsFieldBuilder {
-    // Mark that schema path should be null
-    this.hasNoSchemaIndex = true
+    const newState = cloneBuilder(this)
+    newState.hasNoSchemaIndex = true
     // @ts-expect-error - Prototype chain provides these methods
-    return this
+    return newState
   },
 }
 

--- a/packages/payload/src/utilities/pathBuilder/index.ts
+++ b/packages/payload/src/utilities/pathBuilder/index.ts
@@ -1,0 +1,712 @@
+type PathResult = {
+  /**
+   * Path for accessing data (e.g., 'blocks.0.content.title')
+   * Can be null when noIndex() is used
+   */
+  path: null | string
+  /**
+   * Path for accessing schema (e.g., 'blocks.content.title')
+   * Can be null when noSchemaIndex() is used
+   */
+  schemaPath: null | string
+}
+
+// Root builder - can directly access fields (when withEntity: false)
+type RootBuilder = {
+  /**
+   * Build empty paths (rarely used)
+   */
+  build(): PathResult
+} & FieldBuilder<''>
+
+// Root builder with entity - must start with collections or globals (when withEntity: true)
+type RootBuilderWithEntity = {
+  /**
+   * Build empty paths (rarely used)
+   */
+  build(): PathResult
+
+  /**
+   * Start with a collection slug (must call .id() or .noId() next)
+   */
+  collections<TName extends string>(slug: TName): CollectionAfterSlugBuilder<TName>
+
+  /**
+   * Start with a global slug (can directly access fields)
+   */
+  globals<TName extends string>(slug: TName): GlobalBuilder<TName>
+}
+
+// Collection builder after slug - must specify id or noId
+type CollectionAfterSlugBuilder<TCollection extends string> = {
+  /**
+   * Build without specifying id (rarely used)
+   */
+  build(): PathResult
+
+  /**
+   * Add a document ID to the (data) path (not included in schema path)
+   */
+  id(id: number | string): CollectionBuilder<TCollection>
+
+  /**
+   * Explicitly state no ID context (continues without ID)
+   */
+  noId(): CollectionBuilder<TCollection>
+}
+
+// Common field accessor methods shared across builders
+type FieldAccessors = {
+  /**
+   * Add an array field
+   */
+  array<TName extends string>(name: TName): ArrayFieldBuilder<TName>
+  /**
+   * Add a blocks field
+   */
+  blocks<TName extends string>(name: TName): BlocksFieldBuilder<TName>
+
+  /**
+   * Build and return the final paths
+   */
+  build(): PathResult
+
+  /**
+   * Add a checkbox field (terminal - no nesting allowed)
+   */
+  checkbox<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a code field (terminal - no nesting allowed)
+   */
+  code<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a collapsible field (must call .schemaIndex() or .noSchemaIndex() next)
+   */
+  collapsible(): CollapsibleAfterCallBuilder
+
+  /**
+   * Add a date field (terminal - no nesting allowed)
+   */
+  date<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add an unnamed group field (must call .schemaIndex() or .noSchemaIndex() next)
+   */
+  group(): GroupAfterCallBuilder
+  /**
+   * Add a named group field (allows nesting)
+   */
+  group<TName extends string>(name: TName): FieldBuilder<string>
+
+  /**
+   * Add a JSON field (terminal - no nesting allowed)
+   */
+  json<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a number field (terminal - no nesting allowed)
+   */
+  number<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a point field (terminal - no nesting allowed)
+   */
+  point<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a radio field (terminal - no nesting allowed)
+   */
+  radio<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a relationship field (terminal - no nesting allowed)
+   */
+  relationship<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a rich text field (terminal - no nesting allowed)
+   */
+  richText<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a row field (must call .schemaIndex() or .noSchemaIndex() next)
+   */
+  row(): RowAfterCallBuilder
+
+  /**
+   * Add a select field (terminal - no nesting allowed)
+   */
+  select<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a tabs field (must call .schemaIndex() or .noSchemaIndex() next)
+   */
+  tabs(): TabsAfterCallBuilder
+
+  /**
+   * Add a text field (terminal - no nesting allowed)
+   */
+  text<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add a textarea field (terminal - no nesting allowed)
+   */
+  textarea<TName extends string>(name: TName): TerminalFieldBuilder
+
+  /**
+   * Add an upload field (terminal - no nesting allowed)
+   */
+  upload<TName extends string>(name: TName): TerminalFieldBuilder
+}
+
+// Collection builder - after id/noId, can access fields
+type CollectionBuilder<_TCollection extends string> = FieldAccessors
+
+// Global builder - can directly access fields (same as CollectionBuilder but for globals)
+type GlobalBuilder<TGlobal extends string> = CollectionBuilder<TGlobal>
+
+// Terminal field builder - fields that cannot have nested fields (only build allowed)
+type TerminalFieldBuilder = {
+  /**
+   * Build and return the final paths
+   */
+  build(): PathResult
+}
+
+// Field builder - includes all field methods (both nesting-capable and terminal)
+type FieldBuilder<_TField extends string> = FieldAccessors
+
+// Tabs field builder - after calling tabs(), must specify schema index
+type TabsAfterCallBuilder = {
+  /**
+   * Build without specifying schema index
+   */
+  build(): PathResult
+
+  /**
+   * Skip adding schema index (makes schemaPath null)
+   */
+  noSchemaIndex(): TabsFieldBuilder
+
+  /**
+   * Add schema index for the tabs field
+   */
+  schemaIndex(index: number): TabsFieldBuilder
+}
+
+// Tabs field builder - after schema index, must specify a tab
+type TabsFieldBuilder = {
+  /**
+   * Build without specifying a tab
+   */
+  build(): PathResult
+
+  /**
+   * Navigate to an unnamed tab (must call .schemaIndex() or .noSchemaIndex() next)
+   */
+  tab(): TabAfterCallBuilder
+  /**
+   * Navigate to a specific named tab
+   */
+  tab<TName extends string>(name: TName): FieldBuilder<TName>
+}
+
+// Tab field builder - after calling tab() without name, must specify schema index
+type TabAfterCallBuilder = {
+  /**
+   * Build without specifying schema index
+   */
+  build(): PathResult
+
+  /**
+   * Skip adding schema index (makes schemaPath null)
+   */
+  noSchemaIndex(): FieldBuilder<string>
+
+  /**
+   * Add schema index for the unnamed tab
+   */
+  schemaIndex(index: number): FieldBuilder<string>
+}
+
+// Group field builder - after calling group() without name, must specify schema index
+type GroupAfterCallBuilder = {
+  /**
+   * Build without specifying schema index
+   */
+  build(): PathResult
+
+  /**
+   * Skip adding schema index (makes schemaPath null)
+   */
+  noSchemaIndex(): FieldBuilder<string>
+
+  /**
+   * Add schema index for the unnamed group
+   */
+  schemaIndex(index: number): FieldBuilder<string>
+}
+
+// Row field builder - after calling row(), must specify schema index
+type RowAfterCallBuilder = {
+  /**
+   * Build without specifying schema index
+   */
+  build(): PathResult
+
+  /**
+   * Skip adding schema index (makes schemaPath null)
+   */
+  noSchemaIndex(): FieldBuilder<string>
+
+  /**
+   * Add schema index for the row
+   */
+  schemaIndex(index: number): FieldBuilder<string>
+}
+
+// Collapsible field builder - after calling collapsible(), must specify schema index
+type CollapsibleAfterCallBuilder = {
+  /**
+   * Build without specifying schema index
+   */
+  build(): PathResult
+
+  /**
+   * Skip adding schema index (makes schemaPath null)
+   */
+  noSchemaIndex(): FieldBuilder<string>
+
+  /**
+   * Add schema index for the collapsible
+   */
+  schemaIndex(index: number): FieldBuilder<string>
+}
+
+// Blocks field builder - must specify a block next
+type BlocksFieldBuilder<_TBlocks extends string> = {
+  /**
+   * Specify a block type by its slug
+   */
+  block<TName extends string>(blockSlug: TName): BlockBuilder<TName>
+
+  /**
+   * Build without specifying a block (useful for getting the blocks field path)
+   */
+  build(): PathResult
+}
+
+// Block builder - must specify index or noIndex before accessing fields
+type BlockBuilder<TBlock extends string> = {
+  /**
+   * Build without specifying an index (useful for getting the block path)
+   */
+  build(): PathResult
+
+  /**
+   * Add an array index for the block
+   */
+  index(i: number): FieldBuilder<TBlock>
+
+  /**
+   * Skip adding index to path (useful for schema-only paths)
+   */
+  noIndex(): FieldBuilder<TBlock>
+}
+
+// Array field builder - must specify index or noIndex
+type ArrayFieldBuilder<TArray extends string> = {
+  /**
+   * Build without specifying an index (useful for getting the array field path)
+   */
+  build(): PathResult
+
+  /**
+   * Add an array index
+   */
+  index(i: number): FieldBuilder<TArray>
+
+  /**
+   * Skip adding index to path (useful for schema-only paths)
+   */
+  noIndex(): FieldBuilder<TArray>
+}
+
+// State type for path building
+type PathBuilderState = {
+  /**
+   * Accumulates schema indices for unnamed layout fields (tabs, rows, collapsibles, unnamed groups).
+   * When a named field is encountered, this gets flushed as _index-X-Y-Z...
+   * Examples:
+   * - tabs().schemaIndex(3).tab().schemaIndex(0) accumulates [3, 0] → _index-3-0
+   */
+  accumulatedIndices: number[]
+  /**
+   * Entity slug (collection or global name)
+   */
+  entitySlug?: string
+  /**
+   * Entity context - either 'collection' or 'global'
+   */
+  entityType?: 'collection' | 'global'
+  /**
+   * When true, path should be null (used when noIndex is called)
+   */
+  hasNoIndex: boolean
+  /**
+   * When true, schemaPath should be null (used when noSchemaIndex is called)
+   */
+  hasNoSchemaIndex: boolean
+  pathSegments: string[]
+  schemaPathSegments: string[]
+  skipNextIndex: boolean
+}
+
+// Helper functions that operate on state
+const appendPath = (state: PathBuilderState, segment: string): void => {
+  if (segment) {
+    state.pathSegments.push(segment)
+  }
+}
+
+const appendSchemaPath = (state: PathBuilderState, segment: string): void => {
+  if (segment) {
+    state.schemaPathSegments.push(segment)
+  }
+}
+
+/**
+ * Flush accumulated indices as a single _index-X-Y-Z segment in schema path
+ */
+const flushAccumulatedIndices = (state: PathBuilderState): void => {
+  if (state.accumulatedIndices.length > 0) {
+    const indexMarker = `_index-${state.accumulatedIndices.join('-')}`
+    appendSchemaPath(state, indexMarker)
+    state.accumulatedIndices = []
+  }
+}
+
+/**
+ * Add a named field - flushes accumulated indices first, then adds field to both paths
+ */
+const addField = (state: PathBuilderState, name: string): void => {
+  flushAccumulatedIndices(state)
+  appendPath(state, name)
+  appendSchemaPath(state, name)
+}
+
+// Shared builder methods object (created once, reused for all builders)
+const methods = {
+  array(this: PathBuilderState, name: string): ArrayFieldBuilder<string> {
+    this.skipNextIndex = false // Reset flag when entering a new array
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  block(this: PathBuilderState, blockSlug: string): BlockBuilder<string> {
+    // Block slug is only added to schema path, not data path
+    appendSchemaPath(this, blockSlug)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  blocks(this: PathBuilderState, name: string): BlocksFieldBuilder<string> {
+    this.skipNextIndex = false // Reset flag when entering a new blocks field
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  build(this: PathBuilderState): PathResult {
+    // Flush any remaining accumulated indices before building
+    flushAccumulatedIndices(this)
+
+    // Build the base paths
+    let path = this.pathSegments.join('.')
+    let schemaPath = this.schemaPathSegments.join('.')
+
+    // Prepend entity context if present
+    if (this.entityType && this.entitySlug) {
+      const entityPrefix = `${this.entityType}.${this.entitySlug}`
+      path = path ? `${entityPrefix}.${path}` : entityPrefix
+      schemaPath = schemaPath ? `${entityPrefix}.${schemaPath}` : entityPrefix
+    }
+
+    return {
+      path: this.hasNoIndex ? null : path,
+      schemaPath: this.hasNoSchemaIndex ? null : schemaPath,
+    }
+  },
+
+  checkbox(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  code(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  collapsible(this: PathBuilderState): CollapsibleAfterCallBuilder {
+    // Collapsibles are unnamed layout fields, no args needed
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  collections(this: PathBuilderState, slug: string): CollectionAfterSlugBuilder<string> {
+    // Set entity context
+    this.entityType = 'collection'
+    this.entitySlug = slug
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  date(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  globals(this: PathBuilderState, slug: string): GlobalBuilder<string> {
+    // Set entity context
+    this.entityType = 'global'
+    this.entitySlug = slug
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  group(this: PathBuilderState, name?: string): FieldBuilder<string> | GroupAfterCallBuilder {
+    if (name !== undefined) {
+      // Named group: add to both paths
+      addField(this, name)
+    }
+    // Unnamed group or named group both return the same object
+    // but with different type constraints enforced by TypeScript
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  id(this: PathBuilderState, id: number | string): CollectionBuilder<string> {
+    // ID is added to data path but not schema path
+    appendPath(this, String(id))
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  noId(this: PathBuilderState): CollectionBuilder<string> {
+    // Explicitly state no ID context
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  index(this: PathBuilderState, i: number): FieldBuilder<string> {
+    if (!this.skipNextIndex) {
+      appendPath(this, String(i))
+    }
+    this.skipNextIndex = false
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  json(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  noIndex(this: PathBuilderState): FieldBuilder<string> {
+    this.skipNextIndex = true
+    this.hasNoIndex = true
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  number(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  point(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  radio(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  relationship(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  richText(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  row(this: PathBuilderState): RowAfterCallBuilder {
+    // Rows are unnamed layout fields, no args needed
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  select(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  tab(this: PathBuilderState, name?: string): FieldBuilder<string> | TabAfterCallBuilder {
+    if (name !== undefined) {
+      // Named tab: flush accumulated indices, then add tab name as a named field
+      flushAccumulatedIndices(this)
+      appendPath(this, name)
+      appendSchemaPath(this, name)
+    }
+    // Unnamed tab or named tab both return the same object
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  tabs(this: PathBuilderState): TabsAfterCallBuilder {
+    // Tabs are unnamed layout fields, no args needed
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  text(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  textarea(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  upload(this: PathBuilderState, name: string): TerminalFieldBuilder {
+    addField(this, name)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  schemaIndex(this: PathBuilderState, index: number): FieldBuilder<string> | TabsFieldBuilder {
+    // Add schema index to accumulator for unnamed layout fields
+    this.accumulatedIndices.push(index)
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+
+  noSchemaIndex(
+    this: PathBuilderState,
+  ): FieldBuilder<string> | TabAfterCallBuilder | TabsFieldBuilder {
+    // Mark that schema path should be null
+    this.hasNoSchemaIndex = true
+    // @ts-expect-error - Prototype chain provides these methods
+    return this
+  },
+}
+
+// Create a new builder instance with state
+function createPathBuilder(): RootBuilder {
+  const state: PathBuilderState = {
+    accumulatedIndices: [],
+    entitySlug: undefined,
+    entityType: undefined,
+    hasNoIndex: false,
+    hasNoSchemaIndex: false,
+    pathSegments: [],
+    schemaPathSegments: [],
+    skipNextIndex: false,
+  }
+
+  // Bind all methods to the state object
+  return Object.create(methods, {
+    accumulatedIndices: { value: state.accumulatedIndices, writable: true },
+    entitySlug: { value: undefined, writable: true },
+    entityType: { value: undefined, writable: true },
+    hasNoIndex: { value: false, writable: true },
+    hasNoSchemaIndex: { value: false, writable: true },
+    pathSegments: { value: state.pathSegments, writable: false },
+    schemaPathSegments: { value: state.schemaPathSegments, writable: false },
+    skipNextIndex: { value: false, writable: true },
+  })
+}
+
+/**
+ * Create a new path builder instance
+ *
+ * @example
+ * ```ts
+ * // Simple field path (no entity context)
+ * const result = getPathBuilder()
+ *   .text('title')
+ *   .build()
+ * // { path: 'title', schemaPath: 'title' }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With entity context - collection
+ * const result = getPathBuilder({ withEntity: true })
+ *   .collections('pages')
+ *   .id(123)
+ *   .text('title')
+ *   .build()
+ * // { path: 'title', schemaPath: 'title' }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With entity context - global
+ * const result = getPathBuilder({ withEntity: true })
+ *   .globals('header')
+ *   .text('title')
+ *   .build()
+ * // { path: 'title', schemaPath: 'title' }
+ * ```
+ */
+export function getPathBuilder(): RootBuilder
+export function getPathBuilder(options: { withEntity: true }): RootBuilderWithEntity
+export function getPathBuilder(_options?: {
+  withEntity?: boolean
+}): RootBuilder | RootBuilderWithEntity {
+  return createPathBuilder()
+}
+
+// Export types for consumers
+export type {
+  ArrayFieldBuilder,
+  BlockBuilder,
+  BlocksFieldBuilder,
+  CollapsibleAfterCallBuilder,
+  CollectionAfterSlugBuilder,
+  CollectionBuilder,
+  FieldAccessors,
+  FieldBuilder,
+  GlobalBuilder,
+  GroupAfterCallBuilder,
+  PathResult,
+  RootBuilder,
+  RootBuilderWithEntity,
+  RowAfterCallBuilder,
+  TabAfterCallBuilder,
+  TabsAfterCallBuilder,
+  TabsFieldBuilder,
+  TerminalFieldBuilder,
+}

--- a/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
+++ b/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
@@ -589,5 +589,21 @@ describe('PathBuilder', () => {
         schemaPath: '_index-0.named._index-2.field',
       })
     })
+
+    it('should handle schema index path at the end of the path', () => {
+      const result = getPathBuilder().group().schemaIndex(0).row().schemaIndex(1).build()
+      expect(result).toEqual({
+        path: '_index-0-1',
+        schemaPath: '_index-0-1',
+      })
+    })
+
+    it('should handle schema index path at the end of the path, when schemaIndex was discarded before', () => {
+      const result = getPathBuilder().group('named').row().schemaIndex(1).build()
+      expect(result).toEqual({
+        path: 'named._index-1',
+        schemaPath: 'named._index-1',
+      })
+    })
   })
 })

--- a/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
+++ b/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
@@ -35,8 +35,8 @@ describe('PathBuilder', () => {
   })
 
   describe('Entity context paths', () => {
-    it('should build path with collection (no ID)', () => {
-      const result = getPathBuilder({ withEntity: true })
+    it('should build path with collection (no ID) - entityType.entity prefix', () => {
+      const result = getPathBuilder({ prefix: 'entityType.entity' })
         .collections('pages')
         .noId()
         .text('title')
@@ -49,8 +49,8 @@ describe('PathBuilder', () => {
       })
     })
 
-    it('should build path with collection and ID', () => {
-      const result = getPathBuilder({ withEntity: true })
+    it('should build path with collection and ID - entityType.entity prefix', () => {
+      const result = getPathBuilder({ prefix: 'entityType.entity' })
         .collections('pages')
         .id(123)
         .text('title')
@@ -63,8 +63,8 @@ describe('PathBuilder', () => {
       })
     })
 
-    it('should build path with collection and string ID', () => {
-      const result = getPathBuilder({ withEntity: true })
+    it('should build path with collection and string ID - entityType.entity prefix', () => {
+      const result = getPathBuilder({ prefix: 'entityType.entity' })
         .collections('pages')
         .id('abc123')
         .text('slug')
@@ -77,8 +77,11 @@ describe('PathBuilder', () => {
       })
     })
 
-    it('should build path with global', () => {
-      const result = getPathBuilder({ withEntity: true }).globals('header').text('title').build()
+    it('should build path with global - entityType.entity prefix', () => {
+      const result = getPathBuilder({ prefix: 'entityType.entity' })
+        .globals('header')
+        .text('title')
+        .build()
 
       expect(result).toEqual({
         indexPath: '',
@@ -87,8 +90,8 @@ describe('PathBuilder', () => {
       })
     })
 
-    it('should build path with global and nested fields', () => {
-      const result = getPathBuilder({ withEntity: true })
+    it('should build path with global and nested fields - entityType.entity prefix', () => {
+      const result = getPathBuilder({ prefix: 'entityType.entity' })
         .globals('settings')
         .group('site')
         .text('name')
@@ -98,6 +101,30 @@ describe('PathBuilder', () => {
         indexPath: '',
         path: 'global.settings.site.name',
         schemaPath: 'global.settings.site.name',
+      })
+    })
+
+    it('should build path with collection - entity prefix only', () => {
+      const result = getPathBuilder({ prefix: 'entity' })
+        .collections('pages')
+        .id(123)
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        indexPath: '',
+        path: 'pages.123.title',
+        schemaPath: 'pages.title',
+      })
+    })
+
+    it('should build path with global - entity prefix only', () => {
+      const result = getPathBuilder({ prefix: 'entity' }).globals('header').text('title').build()
+
+      expect(result).toEqual({
+        indexPath: '',
+        path: 'header.title',
+        schemaPath: 'header.title',
       })
     })
   })

--- a/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
+++ b/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
@@ -896,4 +896,97 @@ describe('PathBuilder', () => {
       })
     })
   })
+
+  describe('Legacy schema paths', () => {
+    it('should omit _index- from schemaPath when not at the end (legacySchemaPaths: true)', () => {
+      const result = getPathBuilder({ legacySchemaPaths: true })
+        .group()
+        .schemaIndex(0)
+        .text('field')
+        .build()
+
+      expect(result).toEqual({
+        indexPath: '',
+        path: 'field',
+        schemaPath: 'field', // _index-0 is omitted in legacy mode
+      })
+    })
+
+    it('should include _index- in schemaPath when at the end (legacySchemaPaths: true)', () => {
+      const result = getPathBuilder({ legacySchemaPaths: true })
+        .group()
+        .schemaIndex(0)
+        .row()
+        .schemaIndex(1)
+        .build()
+
+      expect(result).toEqual({
+        indexPath: '_index-0-1',
+        path: '_index-0-1',
+        schemaPath: '_index-0-1', // included because it's at the end
+      })
+    })
+
+    it('should omit nested _index- from schemaPath when followed by named fields (legacySchemaPaths: true)', () => {
+      const result = getPathBuilder({ legacySchemaPaths: true })
+        .group()
+        .schemaIndex(0)
+        .group('named')
+        .group()
+        .schemaIndex(2)
+        .text('field')
+        .build()
+
+      expect(result).toEqual({
+        indexPath: '',
+        path: 'named.field',
+        schemaPath: 'named.field', // both _index-0 and _index-2 are omitted
+      })
+    })
+
+    it('should work with tabs in legacy mode', () => {
+      const result = getPathBuilder({ legacySchemaPaths: true })
+        .tabs()
+        .schemaIndex(0)
+        .tab('general')
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        indexPath: '',
+        path: 'general.title',
+        schemaPath: 'general.title', // _index-0 is omitted
+      })
+    })
+
+    it('should preserve normal behavior when legacySchemaPaths: false', () => {
+      const result = getPathBuilder({ legacySchemaPaths: false })
+        .group()
+        .schemaIndex(0)
+        .text('field')
+        .build()
+
+      expect(result).toEqual({
+        indexPath: '',
+        path: 'field',
+        schemaPath: '_index-0.field', // _index-0 is included (normal behavior)
+      })
+    })
+
+    it('should work with entity prefix in legacy mode', () => {
+      const result = getPathBuilder({ prefix: 'entity', legacySchemaPaths: true })
+        .collections('pages')
+        .noId()
+        .group()
+        .schemaIndex(0)
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        indexPath: '',
+        path: 'pages.title',
+        schemaPath: 'pages.title', // _index-0 is omitted
+      })
+    })
+  })
 })

--- a/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
+++ b/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
@@ -17,6 +17,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().text('title').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'title',
         schemaPath: 'title',
       })
@@ -26,6 +27,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().group('meta').richText('description').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'meta.description',
         schemaPath: 'meta.description',
       })
@@ -41,6 +43,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'collection.pages.title',
         schemaPath: 'collection.pages.title',
       })
@@ -54,6 +57,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'collection.pages.123.title',
         schemaPath: 'collection.pages.title',
       })
@@ -67,6 +71,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'collection.pages.abc123.slug',
         schemaPath: 'collection.pages.slug',
       })
@@ -76,6 +81,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder({ withEntity: true }).globals('header').text('title').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'global.header.title',
         schemaPath: 'global.header.title',
       })
@@ -89,6 +95,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'global.settings.site.name',
         schemaPath: 'global.settings.site.name',
       })
@@ -100,6 +107,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().array('items').index(0).text('name').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'items.0.name',
         schemaPath: 'items.name',
       })
@@ -109,6 +117,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().array('items').index(5).text('name').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'items.5.name',
         schemaPath: 'items.name',
       })
@@ -118,6 +127,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().array('items').noIndex().text('name').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: null,
         schemaPath: 'items.name',
       })
@@ -133,6 +143,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'categories.0.items.2.name',
         schemaPath: 'categories.items.name',
       })
@@ -142,6 +153,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().array('items').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'items',
         schemaPath: 'items',
       })
@@ -158,6 +170,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content.0.title',
         schemaPath: 'content.heroBlock.title',
       })
@@ -172,6 +185,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: null,
         schemaPath: 'content.heroBlock.title',
       })
@@ -189,6 +203,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'layout.0.content.1.body',
         schemaPath: 'layout.section.content.textBlock.body',
       })
@@ -198,6 +213,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().blocks('content').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content',
         schemaPath: 'content',
       })
@@ -207,6 +223,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().blocks('content').block('heroBlock').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content',
         schemaPath: 'content.heroBlock',
       })
@@ -224,6 +241,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content.0.meta.description',
         schemaPath: 'content.heroBlock.meta.description',
       })
@@ -240,6 +258,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'sections.0.features.2.title',
         schemaPath: 'sections.featureList.features.title',
       })
@@ -256,6 +275,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'columns.1.content.0.text',
         schemaPath: 'columns.content.textBlock.text',
       })
@@ -270,6 +290,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'settings.appearance.colors.primary',
         schemaPath: 'settings.appearance.colors.primary',
       })
@@ -335,6 +356,7 @@ describe('PathBuilder', () => {
     it('should handle tabs field with named tab', () => {
       const result = getPathBuilder().tabs().schemaIndex(0).tab('settings').text('apiKey').build()
       expect(result).toEqual({
+        indexPath: '',
         path: 'settings.apiKey',
         schemaPath: '_index-0.settings.apiKey',
       })
@@ -343,6 +365,7 @@ describe('PathBuilder', () => {
     it('should handle collapsible field', () => {
       const result = getPathBuilder().collapsible().schemaIndex(0).checkbox('enabled').build()
       expect(result).toEqual({
+        indexPath: '',
         path: 'enabled',
         schemaPath: '_index-0.enabled',
       })
@@ -354,6 +377,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: '',
         schemaPath: '',
       })
@@ -369,6 +393,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: null,
         schemaPath: 'items.nested.value',
       })
@@ -377,6 +402,7 @@ describe('PathBuilder', () => {
     it('should handle noSchemaIndex calls', () => {
       const result = getPathBuilder().group().noSchemaIndex().text('value').build()
       expect(result).toEqual({
+        indexPath: '',
         path: 'value',
         schemaPath: null,
       })
@@ -392,6 +418,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: null,
         schemaPath: 'first.second.value',
       })
@@ -400,6 +427,7 @@ describe('PathBuilder', () => {
     it('should handle schema index path at the end of the path', () => {
       const result = getPathBuilder().group().schemaIndex(0).row().schemaIndex(1).build()
       expect(result).toEqual({
+        indexPath: '_index-0-1',
         path: '_index-0-1',
         schemaPath: '_index-0-1',
       })
@@ -408,6 +436,7 @@ describe('PathBuilder', () => {
     it('should handle schema index path at the end of the path, when schemaIndex was discarded before', () => {
       const result = getPathBuilder().group('named').row().schemaIndex(1).build()
       expect(result).toEqual({
+        indexPath: '_index-1',
         path: 'named._index-1',
         schemaPath: 'named._index-1',
       })
@@ -421,23 +450,28 @@ describe('PathBuilder', () => {
       const branch4 = basePathBuilder.group('branch3').collapsible().schemaIndex(2)
 
       expect(branch1.build()).toEqual({
+        indexPath: '',
         path: 'base.branch1',
         schemaPath: 'base.branch1',
       })
       expect(branch2.build()).toEqual({
+        indexPath: '',
         path: 'base.branch2.text',
         schemaPath: 'base.branch2.text',
       })
       expect(branch3.build()).toEqual({
+        indexPath: '',
         path: 'base.branch3.text',
         schemaPath: 'base.branch3._index-0.text',
       })
       expect(branch4.build()).toEqual({
+        indexPath: '_index-2',
         path: 'base.branch3._index-2',
         schemaPath: 'base.branch3._index-2',
       })
       // Build basePath at the end
       expect(basePathBuilder.build()).toEqual({
+        indexPath: '',
         path: 'base',
         schemaPath: 'base',
       })
@@ -450,6 +484,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().field(field).build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'title',
         schemaPath: 'title',
       })
@@ -460,6 +495,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().field(field).index(0).text('label').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'items.0.label',
         schemaPath: 'items.label',
       })
@@ -470,6 +506,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().field(field).text('title').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'hero.title',
         schemaPath: 'hero.title',
       })
@@ -480,6 +517,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().field(field).schemaIndex(0).text('content').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content',
         schemaPath: '_index-0.content',
       })
@@ -490,6 +528,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().field(field).schemaIndex(1).text('title').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'title',
         schemaPath: '_index-1.title',
       })
@@ -500,6 +539,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().field(field).schemaIndex(2).text('label').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'label',
         schemaPath: '_index-2.label',
       })
@@ -515,6 +555,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content.body',
         schemaPath: '_index-0.content.body',
       })
@@ -526,6 +567,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().field(groupField).field(textField).build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'hero.title',
         schemaPath: 'hero.title',
       })
@@ -542,6 +584,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'blocksFieldName.2.description',
         schemaPath: 'blocksFieldName.content.description',
       })
@@ -556,6 +599,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'variants.0.pricing.price',
         schemaPath: 'variants.pricing.price',
       })
@@ -572,6 +616,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content.1.images.3.image',
         schemaPath: 'content.imageGallery.images.image',
       })
@@ -586,6 +631,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'fields.0.label',
         schemaPath: 'fields.textField.label',
       })
@@ -601,6 +647,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'general.site.title',
         schemaPath: '_index-0.general.site.title',
       })
@@ -617,6 +664,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'settings.value',
         schemaPath: 'settings._index-2-1.value',
       })
@@ -626,6 +674,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().group().schemaIndex(0).text('title').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'title',
         schemaPath: '_index-0.title',
       })
@@ -635,6 +684,7 @@ describe('PathBuilder', () => {
       const result = getPathBuilder().row().schemaIndex(1).text('content').build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'content',
         schemaPath: '_index-1.content',
       })
@@ -654,6 +704,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'fieldWithinNestedUnnamedTab',
         schemaPath: '_index-3-0-1-0.fieldWithinNestedUnnamedTab',
       })
@@ -668,6 +719,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'namedTab.fieldWithinNamedTab',
         schemaPath: '_index-3.namedTab.fieldWithinNamedTab',
       })
@@ -683,6 +735,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'items.0.fieldWithinRowWithinArray',
         schemaPath: 'items._index-2.fieldWithinRowWithinArray',
       })
@@ -697,6 +750,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'settings.value',
         schemaPath: '_index-1.settings.value',
       })
@@ -712,6 +766,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'nested',
         schemaPath: '_index-0-1.nested',
       })
@@ -728,6 +783,7 @@ describe('PathBuilder', () => {
         .build()
 
       expect(result).toEqual({
+        indexPath: '',
         path: 'named.field',
         schemaPath: '_index-0.named._index-2.field',
       })
@@ -744,6 +800,7 @@ describe('PathBuilder', () => {
 
       expect(childResult).toEqual(parentResult)
       expect(childResult).toEqual({
+        indexPath: '',
         path: 'hero',
         schemaPath: 'hero',
       })
@@ -758,6 +815,7 @@ describe('PathBuilder', () => {
 
       expect(childResult).toEqual(parentResult)
       expect(childResult).toEqual({
+        indexPath: '',
         path: 'hero',
         schemaPath: 'hero',
       })
@@ -772,6 +830,7 @@ describe('PathBuilder', () => {
 
       expect(childResult).toEqual(parentResult)
       expect(childResult).toEqual({
+        indexPath: '',
         path: 'hero',
         schemaPath: 'hero',
       })
@@ -786,6 +845,7 @@ describe('PathBuilder', () => {
 
       expect(childResult).toEqual(parentResult)
       expect(childResult).toEqual({
+        indexPath: '',
         path: 'hero',
         schemaPath: 'hero',
       })
@@ -803,6 +863,7 @@ describe('PathBuilder', () => {
 
       expect(childResult).toEqual(parentResult)
       expect(childResult).toEqual({
+        indexPath: '',
         path: 'outer.inner',
         schemaPath: 'outer.inner',
       })

--- a/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
+++ b/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from '@jest/globals'
 
+import type {
+  ArrayField,
+  CollapsibleField,
+  GroupField,
+  RowField,
+  TabsField,
+  TextField,
+} from '../../fields/config/types.js'
+
 import { getPathBuilder } from './index.js'
 
 describe('PathBuilder', () => {
@@ -431,6 +440,94 @@ describe('PathBuilder', () => {
       expect(basePathBuilder.build()).toEqual({
         path: 'base',
         schemaPath: 'base',
+      })
+    })
+  })
+
+  describe('Field method', () => {
+    it('should handle named text field', () => {
+      const field: TextField = { type: 'text', name: 'title' }
+      const result = getPathBuilder().field(field).build()
+
+      expect(result).toEqual({
+        path: 'title',
+        schemaPath: 'title',
+      })
+    })
+
+    it('should handle named array field', () => {
+      const field: ArrayField = { type: 'array', name: 'items', fields: [] }
+      const result = getPathBuilder().field(field).index(0).text('label').build()
+
+      expect(result).toEqual({
+        path: 'items.0.label',
+        schemaPath: 'items.label',
+      })
+    })
+
+    it('should handle named group field', () => {
+      const field: GroupField = { type: 'group', name: 'hero', fields: [] }
+      const result = getPathBuilder().field(field).text('title').build()
+
+      expect(result).toEqual({
+        path: 'hero.title',
+        schemaPath: 'hero.title',
+      })
+    })
+
+    it('should handle unnamed collapsible field', () => {
+      const field: CollapsibleField = { type: 'collapsible', fields: [], label: 'Collapsible' }
+      const result = getPathBuilder().field(field).schemaIndex(0).text('content').build()
+
+      expect(result).toEqual({
+        path: 'content',
+        schemaPath: '_index-0.content',
+      })
+    })
+
+    it('should handle unnamed group field', () => {
+      const field: GroupField = { type: 'group', fields: [] }
+      const result = getPathBuilder().field(field).schemaIndex(1).text('title').build()
+
+      expect(result).toEqual({
+        path: 'title',
+        schemaPath: '_index-1.title',
+      })
+    })
+
+    it('should handle unnamed row field', () => {
+      const field: RowField = { type: 'row', fields: [] }
+      const result = getPathBuilder().field(field).schemaIndex(2).text('label').build()
+
+      expect(result).toEqual({
+        path: 'label',
+        schemaPath: '_index-2.label',
+      })
+    })
+
+    it('should handle tabs field', () => {
+      const field: TabsField = { type: 'tabs', tabs: [] }
+      const result = getPathBuilder()
+        .field(field)
+        .schemaIndex(0)
+        .tab('content')
+        .text('body')
+        .build()
+
+      expect(result).toEqual({
+        path: 'content.body',
+        schemaPath: '_index-0.content.body',
+      })
+    })
+
+    it('should chain field() calls', () => {
+      const groupField: GroupField = { type: 'group', name: 'hero', fields: [] }
+      const textField: TextField = { type: 'text', name: 'title' }
+      const result = getPathBuilder().field(groupField).field(textField).build()
+
+      expect(result).toEqual({
+        path: 'hero.title',
+        schemaPath: 'hero.title',
       })
     })
   })

--- a/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
+++ b/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
@@ -733,4 +733,79 @@ describe('PathBuilder', () => {
       })
     })
   })
+
+  describe('Unnamed layout fields without continuation', () => {
+    it('should handle .group() without schemaIndex or nested fields - result should match parent', () => {
+      const parent = getPathBuilder().group('hero')
+      const parentResult = parent.build()
+
+      const child = parent.group()
+      const childResult = child.build()
+
+      expect(childResult).toEqual(parentResult)
+      expect(childResult).toEqual({
+        path: 'hero',
+        schemaPath: 'hero',
+      })
+    })
+
+    it('should handle .row() without schemaIndex or nested fields - result should match parent', () => {
+      const parent = getPathBuilder().group('hero')
+      const parentResult = parent.build()
+
+      const child = parent.row()
+      const childResult = child.build()
+
+      expect(childResult).toEqual(parentResult)
+      expect(childResult).toEqual({
+        path: 'hero',
+        schemaPath: 'hero',
+      })
+    })
+
+    it('should handle .collapsible() without schemaIndex or nested fields - result should match parent', () => {
+      const parent = getPathBuilder().group('hero')
+      const parentResult = parent.build()
+
+      const child = parent.collapsible()
+      const childResult = child.build()
+
+      expect(childResult).toEqual(parentResult)
+      expect(childResult).toEqual({
+        path: 'hero',
+        schemaPath: 'hero',
+      })
+    })
+
+    it('should handle .tabs() without schemaIndex or nested fields - result should match parent', () => {
+      const parent = getPathBuilder().group('hero')
+      const parentResult = parent.build()
+
+      const child = parent.tabs()
+      const childResult = child.build()
+
+      expect(childResult).toEqual(parentResult)
+      expect(childResult).toEqual({
+        path: 'hero',
+        schemaPath: 'hero',
+      })
+    })
+
+    it('should handle nested unnamed fields without continuation - result should match parent', () => {
+      const parent = getPathBuilder().group('outer').group('inner')
+      const parentResult = parent.build()
+
+      // @ts-expect-error - TypeScript correctly prevents this from being called on a group field.
+      // This test ensures the result is expected in case type checking is circumvented, e.g. when using
+      // field({type: 'row'} as unknown as Field)
+      const child = parent.group().row().collapsible()
+      const childResult = child.build()
+
+      expect(childResult).toEqual(parentResult)
+      expect(childResult).toEqual({
+        path: 'outer.inner',
+        schemaPath: 'outer.inner',
+      })
+    })
+  })
 })

--- a/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
+++ b/packages/payload/src/utilities/pathBuilder/pathBuilder.spec.ts
@@ -1,0 +1,593 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { getPathBuilder } from './index.js'
+
+describe('PathBuilder', () => {
+  describe('Simple field paths', () => {
+    it('should build path for a single field', () => {
+      const result = getPathBuilder().text('title').build()
+
+      expect(result).toEqual({
+        path: 'title',
+        schemaPath: 'title',
+      })
+    })
+
+    it('should build path using specific field type methods', () => {
+      const result = getPathBuilder().group('meta').richText('description').build()
+
+      expect(result).toEqual({
+        path: 'meta.description',
+        schemaPath: 'meta.description',
+      })
+    })
+  })
+
+  describe('Entity context paths', () => {
+    it('should build path with collection (no ID)', () => {
+      const result = getPathBuilder({ withEntity: true })
+        .collections('pages')
+        .noId()
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        path: 'collection.pages.title',
+        schemaPath: 'collection.pages.title',
+      })
+    })
+
+    it('should build path with collection and ID', () => {
+      const result = getPathBuilder({ withEntity: true })
+        .collections('pages')
+        .id(123)
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        path: 'collection.pages.123.title',
+        schemaPath: 'collection.pages.title',
+      })
+    })
+
+    it('should build path with collection and string ID', () => {
+      const result = getPathBuilder({ withEntity: true })
+        .collections('pages')
+        .id('abc123')
+        .text('slug')
+        .build()
+
+      expect(result).toEqual({
+        path: 'collection.pages.abc123.slug',
+        schemaPath: 'collection.pages.slug',
+      })
+    })
+
+    it('should build path with global', () => {
+      const result = getPathBuilder({ withEntity: true }).globals('header').text('title').build()
+
+      expect(result).toEqual({
+        path: 'global.header.title',
+        schemaPath: 'global.header.title',
+      })
+    })
+
+    it('should build path with global and nested fields', () => {
+      const result = getPathBuilder({ withEntity: true })
+        .globals('settings')
+        .group('site')
+        .text('name')
+        .build()
+
+      expect(result).toEqual({
+        path: 'global.settings.site.name',
+        schemaPath: 'global.settings.site.name',
+      })
+    })
+  })
+
+  describe('Array fields', () => {
+    it('should build path for array with index', () => {
+      const result = getPathBuilder().array('items').index(0).text('name').build()
+
+      expect(result).toEqual({
+        path: 'items.0.name',
+        schemaPath: 'items.name',
+      })
+    })
+
+    it('should build path for array with different index', () => {
+      const result = getPathBuilder().array('items').index(5).text('name').build()
+
+      expect(result).toEqual({
+        path: 'items.5.name',
+        schemaPath: 'items.name',
+      })
+    })
+
+    it('should build path for array without index (noIndex) and ensure using noIndex does not return a path', () => {
+      const result = getPathBuilder().array('items').noIndex().text('name').build()
+
+      expect(result).toEqual({
+        path: null,
+        schemaPath: 'items.name',
+      })
+    })
+
+    it('should build path for nested arrays', () => {
+      const result = getPathBuilder()
+        .array('categories')
+        .index(0)
+        .array('items')
+        .index(2)
+        .text('name')
+        .build()
+
+      expect(result).toEqual({
+        path: 'categories.0.items.2.name',
+        schemaPath: 'categories.items.name',
+      })
+    })
+
+    it('should build path for array field only', () => {
+      const result = getPathBuilder().array('items').build()
+
+      expect(result).toEqual({
+        path: 'items',
+        schemaPath: 'items',
+      })
+    })
+  })
+
+  describe('Blocks fields', () => {
+    it('should build path for blocks with block and index', () => {
+      const result = getPathBuilder()
+        .blocks('content')
+        .block('heroBlock')
+        .index(0)
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        path: 'content.0.title',
+        schemaPath: 'content.heroBlock.title',
+      })
+    })
+
+    it('should build path for blocks without index (noIndex)', () => {
+      const result = getPathBuilder()
+        .blocks('content')
+        .block('heroBlock')
+        .noIndex()
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        path: null,
+        schemaPath: 'content.heroBlock.title',
+      })
+    })
+
+    it('should build path for nested blocks', () => {
+      const result = getPathBuilder()
+        .blocks('layout')
+        .block('section')
+        .index(0)
+        .blocks('content')
+        .block('textBlock')
+        .index(1)
+        .richText('body')
+        .build()
+
+      expect(result).toEqual({
+        path: 'layout.0.content.1.body',
+        schemaPath: 'layout.section.content.textBlock.body',
+      })
+    })
+
+    it('should build path for blocks field only', () => {
+      const result = getPathBuilder().blocks('content').build()
+
+      expect(result).toEqual({
+        path: 'content',
+        schemaPath: 'content',
+      })
+    })
+
+    it('should build path with block but no further fields', () => {
+      const result = getPathBuilder().blocks('content').block('heroBlock').build()
+
+      expect(result).toEqual({
+        path: 'content',
+        schemaPath: 'content.heroBlock',
+      })
+    })
+  })
+
+  describe('Complex nested structures', () => {
+    it('should build path for complex nested structure', () => {
+      const result = getPathBuilder()
+        .blocks('content')
+        .block('heroBlock')
+        .index(0)
+        .group('meta')
+        .richText('description')
+        .build()
+
+      expect(result).toEqual({
+        path: 'content.0.meta.description',
+        schemaPath: 'content.heroBlock.meta.description',
+      })
+    })
+
+    it('should build path for array within blocks', () => {
+      const result = getPathBuilder()
+        .blocks('sections')
+        .block('featureList')
+        .index(0)
+        .array('features')
+        .index(2)
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        path: 'sections.0.features.2.title',
+        schemaPath: 'sections.featureList.features.title',
+      })
+    })
+
+    it('should build path for blocks within array', () => {
+      const result = getPathBuilder()
+        .array('columns')
+        .index(1)
+        .blocks('content')
+        .block('textBlock')
+        .index(0)
+        .richText('text')
+        .build()
+
+      expect(result).toEqual({
+        path: 'columns.1.content.0.text',
+        schemaPath: 'columns.content.textBlock.text',
+      })
+    })
+
+    it('should handle deeply nested group fields', () => {
+      const result = getPathBuilder()
+        .group('settings')
+        .group('appearance')
+        .group('colors')
+        .text('primary')
+        .build()
+
+      expect(result).toEqual({
+        path: 'settings.appearance.colors.primary',
+        schemaPath: 'settings.appearance.colors.primary',
+      })
+    })
+  })
+
+  describe('Various field types', () => {
+    it('should handle text field', () => {
+      const result = getPathBuilder().text('title').build()
+      expect(result.path).toBe('title')
+    })
+
+    it('should handle textarea field', () => {
+      const result = getPathBuilder().textarea('description').build()
+      expect(result.path).toBe('description')
+    })
+
+    it('should handle number field', () => {
+      const result = getPathBuilder().number('count').build()
+      expect(result.path).toBe('count')
+    })
+
+    it('should handle date field', () => {
+      const result = getPathBuilder().date('publishedAt').build()
+      expect(result.path).toBe('publishedAt')
+    })
+
+    it('should handle checkbox field', () => {
+      const result = getPathBuilder().checkbox('isActive').build()
+      expect(result.path).toBe('isActive')
+    })
+
+    it('should handle select field', () => {
+      const result = getPathBuilder().select('status').build()
+      expect(result.path).toBe('status')
+    })
+
+    it('should handle relationship field', () => {
+      const result = getPathBuilder().relationship('author').build()
+      expect(result.path).toBe('author')
+    })
+
+    it('should handle upload field', () => {
+      const result = getPathBuilder().upload('image').build()
+      expect(result.path).toBe('image')
+    })
+
+    it('should handle point field', () => {
+      const result = getPathBuilder().point('location').build()
+      expect(result.path).toBe('location')
+    })
+
+    it('should handle json field', () => {
+      const result = getPathBuilder().json('metadata').build()
+      expect(result.path).toBe('metadata')
+    })
+
+    it('should handle code field', () => {
+      const result = getPathBuilder().code('snippet').build()
+      expect(result.path).toBe('snippet')
+    })
+
+    it('should handle tabs field with named tab', () => {
+      const result = getPathBuilder().tabs().schemaIndex(0).tab('settings').text('apiKey').build()
+      expect(result).toEqual({
+        path: 'settings.apiKey',
+        schemaPath: '_index-0.settings.apiKey',
+      })
+    })
+
+    it('should handle collapsible field', () => {
+      const result = getPathBuilder().collapsible().schemaIndex(0).checkbox('enabled').build()
+      expect(result).toEqual({
+        path: 'enabled',
+        schemaPath: '_index-0.enabled',
+      })
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle empty path', () => {
+      const result = getPathBuilder().build()
+
+      expect(result).toEqual({
+        path: '',
+        schemaPath: '',
+      })
+    })
+
+    it('should handle multiple noIndex calls', () => {
+      const result = getPathBuilder()
+        .array('items')
+        .noIndex()
+        .array('nested')
+        .noIndex()
+        .text('value')
+        .build()
+
+      expect(result).toEqual({
+        path: null,
+        schemaPath: 'items.nested.value',
+      })
+    })
+
+    it('should handle noSchemaIndex calls', () => {
+      const result = getPathBuilder().group().noSchemaIndex().text('value').build()
+      expect(result).toEqual({
+        path: 'value',
+        schemaPath: null,
+      })
+    })
+
+    it('should handle noIndex followed by index', () => {
+      const result = getPathBuilder()
+        .array('first')
+        .noIndex()
+        .array('second')
+        .index(3)
+        .text('value')
+        .build()
+
+      expect(result).toEqual({
+        path: null,
+        schemaPath: 'first.second.value',
+      })
+    })
+  })
+
+  describe('Real-world examples', () => {
+    it('should match the example from the requirements', () => {
+      const result = getPathBuilder()
+        .blocks('blocksFieldName')
+        .block('content')
+        .index(2)
+        .richText('description')
+        .build()
+
+      expect(result).toEqual({
+        path: 'blocksFieldName.2.description',
+        schemaPath: 'blocksFieldName.content.description',
+      })
+    })
+
+    it('should handle e-commerce product with variants', () => {
+      const result = getPathBuilder()
+        .array('variants')
+        .index(0)
+        .group('pricing')
+        .number('price')
+        .build()
+
+      expect(result).toEqual({
+        path: 'variants.0.pricing.price',
+        schemaPath: 'variants.pricing.price',
+      })
+    })
+
+    it('should handle blog post with flexible content', () => {
+      const result = getPathBuilder()
+        .blocks('content')
+        .block('imageGallery')
+        .index(1)
+        .array('images')
+        .index(3)
+        .upload('image')
+        .build()
+
+      expect(result).toEqual({
+        path: 'content.1.images.3.image',
+        schemaPath: 'content.imageGallery.images.image',
+      })
+    })
+
+    it('should handle form builder', () => {
+      const result = getPathBuilder()
+        .blocks('fields')
+        .block('textField')
+        .index(0)
+        .text('label')
+        .build()
+
+      expect(result).toEqual({
+        path: 'fields.0.label',
+        schemaPath: 'fields.textField.label',
+      })
+    })
+
+    it('should handle settings with tabs', () => {
+      const result = getPathBuilder()
+        .tabs()
+        .schemaIndex(0)
+        .tab('general')
+        .group('site')
+        .text('title')
+        .build()
+
+      expect(result).toEqual({
+        path: 'general.site.title',
+        schemaPath: '_index-0.general.site.title',
+      })
+    })
+
+    it('should handle tabs with numeric index', () => {
+      const result = getPathBuilder()
+        .group('settings')
+        .tabs()
+        .schemaIndex(2)
+        .tab()
+        .schemaIndex(1)
+        .text('value')
+        .build()
+
+      expect(result).toEqual({
+        path: 'settings.value',
+        schemaPath: 'settings._index-2-1.value',
+      })
+    })
+
+    it('should handle unnamed group with schema index', () => {
+      const result = getPathBuilder().group().schemaIndex(0).text('title').build()
+
+      expect(result).toEqual({
+        path: 'title',
+        schemaPath: '_index-0.title',
+      })
+    })
+
+    it('should handle row field with schema index', () => {
+      const result = getPathBuilder().row().schemaIndex(1).text('content').build()
+
+      expect(result).toEqual({
+        path: 'content',
+        schemaPath: '_index-1.content',
+      })
+    })
+
+    it('should handle nested unnamed tabs', () => {
+      const result = getPathBuilder()
+        .tabs()
+        .schemaIndex(3)
+        .tab()
+        .schemaIndex(0)
+        .tabs()
+        .schemaIndex(1)
+        .tab()
+        .schemaIndex(0)
+        .text('fieldWithinNestedUnnamedTab')
+        .build()
+
+      expect(result).toEqual({
+        path: 'fieldWithinNestedUnnamedTab',
+        schemaPath: '_index-3-0-1-0.fieldWithinNestedUnnamedTab',
+      })
+    })
+
+    it('should handle named tab within unnamed tabs', () => {
+      const result = getPathBuilder()
+        .tabs()
+        .schemaIndex(3)
+        .tab('namedTab')
+        .text('fieldWithinNamedTab')
+        .build()
+
+      expect(result).toEqual({
+        path: 'namedTab.fieldWithinNamedTab',
+        schemaPath: '_index-3.namedTab.fieldWithinNamedTab',
+      })
+    })
+
+    it('should handle row within array', () => {
+      const result = getPathBuilder()
+        .array('items')
+        .index(0)
+        .row()
+        .schemaIndex(2)
+        .text('fieldWithinRowWithinArray')
+        .build()
+
+      expect(result).toEqual({
+        path: 'items.0.fieldWithinRowWithinArray',
+        schemaPath: 'items._index-2.fieldWithinRowWithinArray',
+      })
+    })
+
+    it('should handle collapsible with nested fields', () => {
+      const result = getPathBuilder()
+        .collapsible()
+        .schemaIndex(1)
+        .group('settings')
+        .text('value')
+        .build()
+
+      expect(result).toEqual({
+        path: 'settings.value',
+        schemaPath: '_index-1.settings.value',
+      })
+    })
+
+    it('should handle multiple unnamed groups', () => {
+      const result = getPathBuilder()
+        .group()
+        .schemaIndex(0)
+        .group()
+        .schemaIndex(1)
+        .text('nested')
+        .build()
+
+      expect(result).toEqual({
+        path: 'nested',
+        schemaPath: '_index-0-1.nested',
+      })
+    })
+
+    it('should handle mix of named and unnamed groups', () => {
+      const result = getPathBuilder()
+        .group()
+        .schemaIndex(0)
+        .group('named')
+        .group()
+        .schemaIndex(2)
+        .text('field')
+        .build()
+
+      expect(result).toEqual({
+        path: 'named.field',
+        schemaPath: '_index-0.named._index-2.field',
+      })
+    })
+  })
+})

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -83,7 +83,7 @@ export type AddFieldStatePromiseArgs = {
   omitParents?: boolean
   operation: 'create' | 'update'
   parentPassesCondition?: boolean
-  parentPath: FieldBuilder<string> | RootBuilder
+  parentPath: FieldBuilder | RootBuilder
   parentPermissions: SanitizedFieldsPermissions
   preferences: DocumentPreferences
   previousFormState: FormState

--- a/packages/ui/src/forms/fieldSchemasToFormState/index.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/index.tsx
@@ -136,7 +136,9 @@ export const fieldSchemasToFormState = async ({
       fullData = documentData
     }
 
-    const parentPath = getPathBuilder({ prefix: 'entity' }).collections(collectionSlug).noId()
+    const parentPath = getPathBuilder({ legacySchemaPaths: true, prefix: 'entity' })
+      .collections(collectionSlug)
+      .noId()
     await iterateFields({
       id,
       addErrorPathToParent: null,

--- a/packages/ui/src/forms/fieldSchemasToFormState/index.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/index.tsx
@@ -1,16 +1,17 @@
-import type {
-  BuildFormStateArgs,
-  ClientFieldSchemaMap,
-  Data,
-  DocumentPreferences,
-  Field,
-  FieldSchemaMap,
-  FormState,
-  FormStateWithoutComponents,
-  PayloadRequest,
-  SanitizedFieldsPermissions,
-  SelectMode,
-  SelectType,
+import {
+  type BuildFormStateArgs,
+  type ClientFieldSchemaMap,
+  type Data,
+  type DocumentPreferences,
+  type Field,
+  type FieldSchemaMap,
+  type FormState,
+  type FormStateWithoutComponents,
+  getPathBuilder,
+  type PayloadRequest,
+  type SanitizedFieldsPermissions,
+  type SelectMode,
+  type SelectType,
 } from 'payload'
 
 import type { RenderFieldMethod } from './types.js'
@@ -135,6 +136,7 @@ export const fieldSchemasToFormState = async ({
       fullData = documentData
     }
 
+    const parentPath = getPathBuilder({ prefix: 'entity' }).collections(collectionSlug).noId()
     await iterateFields({
       id,
       addErrorPathToParent: null,
@@ -147,10 +149,8 @@ export const fieldSchemasToFormState = async ({
       fullData,
       mockRSCs,
       operation,
-      parentIndexPath: '',
       parentPassesCondition: true,
-      parentPath: '',
-      parentSchemaPath: schemaPath,
+      parentPath,
       permissions,
       preferences,
       previousFormState,

--- a/packages/ui/src/forms/fieldSchemasToFormState/iterateFields.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/iterateFields.ts
@@ -56,7 +56,7 @@ type Args = {
    */
   operation: 'create' | 'update'
   parentPassesCondition?: boolean
-  parentPath: FieldBuilder<string> | RootBuilder
+  parentPath: FieldBuilder | RootBuilder
   permissions: SanitizedFieldsPermissions
   preferences?: DocumentPreferences
   previousFormState: FormState


### PR DESCRIPTION
Building field paths, schemaPaths and indexPaths for fields and their nested children is way too complex. This PR provides a type-safe utility to build out these field paths. Instead of the function having to manage _paths/parent paths/parent index paths/`<insert 3 other path types here>`_, that part is encapsulated within the path builder, thus keeping the consuming function simple and type-safe.

## Example

```ts
const { path, schemaPath } = getPathBuilder()
  .blocks('content')
  .block('heroBlock')
  .index(0)
  .text('title')
  .build()
// Result:
// {
//   path: 'content.0.title',              // numeric index
//   schemaPath: 'content.heroBlock.title' // block slug
// }
```

## Todo

- [ ] Write proper PR description
- [ ] Migrate codebase to use `getPathBuilder` instead of `getFieldPaths`. Currently, only `buildFormState` is migrated.