### PR TITLE
fix: localized block fields

### DIFF
--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -236,6 +236,7 @@ const blocks: FieldSchemaGenerator<BlocksField> = (
   parentIsLocalized,
 ): void => {
   const fieldSchema: SchemaTypeOptions<any> = {
+    ...formatBaseSchema({ buildSchemaOptions, field, parentIsLocalized }),
     type: [new mongoose.Schema({}, { _id: false, discriminatorKey: 'blockType' })],
   }
 

--- a/packages/db-mongodb/src/utilities/transform.ts
+++ b/packages/db-mongodb/src/utilities/transform.ts
@@ -340,9 +340,6 @@ const stripFields = ({
           const localeData = fieldData[localeKey]
 
           if (!localeData || typeof localeData !== 'object') {
-            if (field.type === 'blocks') {
-              fieldData[localeKey] = []
-            }
             continue
           }
 

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -134,13 +134,13 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
 
           if (collection && id) {
             entitySlug = collection.slug
-            url = `${serverURL}${api}/${entitySlug}/${id}?depth=0&draft=true&autosave=true&fallback-locale=null&locale=${localeRef.current}`
+            url = `${serverURL}${api}/${entitySlug}/${id}?depth=0&draft=true&autosave=true&locale=${localeRef.current}&fallback-locale=null`
             method = 'PATCH'
           }
 
           if (globalDoc) {
             entitySlug = globalDoc.slug
-            url = `${serverURL}${api}/globals/${entitySlug}?depth=0&draft=true&autosave=true&fallback-locale=null&locale=${localeRef.current}`
+            url = `${serverURL}${api}/globals/${entitySlug}?depth=0&draft=true&autosave=true&locale=${localeRef.current}&fallback-locale=null`
             method = 'POST'
           }
 

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -134,13 +134,13 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
 
           if (collection && id) {
             entitySlug = collection.slug
-            url = `${serverURL}${api}/${entitySlug}/${id}?depth=0&draft=true&autosave=true&locale=${localeRef.current}`
+            url = `${serverURL}${api}/${entitySlug}/${id}?depth=0&draft=true&autosave=true&fallback-locale=null&locale=${localeRef.current}`
             method = 'PATCH'
           }
 
           if (globalDoc) {
             entitySlug = globalDoc.slug
-            url = `${serverURL}${api}/globals/${entitySlug}?depth=0&draft=true&autosave=true&locale=${localeRef.current}`
+            url = `${serverURL}${api}/globals/${entitySlug}?depth=0&draft=true&autosave=true&fallback-locale=null&locale=${localeRef.current}`
             method = 'POST'
           }
 

--- a/test/localization/collections/Blocks/index.ts
+++ b/test/localization/collections/Blocks/index.ts
@@ -4,8 +4,20 @@ export const blocksCollectionSlug = 'blocks-fields'
 
 export const BlocksCollection: CollectionConfig = {
   slug: blocksCollectionSlug,
-  versions: { drafts: { autosave: true } },
+  admin: {
+    useAsTitle: 'title',
+  },
+  versions: {
+    drafts: {
+      autosave: true,
+    },
+  },
   fields: [
+    {
+      name: 'title',
+      type: 'text',
+      localized: true,
+    },
     {
       type: 'tabs',
       tabs: [

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -658,12 +658,18 @@ describe('Localization', () => {
     })
 
     test('blocks - should show fallback checkbox for non-default locale', async () => {
+      await changeLocale(page, 'en')
       await page.goto(urlBlocks.create)
+      const titleLocator = page.locator('#field-title')
+      await titleLocator.fill('Block Test')
       await addBlock({ page, blockToSelect: 'Block Inside Block', fieldName: 'content' })
       const rowTextInput = page.locator(`#field-content__0__text`)
       await rowTextInput.fill('text')
       await saveDocAndAssert(page)
-      await changeLocale(page, 'pt')
+
+      await changeLocale(page, spanishLocale)
+      await titleLocator.fill('PT Block Test')
+      await waitForAutoSaveToRunAndComplete(page)
       const fallbackCheckbox = page.locator('#field-content', {
         hasText: 'Fallback to default locale',
       })

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -452,7 +452,7 @@ describe('Versions', () => {
       await assertNetworkRequests(
         page,
         // Important: assert that depth is 0 in this request
-        `${serverURL}/api/autosave-posts/${docID}?depth=0&draft=true&autosave=true&locale=en`,
+        `${serverURL}/api/autosave-posts/${docID}?depth=0&draft=true&autosave=true&locale=en&fallback-locale=null`,
         async () => {
           await page.locator('#field-title').fill('changed title')
         },


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13663

Previously https://github.com/payloadcms/payload/pull/13974 was merged but it didn't actually fix the issue. I updated the tests to make them fail before making the fix in this PR.

The visual issue stemmed from to autosave not passing the `fallback-locale=null` param. So the update function would pass the default fallback locale into afterRead and data for the nullified field would come back.

The data part of that issue was previously solved by adding an array to other locales if not defined. However that clutters the db with unused data. This can be fixed by including the `formatBaseSchema` in the block schema which (for localized fields) sets `schema.sparse = true`, so the data is only added when it is saved. 