### PR TITLE
fix(storage-r2): respect data.prefix in handleUpload path construction

### DIFF
--- a/packages/storage-r2/src/handleUpload.ts
+++ b/packages/storage-r2/src/handleUpload.ts
@@ -15,7 +15,7 @@ export const getHandleUpload = ({ bucket, prefix = '' }: Args): HandleUpload => 
   return async ({ data, file }) => {
     // Read more: https://github.com/cloudflare/workers-sdk/issues/6047#issuecomment-2691217843
     const buffer = process.env.NODE_ENV === 'development' ? new Blob([file.buffer]) : file.buffer
-    await bucket.put(path.posix.join(prefix, file.filename), buffer, {
+    await bucket.put(path.posix.join(data.prefix || prefix, file.filename), buffer, {
       httpMetadata: { contentType: file.mimeType },
     })
 


### PR DESCRIPTION
### What?
Aligns the `storage-r2` adapter’s prefix handling with `storage-s3`.
Previously, `storage-r2` always used the static prefix value from the adapter config, ignoring any dynamic `data.prefix` set via hooks (e.g., in `beforeOperation`).

### Why?
In multi-tenant setups or other dynamic upload scenarios, developers may set a custom `req.data.prefix` to determine where files should be stored (e.g., under `<tenant>/<filename>`).
This behavior worked correctly with the S3 adapter but was ignored by the R2 adapter, leading to inconsistent upload paths.

### How?

Updated `handleUpload.ts` in the R2 adapter to respect `data.prefix` when present, falling back to the configured prefix otherwise.

Fixes #14483
