### PR TITLE
fix(db-mongodb): remove process.exit(1) in connect error handling as it crashes Lambda functions

### DIFF
--- a/packages/db-mongodb/src/connect.ts
+++ b/packages/db-mongodb/src/connect.ts
@@ -108,6 +108,5 @@ export const connect: Connect = async function connect(
       err,
       msg,
     })
-    process.exit(1)
   }
 }


### PR DESCRIPTION
### What?

Removes the `process.exit(1)` in the `db-mongodb` `connect` function's error handling.

### Why?

When running in serverless environments (AWS Lambda a hosting provider like Netlify or Vercel) calling `process.exit(1)` ungracefully and immediately terminates the Lambda which causes the entire Next.js application to crash when there's any sort of MongoDB connection error. Error handling should be done gracefully, even if it's re-throwing the error and allowing it to bubble up to client side code to be handled in an error boundary. When the entire node process is exited, it doesn't leave room for any further error handling.

Let me know if there are any additions to be made here in terms of re-throwing the error or anything else. If this is a bad idea or will cause other issues, please let me know, but from a Lambda execution/lifecycle point of view this is quite bad and I'm unsure how nobody else has run into this up until this point.