### PR TITLE
fix: tighten up error visibility handling

### DIFF
--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -749,6 +749,7 @@ export type BulkOperationResult<TSlug extends CollectionSlug, TSelect extends Se
   docs: TransformCollectionWithSelect<TSlug, TSelect>[]
   errors: {
     id: DataFromCollectionSlug<TSlug>['id']
+    isPublic: boolean
     message: string
   }[]
 }

--- a/packages/payload/src/collections/endpoints/delete.ts
+++ b/packages/payload/src/collections/endpoints/delete.ts
@@ -50,6 +50,15 @@ export const deleteHandler: PayloadHandler = async (req) => {
     )
   }
 
+  result.errors = result.errors.map((error) =>
+    error.isPublic
+      ? error
+      : {
+          ...error,
+          message: 'Something went wrong.',
+        },
+  )
+
   const total = result.docs.length + result.errors.length
 
   const message = req.t('error:unableToDeleteCount', {

--- a/packages/payload/src/collections/endpoints/update.ts
+++ b/packages/payload/src/collections/endpoints/update.ts
@@ -56,6 +56,15 @@ export const updateHandler: PayloadHandler = async (req) => {
     )
   }
 
+  result.errors = result.errors.map((error) =>
+    error.isPublic
+      ? error
+      : {
+          ...error,
+          message: 'Something went wrong.',
+        },
+  )
+
   const total = result.docs.length + result.errors.length
   const message = req.t('error:unableToUpdateCount', {
     count: result.errors.length,

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -22,6 +22,7 @@ import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.j
 import { checkDocumentLockStatus } from '../../utilities/checkDocumentLockStatus.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
+import { isErrorPublic } from '../../utilities/isErrorPublic.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions.js'
@@ -138,7 +139,7 @@ export const deleteOperation = async <
       where: fullWhere,
     })
 
-    const errors: { id: number | string; message: string }[] = []
+    const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
 
     const promises = docs.map(async (doc) => {
       let result
@@ -281,8 +282,11 @@ export const deleteOperation = async <
 
         return result
       } catch (error) {
+        const isPublic = error instanceof Error ? isErrorPublic(error, config) : false
+
         errors.push({
           id: doc.id,
+          isPublic,
           message: error instanceof Error ? error.message : 'Unknown error',
         })
       }

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -23,6 +23,7 @@ import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
+import { isErrorPublic } from '../../utilities/isErrorPublic.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
@@ -225,7 +226,7 @@ export const updateOperation = async <
       throwOnMissingFile: false,
     })
 
-    const errors: { id: number | string; message: string }[] = []
+    const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
 
     const promises = docs.map(async (docWithLocales) => {
       const { id } = docWithLocales
@@ -265,8 +266,11 @@ export const updateOperation = async <
 
         return updatedDoc
       } catch (error) {
+        const isPublic = error instanceof Error ? isErrorPublic(error, config) : false
+
         errors.push({
           id,
+          isPublic,
           message: error instanceof Error ? error.message : 'Unknown error',
         })
       }

--- a/packages/payload/src/errors/APIError.ts
+++ b/packages/payload/src/errors/APIError.ts
@@ -47,8 +47,13 @@ export class APIError<
     message: string,
     status: number = httpStatus.INTERNAL_SERVER_ERROR,
     data: TData = null!,
-    isPublic = false,
+    isPublic?: boolean,
   ) {
-    super(message, status, data, isPublic)
+    super(
+      message,
+      status,
+      data,
+      typeof isPublic === 'boolean' ? isPublic : status !== httpStatus.INTERNAL_SERVER_ERROR,
+    )
   }
 }

--- a/packages/payload/src/utilities/isErrorPublic.ts
+++ b/packages/payload/src/utilities/isErrorPublic.ts
@@ -1,3 +1,5 @@
+import { status as httpStatus } from 'http-status'
+
 import type { SanitizedConfig } from '../config/types.js'
 
 type PayloadError = {
@@ -9,11 +11,18 @@ type PayloadError = {
  * Determines if an error should be shown to the user.
  */
 export function isErrorPublic(error: Error, config: SanitizedConfig) {
+  const payloadError = error as PayloadError
+
   if (config.debug) {
     return true
   }
-
-  if ((error as PayloadError).isPublic === true) {
+  if (payloadError.isPublic === true) {
+    return true
+  }
+  if (payloadError.isPublic === false) {
+    return false
+  }
+  if (payloadError.status && payloadError.status !== httpStatus.INTERNAL_SERVER_ERROR) {
     return true
   }
 

--- a/packages/payload/src/utilities/isErrorPublic.ts
+++ b/packages/payload/src/utilities/isErrorPublic.ts
@@ -1,0 +1,21 @@
+import type { SanitizedConfig } from '../config/types.js'
+
+type PayloadError = {
+  isPublic?: boolean
+  status?: number
+} & Error
+
+/**
+ * Determines if an error should be shown to the user.
+ */
+export function isErrorPublic(error: Error, config: SanitizedConfig) {
+  if (config.debug) {
+    return true
+  }
+
+  if ((error as PayloadError).isPublic === true) {
+    return true
+  }
+
+  return false
+}

--- a/packages/payload/src/utilities/routeError.ts
+++ b/packages/payload/src/utilities/routeError.ts
@@ -8,6 +8,7 @@ import { APIError } from '../errors/APIError.js'
 import { getPayload } from '../index.js'
 import { formatErrors } from './formatErrors.js'
 import { headersWithCors } from './headersWithCors.js'
+import { isErrorPublic } from './isErrorPublic.js'
 import { logError } from './logError.js'
 import { mergeHeaders } from './mergeHeaders.js'
 
@@ -68,7 +69,7 @@ export const routeError = async ({
 
   // Internal server errors can contain anything, including potentially sensitive data.
   // Therefore, error details will be hidden from the response unless `config.debug` is `true`
-  if (!config.debug && !err.isPublic && status === httpStatus.INTERNAL_SERVER_ERROR) {
+  if (!isErrorPublic(err, config)) {
     response = formatErrors(new APIError('Something went wrong.'))
   }
 

--- a/packages/ui/src/elements/Table/index.tsx
+++ b/packages/ui/src/elements/Table/index.tsx
@@ -41,26 +41,29 @@ export const Table: React.FC<Props> = ({ appearance, BeforeTable, columns, data 
         </thead>
         <tbody>
           {data &&
-            data?.map((row, rowIndex) => (
-              <tr
-                className={`row-${rowIndex + 1}`}
-                key={
-                  typeof row.id === 'string' || typeof row.id === 'number'
-                    ? String(row.id)
-                    : rowIndex
-                }
-              >
-                {activeColumns.map((col, colIndex) => {
-                  const { accessor } = col
+            data?.map((row, rowIndex) => {
+              return (
+                <tr
+                  className={`row-${rowIndex + 1}`}
+                  data-id={row.id}
+                  key={
+                    typeof row.id === 'string' || typeof row.id === 'number'
+                      ? String(row.id)
+                      : rowIndex
+                  }
+                >
+                  {activeColumns.map((col, colIndex) => {
+                    const { accessor } = col
 
-                  return (
-                    <td className={`cell-${accessor.replace(/\./g, '__')}`} key={colIndex}>
-                      {col.renderedCells[rowIndex]}
-                    </td>
-                  )
-                })}
-              </tr>
-            ))}
+                    return (
+                      <td className={`cell-${accessor.replace(/\./g, '__')}`} key={colIndex}>
+                        {col.renderedCells[rowIndex]}
+                      </td>
+                    )
+                  })}
+                </tr>
+              )
+            })}
         </tbody>
       </table>
     </div>

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -131,22 +131,24 @@ export async function buildConfigWithDefaults(
       ],
     }),
     email: testEmailAdapter,
-    endpoints: [localAPIEndpoint, reInitEndpoint],
     secret: 'TEST_SECRET',
     sharp,
     telemetry: false,
     ...testConfig,
+    endpoints: [localAPIEndpoint, reInitEndpoint, ...(testConfig?.endpoints || [])],
     i18n: {
       supportedLanguages: {
         de,
         en,
         es,
+        ...(testConfig?.i18n?.supportedLanguages || {}),
       },
       ...(testConfig?.i18n || {}),
     },
     typescript: {
       declare: {
         ignoreTSError: true,
+        ...(testConfig?.typescript?.declare || {}),
       },
       ...testConfig?.typescript,
     },

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -34,9 +34,10 @@ describe('Config', () => {
     })
 
     it('allows a custom field in the root endpoints', () => {
-      const [endpoint] = payload.config.endpoints
+      const endpoints = payload.config.endpoints
+      const customEndpoint = endpoints?.find((endpoint) => endpoint.path === '/config')
 
-      expect(endpoint.custom).toEqual({
+      expect(customEndpoint?.custom).toEqual({
         description: 'Get the sanitized payload config',
       })
     })

--- a/test/hooks/collections/BeforeDelete/index.ts
+++ b/test/hooks/collections/BeforeDelete/index.ts
@@ -5,7 +5,7 @@ export const BeforeDeleteCollection: CollectionConfig = {
   hooks: {
     beforeDelete: [
       ({ id }) => {
-        throw new APIError(`Test error: cannot delete document with ID ${id}`, 401, null, true)
+        throw new APIError(`Test error: cannot delete document with ID ${id}`, 401)
       },
     ],
   },

--- a/test/hooks/collections/BeforeDelete/index.ts
+++ b/test/hooks/collections/BeforeDelete/index.ts
@@ -1,0 +1,35 @@
+import { APIError, type CollectionConfig } from 'payload'
+
+export const BeforeDeleteCollection: CollectionConfig = {
+  slug: 'before-delete-hooks',
+  hooks: {
+    beforeDelete: [
+      ({ id }) => {
+        throw new APIError(`Test error: cannot delete document with ID ${id}`, 401, null, true)
+      },
+    ],
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}
+
+export const BeforeDelete2Collection: CollectionConfig = {
+  slug: 'before-delete-2-hooks',
+  hooks: {
+    beforeDelete: [
+      ({ id }) => {
+        throw new Error(`Test error: cannot delete document with ID ${id}`)
+      },
+    ],
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}

--- a/test/hooks/config.ts
+++ b/test/hooks/config.ts
@@ -9,6 +9,10 @@ import { APIError } from 'payload'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { AfterOperationCollection } from './collections/AfterOperation/index.js'
 import { BeforeChangeHooks } from './collections/BeforeChange/index.js'
+import {
+  BeforeDelete2Collection,
+  BeforeDeleteCollection,
+} from './collections/BeforeDelete/index.js'
 import { BeforeValidateCollection } from './collections/BeforeValidate/index.js'
 import ChainingHooks from './collections/ChainingHooks/index.js'
 import ContextHooks from './collections/ContextHooks/index.js'
@@ -42,6 +46,8 @@ export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
     Relations,
     Users,
     DataHooks,
+    BeforeDeleteCollection,
+    BeforeDelete2Collection,
     FieldPaths,
     ValueCollection,
   ],

--- a/test/hooks/payload-types.ts
+++ b/test/hooks/payload-types.ts
@@ -79,6 +79,8 @@ export interface Config {
     relations: Relation;
     'hooks-users': HooksUser;
     'data-hooks': DataHook;
+    'before-delete-hooks': BeforeDeleteHook;
+    'before-delete-2-hooks': BeforeDelete2Hook;
     'field-paths': FieldPath;
     'value-hooks': ValueHook;
     'payload-kv': PayloadKv;
@@ -100,6 +102,8 @@ export interface Config {
     relations: RelationsSelect<false> | RelationsSelect<true>;
     'hooks-users': HooksUsersSelect<false> | HooksUsersSelect<true>;
     'data-hooks': DataHooksSelect<false> | DataHooksSelect<true>;
+    'before-delete-hooks': BeforeDeleteHooksSelect<false> | BeforeDeleteHooksSelect<true>;
+    'before-delete-2-hooks': BeforeDelete2HooksSelect<false> | BeforeDelete2HooksSelect<true>;
     'field-paths': FieldPathsSelect<false> | FieldPathsSelect<true>;
     'value-hooks': ValueHooksSelect<false> | ValueHooksSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -108,7 +112,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {
     'data-hooks-global': DataHooksGlobal;
@@ -148,7 +152,7 @@ export interface HooksUserAuthOperations {
  * via the `definition` "before-change-hooks".
  */
 export interface BeforeChangeHook {
-  id: string;
+  id: number;
   title: string;
   updatedAt: string;
   createdAt: string;
@@ -158,7 +162,7 @@ export interface BeforeChangeHook {
  * via the `definition` "before-validate".
  */
 export interface BeforeValidate {
-  id: string;
+  id: number;
   title?: string | null;
   selection?: ('a' | 'b') | null;
   updatedAt: string;
@@ -169,7 +173,7 @@ export interface BeforeValidate {
  * via the `definition` "afterOperation".
  */
 export interface AfterOperation {
-  id: string;
+  id: number;
   title: string;
   updatedAt: string;
   createdAt: string;
@@ -179,7 +183,7 @@ export interface AfterOperation {
  * via the `definition` "context-hooks".
  */
 export interface ContextHook {
-  id: string;
+  id: number;
   value?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -189,7 +193,7 @@ export interface ContextHook {
  * via the `definition` "transforms".
  */
 export interface Transform {
-  id: string;
+  id: number;
   /**
    * @minItems 2
    * @maxItems 2
@@ -208,7 +212,7 @@ export interface Transform {
  * via the `definition` "hooks".
  */
 export interface Hook {
-  id: string;
+  id: number;
   fieldBeforeValidate?: boolean | null;
   fieldBeforeChange?: boolean | null;
   fieldAfterChange?: boolean | null;
@@ -226,20 +230,20 @@ export interface Hook {
  * via the `definition` "nested-after-read-hooks".
  */
 export interface NestedAfterReadHook {
-  id: string;
+  id: number;
   text?: string | null;
   group?: {
     array?:
       | {
           input?: string | null;
           afterRead?: string | null;
-          shouldPopulate?: (string | null) | Relation;
+          shouldPopulate?: (number | null) | Relation;
           id?: string | null;
         }[]
       | null;
     subGroup?: {
       afterRead?: string | null;
-      shouldPopulate?: (string | null) | Relation;
+      shouldPopulate?: (number | null) | Relation;
     };
   };
   updatedAt: string;
@@ -250,7 +254,7 @@ export interface NestedAfterReadHook {
  * via the `definition` "relations".
  */
 export interface Relation {
-  id: string;
+  id: number;
   title: string;
   updatedAt: string;
   createdAt: string;
@@ -278,7 +282,7 @@ export interface NestedAfterChangeHook {
  * via the `definition` "chaining-hooks".
  */
 export interface ChainingHook {
-  id: string;
+  id: number;
   text?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -288,7 +292,7 @@ export interface ChainingHook {
  * via the `definition` "hooks-users".
  */
 export interface HooksUser {
-  id: string;
+  id: number;
   roles: ('admin' | 'user')[];
   afterLoginHook?: boolean | null;
   updatedAt: string;
@@ -314,7 +318,7 @@ export interface HooksUser {
  * via the `definition` "data-hooks".
  */
 export interface DataHook {
-  id: string;
+  id: number;
   field_collectionAndField?: string | null;
   collection_beforeOperation_collection?: string | null;
   collection_beforeChange_collection?: string | null;
@@ -327,10 +331,30 @@ export interface DataHook {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "before-delete-hooks".
+ */
+export interface BeforeDeleteHook {
+  id: number;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "before-delete-2-hooks".
+ */
+export interface BeforeDelete2Hook {
+  id: number;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "field-paths".
  */
 export interface FieldPath {
-  id: string;
+  id: number;
   topLevelNamedField?: string | null;
   array?:
     | {
@@ -647,7 +671,7 @@ export interface FieldPath {
  * via the `definition` "value-hooks".
  */
 export interface ValueHook {
-  id: string;
+  id: number;
   slug?: string | null;
   beforeValidate_value?: string | null;
   beforeChange_value?: string | null;
@@ -659,7 +683,7 @@ export interface ValueHook {
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
-  id: string;
+  id: number;
   key: string;
   data:
     | {
@@ -676,35 +700,35 @@ export interface PayloadKv {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'before-change-hooks';
-        value: string | BeforeChangeHook;
+        value: number | BeforeChangeHook;
       } | null)
     | ({
         relationTo: 'before-validate';
-        value: string | BeforeValidate;
+        value: number | BeforeValidate;
       } | null)
     | ({
         relationTo: 'afterOperation';
-        value: string | AfterOperation;
+        value: number | AfterOperation;
       } | null)
     | ({
         relationTo: 'context-hooks';
-        value: string | ContextHook;
+        value: number | ContextHook;
       } | null)
     | ({
         relationTo: 'transforms';
-        value: string | Transform;
+        value: number | Transform;
       } | null)
     | ({
         relationTo: 'hooks';
-        value: string | Hook;
+        value: number | Hook;
       } | null)
     | ({
         relationTo: 'nested-after-read-hooks';
-        value: string | NestedAfterReadHook;
+        value: number | NestedAfterReadHook;
       } | null)
     | ({
         relationTo: 'nested-after-change-hooks';
@@ -712,32 +736,40 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'chaining-hooks';
-        value: string | ChainingHook;
+        value: number | ChainingHook;
       } | null)
     | ({
         relationTo: 'relations';
-        value: string | Relation;
+        value: number | Relation;
       } | null)
     | ({
         relationTo: 'hooks-users';
-        value: string | HooksUser;
+        value: number | HooksUser;
       } | null)
     | ({
         relationTo: 'data-hooks';
-        value: string | DataHook;
+        value: number | DataHook;
+      } | null)
+    | ({
+        relationTo: 'before-delete-hooks';
+        value: number | BeforeDeleteHook;
+      } | null)
+    | ({
+        relationTo: 'before-delete-2-hooks';
+        value: number | BeforeDelete2Hook;
       } | null)
     | ({
         relationTo: 'field-paths';
-        value: string | FieldPath;
+        value: number | FieldPath;
       } | null)
     | ({
         relationTo: 'value-hooks';
-        value: string | ValueHook;
+        value: number | ValueHook;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'hooks-users';
-    value: string | HooksUser;
+    value: number | HooksUser;
   };
   updatedAt: string;
   createdAt: string;
@@ -747,10 +779,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'hooks-users';
-    value: string | HooksUser;
+    value: number | HooksUser;
   };
   key?: string | null;
   value?:
@@ -770,7 +802,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -945,6 +977,24 @@ export interface DataHooksSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "before-delete-hooks_select".
+ */
+export interface BeforeDeleteHooksSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "before-delete-2-hooks_select".
+ */
+export interface BeforeDelete2HooksSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "field-paths_select".
  */
 export interface FieldPathsSelect<T extends boolean = true> {
@@ -1061,7 +1111,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "data-hooks-global".
  */
 export interface DataHooksGlobal {
-  id: string;
+  id: number;
   field_globalAndField?: string | null;
   global_beforeChange_global?: string | null;
   global_afterChange_global?: string | null;
@@ -1094,6 +1144,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore 
+  // @ts-ignore
   export interface GeneratedTypes extends Config {}
 }

--- a/test/hooks/payload-types.ts
+++ b/test/hooks/payload-types.ts
@@ -264,7 +264,7 @@ export interface Relation {
  * via the `definition` "nested-after-change-hooks".
  */
 export interface NestedAfterChangeHook {
-  id: string;
+  id: number;
   text?: string | null;
   group?: {
     array?:
@@ -732,7 +732,7 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'nested-after-change-hooks';
-        value: string | NestedAfterChangeHook;
+        value: number | NestedAfterChangeHook;
       } | null)
     | ({
         relationTo: 'chaining-hooks';
@@ -1144,6 +1144,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -986,7 +986,7 @@ describe('Versions', () => {
 
         expect(updateManyResult.docs).toHaveLength(0)
         expect(updateManyResult.errors).toStrictEqual([
-          { id: doc.id, message: 'The following field is invalid: Group > Title' },
+          { id: doc.id, message: 'The following field is invalid: Group > Title', isPublic: true },
         ])
       })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14377

## Non-public errors were returned from delete and update endpoints

Previously, non-public errors (`500` errors, or errors without `isPublic: true` and `status`) were returned from the delete and update endpoint. For security reason, this PR excludes the error messages from the response.

This aligns bulk endpoints with others (e.g., deleteByID) that already gate error details through `routeError.ts`.

## Loosen up isPublic check when throwing API error

`APIError` now infers `isPublic` from the status code unless explicitly provided:
- Non-500 (e.g., 4xx): `isPublic` defaults to `true`.
- 500 or missing status: `isPublic` defaults to `false`.

You can still override by passing a boolean `isPublic` explicitly. Previously, the only way to mark the error as public was:

`throw new APIError('error message', 401, null ,false)`

which feels unnecessary explicit.

Now, you can do this:

`throw new APIError('error message', 401)`

which previously resulted in `isPublic: false` and now results in `isPublic: true`.

## Stricter error check in routeError

`routeError` now uses `isErrorPublic(err, config)` to decide whether to expose the error message. Compared to the old condition (`!config.debug && !err.isPublic && status === 500)`, this is a bit stricter and easier to understand. Errors with `isPublic === false` are now hidden even for non-500 statuses (previously they were shown).