### PR TITLE
fix: close modal when opening full document from within drawer

### DIFF
--- a/packages/ui/src/elements/IDLabel/index.tsx
+++ b/packages/ui/src/elements/IDLabel/index.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useModal } from '@faceless-ui/modal'
 import React from 'react'
 
 import './index.scss'
@@ -7,6 +8,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { formatAdminURL } from '../../utilities/formatAdminURL.js'
 import { sanitizeID } from '../../utilities/sanitizeID.js'
+import { useDocumentDrawerContext } from '../DocumentDrawer/Provider.js'
 import { useDrawerDepth } from '../Drawer/index.js'
 
 const baseClass = 'id-label'
@@ -21,8 +23,10 @@ export const IDLabel: React.FC<{ className?: string; id: string; prefix?: string
       routes: { admin: adminRoute },
     },
   } = useConfig()
+  const { closeModal, modalState } = useModal()
 
   const { collectionSlug, globalSlug } = useDocumentInfo()
+  const { drawerSlug } = useDocumentDrawerContext()
   const drawerDepth = useDrawerDepth()
 
   const docPath = formatAdminURL({
@@ -30,11 +34,23 @@ export const IDLabel: React.FC<{ className?: string; id: string; prefix?: string
     path: `/${collectionSlug ? `collections/${collectionSlug}` : `globals/${globalSlug}`}/${id}`,
   })
 
+  const handleCloseDrawer = () => {
+    if (drawerSlug && !!modalState[drawerSlug]?.isOpen) {
+      closeModal(drawerSlug)
+    }
+  }
+
   return (
     <div className={[baseClass, className].filter(Boolean).join(' ')} title={id}>
       {prefix}
       &nbsp;
-      {drawerDepth > 1 ? <Link href={docPath}>{sanitizeID(id)}</Link> : sanitizeID(id)}
+      {drawerDepth > 1 ? (
+        <Link href={docPath} onClick={handleCloseDrawer}>
+          {sanitizeID(id)}
+        </Link>
+      ) : (
+        sanitizeID(id)
+      )}
     </div>
   )
 }


### PR DESCRIPTION
### What?

When clicking the link in the IDLabel of the document view inside a drawer the modal stays open and since it is on top of the rest of the content on the page, nothing is selectable. The page has to be refreshed to be able to use the document like normal. This fixes the issue by adding an onClick handler to the link in the IDLabel component that closes the drawer.

### Why?

The bug makes it difficult and annoying to navigate relationships in the admin because the page has to be refreshed anytime a full document is opened from within a drawer

### How?

Adds onClick handler to close the drawer when a document is opened 

Fixes #13048
