### PR TITLE
fix: minified payload error names in production builds, using instanceof not possible

### DIFF
--- a/packages/payload/src/errors/APIError.ts
+++ b/packages/payload/src/errors/APIError.ts
@@ -1,7 +1,9 @@
 import { status as httpStatus } from 'http-status'
 
-// This gets dynamically reassigned during compilation
-export let APIErrorName = 'APIError'
+/**
+ * @deprecated Remove this in 4.0 - this is no longer needed as we assign the prototype correctly in the constructor
+ */
+export const APIErrorName = 'APIError'
 
 class ExtendableError<TData extends object = { [key: string]: unknown }> extends Error {
   data: TData
@@ -17,13 +19,18 @@ class ExtendableError<TData extends object = { [key: string]: unknown }> extends
       // show data in cause
       cause: data,
     })
-    APIErrorName = this.constructor.name
-    this.name = this.constructor.name
     this.message = message
     this.status = status
     this.data = data
     this.isPublic = isPublic
     this.isOperational = true // This is required since bluebird 4 doesn't append it anymore.
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'ExtendableError'
+    Object.defineProperty(this.constructor, 'name', { value: 'ExtendableError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, ExtendableError.prototype)
+
     Error.captureStackTrace(this, this.constructor)
   }
 }
@@ -50,5 +57,11 @@ export class APIError<
     isPublic = false,
   ) {
     super(message, status, data, isPublic)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'APIError'
+    Object.defineProperty(this.constructor, 'name', { value: 'APIError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, APIError.prototype)
   }
 }

--- a/packages/payload/src/errors/APIError.ts
+++ b/packages/payload/src/errors/APIError.ts
@@ -27,7 +27,6 @@ class ExtendableError<TData extends object = { [key: string]: unknown }> extends
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'ExtendableError'
-    Object.defineProperty(this.constructor, 'name', { value: 'ExtendableError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, ExtendableError.prototype)
 
@@ -60,7 +59,6 @@ export class APIError<
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'APIError'
-    Object.defineProperty(this.constructor, 'name', { value: 'APIError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, APIError.prototype)
   }

--- a/packages/payload/src/errors/AuthenticationError.ts
+++ b/packages/payload/src/errors/AuthenticationError.ts
@@ -16,7 +16,6 @@ export class AuthenticationError extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'AuthenticationError'
-    Object.defineProperty(this.constructor, 'name', { value: 'AuthenticationError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, AuthenticationError.prototype)
   }

--- a/packages/payload/src/errors/AuthenticationError.ts
+++ b/packages/payload/src/errors/AuthenticationError.ts
@@ -13,5 +13,11 @@ export class AuthenticationError extends APIError {
         : en.translations.error.emailOrPasswordIncorrect,
       httpStatus.UNAUTHORIZED,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'AuthenticationError'
+    Object.defineProperty(this.constructor, 'name', { value: 'AuthenticationError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, AuthenticationError.prototype)
   }
 }

--- a/packages/payload/src/errors/DuplicateCollection.ts
+++ b/packages/payload/src/errors/DuplicateCollection.ts
@@ -6,7 +6,6 @@ export class DuplicateCollection extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'DuplicateCollection'
-    Object.defineProperty(this.constructor, 'name', { value: 'DuplicateCollection' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, DuplicateCollection.prototype)
   }

--- a/packages/payload/src/errors/DuplicateCollection.ts
+++ b/packages/payload/src/errors/DuplicateCollection.ts
@@ -3,5 +3,11 @@ import { APIError } from './APIError.js'
 export class DuplicateCollection extends APIError {
   constructor(propertyName: string, duplicate: string) {
     super(`Collection ${propertyName} already in use: "${duplicate}"`)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'DuplicateCollection'
+    Object.defineProperty(this.constructor, 'name', { value: 'DuplicateCollection' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, DuplicateCollection.prototype)
   }
 }

--- a/packages/payload/src/errors/DuplicateFieldName.ts
+++ b/packages/payload/src/errors/DuplicateFieldName.ts
@@ -8,7 +8,6 @@ export class DuplicateFieldName extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'DuplicateFieldName'
-    Object.defineProperty(this.constructor, 'name', { value: 'DuplicateFieldName' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, DuplicateFieldName.prototype)
   }

--- a/packages/payload/src/errors/DuplicateFieldName.ts
+++ b/packages/payload/src/errors/DuplicateFieldName.ts
@@ -5,5 +5,11 @@ export class DuplicateFieldName extends APIError {
     super(
       `A field with the name '${fieldName}' was found multiple times on the same level. Field names must be unique.`,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'DuplicateFieldName'
+    Object.defineProperty(this.constructor, 'name', { value: 'DuplicateFieldName' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, DuplicateFieldName.prototype)
   }
 }

--- a/packages/payload/src/errors/DuplicateGlobal.ts
+++ b/packages/payload/src/errors/DuplicateGlobal.ts
@@ -8,7 +8,6 @@ export class DuplicateGlobal extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'DuplicateGlobal'
-    Object.defineProperty(this.constructor, 'name', { value: 'DuplicateGlobal' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, DuplicateGlobal.prototype)
   }

--- a/packages/payload/src/errors/DuplicateGlobal.ts
+++ b/packages/payload/src/errors/DuplicateGlobal.ts
@@ -5,5 +5,11 @@ import { APIError } from './APIError.js'
 export class DuplicateGlobal extends APIError {
   constructor(config: GlobalConfig) {
     super(`Global label "${config.label}" is already in use`)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'DuplicateGlobal'
+    Object.defineProperty(this.constructor, 'name', { value: 'DuplicateGlobal' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, DuplicateGlobal.prototype)
   }
 }

--- a/packages/payload/src/errors/ErrorDeletingFile.ts
+++ b/packages/payload/src/errors/ErrorDeletingFile.ts
@@ -11,5 +11,11 @@ export class ErrorDeletingFile extends APIError {
       t ? t('error:deletingFile') : en.translations.error.deletingFile,
       httpStatus.INTERNAL_SERVER_ERROR,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'ErrorDeletingFile'
+    Object.defineProperty(this.constructor, 'name', { value: 'ErrorDeletingFile' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, ErrorDeletingFile.prototype)
   }
 }

--- a/packages/payload/src/errors/ErrorDeletingFile.ts
+++ b/packages/payload/src/errors/ErrorDeletingFile.ts
@@ -14,7 +14,6 @@ export class ErrorDeletingFile extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'ErrorDeletingFile'
-    Object.defineProperty(this.constructor, 'name', { value: 'ErrorDeletingFile' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, ErrorDeletingFile.prototype)
   }

--- a/packages/payload/src/errors/FileRetrievalError.ts
+++ b/packages/payload/src/errors/FileRetrievalError.ts
@@ -15,7 +15,6 @@ export class FileRetrievalError extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'FileRetrievalError'
-    Object.defineProperty(this.constructor, 'name', { value: 'FileRetrievalError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, FileRetrievalError.prototype)
   }

--- a/packages/payload/src/errors/FileRetrievalError.ts
+++ b/packages/payload/src/errors/FileRetrievalError.ts
@@ -12,5 +12,11 @@ export class FileRetrievalError extends APIError {
       msg += ` ${message}`
     }
     super(msg, httpStatus.INTERNAL_SERVER_ERROR)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'FileRetrievalError'
+    Object.defineProperty(this.constructor, 'name', { value: 'FileRetrievalError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, FileRetrievalError.prototype)
   }
 }

--- a/packages/payload/src/errors/FileUploadError.ts
+++ b/packages/payload/src/errors/FileUploadError.ts
@@ -14,7 +14,6 @@ export class FileUploadError extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'FileUploadError'
-    Object.defineProperty(this.constructor, 'name', { value: 'FileUploadError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, FileUploadError.prototype)
   }

--- a/packages/payload/src/errors/FileUploadError.ts
+++ b/packages/payload/src/errors/FileUploadError.ts
@@ -11,5 +11,11 @@ export class FileUploadError extends APIError {
       t ? t('error:problemUploadingFile') : en.translations.error.problemUploadingFile,
       httpStatus.BAD_REQUEST,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'FileUploadError'
+    Object.defineProperty(this.constructor, 'name', { value: 'FileUploadError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, FileUploadError.prototype)
   }
 }

--- a/packages/payload/src/errors/Forbidden.ts
+++ b/packages/payload/src/errors/Forbidden.ts
@@ -11,5 +11,11 @@ export class Forbidden extends APIError {
       t ? t('error:notAllowedToPerformAction') : en.translations.error.notAllowedToPerformAction,
       httpStatus.FORBIDDEN,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'Forbidden'
+    Object.defineProperty(this.constructor, 'name', { value: 'Forbidden' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, Forbidden.prototype)
   }
 }

--- a/packages/payload/src/errors/Forbidden.ts
+++ b/packages/payload/src/errors/Forbidden.ts
@@ -14,7 +14,6 @@ export class Forbidden extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'Forbidden'
-    Object.defineProperty(this.constructor, 'name', { value: 'Forbidden' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, Forbidden.prototype)
   }

--- a/packages/payload/src/errors/InvalidConfiguration.ts
+++ b/packages/payload/src/errors/InvalidConfiguration.ts
@@ -5,5 +5,11 @@ import { APIError } from './APIError.js'
 export class InvalidConfiguration extends APIError {
   constructor(message: string) {
     super(message, httpStatus.INTERNAL_SERVER_ERROR)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'InvalidConfiguration'
+    Object.defineProperty(this.constructor, 'name', { value: 'InvalidConfiguration' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, InvalidConfiguration.prototype)
   }
 }

--- a/packages/payload/src/errors/InvalidConfiguration.ts
+++ b/packages/payload/src/errors/InvalidConfiguration.ts
@@ -8,7 +8,6 @@ export class InvalidConfiguration extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'InvalidConfiguration'
-    Object.defineProperty(this.constructor, 'name', { value: 'InvalidConfiguration' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, InvalidConfiguration.prototype)
   }

--- a/packages/payload/src/errors/InvalidFieldJoin.ts
+++ b/packages/payload/src/errors/InvalidFieldJoin.ts
@@ -7,5 +7,11 @@ export class InvalidFieldJoin extends APIError {
     super(
       `Invalid join field ${field.name}. The config does not have a field '${field.on}' in collection '${field.collection}'.`,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'InvalidFieldJoin'
+    Object.defineProperty(this.constructor, 'name', { value: 'InvalidFieldJoin' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, InvalidFieldJoin.prototype)
   }
 }

--- a/packages/payload/src/errors/InvalidFieldJoin.ts
+++ b/packages/payload/src/errors/InvalidFieldJoin.ts
@@ -10,7 +10,6 @@ export class InvalidFieldJoin extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'InvalidFieldJoin'
-    Object.defineProperty(this.constructor, 'name', { value: 'InvalidFieldJoin' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, InvalidFieldJoin.prototype)
   }

--- a/packages/payload/src/errors/InvalidFieldName.ts
+++ b/packages/payload/src/errors/InvalidFieldName.ts
@@ -7,5 +7,11 @@ export class InvalidFieldName extends APIError {
     super(
       `Field ${field.label} has invalid name '${fieldName}'. Field names can not include periods (.) and must be alphanumeric.`,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'InvalidFieldName'
+    Object.defineProperty(this.constructor, 'name', { value: 'InvalidFieldName' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, InvalidFieldName.prototype)
   }
 }

--- a/packages/payload/src/errors/InvalidFieldName.ts
+++ b/packages/payload/src/errors/InvalidFieldName.ts
@@ -10,7 +10,6 @@ export class InvalidFieldName extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'InvalidFieldName'
-    Object.defineProperty(this.constructor, 'name', { value: 'InvalidFieldName' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, InvalidFieldName.prototype)
   }

--- a/packages/payload/src/errors/InvalidFieldRelationship.ts
+++ b/packages/payload/src/errors/InvalidFieldRelationship.ts
@@ -8,7 +8,6 @@ export class InvalidFieldRelationship extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'InvalidFieldRelationship'
-    Object.defineProperty(this.constructor, 'name', { value: 'InvalidFieldRelationship' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, InvalidFieldRelationship.prototype)
   }

--- a/packages/payload/src/errors/InvalidFieldRelationship.ts
+++ b/packages/payload/src/errors/InvalidFieldRelationship.ts
@@ -5,5 +5,11 @@ import { APIError } from './APIError.js'
 export class InvalidFieldRelationship extends APIError {
   constructor(field: RelationshipField | UploadField, relationship: string) {
     super(`Field ${field.label} has invalid relationship '${relationship}'.`)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'InvalidFieldRelationship'
+    Object.defineProperty(this.constructor, 'name', { value: 'InvalidFieldRelationship' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, InvalidFieldRelationship.prototype)
   }
 }

--- a/packages/payload/src/errors/InvalidSchema.ts
+++ b/packages/payload/src/errors/InvalidSchema.ts
@@ -8,7 +8,6 @@ export class InvalidSchema extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'InvalidSchema'
-    Object.defineProperty(this.constructor, 'name', { value: 'InvalidSchema' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, InvalidSchema.prototype)
   }

--- a/packages/payload/src/errors/InvalidSchema.ts
+++ b/packages/payload/src/errors/InvalidSchema.ts
@@ -5,5 +5,11 @@ import { APIError } from './APIError.js'
 export class InvalidSchema extends APIError {
   constructor(message: string, results: any) {
     super(message, httpStatus.INTERNAL_SERVER_ERROR, results)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'InvalidSchema'
+    Object.defineProperty(this.constructor, 'name', { value: 'InvalidSchema' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, InvalidSchema.prototype)
   }
 }

--- a/packages/payload/src/errors/Locked.ts
+++ b/packages/payload/src/errors/Locked.ts
@@ -5,5 +5,11 @@ import { APIError } from './APIError.js'
 export class Locked extends APIError {
   constructor(message: string) {
     super(message, httpStatus.LOCKED)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'Locked'
+    Object.defineProperty(this.constructor, 'name', { value: 'Locked' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, Locked.prototype)
   }
 }

--- a/packages/payload/src/errors/Locked.ts
+++ b/packages/payload/src/errors/Locked.ts
@@ -8,7 +8,6 @@ export class Locked extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'Locked'
-    Object.defineProperty(this.constructor, 'name', { value: 'Locked' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, Locked.prototype)
   }

--- a/packages/payload/src/errors/LockedAuth.ts
+++ b/packages/payload/src/errors/LockedAuth.ts
@@ -8,5 +8,11 @@ import { APIError } from './APIError.js'
 export class LockedAuth extends APIError {
   constructor(t?: TFunction) {
     super(t ? t('error:userLocked') : en.translations.error.userLocked, httpStatus.UNAUTHORIZED)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'LockedAuth'
+    Object.defineProperty(this.constructor, 'name', { value: 'LockedAuth' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, LockedAuth.prototype)
   }
 }

--- a/packages/payload/src/errors/LockedAuth.ts
+++ b/packages/payload/src/errors/LockedAuth.ts
@@ -11,7 +11,6 @@ export class LockedAuth extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'LockedAuth'
-    Object.defineProperty(this.constructor, 'name', { value: 'LockedAuth' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, LockedAuth.prototype)
   }

--- a/packages/payload/src/errors/MissingCollectionLabel.ts
+++ b/packages/payload/src/errors/MissingCollectionLabel.ts
@@ -6,7 +6,6 @@ export class MissingCollectionLabel extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'MissingCollectionLabel'
-    Object.defineProperty(this.constructor, 'name', { value: 'MissingCollectionLabel' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, MissingCollectionLabel.prototype)
   }

--- a/packages/payload/src/errors/MissingCollectionLabel.ts
+++ b/packages/payload/src/errors/MissingCollectionLabel.ts
@@ -3,5 +3,11 @@ import { APIError } from './APIError.js'
 export class MissingCollectionLabel extends APIError {
   constructor() {
     super('payload.config.collection object is missing label')
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'MissingCollectionLabel'
+    Object.defineProperty(this.constructor, 'name', { value: 'MissingCollectionLabel' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, MissingCollectionLabel.prototype)
   }
 }

--- a/packages/payload/src/errors/MissingEditorProp.ts
+++ b/packages/payload/src/errors/MissingEditorProp.ts
@@ -11,7 +11,6 @@ export class MissingEditorProp extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'MissingEditorProp'
-    Object.defineProperty(this.constructor, 'name', { value: 'MissingEditorProp' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, MissingEditorProp.prototype)
   }

--- a/packages/payload/src/errors/MissingEditorProp.ts
+++ b/packages/payload/src/errors/MissingEditorProp.ts
@@ -8,5 +8,11 @@ export class MissingEditorProp extends APIError {
     super(
       `RichText field${fieldAffectsData(field) ? ` "${field.name}"` : ''} is missing the editor prop. For sub-richText fields, the editor props is required, as it would otherwise create infinite recursion.`,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'MissingEditorProp'
+    Object.defineProperty(this.constructor, 'name', { value: 'MissingEditorProp' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, MissingEditorProp.prototype)
   }
 }

--- a/packages/payload/src/errors/MissingFieldInputOptions.ts
+++ b/packages/payload/src/errors/MissingFieldInputOptions.ts
@@ -5,5 +5,11 @@ import { APIError } from './APIError.js'
 export class MissingFieldInputOptions extends APIError {
   constructor(field: RadioField | SelectField) {
     super(`Field ${field.label} is missing options.`)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'MissingFieldInputOptions'
+    Object.defineProperty(this.constructor, 'name', { value: 'MissingFieldInputOptions' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, MissingFieldInputOptions.prototype)
   }
 }

--- a/packages/payload/src/errors/MissingFieldInputOptions.ts
+++ b/packages/payload/src/errors/MissingFieldInputOptions.ts
@@ -8,7 +8,6 @@ export class MissingFieldInputOptions extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'MissingFieldInputOptions'
-    Object.defineProperty(this.constructor, 'name', { value: 'MissingFieldInputOptions' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, MissingFieldInputOptions.prototype)
   }

--- a/packages/payload/src/errors/MissingFieldType.ts
+++ b/packages/payload/src/errors/MissingFieldType.ts
@@ -10,5 +10,11 @@ export class MissingFieldType extends APIError {
         fieldAffectsData(field) ? ` "${field.name}"` : ''
       } is either missing a field type or it does not match an available field type`,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'MissingFieldType'
+    Object.defineProperty(this.constructor, 'name', { value: 'MissingFieldType' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, MissingFieldType.prototype)
   }
 }

--- a/packages/payload/src/errors/MissingFieldType.ts
+++ b/packages/payload/src/errors/MissingFieldType.ts
@@ -13,7 +13,6 @@ export class MissingFieldType extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'MissingFieldType'
-    Object.defineProperty(this.constructor, 'name', { value: 'MissingFieldType' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, MissingFieldType.prototype)
   }

--- a/packages/payload/src/errors/MissingFile.ts
+++ b/packages/payload/src/errors/MissingFile.ts
@@ -11,5 +11,11 @@ export class MissingFile extends APIError {
       t ? t('error:noFilesUploaded') : en.translations.error.noFilesUploaded,
       httpStatus.BAD_REQUEST,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'MissingFile'
+    Object.defineProperty(this.constructor, 'name', { value: 'MissingFile' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, MissingFile.prototype)
   }
 }

--- a/packages/payload/src/errors/MissingFile.ts
+++ b/packages/payload/src/errors/MissingFile.ts
@@ -14,7 +14,6 @@ export class MissingFile extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'MissingFile'
-    Object.defineProperty(this.constructor, 'name', { value: 'MissingFile' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, MissingFile.prototype)
   }

--- a/packages/payload/src/errors/NotFound.ts
+++ b/packages/payload/src/errors/NotFound.ts
@@ -8,5 +8,11 @@ import { APIError } from './APIError.js'
 export class NotFound extends APIError {
   constructor(t?: TFunction) {
     super(t ? t('general:notFound') : en.translations.general.notFound, httpStatus.NOT_FOUND)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'NotFound'
+    Object.defineProperty(this.constructor, 'name', { value: 'NotFound' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, NotFound.prototype)
   }
 }

--- a/packages/payload/src/errors/NotFound.ts
+++ b/packages/payload/src/errors/NotFound.ts
@@ -11,7 +11,6 @@ export class NotFound extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'NotFound'
-    Object.defineProperty(this.constructor, 'name', { value: 'NotFound' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, NotFound.prototype)
   }

--- a/packages/payload/src/errors/QueryError.ts
+++ b/packages/payload/src/errors/QueryError.ts
@@ -11,5 +11,11 @@ export class QueryError extends APIError<{ path: string }[]> {
       httpStatus.BAD_REQUEST,
       results,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'QueryError'
+    Object.defineProperty(this.constructor, 'name', { value: 'QueryError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, QueryError.prototype)
   }
 }

--- a/packages/payload/src/errors/QueryError.ts
+++ b/packages/payload/src/errors/QueryError.ts
@@ -14,7 +14,6 @@ export class QueryError extends APIError<{ path: string }[]> {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'QueryError'
-    Object.defineProperty(this.constructor, 'name', { value: 'QueryError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, QueryError.prototype)
   }

--- a/packages/payload/src/errors/ReservedFieldName.ts
+++ b/packages/payload/src/errors/ReservedFieldName.ts
@@ -5,5 +5,11 @@ import { APIError } from './APIError.js'
 export class ReservedFieldName extends APIError {
   constructor(field: FieldAffectingData, fieldName: string) {
     super(`Field ${field.label} has reserved name '${fieldName}'.`)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'ReservedFieldName'
+    Object.defineProperty(this.constructor, 'name', { value: 'ReservedFieldName' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, ReservedFieldName.prototype)
   }
 }

--- a/packages/payload/src/errors/ReservedFieldName.ts
+++ b/packages/payload/src/errors/ReservedFieldName.ts
@@ -8,7 +8,6 @@ export class ReservedFieldName extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'ReservedFieldName'
-    Object.defineProperty(this.constructor, 'name', { value: 'ReservedFieldName' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, ReservedFieldName.prototype)
   }

--- a/packages/payload/src/errors/TimestampsRequired.ts
+++ b/packages/payload/src/errors/TimestampsRequired.ts
@@ -7,5 +7,11 @@ export class TimestampsRequired extends APIError {
     super(
       `Timestamps are required in the collection ${collection.slug} because you have opted in to Versions.`,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'TimestampsRequired'
+    Object.defineProperty(this.constructor, 'name', { value: 'TimestampsRequired' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, TimestampsRequired.prototype)
   }
 }

--- a/packages/payload/src/errors/TimestampsRequired.ts
+++ b/packages/payload/src/errors/TimestampsRequired.ts
@@ -10,7 +10,6 @@ export class TimestampsRequired extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'TimestampsRequired'
-    Object.defineProperty(this.constructor, 'name', { value: 'TimestampsRequired' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, TimestampsRequired.prototype)
   }

--- a/packages/payload/src/errors/UnauthorizedError.ts
+++ b/packages/payload/src/errors/UnauthorizedError.ts
@@ -8,5 +8,11 @@ import { APIError } from './APIError.js'
 export class UnauthorizedError extends APIError {
   constructor(t?: TFunction) {
     super(t ? t('error:unauthorized') : en.translations.error.unauthorized, httpStatus.UNAUTHORIZED)
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'UnauthorizedError'
+    Object.defineProperty(this.constructor, 'name', { value: 'UnauthorizedError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, UnauthorizedError.prototype)
   }
 }

--- a/packages/payload/src/errors/UnauthorizedError.ts
+++ b/packages/payload/src/errors/UnauthorizedError.ts
@@ -11,7 +11,6 @@ export class UnauthorizedError extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'UnauthorizedError'
-    Object.defineProperty(this.constructor, 'name', { value: 'UnauthorizedError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, UnauthorizedError.prototype)
   }

--- a/packages/payload/src/errors/UnverifiedEmail.ts
+++ b/packages/payload/src/errors/UnverifiedEmail.ts
@@ -11,5 +11,11 @@ export class UnverifiedEmail extends APIError {
       t ? t('error:unverifiedEmail') : en.translations.error.unverifiedEmail,
       httpStatus.FORBIDDEN,
     )
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'UnverifiedEmail'
+    Object.defineProperty(this.constructor, 'name', { value: 'UnverifiedEmail' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, UnverifiedEmail.prototype)
   }
 }

--- a/packages/payload/src/errors/UnverifiedEmail.ts
+++ b/packages/payload/src/errors/UnverifiedEmail.ts
@@ -14,7 +14,6 @@ export class UnverifiedEmail extends APIError {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'UnverifiedEmail'
-    Object.defineProperty(this.constructor, 'name', { value: 'UnverifiedEmail' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, UnverifiedEmail.prototype)
   }

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -80,7 +80,6 @@ export class ValidationError extends APIError<{
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'ValidationError'
-    Object.defineProperty(this.constructor, 'name', { value: 'ValidationError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, ValidationError.prototype)
   }

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -8,8 +8,10 @@ import type { PayloadRequest } from '../types/index.js'
 
 import { APIError } from './APIError.js'
 
-// This gets dynamically reassigned during compilation
-export let ValidationErrorName = 'ValidationError'
+/**
+ * @deprecated Remove this in 4.0 - this is no longer needed as we assign the prototype correctly in the constructor
+ */
+export const ValidationErrorName = 'ValidationError'
 
 export type ValidationFieldError = {
   label?: LabelFunction | StaticLabel
@@ -76,6 +78,10 @@ export class ValidationError extends APIError<{
       results,
     )
 
-    ValidationErrorName = this.constructor.name
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'ValidationError'
+    Object.defineProperty(this.constructor, 'name', { value: 'ValidationError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, ValidationError.prototype)
   }
 }

--- a/packages/payload/src/queues/errors/index.ts
+++ b/packages/payload/src/queues/errors/index.ts
@@ -28,6 +28,12 @@ export class TaskError extends Error {
   constructor(args: TaskErrorArgs) {
     super(args.message)
     this.args = args
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'TaskError'
+    Object.defineProperty(this.constructor, 'name', { value: 'TaskError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, TaskError.prototype)
   }
 }
 export class WorkflowError extends Error {
@@ -36,6 +42,12 @@ export class WorkflowError extends Error {
   constructor(args: WorkflowErrorArgs) {
     super(args.message)
     this.args = args
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'WorkflowError'
+    Object.defineProperty(this.constructor, 'name', { value: 'WorkflowError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, WorkflowError.prototype)
   }
 }
 
@@ -47,5 +59,11 @@ export class JobCancelledError extends Error {
   constructor(args: { job: Job }) {
     super(`Job ${args.job.id} was cancelled`)
     this.args = args
+
+    // Ensure error name is not lost during swc minification when running next build
+    this.name = 'JobCancelledError'
+    Object.defineProperty(this.constructor, 'name', { value: 'JobCancelledError' })
+    // Ensure instanceof works correctly
+    Object.setPrototypeOf(this, JobCancelledError.prototype)
   }
 }

--- a/packages/payload/src/queues/errors/index.ts
+++ b/packages/payload/src/queues/errors/index.ts
@@ -31,7 +31,6 @@ export class TaskError extends Error {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'TaskError'
-    Object.defineProperty(this.constructor, 'name', { value: 'TaskError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, TaskError.prototype)
   }
@@ -45,7 +44,6 @@ export class WorkflowError extends Error {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'WorkflowError'
-    Object.defineProperty(this.constructor, 'name', { value: 'WorkflowError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, WorkflowError.prototype)
   }
@@ -62,7 +60,6 @@ export class JobCancelledError extends Error {
 
     // Ensure error name is not lost during swc minification when running next build
     this.name = 'JobCancelledError'
-    Object.defineProperty(this.constructor, 'name', { value: 'JobCancelledError' })
     // Ensure instanceof works correctly
     Object.setPrototypeOf(this, JobCancelledError.prototype)
   }

--- a/packages/payload/src/utilities/formatErrors.ts
+++ b/packages/payload/src/utilities/formatErrors.ts
@@ -19,7 +19,13 @@ export const formatErrors = (incoming: unknown): ErrorResult => {
     }
 
     // Mongoose 'ValidationError': https://mongoosejs.com/docs/api/error.html#Error.ValidationError
-    if (!(incoming instanceof APIError || incoming instanceof Error) && incoming.errors) {
+    if (
+      typeof incoming === 'object' &&
+      incoming !== null &&
+      !(incoming instanceof APIError || incoming instanceof Error) &&
+      'errors' in incoming &&
+      incoming.errors
+    ) {
       return {
         errors: Object.keys(incoming.errors).reduce(
           (acc, key) => {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13645

Previously, error names were minified after running Next.js build. This is fixed by defining the `name` property on the error class and constructor.

Previous:

```ts
[21:44:07] ERROR: Error running onInit function
    err: {
      "type": "h",  // <= This is fixed by explicitly setting this.constructor.name, NOT this.name
      "message": "The following fields are invalid: ",
      "stack":
          h: The following fields are invalid:  // <= This is fixed by explicitly setting this.name
              at onInit (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/5332.js:1:4432)
              at c.onInit (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:48:182751)
              at c.onInit (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:97:72894)
              at bE.init (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:363:9073)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async bH (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:363:10682)
              at async l (/Users/alessio/Documents/GitHub/payload-demo/.next/server/app/(payload)/api/graphql-playground/route.js:1:32832)
              at async o (/Users/alessio/Documents/GitHub/payload-demo/.next/server/app/(payload)/api/[...slug]/route.js:1:14549)
              at async /Users/alessio/Documents/GitHub/payload-demo/.next/server/app/(payload)/api/[...slug]/route.js:1:18461
              at async rb.do (/Users/alessio/Documents/GitHub/payload-demo/node_modules/.pnpm/next@15.4.5_@opentelemetry+api@1.9.0_react-dom@19.1.1_react@19.1.1__react@19.1.1_sass@1.77.4/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:5:21059)
      "data": {
        "errors": []
      },
      "isOperational": true,
      "isPublic": false,
      "status": 400,
      "name": "h" // <= This is fixed by explicitly setting this.name
    }
```

Now:

```ts
[21:53:27] ERROR: Error running onInit function
    err: {
      "type": "h",
      "message": "The following fields are invalid: ",
      "stack":
          ValidationError: The following fields are invalid: 
              at onInit (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/5332.js:1:4432)
              at c.onInit (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:48:182751)
              at c.onInit (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:97:72894)
              at bE.init (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:363:9073)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async bH (/Users/alessio/Documents/GitHub/payload-demo/.next/server/chunks/8891.js:363:10682)
              at async l (/Users/alessio/Documents/GitHub/payload-demo/.next/server/app/(payload)/api/[...slug]/route.js:1:11401)
              at async o (/Users/alessio/Documents/GitHub/payload-demo/.next/server/app/(payload)/api/[...slug]/route.js:1:14549)
              at async /Users/alessio/Documents/GitHub/payload-demo/.next/server/app/(payload)/api/[...slug]/route.js:1:18461
              at async rb.do (/Users/alessio/Documents/GitHub/payload-demo/node_modules/.pnpm/next@15.4.5_@opentelemetry+api@1.9.0_react-dom@19.1.1_react@19.1.1__react@19.1.1_sass@1.77.4/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:5:21059)
      "data": {
        "errors": []
      },
      "isOperational": true,
      "isPublic": false,
      "status": 400,
      "name": "ValidationError"
    }
```

If we wanted to fix `err.type` too, we'd have to override constructor.name; however that property is read-only. See [relevant pino code](https://github.com/pinojs/pino/blob/14d6da548afe0212736330ba2326b3c1c0f908d2/browser.js#L453). We can address this in a separate PR using a custom error serializer.

Additionally, this adds explicitly sets the prototype of error classes which should fix `instanceof` support. This approach is documented [here](https://github.com/microsoft/TypeScript-wiki/blob/94fb0618c7185f86afec26e6b4d2d6eb7c049e47/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work).

[This](https://github.com/payloadcms/payload/commit/2cd534526f8569c8ab52861a5d2ff5792dbb0b24) is how formatErrors worked previously.


TODO: @jacobsfletch [mentioned that this instanceof fix does not work](https://github.com/payloadcms/payload/pull/5482). Need to test if this is still the case.