### PR TITLE
fix(storage-s3): encode filename in generated URL

### DIFF
--- a/packages/storage-s3/src/generateURL.ts
+++ b/packages/storage-s3/src/generateURL.ts
@@ -12,5 +12,5 @@ export const getGenerateURL =
   ({ bucket, config: { endpoint } }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
     const stringifiedEndpoint = typeof endpoint === 'string' ? endpoint : endpoint?.toString()
-    return `${stringifiedEndpoint}/${bucket}/${path.posix.join(prefix, filename)}`
+    return `${stringifiedEndpoint}/${bucket}/${path.posix.join(prefix, encodeURIComponent(filename))}`
   }


### PR DESCRIPTION
### What

This PR updates the `getGenerateURL` function in the `s3-storage` adapter to properly encode filenames using `encodeURIComponent` when constructing file URLs. This ensures that the URL is properly encoded when using the `disablePayloadAccessControl` option.

 ### Why

Without URL encoding, filenames containing special characters (spaces, unicode characters, special symbols, etc.) can break URL generation and lead to: 
- 404 errors when accessing files with special characters 
- Malformed URLs that don't properly resolve 
- Security issues with improperly escaped characters

###  How

The fix wraps the filename parameter with `encodeURIComponent()` in the URL construction, similar to how it is done in the [storage-vercel-blob package](https://github.com/payloadcms/payload/blob/53d85574d8405f45423871ccf1da3209371ad2da/packages/storage-vercel-blob/src/generateURL.ts#L12).

###  Example:
- Before: `https://s3.endpoint.com/bucket/my file.jpg` (breaks)
- After: `https://s3.endpoint.com/bucket/my%20file.jpg` (works correctly)