### PR TITLE
feat(ui): add System Info page to settings menu

### DIFF
--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -277,7 +277,7 @@ The following options are available:
 
 ### System Info Page
 
-The System Info page displays important technical information about your Payload installation and runtime environment. This page is accessible from the settings menu (gear icon) in the top-right corner of the Admin Panel.
+The System Info page displays important technical information about your Payload installation and runtime environment. This page is accessible from the settings menu (gear icon) in the bottom left corner of the navigation, above the logout button.
 
 The following information is displayed on the System Info page:
 

--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -257,22 +257,64 @@ const config = buildConfig({
 
 The following options are available:
 
-| Option            | Default route        | Description                               |
-| ----------------- | -------------------- | ----------------------------------------- |
-| `account`         | `/account`           | The user's account page.                  |
-| `createFirstUser` | `/create-first-user` | The page to create the first user.        |
-| `forgot`          | `/forgot`            | The password reset page.                  |
-| `inactivity`      | `/logout-inactivity` | The page to redirect to after inactivity. |
-| `login`           | `/login`             | The login page.                           |
-| `logout`          | `/logout`            | The logout page.                          |
-| `reset`           | `/reset`             | The password reset page.                  |
-| `unauthorized`    | `/unauthorized`      | The unauthorized page.                    |
+| Option            | Default route        | Description                                                                               |
+| ----------------- | -------------------- | ----------------------------------------------------------------------------------------- |
+| `account`         | `/account`           | The user's account page.                                                                  |
+| `createFirstUser` | `/create-first-user` | The page to create the first user.                                                        |
+| `forgot`          | `/forgot`            | The password reset page.                                                                  |
+| `inactivity`      | `/logout-inactivity` | The page to redirect to after inactivity.                                                 |
+| `login`           | `/login`             | The login page.                                                                           |
+| `logout`          | `/logout`            | The logout page.                                                                          |
+| `reset`           | `/reset`             | The password reset page.                                                                  |
+| `systemInfo`      | `/system-info`       | The system information page. Set to `false` to disable. [More details](#system-info-page) |
+| `unauthorized`    | `/unauthorized`      | The unauthorized page.                                                                    |
 
 <Banner type="success">
   **Note:** You can also swap out entire _views_ out for your own, using the
   `admin.views` property of the Payload Config. See [Custom
   Views](../custom-components/custom-views) for more information.
 </Banner>
+
+### System Info Page
+
+The System Info page displays important technical information about your Payload installation and runtime environment. This page is accessible from the settings menu (gear icon) in the top-right corner of the Admin Panel.
+
+The following information is displayed on the System Info page:
+
+**Version Information:**
+
+- Payload version
+- Next.js version
+- Node.js version
+
+**Configuration:**
+
+- Environment (NODE_ENV)
+- Server URL
+- Database Adapter (MongoDB, PostgreSQL, SQLite, or Cloudflare D1 SQLite)
+
+**Current Session:**
+
+- Logged-in user information
+
+#### Disabling the System Info Page
+
+If you want to disable the System Info page entirely, you can set `admin.routes.systemInfo` to `false`:
+
+```ts
+import { buildConfig } from 'payload'
+
+const config = buildConfig({
+  // ...
+  admin: {
+    routes: {
+      systemInfo: false, // highlight-line
+    },
+  },
+})
+```
+
+When disabled, the System Info page will not be accessible and will not appear in the settings menu.
 
 ## I18n
 
@@ -312,19 +354,19 @@ const config = buildConfig({
     timezones: {
       supportedTimezones: [
         {
-          label: "Europe/Dublin",
-          value: "Europe/Dublin",
+          label: 'Europe/Dublin',
+          value: 'Europe/Dublin',
         },
         {
-          label: "Europe/Amsterdam",
-          value: "Europe/Amsterdam",
+          label: 'Europe/Amsterdam',
+          value: 'Europe/Amsterdam',
         },
         {
-          label: "Europe/Bucharest",
-          value: "Europe/Bucharest",
+          label: 'Europe/Bucharest',
+          value: 'Europe/Bucharest',
         },
       ],
-      defaultTimezone: "Europe/Amsterdam",
+      defaultTimezone: 'Europe/Amsterdam',
     },
   },
 })

--- a/packages/next/src/elements/Nav/SettingsMenuButton/DefaultSystemInfoItem.tsx
+++ b/packages/next/src/elements/Nav/SettingsMenuButton/DefaultSystemInfoItem.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { PopupList, useConfig } from '@payloadcms/ui'
+import React from 'react'
+
+export const DefaultSystemInfoItem: React.FC = () => {
+  const {
+    config: {
+      admin: {
+        routes: { systemInfo },
+      },
+      routes: { admin: adminRoute },
+    },
+  } = useConfig()
+
+  return (
+    <PopupList.ButtonGroup>
+      <PopupList.Button href={`${adminRoute}${systemInfo}`}>System Info</PopupList.Button>
+    </PopupList.ButtonGroup>
+  )
+}

--- a/packages/next/src/elements/Nav/SettingsMenuButton/SettingsDivider.tsx
+++ b/packages/next/src/elements/Nav/SettingsMenuButton/SettingsDivider.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { PopupList } from '@payloadcms/ui'
+import React from 'react'
+
+export const SettingsDivider: React.FC = () => {
+  return <PopupList.Divider />
+}

--- a/packages/next/src/elements/Nav/index.tsx
+++ b/packages/next/src/elements/Nav/index.tsx
@@ -8,7 +8,9 @@ import React from 'react'
 
 import { NavHamburger } from './NavHamburger/index.js'
 import { NavWrapper } from './NavWrapper/index.js'
+import { DefaultSystemInfoItem } from './SettingsMenuButton/DefaultSystemInfoItem.js'
 import { SettingsMenuButton } from './SettingsMenuButton/index.js'
+import { SettingsDivider } from './SettingsMenuButton/SettingsDivider.js'
 import './index.scss'
 
 const baseClass = 'nav'
@@ -93,7 +95,13 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
     },
   })
 
-  const renderedSettingsMenu =
+  // Include the default System Info menu item only if not disabled
+  const defaultSystemInfoItem =
+    payload.config.admin.routes.systemInfo !== false ? (
+      <DefaultSystemInfoItem key="default-system-info-item" />
+    ) : null
+
+  const customSettingsMenuItems =
     settingsMenu && Array.isArray(settingsMenu)
       ? settingsMenu.map((item, index) =>
           RenderServerComponent({
@@ -116,6 +124,18 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
           }),
         )
       : []
+
+  // Reorganize settings menu: user-defined items first, then divider (if custom items exist), then System Info
+  const settingsDivider =
+    customSettingsMenuItems.length > 0 && defaultSystemInfoItem ? (
+      <SettingsDivider key="settings-divider" />
+    ) : null
+
+  const renderedSettingsMenu = [
+    ...customSettingsMenuItems,
+    settingsDivider,
+    defaultSystemInfoItem,
+  ].filter(Boolean)
 
   return (
     <NavWrapper baseClass={baseClass}>

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -28,6 +28,7 @@ import { ListView } from '../List/index.js'
 import { loginBaseClass, LoginView } from '../Login/index.js'
 import { LogoutInactivity, LogoutView } from '../Logout/index.js'
 import { ResetPassword, resetPasswordBaseClass } from '../ResetPassword/index.js'
+import { SystemInfoView } from '../SystemInfo/index.js'
 import { UnauthorizedView } from '../Unauthorized/index.js'
 import { Verify, verifyBaseClass } from '../Verify/index.js'
 import { getSubViewActions, getViewActions } from './attachViewActions.js'
@@ -42,6 +43,7 @@ const baseClasses = {
   forgot: forgotPasswordBaseClass,
   login: loginBaseClass,
   reset: resetPasswordBaseClass,
+  systemInfo: 'system-info',
   verify: verifyBaseClass,
 }
 
@@ -62,6 +64,7 @@ const oneSegmentViews: OneSegmentViews = {
   inactivity: LogoutInactivity,
   login: LoginView,
   logout: LogoutView,
+  systemInfo: SystemInfoView,
   unauthorized: UnauthorizedView,
 }
 
@@ -157,6 +160,10 @@ export const getRouteData = ({
 
       if (config.admin.routes) {
         const matchedRoute = Object.entries(config.admin.routes).find(([, route]) => {
+          // Skip routes that are explicitly disabled (set to false)
+          if (route === false) {
+            return false
+          }
           return isPathMatchingRoute({
             currentRoute,
             exact: true,
@@ -205,6 +212,12 @@ export const getRouteData = ({
         // --> /logout-inactivity
         // --> /unauthorized
 
+        // Check if the System Info page is explicitly disabled
+        if (viewKey === 'systemInfo' && config.admin.routes.systemInfo === false) {
+          // System Info page is disabled, don't render it
+          break
+        }
+
         ViewToRender = {
           Component: oneSegmentViews[viewKey],
         }
@@ -214,7 +227,7 @@ export const getRouteData = ({
         templateClassName = baseClasses[viewKey]
         templateType = 'minimal'
 
-        if (viewKey === 'account') {
+        if (viewKey === 'systemInfo' || viewKey === 'account') {
           templateType = 'default'
         }
 

--- a/packages/next/src/views/SystemInfo/index.client.tsx
+++ b/packages/next/src/views/SystemInfo/index.client.tsx
@@ -1,0 +1,89 @@
+'use client'
+import { Gutter, useStepNav } from '@payloadcms/ui'
+import React, { useEffect } from 'react'
+
+import type { SystemInfoViewProps } from './index.js'
+
+import './index.scss'
+
+const baseClass = 'system-info-view'
+
+export const SystemInfoClient: React.FC<SystemInfoViewProps> = (props) => {
+  const {
+    databaseAdapter,
+    nextVersion,
+    nodeEnv,
+    nodeVersion,
+    payloadVersion,
+    serverURL,
+    userName,
+  } = props
+
+  const { setStepNav } = useStepNav()
+
+  useEffect(() => {
+    setStepNav([
+      {
+        label: 'System Info',
+      },
+    ])
+  }, [setStepNav])
+
+  return (
+    <div className={baseClass}>
+      <Gutter className={`${baseClass}__wrap`}>
+        <div className={`${baseClass}__content`}>
+          <h1>System Info</h1>
+
+          <section className={`${baseClass}__section`}>
+            <h2>Version Information</h2>
+            <dl className={`${baseClass}__info-list`}>
+              <div className={`${baseClass}__info-item`}>
+                <dt>Payload Version</dt>
+                <dd>{payloadVersion}</dd>
+              </div>
+              <div className={`${baseClass}__info-item`}>
+                <dt>Next.js Version</dt>
+                <dd>{nextVersion}</dd>
+              </div>
+              <div className={`${baseClass}__info-item`}>
+                <dt>Node.js Version</dt>
+                <dd>{nodeVersion}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className={`${baseClass}__section`}>
+            <h2>Configuration</h2>
+            <dl className={`${baseClass}__info-list`}>
+              <div className={`${baseClass}__info-item`}>
+                <dt>Environment (NODE_ENV)</dt>
+                <dd>{nodeEnv}</dd>
+              </div>
+              <div className={`${baseClass}__info-item`}>
+                <dt>Server URL</dt>
+                <dd>{serverURL}</dd>
+              </div>
+              <div className={`${baseClass}__info-item`}>
+                <dt>Database Adapter</dt>
+                <dd>{databaseAdapter}</dd>
+              </div>
+            </dl>
+          </section>
+
+          {userName && (
+            <section className={`${baseClass}__section`}>
+              <h2>Current Session</h2>
+              <dl className={`${baseClass}__info-list`}>
+                <div className={`${baseClass}__info-item`}>
+                  <dt>Logged in as</dt>
+                  <dd>{userName}</dd>
+                </div>
+              </dl>
+            </section>
+          )}
+        </div>
+      </Gutter>
+    </div>
+  )
+}

--- a/packages/next/src/views/SystemInfo/index.scss
+++ b/packages/next/src/views/SystemInfo/index.scss
@@ -1,0 +1,74 @@
+@import '~@payloadcms/ui/scss';
+
+@layer payload-default {
+  .system-info-view {
+    &__wrap {
+      padding-block: var(--gutter-v);
+    }
+
+    &__content {
+      max-width: 800px;
+
+      h1 {
+        margin-bottom: var(--base);
+      }
+    }
+
+    &__section {
+      margin-top: var(--base);
+      padding-top: var(--base);
+      border-top: 1px solid var(--theme-elevation-150);
+
+      &:first-child {
+        margin-top: 0;
+        padding-top: 0;
+        border-top: none;
+      }
+
+      h2 {
+        font-size: 1.25rem;
+        margin-bottom: calc(var(--base) / 2);
+        font-weight: 600;
+      }
+    }
+
+    &__info-list {
+      display: grid;
+      gap: calc(var(--base) / 2);
+      margin: 0;
+    }
+
+    &__info-item {
+      display: grid;
+      grid-template-columns: 200px 1fr;
+      gap: var(--base);
+      padding: calc(var(--base) / 4) 0;
+
+      dt {
+        font-weight: 600;
+        color: var(--theme-text);
+      }
+
+      dd {
+        margin: 0;
+        color: var(--theme-elevation-800);
+        word-break: break-word;
+      }
+    }
+
+    &__plugin-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: calc(var(--base) / 4);
+    }
+
+    &__plugin-item {
+      padding: calc(var(--base) / 4) calc(var(--base) / 2);
+      background-color: var(--theme-elevation-50);
+      border-radius: 4px;
+      color: var(--theme-elevation-800);
+    }
+  }
+}

--- a/packages/next/src/views/SystemInfo/index.tsx
+++ b/packages/next/src/views/SystemInfo/index.tsx
@@ -1,0 +1,69 @@
+import type { AdminViewServerProps } from 'payload'
+
+import React from 'react'
+
+import { SystemInfoClient } from './index.client.js'
+
+// Import Next.js version
+let nextVersion = 'unknown'
+try {
+  const nextPackage = await import('next/package.json')
+  nextVersion = nextPackage.default.version
+} catch {
+  // Next.js version not available
+}
+
+// Import Payload version
+let payloadVersion = 'unknown'
+try {
+  const payloadPackage = await import('payload/package.json')
+  payloadVersion = payloadPackage.default.version
+} catch {
+  // Payload version not available
+}
+
+export interface SystemInfoViewProps {
+  databaseAdapter: string
+  nextVersion: string
+  nodeEnv: string
+  nodeVersion: string
+  payloadVersion: string
+  serverURL: string
+  userName: string | undefined
+}
+
+// Map internal adapter names to user-friendly display names
+const databaseAdapterDisplayNames: Record<string, string> = {
+  'd1-sqlite': 'Cloudflare D1 SQLite',
+  mongoose: 'MongoDB',
+  postgres: 'PostgreSQL',
+  sqlite: 'SQLite',
+}
+
+export function SystemInfoView({ initPageResult }: AdminViewServerProps) {
+  const {
+    req: {
+      payload: { config },
+      user,
+    },
+  } = initPageResult
+
+  // Get database adapter name and map to display name
+  const adapterName = config.db?.name || 'unknown'
+  const databaseAdapter = databaseAdapterDisplayNames[adapterName] || adapterName
+
+  // Strip 'v' prefix from Node.js version for consistency
+  const nodeVersion = process.version.startsWith('v') ? process.version.slice(1) : process.version
+
+  const systemInfoData: SystemInfoViewProps = {
+    databaseAdapter,
+    nextVersion,
+    nodeEnv: process.env.NODE_ENV || 'unknown',
+    nodeVersion,
+    payloadVersion,
+    serverURL: config.serverURL || 'Not configured',
+    userName: user?.email || user?.id?.toString(),
+  }
+
+  return <SystemInfoClient {...systemInfoData} />
+}

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -59,7 +59,8 @@
       "import": "./src/exports/i18n/*.ts",
       "types": "./src/exports/i18n/*.ts",
       "default": "./src/exports/i18n/*.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/payload/src/admin/views/index.ts
+++ b/packages/payload/src/admin/views/index.ts
@@ -97,6 +97,7 @@ export type ViewTypes =
   | 'folders'
   | 'list'
   | 'reset'
+  | 'systemInfo'
   | 'trash'
   | 'verify'
   | 'version'

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -107,6 +107,7 @@ export const addDefaultsToConfig = (config: Config): Config => {
       login: '/login',
       logout: '/logout',
       reset: '/reset',
+      systemInfo: '/system-info',
       unauthorized: '/unauthorized',
       ...(config?.admin?.routes || {}),
     },

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -942,6 +942,11 @@ export type Config = {
        * @default '/reset'
        */
       reset?: `/${string}`
+      /** The route for the System Info page. Set to false to disable the System Info page.
+       *
+       * @default '/system-info'
+       */
+      systemInfo?: `/${string}` | false
       /** The route for the unauthorized page.
        *
        * @default '/unauthorized'

--- a/packages/ui/src/icons/Gear/index.scss
+++ b/packages/ui/src/icons/Gear/index.scss
@@ -9,7 +9,7 @@
 
     path {
       stroke: currentColor;
-      stroke-width: 1px;
+      stroke-width: 2px;
     }
   }
 }


### PR DESCRIPTION
## What?

Add a new System Info page accessible from the settings menu displaying technical information about the Payload installation and runtime environment.

## Why?

Administrators and developers need easy access at runtime to important system information about their Payload installation for debugging, troubleshooting, and support purposes. This information is currently not readily available in the Admin Panel, requiring developers to check package.json files and configuration manually.

## How?

- Created new System Info view at `/system-info` displaying:
  - Version information (Payload, Next.js, Node.js) - dynamically loaded from package.json files
  - Configuration (Environment/NODE_ENV, Server URL, Database Adapter)
  - Current session information (logged-in user)
- Reorganized settings menu to show user-defined items first, followed by a separator, then System Info
- Added `admin.routes.systemInfo` config option (set to `false` to disable the page)
- Mapped internal database adapter names to user-friendly display names (e.g., `mongoose` → "MongoDB", `postgres` → "PostgreSQL")
- Fixed gear icon stroke-width from 1px to 2px to match logout icon consistency
- Added comprehensive documentation to `docs/admin/overview.mdx`
- Can be extended with more relevant information later

### Screenshots

<img width="924" height="755" alt="system-info" src="https://github.com/user-attachments/assets/6ce140d5-51b1-488d-be4e-9f9d1602f157" />

### Related

N/A - New feature implementation