### PR TITLE
fix(graphql): avoid errors with sort as empty string

### DIFF
--- a/packages/graphql/src/resolvers/collections/find.ts
+++ b/packages/graphql/src/resolvers/collections/find.ts
@@ -61,7 +61,7 @@ export function findResolver(collection: Collection): Resolver {
       pagination: args.pagination,
       req,
       select,
-      sort: typeof sort === 'string' ? sort.split(',') : undefined,
+      sort: sort && typeof sort === 'string' ? sort.split(',') : undefined,
       trash: args.trash,
       where: args.where,
     }

--- a/packages/graphql/src/resolvers/collections/findVersions.ts
+++ b/packages/graphql/src/resolvers/collections/findVersions.ts
@@ -58,7 +58,7 @@ export function findVersionsResolver(collection: Collection): Resolver {
       pagination: args.pagination,
       req,
       select,
-      sort: typeof sort === 'string' ? sort.split(',') : undefined,
+      sort: sort && typeof sort === 'string' ? sort.split(',') : undefined,
       trash: args.trash,
       where: args.where,
     }

--- a/packages/graphql/src/resolvers/globals/findVersions.ts
+++ b/packages/graphql/src/resolvers/globals/findVersions.ts
@@ -46,7 +46,7 @@ export function findVersions(globalConfig: SanitizedGlobalConfig): Resolver {
       pagination: args.pagination,
       req,
       select,
-      sort: typeof sort === 'string' ? sort.split(',') : undefined,
+      sort: sort && typeof sort === 'string' ? sort.split(',') : undefined,
       where: args.where,
     }
 

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -135,6 +135,25 @@ describe('collections-graphql', () => {
       expect(docs.map((doc) => doc.id)).toEqual([doc3.id, doc1.id, doc4.id, doc2.id])
     })
 
+    it('should not fail with sort as empty string', async () => {
+      const query = `query {
+        Sorts(sort: "") {
+          docs {
+            id
+            title
+            number
+          }
+        }
+      }`
+
+      const { data } = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        .then((res) => res.json())
+      const { docs } = data.Sorts
+
+      expect(docs).toBeTruthy()
+    })
+
     it('should count', async () => {
       const query = `query {
         countPosts {


### PR DESCRIPTION
https://github.com/payloadcms/payload/pull/14486 introduced a regression when you pass `sort` parameter as `""` to a GraphQL query, for example:
```graphql
query {
  Sorts(sort: "") {
    docs {
      id
      title
      number
    }
  }
}

```

In this case, MongoDB gives an error:
```
"FieldPath must not end with a '.'."
```

This PR fixes that by avoiding passing `sort: ['']` to the Local API.
