### PR TITLE
refactor: deprecate job queue depth property

### DIFF
--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -127,6 +127,7 @@ export type JobsConfig = {
    * queries will be used.
    *
    * @default 0
+   * @deprecated - this will be removed in 4.0
    */
   depth?: number
   /**


### PR DESCRIPTION
Similar to how we deprecated the `runHooks` property in https://github.com/payloadcms/payload/pull/13617, this PR deprecates the `depth` property.

Just like `runHooks`, setting depth to 1 or higher will massively slow down the job system and make it less reliable. It's also adds a lot of unnecessary code we will need to maintain.

To further discourage using this property, this PR marks it as deprecated and for removal in 4.0.