### PR TITLE
fix(plugin-multi-tenant): fix infinite sync tenant network calls

### DIFF
--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -224,10 +224,11 @@ export const TenantSelectionProviderClient = ({
         if (tenantOptions.length > 0) {
           setTenantOptions([])
         }
+        router.refresh()
       }
       prevUserID.current = userID
     }
-  }, [userID, userChanged, syncTenants, tenantOptions, initialValue])
+  }, [userID, userChanged, syncTenants, tenantOptions, initialValue, router])
 
   /**
    * If there is no initial value, clear the tenant and refresh the router.


### PR DESCRIPTION
Fixes an issue where selecting a tenant, logging out and back in would cause the network to be cluttered with sync tenant calls. This happened because the initialValue (initialCookie) for the tenant does not clear when the user logs out. This PR calls router.refresh on log out so the initialValue is reset after the cookie is deleted from logging out.
