### PR TITLE
fix(drizzle): string defaults in numeric fields

### DIFF
--- a/packages/drizzle/src/postgres/columnToCodeConverter.ts
+++ b/packages/drizzle/src/postgres/columnToCodeConverter.ts
@@ -82,8 +82,14 @@ export const columnToCodeConverter: ColumnToCodeConverter = ({
       sanitizedDefault = `sql\`${column.default}\``
     } else if (column.type === 'jsonb') {
       sanitizedDefault = `sql\`'${JSON.stringify(column.default)}'::jsonb\``
-    } else if (column.type === 'numeric') {
-      sanitizedDefault = `${column.default}`
+    } else if (column.type === 'numeric' || column.type === 'integer' || column.type === 'serial') {
+      const numericValue =
+        typeof column.default === 'string' ? Number(column.default) : column.default
+      sanitizedDefault = `${numericValue}`
+    } else if (column.type === 'boolean') {
+      const booleanValue =
+        typeof column.default === 'string' ? column.default === 'true' : column.default
+      sanitizedDefault = `${booleanValue}`
     } else if (typeof column.default === 'string') {
       sanitizedDefault = `${JSON.stringify(column.default)}`
     }

--- a/packages/drizzle/src/sqlite/columnToCodeConverter.ts
+++ b/packages/drizzle/src/sqlite/columnToCodeConverter.ts
@@ -112,10 +112,16 @@ export const columnToCodeConverter: ColumnToCodeConverter = ({
 
     if (column.type === 'jsonb' || column.type === 'geometry') {
       sanitizedDefault = `'${JSON.stringify(column.default)}'`
+    } else if (column.type === 'numeric' || column.type === 'integer' || column.type === 'serial') {
+      const numericValue =
+        typeof column.default === 'string' ? Number(column.default) : column.default
+      sanitizedDefault = `${numericValue}`
+    } else if (column.type === 'boolean') {
+      const booleanValue =
+        typeof column.default === 'string' ? column.default === 'true' : column.default
+      sanitizedDefault = `${booleanValue ? 1 : 0}`
     } else if (typeof column.default === 'string') {
       sanitizedDefault = JSON.stringify(column.default)
-    } else if (column.type === 'numeric') {
-      sanitizedDefault = `${column.default}`
     }
 
     code = `${code}.default(${sanitizedDefault})`


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

This PR fixes an issue in the drizzle schema generation where numeric fields in Postgres/SQLite databases could have string default values. This would cause type errors, even in blank templates after running "pnpx payload generate:db-schema".

Improved type checking within the generation of the default statements, we now properly convert output numeric default values. 

Example of a generated drizzle schema before and after the fixes:
```js
// Before
{ loginAttempts: numeric('login_attempts', { mode: 'number' }).default('0'), }

// After
{ loginAttempts: numeric('login_attempts', { mode: 'number' }).default(0), }
```

