### PR TITLE
test: use `autoGenerate` only if the db adapter has `defaultIdType` equals to `text`

### DIFF
--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -148,6 +148,7 @@ export async function buildConfigWithDefaults(
       declare: {
         ignoreTSError: true,
       },
+      autoGenerate: databaseAdapter.defaultIDType === 'text',
       ...testConfig?.typescript,
     },
   }


### PR DESCRIPTION
This avoids creating diff like this every time we run tests with Postgres/SQLite. (still can be overriden in a test suite if required)
<img width="1118" height="609" alt="image" src="https://github.com/user-attachments/assets/f4e5580b-5878-4bfb-af65-cd7c04088424" />
