### PR TITLE
fix: disable `lockedDocuments` if the kv adapter uses a collection

### DIFF
--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -172,6 +172,7 @@ export const addDefaultsToConfig = (config: Config): Config => {
   config.kv = config.kv ?? databaseKVAdapter()
 
   if (config.kv?.kvCollection) {
+    config.kv.kvCollection.lockDocuments = false
     config.collections.push(config.kv.kvCollection)
   }
 

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -172,7 +172,6 @@ export const addDefaultsToConfig = (config: Config): Config => {
   config.kv = config.kv ?? databaseKVAdapter()
 
   if (config.kv?.kvCollection) {
-    config.kv.kvCollection.lockDocuments = false
     config.collections.push(config.kv.kvCollection)
   }
 

--- a/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
@@ -122,6 +122,7 @@ export const databaseKVAdapter = (options: DatabaseKVAdapterOptions = {}): KVAda
           required: true,
         },
       ],
+      lockDocuments: false,
       timestamps: false,
       ...options.kvCollectionOverrides,
     },

--- a/packages/payload/src/locked-documents/config.ts
+++ b/packages/payload/src/locked-documents/config.ts
@@ -22,7 +22,11 @@ export const getLockedDocumentsCollection = (config: Config): CollectionConfig =
       type: 'relationship',
       index: true,
       maxDepth: 0,
-      relationTo: [...config.collections!.map((collectionConfig) => collectionConfig.slug)],
+      relationTo: [
+        ...config
+          .collections!.filter((collectionConfig) => collectionConfig.lockDocuments !== false)
+          .map((collectionConfig) => collectionConfig.slug),
+      ],
     },
     {
       name: 'globalSlug',


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/discussions/14452

* Adds `collection.lockDocuments: false` to the KV storage collection if the adapter has one.
* Filters `relationTo` for the locked documents collection with removing collections that have `lockDocuments: false` in their config.