### PR TITLE
fix: findGlobalVersionByID id type

### DIFF
--- a/packages/payload/src/globals/operations/local/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/local/findVersionByID.ts
@@ -32,7 +32,7 @@ export type Options<TSlug extends GlobalSlug> = {
   /**
    * The ID of the version to find.
    */
-  id: string
+  id: number | string
   /**
    * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
    */


### PR DESCRIPTION
Adjusts the `id` type on `findGlobalVersionByID` to be `number | string`, previously was `string`.