### PR TITLE
feat: timezone config can now be added on a per field basis

### DIFF
--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -236,7 +236,28 @@ To enable timezone selection on a Date field, set the `timezone` property to `tr
 
 This will add a dropdown to the date picker that allows users to select a timezone. The selected timezone will be saved in the database along with the date in a new column named `date_tz`.
 
-You can customise the available list of timezones in the [global admin config](../admin/overview#timezones).
+You can customise the available list of timezones in the [global admin config](../admin/overview#timezones) or on the field config itself which accepts the following config as well:
+
+| Property             | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| `defaultTimezone`    | A value for the default timezone to be set.                               |
+| `supportedTimezones` | An array of supported timezones with label and value object.              |
+| `required`           | If true, the timezone selection will be required even if the date is not. |
+
+```ts
+{
+  name: 'date',
+  type: 'date',
+  timezone: {
+    defaultTimezone: 'America/New_York',
+    supportedTimezones: [
+      { label: 'New York', value: 'America/New_York' },
+      { label: 'Los Angeles', value: 'America/Los_Angeles' },
+      { label: 'London', value: 'Europe/London' },
+    ],
+  },
+}
+```
 
 <Banner type="info">
   **Good to know:**

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -439,7 +439,7 @@ export type Timezone = {
 
 type SupportedTimezonesFn = (args: { defaultTimezones: Timezone[] }) => Timezone[]
 
-type TimezonesConfig = {
+export type TimezonesConfig = {
   /**
    * The default timezone to use for the admin panel.
    */

--- a/packages/payload/src/exports/shared.ts
+++ b/packages/payload/src/exports/shared.ts
@@ -62,30 +62,31 @@ export { isImage } from '../uploads/isImage.js'
 export { appendUploadSelectFields } from '../utilities/appendUploadSelectFields.js'
 export { applyLocaleFiltering } from '../utilities/applyLocaleFiltering.js'
 export { combineWhereConstraints } from '../utilities/combineWhereConstraints.js'
-
 export {
   deepCopyObject,
   deepCopyObjectComplex,
   deepCopyObjectSimple,
   deepCopyObjectSimpleWithoutReactComponents,
 } from '../utilities/deepCopyObject.js'
+
 export {
   deepMerge,
   deepMergeWithCombinedArrays,
   deepMergeWithReactComponents,
   deepMergeWithSourceArrays,
 } from '../utilities/deepMerge.js'
-
 export { extractID } from '../utilities/extractID.js'
 
 export { flattenAllFields } from '../utilities/flattenAllFields.js'
+
 export { flattenTopLevelFields } from '../utilities/flattenTopLevelFields.js'
 export { formatAdminURL } from '../utilities/formatAdminURL.js'
 export { formatLabels, toWords } from '../utilities/formatLabels.js'
-
 export { getBestFitFromSizes } from '../utilities/getBestFitFromSizes.js'
+
 export { getDataByPath } from '../utilities/getDataByPath.js'
 export { getFieldPermissions } from '../utilities/getFieldPermissions.js'
+export { getObjectDotNotation } from '../utilities/getObjectDotNotation.js'
 export { getSafeRedirect } from '../utilities/getSafeRedirect.js'
 
 export { getSelectMode } from '../utilities/getSelectMode.js'

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -407,9 +407,20 @@ export const sanitizeFields = async ({
     // Insert our field after assignment
     if (field.type === 'date' && field.timezone) {
       const name = field.name + '_tz'
-      const defaultTimezone = config.admin?.timezones?.defaultTimezone
 
-      const supportedTimezones = config.admin?.timezones?.supportedTimezones
+      const defaultTimezone =
+        field.timezone && typeof field.timezone === 'object'
+          ? field.timezone.defaultTimezone
+          : config.admin?.timezones?.defaultTimezone
+
+      const required =
+        field.required ||
+        (field.timezone && typeof field.timezone === 'object' && field.timezone.required)
+
+      const supportedTimezones =
+        field.timezone && typeof field.timezone === 'object' && field.timezone.supportedTimezones
+          ? field.timezone.supportedTimezones
+          : config.admin?.timezones?.supportedTimezones
 
       const options =
         typeof supportedTimezones === 'function'
@@ -422,7 +433,7 @@ export const sanitizeFields = async ({
         name,
         defaultValue: defaultTimezone,
         options,
-        required: field.required,
+        required,
       })
 
       fields.splice(++i, 0, timezoneField)

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -116,6 +116,8 @@ import type {
   LabelFunction,
   PayloadComponent,
   StaticLabel,
+  Timezone,
+  TimezonesConfig,
 } from '../../config/types.js'
 import type { DBIdentifierName } from '../../database/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'
@@ -723,6 +725,14 @@ export type CheckboxFieldClient = {
 } & FieldBaseClient &
   Pick<CheckboxField, 'type'>
 
+type DateFieldTimezoneConfig = {
+  /**
+   * Make only the timezone required in the admin interface. This means a timezone is always required to be selected.
+   */
+  required?: boolean
+  supportedTimezones?: Timezone[]
+} & Pick<TimezonesConfig, 'defaultTimezone'>
+
 export type DateField = {
   admin?: {
     components?: {
@@ -737,7 +747,7 @@ export type DateField = {
   /**
    * Enable timezone selection in the admin interface.
    */
-  timezone?: true
+  timezone?: DateFieldTimezoneConfig | true
   type: 'date'
   validate?: DateFieldValidation
 } & Omit<FieldBase, 'validate'>

--- a/packages/payload/src/utilities/getObjectDotNotation.ts
+++ b/packages/payload/src/utilities/getObjectDotNotation.ts
@@ -1,3 +1,17 @@
+/**
+ *
+ * @deprecated use getObjectDotNotation from `'payload/shared'` instead of `'payload'`
+ *
+ * @example
+ *
+ * ```ts
+ * import { getObjectDotNotation } from 'payload/shared'
+ *
+ * const obj = { a: { b: { c: 42 } } }
+ * const value = getObjectDotNotation<number>(obj, 'a.b.c', 0) // value is 42
+ * const defaultValue = getObjectDotNotation<number>(obj, 'a.b.x', 0) // defaultValue is 0
+ * ```
+ */
 export const getObjectDotNotation = <T>(
   obj: Record<string, unknown>,
   path: string,

--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -123,7 +123,7 @@ const DatePicker: React.FC<Props> = (props) => {
   }, [i18n.language, i18n.dateFNS])
 
   return (
-    <div className={classes} id={id}>
+    <div className={classes}>
       <div className={`${baseClass}__icon-wrap`}>
         {dateTimePickerProps.selected && (
           <button
@@ -140,6 +140,7 @@ const DatePicker: React.FC<Props> = (props) => {
         <ReactDatePicker
           {...dateTimePickerProps}
           dropdownMode="select"
+          id={id}
           showMonthDropdown
           showYearDropdown
         />

--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -123,7 +123,7 @@ const DatePicker: React.FC<Props> = (props) => {
   }, [i18n.language, i18n.dateFNS])
 
   return (
-    <div className={classes}>
+    <div className={classes} id={id}>
       <div className={`${baseClass}__icon-wrap`}>
         {dateTimePickerProps.selected && (
           <button
@@ -140,7 +140,6 @@ const DatePicker: React.FC<Props> = (props) => {
         <ReactDatePicker
           {...dateTimePickerProps}
           dropdownMode="select"
-          id={id}
           showMonthDropdown
           showYearDropdown
         />

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Date/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Date/index.tsx
@@ -13,7 +13,7 @@ export const DateCell: React.FC<
 > = (props) => {
   const {
     cellData,
-    field: { accessor, admin: { date } = {}, timezone: timezoneFromField },
+    field: { name, accessor, admin: { date } = {}, timezone: timezoneFromField },
     rowData,
   } = props
 
@@ -24,7 +24,9 @@ export const DateCell: React.FC<
   } = useConfig()
   const { i18n } = useTranslation()
 
-  const timezoneFieldName = `${accessor}_tz`
+  const fieldPath = accessor || name
+
+  const timezoneFieldName = `${fieldPath}_tz`
   const timezone =
     Boolean(timezoneFromField) && rowData
       ? getObjectDotNotation(rowData, timezoneFieldName, undefined)

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Date/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Date/index.tsx
@@ -1,25 +1,40 @@
 'use client'
 import type { DateFieldClient, DefaultCellComponentProps } from 'payload'
 
+import { getObjectDotNotation } from 'payload/shared'
 import React from 'react'
 
 import { useConfig } from '../../../../../providers/Config/index.js'
 import { useTranslation } from '../../../../../providers/Translation/index.js'
 import { formatDate } from '../../../../../utilities/formatDocTitle/formatDateTitle.js'
 
-export const DateCell: React.FC<DefaultCellComponentProps<DateFieldClient>> = ({
-  cellData,
-  field: { admin: { date } = {} },
-}) => {
+export const DateCell: React.FC<
+  DefaultCellComponentProps<{ accessor?: string } & DateFieldClient>
+> = (props) => {
+  const {
+    cellData,
+    field: { accessor, admin: { date } = {}, timezone: timezoneFromField },
+    rowData,
+  } = props
+
   const {
     config: {
       admin: { dateFormat: dateFormatFromRoot },
     },
   } = useConfig()
+  const { i18n } = useTranslation()
+
+  const timezoneFieldName = `${accessor}_tz`
+  const timezone =
+    Boolean(timezoneFromField) && rowData
+      ? getObjectDotNotation(rowData, timezoneFieldName, undefined)
+      : undefined
 
   const dateFormat = date?.displayFormat || dateFormatFromRoot
 
-  const { i18n } = useTranslation()
-
-  return <span>{cellData && formatDate({ date: cellData, i18n, pattern: dateFormat })}</span>
+  return (
+    <span>
+      {Boolean(cellData) && formatDate({ date: cellData, i18n, pattern: dateFormat, timezone })}
+    </span>
+  )
 }

--- a/packages/ui/src/elements/TimezonePicker/index.scss
+++ b/packages/ui/src/elements/TimezonePicker/index.scss
@@ -28,6 +28,7 @@
         background: none;
         border: none;
         padding: 0;
+        padding-left: calc(var(--base) * 0.25);
         min-height: auto !important;
         position: relative;
         box-shadow: unset;

--- a/packages/ui/src/elements/TimezonePicker/index.tsx
+++ b/packages/ui/src/elements/TimezonePicker/index.tsx
@@ -18,6 +18,7 @@ export const TimezonePicker: React.FC<Props> = (props) => {
     id,
     onChange: onChangeFromProps,
     options: optionsFromProps,
+    readOnly: readOnlyFromProps,
     required,
     selectedTimezone: selectedTimezoneFromProps,
   } = props
@@ -33,6 +34,8 @@ export const TimezonePicker: React.FC<Props> = (props) => {
     })
   }, [options, selectedTimezoneFromProps])
 
+  const readOnly = Boolean(readOnlyFromProps) || options.length === 1
+
   return (
     <div className="timezone-picker-wrapper">
       <FieldLabel
@@ -43,8 +46,9 @@ export const TimezonePicker: React.FC<Props> = (props) => {
       />
       <ReactSelect
         className="timezone-picker"
+        disabled={readOnly}
         inputId={id}
-        isClearable={true}
+        isClearable={!required}
         isCreatable={false}
         onChange={(val: OptionObject) => {
           if (onChangeFromProps) {

--- a/packages/ui/src/elements/TimezonePicker/types.ts
+++ b/packages/ui/src/elements/TimezonePicker/types.ts
@@ -3,6 +3,7 @@ import type { SelectFieldClient } from 'payload'
 export type Props = {
   id: string
   onChange?: (val: string) => void
+  readOnly?: boolean
   required?: boolean
   selectedTimezone?: string
 } & Pick<SelectFieldClient, 'options'>

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -70,13 +70,23 @@ const DateTimeFieldComponent: DateFieldClientComponent = (props) => {
 
   const timezonePath = path + '_tz'
   const timezoneField = useFormFields(([fields, _]) => fields?.[timezonePath])
-  const supportedTimezones = config.admin.timezones.supportedTimezones
+
+  const supportedTimezones = useMemo(() => {
+    if (timezone && typeof timezone === 'object' && timezone.supportedTimezones) {
+      return timezone.supportedTimezones
+    }
+
+    return config.admin.timezones.supportedTimezones
+  }, [config.admin.timezones.supportedTimezones, timezone])
+
   /**
    * Date appearance doesn't include timestamps,
    * which means we need to pin the time to always 12:00 for the selected date
    */
   const isDateOnly = ['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)
   const selectedTimezone = timezoneField?.value as string
+  const timezoneRequired =
+    required || (timezone && typeof timezone === 'object' && timezone.required)
 
   // The displayed value should be the original value, adjusted to the user's timezone
   const displayedValue = useMemo(() => {
@@ -192,7 +202,8 @@ const DateTimeFieldComponent: DateFieldClientComponent = (props) => {
             id={`${path}-timezone-picker`}
             onChange={onChangeTimezone}
             options={supportedTimezones}
-            required={required}
+            readOnly={readOnly || disabled}
+            required={timezoneRequired}
             selectedTimezone={selectedTimezone}
           />
         )}

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -572,848 +572,279 @@ describe('Date', () => {
   })
 })
 
-describe('Date with TZ - Context: America/Detroit', () => {
-  beforeAll(async ({ browser }, testInfo) => {
-    testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
-      dirname,
-      // prebuild,
-    }))
-    url = new AdminUrlUtil(serverURL, dateFieldsSlug)
+/**
+ * Helper function to create timezone context test suites
+ * Reduces repetition across different timezone test scenarios
+ */
+const createTimezoneContextTests = (contextName: string, timezoneId: string) => {
+  describe(`Date with TZ - Context: ${contextName}`, () => {
+    beforeAll(async ({ browser }, testInfo) => {
+      testInfo.setTimeout(TEST_TIMEOUT_LONG)
+      process.env.SEED_IN_CONFIG_ONINIT = 'false'
+      ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
+        dirname,
+      }))
+      url = new AdminUrlUtil(serverURL, dateFieldsSlug)
 
-    const context = await browser.newContext({ timezoneId: detroitTimezone })
-    page = await context.newPage()
-    initPageConsoleErrorCatch(page)
+      const context = await browser.newContext({ timezoneId })
+      page = await context.newPage()
+      initPageConsoleErrorCatch(page)
 
-    await ensureCompilationIsDone({ page, serverURL })
-  })
-  beforeEach(async () => {
-    await reInitializeDB({
-      serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
+      await ensureCompilationIsDone({ page, serverURL })
     })
 
-    if (client) {
-      await client.logout()
-    }
-    client = new RESTClient({ defaultSlug: 'users', serverURL })
-    await client.login()
+    beforeEach(async () => {
+      await reInitializeDB({
+        serverURL,
+        snapshotKey: 'fieldsTest',
+        uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
+      })
 
-    await ensureCompilationIsDone({ page, serverURL })
-  })
+      if (client) {
+        await client.logout()
+      }
+      client = new RESTClient({ defaultSlug: 'users', serverURL })
+      await client.login()
 
-  test('displayed value should remain unchanged', async () => {
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
+      await ensureCompilationIsDone({ page, serverURL })
     })
 
-    await page.goto(url.edit(existingDoc!.id))
+    test('displayed value should remain unchanged', async () => {
+      const {
+        docs: [existingDoc],
+      } = await payload.find({
+        collection: dateFieldsSlug,
+      })
 
-    const result = await page.evaluate(() => {
-      return Intl.DateTimeFormat().resolvedOptions().timeZone
+      await page.goto(url.edit(existingDoc!.id))
+
+      const result = await page.evaluate(() => {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone
+      })
+
+      await expect(() => {
+        expect(result).toEqual(timezoneId)
+      }).toPass({ timeout: 10000, intervals: [100] })
+
+      const dateOnlyLocator = page.locator(
+        '#field-defaultWithTimezone .react-datepicker-wrapper input',
+      )
+      const dateTimeLocator = page.locator(
+        '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+      )
+
+      const expectedDateOnlyValue = '08/12/2027'
+      const expectedDateTimeValue = 'Aug 12, 2027 10:00 AM'
+
+      await expect(dateOnlyLocator).toHaveValue(expectedDateOnlyValue)
+      await expect(dateTimeLocator).toHaveValue(expectedDateTimeValue)
     })
 
-    await expect(() => {
-      // Confirm that the emulated timezone is set to London
-      expect(result).toEqual(detroitTimezone)
-    }).toPass({ timeout: 10000, intervals: [100] })
+    test('displayed value in list view should remain unchanged', async () => {
+      await page.goto(url.list)
 
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
+      const dateTimeLocator = page.locator('.cell-timezoneGroup__dayAndTime').first()
 
-    const expectedDateOnlyValue = '08/12/2027'
-    const expectedDateTimeValue = 'Aug 12, 2027 10:00 AM' // This is the seeded value for 10AM at Asia/Tokyo time
+      await expect(async () => {
+        await expect(dateTimeLocator).toHaveText('January 31st 2025, 10:00 AM')
+      }).toPass({ timeout: 10000, intervals: [100] })
+    })
 
-    await expect(dateOnlyLocator).toHaveValue(expectedDateOnlyValue)
-    await expect(dateTimeLocator).toHaveValue(expectedDateTimeValue)
-  })
+    test('creates the expected UTC value when the selected timezone is Paris - no daylight savings', async () => {
+      const expectedDateInput = 'Jan 1, 2025 6:00 PM'
+      const expectedUTCValue = '2025-01-01T17:00:00.000Z'
 
-  test('creates the expected UTC value when the selected timezone is Paris - no daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateInput = 'Jan 1, 2025 6:00 PM'
-    // We're testing this specific date because Paris has no daylight savings time in January
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedUTCValue = '2025-01-01T17:00:00.000Z'
+      await page.goto(url.create)
 
-    await page.goto(url.create)
+      const dateField = page.locator('#field-default input')
+      await dateField.fill('01/01/2025')
 
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
+      const dateTimeLocator = page.locator(
+        '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+      )
 
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
+      const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
+      const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
 
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
+      await page.click(dropdownControlSelector)
+      await page.click(timezoneOptionSelector)
+      await dateTimeLocator.fill(expectedDateInput)
 
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateInput)
+      await saveDocAndAssert(page)
 
-    await saveDocAndAssert(page)
+      const docID = page.url().split('/').pop()
 
-    const docID = page.url().split('/').pop()
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(docID).toBeTruthy()
 
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
+      const {
+        docs: [existingDoc],
+      } = await payload.find({
+        collection: dateFieldsSlug,
+        where: {
+          id: {
+            equals: docID,
+          },
         },
-      },
+      })
+
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
     })
 
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
-  })
+    test('creates the expected UTC value when the selected timezone is Paris - with daylight savings', async () => {
+      const expectedDateInput = 'Jul 1, 2025 6:00 PM'
+      const expectedUTCValue = '2025-07-01T16:00:00.000Z'
 
-  test('creates the expected UTC value when the selected timezone is Paris - with daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateInput = 'Jul 1, 2025 6:00 PM'
+      await page.goto(url.create)
 
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedUTCValue = '2025-07-01T16:00:00.000Z'
+      const dateField = page.locator('#field-default input')
+      await dateField.fill('01/01/2025')
 
-    await page.goto(url.create)
+      const dateTimeLocator = page.locator(
+        '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+      )
 
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
+      const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
+      const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
 
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
+      await page.click(dropdownControlSelector)
+      await page.click(timezoneOptionSelector)
+      await dateTimeLocator.fill(expectedDateInput)
 
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
+      await saveDocAndAssert(page)
 
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateInput)
+      const docID = page.url().split('/').pop()
 
-    await saveDocAndAssert(page)
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(docID).toBeTruthy()
 
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
+      const {
+        docs: [existingDoc],
+      } = await payload.find({
+        collection: dateFieldsSlug,
+        where: {
+          id: {
+            equals: docID,
+          },
         },
-      },
+      })
+
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
     })
 
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
-  })
+    test('creates the expected UTC value when the selected timezone is Auckland - no daylight savings', async () => {
+      const expectedDateTimeInput = 'Jan 1, 2025 6:00 PM'
+      const expectedDateOnlyInput = '01/02/2025'
 
-  test('creates the expected UTC value when the selected timezone is Auckland - no daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateTimeInput = 'Jan 1, 2025 6:00 PM'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyInput = '01/02/2025' // 2nd July 2025
+      const expectedDateTimeUTCValue = '2025-01-01T05:00:00.000Z'
+      const expectedDateOnlyUTCValue = '2025-01-01T23:00:00.000Z'
 
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedDateTimeUTCValue = '2025-01-01T05:00:00.000Z'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyUTCValue = '2025-01-01T23:00:00.000Z' // 2nd July 2025 at 12PM in Auckland
+      await page.goto(url.create)
 
-    await page.goto(url.create)
+      const dateField = page.locator('#field-default input')
+      await dateField.fill('01/01/2025')
 
-    // Default date field - filling it because it's required for the form to be valid
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
+      const dateTimeLocator = page.locator(
+        '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+      )
+      const dateOnlyLocator = page.locator(
+        '#field-defaultWithTimezone .react-datepicker-wrapper input',
+      )
 
-    // Date input fields
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
+      const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
+      const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
+      await page.click(dateOnlyDropdownSelector)
+      await page.click(dateOnlytimezoneSelector)
+      await dateOnlyLocator.fill(expectedDateOnlyInput)
 
-    // Fill in date only
-    const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
-    const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dateOnlyDropdownSelector)
-    await page.click(dateOnlytimezoneSelector)
-    await dateOnlyLocator.fill(expectedDateOnlyInput)
+      const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
+      const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
+      await page.click(dropdownControlSelector)
+      await page.click(timezoneOptionSelector)
+      await dateTimeLocator.fill(expectedDateTimeInput)
 
-    // Fill in date and time
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateTimeInput)
+      await saveDocAndAssert(page)
 
-    await saveDocAndAssert(page)
+      const docID = page.url().split('/').pop()
 
-    const docID = page.url().split('/').pop()
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(docID).toBeTruthy()
 
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
+      const {
+        docs: [existingDoc],
+      } = await payload.find({
+        collection: dateFieldsSlug,
+        where: {
+          id: {
+            equals: docID,
+          },
         },
-      },
+      })
+
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
+      expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
     })
 
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
-    expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
-  })
+    test('creates the expected UTC value when the selected timezone is Auckland - with daylight savings', async () => {
+      const expectedDateTimeInput = 'Jul 1, 2025 6:00 PM'
+      const expectedDateOnlyInput = '07/02/2025'
 
-  test('creates the expected UTC value when the selected timezone is Auckland - with daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateTimeInput = 'Jul 1, 2025 6:00 PM'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyInput = '07/02/2025' // 2nd July 2025
+      const expectedDateTimeUTCValue = '2025-07-01T06:00:00.000Z'
+      const expectedDateOnlyUTCValue = '2025-07-02T00:00:00.000Z'
 
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedDateTimeUTCValue = '2025-07-01T06:00:00.000Z'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyUTCValue = '2025-07-02T00:00:00.000Z' // 2nd July 2025 at 12PM in Auckland
+      await page.goto(url.create)
 
-    await page.goto(url.create)
+      const dateField = page.locator('#field-default input')
+      await dateField.fill('01/01/2025')
 
-    // Default date field - filling it because it's required for the form to be valid
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
+      const dateTimeLocator = page.locator(
+        '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+      )
+      const dateOnlyLocator = page.locator(
+        '#field-defaultWithTimezone .react-datepicker-wrapper input',
+      )
 
-    // Date input fields
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
+      const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
+      const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
+      await page.click(dateOnlyDropdownSelector)
+      await page.click(dateOnlytimezoneSelector)
+      await dateOnlyLocator.fill(expectedDateOnlyInput)
 
-    // Fill in date only
-    const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
-    const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dateOnlyDropdownSelector)
-    await page.click(dateOnlytimezoneSelector)
-    await dateOnlyLocator.fill(expectedDateOnlyInput)
+      const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
+      const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
+      await page.click(dropdownControlSelector)
+      await page.click(timezoneOptionSelector)
+      await dateTimeLocator.fill(expectedDateTimeInput)
 
-    // Fill in date and time
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateTimeInput)
+      await saveDocAndAssert(page)
 
-    await saveDocAndAssert(page)
+      const docID = page.url().split('/').pop()
 
-    const docID = page.url().split('/').pop()
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(docID).toBeTruthy()
 
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
+      const {
+        docs: [existingDoc],
+      } = await payload.find({
+        collection: dateFieldsSlug,
+        where: {
+          id: {
+            equals: docID,
+          },
         },
-      },
+      })
+
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
+      expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
     })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
-    expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
   })
-})
-
-describe('Date with TZ - Context: Europe/London', () => {
-  beforeAll(async ({ browser }, testInfo) => {
-    testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
-      dirname,
-      // prebuild,
-    }))
-    url = new AdminUrlUtil(serverURL, dateFieldsSlug)
-
-    const context = await browser.newContext({ timezoneId: londonTimezone })
-    page = await context.newPage()
-    initPageConsoleErrorCatch(page)
-
-    await ensureCompilationIsDone({ page, serverURL })
-  })
-  beforeEach(async () => {
-    await reInitializeDB({
-      serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
-    })
-
-    if (client) {
-      await client.logout()
-    }
-    client = new RESTClient({ defaultSlug: 'users', serverURL })
-    await client.login()
-
-    await ensureCompilationIsDone({ page, serverURL })
-  })
-
-  test('displayed value should remain unchanged', async () => {
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-    })
-
-    await page.goto(url.edit(existingDoc!.id))
-
-    const result = await page.evaluate(() => {
-      return Intl.DateTimeFormat().resolvedOptions().timeZone
-    })
-
-    await expect(() => {
-      // Confirm that the emulated timezone is set to London
-      expect(result).toEqual(londonTimezone)
-    }).toPass({ timeout: 10000, intervals: [100] })
-
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-
-    const expectedDateOnlyValue = '08/12/2027'
-    const expectedDateTimeValue = 'Aug 12, 2027 10:00 AM' // This is the seeded value for 10AM at Asia/Tokyo time
-
-    await expect(dateOnlyLocator).toHaveValue(expectedDateOnlyValue)
-    await expect(dateTimeLocator).toHaveValue(expectedDateTimeValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Paris - no daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateInput = 'Jan 1, 2025 6:00 PM'
-    // We're testing this specific date because Paris has no daylight savings time in January
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedUTCValue = '2025-01-01T17:00:00.000Z'
-
-    await page.goto(url.create)
-
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
-
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Paris - with daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateInput = 'Jul 1, 2025 6:00 PM'
-
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedUTCValue = '2025-07-01T16:00:00.000Z'
-
-    await page.goto(url.create)
-
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
-
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Auckland - no daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateTimeInput = 'Jan 1, 2025 6:00 PM'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyInput = '01/02/2025' // 2nd July 2025
-
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedDateTimeUTCValue = '2025-01-01T05:00:00.000Z'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyUTCValue = '2025-01-01T23:00:00.000Z' // 2nd July 2025 at 12PM in Auckland
-
-    await page.goto(url.create)
-
-    // Default date field - filling it because it's required for the form to be valid
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    // Date input fields
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
-
-    // Fill in date only
-    const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
-    const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dateOnlyDropdownSelector)
-    await page.click(dateOnlytimezoneSelector)
-    await dateOnlyLocator.fill(expectedDateOnlyInput)
-
-    // Fill in date and time
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateTimeInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
-    expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Auckland - with daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateTimeInput = 'Jul 1, 2025 6:00 PM'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyInput = '07/02/2025' // 2nd July 2025
-
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedDateTimeUTCValue = '2025-07-01T06:00:00.000Z'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyUTCValue = '2025-07-02T00:00:00.000Z' // 2nd July 2025 at 12PM in Auckland
-
-    await page.goto(url.create)
-
-    // Default date field - filling it because it's required for the form to be valid
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    // Date input fields
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
-
-    // Fill in date only
-    const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
-    const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dateOnlyDropdownSelector)
-    await page.click(dateOnlytimezoneSelector)
-    await dateOnlyLocator.fill(expectedDateOnlyInput)
-
-    // Fill in date and time
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateTimeInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
-    expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
-  })
-})
-
-describe('Date with TZ - Context: Pacific/Auckland', () => {
-  beforeAll(async ({ browser }, testInfo) => {
-    testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
-      dirname,
-      // prebuild,
-    }))
-    url = new AdminUrlUtil(serverURL, dateFieldsSlug)
-
-    const context = await browser.newContext({ timezoneId: aucklandTimezone })
-    page = await context.newPage()
-    initPageConsoleErrorCatch(page)
-
-    await ensureCompilationIsDone({ page, serverURL })
-  })
-  beforeEach(async () => {
-    await reInitializeDB({
-      serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
-    })
-
-    if (client) {
-      await client.logout()
-    }
-    client = new RESTClient({ defaultSlug: 'users', serverURL })
-    await client.login()
-
-    await ensureCompilationIsDone({ page, serverURL })
-  })
-
-  test('displayed value should remain unchanged', async () => {
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-    })
-
-    await page.goto(url.edit(existingDoc!.id))
-
-    const result = await page.evaluate(() => {
-      return Intl.DateTimeFormat().resolvedOptions().timeZone
-    })
-
-    await expect(() => {
-      // Confirm that the emulated timezone is set to London
-      expect(result).toEqual(aucklandTimezone)
-    }).toPass({ timeout: 10000, intervals: [100] })
-
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-
-    const expectedDateOnlyValue = '08/12/2027'
-    const expectedDateTimeValue = 'Aug 12, 2027 10:00 AM' // This is the seeded value for 10AM at Asia/Tokyo time
-
-    await expect(dateOnlyLocator).toHaveValue(expectedDateOnlyValue)
-    await expect(dateTimeLocator).toHaveValue(expectedDateTimeValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Paris - no daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateInput = 'Jan 1, 2025 6:00 PM'
-    // We're testing this specific date because Paris has no daylight savings time in January
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedUTCValue = '2025-01-01T17:00:00.000Z'
-
-    await page.goto(url.create)
-
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
-
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Paris - with daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateInput = 'Jul 1, 2025 6:00 PM'
-
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedUTCValue = '2025-07-01T16:00:00.000Z'
-
-    await page.goto(url.create)
-
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Paris")`
-
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Auckland - no daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateTimeInput = 'Jan 1, 2025 6:00 PM'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyInput = '01/02/2025' // 2nd July 2025
-
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedDateTimeUTCValue = '2025-01-01T05:00:00.000Z'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyUTCValue = '2025-01-01T23:00:00.000Z' // 2nd July 2025 at 12PM in Auckland
-
-    await page.goto(url.create)
-
-    // Default date field - filling it because it's required for the form to be valid
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    // Date input fields
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
-
-    // Fill in date only
-    const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
-    const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dateOnlyDropdownSelector)
-    await page.click(dateOnlytimezoneSelector)
-    await dateOnlyLocator.fill(expectedDateOnlyInput)
-
-    // Fill in date and time
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateTimeInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
-    expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
-  })
-
-  test('creates the expected UTC value when the selected timezone is Auckland - with daylight savings', async () => {
-    // We send this value through the input
-    const expectedDateTimeInput = 'Jul 1, 2025 6:00 PM'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyInput = '07/02/2025' // 2nd July 2025
-
-    // We're testing specific date because Paris has daylight savings time in July (+1 hour to the local timezone)
-    // but the UTC date will be different from 6PM local time in the summer versus the winter
-    const expectedDateTimeUTCValue = '2025-07-01T06:00:00.000Z'
-    // The timestamp for this date should be normalised to 12PM local time
-    const expectedDateOnlyUTCValue = '2025-07-02T00:00:00.000Z' // 2nd July 2025 at 12PM in Auckland
-
-    await page.goto(url.create)
-
-    // Default date field - filling it because it's required for the form to be valid
-    const dateField = page.locator('#field-default input')
-    await dateField.fill('01/01/2025')
-
-    // Date input fields
-    const dateTimeLocator = page.locator(
-      '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
-    )
-    const dateOnlyLocator = page.locator(
-      '#field-defaultWithTimezone .react-datepicker-wrapper input',
-    )
-
-    // Fill in date only
-    const dateOnlyDropdownSelector = `#field-defaultWithTimezone .rs__control`
-    const dateOnlytimezoneSelector = `#field-defaultWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dateOnlyDropdownSelector)
-    await page.click(dateOnlytimezoneSelector)
-    await dateOnlyLocator.fill(expectedDateOnlyInput)
-
-    // Fill in date and time
-    const dropdownControlSelector = `#field-dayAndTimeWithTimezone .rs__control`
-    const timezoneOptionSelector = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Auckland")`
-    await page.click(dropdownControlSelector)
-    await page.click(timezoneOptionSelector)
-    await dateTimeLocator.fill(expectedDateTimeInput)
-
-    await saveDocAndAssert(page)
-
-    const docID = page.url().split('/').pop()
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(docID).toBeTruthy()
-
-    const {
-      docs: [existingDoc],
-    } = await payload.find({
-      collection: dateFieldsSlug,
-      where: {
-        id: {
-          equals: docID,
-        },
-      },
-    })
-
-    // eslint-disable-next-line payload/no-flaky-assertions
-    expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
-    expect(existingDoc?.defaultWithTimezone).toEqual(expectedDateOnlyUTCValue)
-  })
-})
+}
+
+// Create timezone context test suites for different timezones
+createTimezoneContextTests('America/Detroit', detroitTimezone)
+createTimezoneContextTests('Europe/London', londonTimezone)
+createTimezoneContextTests('Pacific/Auckland', aucklandTimezone)

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -8,7 +8,13 @@ const DateFields: CollectionConfig = {
   slug: dateFieldsSlug,
   admin: {
     useAsTitle: 'default',
-    defaultColumns: ['default', 'timeOnly', 'dayAndTimeWithTimezone', 'timezoneGroup.dayAndTime'],
+    defaultColumns: [
+      'default',
+      'timeOnly',
+      'dayAndTimeWithTimezone',
+      'timezoneGroup.dayAndTime',
+      'dayAndTimeWithTimezoneFixed',
+    ],
   },
   fields: [
     {
@@ -86,6 +92,43 @@ const DateFields: CollectionConfig = {
           pickerAppearance: 'dayAndTime',
         },
         description: 'This date here should be required.',
+      },
+      timezone: true,
+    },
+    {
+      name: 'dayAndTimeWithTimezoneFixed',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+      timezone: {
+        defaultTimezone: 'Europe/London',
+        supportedTimezones: [{ label: 'London', value: 'Europe/London' }],
+      },
+    },
+    {
+      name: 'dayAndTimeWithTimezoneRequired',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+      timezone: {
+        defaultTimezone: 'America/New_York',
+        required: true,
+      },
+    },
+    {
+      name: 'dayAndTimeWithTimezoneReadOnly',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+        readOnly: true,
       },
       timezone: true,
     },

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -8,6 +8,7 @@ const DateFields: CollectionConfig = {
   slug: dateFieldsSlug,
   admin: {
     useAsTitle: 'default',
+    defaultColumns: ['default', 'timeOnly', 'dayAndTimeWithTimezone', 'timezoneGroup.dayAndTime'],
   },
   fields: [
     {
@@ -112,6 +113,22 @@ const DateFields: CollectionConfig = {
     {
       type: 'array',
       name: 'timezoneArray',
+      fields: [
+        {
+          name: 'dayAndTime',
+          type: 'date',
+          admin: {
+            date: {
+              pickerAppearance: 'dayAndTime',
+            },
+          },
+          timezone: true,
+        },
+      ],
+    },
+    {
+      type: 'group',
+      name: 'timezoneGroup',
       fields: [
         {
           name: 'dayAndTime',

--- a/test/fields/collections/Date/shared.ts
+++ b/test/fields/collections/Date/shared.ts
@@ -24,4 +24,8 @@ export const dateDoc: Partial<DateField> = {
       dayAndTime_tz: 'Europe/Berlin',
     },
   ],
+  timezoneGroup: {
+    dayAndTime: '2025-01-31T09:00:00.000Z',
+    dayAndTime_tz: 'Europe/Berlin',
+  },
 }

--- a/test/fields/collections/Date/shared.ts
+++ b/test/fields/collections/Date/shared.ts
@@ -28,4 +28,7 @@ export const dateDoc: Partial<DateField> = {
     dayAndTime: '2025-01-31T09:00:00.000Z',
     dayAndTime_tz: 'Europe/Berlin',
   },
+  dayAndTimeWithTimezoneReadOnly: '2027-08-12T01:00:00.000+00:00',
+  dayAndTimeWithTimezoneReadOnly_tz: 'Asia/Tokyo',
+  dayAndTimeWithTimezoneFixed: '2025-10-29T20:00:00.000+00:00',
 }

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1010,6 +1010,10 @@ export interface DateField {
         id?: string | null;
       }[]
     | null;
+  timezoneGroup?: {
+    dayAndTime?: string | null;
+    dayAndTime_tz?: SupportedTimezones;
+  };
   array?:
     | {
         date?: string | null;
@@ -2733,6 +2737,12 @@ export interface DateFieldsSelect<T extends boolean = true> {
         dayAndTime?: T;
         dayAndTime_tz?: T;
         id?: T;
+      };
+  timezoneGroup?:
+    | T
+    | {
+        dayAndTime?: T;
+        dayAndTime_tz?: T;
       };
   array?:
     | T

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -994,6 +994,12 @@ export interface DateField {
    */
   dayAndTimeWithTimezone: string;
   dayAndTimeWithTimezone_tz: SupportedTimezones;
+  dayAndTimeWithTimezoneFixed?: string | null;
+  dayAndTimeWithTimezoneFixed_tz?: SupportedTimezones;
+  dayAndTimeWithTimezoneRequired?: string | null;
+  dayAndTimeWithTimezoneRequired_tz: SupportedTimezones;
+  dayAndTimeWithTimezoneReadOnly?: string | null;
+  dayAndTimeWithTimezoneReadOnly_tz?: SupportedTimezones;
   timezoneBlocks?:
     | {
         dayAndTime?: string | null;
@@ -2719,6 +2725,12 @@ export interface DateFieldsSelect<T extends boolean = true> {
   defaultWithTimezone_tz?: T;
   dayAndTimeWithTimezone?: T;
   dayAndTimeWithTimezone_tz?: T;
+  dayAndTimeWithTimezoneFixed?: T;
+  dayAndTimeWithTimezoneFixed_tz?: T;
+  dayAndTimeWithTimezoneRequired?: T;
+  dayAndTimeWithTimezoneRequired_tz?: T;
+  dayAndTimeWithTimezoneReadOnly?: T;
+  dayAndTimeWithTimezoneReadOnly_tz?: T;
   timezoneBlocks?:
     | T
     | {


### PR DESCRIPTION
This PR enables you to add timezone specific config on a per field basis so each field can support its own list of timezones

```ts
{
  name: 'date',
  type: 'date',
  timezone: {
    defaultTimezone: 'America/New_York',
    supportedTimezones: [
      { label: 'New York', value: 'America/New_York' },
      { label: 'Los Angeles', value: 'America/Los_Angeles' },
      { label: 'London', value: 'Europe/London' },
    ],
  },
}
```

You can also enforce a specific timezone by specifying just one with a default value:

```ts
{
  name: 'date',
  type: 'date',
  timezone: {
    defaultTimezone: 'Europe/London',
    supportedTimezones: [
      { label: 'London', value: 'Europe/London' },
    ],
  },
}
```

It also fixes a bug with date fields in list view not showing the date in the formatted timezone correctly.