### PR TITLE
fix: globals with versions return _status field when access denied

### DIFF
--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -373,12 +373,19 @@ export const promise = async ({
     }
 
     // Set defaultValue on the field for globals being returned without being first created
-    // or collection documents created prior to having a default
+    // or collection documents created prior to having a default.
+
+    // Skip setting defaults when: global has no ID (never created or filtered by access)
+    // AND access control is active (not overriding). This prevents default values like
+    // `_status: 'draft'` from appearing when access control filters out the document.
+    const shouldSkipDefaults = global && !doc.id && !overrideAccess
+
     if (
       !removedFieldValue &&
       allowDefaultValue &&
       typeof siblingDoc[field.name!] === 'undefined' &&
-      typeof field.defaultValue !== 'undefined'
+      typeof field.defaultValue !== 'undefined' &&
+      !shouldSkipDefaults
     ) {
       siblingDoc[field.name!] = await getDefaultValue({
         defaultValue: field.defaultValue,

--- a/test/versions/globals/DraftWithMax.ts
+++ b/test/versions/globals/DraftWithMax.ts
@@ -4,7 +4,7 @@ import { draftWithMaxGlobalSlug } from '../slugs.js'
 
 const DraftWithMaxGlobal: GlobalConfig = {
   slug: draftWithMaxGlobalSlug,
-  label: 'Draft Global',
+  label: 'Draft with Max Global',
   admin: {
     components: {
       views: {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -2567,16 +2567,15 @@ describe('Versions', () => {
 
       expect(draft._status).toStrictEqual('draft')
 
-      // Read with a custom req that has no user (simulating unauthenticated request)
+      // Create a request without a user (simulating unauthenticated request)
       // Access control on draftGlobalSlug requires published status when no user
+      const req = await createLocalReq({}, payload)
+      req.user = null
+
       const result = await payload.findGlobal({
         slug: draftGlobalSlug,
         overrideAccess: false,
-        req: {
-          ...payload.config,
-          user: null,
-          payload,
-        } as any,
+        req,
       })
 
       // Should return empty object, not {_status: 'draft'}

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -209,7 +209,7 @@ export interface AutosavePost {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -514,7 +514,7 @@ export interface Diff {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -529,7 +529,7 @@ export interface Diff {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];


### PR DESCRIPTION
### What?

Fixes an issue where globals with drafts/versions enabled would return the `_status` field with its default value (`'draft'`) when access control denied read access, instead of returning an empty object.

### Why?

When a global has:
1. Versions/drafts enabled (which adds the `_status` field with `defaultValue: 'draft'`)
2. Read access control with a where clause (e.g., `return {_status: {equals: 'published'}}`)

And a user without permissions requests the global (e.g., an unpublished draft exists), the API was returning `{"_status": "draft"}` instead of an empty object `{}`. This exposes the document's status even when access is denied.

The issue occurred because when the DB query returned `null` (filtered by access control), the `findOne` operation would set `doc = {}`, and then the `afterRead` hook would populate default values including `_status: 'draft'`.

### How?

- Modified `afterRead/promise.ts` to skip setting default values for globals when:
  - The document has no `id` (indicating it doesn't exist or was filtered)
  - AND access control is active (`!overrideAccess`)

Fixes #14096 

