### PR TITLE
fix: unlock access not being correctly denied when using a where query

### DIFF
--- a/packages/payload/src/auth/executeAccess.ts
+++ b/packages/payload/src/auth/executeAccess.ts
@@ -15,20 +15,20 @@ export const executeAccess = async (
   access: Access,
 ): Promise<AccessResult> => {
   if (access) {
-    const result = await access({
+    const resolvedConstraint = await access({
       id,
       data,
       isReadingStaticFile,
       req,
     })
 
-    if (!result) {
+    if (!resolvedConstraint) {
       if (!disableErrors) {
         throw new Forbidden(req.t)
       }
     }
 
-    return result
+    return resolvedConstraint
   }
 
   if (req.user) {

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -25,6 +25,40 @@ export type UserWithToken<T = ClientUser> = {
 export type AuthContext<T = ClientUser> = {
   fetchFullUser: () => Promise<null | TypedUser>
   logOut: () => Promise<boolean>
+  /**
+   * These are the permissions for the current user from a global scope.
+   *
+   * When checking for permissions on document specific level, use the `useDocumentInfo` hook instead.
+   *
+   * @example
+   *
+   * ```tsx
+   * import { useAuth } from 'payload/ui'
+   *
+   * const MyComponent: React.FC = () => {
+   *   const { permissions } = useAuth()
+   *
+   *   if (permissions?.collections?.myCollection?.create) {
+   *     // user can create documents in 'myCollection'
+   *   }
+   *
+   *   return null
+   * }
+   * ```
+   *
+   * with useDocumentInfo:
+   *
+   * ```tsx
+   * import { useDocumentInfo } from 'payload/ui'
+   *
+   * const MyComponent: React.FC = () => {
+   *  const { docPermissions } = useDocumentInfo()
+   *  if (docPermissions?.create) {
+   *   // user can create this document
+   *  }
+   *  return null
+   * } ```
+   */
   permissions?: SanitizedPermissions
   refreshCookie: (forceRefresh?: boolean) => void
   refreshCookieAsync: () => Promise<ClientUser>

--- a/packages/ui/src/views/Edit/Auth/index.tsx
+++ b/packages/ui/src/views/Edit/Auth/index.tsx
@@ -14,7 +14,6 @@ import { CheckboxField } from '../../../fields/Checkbox/index.js'
 import { ConfirmPasswordField } from '../../../fields/ConfirmPassword/index.js'
 import { PasswordField } from '../../../fields/Password/index.js'
 import { useFormFields, useFormModified } from '../../../forms/Form/context.js'
-import { useAuth } from '../../../providers/Auth/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useDocumentInfo } from '../../../providers/DocumentInfo/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
@@ -39,7 +38,6 @@ export const Auth: React.FC<Props> = (props) => {
     verify,
   } = props
 
-  const { permissions } = useAuth()
   const [changingPassword, setChangingPassword] = useState(requirePassword)
   const enableAPIKey = useFormFields(([fields]) => (fields && fields?.enableAPIKey) || null)
   const dispatchFields = useFormFields((reducer) => reducer[1])
@@ -131,14 +129,12 @@ export const Auth: React.FC<Props> = (props) => {
   const canReadApiKey = apiKeyPermissions === true || apiKeyPermissions?.read
 
   const hasPermissionToUnlock: boolean = useMemo(() => {
-    const collection = permissions?.collections?.[collectionSlug]
-
-    if (collection) {
-      return Boolean('unlock' in collection ? collection.unlock : undefined)
+    if (docPermissions) {
+      return Boolean('unlock' in docPermissions ? docPermissions.unlock : undefined)
     }
 
     return false
-  }, [permissions, collectionSlug])
+  }, [docPermissions])
 
   const handleChangePassword = useCallback(
     (changingPassword: boolean) => {

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'path'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-import type { FieldAccess } from 'payload'
+import type { FieldAccess, Where } from 'payload'
 
 import { buildEditorState, type DefaultNodeTypes } from '@payloadcms/richtext-lexical'
 
@@ -111,6 +111,18 @@ export default buildConfigWithDefaults(
               // Simulate a request to an external service to determine access, i.e. another instance of Payload
               setTimeout(resolve, 50, true) // set to 'true' or 'false' here to simulate the response
             })
+          },
+          unlock: ({ req }) => {
+            if (req.user && req.user.collection === 'users' && req.user?.roles?.includes('admin')) {
+              // admin users can only unlock themselves
+              return {
+                id: {
+                  equals: req.user.id,
+                },
+              }
+            }
+
+            return false
           },
         },
         auth: true,
@@ -687,6 +699,7 @@ export default buildConfigWithDefaults(
         data: {
           email: devUser.email,
           password: devUser.password,
+          roles: ['admin'],
         },
       })
 

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -113,7 +113,7 @@ export default buildConfigWithDefaults(
             })
           },
           unlock: ({ req }) => {
-            if (req.user && req.user.collection === 'users' && req.user?.roles?.includes('admin')) {
+            if (req.user && req.user.collection === 'users') {
               // admin users can only unlock themselves
               return {
                 id: {
@@ -699,7 +699,6 @@ export default buildConfigWithDefaults(
         data: {
           email: devUser.email,
           password: devUser.password,
-          roles: ['admin'],
         },
       })
 

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -61,6 +61,7 @@ let payload: PayloadTestSDK<Config>
 describe('Access Control', () => {
   let page: Page
   let url: AdminUrlUtil
+  let usersUrl: AdminUrlUtil
   let restrictedUrl: AdminUrlUtil
   let unrestrictedURL: AdminUrlUtil
   let readOnlyCollectionUrl: AdminUrlUtil
@@ -81,6 +82,7 @@ describe('Access Control', () => {
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     url = new AdminUrlUtil(serverURL, slug)
+    usersUrl = new AdminUrlUtil(serverURL, 'users')
     restrictedUrl = new AdminUrlUtil(serverURL, fullyRestrictedSlug)
     richTextUrl = new AdminUrlUtil(serverURL, 'rich-text')
     unrestrictedURL = new AdminUrlUtil(serverURL, unrestrictedSlug)
@@ -613,6 +615,29 @@ describe('Access Control', () => {
       await saveDocAndAssert(page)
       await openDocControls(page)
       await expect(page.locator('#action-delete')).toBeVisible()
+    })
+
+    test('can only unlock self when admin', async () => {
+      await page.goto(usersUrl.list)
+
+      const adminUserRow = page.locator('.table tr').filter({ hasText: devUser.email })
+      const nonAdminUserRow = page.locator('.table tr').filter({ hasText: nonAdminEmail })
+
+      // Ensure admin user cannot unlock other users
+      await adminUserRow.locator('.cell-id a').click()
+      await page.waitForURL(`**/collections/users/**`)
+
+      const unlockButton = page.locator('#force-unlock')
+      await expect(unlockButton).toBeVisible()
+      await unlockButton.click()
+      await expect(page.locator('.payload-toast-container')).toContainText('Successfully unlocked')
+
+      await page.goto(usersUrl.list)
+
+      // Ensure non-admin user cannot see unlock button
+      await nonAdminUserRow.locator('.cell-id a').click()
+      await page.waitForURL(`**/collections/users/**`)
+      await expect(page.locator('#force-unlock')).toBeHidden()
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14459

We were previously not throwing an error from the endpoint if validation failed for unlock and the UI was using permissions from the wrong hook, I've added a jsdoc to explain the difference between permissions form useAuth and useDocumentInfo