### PR TITLE
fix(richtext-lexical): prevent TS CodeBlocks from sharing Monaco model (useId)

### DIFF
--- a/packages/richtext-lexical/src/exports/client/index.ts
+++ b/packages/richtext-lexical/src/exports/client/index.ts
@@ -135,6 +135,12 @@ export {
   InlineBlockNode,
 } from '../../features/blocks/client/nodes/InlineBlocksNode.js'
 
+export {
+  $createHorizontalRuleNode,
+  $isHorizontalRuleNode,
+  HorizontalRuleNode,
+} from '../../features/horizontalRule/client/nodes/HorizontalRuleNode.js'
+
 export { FieldsDrawer } from '../../utilities/fieldsDrawer/Drawer.js'
 export { useLexicalDocumentDrawer } from '../../utilities/fieldsDrawer/useLexicalDocumentDrawer.js'
 export { useLexicalDrawer } from '../../utilities/fieldsDrawer/useLexicalDrawer.js'


### PR DESCRIPTION
### Changes
- Used React’s built-in useId() to give each TypeScript CodeBlock instance a unique Monaco defaultPath. This ensures every TS code block creates its own Monaco model instead of reusing a single shared model.
- Exported the Horizontal Rule node from the client exports so it’s available to consumers.

### Why I did it
Issue + Video mentioned [here](https://github.com/payloadcms/payload/pull/13813#issuecomment-3421787467)
According to the [@monaco-editor/react documentation](https://www.npmjs.com/package/@monaco-editor/react#multi-model-editor), the path/defaultPath parameter is used as an identifier for the model:

> There are three parameters to create a model - value, language and path (monaco.editor.createModel(value, language, monaco.Uri.parse(path))). You can consider last one (path) as an identifier for the model. The Editor component, now, has a path prop. When you specify a path prop, the Editor component checks if it has a model by that path or not. If yes, the existing model will be shown, otherwise, a new one will be created (and stored).

When multiple code blocks share the same defaultPath: 'file.tsx', @monaco-editor/react treats them as the same model identifier, causing:

- Model reuse across different code block instances
- Content synchronization between blocks
- Loss of independent state per block
