### PR TITLE
fix: support generic types for kv.get

### DIFF
--- a/packages/kv-redis/src/index.ts
+++ b/packages/kv-redis/src/index.ts
@@ -24,11 +24,11 @@ export class RedisKVAdapter implements KVAdapter {
     await this.redisClient.del(`${this.keyPrefix}${key}`)
   }
 
-  async get(key: string): Promise<KVStoreValue | null> {
+  async get<T extends KVStoreValue>(key: string): Promise<null | T> {
     const data = await this.redisClient.get(`${this.keyPrefix}${key}`)
 
     if (data === null) {
-      return data
+      return null
     }
 
     return JSON.parse(data)

--- a/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
@@ -27,9 +27,9 @@ export class DatabaseKVAdapter implements KVAdapter {
     })
   }
 
-  async get(key: string): Promise<KVStoreValue | null> {
+  async get<T extends KVStoreValue>(key: string): Promise<null | T> {
     const doc = await this.payload.db.findOne<{
-      data: KVStoreValue
+      data: T
       id: number | string
     }>({
       collection: this.collectionSlug,

--- a/packages/payload/src/kv/adapters/InMemoryKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/InMemoryKVAdapter.ts
@@ -12,8 +12,8 @@ export class InMemoryKVAdapter implements KVAdapter {
     this.store.delete(key)
   }
 
-  async get(key: string): Promise<KVStoreValue | null> {
-    const value = this.store.get(key)
+  async get<T extends KVStoreValue>(key: string): Promise<null | T> {
+    const value = this.store.get(key) as T | undefined
 
     if (typeof value === 'undefined') {
       return null

--- a/packages/payload/src/kv/index.ts
+++ b/packages/payload/src/kv/index.ts
@@ -22,7 +22,7 @@ export interface KVAdapter {
    * @param key - The key to look up.
    * @returns A promise that resolves to the value, or `null` if not found.
    */
-  get(key: string): Promise<KVStoreValue | null>
+  get<T extends KVStoreValue>(key: string): Promise<null | T>
 
   /**
    * Checks if a key exists in the store.


### PR DESCRIPTION
When getting values from the KV store, it is currently not possible to type the return value without using assertions, etc. This is because `payload.kv.get()` does not support generic types, forcing you to use a workaround like this:

```ts
const value = await payload.kv.get('my-key') as MyValue
// or
const value: MyValue = await payload.kv.get('my-key')
// and so on...
```

Now, you can use generics and the return type will be applied automatically:

```ts
const value = await payload.kv.get<MyValue>('my-key') // `value` is now typed as `MyValue`
```