### PR TITLE
fix(richtext-lexical): do not run json.parse if value is undefined or null

### DIFF
--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -147,7 +147,12 @@ const RichTextComponent: React.FC<
       // If we used JSON.stringify, the editor would re-mount every time you save the document, as the order of keys changes => change detected => re-mount.
       if (
         prevValueRef.current !== value &&
-        !dequal(JSON.parse(JSON.stringify(prevValueRef.current)), value)
+        !dequal(
+          prevValueRef.current != null
+            ? JSON.parse(JSON.stringify(prevValueRef.current))
+            : prevValueRef.current,
+          value,
+        )
       ) {
         prevInitialValueRef.current = initialValue
         prevValueRef.current = value


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14372

This prevents running `JSON.parse(JSON.stringify` against `undefined` or `null` values (`!= null` checks both `null` and `undefined`)