### PR TITLE
fix(richtext-lexical): bulk upload drawer rendered at the wrong depth if already in a drawer

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -11,6 +11,7 @@ import type {
 } from 'payload'
 
 import {
+  BulkUploadProvider,
   DocumentInfoProvider,
   EditDepthProvider,
   HydrateAuthProvider,
@@ -420,12 +421,14 @@ export const renderDocument = async ({
           )}
           <HydrateAuthProvider permissions={permissions} />
           <EditDepthProvider>
-            {RenderServerComponent({
-              clientProps,
-              Component: View,
-              importMap,
-              serverProps: documentViewServerProps,
-            })}
+            <BulkUploadProvider drawerSlugPrefix={drawerSlug}>
+              {RenderServerComponent({
+                clientProps,
+                Component: View,
+                importMap,
+                serverProps: documentViewServerProps,
+              })}
+            </BulkUploadProvider>
           </EditDepthProvider>
         </LivePreviewProvider>
       </DocumentInfoProvider>

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -11,7 +11,6 @@ import type {
 } from 'payload'
 
 import {
-  BulkUploadProvider,
   DocumentInfoProvider,
   EditDepthProvider,
   HydrateAuthProvider,
@@ -421,14 +420,12 @@ export const renderDocument = async ({
           )}
           <HydrateAuthProvider permissions={permissions} />
           <EditDepthProvider>
-            <BulkUploadProvider drawerSlugPrefix={drawerSlug}>
-              {RenderServerComponent({
-                clientProps,
-                Component: View,
-                importMap,
-                serverProps: documentViewServerProps,
-              })}
-            </BulkUploadProvider>
+            {RenderServerComponent({
+              clientProps,
+              Component: View,
+              importMap,
+              serverProps: documentViewServerProps,
+            })}
           </EditDepthProvider>
         </LivePreviewProvider>
       </DocumentInfoProvider>

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -2,7 +2,6 @@
 import type { EditorState, SerializedEditorState } from 'lexical'
 
 import {
-  BulkUploadProvider,
   FieldDescription,
   FieldError,
   FieldLabel,

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -2,6 +2,7 @@
 import type { EditorState, SerializedEditorState } from 'lexical'
 
 import {
+  BulkUploadProvider,
   FieldDescription,
   FieldError,
   FieldLabel,
@@ -181,16 +182,18 @@ const RichTextComponent: React.FC<
       <div className={`${baseClass}__wrap`}>
         <ErrorBoundary fallbackRender={fallbackRender} onReset={() => {}}>
           {BeforeInput}
-          <LexicalProvider
-            composerKey={pathWithEditDepth}
-            editorConfig={editorConfig}
-            fieldProps={props}
-            isSmallWidthViewport={isSmallWidthViewport}
-            key={JSON.stringify({ path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
-            onChange={handleChange}
-            readOnly={disabled}
-            value={value}
-          />
+          <BulkUploadProvider drawerSlugPrefix={path}>
+            <LexicalProvider
+              composerKey={pathWithEditDepth}
+              editorConfig={editorConfig}
+              fieldProps={props}
+              isSmallWidthViewport={isSmallWidthViewport}
+              key={JSON.stringify({ path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
+              onChange={handleChange}
+              readOnly={disabled}
+              value={value}
+            />
+          </BulkUploadProvider>
           {AfterInput}
         </ErrorBoundary>
         <RenderCustomComponent

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -182,18 +182,16 @@ const RichTextComponent: React.FC<
       <div className={`${baseClass}__wrap`}>
         <ErrorBoundary fallbackRender={fallbackRender} onReset={() => {}}>
           {BeforeInput}
-          <BulkUploadProvider drawerSlugPrefix={path}>
-            <LexicalProvider
-              composerKey={pathWithEditDepth}
-              editorConfig={editorConfig}
-              fieldProps={props}
-              isSmallWidthViewport={isSmallWidthViewport}
-              key={JSON.stringify({ path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
-              onChange={handleChange}
-              readOnly={disabled}
-              value={value}
-            />
-          </BulkUploadProvider>
+          <LexicalProvider
+            composerKey={pathWithEditDepth}
+            editorConfig={editorConfig}
+            fieldProps={props}
+            isSmallWidthViewport={isSmallWidthViewport}
+            key={JSON.stringify({ path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
+            onChange={handleChange}
+            readOnly={disabled}
+            value={value}
+          />
           {AfterInput}
         </ErrorBoundary>
         <RenderCustomComponent

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -182,6 +182,8 @@ const RichTextComponent: React.FC<
       <div className={`${baseClass}__wrap`}>
         <ErrorBoundary fallbackRender={fallbackRender} onReset={() => {}}>
           {BeforeInput}
+          {/* Lexical may be in a drawer. We need to define another BulkUploadProvider to ensure that the bulk upload drawer
+          is rendered in the correct depth (not displayed *behind* the current drawer)*/}
           <BulkUploadProvider drawerSlugPrefix={path}>
             <LexicalProvider
               composerKey={pathWithEditDepth}


### PR DESCRIPTION
This wraps the Lexical editor in the BulkUploadProvider which matches the Upload Field. Now, when the lexical upload feature calls the useBulkUpload hook it has access to the correct edit depth. 

Alternative approaches might be to modify the BulkUploadProvider to pass in the depth directly but this seemed simplest and matches the Upload field. 

Fixes #14426
