### PR TITLE
fix(next): version._status field queried/returned for entities without drafts

### DIFF
--- a/packages/next/src/views/Version/fetchVersions.ts
+++ b/packages/next/src/views/Version/fetchVersions.ts
@@ -163,12 +163,26 @@ export const fetchLatestVersion = async <TVersionData extends object = object>({
   user?: TypedUser
   where?: Where
 }): Promise<null | TypeWithVersion<TVersionData>> => {
+  // Get the entity config to check if drafts are enabled
+  const entityConfig = collectionSlug
+    ? req.payload.collections[collectionSlug]?.config
+    : globalSlug
+      ? req.payload.globals[globalSlug]?.config
+      : undefined
+
+  // Only query by _status if drafts are enabled (since _status field only exists with drafts)
+  const draftsEnabled = entityConfig?.versions?.drafts
+
   const and: Where[] = [
-    {
-      'version._status': {
-        equals: status,
-      },
-    },
+    ...(draftsEnabled
+      ? [
+          {
+            'version._status': {
+              equals: status,
+            },
+          },
+        ]
+      : []),
     ...(where ? [where] : []),
   ]
 

--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -143,33 +143,36 @@ export async function VersionView(props: DocumentViewServerProps) {
         })
       : Promise.resolve(null),
     // Previous published version
-    fetchVersions({
-      collectionSlug,
-      depth: 0,
-      draft: true,
-      globalSlug,
-      limit: 1,
-      locale: 'all',
-      overrideAccess: false,
-      parentID: id,
-      req,
-      sort: '-updatedAt',
-      user,
-      where: {
-        and: [
-          {
-            updatedAt: {
-              less_than: versionTo.updatedAt,
-            },
+    // Only query for published versions if drafts are enabled (since _status field only exists with drafts)
+    draftsEnabled
+      ? fetchVersions({
+          collectionSlug,
+          depth: 0,
+          draft: true,
+          globalSlug,
+          limit: 1,
+          locale: 'all',
+          overrideAccess: false,
+          parentID: id,
+          req,
+          sort: '-updatedAt',
+          user,
+          where: {
+            and: [
+              {
+                updatedAt: {
+                  less_than: versionTo.updatedAt,
+                },
+              },
+              {
+                'version._status': {
+                  equals: 'published',
+                },
+              },
+            ],
           },
-          {
-            'version._status': {
-              equals: 'published',
-            },
-          },
-        ],
-      },
-    }),
+        })
+      : Promise.resolve(null),
   ])
 
   const previousVersion: null | TypeWithVersion<object> = previousVersionResult?.docs?.[0] ?? null

--- a/test/versions/collections/Versions.ts
+++ b/test/versions/collections/Versions.ts
@@ -10,20 +10,7 @@ const VersionPosts: CollectionConfig = {
         return true
       }
 
-      return {
-        or: [
-          {
-            _status: {
-              equals: 'published',
-            },
-          },
-          {
-            _status: {
-              exists: false,
-            },
-          },
-        ],
-      }
+      return false
     },
     readVersions: ({ req: { user } }) => Boolean(user),
   },

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -85,6 +85,7 @@ export interface Config {
     text: Text;
     media: Media;
     media2: Media2;
+    'payload-kv': PayloadKv;
     users: User;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -111,6 +112,7 @@ export interface Config {
     text: TextSelect<false> | TextSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     media2: Media2Select<false> | Media2Select<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -607,6 +609,23 @@ export interface Media2 {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -799,6 +818,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media2';
         value: string | Media2;
+      } | null)
+    | ({
+        relationTo: 'payload-kv';
+        value: string | PayloadKv;
       } | null)
     | ({
         relationTo: 'users';
@@ -1190,6 +1213,14 @@ export interface Media2Select<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?

Fixes an issue where the `_status` field was being queried or returned for entities (collections/globals) that have versions enabled but drafts disabled.

### Why?

The `_status` field only exists when `drafts` are enabled (not just `versions`). So the following issue occurred:

**Collections with versions (no drafts)**: When viewing version comparison pages in the admin UI, the app threw `QueryError: The following path cannot be queried: version._status` because the view code was attempting to filter versions by `_status` for collections that don't have drafts enabled.

### How?

- Check if drafts are enabled before querying `version._status` in version comparison views
