### PR TITLE
fix(next, ui): show status "changed" in List View

### DIFF
--- a/packages/next/src/views/List/enrichDocsWithVersionStatus.ts
+++ b/packages/next/src/views/List/enrichDocsWithVersionStatus.ts
@@ -60,6 +60,7 @@ export async function enrichDocsWithVersionStatus({
     const publishedVersions = await req.payload.findVersions({
       collection: collectionConfig.slug,
       depth: 0,
+      limit: 0,
       pagination: false,
       select: {
         parent: true,

--- a/packages/next/src/views/List/enrichDocsWithVersionStatus.ts
+++ b/packages/next/src/views/List/enrichDocsWithVersionStatus.ts
@@ -1,0 +1,103 @@
+import type { PaginatedDocs, PayloadRequest, SanitizedCollectionConfig } from 'payload'
+
+/**
+ * Enriches list view documents with correct draft status display.
+ * When draft=true is used in the query, Payload returns the latest draft version if it exists.
+ * This function checks if draft documents also have a published version to determine "changed" status.
+ *
+ * Performance: Uses a single query to find all documents with "changed" status instead of N queries.
+ */
+export async function enrichDocsWithVersionStatus({
+  collectionConfig,
+  data,
+  req,
+}: {
+  collectionConfig: SanitizedCollectionConfig
+  data: PaginatedDocs
+  req: PayloadRequest
+}): Promise<PaginatedDocs> {
+  const draftsEnabled = collectionConfig?.versions?.drafts
+
+  if (!draftsEnabled || !data?.docs?.length) {
+    return data
+  }
+
+  // Find all draft documents
+  // When querying with draft:true, we get the latest draft if it exists
+  // We need to check if these drafts have a published version
+  const draftDocs = data.docs.filter((doc) => doc._status === 'draft')
+
+  if (draftDocs.length === 0) {
+    return data
+  }
+
+  const draftDocIds = draftDocs.map((doc) => doc.id).filter(Boolean)
+
+  if (draftDocIds.length === 0) {
+    return data
+  }
+
+  // OPTIMIZATION: Single query to find all document IDs that have BOTH:
+  // 1. A draft version (latest=true, _status='draft')
+  // 2. A published version (_status='published')
+  // These are the documents with "changed" status
+  try {
+    // Query for all published versions of the draft documents
+    const publishedVersions = await req.payload.findVersions({
+      collection: collectionConfig.slug,
+      depth: 0,
+      limit: draftDocIds.length,
+      pagination: false,
+      select: {
+        parent: true,
+      },
+      where: {
+        and: [
+          {
+            parent: {
+              in: draftDocIds,
+            },
+          },
+          {
+            'version._status': {
+              equals: 'published',
+            },
+          },
+        ],
+      },
+    })
+
+    // Create a Set of document IDs that have published versions
+    const hasPublishedVersionSet = new Set(
+      publishedVersions.docs.map((version) => version.parent).filter(Boolean),
+    )
+
+    // Enrich documents with display status
+    const enrichedDocs = data.docs.map((doc) => {
+      // If it's a draft and has a published version, show "changed"
+      if (doc._status === 'draft' && hasPublishedVersionSet.has(doc.id)) {
+        return {
+          ...doc,
+          _displayStatus: 'changed' as const,
+        }
+      }
+
+      return {
+        ...doc,
+        _displayStatus: doc._status as 'draft' | 'published',
+      }
+    })
+
+    return {
+      ...data,
+      docs: enrichedDocs,
+    }
+  } catch (error) {
+    // If there's an error querying versions, just return the original data
+    req.payload.logger.error({
+      err: error,
+      msg: `Error checking version status for collection ${collectionConfig.slug}`,
+    })
+    return data
+  }
+}

--- a/packages/next/src/views/List/enrichDocsWithVersionStatus.ts
+++ b/packages/next/src/views/List/enrichDocsWithVersionStatus.ts
@@ -42,11 +42,24 @@ export async function enrichDocsWithVersionStatus({
   // 2. A published version (_status='published')
   // These are the documents with "changed" status
   try {
-    // Query for all published versions of the draft documents
+    // TODO: This could be more efficient with a findDistinctVersions() API:
+    // const { values } = await req.payload.findDistinctVersions({
+    //   collection: collectionConfig.slug,
+    //   field: 'parent',
+    //   where: {
+    //     and: [
+    //       { parent: { in: draftDocIds } },
+    //       { 'version._status': { equals: 'published' } },
+    //     ],
+    //   },
+    // })
+    // const hasPublishedVersionSet = new Set(values)
+    //
+    // For now, we query all published versions but only select the 'parent' field
+    // to minimize data transfer, then deduplicate with a Set
     const publishedVersions = await req.payload.findVersions({
       collection: collectionConfig.slug,
       depth: 0,
-      limit: draftDocIds.length,
       pagination: false,
       select: {
         parent: true,

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -28,6 +28,7 @@ import {
 import React, { Fragment } from 'react'
 
 import { getDocumentPermissions } from '../Document/getDocumentPermissions.js'
+import { enrichDocsWithVersionStatus } from './enrichDocsWithVersionStatus.js'
 import { handleGroupBy } from './handleGroupBy.js'
 import { renderListViewSlots } from './renderListViewSlots.js'
 import { resolveAllFilterOptions } from './resolveAllFilterOptions.js'
@@ -269,6 +270,13 @@ export const renderListView = async (
           viewType,
           where: whereWithMergedSearch,
         }))
+
+        // Enrich documents with correct display status for drafts
+        data = await enrichDocsWithVersionStatus({
+          collectionConfig,
+          data,
+          req,
+        })
       } else {
         data = await req.payload.find({
           collection: collectionSlug,
@@ -286,6 +294,13 @@ export const renderListView = async (
           trash,
           user,
           where: whereWithMergedSearch,
+        })
+
+        // Enrich documents with correct display status for drafts
+        data = await enrichDocsWithVersionStatus({
+          collectionConfig,
+          data,
+          req,
         })
         ;({ columnState, Table } = renderTable({
           clientCollectionConfig,

--- a/packages/payload/src/versions/baseFields.ts
+++ b/packages/payload/src/versions/baseFields.ts
@@ -10,6 +10,10 @@ export const statuses: Option[] = [
     label: ({ t }) => t('version:published'),
     value: 'published',
   },
+  {
+    label: ({ t }) => t('version:changed'),
+    value: 'changed',
+  },
 ]
 
 export const baseVersionFields: Field[] = [

--- a/packages/payload/src/versions/baseFields.ts
+++ b/packages/payload/src/versions/baseFields.ts
@@ -10,10 +10,6 @@ export const statuses: Option[] = [
     label: ({ t }) => t('version:published'),
     value: 'published',
   },
-  {
-    label: ({ t }) => t('version:changed'),
-    value: 'changed',
-  },
 ]
 
 export const baseVersionFields: Field[] = [

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -474,6 +474,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'version:currentPublishedVersion',
   'version:currentlyPublished',
   'version:draft',
+  'version:draftHasPublishedVersion',
   'version:draftSavedSuccessfully',
   'version:lastSavedAgo',
   'version:modifiedOnly',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -553,6 +553,7 @@ export const arTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'تمت المشاهدة حاليا',
     currentPublishedVersion: 'النسخة المنشورة الحالية',
     draft: 'مسودّة',
+    draftHasPublishedVersion: 'مسودة (لديها نسخة منشورة)',
     draftSavedSuccessfully: 'تمّ حفظ المسودّة بنجاح.',
     lastSavedAgo: 'تم الحفظ آخر مرة قبل {{distance}}',
     modifiedOnly: 'تم التعديل فقط',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -571,6 +571,7 @@ export const azTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Hazırda baxılır',
     currentPublishedVersion: 'Hazırki Nəşr Versiyası',
     draft: 'Qaralama',
+    draftHasPublishedVersion: 'Qaralamalar (nəşr olunmuş versiyası var)',
     draftSavedSuccessfully: 'Qaralama uğurla yadda saxlandı.',
     lastSavedAgo: '{{distance}} əvvəl son yadda saxlanıldı',
     modifiedOnly: 'Yalnızca dəyişdirilmişdir',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -567,6 +567,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'В момента преглеждате',
     currentPublishedVersion: 'Текуща публикувана версия',
     draft: 'Чернова',
+    draftHasPublishedVersion: 'Чернова (има публикувана версия)',
     draftSavedSuccessfully: 'Чернова запазена успешно.',
     lastSavedAgo: 'последно запазено преди {{distance}}',
     modifiedOnly: 'Само променени',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -573,6 +573,7 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'বর্তমানে দেখছেন',
     currentPublishedVersion: 'বর্তমান প্রকাশিত সংস্করণ',
     draft: 'খসড়া',
+    draftHasPublishedVersion: 'খসড়া (প্রকাশিত সংস্করণ রয়েছে)',
     draftSavedSuccessfully: 'খসড়া সফলভাবে সংরক্ষিত হয়েছে।',
     lastSavedAgo: 'সর্বশেষ সংরক্ষণ করা হয়েছে {{distance}} আগে',
     modifiedOnly: 'শুধুমাত্র পরিবর্তিত',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -572,6 +572,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'বর্তমানে দেখছেন',
     currentPublishedVersion: 'বর্তমান প্রকাশিত সংস্করণ',
     draft: 'খসড়া',
+    draftHasPublishedVersion: 'খসড়া (প্রকাশিত সংস্করণ রয়েছে)',
     draftSavedSuccessfully: 'খসড়া সফলভাবে সংরক্ষিত হয়েছে।',
     lastSavedAgo: 'সর্বশেষ সংরক্ষণ করা হয়েছে {{distance}} আগে',
     modifiedOnly: 'শুধুমাত্র পরিবর্তিত',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -572,6 +572,7 @@ export const caTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Actualment veient',
     currentPublishedVersion: 'Versió publicada actual',
     draft: 'Borrador',
+    draftHasPublishedVersion: 'Esborrany (té versió publicada)',
     draftSavedSuccessfully: 'Borrador desat amb èxit.',
     lastSavedAgo: 'Últim desament fa {{distance}}',
     modifiedOnly: 'Només modificat',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -565,6 +565,7 @@ export const csTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Aktuálně prohlížíte',
     currentPublishedVersion: 'Aktuálně publikovaná verze',
     draft: 'Koncept',
+    draftHasPublishedVersion: 'Koncept (má publikovanou verzi)',
     draftSavedSuccessfully: 'Koncept úspěšně uložen.',
     lastSavedAgo: 'Naposledy uloženo před {{distance}}',
     modifiedOnly: 'Pouze upraveno',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -567,6 +567,7 @@ export const daTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Aktuelt visning',
     currentPublishedVersion: 'Nuværende offentliggjort version',
     draft: 'Kladde',
+    draftHasPublishedVersion: 'Udkast (har offentliggjort version)',
     draftSavedSuccessfully: 'Kladde gemt.',
     lastSavedAgo: 'Sidst gemt {{distance}}',
     modifiedOnly: 'Kun ændret',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -579,6 +579,7 @@ export const deTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Derzeitige Ansicht',
     currentPublishedVersion: 'Aktuell veröffentlichte Version',
     draft: 'Entwurf',
+    draftHasPublishedVersion: 'Entwurf (hat veröffentlichte Version)',
     draftSavedSuccessfully: 'Entwurf erfolgreich gespeichert.',
     lastSavedAgo: 'Zuletzt vor {{distance}} gespeichert',
     modifiedOnly: 'Nur modifiziert',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -569,6 +569,7 @@ export const enTranslations = {
     currentlyViewing: 'Currently viewing',
     currentPublishedVersion: 'Current Published Version',
     draft: 'Draft',
+    draftHasPublishedVersion: 'Draft (has published version)',
     draftSavedSuccessfully: 'Draft saved successfully.',
     lastSavedAgo: 'Last saved {{distance}} ago',
     modifiedOnly: 'Modified only',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -574,6 +574,7 @@ export const esTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Actualmente viendo',
     currentPublishedVersion: 'Versión publicada actual',
     draft: 'Borrador',
+    draftHasPublishedVersion: 'Borrador (tiene versión publicada)',
     draftSavedSuccessfully: 'Borrador guardado con éxito.',
     lastSavedAgo: 'Guardado por última vez hace {{distance}}',
     modifiedOnly: 'Modificado solamente',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -560,6 +560,7 @@ export const etTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Praegu vaatamine',
     currentPublishedVersion: 'Praegune avaldatud versioon',
     draft: 'Mustand',
+    draftHasPublishedVersion: 'Mustand (on avaldatud versioon)',
     draftSavedSuccessfully: 'Mustand edukalt salvestatud.',
     lastSavedAgo: 'Viimati salvestatud {{distance}} tagasi',
     modifiedOnly: 'Muudetud ainult',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -557,6 +557,7 @@ export const faTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'در حال مشاهده',
     currentPublishedVersion: 'آخرین نسخه منتشر شده',
     draft: 'پیش‌نویس',
+    draftHasPublishedVersion: 'پیش‌نویس (نسخه منتشر شده دارد)',
     draftSavedSuccessfully: 'پیش‌نویس با موفقیت ذخیره شد.',
     lastSavedAgo: 'آخرین ذخیره {{distance}} پیش',
     modifiedOnly: 'فقط موارد تغییر کرده',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -583,6 +583,7 @@ export const frTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Actuellement en train de regarder',
     currentPublishedVersion: 'Version Publiée Actuelle',
     draft: 'Brouillon',
+    draftHasPublishedVersion: 'Brouillon (a une version publiée)',
     draftSavedSuccessfully: 'Brouillon enregistré avec succès.',
     lastSavedAgo: 'Dernière sauvegarde il y a {{distance}}',
     modifiedOnly: 'Modifié uniquement',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -549,6 +549,7 @@ export const heTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'מציג כרגע',
     currentPublishedVersion: 'הגרסה שפורסמה כעת',
     draft: 'טיוטה',
+    draftHasPublishedVersion: 'טיוטה (יש גרסה שפורסמה)',
     draftSavedSuccessfully: 'טיוטה נשמרה בהצלחה.',
     lastSavedAgo: 'נשמר לאחרונה לפני {{distance}}',
     modifiedOnly: 'מותאם בלבד',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -565,6 +565,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Trenutno pregledavate',
     currentPublishedVersion: 'Trenutno Objavljena Verzija',
     draft: 'Nacrt',
+    draftHasPublishedVersion: 'Nacrt (ima objavljenu verziju)',
     draftSavedSuccessfully: 'Nacrt uspješno spremljen.',
     lastSavedAgo: 'Zadnji put spremljeno prije {{distance}',
     modifiedOnly: 'Samo modificirano',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -575,6 +575,7 @@ export const huTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Jelenlegi megtekintés',
     currentPublishedVersion: 'Jelenleg Közzétett Verzió',
     draft: 'Piszkozat',
+    draftHasPublishedVersion: 'Piszkozat (van közzétett verziója)',
     draftSavedSuccessfully: 'A piszkozat sikeresen mentve.',
     lastSavedAgo: 'Utoljára mentve {{distance}} órája',
     modifiedOnly: 'Módosítva csak',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -576,6 +576,7 @@ export const hyTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Ներկայումս դիտում է',
     currentPublishedVersion: 'Ընթացիկ հրապարակված տարբերակ',
     draft: 'Սևագիր',
+    draftHasPublishedVersion: 'Սրաց (ունի հրատարակված տարբերակ)',
     draftSavedSuccessfully: 'Սևագիրը հաջողությամբ պահպանվել է։',
     lastSavedAgo: 'Վերջին անգամ պահպանվել է {{distance}} առաջ',
     modifiedOnly: 'Միայն փոփոխված',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -569,6 +569,7 @@ export const idTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Sedang melihat',
     currentPublishedVersion: 'Versi Terbitan Saat Ini',
     draft: 'Draf',
+    draftHasPublishedVersion: 'Draf (memiliki versi yang dipublikasikan)',
     draftSavedSuccessfully: 'Draf berhasil disimpan.',
     lastSavedAgo: 'Terakhir disimpan {{distance}} yang lalu',
     modifiedOnly: 'Hanya yang diubah',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -565,6 +565,7 @@ export const isTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Skoða núna',
     currentPublishedVersion: 'Núverandi útgefin útgáfa',
     draft: 'Drög',
+    draftHasPublishedVersion: 'Drög (hafa birt útgáfu)',
     draftSavedSuccessfully: 'Drög vistuð með góðum árangri.',
     lastSavedAgo: 'Síðast vistað {{distance}} síðan',
     modifiedOnly: 'Aðeins breytt',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -573,6 +573,7 @@ export const itTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Visualizzazione attuale',
     currentPublishedVersion: 'Versione Pubblicata Attuale',
     draft: 'Bozza',
+    draftHasPublishedVersion: 'Bozza (ha una versione pubblicata)',
     draftSavedSuccessfully: 'Bozza salvata con successo.',
     lastSavedAgo: 'Ultimo salvataggio {{distance}} fa',
     modifiedOnly: 'Modificato solo',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -568,6 +568,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     currentlyViewing: '現在表示中',
     currentPublishedVersion: '現在公開されているバージョン',
     draft: 'ドラフト',
+    draftHasPublishedVersion: 'ドラフト（公開版が存在する）',
     draftSavedSuccessfully: '下書きは正常に保存されました。',
     lastSavedAgo: '{{distance}}前に最後に保存されました',
     modifiedOnly: '変更済みのみ',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -561,6 +561,7 @@ export const koTranslations: DefaultTranslationsObject = {
     currentlyViewing: '현재 보고 있습니다',
     currentPublishedVersion: '현재 게시된 버전',
     draft: '초안',
+    draftHasPublishedVersion: '발행된 버전이 있는 초안',
     draftSavedSuccessfully: '초안이 저장되었습니다.',
     lastSavedAgo: '마지막으로 저장한지 {{distance}} 전',
     modifiedOnly: '수정된 것만',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -572,6 +572,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Šiuo metu peržiūrima',
     currentPublishedVersion: 'Dabartinė publikuota versija',
     draft: 'Projektas',
+    draftHasPublishedVersion: 'Juodraštis (turi publikuotą versiją)',
     draftSavedSuccessfully: 'Juosmuo sėkmingai išsaugotas.',
     lastSavedAgo: 'Paskutinį kartą išsaugota prieš {{distance}}',
     modifiedOnly: 'Tik modifikuotas',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -568,6 +568,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Pašlaik skatās',
     currentPublishedVersion: 'Pašreizējā publicētā versija',
     draft: 'Melnraksts',
+    draftHasPublishedVersion: 'Projekts (ir publicēta versija)',
     draftSavedSuccessfully: 'Melnraksts veiksmīgi saglabāts.',
     lastSavedAgo: 'Pēdējo reizi saglabāts pirms {{distance}}',
     modifiedOnly: 'Tikai modificētie',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -577,6 +577,7 @@ export const myTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Sedang melihat sekarang',
     currentPublishedVersion: 'လက်ရှိထုတ်ဝေထားသောဗားရှင်း',
     draft: 'မူကြမ်း',
+    draftHasPublishedVersion: 'Draf (mempunyai versi yang diterbitkan)',
     draftSavedSuccessfully: 'မူကြမ်းကို အောင်မြင်စွာ သိမ်းဆည်းပြီးပါပြီ။',
     lastSavedAgo: 'နောက်ဆုံး သိမ်းချက် {{distance}} ကြာပြီး',
     modifiedOnly: 'Hanya diubah',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -569,6 +569,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Ser på for øyeblikket',
     currentPublishedVersion: 'Nåværende publiserte versjon',
     draft: 'Utkast',
+    draftHasPublishedVersion: 'Utkast (har publisert versjon)',
     draftSavedSuccessfully: 'Utkast lagret.',
     lastSavedAgo: 'Sist lagret {{distance}} siden',
     modifiedOnly: 'Kun endret',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -577,6 +577,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Momenteel bekijken',
     currentPublishedVersion: 'Huidige Gepubliceerde Versie',
     draft: 'Concept',
+    draftHasPublishedVersion: 'Concept (heeft gepubliceerde versie)',
     draftSavedSuccessfully: 'Concept succesvol bewaard.',
     lastSavedAgo: 'Laatst opgeslagen {{distance}} geleden',
     modifiedOnly: 'Alleen gewijzigd',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -566,6 +566,7 @@ export const plTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Obecnie przeglądasz',
     currentPublishedVersion: 'Aktualna Opublikowana Wersja',
     draft: 'Szkic',
+    draftHasPublishedVersion: 'Szkic (ma opublikowaną wersję)',
     draftSavedSuccessfully: 'Wersja robocza została pomyślnie zapisana.',
     lastSavedAgo: 'Ostatnio zapisane {{distance}} temu',
     modifiedOnly: 'Tylko zmodyfikowany',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -570,6 +570,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Atualmente visualizando',
     currentPublishedVersion: 'Versão Publicada Atual',
     draft: 'Rascunho',
+    draftHasPublishedVersion: 'Rascunho (tem versão publicada)',
     draftSavedSuccessfully: 'Rascunho salvo com sucesso.',
     lastSavedAgo: 'Última gravação há {{distance}}',
     modifiedOnly: 'Modificado apenas',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -577,6 +577,7 @@ export const roTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Vizualizare curentă',
     currentPublishedVersion: 'Versiunea Publicată Curentă',
     draft: 'Proiect',
+    draftHasPublishedVersion: 'Proiect (are versiune publicată)',
     draftSavedSuccessfully: 'Proiect salvat cu succes.',
     lastSavedAgo: 'Ultima salvare acum {{distance}}',
     modifiedOnly: 'Modificat doar',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -564,6 +564,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Trenutno gledate',
     currentPublishedVersion: 'Trenutno Objavljena Verzija',
     draft: 'Нацрт',
+    draftHasPublishedVersion: 'Nacrt (ima objavljenu verziju)',
     draftSavedSuccessfully: 'Нацрт успешно сачуван.',
     lastSavedAgo: 'Задњи пут сачувано пре {{distance}',
     modifiedOnly: 'Samo izmenjen',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -566,6 +566,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Trenutno gledate',
     currentPublishedVersion: 'Trenutna Objavljena Verzija',
     draft: 'Nacrt',
+    draftHasPublishedVersion: 'Nacrt (ima objavljenu verziju)',
     draftSavedSuccessfully: 'Nacrt uspešno sačuvan.',
     lastSavedAgo: 'Zadnji put sačuvano pre {{distance}}',
     modifiedOnly: 'Samo izmenjen',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -570,6 +570,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'В настоящее время просматривается',
     currentPublishedVersion: 'Текущая опубликованная версия',
     draft: 'Черновик',
+    draftHasPublishedVersion: 'Черновик (имеет опубликованную версию)',
     draftSavedSuccessfully: 'Черновик успешно сохранен.',
     lastSavedAgo: 'Последний раз сохранено {{distance}} назад',
     modifiedOnly: 'Модифицирован только',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -566,6 +566,7 @@ export const skTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Práve prezeráte',
     currentPublishedVersion: 'Aktuálne publikovaná verzia',
     draft: 'Návrh',
+    draftHasPublishedVersion: 'Koncept (má publikovanú verziu)',
     draftSavedSuccessfully: 'Návrh úspešne uložený.',
     lastSavedAgo: 'Naposledy uložené pred {{distance}}',
     modifiedOnly: 'Iba upravené',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -565,6 +565,7 @@ export const slTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Trenutno pregledujete',
     currentPublishedVersion: 'Trenutna objavljena različica',
     draft: 'Osnutek',
+    draftHasPublishedVersion: 'Osnutek (ima objavljeno različico)',
     draftSavedSuccessfully: 'Osnutek uspešno shranjen.',
     lastSavedAgo: 'Nazadnje shranjeno pred {{distance}}',
     modifiedOnly: 'Samo spremenjeno',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -568,6 +568,7 @@ export const svTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Visar för tillfället',
     currentPublishedVersion: 'Aktuell publicerad version',
     draft: 'Utkast',
+    draftHasPublishedVersion: 'Utkast (har publicerad version)',
     draftSavedSuccessfully: 'Utkastet sparades',
     lastSavedAgo: 'Senast sparad för {{distance}} sedan',
     modifiedOnly: 'Endast ändringar',

--- a/packages/translations/src/languages/ta.ts
+++ b/packages/translations/src/languages/ta.ts
@@ -569,6 +569,7 @@ export const taTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'தற்போது காணப்படுகிறது',
     currentPublishedVersion: 'தற்போதைய வெளியிடப்பட்ட பதிப்பு',
     draft: 'வரைவு',
+    draftHasPublishedVersion: 'வரைவு (வெளியிடப்பட்ட பதிப்பு உள்ளது)',
     draftSavedSuccessfully: 'வரைவு வெற்றிகரமாக சேமிக்கப்பட்டது.',
     lastSavedAgo: 'கடைசியாக {{distance}} முன்பு சேமிக்கப்பட்டது',
     modifiedOnly: 'மாற்றப்பட்டவை மட்டும்',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -555,6 +555,7 @@ export const thTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'กำลังดูอยู่ในขณะนี้',
     currentPublishedVersion: 'เวอร์ชันที่เผยแพร่ในปัจจุบัน',
     draft: 'ฉบับร่าง',
+    draftHasPublishedVersion: 'ร่าง (มีรุ่นที่เผยแพร่แล้ว)',
     draftSavedSuccessfully: 'บันทึกร่างสำเร็จ',
     lastSavedAgo: 'บันทึกครั้งล่าสุด {{distance}} ที่ผ่านมา',
     modifiedOnly: 'แก้ไขเท่านั้น',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -570,6 +570,7 @@ export const trTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Şu anda görüntüleniyor',
     currentPublishedVersion: 'Mevcut Yayınlanan Sürüm',
     draft: 'Taslak',
+    draftHasPublishedVersion: 'Taslak (yayınlanmış versiyonu var)',
     draftSavedSuccessfully: 'Taslak başarıyla kaydedildi.',
     lastSavedAgo: 'Son kaydedildi {{distance}} önce',
     modifiedOnly: 'Yalnızca değiştirilmiş',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -565,6 +565,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Поточний перегляд',
     currentPublishedVersion: 'Поточна опублікована версія',
     draft: 'Чернетка',
+    draftHasPublishedVersion: 'Чернетка (має опубліковану версію)',
     draftSavedSuccessfully: 'Чернетку успішно збережено.',
     lastSavedAgo: 'Востаннє збережено {{distance}} тому',
     modifiedOnly: 'Модифіковано тільки',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -563,6 +563,7 @@ export const viTranslations: DefaultTranslationsObject = {
     currentlyViewing: 'Đang xem',
     currentPublishedVersion: 'Phiên bản Đã Xuất bản Hiện tại',
     draft: 'Bản nháp',
+    draftHasPublishedVersion: 'Bản nháp (có phiên bản đã xuất bản)',
     draftSavedSuccessfully: 'Bản nháp đã được lưu thành công.',
     lastSavedAgo: 'Lần lưu cuối cùng {{distance}} trước đây',
     modifiedOnly: 'Chỉ được sửa đổi',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -541,6 +541,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     currentlyViewing: '当前正在查看',
     currentPublishedVersion: '当前发布的版本',
     draft: '草稿',
+    draftHasPublishedVersion: '草稿（有已发布版本）',
     draftSavedSuccessfully: '草稿成功保存。',
     lastSavedAgo: '上次保存 {{distance}} 之前',
     modifiedOnly: '仅修改过的',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -540,6 +540,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     currentlyViewing: '目前檢視',
     currentPublishedVersion: '目前已發佈版本',
     draft: '草稿',
+    draftHasPublishedVersion: '草稿（有已發佈版本）',
     draftSavedSuccessfully: '草稿已成功儲存。',
     lastSavedAgo: '上次儲存時間：{{distance}} 前',
     modifiedOnly: '僅顯示已變更的內容',

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -104,9 +104,17 @@ export function renderCell({
     }
   }
 
+  // For _status field, use _displayStatus if available (for showing "changed" status in list view)
+  const cellData =
+    'name' in clientField && accessor === '_status' && '_displayStatus' in doc
+      ? doc._displayStatus
+      : 'name' in clientField
+        ? findValueFromPath(doc, accessor)
+        : undefined
+
   const cellClientProps: DefaultCellComponentProps = {
     ...baseCellClientProps,
-    cellData: 'name' in clientField ? findValueFromPath(doc, accessor) : undefined,
+    cellData,
     link: shouldLink,
     linkURL: customLinkURL,
     rowData: doc,

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -125,7 +125,7 @@ export function renderCell({
         options: [
           ...(clientField.options || []),
           {
-            label: i18n.t('version:changed'),
+            label: i18n.t('version:draftHasPublishedVersion'),
             value: 'changed',
           },
         ],

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -112,9 +112,31 @@ export function renderCell({
         ? findValueFromPath(doc, accessor)
         : undefined
 
+  // For _status field, add 'changed' option for display purposes
+  // The 'changed' status is computed at runtime
+  let enrichedClientField = clientField
+  if ('name' in clientField && accessor === '_status' && clientField.type === 'select') {
+    const hasChangedOption = clientField.options?.some(
+      (opt) => (typeof opt === 'object' ? opt.value : opt) === 'changed',
+    )
+    if (!hasChangedOption) {
+      enrichedClientField = {
+        ...clientField,
+        options: [
+          ...(clientField.options || []),
+          {
+            label: i18n.t('version:changed'),
+            value: 'changed',
+          },
+        ],
+      }
+    }
+  }
+
   const cellClientProps: DefaultCellComponentProps = {
     ...baseCellClientProps,
     cellData,
+    field: enrichedClientField,
     link: shouldLink,
     linkURL: customLinkURL,
     rowData: doc,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -134,6 +134,44 @@ describe('Versions', () => {
       errorOnUnpublishURL = new AdminUrlUtil(serverURL, errorOnUnpublishSlug)
     })
 
+    test('collection — should show "changed" status in list view when draft is saved after publish', async () => {
+      // Create a published document
+      const publishedDoc = await payload.create({
+        collection: draftCollectionSlug,
+        data: {
+          _status: 'published',
+          title: 'Published Document',
+          description: 'This is published',
+        },
+      })
+
+      // Navigate to the document
+      await page.goto(url.edit(publishedDoc.id))
+
+      // Verify status shows "Published"
+      const status = page.locator('.status__value')
+      await expect(status).toContainText('Published')
+
+      // Modify the document and save as draft
+      await page.locator('#field-description').fill('Modified description')
+      await saveDocAndAssert(page, '#action-save-draft')
+
+      // Verify status shows "Changed" in the document view
+      await expect(status).toContainText('Changed')
+
+      // Go back to list view
+      await page.goto(url.list)
+
+      // Find the row for our document
+      const documentRow = page.locator(`tbody tr:has(.cell-title a:has-text("Published Document"))`)
+      await expect(documentRow).toBeVisible()
+
+      // Verify the status column shows "Changed" and not "Draft"
+      const statusCell = documentRow.locator('.cell-_status')
+      await expect(statusCell).toContainText('Changed')
+      await expect(statusCell).not.toContainText('Draft')
+    })
+
     test('collection — has versions tab', async () => {
       await page.goto(url.list)
       await page.locator('tbody tr .cell-title a').first().click()

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -134,7 +134,7 @@ describe('Versions', () => {
       errorOnUnpublishURL = new AdminUrlUtil(serverURL, errorOnUnpublishSlug)
     })
 
-    test('collection — should show "changed" status in list view when draft is saved after publish', async () => {
+    test('collection — should show "has published version" status in list view when draft is saved after publish', async () => {
       // Create a published document
       const publishedDoc = await payload.create({
         collection: draftCollectionSlug,
@@ -168,8 +168,7 @@ describe('Versions', () => {
 
       // Verify the status column shows "Changed" and not "Draft"
       const statusCell = documentRow.locator('.cell-_status')
-      await expect(statusCell).toContainText('Changed')
-      await expect(statusCell).not.toContainText('Draft')
+      await expect(statusCell).toContainText('Draft (has published version)')
     })
 
     test('collection — has versions tab', async () => {

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -820,16 +820,8 @@ export interface PayloadLockedDocument {
         value: string | Media2;
       } | null)
     | ({
-        relationTo: 'payload-kv';
-        value: string | PayloadKv;
-      } | null)
-    | ({
         relationTo: 'users';
         value: string | User;
-      } | null)
-    | ({
-        relationTo: 'payload-jobs';
-        value: string | PayloadJob;
       } | null);
   globalSlug?: string | null;
   user: {


### PR DESCRIPTION
### Description

This PR displays `draft (has published version)` in the List View, similar to how the Document View displays `changed`.

The reason we don't display `changed` in the same way as in the Document View is that the change here is only in the UI. In the database, the only two options are `draft` and `published`. Therefore, it would be confusing since the "changed" option wouldn't appear in the filters.

In version 4, we can reconsider two options:

1. Add `changed` to the database options enum. This is very unlikely since that breaking change would be extremely aggressive.

2. Add a new `changed` column to the database with a boolean value. This is the most plausible option.

### How: 

The solution addresses a performance concern discussed internally by using one query for all documents on the page rather than N queries per row, and transferring only parent IDs. I added a TODO comment documenting that a future `findDistinctVersions()` API could optimize this further.

### After

<img width="1088" height="436" alt="image" src="https://github.com/user-attachments/assets/1952e74e-783c-4c23-af52-deeec8e8134b" />


Fixes #14449
