### PR TITLE
fix: error when calling jobs.handleSchedules when there are no schedules defined

### DIFF
--- a/packages/payload/src/queues/operations/handleSchedules/index.ts
+++ b/packages/payload/src/queues/operations/handleSchedules/index.ts
@@ -48,6 +48,15 @@ export async function handleSchedules({
     jobsConfig,
   })
 
+  if (Object.keys(queuesWithSchedules).length === 0) {
+    // No schedules defined => return early, before fetching jobsStatsGlobal, as the global may not even exist
+    return {
+      errored: [],
+      queued: [],
+      skipped: [],
+    }
+  }
+
   const stats: JobStats = await req.payload.db.findGlobal({
     slug: jobStatsGlobalSlug,
     req,


### PR DESCRIPTION
Previously, if you called jobs.handleSchedules() with no schedules defined, the function would throw an error, as the jobs stats global is not registered when there are no schedules defined.

Now, instead of erroring, the handleSchedules function will return early with empty arrays for `errored`, `queued` and `skipped`.