### PR TITLE
fix(next): withPayload wrapper next.js 16 support

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -6,7 +6,7 @@
  * @returns {import('next').NextConfig}
  * */
 export const withPayload = (nextConfig = {}, options = {}) => {
-  const env = nextConfig?.env || {}
+  const env = nextConfig.env || {}
 
   if (nextConfig.experimental?.staleTimes?.dynamic) {
     console.warn(
@@ -45,22 +45,22 @@ export const withPayload = (nextConfig = {}, options = {}) => {
     ...nextConfig,
     env,
     turbopack: {
-      ...(nextConfig?.turbopack || {}),
+      ...(nextConfig.turbopack || {}),
     },
     outputFileTracingExcludes: {
-      ...(nextConfig?.outputFileTracingExcludes || {}),
+      ...(nextConfig.outputFileTracingExcludes || {}),
       '**/*': [
-        ...(nextConfig?.outputFileTracingExcludes?.['**/*'] || []),
+        ...(nextConfig.outputFileTracingExcludes?.['**/*'] || []),
         'drizzle-kit',
         'drizzle-kit/api',
       ],
     },
     outputFileTracingIncludes: {
-      ...(nextConfig?.outputFileTracingIncludes || {}),
-      '**/*': [...(nextConfig?.outputFileTracingIncludes?.['**/*'] || []), '@libsql/client'],
+      ...(nextConfig.outputFileTracingIncludes || {}),
+      '**/*': [...(nextConfig.outputFileTracingIncludes?.['**/*'] || []), '@libsql/client'],
     },
     // We disable the poweredByHeader here because we add it manually in the headers function below
-    ...(nextConfig?.poweredByHeader !== false ? { poweredByHeader: false } : {}),
+    ...(nextConfig.poweredByHeader !== false ? { poweredByHeader: false } : {}),
     headers: async () => {
       const headersFromConfig = 'headers' in nextConfig ? await nextConfig.headers() : []
 
@@ -81,13 +81,13 @@ export const withPayload = (nextConfig = {}, options = {}) => {
               key: 'Critical-CH',
               value: 'Sec-CH-Prefers-Color-Scheme',
             },
-            ...(nextConfig?.poweredByHeader !== false ? [poweredByHeader] : []),
+            ...(nextConfig.poweredByHeader !== false ? [poweredByHeader] : []),
           ],
         },
       ]
     },
     serverExternalPackages: [
-      ...(nextConfig?.serverExternalPackages || []),
+      ...(nextConfig.serverExternalPackages || []),
       'drizzle-kit',
       'drizzle-kit/api',
       'pino',

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -44,6 +44,9 @@ export const withPayload = (nextConfig = {}, options = {}) => {
   const toReturn = {
     ...nextConfig,
     env,
+    turbopack: {
+      ...(nextConfig?.turbopack || {}),
+    },
     outputFileTracingExcludes: {
       ...(nextConfig?.outputFileTracingExcludes || {}),
       '**/*': [


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/pull/14473

Next.js 16 throws the following error:

```ts
 ERROR: This build is using Turbopack, with a `webpack` config and no `turbopack` config.
   This may be a mistake.

   As of Next.js 16 Turbopack is enabled by default and
   custom webpack configurations may need to be migrated to Turbopack.

   NOTE: your `webpack` config may have been added by a configuration plugin.

   To configure Turbopack, see https://nextjs.org/docs/app/api-reference/next-config-js/turbopack

   TIP: Many applications work fine under Turbopack with no configuration,
   if that is the case for you, you can silence this error by passing the
   `--turbopack` or `--webpack` flag explicitly or simply setting an 
   empty turbopack config in your Next config file (e.g. `turbopack: {}`).
```

This PR fixes this error by adding a turbopack property to our next.js config wrapper.