### PR TITLE
fix(templates): pin docker image postgres to :17, mongo to :8

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -251,7 +251,7 @@ services:
 
   # Ensure your DATABASE_URI uses 'mongo' as the hostname ie. mongodb://mongo/my-db-name
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -264,7 +264,7 @@ services:
   # Uncomment the following to use postgres
   # postgres:
   #   restart: always
-  #   image: postgres:latest
+  #   image: postgres:17
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
   #   ports:

--- a/examples/astro/payload/docker-compose.yml
+++ b/examples/astro/payload/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   # Uncomment the following to use postgres
   # postgres:
   #   restart: always
-  #   image: postgres:latest
+  #   image: postgres:17
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
   #   ports:

--- a/examples/astro/payload/docker-compose.yml
+++ b/examples/astro/payload/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # Ensure your DATABASE_URI uses 'mongo' as the hostname ie. mongodb://mongo/my-db-name
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/examples/localization/docker-compose.yml
+++ b/examples/localization/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - .env
 
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/examples/remix/payload/docker-compose.yml
+++ b/examples/remix/payload/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   # Uncomment the following to use postgres
   # postgres:
   #   restart: always
-  #   image: postgres:latest
+  #   image: postgres:17
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
   #   ports:

--- a/examples/remix/payload/docker-compose.yml
+++ b/examples/remix/payload/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # Ensure your DATABASE_URI uses 'mongo' as the hostname ie. mongodb://mongo/my-db-name
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/templates/_template/docker-compose.yml
+++ b/templates/_template/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   # Uncomment the following to use postgres
   # postgres:
   #   restart: always
-  #   image: postgres:latest
+  #   image: postgres:17
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
   #   ports:

--- a/templates/_template/docker-compose.yml
+++ b/templates/_template/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # Ensure your DATABASE_URI uses 'mongo' as the hostname ie. mongodb://mongo/my-db-name
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/templates/blank/docker-compose.yml
+++ b/templates/blank/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   # Uncomment the following to use postgres
   # postgres:
   #   restart: always
-  #   image: postgres:latest
+  #   image: postgres:17
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
   #   ports:

--- a/templates/blank/docker-compose.yml
+++ b/templates/blank/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # Ensure your DATABASE_URI uses 'mongo' as the hostname ie. mongodb://mongo/my-db-name
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/templates/website/docker-compose.yml
+++ b/templates/website/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - .env
 
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/templates/with-payload-cloud/docker-compose.yml
+++ b/templates/with-payload-cloud/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   # Uncomment the following to use postgres
   # postgres:
   #   restart: always
-  #   image: postgres:latest
+  #   image: postgres:17
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
   #   ports:

--- a/templates/with-payload-cloud/docker-compose.yml
+++ b/templates/with-payload-cloud/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # Ensure your DATABASE_URI uses 'mongo' as the hostname ie. mongodb://mongo/my-db-name
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/templates/with-postgres/docker-compose.yml
+++ b/templates/with-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   # Ensure your DATABASE_URI uses 'postgresql' as the hostname ie. postgresql://127.0.0.1:5432/your-database-name
   postgres:
     restart: always
-    image: postgres:latest
+    image: postgres:17
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:

--- a/templates/with-postgres/docker-compose.yml
+++ b/templates/with-postgres/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   # Uncomment the following to use mongodb
   # mongo:
-  #   image: mongo:latest
+  #   image: mongo:8
   #   ports:
   #     - '27017:27017'
   #   command:

--- a/templates/with-vercel-mongodb/docker-compose.yml
+++ b/templates/with-vercel-mongodb/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   # Uncomment the following to use postgres
   # postgres:
   #   restart: always
-  #   image: postgres:latest
+  #   image: postgres:17
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
   #   ports:

--- a/templates/with-vercel-mongodb/docker-compose.yml
+++ b/templates/with-vercel-mongodb/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # Ensure your DATABASE_URI uses 'mongo' as the hostname ie. mongodb://mongo/my-db-name
   mongo:
-    image: mongo:latest
+    image: mongo:8
     ports:
       - '27017:27017'
     command:

--- a/templates/with-vercel-postgres/docker-compose.yml
+++ b/templates/with-vercel-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   # Ensure your DATABASE_URI uses 'postgresql' as the hostname ie. postgresql://127.0.0.1:5432/your-database-name
   postgres:
     restart: always
-    image: postgres:latest
+    image: postgres:17
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:

--- a/templates/with-vercel-postgres/docker-compose.yml
+++ b/templates/with-vercel-postgres/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   # Uncomment the following to use mongodb
   # mongo:
-  #   image: mongo:latest
+  #   image: mongo:8
   #   ports:
   #     - '27017:27017'
   #   command:


### PR DESCRIPTION
Docker-compose files refer to 'postgres:latest', there appears to be issues with the recently released Postgres18.

### What?

- Pins the Postgres docker image to the [`:17` release tag](https://hub.docker.com/layers/library/postgres/17) (it was pinned to the [`:latest` release tag](https://hub.docker.com/layers/library/postgres/latest)).
- Also pins MongoDB docker image to `:8` release tag. This would prevent an issue similar to what we are experiencing with `postgres:18`

### Why?

Since Postgres18 released a little while ago, using the default docker-compose template would provide you with Postgre18. When `postgres:latest` was first written into the codebase (0287acb) Postgres16 (!!) was the "latest".

### Related issues and discussions

- #13963
- #13479
- Possibly: #12858
- Drizzle issue: drizzle-team/drizzle-orm/issues/4944
- https://discord.com/channels/1043890932593987624/1421836581433770036