### PR TITLE
fix(plugin-multi-tenant): remove unused syncTenants from useEffect deps

### DIFF
--- a/packages/plugin-multi-tenant/src/components/WatchTenantCollection/index.tsx
+++ b/packages/plugin-multi-tenant/src/components/WatchTenantCollection/index.tsx
@@ -41,7 +41,7 @@ export const WatchTenantCollection = () => {
     if (id && titleField?.initialValue) {
       void syncTenantTitle()
     }
-  }, [id, titleField?.initialValue, syncTenants])
+  }, [id, titleField?.initialValue])
 
   React.useEffect(() => {
     if (operation === 'create' && submitted) {


### PR DESCRIPTION
https://discord.com/channels/967097582721572934/1004009734115966976/1425988296835858523

## Change
Fixes infinite loop bug in the multi-tenant plugin: `WatchTenantCollection` component causes repeated API calls to `/api/tenants/populate-tenant-options` in admin.

<img width="1800" height="765" alt="image" src="https://github.com/user-attachments/assets/715541d6-5075-47eb-97f0-ce0a516d5141" />

## Fix
Remove `syncTenants` from the first useEffect dependency array.