### PR TITLE
fix: custom dashboard component causes runtime error on create-first-user and account views

### DIFF
--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -137,7 +137,7 @@ export const getRouteData = ({
     []
 
   const viewActions: CustomComponent[] = [...(config?.admin?.components?.actions || [])]
-  console.log('getRouteData segments', { adminRoute, currentRoute, segments })
+
   switch (segments.length) {
     case 0: {
       if (currentRoute === adminRoute) {
@@ -155,9 +155,6 @@ export const getRouteData = ({
       // i.e.{ admin: { routes: { logout: '/sign-out', inactivity: '/idle' }}}
       let viewKey: keyof typeof oneSegmentViews
 
-      console.log('admin.routes', config.admin.routes, {
-        entries: Object.entries(config.admin.routes),
-      })
       if (config.admin.routes) {
         const matchedRoute = Object.entries(config.admin.routes).find(([, route]) => {
           const path = formatAdminURL({ adminRoute, path: route })
@@ -173,22 +170,16 @@ export const getRouteData = ({
           })
         })
 
-        console.log({ matchedRoute })
-
         if (matchedRoute) {
           viewKey = matchedRoute[0] as keyof typeof oneSegmentViews
         }
       }
-
-      console.log({ viewKey })
 
       // Check if a custom view is configured for this viewKey
       // First try to get custom view by the known viewKey, then fallback to route matching
       const customView =
         (viewKey && getCustomViewByKey({ config, viewKey })) ||
         getCustomViewByRoute({ config, currentRoute })
-
-      console.log({ customView })
 
       if (customView?.view?.payloadComponent || customView?.view?.Component) {
         // User has configured a custom view (either overriding a built-in or a new custom view)

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -137,7 +137,7 @@ export const getRouteData = ({
     []
 
   const viewActions: CustomComponent[] = [...(config?.admin?.components?.actions || [])]
-
+  console.log('getRouteData segments', { adminRoute, currentRoute, segments })
   switch (segments.length) {
     case 0: {
       if (currentRoute === adminRoute) {
@@ -155,6 +155,9 @@ export const getRouteData = ({
       // i.e.{ admin: { routes: { logout: '/sign-out', inactivity: '/idle' }}}
       let viewKey: keyof typeof oneSegmentViews
 
+      console.log('admin.routes', config.admin.routes, {
+        entries: Object.entries(config.admin.routes),
+      })
       if (config.admin.routes) {
         const matchedRoute = Object.entries(config.admin.routes).find(([, route]) => {
           return isPathMatchingRoute({

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -157,16 +157,10 @@ export const getRouteData = ({
 
       if (config.admin.routes) {
         const matchedRoute = Object.entries(config.admin.routes).find(([, route]) => {
-          const path = formatAdminURL({ adminRoute, path: route })
-
-          if (!path) {
-            return false
-          }
-
           return isPathMatchingRoute({
             currentRoute,
             exact: true,
-            path,
+            path: formatAdminURL({ adminRoute, path: route }),
           })
         })
 

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -160,23 +160,35 @@ export const getRouteData = ({
       })
       if (config.admin.routes) {
         const matchedRoute = Object.entries(config.admin.routes).find(([, route]) => {
+          const path = formatAdminURL({ adminRoute, path: route })
+
+          if (!path) {
+            return false
+          }
+
           return isPathMatchingRoute({
             currentRoute,
             exact: true,
-            path: formatAdminURL({ adminRoute, path: route }),
+            path,
           })
         })
+
+        console.log({ matchedRoute })
 
         if (matchedRoute) {
           viewKey = matchedRoute[0] as keyof typeof oneSegmentViews
         }
       }
 
+      console.log({ viewKey })
+
       // Check if a custom view is configured for this viewKey
       // First try to get custom view by the known viewKey, then fallback to route matching
       const customView =
         (viewKey && getCustomViewByKey({ config, viewKey })) ||
         getCustomViewByRoute({ config, currentRoute })
+
+      console.log({ customView })
 
       if (customView?.view?.payloadComponent || customView?.view?.Component) {
         // User has configured a custom view (either overriding a built-in or a new custom view)

--- a/packages/next/src/views/Root/isPathMatchingRoute.ts
+++ b/packages/next/src/views/Root/isPathMatchingRoute.ts
@@ -14,7 +14,7 @@ export const isPathMatchingRoute = ({
   strict?: boolean
 }) => {
   const keys = []
-
+  console.log('isPathMatchingRoute', { keys, viewPath })
   // run the view path through `pathToRegexp` to resolve any dynamic segments
   // i.e. `/admin/custom-view/:id` -> `/admin/custom-view/123`
   const regex = pathToRegexp(viewPath, keys, {

--- a/packages/next/src/views/Root/isPathMatchingRoute.ts
+++ b/packages/next/src/views/Root/isPathMatchingRoute.ts
@@ -13,8 +13,13 @@ export const isPathMatchingRoute = ({
   sensitive?: boolean
   strict?: boolean
 }) => {
+  // if no path is defined, we cannot match it so return false early
+  if (!viewPath) {
+    return false
+  }
+
   const keys = []
-  console.log('isPathMatchingRoute', { keys, viewPath })
+
   // run the view path through `pathToRegexp` to resolve any dynamic segments
   // i.e. `/admin/custom-view/:id` -> `/admin/custom-view/123`
   const regex = pathToRegexp(viewPath, keys, {

--- a/test/auth-basic/Dashboard.tsx
+++ b/test/auth-basic/Dashboard.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+
+const MinimalDashboard = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Minimal Dashboard</h1>
+      <p>If you can see this, the dashboard component is loading correctly.</p>
+    </div>
+  )
+}
+
+export default MinimalDashboard

--- a/test/auth-basic/config.ts
+++ b/test/auth-basic/config.ts
@@ -5,12 +5,16 @@ const dirname = path.dirname(filename)
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 
-// eslint-disable-next-line no-restricted-exports
 export default buildConfigWithDefaults({
   admin: {
     autoLogin: false,
     importMap: {
       baseDir: path.resolve(dirname),
+    },
+    components: {
+      views: {
+        dashboard: { Component: './Dashboard.js' },
+      },
     },
   },
   typescript: {

--- a/test/auth-basic/payload-types.ts
+++ b/test/auth-basic/payload-types.ts
@@ -126,6 +126,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -194,6 +201,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14373

The basic auth test suite fails with a custom dashboard component without this fix.

The fix in particular isn't related to the dashboard view, instead this component has its type for `path` as optional, so then it causes this matching function to error.