### PR TITLE
fix: inject custom translations into supportedLanguages in sanitization

### DIFF
--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -1,4 +1,4 @@
-import type { AcceptedLanguages } from '@payloadcms/translations'
+import type { AcceptedLanguages, Language } from '@payloadcms/translations'
 
 import { en } from '@payloadcms/translations/languages/en'
 import { deepMergeSimple } from '@payloadcms/translations/utilities'

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -199,7 +199,7 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
           i18nConfig.supportedLanguages[langKey] = {
             ...en,
             translations: mergedTranslations,
-          } as any
+          } as Language<typeof en.translations>
         }
       }
     })


### PR DESCRIPTION
## Description

Automatically injects custom translations from `i18n.translations` into `supportedLanguages` during config sanitization. This allows translation functions like `({ t }) => t('namespace:key')` to work with user-defined custom translations, not just the default translations from `@payloadcms/translations`.

## Problem

Currently, when users define custom translations in their config:

```typescript
i18n: {
  translations: {
    de: {
      'my-namespace': {
        customKey: 'Wert'
      }
    }
  }
}
```

These translations are **not** accessible to the `t` function used in field labels and options. The `t` function only searches in `config.i18n.supportedLanguages[lang].translations`, causing custom translations to be ignored.

This issue was discovered while implementing translation support for plugins in PR #14548, where radio button options using `label: ({ t }) => t('plugin-redirects:key')` failed to translate for custom languages.

## Solution

During config sanitization (in `packages/payload/src/config/sanitize.ts`), the code now:

1. Iterates through all languages in `i18n.translations`
2. For existing languages in `supportedLanguages`: merges custom translations with existing ones
3. For new languages: creates them using English as a template, then merges custom translations

This ensures that **all custom translations** defined by users or plugins are automatically available to the `t` function throughout the application.
