### PR TITLE
docs: fix anchor link reference for settingsMenu

### DIFF
--- a/docs/custom-components/root-components.mdx
+++ b/docs/custom-components/root-components.mdx
@@ -45,7 +45,7 @@ The following options are available:
 | `header`          | An array of Custom Components to be injected above the Payload header. [More details](#header).                                                                          |
 | `logout.Button`   | The button displayed in the sidebar that logs the user out. [More details](#logoutbutton).                                                                               |
 | `Nav`             | Contains the sidebar / mobile menu in its entirety. [More details](#nav).                                                                                                |
-| `settingsMenu`    | An array of Custom Components to inject into a popup menu accessible via a gear icon above the logout button. [More details](#settingsMenu).                             |
+| `settingsMenu`    | An array of Custom Components to inject into a popup menu accessible via a gear icon above the logout button. [More details](#settingsmenu).                             |
 | `providers`       | Custom [React Context](https://react.dev/learn/scaling-up-with-reducer-and-context) providers that will wrap the entire Admin Panel. [More details](./custom-providers). |
 | `views`           | Override or create new views within the Admin Panel. [More details](./custom-views).                                                                                     |
 


### PR DESCRIPTION
The uppercase `M` means clicking the link doesn't scroll down to the anchored heading as it has an `id="settingsmenu"` – we change the casing to be all lowercase to match.