### PR TITLE
feat: add access control for jobs queue and cancel operations

### DIFF
--- a/docs/jobs-queue/jobs.mdx
+++ b/docs/jobs-queue/jobs.mdx
@@ -47,6 +47,51 @@ const createdJob = await payload.jobs.queue({
 })
 ```
 
+#### Access Control
+
+By default, Payload's job operations bypass access control when used from the Local API. You can enable access control by passing `overrideAccess: false` to any job operation.
+
+To define custom access control for jobs, add an `access` property to your Jobs Config:
+
+```ts
+import type { SanitizedConfig } from 'payload'
+
+const config: SanitizedConfig = {
+  // ...
+  jobs: {
+    access: {
+      // Control who can queue new jobs
+      queue: ({ req }) => {
+        return req.user?.roles?.includes('admin')
+      },
+      // Control who can run jobs
+      run: ({ req }) => {
+        return req.user?.roles?.includes('admin')
+      },
+      // Control who can cancel jobs
+      cancel: ({ req }) => {
+        return req.user?.roles?.includes('admin')
+      },
+    },
+  },
+}
+```
+
+Each access control function receives the current `req` object and should return a boolean. If no access control is defined, the default behavior allows any authenticated user to perform the operation.
+
+To use access control in the Local API:
+
+```ts
+const req = await createLocalReq({ user }, payload)
+
+await payload.jobs.queue({
+  workflow: 'createPost',
+  input: { title: 'My Post' },
+  overrideAccess: false, // Enable access control
+  req, // Pass the request with user context
+})
+```
+
 #### Cancelling Jobs
 
 Payload allows you to cancel jobs that are either queued or currently running. When cancelling a running job, the current task will finish executing, but no subsequent tasks will run. This happens because the job checks its cancellation status between tasks.

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -57,6 +57,8 @@ export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
   i18n: {},
   jobs: {
     access: {
+      cancel: defaultAccess,
+      queue: defaultAccess,
       run: defaultAccess,
     },
     deleteJobOnComplete: true,
@@ -136,6 +138,8 @@ export const addDefaultsToConfig = (config: Config): Config => {
     depth: 0,
     ...(config.jobs || {}),
     access: {
+      cancel: defaultAccess,
+      queue: defaultAccess,
       run: defaultAccess,
       ...(config.jobs?.access || {}),
     },

--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -71,6 +71,16 @@ export type RunJobAccessArgs = {
 
 export type RunJobAccess = (args: RunJobAccessArgs) => boolean | Promise<boolean>
 
+export type QueueJobAccessArgs = {
+  req: PayloadRequest
+}
+
+export type CancelJobAccessArgs = {
+  req: PayloadRequest
+}
+export type CancelJobAccess = (args: CancelJobAccessArgs) => boolean | Promise<boolean>
+export type QueueJobAccess = (args: QueueJobAccessArgs) => boolean | Promise<boolean>
+
 export type SanitizedJobsConfig = {
   /**
    * If set to `true`, the job system is enabled and a payload-jobs collection exists.
@@ -94,7 +104,15 @@ export type JobsConfig = {
    */
   access?: {
     /**
-     * By default, all logged-in users can trigger jobs.
+     * By default, all logged-in users can cancel jobs.
+     */
+    cancel?: CancelJobAccess
+    /**
+     * By default, all logged-in users can queue jobs.
+     */
+    queue?: QueueJobAccess
+    /**
+     * By default, all logged-in users can run jobs.
      */
     run?: RunJobAccess
   }

--- a/packages/payload/src/queues/localAPI.ts
+++ b/packages/payload/src/queues/localAPI.ts
@@ -2,6 +2,8 @@ import type { BaseJob, RunningJobFromTask } from './config/types/workflowTypes.j
 
 import {
   createLocalReq,
+  executeAccess,
+  Forbidden,
   type Job,
   type Payload,
   type PayloadRequest,
@@ -56,9 +58,17 @@ export const getJobsLocalAPI = (payload: Payload) => ({
       | {
           input: TypedJobs['tasks'][TTaskOrWorkflowSlug]['input']
           meta?: BaseJob['meta']
+          /**
+           * If set to false, access control as defined in jobsConfig.access.queue will be run.
+           * By default, this is true and no access control will be run.
+           * If you set this to false and do not have jobsConfig.access.queue defined, the default access control will be
+           * run (which is a function that returns `true` if the user is logged in).
+           *
+           * @default true
+           */
+          overrideAccess?: boolean
           queue?: string
           req?: PayloadRequest
-          // TTaskOrWorkflowlug with keyof TypedJobs['workflows'] removed:
           task: TTaskOrWorkflowSlug extends keyof TypedJobs['tasks'] ? TTaskOrWorkflowSlug : never
           waitUntil?: Date
           workflow?: never
@@ -66,6 +76,15 @@ export const getJobsLocalAPI = (payload: Payload) => ({
       | {
           input: TypedJobs['workflows'][TTaskOrWorkflowSlug]['input']
           meta?: BaseJob['meta']
+          /**
+           * If set to false, access control as defined in jobsConfig.access.queue will be run.
+           * By default, this is true and no access control will be run.
+           * If you set this to false and do not have jobsConfig.access.queue defined, the default access control will be
+           * run (which is a function that returns `true` if the user is logged in).
+           *
+           * @default true
+           */
+          overrideAccess?: boolean
           queue?: string
           req?: PayloadRequest
           task?: never
@@ -118,20 +137,36 @@ export const getJobsLocalAPI = (payload: Payload) => ({
       ? Job<TTaskOrWorkflowSlug>
       : RunningJobFromTask<TTaskOrWorkflowSlug> // Type assertion is still needed here
 
+    const overrideAccess = args?.overrideAccess !== false
+
+    const req: PayloadRequest = args.req ?? (await createLocalReq({}, payload))
+
     if (payload?.config?.jobs?.depth || payload?.config?.jobs?.runHooks) {
       return (await payload.create({
         collection: jobsCollectionSlug,
         data,
         depth: payload.config.jobs.depth ?? 0,
-        req: args.req,
+        overrideAccess,
+        req,
       })) as ReturnType
     } else {
+      if (!overrideAccess) {
+        /**
+         * By default, jobsConfig.access.queue will be `defaultAccess` which is a function that returns `true` if the user is logged in.
+         */
+        const accessFn = payload.config.jobs?.access?.queue ?? (() => true)
+        const hasAccess = await accessFn({ req })
+        if (!hasAccess) {
+          throw new Forbidden(req.t)
+        }
+      }
+
       return jobAfterRead({
         config: payload.config,
         doc: await payload.db.create({
           collection: jobsCollectionSlug,
           data,
-          req: args.req,
+          req,
         }),
       }) as unknown as ReturnType
     }
@@ -151,6 +186,14 @@ export const getJobsLocalAPI = (payload: Payload) => ({
      * @default 10
      */
     limit?: number
+    /**
+     * If set to false, access control as defined in jobsConfig.access.run will be run.
+     * By default, this is true and no access control will be run.
+     * If you set this to false and do not have jobsConfig.access.run defined, the default access control will be
+     * run (which is a function that returns `true` if the user is logged in).
+     *
+     * @default true
+     */
     overrideAccess?: boolean
     /**
      * Adjust the job processing order using a Payload sort string.
@@ -198,6 +241,14 @@ export const getJobsLocalAPI = (payload: Payload) => ({
 
   runByID: async (args: {
     id: number | string
+    /**
+     * If set to false, access control as defined in jobsConfig.access.run will be run.
+     * By default, this is true and no access control will be run.
+     * If you set this to false and do not have jobsConfig.access.run defined, the default access control will be
+     * run (which is a function that returns `true` if the user is logged in).
+     *
+     * @default true
+     */
     overrideAccess?: boolean
     req?: PayloadRequest
     /**
@@ -221,12 +272,32 @@ export const getJobsLocalAPI = (payload: Payload) => ({
   },
 
   cancel: async (args: {
+    /**
+     * If set to false, access control as defined in jobsConfig.access.cancel will be run.
+     * By default, this is true and no access control will be run.
+     * If you set this to false and do not have jobsConfig.access.cancel defined, the default access control will be
+     * run (which is a function that returns `true` if the user is logged in).
+     *
+     * @default true
+     */
     overrideAccess?: boolean
     queue?: string
     req?: PayloadRequest
     where: Where
   }): Promise<void> => {
-    const newReq: PayloadRequest = args.req ?? (await createLocalReq({}, payload))
+    const req: PayloadRequest = args.req ?? (await createLocalReq({}, payload))
+
+    const overrideAccess = args.overrideAccess !== false
+    if (!overrideAccess) {
+      /**
+       * By default, jobsConfig.access.cancel will be `defaultAccess` which is a function that returns `true` if the user is logged in.
+       */
+      const accessFn = payload.config.jobs?.access?.cancel ?? (() => true)
+      const hasAccess = await accessFn({ req })
+      if (!hasAccess) {
+        throw new Forbidden(req.t)
+      }
+    }
 
     const and: Where[] = [
       args.where,
@@ -262,7 +333,7 @@ export const getJobsLocalAPI = (payload: Payload) => ({
       },
       depth: 0, // No depth, since we're not returning
       disableTransaction: true,
-      req: newReq,
+      req,
       returning: false,
       where: { and },
     })
@@ -270,10 +341,30 @@ export const getJobsLocalAPI = (payload: Payload) => ({
 
   cancelByID: async (args: {
     id: number | string
+    /**
+     * If set to false, access control as defined in jobsConfig.access.cancel will be run.
+     * By default, this is true and no access control will be run.
+     * If you set this to false and do not have jobsConfig.access.cancel defined, the default access control will be
+     * run (which is a function that returns `true` if the user is logged in).
+     *
+     * @default true
+     */
     overrideAccess?: boolean
     req?: PayloadRequest
   }): Promise<void> => {
-    const newReq: PayloadRequest = args.req ?? (await createLocalReq({}, payload))
+    const req: PayloadRequest = args.req ?? (await createLocalReq({}, payload))
+
+    const overrideAccess = args.overrideAccess !== false
+    if (!overrideAccess) {
+      /**
+       * By default, jobsConfig.access.cancel will be `defaultAccess` which is a function that returns `true` if the user is logged in.
+       */
+      const accessFn = payload.config.jobs?.access?.cancel ?? (() => true)
+      const hasAccess = await accessFn({ req })
+      if (!hasAccess) {
+        throw new Forbidden(req.t)
+      }
+    }
 
     await updateJob({
       id: args.id,
@@ -288,7 +379,7 @@ export const getJobsLocalAPI = (payload: Payload) => ({
       },
       depth: 0, // No depth, since we're not returning
       disableTransaction: true,
-      req: newReq,
+      req,
       returning: false,
     })
   },

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -100,6 +100,9 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
   } = args
 
   if (!overrideAccess) {
+    /**
+     * By default, jobsConfig.access.run will be `defaultAccess` which is a function that returns `true` if the user is logged in.
+     */
     const accessFn = jobsConfig?.access?.run ?? (() => true)
     const hasAccess = await accessFn({ req })
     if (!hasAccess) {


### PR DESCRIPTION
Adds access control for jobs `queue` and `cancel` operations, similar to what we have for `run` operations.

**Implementation:**
Both operations now support `overrideAccess` parameter (defaults to `true`) and respect `jobsConfig.access.queue` and `jobsConfig.access.cancel` functions. When `overrideAccess: false` is passed without an authenticated request, operations throw `Forbidden` error. 

**Configuration:**
Access control functions can be defined in the Jobs Config under `jobs.access.queue`, `jobs.access.run`, and `jobs.access.cancel`. Each function receives `{ req }` and returns a boolean. If no custom access control is defined, the default allows any authenticated user to perform the operation.

**Example:**
```ts
// Configure access control
jobs: {
  access: {
    queue: ({ req }) => req.user?.roles?.includes('admin'),
    cancel: ({ req }) => req.user?.roles?.includes('admin'),
  }
}

// Use in Local API
await payload.jobs.cancel({
  where: { workflowSlug: { equals: 'sync' } },
  overrideAccess: false,
  req,
})
```