### PR TITLE
fix(ui): virtual fields disappearing from filter/groupBy dropdowns with access control

### DIFF
--- a/packages/ui/src/utilities/reduceFieldsToOptions.tsx
+++ b/packages/ui/src/utilities/reduceFieldsToOptions.tsx
@@ -45,11 +45,16 @@ export const reduceFieldsToOptions = ({
     }
 
     // Handle virtual:string fields (virtual relationships, e.g. "post.title")
+    // IMPORTANT: We DON'T mutate field.name here because the field object is shared across
+    // multiple components (WhereBuilder, GroupByBuilder, etc.). Mutating it would break
+    // permission checks and cause issues in other components that need the field name.
+    // Instead, we use a flag to determine whether to include the field name in the path.
+    let shouldIgnoreFieldName = false
     if ('virtual' in field && typeof field.virtual === 'string') {
       pathPrefix = pathPrefix ? pathPrefix + '.' + field.virtual : field.virtual
       if (fieldAffectsData(field)) {
-        // ignore virtual field names
-        field.name = ''
+        // Mark that we should ignore the field name when constructing the field path
+        shouldIgnoreFieldName = true
       }
     }
 
@@ -237,7 +242,13 @@ export const reduceFieldsToOptions = ({
             })
           : localizedLabel
 
-        const fieldPath = pathPrefix ? createNestedClientFieldPath(pathPrefix, field) : field.name
+        // For virtual fields, we use just the pathPrefix (the virtual path) without appending the field name
+        // For regular fields, we use createNestedClientFieldPath which appends the field name to the path
+        const fieldPath = shouldIgnoreFieldName
+          ? pathPrefix
+          : pathPrefix
+            ? createNestedClientFieldPath(pathPrefix, field)
+            : field.name
 
         const formattedField: ReducedField = {
           label: formattedLabel,

--- a/packages/ui/src/utilities/reduceFieldsToOptions.tsx
+++ b/packages/ui/src/utilities/reduceFieldsToOptions.tsx
@@ -44,12 +44,13 @@ export const reduceFieldsToOptions = ({
       return reduced
     }
 
-    // Handle virtual:string fields (virtual relationships, e.g. "post.title")
     // IMPORTANT: We DON'T mutate field.name here because the field object is shared across
     // multiple components (WhereBuilder, GroupByBuilder, etc.). Mutating it would break
     // permission checks and cause issues in other components that need the field name.
     // Instead, we use a flag to determine whether to include the field name in the path.
     let shouldIgnoreFieldName = false
+
+    // Handle virtual:string fields (virtual relationships, e.g. "post.title")
     if ('virtual' in field && typeof field.virtual === 'string') {
       pathPrefix = pathPrefix ? pathPrefix + '.' + field.virtual : field.virtual
       if (fieldAffectsData(field)) {
@@ -244,11 +245,14 @@ export const reduceFieldsToOptions = ({
 
         // For virtual fields, we use just the pathPrefix (the virtual path) without appending the field name
         // For regular fields, we use createNestedClientFieldPath which appends the field name to the path
-        const fieldPath = shouldIgnoreFieldName
-          ? pathPrefix
-          : pathPrefix
-            ? createNestedClientFieldPath(pathPrefix, field)
-            : field.name
+        let fieldPath: string
+        if (shouldIgnoreFieldName) {
+          fieldPath = pathPrefix
+        } else if (pathPrefix) {
+          fieldPath = createNestedClientFieldPath(pathPrefix, field)
+        } else {
+          fieldPath = field.name
+        }
 
         const formattedField: ReducedField = {
           label: formattedLabel,

--- a/test/access-control/collections/ReadRestricted/index.ts
+++ b/test/access-control/collections/ReadRestricted/index.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { unrestrictedSlug } from '../../shared.js'
+
 export const readRestrictedSlug = 'read-restricted'
 
 export const ReadRestricted: CollectionConfig = {
@@ -53,6 +55,19 @@ export const ReadRestricted: CollectionConfig = {
         {
           name: 'publicPhone',
           type: 'text',
+        },
+        {
+          name: 'virtualContactName',
+          type: 'text',
+          virtual: 'unrestricted.name',
+        },
+        {
+          name: 'restrictedVirtualContactInfo',
+          type: 'text',
+          virtual: 'unrestricted.name',
+          access: {
+            read: () => false,
+          },
         },
       ],
     },
@@ -226,6 +241,39 @@ export const ReadRestricted: CollectionConfig = {
           ],
         },
       ],
+    },
+    {
+      name: 'unrestricted',
+      type: 'relationship',
+      relationTo: unrestrictedSlug,
+    },
+    {
+      name: 'unrestrictedVirtualFieldName',
+      type: 'text',
+      virtual: 'unrestricted.name',
+    },
+    {
+      name: 'unrestrictedVirtualGroupInfo',
+      type: 'group',
+      virtual: 'unrestricted.info',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+        },
+      ],
+    },
+    {
+      name: 'restrictedVirtualField',
+      type: 'text',
+      virtual: 'unrestricted.name',
+      access: {
+        read: () => false,
+      },
     },
   ],
 }

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -205,6 +205,20 @@ export default buildConfigWithDefaults(
             type: 'text',
           },
           {
+            name: 'info',
+            type: 'group',
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+              },
+              {
+                name: 'description',
+                type: 'textarea',
+              },
+            ],
+          },
+          {
             name: 'userRestrictedDocs',
             type: 'relationship',
             hasMany: true,

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -1315,6 +1315,223 @@ describe('Access Control', () => {
       })
     })
 
+    describe('virtual fields', () => {
+      test('should show virtual field in filter dropdown when collection has field with access control', async () => {
+        await page.goto(readRestrictedUrl.list)
+        await openListFilters(page, {})
+        await page.locator('.where-builder__add-first-filter').click()
+
+        const initialField = page.locator('.condition__field')
+        await initialField.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = initialField.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Virtual field should be visible in the filter dropdown
+        const virtualFieldOption = initialField.locator('.rs__option', {
+          hasText: 'Unrestricted Virtual Field Name',
+        })
+        await expect(virtualFieldOption).toBeVisible()
+      })
+
+      test('should show virtual field in groupBy dropdown when collection has field with access control', async () => {
+        await page.goto(readRestrictedUrl.list)
+        const { groupByContainer } = await openGroupBy(page)
+
+        const field = groupByContainer.locator('#group-by--field-select')
+        await field.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = field.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Virtual field should be visible in the groupBy dropdown
+        const virtualFieldOption = field.locator('.rs__option', {
+          hasText: 'Unrestricted Virtual Field Name',
+        })
+        await expect(virtualFieldOption).toBeVisible()
+      })
+
+      test('should show nested fields within virtual group field in filter dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        await openListFilters(page, {})
+        await page.locator('.where-builder__add-first-filter').click()
+
+        const initialField = page.locator('.condition__field')
+        await initialField.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = initialField.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Nested fields within the virtual group should be visible
+        const virtualGroupTitleOption = initialField.locator('.rs__option', {
+          hasText: 'Unrestricted Virtual Group Info > Title',
+        })
+        await expect(virtualGroupTitleOption).toBeVisible()
+
+        const virtualGroupDescriptionOption = initialField.locator('.rs__option', {
+          hasText: 'Unrestricted Virtual Group Info > Description',
+        })
+        await expect(virtualGroupDescriptionOption).toBeVisible()
+      })
+
+      test('should show nested fields within virtual group field in groupBy dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        const { groupByContainer } = await openGroupBy(page)
+
+        const field = groupByContainer.locator('#group-by--field-select')
+        await field.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = field.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Nested fields within the virtual group should be visible
+        const virtualGroupTitleOption = field.locator('.rs__option', {
+          hasText: 'Unrestricted Virtual Group Info > Title',
+        })
+        await expect(virtualGroupTitleOption).toBeVisible()
+
+        const virtualGroupDescriptionOption = field.locator('.rs__option', {
+          hasText: 'Unrestricted Virtual Group Info > Description',
+        })
+        await expect(virtualGroupDescriptionOption).toBeVisible()
+      })
+
+      test('should show virtual field nested inside group in filter dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        await openListFilters(page, {})
+        await page.locator('.where-builder__add-first-filter').click()
+
+        const initialField = page.locator('.condition__field')
+        await initialField.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = initialField.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Virtual field nested inside contactInfo group should be visible
+        const nestedVirtualFieldOption = initialField.locator('.rs__option', {
+          hasText: 'Contact Info > Virtual Contact Name',
+        })
+        await expect(nestedVirtualFieldOption).toBeVisible()
+      })
+
+      test('should show virtual field nested inside group in groupBy dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        const { groupByContainer } = await openGroupBy(page)
+
+        const field = groupByContainer.locator('#group-by--field-select')
+        await field.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = field.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Virtual field nested inside contactInfo group should be visible
+        const nestedVirtualFieldOption = field.locator('.rs__option', {
+          hasText: 'Contact Info > Virtual Contact Name',
+        })
+        await expect(nestedVirtualFieldOption).toBeVisible()
+      })
+
+      test('should hide top-level virtual field with read: false in filter dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        await openListFilters(page, {})
+        await page.locator('.where-builder__add-first-filter').click()
+
+        const initialField = page.locator('.condition__field')
+        await initialField.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = initialField.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Restricted virtual field should be hidden (use exactText to avoid matching "Unrestricted...")
+        await expect(
+          initialField.locator('.rs__option', { hasText: exactText('Restricted Virtual Field') }),
+        ).toBeHidden()
+      })
+
+      test('should hide top-level virtual field with read: false in groupBy dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        const { groupByContainer } = await openGroupBy(page)
+
+        const field = groupByContainer.locator('#group-by--field-select')
+        await field.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = field.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Restricted virtual field should be hidden (use exactText to avoid matching "Unrestricted...")
+        await expect(
+          field.locator('.rs__option', { hasText: exactText('Restricted Virtual Field') }),
+        ).toBeHidden()
+      })
+
+      test('should hide nested virtual field with read: false in filter dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        await openListFilters(page, {})
+        await page.locator('.where-builder__add-first-filter').click()
+
+        const initialField = page.locator('.condition__field')
+        await initialField.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = initialField.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Restricted virtual field nested in contactInfo should be hidden
+        await expect(
+          initialField.locator('.rs__option', {
+            hasText: 'Contact Info > Restricted Virtual Contact Info',
+          }),
+        ).toBeHidden()
+      })
+
+      test('should hide nested virtual field with read: false in groupBy dropdown', async () => {
+        await page.goto(readRestrictedUrl.list)
+        const { groupByContainer } = await openGroupBy(page)
+
+        const field = groupByContainer.locator('#group-by--field-select')
+        await field.click()
+
+        // Wait for dropdown options to load
+        const visibleOption = field.locator('.rs__option', {
+          hasText: 'Visible Top Level',
+        })
+        await expect(visibleOption).toBeVisible()
+
+        // Restricted virtual field nested in contactInfo should be hidden
+        await expect(
+          field.locator('.rs__option', {
+            hasText: 'Contact Info > Restricted Virtual Contact Info',
+          }),
+        ).toBeHidden()
+      })
+    })
+
     describe('default list view columns', () => {
       test('should not render column for top-level field with read: false by default', async () => {
         await page.goto(readRestrictedUrl.list)

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -97,6 +97,7 @@ export interface Config {
     hooks: Hook;
     'auth-collection': AuthCollection;
     'read-restricted': ReadRestricted;
+    'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -129,6 +130,7 @@ export interface Config {
     hooks: HooksSelect<false> | HooksSelect<true>;
     'auth-collection': AuthCollectionSelect<false> | AuthCollectionSelect<true>;
     'read-restricted': ReadRestrictedSelect<false> | ReadRestrictedSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -301,6 +303,10 @@ export interface Post {
 export interface Unrestricted {
   id: string;
   name?: string | null;
+  info?: {
+    title?: string | null;
+    description?: string | null;
+  };
   userRestrictedDocs?: (string | UserRestrictedCollection)[] | null;
   createNotUpdateDocs?: (string | CreateNotUpdateCollection)[] | null;
   updatedAt: string;
@@ -831,6 +837,8 @@ export interface ReadRestricted {
     email?: string | null;
     secretPhone?: string | null;
     publicPhone?: string | null;
+    virtualContactName?: string | null;
+    restrictedVirtualContactInfo?: string | null;
   };
   visibleInRow?: string | null;
   restrictedInRow?: string | null;
@@ -865,8 +873,32 @@ export interface ReadRestricted {
     visibleAdvanced?: string | null;
     restrictedAdvanced?: string | null;
   };
+  unrestricted?: (string | null) | Unrestricted;
+  unrestrictedVirtualFieldName?: string | null;
+  unrestrictedVirtualGroupInfo?: {
+    title?: string | null;
+    description?: string | null;
+  };
+  restrictedVirtualField?: string | null;
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1106,6 +1138,12 @@ export interface PostsSelect<T extends boolean = true> {
  */
 export interface UnrestrictedSelect<T extends boolean = true> {
   name?: T;
+  info?:
+    | T
+    | {
+        title?: T;
+        description?: T;
+      };
   userRestrictedDocs?: T;
   createNotUpdateDocs?: T;
   updatedAt?: T;
@@ -1497,6 +1535,8 @@ export interface ReadRestrictedSelect<T extends boolean = true> {
         email?: T;
         secretPhone?: T;
         publicPhone?: T;
+        virtualContactName?: T;
+        restrictedVirtualContactInfo?: T;
       };
   visibleInRow?: T;
   restrictedInRow?: T;
@@ -1541,8 +1581,25 @@ export interface ReadRestrictedSelect<T extends boolean = true> {
         visibleAdvanced?: T;
         restrictedAdvanced?: T;
       };
+  unrestricted?: T;
+  unrestrictedVirtualFieldName?: T;
+  unrestrictedVirtualGroupInfo?:
+    | T
+    | {
+        title?: T;
+        description?: T;
+      };
+  restrictedVirtualField?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?

Virtual fields with `virtual: string` syntax (e.g., `virtual: 'post.title'`) were disappearing from the filter (WhereBuilder) and groupBy dropdowns when the collection had at least one field with custom `access.read` control.

### Why?

The bug was introduced in commit `bcd40b6df7` which added permission checks to hide fields with `read: false`. The implementation had two problems:

1. **Permission check failure**: The code was setting `field.name = ''` for virtual fields BEFORE checking permissions. This caused `fieldPermissions?.[field.name]` to become `fieldPermissions?.['']` which evaluated to `undefined`, failing the permission check and hiding all virtual fields.

2. **Object mutation bug**: The field object is shared across multiple components (WhereBuilder, GroupByBuilder, etc.). Mutating `field.name = ''` affected all components that used the same field object, breaking permission checks and field path construction everywhere.

### How?

The fix eliminates the mutation entirely:

- Instead of mutating `field.name = ''`, we now use a flag `shouldIgnoreFieldName` to track whether to include the field name in the path
- The original `field.name` is preserved throughout, ensuring permission checks work correctly: `fieldPermissions?.[field.name]`
- The field path is constructed conditionally based on the `shouldIgnoreFieldName` flag

This ensures:
- Permission checks always have access to the correct field name
- The shared field object is never mutated
- Virtual fields appear in dropdowns when they should
- Virtual fields with `access.read: false` are properly hidden

Added e2e tests covering:
- Virtual fields in filter and groupBy dropdowns with access control present
- Virtual group fields with nested fields
- Virtual fields nested inside groups
- Virtual fields with `access.read: false` (properly hidden)
