### PR TITLE
fix(ui): safely access fieldPermissions

### DIFF
--- a/packages/ui/src/providers/TableColumns/buildColumnState/filterFieldsWithPermissions.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/filterFieldsWithPermissions.tsx
@@ -53,7 +53,7 @@ export const filterFieldsWithPermissions = <T extends ClientField | Field = Clie
             typeof fieldPermissions === 'boolean'
               ? fieldPermissions
               : 'name' in field && field.name
-                ? fieldPermissions[field.name]?.fields || fieldPermissions[field.name]
+                ? fieldPermissions?.[field.name]?.fields || fieldPermissions?.[field.name]
                 : fieldPermissions,
           fields: field.fields,
         }),
@@ -68,7 +68,7 @@ export const filterFieldsWithPermissions = <T extends ClientField | Field = Clie
     }
 
     if (fieldAffectsData(field)) {
-      const fieldPermission = fieldPermissions[field.name]
+      const fieldPermission = fieldPermissions?.[field.name]
       // Always allow ID fields, or if explicitly granted (true or { read: true })
       // undefined means field is not in permissions object = denied
       if (fieldIsID(field) || fieldPermission === true || fieldPermission?.read === true) {

--- a/packages/ui/src/utilities/reduceFieldsToOptions.tsx
+++ b/packages/ui/src/utilities/reduceFieldsToOptions.tsx
@@ -79,7 +79,7 @@ export const reduceFieldsToOptions = ({
                   typeof fieldPermissions === 'boolean'
                     ? fieldPermissions
                     : tabHasName(tab) && tab.name
-                      ? fieldPermissions[tab.name]?.fields || fieldPermissions[tab.name]
+                      ? fieldPermissions?.[tab.name]?.fields || fieldPermissions?.[tab.name]
                       : fieldPermissions,
                 fields: tab.fields,
                 i18n,
@@ -148,7 +148,7 @@ export const reduceFieldsToOptions = ({
             fieldPermissions:
               typeof fieldPermissions === 'boolean'
                 ? fieldPermissions
-                : fieldPermissions[field.name]?.fields || fieldPermissions[field.name],
+                : fieldPermissions?.[field.name]?.fields || fieldPermissions?.[field.name],
             fields: field.fields,
             i18n,
             labelPrefix: labelWithPrefix,
@@ -191,7 +191,7 @@ export const reduceFieldsToOptions = ({
           fieldPermissions:
             typeof fieldPermissions === 'boolean'
               ? fieldPermissions
-              : fieldPermissions[field.name]?.fields || fieldPermissions[field.name],
+              : fieldPermissions?.[field.name]?.fields || fieldPermissions?.[field.name],
           fields: field.fields,
           i18n,
           labelPrefix: labelWithPrefix,


### PR DESCRIPTION
This prevents an error thrown when trying to read from `fieldPermissions` despite it being undefined. This occasionally happened when navigating to the list view through login redirect.

This would have been caught by typescript if we had strict mode enabled in the ui package.