### PR TITLE
fix: hmr not working in next.js 16

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1144,7 +1144,11 @@ export const getPayload = async (
           if (typeof event.data === 'string') {
             const data = JSON.parse(event.data)
 
-            if ('action' in data && data.action === 'serverComponentChanges') {
+            if (
+              // On Next.js 15, we need to check for data.action. On Next.js 16, we need to check for data.type.
+              data.type === 'serverComponentChanges' ||
+              data.action === 'serverComponentChanges'
+            ) {
               cached.reload = true
             }
           }


### PR DESCRIPTION
Next.js 16 broke HMR, as the shape of the data sent by the hmr websocket has changed.

Next.js 15: `{ action: 'serverComponentChanges', hash: '11' }`
Next.js 16: `{ type: 'serverComponentChanges', hash: '16' }`

This PR adds back HMR support by checking for both `action` and `type`.