### PR TITLE
chore: standardize query param parsing

### DIFF
--- a/packages/payload/src/collections/endpoints/count.ts
+++ b/packages/payload/src/collections/endpoints/count.ts
@@ -3,7 +3,7 @@ import { status as httpStatus } from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { countOperation } from '../operations/count.js'
 
 export const countHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/count.ts
+++ b/packages/payload/src/collections/endpoints/count.ts
@@ -1,22 +1,20 @@
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
-import type { Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { countOperation } from '../operations/count.js'
 
 export const countHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
-  const { trash, where } = req.query as {
-    trash?: string
-    where?: Where
-  }
+
+  const { trash, where } = parseParams(req.query)
 
   const result = await countOperation({
     collection,
     req,
-    trash: trash === 'true',
+    trash,
     where,
   })
 

--- a/packages/payload/src/collections/endpoints/create.ts
+++ b/packages/payload/src/collections/endpoints/create.ts
@@ -5,7 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { createOperation } from '../operations/create.js'
 
 export const createHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/create.ts
+++ b/packages/payload/src/collections/endpoints/create.ts
@@ -5,29 +5,26 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { createOperation } from '../operations/create.js'
 
 export const createHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
-  const { searchParams } = req
-  const autosave = searchParams.get('autosave') === 'true'
-  const draft = searchParams.get('draft') === 'true'
-  const depth = searchParams.get('depth')
+
+  const { autosave, depth, draft, populate, select } = parseParams(req.query)
+
   const publishSpecificLocale = req.query.publishSpecificLocale as string | undefined
 
   const doc = await createOperation({
     autosave,
     collection,
     data: req.data!,
-    depth: isNumber(depth) ? depth : undefined,
+    depth,
     draft,
-    populate: sanitizePopulateParam(req.query.populate),
+    populate,
     publishSpecificLocale,
     req,
-    select: sanitizeSelectParam(req.query.select),
+    select,
   })
 
   return Response.json(

--- a/packages/payload/src/collections/endpoints/delete.ts
+++ b/packages/payload/src/collections/endpoints/delete.ts
@@ -2,34 +2,25 @@ import { getTranslation } from '@payloadcms/translations'
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
-import type { Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { deleteOperation } from '../operations/delete.js'
 
 export const deleteHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
-  const { depth, overrideLock, populate, select, trash, where } = req.query as {
-    depth?: string
-    overrideLock?: string
-    populate?: Record<string, unknown>
-    select?: Record<string, unknown>
-    trash?: string
-    where?: Where
-  }
+
+  const { depth, overrideLock, populate, select, trash, where } = parseParams(req.query)
 
   const result = await deleteOperation({
     collection,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    overrideLock: Boolean(overrideLock === 'true'),
-    populate: sanitizePopulateParam(populate),
+    depth,
+    overrideLock,
+    populate,
     req,
-    select: sanitizeSelectParam(select),
-    trash: trash === 'true',
+    select,
+    trash,
     where: where!,
   })
 

--- a/packages/payload/src/collections/endpoints/delete.ts
+++ b/packages/payload/src/collections/endpoints/delete.ts
@@ -16,7 +16,7 @@ export const deleteHandler: PayloadHandler = async (req) => {
   const result = await deleteOperation({
     collection,
     depth,
-    overrideLock,
+    overrideLock: overrideLock ?? false,
     populate,
     req,
     select,

--- a/packages/payload/src/collections/endpoints/delete.ts
+++ b/packages/payload/src/collections/endpoints/delete.ts
@@ -5,7 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { deleteOperation } from '../operations/delete.js'
 
 export const deleteHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/deleteByID.ts
+++ b/packages/payload/src/collections/endpoints/deleteByID.ts
@@ -4,7 +4,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { deleteByIDOperation } from '../operations/deleteByID.js'
 
 export const deleteByIDHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/deleteByID.ts
+++ b/packages/payload/src/collections/endpoints/deleteByID.ts
@@ -4,26 +4,22 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { deleteByIDOperation } from '../operations/deleteByID.js'
 
 export const deleteByIDHandler: PayloadHandler = async (req) => {
   const { id, collection } = getRequestCollectionWithID(req)
-  const { searchParams } = req
-  const depth = searchParams.get('depth')
-  const overrideLock = searchParams.get('overrideLock')
-  const trash = searchParams.get('trash') === 'true'
+
+  const { depth, overrideLock, populate, select, trash } = parseParams(req.query)
 
   const doc = await deleteByIDOperation({
     id,
     collection,
-    depth: isNumber(depth) ? depth : undefined,
-    overrideLock: Boolean(overrideLock === 'true'),
-    populate: sanitizePopulateParam(req.query.populate),
+    depth,
+    overrideLock,
+    populate,
     req,
-    select: sanitizeSelectParam(req.query.select),
+    select,
     trash,
   })
 

--- a/packages/payload/src/collections/endpoints/deleteByID.ts
+++ b/packages/payload/src/collections/endpoints/deleteByID.ts
@@ -16,7 +16,7 @@ export const deleteByIDHandler: PayloadHandler = async (req) => {
     id,
     collection,
     depth,
-    overrideLock,
+    overrideLock: overrideLock ?? false,
     populate,
     req,
     select,

--- a/packages/payload/src/collections/endpoints/docAccess.ts
+++ b/packages/payload/src/collections/endpoints/docAccess.ts
@@ -8,6 +8,7 @@ import { docAccessOperation } from '../operations/docAccess.js'
 
 export const docAccessHandler: PayloadHandler = async (req) => {
   const { id, collection } = getRequestCollectionWithID(req, { optionalID: true })
+
   const result = await docAccessOperation({
     id,
     collection,

--- a/packages/payload/src/collections/endpoints/duplicate.ts
+++ b/packages/payload/src/collections/endpoints/duplicate.ts
@@ -5,30 +5,23 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { duplicateOperation } from '../operations/duplicate.js'
 
 export const duplicateHandler: PayloadHandler = async (req) => {
   const { id, collection } = getRequestCollectionWithID(req)
-  const { depth, draft, populate, select, selectedLocales } = req.query as {
-    depth?: string
-    draft?: string
-    populate?: Record<string, unknown>
-    select?: Record<string, unknown>
-    selectedLocales?: string[]
-  }
+
+  const { depth, draft, populate, select, selectedLocales } = parseParams(req.query)
 
   const doc = await duplicateOperation({
     id,
     collection,
     data: req.data,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: draft === 'true',
-    populate: sanitizePopulateParam(populate),
+    depth,
+    draft,
+    populate,
     req,
-    select: sanitizeSelectParam(select),
+    select,
     selectedLocales,
   })
 

--- a/packages/payload/src/collections/endpoints/duplicate.ts
+++ b/packages/payload/src/collections/endpoints/duplicate.ts
@@ -5,7 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { duplicateOperation } from '../operations/duplicate.js'
 
 export const duplicateHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/find.ts
+++ b/packages/payload/src/collections/endpoints/find.ts
@@ -4,7 +4,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { findOperation } from '../operations/find.js'
 
 export const findHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/find.ts
+++ b/packages/payload/src/collections/endpoints/find.ts
@@ -1,47 +1,31 @@
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
-import type { Where } from '../../types/index.js'
-import type { JoinParams } from '../../utilities/sanitizeJoinParams.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizeJoinParams } from '../../utilities/sanitizeJoinParams.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { findOperation } from '../operations/find.js'
 
 export const findHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
+
   const { depth, draft, joins, limit, page, pagination, populate, select, sort, trash, where } =
-    req.query as {
-      depth?: string
-      draft?: string
-      joins?: JoinParams
-      limit?: string
-      page?: string
-      pagination?: string
-      populate?: Record<string, unknown>
-      select?: Record<string, unknown>
-      sort?: string
-      trash?: string
-      where?: Where
-    }
+    parseParams(req.query)
 
   const result = await findOperation({
     collection,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: draft === 'true',
-    joins: sanitizeJoinParams(joins),
-    limit: isNumber(limit) ? Number(limit) : undefined,
-    page: isNumber(page) ? Number(page) : undefined,
-    pagination: pagination === 'false' ? false : undefined,
-    populate: sanitizePopulateParam(populate),
+    depth,
+    draft,
+    joins,
+    limit,
+    page,
+    pagination,
+    populate,
     req,
-    select: sanitizeSelectParam(select),
-    sort: typeof sort === 'string' ? sort.split(',') : undefined,
-    trash: trash === 'true',
+    select,
+    sort,
+    trash,
     where,
   })
 

--- a/packages/payload/src/collections/endpoints/findByID.ts
+++ b/packages/payload/src/collections/endpoints/findByID.ts
@@ -4,7 +4,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { findByIDOperation } from '../operations/findByID.js'
 
 export const findByIDHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/findByID.ts
+++ b/packages/payload/src/collections/endpoints/findByID.ts
@@ -22,7 +22,7 @@ export const findByIDHandler: PayloadHandler = async (req) => {
     data,
     depth,
     draft,
-    flattenLocales: flattenLocales ?? false,
+    flattenLocales,
     joins,
     populate,
     req,

--- a/packages/payload/src/collections/endpoints/findByID.ts
+++ b/packages/payload/src/collections/endpoints/findByID.ts
@@ -4,39 +4,29 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { type JoinParams, sanitizeJoinParams } from '../../utilities/sanitizeJoinParams.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { findByIDOperation } from '../operations/findByID.js'
 
 export const findByIDHandler: PayloadHandler = async (req) => {
-  const { data, searchParams } = req
+  const { data: dataArg } = req
   const { id, collection } = getRequestCollectionWithID(req)
-  const depth = data ? data.depth : searchParams.get('depth')
-  const trash = data ? data.trash : searchParams.get('trash') === 'true'
-  const flattenLocales = data
-    ? data.flattenLocales
-    : searchParams.has('flattenLocales')
-      ? searchParams.get('flattenLocales') === 'true'
-      : // flattenLocales should be undefined if not provided, so that the default (true) is applied in the operation
-        undefined
+
+  const { data, depth, draft, flattenLocales, joins, populate, select, trash } = parseParams({
+    ...req.query,
+    ...dataArg,
+  })
 
   const result = await findByIDOperation({
     id,
     collection,
-    data: data
-      ? data?.data
-      : searchParams.get('data')
-        ? JSON.parse(searchParams.get('data') as string)
-        : undefined,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: data ? data.draft : searchParams.get('draft') === 'true',
+    data,
+    depth,
+    draft,
     flattenLocales,
-    joins: sanitizeJoinParams(req.query.joins as JoinParams),
-    populate: sanitizePopulateParam(req.query.populate),
+    joins,
+    populate,
     req,
-    select: sanitizeSelectParam(req.query.select),
+    select,
     trash,
   })
 

--- a/packages/payload/src/collections/endpoints/findByID.ts
+++ b/packages/payload/src/collections/endpoints/findByID.ts
@@ -22,7 +22,7 @@ export const findByIDHandler: PayloadHandler = async (req) => {
     data,
     depth,
     draft,
-    flattenLocales,
+    flattenLocales: flattenLocales ?? false,
     joins,
     populate,
     req,

--- a/packages/payload/src/collections/endpoints/findDistinct.ts
+++ b/packages/payload/src/collections/endpoints/findDistinct.ts
@@ -1,26 +1,17 @@
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
-import type { Where } from '../../types/index.js'
 
 import { APIError } from '../../errors/APIError.js'
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { findDistinctOperation } from '../operations/findDistinct.js'
 
 export const findDistinctHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
-  const { depth, field, limit, page, sort, trash, where } = req.query as {
-    depth?: string
-    field?: string
-    limit?: string
-    page?: string
-    sort?: string
-    sortOrder?: string
-    trash?: string
-    where?: Where
-  }
+
+  const { depth, field, limit, page, sort, trash, where } = parseParams(req.query)
 
   if (!field) {
     throw new APIError('field must be specified', httpStatus.BAD_REQUEST)
@@ -28,13 +19,13 @@ export const findDistinctHandler: PayloadHandler = async (req) => {
 
   const result = await findDistinctOperation({
     collection,
-    depth: isNumber(depth) ? Number(depth) : undefined,
+    depth,
     field,
-    limit: isNumber(limit) ? Number(limit) : undefined,
-    page: isNumber(page) ? Number(page) : undefined,
+    limit,
+    page,
     req,
-    sort: typeof sort === 'string' ? sort.split(',') : undefined,
-    trash: trash === 'true',
+    sort,
+    trash,
     where,
   })
 

--- a/packages/payload/src/collections/endpoints/findDistinct.ts
+++ b/packages/payload/src/collections/endpoints/findDistinct.ts
@@ -5,7 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 import { APIError } from '../../errors/APIError.js'
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { findDistinctOperation } from '../operations/findDistinct.js'
 
 export const findDistinctHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/findVersionByID.ts
+++ b/packages/payload/src/collections/endpoints/findVersionByID.ts
@@ -4,25 +4,21 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { findVersionByIDOperation } from '../operations/findVersionByID.js'
 
 export const findVersionByIDHandler: PayloadHandler = async (req) => {
-  const { searchParams } = req
-  const depth = searchParams.get('depth')
-  const trash = searchParams.get('trash') === 'true'
+  const { depth, populate, select, trash } = parseParams(req.query)
 
   const { id, collection } = getRequestCollectionWithID(req)
 
   const result = await findVersionByIDOperation({
     id,
     collection,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    populate: sanitizePopulateParam(req.query.populate),
+    depth,
+    populate,
     req,
-    select: sanitizeSelectParam(req.query.select),
+    select,
     trash,
   })
 

--- a/packages/payload/src/collections/endpoints/findVersionByID.ts
+++ b/packages/payload/src/collections/endpoints/findVersionByID.ts
@@ -4,7 +4,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { findVersionByIDOperation } from '../operations/findVersionByID.js'
 
 export const findVersionByIDHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/findVersions.ts
+++ b/packages/payload/src/collections/endpoints/findVersions.ts
@@ -4,7 +4,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { findVersionsOperation } from '../operations/findVersions.js'
 
 export const findVersionsHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/findVersions.ts
+++ b/packages/payload/src/collections/endpoints/findVersions.ts
@@ -1,40 +1,30 @@
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
-import type { Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { findVersionsOperation } from '../operations/findVersions.js'
 
 export const findVersionsHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
-  const { depth, limit, page, pagination, populate, select, sort, trash, where } = req.query as {
-    depth?: string
-    limit?: string
-    page?: string
-    pagination?: string
-    populate?: Record<string, unknown>
-    select?: Record<string, unknown>
-    sort?: string
-    trash?: string
-    where?: Where
-  }
+
+  const { depth, limit, page, pagination, populate, select, sort, trash, where } = parseParams(
+    req.query,
+  )
 
   const result = await findVersionsOperation({
     collection,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    limit: isNumber(limit) ? Number(limit) : undefined,
-    page: isNumber(page) ? Number(page) : undefined,
-    pagination: pagination === 'false' ? false : undefined,
-    populate: sanitizePopulateParam(populate),
+    depth,
+    limit,
+    page,
+    pagination,
+    populate,
     req,
-    select: sanitizeSelectParam(select),
-    sort: typeof sort === 'string' ? sort.split(',') : undefined,
-    trash: trash === 'true',
+    select,
+    sort,
+    trash,
     where,
   })
 

--- a/packages/payload/src/collections/endpoints/restoreVersion.ts
+++ b/packages/payload/src/collections/endpoints/restoreVersion.ts
@@ -4,22 +4,20 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { restoreVersionOperation } from '../operations/restoreVersion.js'
 
 export const restoreVersionHandler: PayloadHandler = async (req) => {
   const { id, collection } = getRequestCollectionWithID(req)
-  const { searchParams } = req
-  const depth = searchParams.get('depth')
-  const draft = searchParams.get('draft')
+
+  const { depth, draft, populate } = parseParams(req.query)
 
   const result = await restoreVersionOperation({
     id,
     collection,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: draft === 'true' ? true : undefined,
-    populate: sanitizePopulateParam(req.query.populate),
+    depth,
+    draft,
+    populate,
     req,
   })
 

--- a/packages/payload/src/collections/endpoints/restoreVersion.ts
+++ b/packages/payload/src/collections/endpoints/restoreVersion.ts
@@ -4,7 +4,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { restoreVersionOperation } from '../operations/restoreVersion.js'
 
 export const restoreVersionHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/update.ts
+++ b/packages/payload/src/collections/endpoints/update.ts
@@ -21,7 +21,7 @@ export const updateHandler: PayloadHandler = async (req) => {
     depth,
     draft,
     limit,
-    overrideLock,
+    overrideLock: overrideLock ?? false,
     populate,
     req,
     select,

--- a/packages/payload/src/collections/endpoints/update.ts
+++ b/packages/payload/src/collections/endpoints/update.ts
@@ -2,41 +2,31 @@ import { getTranslation } from '@payloadcms/translations'
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
-import type { Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { updateOperation } from '../operations/update.js'
 
 export const updateHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
-  const { depth, draft, limit, overrideLock, populate, select, sort, trash, where } = req.query as {
-    depth?: string
-    draft?: string
-    limit?: string
-    overrideLock?: string
-    populate?: Record<string, unknown>
-    select?: Record<string, unknown>
-    sort?: string
-    trash?: string
-    where?: Where
-  }
+
+  const { depth, draft, limit, overrideLock, populate, select, sort, trash, where } = parseParams(
+    req.query,
+  )
 
   const result = await updateOperation({
     collection,
     data: req.data!,
-    depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: draft === 'true',
-    limit: isNumber(limit) ? Number(limit) : undefined,
-    overrideLock: Boolean(overrideLock === 'true'),
-    populate: sanitizePopulateParam(populate),
+    depth,
+    draft,
+    limit,
+    overrideLock,
+    populate,
     req,
-    select: sanitizeSelectParam(select),
-    sort: typeof sort === 'string' ? sort.split(',') : undefined,
-    trash: trash === 'true',
+    select,
+    sort,
+    trash,
     where: where!,
   })
 

--- a/packages/payload/src/collections/endpoints/update.ts
+++ b/packages/payload/src/collections/endpoints/update.ts
@@ -5,7 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { updateOperation } from '../operations/update.js'
 
 export const updateHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/endpoints/updateByID.ts
+++ b/packages/payload/src/collections/endpoints/updateByID.ts
@@ -4,33 +4,27 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { isNumber } from '../../utilities/isNumber.js'
-import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
-import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
+import { parseParams } from '../../utilities/parseParams.js'
 import { updateByIDOperation } from '../operations/updateByID.js'
 
 export const updateByIDHandler: PayloadHandler = async (req) => {
   const { id, collection } = getRequestCollectionWithID(req)
-  const { searchParams } = req
-  const depth = searchParams.get('depth')
-  const autosave = searchParams.get('autosave') === 'true'
-  const draft = searchParams.get('draft') === 'true'
-  const overrideLock = searchParams.get('overrideLock')
-  const trash = searchParams.get('trash') === 'true'
-  const publishSpecificLocale = req.query.publishSpecificLocale as string | undefined
+
+  const { autosave, depth, draft, overrideLock, populate, publishSpecificLocale, select, trash } =
+    parseParams(req.query)
 
   const doc = await updateByIDOperation({
     id,
     autosave,
     collection,
     data: req.data!,
-    depth: isNumber(depth) ? Number(depth) : undefined,
+    depth,
     draft,
-    overrideLock: Boolean(overrideLock === 'true'),
-    populate: sanitizePopulateParam(req.query.populate),
+    overrideLock,
+    populate,
     publishSpecificLocale,
     req,
-    select: sanitizeSelectParam(req.query.select),
+    select,
     trash,
   })
 

--- a/packages/payload/src/collections/endpoints/updateByID.ts
+++ b/packages/payload/src/collections/endpoints/updateByID.ts
@@ -20,7 +20,7 @@ export const updateByIDHandler: PayloadHandler = async (req) => {
     data: req.data!,
     depth,
     draft,
-    overrideLock,
+    overrideLock: overrideLock ?? false,
     populate,
     publishSpecificLocale,
     req,

--- a/packages/payload/src/collections/endpoints/updateByID.ts
+++ b/packages/payload/src/collections/endpoints/updateByID.ts
@@ -4,7 +4,7 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
-import { parseParams } from '../../utilities/parseParams.js'
+import { parseParams } from '../../utilities/parseParams/index.js'
 import { updateByIDOperation } from '../operations/updateByID.js'
 
 export const updateByIDHandler: PayloadHandler = async (req) => {

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -161,6 +161,7 @@ export const findByIDOperation = async <
         where,
       })
     }
+
     // /////////////////////////////////////
     // Find by ID
     // /////////////////////////////////////

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -77,7 +77,7 @@ export const handleEndpoints = async ({
 
   // This can be used against GET request search params size limit.
   // Instead you can do POST request with a text body as search params.
-  // We use this interally for relationships querying on the frontend
+  // We use this internally for relationships querying on the frontend
   // packages/ui/src/fields/Relationship/index.tsx
   if (
     request.method.toLowerCase() === 'post' &&
@@ -86,6 +86,7 @@ export const handleEndpoints = async ({
   ) {
     let url = request.url
     let data: any = undefined
+
     if (request.headers.get('Content-Type') === 'application/x-www-form-urlencoded') {
       const search = await request.text()
       url = `${request.url}?${search}`

--- a/packages/payload/src/utilities/parseBooleanString.ts
+++ b/packages/payload/src/utilities/parseBooleanString.ts
@@ -1,0 +1,15 @@
+/**
+ * Useful when parsing query parameters where booleans are represented as strings.
+ * Falls back to `undefined` to allow default handling elsewhere.
+ */
+export const parseBooleanString = (value: null | string | undefined): boolean | undefined => {
+  if (value === 'true') {
+    return true
+  }
+
+  if (value === 'false') {
+    return false
+  }
+
+  return undefined
+}

--- a/packages/payload/src/utilities/parseBooleanString.ts
+++ b/packages/payload/src/utilities/parseBooleanString.ts
@@ -2,7 +2,13 @@
  * Useful when parsing query parameters where booleans are represented as strings.
  * Falls back to `undefined` to allow default handling elsewhere.
  */
-export const parseBooleanString = (value: null | string | undefined): boolean | undefined => {
+export const parseBooleanString = (
+  value: boolean | null | string | undefined,
+): boolean | undefined => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
   if (value === 'true') {
     return true
   }

--- a/packages/payload/src/utilities/parseParams.ts
+++ b/packages/payload/src/utilities/parseParams.ts
@@ -1,0 +1,102 @@
+import type { JoinQuery, PopulateType, SelectType, Where } from '../types/index.js'
+import type { JoinParams } from './sanitizeJoinParams.js'
+
+import { isNumber } from './isNumber.js'
+import { parseBooleanString } from './parseBooleanString.js'
+import { sanitizeJoinParams } from './sanitizeJoinParams.js'
+import { sanitizePopulateParam } from './sanitizePopulateParam.js'
+import { sanitizeSelectParam } from './sanitizeSelectParam.js'
+
+type ParsedParams = {
+  autosave?: boolean
+  data?: Record<string, unknown>
+  depth?: number
+  draft?: boolean
+  field?: string
+  flattenLocales?: boolean
+  joins?: JoinQuery
+  limit?: number
+  overrideLock?: boolean
+  page?: number
+  pagination?: boolean
+  populate?: PopulateType
+  publishSpecificLocale?: string
+  select?: SelectType
+  selectedLocales?: string[]
+  sort?: string[]
+  trash?: boolean
+  where?: Where
+} & Record<string, unknown>
+
+type RawParams = {
+  [key: string]: unknown
+  autosave?: string
+  data?: string
+  depth?: string
+  draft?: string
+  field?: string
+  flattenLocales?: string
+  joins?: JoinParams
+  limit?: string
+  overrideLock?: string
+  page?: string
+  pagination?: string
+  populate?: unknown
+  publishSpecificLocale?: string
+  select?: unknown
+  selectedLocales?: string
+  sort?: string
+  trash?: string
+  where?: Where
+}
+
+export const parseParams = (params: RawParams): ParsedParams => {
+  const knownBooleanParams = [
+    'autosave',
+    'draft',
+    'trash',
+    'overrideLock',
+    'pagination',
+    'flattenLocales',
+  ]
+  const knownNumberParams = ['depth', 'limit', 'page']
+
+  const parsedParams: ParsedParams = {}
+
+  // iterate through known params to make this very fast
+  for (const key of knownBooleanParams) {
+    if (key in params) {
+      parsedParams[key] = parseBooleanString(params[key] as string)
+    }
+  }
+
+  for (const key of knownNumberParams) {
+    if (key in params) {
+      if (isNumber(params[key])) {
+        parsedParams[key] = Number(params[key])
+      }
+    }
+  }
+
+  if ('populate' in params) {
+    parsedParams.populate = sanitizePopulateParam(params.populate)
+  }
+
+  if ('select' in params) {
+    parsedParams.select = sanitizeSelectParam(params.select)
+  }
+
+  if ('joins' in params) {
+    parsedParams.joins = sanitizeJoinParams(params.joins as JoinParams)
+  }
+
+  if ('sort' in params) {
+    parsedParams.sort = typeof params.sort === 'string' ? params.sort.split(',') : undefined
+  }
+
+  if ('data' in params) {
+    parsedParams.data = JSON.parse(params.data || '')
+  }
+
+  return parsedParams
+}

--- a/packages/payload/src/utilities/parseParams.ts
+++ b/packages/payload/src/utilities/parseParams.ts
@@ -50,6 +50,13 @@ type RawParams = {
   where?: Where
 }
 
+/**
+ * Takes raw query parameters and parses them into the correct types that Payload expects.
+ * Examples:
+ *   a. `draft` provided as a string of "true" is converted to a boolean
+ *   b. `depth` provided as a string of "0" is converted to a number
+ *   c. `sort` provided as a comma-separated string is converted to an array of strings
+ */
 export const parseParams = (params: RawParams): ParsedParams => {
   const knownBooleanParams = [
     'autosave',

--- a/packages/payload/src/utilities/parseParams.ts
+++ b/packages/payload/src/utilities/parseParams.ts
@@ -102,8 +102,8 @@ export const parseParams = (params: RawParams): ParsedParams => {
     parsedParams.sort = typeof params.sort === 'string' ? params.sort.split(',') : undefined
   }
 
-  if ('data' in params) {
-    parsedParams.data = JSON.parse(params.data || '')
+  if ('data' in params && typeof params.data === 'string' && params.data.length > 0) {
+    parsedParams.data = JSON.parse(params.data)
   }
 
   return parsedParams

--- a/packages/payload/src/utilities/parseParams.ts
+++ b/packages/payload/src/utilities/parseParams.ts
@@ -66,9 +66,10 @@ export const parseParams = (params: RawParams): ParsedParams => {
     'pagination',
     'flattenLocales',
   ]
+
   const knownNumberParams = ['depth', 'limit', 'page']
 
-  const parsedParams: ParsedParams = {}
+  const parsedParams = (params || {}) as ParsedParams
 
   // iterate through known params to make this very fast
   for (const key of knownBooleanParams) {

--- a/packages/payload/src/utilities/parseParams.ts
+++ b/packages/payload/src/utilities/parseParams.ts
@@ -74,7 +74,7 @@ export const parseParams = (params: RawParams): ParsedParams => {
   // iterate through known params to make this very fast
   for (const key of knownBooleanParams) {
     if (key in params) {
-      parsedParams[key] = parseBooleanString(params[key] as string)
+      parsedParams[key] = parseBooleanString(params[key] as boolean | string)
     }
   }
 

--- a/packages/payload/src/utilities/parseParams/index.spec.ts
+++ b/packages/payload/src/utilities/parseParams/index.spec.ts
@@ -1,0 +1,269 @@
+import { parseParams, booleanParams, numberParams } from './index.js'
+
+describe('parseParams', () => {
+  describe('boolean parameters', () => {
+    booleanParams.forEach((param) => {
+      describe(param, () => {
+        it('should parse string "true" to boolean true', () => {
+          const result = parseParams({ [param]: 'true' })
+          expect(result[param]).toBe(true)
+        })
+
+        it('should parse string "false" to boolean false', () => {
+          const result = parseParams({ [param]: 'false' })
+          expect(result[param]).toBe(false)
+        })
+
+        it('should parse boolean true to boolean true', () => {
+          const result = parseParams({ [param]: true })
+          expect(result[param]).toBe(true)
+        })
+
+        it('should parse boolean false to boolean false', () => {
+          const result = parseParams({ [param]: false })
+          expect(result[param]).toBe(false)
+        })
+
+        it('should return undefined for truthy strings (not exact "true")', () => {
+          const result = parseParams({ [param]: '1' })
+          expect(result[param]).toBeUndefined()
+        })
+
+        it('should return undefined for falsy strings (not exact "false")', () => {
+          const result = parseParams({ [param]: '0' })
+          expect(result[param]).toBeUndefined()
+        })
+
+        it('should return undefined for empty string', () => {
+          const result = parseParams({ [param]: '' })
+          expect(result[param]).toBeUndefined()
+        })
+      })
+    })
+  })
+
+  describe('number parameters', () => {
+    numberParams.forEach((param) => {
+      describe(param, () => {
+        it('should parse valid number string to number', () => {
+          const result = parseParams({ [param]: '42' })
+          expect(result[param]).toBe(42)
+        })
+
+        it('should parse zero string to zero', () => {
+          const result = parseParams({ [param]: '0' })
+          expect(result[param]).toBe(0)
+        })
+
+        it('should parse negative number string to negative number', () => {
+          const result = parseParams({ [param]: '-5' })
+          expect(result[param]).toBe(-5)
+        })
+
+        it('should parse decimal number string to decimal number', () => {
+          const result = parseParams({ [param]: '3.14' })
+          expect(result[param]).toBe(3.14)
+        })
+
+        it('should not parse invalid number strings', () => {
+          const result = parseParams({ [param]: 'not-a-number' })
+          expect(result[param]).toBe('not-a-number') // remains as string
+        })
+
+        it('should not parse empty string', () => {
+          const result = parseParams({ [param]: '' })
+          expect(result[param]).toBe('') // remains as string
+        })
+
+        it('should handle already numeric values', () => {
+          const result = parseParams({ [param]: 123 })
+          expect(result[param]).toBe(123)
+        })
+      })
+    })
+  })
+
+  describe('sort parameter', () => {
+    it('should parse comma-separated string to array', () => {
+      const result = parseParams({ sort: 'name,createdAt,-updatedAt' })
+      expect(result.sort).toEqual(['name', 'createdAt', '-updatedAt'])
+    })
+
+    it('should parse single value string to array with one element', () => {
+      const result = parseParams({ sort: 'name' })
+      expect(result.sort).toEqual(['name'])
+    })
+
+    it('should handle empty string', () => {
+      const result = parseParams({ sort: '' })
+      expect(result.sort).toEqual([''])
+    })
+
+    it('should handle comma-separated string with spaces', () => {
+      const result = parseParams({ sort: 'name, createdAt , -updatedAt' })
+      expect(result.sort).toEqual(['name', ' createdAt ', ' -updatedAt'])
+    })
+
+    it('should return undefined for non-string sort values', () => {
+      const result = parseParams({ sort: 123 as any })
+      expect(result.sort).toBeUndefined()
+    })
+
+    it('should return undefined for null sort values', () => {
+      const result = parseParams({ sort: null as any })
+      expect(result.sort).toBeUndefined()
+    })
+  })
+
+  describe('data parameter', () => {
+    it('should parse valid JSON string', () => {
+      const data = { name: 'test', value: 42 }
+      const result = parseParams({ data: JSON.stringify(data) })
+      expect(result.data).toEqual(data)
+    })
+
+    it('should parse empty object JSON string', () => {
+      const result = parseParams({ data: '{}' })
+      expect(result.data).toEqual({})
+    })
+
+    it('should parse array JSON string', () => {
+      const data = [1, 2, 3]
+      const result = parseParams({ data: JSON.stringify(data) })
+      expect(result.data).toEqual(data)
+    })
+
+    it('should not process empty string', () => {
+      const result = parseParams({ data: '' })
+      expect(result.data).toBe('') // empty string is not processed, remains as string
+    })
+
+    it('should throw error for invalid JSON', () => {
+      expect(() => {
+        parseParams({ data: 'invalid-json' })
+      }).toThrow()
+    })
+
+    it('should not process non-string data values', () => {
+      const result = parseParams({ data: { already: 'parsed' } as any })
+      expect(result.data).toEqual({ already: 'parsed' })
+    })
+  })
+
+  describe('special parameters', () => {
+    it('should handle populate parameter', () => {
+      const result = parseParams({ populate: 'field1,field2' })
+      expect(result).toHaveProperty('populate')
+      // Note: actual sanitization logic is tested in sanitizePopulateParam tests
+    })
+
+    it('should handle select parameter', () => {
+      const result = parseParams({ select: 'field1,field2' })
+      expect(result).toHaveProperty('select')
+      // Note: actual sanitization logic is tested in sanitizeSelectParam tests
+    })
+
+    it('should handle joins parameter', () => {
+      const joins = { collection: 'posts' }
+      const result = parseParams({ joins })
+      expect(result).toHaveProperty('joins')
+      // Note: actual sanitization logic is tested in sanitizeJoinParams tests
+    })
+  })
+
+  describe('selectedLocales parameter', () => {
+    it('should pass through selectedLocales as-is', () => {
+      const selectedLocales = 'en,es,fr'
+      const result = parseParams({ selectedLocales })
+      expect(result.selectedLocales).toBe(selectedLocales)
+    })
+  })
+
+  describe('publishSpecificLocale parameter', () => {
+    it('should pass through publishSpecificLocale as-is', () => {
+      const publishSpecificLocale = 'en'
+      const result = parseParams({ publishSpecificLocale })
+      expect(result.publishSpecificLocale).toBe(publishSpecificLocale)
+    })
+  })
+
+  describe('field parameter', () => {
+    it('should pass through field as-is', () => {
+      const field = 'myField'
+      const result = parseParams({ field })
+      expect(result.field).toBe(field)
+    })
+  })
+
+  describe('where parameter', () => {
+    it('should pass through where as-is', () => {
+      const where = { name: { equals: 'test' } }
+      const result = parseParams({ where })
+      expect(result.where).toBe(where)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty params object', () => {
+      const result = parseParams({})
+      expect(result).toEqual({})
+    })
+
+    it('should throw error for null params (current implementation bug)', () => {
+      expect(() => {
+        parseParams(null as any)
+      }).toThrow(TypeError)
+    })
+
+    it('should throw error for undefined params (current implementation bug)', () => {
+      expect(() => {
+        parseParams(undefined as any)
+      }).toThrow(TypeError)
+    })
+
+    it('should preserve unknown parameters', () => {
+      const result = parseParams({ customParam: 'customValue' })
+      expect(result.customParam).toBe('customValue')
+    })
+
+    it('should handle mixed parameter types', () => {
+      const result = parseParams({
+        draft: 'true',
+        depth: '5',
+        sort: 'name,createdAt',
+        data: '{"test": true}',
+        customParam: 'custom',
+      })
+
+      expect(result.draft).toBe(true)
+      expect(result.depth).toBe(5)
+      expect(result.sort).toEqual(['name', 'createdAt'])
+      expect(result.data).toEqual({ test: true })
+      expect(result.customParam).toBe('custom')
+    })
+  })
+
+  describe('parameter preservation', () => {
+    it('should not modify parameters that are not in known lists', () => {
+      const params = {
+        unknownBoolean: 'true',
+        unknownNumber: '42',
+        unknownString: 'test',
+      }
+      const result = parseParams(params)
+
+      expect(result.unknownBoolean).toBe('true') // should remain string
+      expect(result.unknownNumber).toBe('42') // should remain string
+      expect(result.unknownString).toBe('test')
+    })
+
+    it('should only process parameters that exist in the input', () => {
+      const result = parseParams({ draft: 'true' })
+
+      expect(result.draft).toBe(true)
+      expect(result).not.toHaveProperty('autosave')
+      expect(result).not.toHaveProperty('depth')
+      expect(result).not.toHaveProperty('sort')
+    })
+  })
+})

--- a/packages/payload/src/utilities/parseParams/index.ts
+++ b/packages/payload/src/utilities/parseParams/index.ts
@@ -1,11 +1,11 @@
-import type { JoinQuery, PopulateType, SelectType, Where } from '../types/index.js'
-import type { JoinParams } from './sanitizeJoinParams.js'
+import type { JoinQuery, PopulateType, SelectType, Where } from '../../types/index.js'
+import type { JoinParams } from '../sanitizeJoinParams.js'
 
-import { isNumber } from './isNumber.js'
-import { parseBooleanString } from './parseBooleanString.js'
-import { sanitizeJoinParams } from './sanitizeJoinParams.js'
-import { sanitizePopulateParam } from './sanitizePopulateParam.js'
-import { sanitizeSelectParam } from './sanitizeSelectParam.js'
+import { isNumber } from '../isNumber.js'
+import { parseBooleanString } from '../parseBooleanString.js'
+import { sanitizeJoinParams } from '../sanitizeJoinParams.js'
+import { sanitizePopulateParam } from '../sanitizePopulateParam.js'
+import { sanitizeSelectParam } from '../sanitizeSelectParam.js'
 
 type ParsedParams = {
   autosave?: boolean
@@ -50,6 +50,17 @@ type RawParams = {
   where?: Where
 }
 
+export const booleanParams = [
+  'autosave',
+  'draft',
+  'trash',
+  'overrideLock',
+  'pagination',
+  'flattenLocales',
+]
+
+export const numberParams = ['depth', 'limit', 'page']
+
 /**
  * Takes raw query parameters and parses them into the correct types that Payload expects.
  * Examples:
@@ -58,27 +69,16 @@ type RawParams = {
  *   c. `sort` provided as a comma-separated string is converted to an array of strings
  */
 export const parseParams = (params: RawParams): ParsedParams => {
-  const knownBooleanParams = [
-    'autosave',
-    'draft',
-    'trash',
-    'overrideLock',
-    'pagination',
-    'flattenLocales',
-  ]
-
-  const knownNumberParams = ['depth', 'limit', 'page']
-
   const parsedParams = (params || {}) as ParsedParams
 
   // iterate through known params to make this very fast
-  for (const key of knownBooleanParams) {
+  for (const key of booleanParams) {
     if (key in params) {
       parsedParams[key] = parseBooleanString(params[key] as boolean | string)
     }
   }
 
-  for (const key of knownNumberParams) {
+  for (const key of numberParams) {
     if (key in params) {
       if (isNumber(params[key])) {
         parsedParams[key] = Number(params[key])


### PR DESCRIPTION
The way we parse query params within endpoint handlers is currently non-standard. This leads to subtle differences in how they are handled across endpoints, e.g. using searchParams vs req.query, allowing values to fallback to undefined, etc.

For background, each endpoint accepts arbitrary query params and must transform them into what Payload expects.

For example:
- `draft` provided as a string of "true" is converted to a boolean
- `depth` provided as a string of "0" is converted to a number
- `sort` provided as a comma-separated string is converted to an array of strings

It is also easy to overlook params that should fallback to `undefined`. Not doing so will prevent the underlying operation from using its defaults, if any:

```ts
await update({
  // ...
  trash: trash === 'true' // This is never `undefined` so the default arg will not used (if any)
})
```

Parsing these params is now shared via a single `parseParams` utility, which takes in raw query parameters and returns them typed and properly formatted.

```ts
const {
  depth, // number | undefined
  draft // number | undefined
} = parseParams(req.query)
```