### PR TITLE
fix(ui): account for array values in transformWhereToNaturalLanguage

### DIFF
--- a/packages/ui/src/elements/QueryPresets/cells/WhereCell/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/cells/WhereCell/index.tsx
@@ -22,7 +22,11 @@ const transformWhereToNaturalLanguage = (where: Where): string => {
     const operator = Object.keys(andQuery[key])[0]
     const value = andQuery[key][operator]
 
-    return `${toWords(key)} ${operator} ${toWords(value)}`
+    if (typeof value === 'string') {
+      return `${toWords(key)} ${operator} ${toWords(value)}`
+    } else if (Array.isArray(value)) {
+      return `${toWords(key)} ${operator} ${value.map((val) => toWords(val)).join(' or ')}`
+    }
   }
 
   return ''


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14331

Some queries contain arrays, this PR checks for that and renders the values within.