### PR TITLE
ci: fix ERR_PNPM_ADDING_TO_ROOT in create-payload-app int

### DIFF
--- a/packages/create-payload-app/src/lib/install-packages.ts
+++ b/packages/create-payload-app/src/lib/install-packages.ts
@@ -23,6 +23,10 @@ export async function installPackages(args: {
       }
       ;({ exitCode, stderr } = await execa(packageManager, ['add', ...packagesToInstall], {
         cwd: projectDir,
+        env: {
+          ...process.env,
+          ...(packageManager === 'pnpm' && { npm_config_ignore_workspace_root_check: 'true' }),
+        },
       }))
       break
     }


### PR DESCRIPTION
`ERR_PNPM_ADDING_TO_ROOT` errors randomly started in the create-payload-app int suite despite no changes in related code on our end.

Solving this by ignoring workspace root with pnpm. It is still unclear what in this test flow actually changed in CI.

---

## Investigation

- Last successful runs: ~17 hours ago (2025-11-11 ~20:51 UTC)
- Failures started: ~12 hours ago (2025-11-11 ~11:00 UTC)
- 100% of integration tests fail, e2e tests pass

1. Code Changes

- No PRs merged to main between last success and first failure
- No changes to:
  - create-payload-app package
  - Workspace config (.npmrc, pnpm-workspace.yaml)
  - pnpm version (still 9.7.1 in .tool-versions)
  - Test files

2. GitHub Actions Environment

- Runner image: ubuntu-24.04 (20251102.99.1) - deployed Nov 3, 2025
- No breaking changes found in Nov image update
- pnpm/action-setup@v4: Latest is v4.2.0 (Oct 2024) - no recent updates

3. pnpm Behavior 
- pnpm 9.7.1 released Aug 2024 (no recent changes)
- No changes to ERR_PNPM_ADDING_TO_ROOT logic in 9.7.1
- Error occurs when pnpm detects directory as workspace root

6. Test Flow

- Test creates temp directory
- scaffolds Next.js with pnpm create next-app@canary
- calls pnpm add payload@latest...
- pnpm rejects, treating temp directory as workspace root