### PR TITLE
fix: potential error spam during hmr, when using next.js 16 and turbopack

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1000,17 +1000,6 @@ export const reload = async (
     })
   }
 
-  // Generate import map
-  if (skipImportMapGeneration !== true && config.admin?.importMap?.autoGenerate !== false) {
-    // This may run outside of the admin panel, e.g. in the user's frontend, where we don't have an import map file.
-    // We don't want to throw an error in this case, as it would break the user's frontend.
-    // => just skip it => ignoreResolveError: true
-    await generateImportMap(config, {
-      ignoreResolveError: true,
-      log: true,
-    })
-  }
-
   if (payload.db?.init) {
     await payload.db.init()
   }
@@ -1025,6 +1014,25 @@ export const reload = async (
   ;(global as any)._payload_doNotCacheClientConfig = true // This will help refreshing the client config cache more reliably. If you remove this, please test HMR + client config refreshing (do new fields appear in the document?)
   ;(global as any)._payload_doNotCacheSchemaMap = true
   ;(global as any)._payload_doNotCacheClientSchemaMap = true
+
+  // Generate import map
+  if (skipImportMapGeneration !== true && config.admin?.importMap?.autoGenerate !== false) {
+    // We need to run import map generation in the background, using setTimeout + a floating promise.
+    // Otherwise, in Next.js 16 and turbopack, the console will be spammed with errors that look like this:
+    // Error: Could not find the module "[project]/node_modules/.pnpm/[path-to-importmap-entry]" in the React Client Manifest. This is probably a bug in the React Server Components bundler.
+    // This will happen when running HMR for multiple getPayload calls, e.g. getPayload from admin panel and frontend.
+    // This usually happens for live-preview enabled collections.
+    // Once the generateImportMap accesses the import map file using fs, these errors will be thrown.
+    setTimeout(() => {
+      void generateImportMap(config, {
+        // This may run outside of the admin panel, e.g. in the user's frontend, where we don't have an import map file.
+        // We don't want to throw an error in this case, as it would break the user's frontend.
+        // => just skip it => ignoreResolveError: true
+        ignoreResolveError: true,
+        log: true,
+      })
+    }, 0)
+  }
 }
 
 let _cached: Map<

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1116,6 +1116,7 @@ export const getPayload = async (
       await reload(config, cached.payload, false, options)
 
       resolve()
+      cached.reload = false
     }
 
     if (cached.reload instanceof Promise) {
@@ -1156,6 +1157,14 @@ export const getPayload = async (
         )
 
         cached.ws.onmessage = (event) => {
+          if (cached.reload instanceof Promise) {
+            // If there is an in-progress reload in the same getPayload
+            // cache instance, do not set reload to true again, which would
+            // trigger another reload.
+            // Instead, wait for the in-progress reload to finish.
+            return
+          }
+
           if (typeof event.data === 'string') {
             const data = JSON.parse(event.data)
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14419.

In a live-preview enabled page, both the admin panel and the frontend initialize their own `getPayload` instances, each subscribing to HMR updates. In Next.js 16 with Turbopack, this setup can cause the server console to be flooded with errors like:

```ts
Error: Could not find the module "[project]/node_modules/.pnpm/[path-to-importmap-entry]" in the React Client Manifest. This is probably a bug in the React Server Components bundler.
```

These errors occur when an `fs` call tries to access the import map during the reload process.

## Fix

The import map generation is now deferred using `setTimeout` and is no longer awaited. This prevents the problematic awaited `fs` access during HMR reloads.

Video that showcases this issue and the solution on the website template:

https://github.com/user-attachments/assets/afd5e6cf-09ac-4cda-bbdc-88dc4d1e7108

## Additional Improvements

Additionally, this PR prevents multiple reload operations from overlapping by skipping new reloads while one is already in progress.

This reduces redundant reload triggers when multiple getPayload instances are subscribed to the same HMR websocket,  reducing the chance of something going wrong.