### PR TITLE
fix: changing the language of the admin panel does not work for "radio" and "select" fields.

### DIFF
--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -358,7 +358,7 @@ export const createClientField = ({
             }
           } else if (typeof option === 'object') {
             field.options[i] = {
-              label: option.label as string,
+              label: option.label,
               value: option.value,
             }
           } else if (typeof option === 'string') {

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -361,6 +361,8 @@ export const createClientField = ({
               label: option.label as string,
               value: option.value,
             }
+          } else if (typeof option === 'string') {
+            field.options[i] = option
           }
         }
       }

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -226,6 +226,10 @@ export const createClientField = ({
         // Skip - we handle sub-fields in the switch below
         break
 
+      case 'options':
+        // Skip - we handle options in the radio/select switch below to avoid mutating the global config
+        break
+
       case 'label':
         //@ts-expect-error - would need to type narrow
         if (typeof incomingField.label === 'function') {
@@ -342,16 +346,19 @@ export const createClientField = ({
       const field = clientField as RadioFieldClient | SelectFieldClient
 
       if (incomingField.options?.length) {
+        field.options = [] // Create new array to avoid mutating global config
+
         for (let i = 0; i < incomingField.options.length; i++) {
           const option = incomingField.options[i]
 
           if (typeof option === 'object' && typeof option.label === 'function') {
-            if (!field.options) {
-              field.options = []
-            }
-
             field.options[i] = {
               label: option.label({ i18n, t: i18n.t as TFunction }),
+              value: option.value,
+            }
+          } else if (typeof option === 'object') {
+            field.options[i] = {
+              label: option.label as string,
               value: option.value,
             }
           }


### PR DESCRIPTION
Plugin-defined label functions (e.g., `label: ({ t }) => t('plugin-redirects:internalLink')`) don't update when switching languages.

## Root Cause

The global Payload config was being **mutated**. When `createClientField` copied the `options` array by reference, it would evaluate label functions and replace them with strings in the global config. Subsequent requests would find strings instead of functions and couldn't re-evaluate.

## Why PR #11725 Wasn't Enough

[PR #11725](https://github.com/payloadcms/payload/pull/11725) fixed the client config cache to store separate configs per language, but didn't prevent the source config from being mutated.

## Solution

**File**: `packages/payload/src/fields/config/client.ts`

- Skip copying `options` in the default case
- Create a fresh array in the radio/select handler instead of reusing the reference
- This prevents mutating the global config while still evaluating labels correctly per language

## Testing

The testing is located at https://github.com/payloadcms/payload/pull/14569, which depends on this PR. You can see that the new tests there pass because they already contain this commit.

I originally created it into a different PR because CI was failing and I wasn't sure if it was due to this change. Now I've left them separate for traceability and clarity. The other pull request is a feature, this one is a fix.