### PR TITLE
fix: use `TSiblingData` for `previousSiblingDoc` in `FieldHook`

### DIFF
--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -57,7 +57,6 @@ export type AfterReadRichTextHookArgs<
 export type AfterChangeRichTextHookArgs<
   TData extends TypeWithID = any,
   TValue = any,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TSiblingData = any,
 > = {
   /** A string relating to which operation the field type is currently executing within. */
@@ -65,30 +64,30 @@ export type AfterChangeRichTextHookArgs<
   /** The document before changes were applied. */
   previousDoc?: TData
   /** The sibling data of the document before changes being applied. */
-  previousSiblingDoc?: TData
+  previousSiblingDoc?: TSiblingData
   /** The previous value of the field, before changes */
   previousValue?: TValue
 }
 
 export type BeforeValidateRichTextHookArgs<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TData extends TypeWithID = any,
   TValue = any,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TSiblingData = any,
 > = {
   /** A string relating to which operation the field type is currently executing within. */
   operation: 'create' | 'update'
   overrideAccess?: boolean
   /** The sibling data of the document before changes being applied. */
-  previousSiblingDoc?: TData
+  previousSiblingDoc?: TSiblingData
   /** The previous value of the field, before changes */
   previousValue?: TValue
 }
 
 export type BeforeChangeRichTextHookArgs<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TData extends TypeWithID = any,
   TValue = any,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TSiblingData = any,
 > = {
   /**
@@ -111,7 +110,7 @@ export type BeforeChangeRichTextHookArgs<
   operation?: 'create' | 'delete' | 'read' | 'update'
   overrideAccess: boolean
   /** The sibling data of the document before changes being applied. */
-  previousSiblingDoc?: TData
+  previousSiblingDoc?: TSiblingData
   /** The previous value of the field, before changes */
   previousValue?: TValue
   /**

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -201,7 +201,7 @@ export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSibling
   /** The document before changes were applied, only in `afterChange` hooks. */
   previousDoc?: TData
   /** The sibling data of the document before changes being applied, only in `beforeChange`, `beforeValidate`, `beforeDuplicate` and `afterChange` field hooks. */
-  previousSiblingDoc?: TData
+  previousSiblingDoc?: TSiblingData
   /** The previous value of the field, before changes, only in `beforeChange`, `afterChange`, `beforeDuplicate` and `beforeValidate` field hooks. */
   previousValue?: TValue
   /** The Express request object. It is mocked for Local API operations. */


### PR DESCRIPTION
### What?
In field hooks, `previousSiblingDoc` is typed as `TData`.

### Why?
This value should actually be typed as `TSiblingData`, I've confirmed the sibling data is actually what is returned when a field hook runs.

### How?
Updated `FieldHook` typing, as well as `RichText` field hook typings

Fixes #9735
