### PR TITLE
fix: logout-inactivity route gets stuck on loading indicator when inactivity and isLoggedIn are true

### DIFF
--- a/packages/next/src/views/Logout/LogoutClient.tsx
+++ b/packages/next/src/views/Logout/LogoutClient.tsx
@@ -45,11 +45,10 @@ export const LogoutClient: React.FC<{
   const [loginRoute] = React.useState(() =>
     formatAdminURL({
       adminRoute,
-      path: `/login${
-        inactivity && redirect && redirect.length > 0
+      path: `/login${inactivity && redirect && redirect.length > 0
           ? `?redirect=${encodeURIComponent(redirect)}`
           : ''
-      }`,
+        }`,
     }),
   )
 
@@ -57,14 +56,14 @@ export const LogoutClient: React.FC<{
   const router = useRouter()
 
   const handleLogOut = React.useCallback(async () => {
-    if (!inactivity && !navigatingToLoginRef.current) {
+    if (!navigatingToLoginRef.current) {
       navigatingToLoginRef.current = true
       await logOut()
       toast.success(t('authentication:loggedOutSuccessfully'))
       startRouteTransition(() => router.push(loginRoute))
       return
     }
-  }, [inactivity, logOut, loginRoute, router, startRouteTransition, t])
+  }, [logOut, loginRoute, router, startRouteTransition, t])
 
   useEffect(() => {
     if (isLoggedIn && !inactivity) {

--- a/packages/next/src/views/Logout/LogoutClient.tsx
+++ b/packages/next/src/views/Logout/LogoutClient.tsx
@@ -67,13 +67,13 @@ export const LogoutClient: React.FC<{
   }, [inactivity, logOut, loginRoute, router, startRouteTransition, t])
 
   useEffect(() => {
-    if (isLoggedIn) {
+    if (isLoggedIn && !inactivity) {
       void handleLogOut()
     } else if (!navigatingToLoginRef.current) {
       navigatingToLoginRef.current = true
       startRouteTransition(() => router.push(loginRoute))
     }
-  }, [handleLogOut, isLoggedIn, loginRoute, router, startRouteTransition])
+  }, [handleLogOut, isLoggedIn, loginRoute, router, startRouteTransition, inactivity])
 
   if (!isLoggedIn && inactivity) {
     return (


### PR DESCRIPTION
### What?
Updates logic within the `logout-inactivity` route to handle scenarios when `inactivity` and `isLoggedIn` are true, which can occur when the app is open in multiple tabs.

### Why

A client found that the `/logout-inactivity` route can get stuck on the loading indicator when you are running Payload in multiple tabs.

For example:
1. You have 2 tabs
2. Both tabs logout due to inactivity and redirect to `/logout-inactivity`
3. I open one tab and login without opening the second tab
4. I open the second tab, the `logout-inactivity` route is still present and now receives `inactivity: true` and `isLoggedIn: true` because you logged in using the other tab
5. This combination falls between the gaps in the `/logout-inactivity` handler and does not get redirected

### How

On the `/logout-inactivity` we  have a `useEffect` that checks if `isLoggedIn: true`, if yes it calls the logout handlers, if false it redirects to the login screen.

In this above example, it calls the logout handler. The logout handler immediately checks `!inactivity` and skips the logic.

This change moves the `inactivity` check out of the logout handler and into the useEffect condition alongside `isLoggedIn`. 
Now, if the user is both logged in and inactive, we skip the logout call and instead redirect straight to the login page, allowing that page to handle the redirect logic properly.