### PR TITLE
fix(next): turbopack error when using db-d1-sqlite package

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -86,6 +86,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
       '@payloadcms/db-sqlite',
       '@payloadcms/db-vercel-postgres',
       '@payloadcms/drizzle',
+      '@payloadcms/db-d1-sqlite',
       // External because they install @aws-sdk/client-s3:
       '@payloadcms/payload-cloud',
       // External, because it installs import-in-the-middle and require-in-the-middle - both in the default serverExternalPackages list.


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14338 for real

We forgot to add `@payloadcms/db-d1-sqlite` package to `serverExternalPackages`. As the install entry-point to packages that cannot be bundled (like esbuild), it needs to be externalized just like our other db adapters.