### PR TITLE
templates: remove outdated cloning and payload cloud information

### DIFF
--- a/templates/_template/README.md
+++ b/templates/_template/README.md
@@ -1,6 +1,6 @@
 # Payload Blank Template
 
-A blank template for [Payload](https://github.com/payloadcms/payload) to help you get up and running quickly. This repo may have been created by running `npx create-payload-app@latest` and selecting the "blank" template or by cloning this template on [Payload Cloud](https://payloadcms.com/new/clone/blank).
+A blank template for [Payload](https://github.com/payloadcms/payload) to help you get up and running quickly. This repo may have been created by running `npx create-payload-app@latest` and selecting the "blank" template.
 
 See the official [Examples Directory](https://github.com/payloadcms/payload/tree/main/examples) for details on how to use Payload in a variety of different ways.
 
@@ -35,7 +35,7 @@ To run Payload in production, you need to build and start the Admin panel. To do
 
 ### Deployment
 
-The easiest way to deploy your project is to use [Payload Cloud](https://payloadcms.com/new/import), a one-click hosting solution to deploy production-ready instances of your Payload apps directly from your GitHub repo. You can also deploy your app manually, check out the [deployment documentation](https://payloadcms.com/docs/production/deployment) for full details.
+Check out the [deployment documentation](https://payloadcms.com/docs/production/deployment) for details on how to deploy your project.
 
 ## Questions
 

--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -36,20 +36,10 @@ To spin up this example locally, follow these steps:
 
 If you have not done so already, you need to have standalone copy of this repo on your machine. If you've already cloned this repo, skip to [Development](#development).
 
-#### Method 1
-
 Use the `create-payload-app` CLI to clone this template directly to your machine:
 
 ```bash
 pnpx create-payload-app my-project -t ecommerce
-```
-
-#### Method 2
-
-Use the `git` CLI to clone this template directly to your machine:
-
-```bash
-git clone -n --depth=1 --filter=tree:0 https://github.com/payloadcms/payload my-project && cd my-project && git sparse-checkout set --no-cone templates/ecommerce && git checkout && rm -rf .git && git init && git add . && git mv -f templates/ecommerce/{.,}* . && git add . && git commit -m "Initial commit"
 ```
 
 ### Development

--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -31,24 +31,10 @@ To spin up this example locally, follow these steps:
 
 If you have not done so already, you need to have standalone copy of this repo on your machine. If you've already cloned this repo, skip to [Development](#development).
 
-#### Method 1 (recommended)
-
-Go to Payload Cloud and [clone this template](https://payloadcms.com/new/clone/website). This will create a new repository on your GitHub account with this template's code which you can then clone to your own machine.
-
-#### Method 2
-
 Use the `create-payload-app` CLI to clone this template directly to your machine:
 
 ```bash
 pnpx create-payload-app my-project -t website
-```
-
-#### Method 3
-
-Use the `git` CLI to clone this template directly to your machine:
-
-```bash
-git clone -n --depth=1 --filter=tree:0 https://github.com/payloadcms/payload my-project && cd my-project && git sparse-checkout set --no-cone templates/website && git checkout && rm -rf .git && git init && git add . && git mv -f templates/website/{.,}* . && git add . && git commit -m "Initial commit"
 ```
 
 ### Development
@@ -255,10 +241,6 @@ To run Payload in production, you need to build and start the Admin panel. To do
 1. Invoke the `next build` script by running `pnpm build` or `npm run build` in your project root. This creates a `.next` directory with a production-ready admin bundle.
 1. Finally run `pnpm start` or `npm run start` to run Node in production and serve Payload from the `.build` directory.
 1. When you're ready to go live, see Deployment below for more details.
-
-### Deploying to Payload Cloud
-
-The easiest way to deploy your project is to use [Payload Cloud](https://payloadcms.com/new/import), a one-click hosting solution to deploy production-ready instances of your Payload apps directly from your GitHub repo.
 
 ### Deploying to Vercel
 

--- a/templates/website/src/components/BeforeDashboard/index.tsx
+++ b/templates/website/src/components/BeforeDashboard/index.tsx
@@ -23,11 +23,6 @@ const BeforeDashboard: React.FC = () => {
           {' to see the results.'}
         </li>
         <li>
-          If you created this repo using Payload Cloud, head over to GitHub and clone it to your
-          local machine. It will be under the <i>GitHub Scope</i> that you selected when creating
-          this project.
-        </li>
-        <li>
           {'Modify your '}
           <a
             href="https://payloadcms.com/docs/configuration/collections"

--- a/templates/with-vercel-website/src/components/BeforeDashboard/index.tsx
+++ b/templates/with-vercel-website/src/components/BeforeDashboard/index.tsx
@@ -23,11 +23,6 @@ const BeforeDashboard: React.FC = () => {
           {' to see the results.'}
         </li>
         <li>
-          If you created this repo using Payload Cloud, head over to GitHub and clone it to your
-          local machine. It will be under the <i>GitHub Scope</i> that you selected when creating
-          this project.
-        </li>
-        <li>
           {'Modify your '}
           <a
             href="https://payloadcms.com/docs/configuration/collections"


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14036

- Removes outdated readme section advising users to clone the templates using `git clone`. The `package.json` of those templates uses `workspace:*` syntax - this means they _have_ to go through create-payload-app now.
- Removes docs and references to payload cloud