### PR TITLE
fix(templates): remove deprecated cloudflare remote bindings

### DIFF
--- a/templates/with-cloudflare-d1/package.json
+++ b/templates/with-cloudflare-d1/package.json
@@ -55,7 +55,7 @@
     "typescript": "5.7.3",
     "vite-tsconfig-paths": "5.1.4",
     "vitest": "3.2.3",
-    "wrangler": "~4.42.0"
+    "wrangler": "~4.45.0"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",


### PR DESCRIPTION
The latest wrangler release [4.45.0](https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.45.0) seems not to like this line from the Payload+Cloudflare template:

```
experimental: { remoteBindings: cloudflareRemoteBindings }
```

[This PR](https://github.com/cloudflare/workers-sdk/pull/10741) part of the wrangler `4.45.0` release removes the remote bindings flag - it's on by default and will no longer be possible to disable, therefore I adjusted the payload config in the D1 template to remove the `remoteBindings`.

I've also bumped and pinned the wrangler version in the template to `4.45.0`.