### PR TITLE
fix(ui): portal out the popup

### DIFF
--- a/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
+++ b/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
@@ -41,15 +41,18 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
   if (buttonType === 'custom') {
     return (
       <div
+        aria-expanded={active}
+        aria-haspopup="true"
         className={classes}
         onClick={handleClick}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
             handleClick()
           }
         }}
         role="button"
-        tabIndex={0}
+        tabIndex={active ? -1 : 0}
       >
         {button}
       </div>
@@ -58,15 +61,18 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
 
   return (
     <button
+      aria-expanded={active}
+      aria-haspopup="true"
       className={classes}
       disabled={disabled}
       onClick={handleClick}
       onKeyDown={(e) => {
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
           handleClick()
         }
       }}
-      tabIndex={0}
+      tabIndex={active ? -1 : 0}
       type="button"
     >
       {button}

--- a/packages/ui/src/elements/Popup/index.scss
+++ b/packages/ui/src/elements/Popup/index.scss
@@ -19,7 +19,6 @@
     }
 
     &__content {
-      position: absolute;
       background: var(--popup-bg);
       opacity: 0;
       visibility: hidden;
@@ -131,7 +130,6 @@
     }
     &--h-align-center {
       .popup__content {
-        left: 50%;
         transform: translateX(-50%);
       }
 
@@ -143,19 +141,17 @@
 
     [dir='rtl'] &--h-align-right {
       .popup__content {
-        right: unset;
-        left: 0;
+        transform: translateX(-100%);
       }
 
       .popup__caret {
-        right: unset;
         left: var(--popup-padding);
       }
     }
 
     &--h-align-right {
       .popup__content {
-        right: var(--button-size-offset);
+        transform: translateX(-100%);
       }
 
       .popup__caret {
@@ -175,11 +171,10 @@
     &--v-align-top {
       .popup__content {
         @include shadow-lg;
-        bottom: calc(100% + var(--popup-caret-size));
       }
 
       .popup__caret {
-        top: calc(100% - 1px);
+        top: 100%;
         border-top-color: var(--popup-bg);
       }
     }
@@ -187,11 +182,10 @@
     &--v-align-bottom {
       .popup__content {
         @include shadow-lg-top;
-        top: calc(100% + var(--popup-caret-size));
       }
 
       .popup__caret {
-        bottom: calc(100% - 1px);
+        bottom: 100%;
         border-bottom-color: var(--popup-bg);
       }
     }
@@ -211,32 +205,8 @@
     @include mid-break {
       --popup-padding: calc(var(--base) * 0.25);
 
-      &--h-align-center {
-        .popup__content {
-          left: 50%;
-          transform: translateX(-0%);
-        }
-
-        .popup__caret {
-          left: 50%;
-          transform: translateX(-0%);
-        }
-      }
-
-      &--h-align-right {
-        .popup__content {
-          right: 0;
-        }
-
-        .popup__caret {
-          right: var(--popup-padding);
-        }
-      }
-
       &--force-h-align-left {
         .popup__content {
-          left: 0;
-          right: unset;
           transform: unset;
         }
 
@@ -249,9 +219,7 @@
 
       &--force-h-align-right {
         .popup__content {
-          right: 0;
-          left: unset;
-          transform: unset;
+          transform: translateX(-100%);
         }
 
         .popup__caret {

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -5,6 +5,7 @@ export * as PopupList from './PopupButtonList/index.js'
 
 import { useWindowInfo } from '@faceless-ui/window-info'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import { useIntersect } from '../../hooks/useIntersect.js'
 import { PopupTrigger } from './PopupTrigger/index.js'
@@ -74,14 +75,34 @@ export const Popup: React.FC<PopupProps> = (props) => {
   const [active, setActive_Internal] = useState(initActive)
   const [verticalAlign, setVerticalAlign] = useState(verticalAlignFromProps)
   const [horizontalAlign, setHorizontalAlign] = useState(horizontalAlignFromProps)
+  const [isMounted, setIsMounted] = useState(false)
+  const [contentPosition, setContentPosition] = useState<{
+    left: number
+    top: number
+    width: number
+  }>({
+    left: 0,
+    top: 0,
+    width: 0,
+  })
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null)
 
   const setActive = React.useCallback(
     (active: boolean) => {
-      if (active && typeof onToggleOpen === 'function') {
-        onToggleOpen(true)
-      }
-      if (!active && typeof onToggleClose === 'function') {
-        onToggleClose()
+      if (active) {
+        // Store the currently focused element before opening popup
+        previouslyFocusedElement.current = document.activeElement as HTMLElement
+        if (typeof onToggleOpen === 'function') {
+          onToggleOpen(true)
+        }
+      } else {
+        if (typeof onToggleClose === 'function') {
+          onToggleClose()
+        }
+        // Return focus to the previously focused element (usually the trigger button)
+        if (previouslyFocusedElement.current) {
+          previouslyFocusedElement.current.focus()
+        }
       }
       setActive_Internal(active)
     },
@@ -90,15 +111,17 @@ export const Popup: React.FC<PopupProps> = (props) => {
 
   const setPosition = useCallback(
     ({ horizontal = false, vertical = false }) => {
-      if (contentRef.current) {
-        const bounds = contentRef.current.getBoundingClientRect()
+      if (contentRef.current && triggerRef.current) {
+        const contentBounds = contentRef.current.getBoundingClientRect()
+        const triggerBounds = triggerRef.current.getBoundingClientRect()
 
         const {
           bottom: contentBottomPos,
+          height: contentHeight,
           left: contentLeftPos,
           right: contentRightPos,
           top: contentTopPos,
-        } = bounds
+        } = contentBounds
 
         let boundingTopPos = 100
         let boundingRightPos = document.documentElement.clientWidth
@@ -114,29 +137,64 @@ export const Popup: React.FC<PopupProps> = (props) => {
           } = boundingRef.current.getBoundingClientRect())
         }
 
+        let newHorizontalAlign = horizontalAlign
+        let newVerticalAlign = verticalAlign
+
         if (horizontal) {
           if (contentRightPos > boundingRightPos && contentLeftPos > boundingLeftPos) {
+            newHorizontalAlign = 'right'
             setHorizontalAlign('right')
           } else if (contentLeftPos < boundingLeftPos && contentRightPos < boundingRightPos) {
+            newHorizontalAlign = 'left'
             setHorizontalAlign('left')
           }
         }
 
         if (vertical) {
           if (contentTopPos < boundingTopPos && contentBottomPos < boundingBottomPos) {
+            newVerticalAlign = 'bottom'
             setVerticalAlign('bottom')
           } else if (contentBottomPos > boundingBottomPos && contentTopPos > boundingTopPos) {
+            newVerticalAlign = 'top'
             setVerticalAlign('top')
           }
         }
+
+        // Calculate absolute position for portal
+        const scrollTop = window.scrollY || document.documentElement.scrollTop
+        const scrollLeft = window.scrollX || document.documentElement.scrollLeft
+        const caretSize = 10 // matches --popup-caret-size
+
+        let topPosition = triggerBounds.top + scrollTop
+        let leftPosition = triggerBounds.left + scrollLeft
+
+        // Adjust vertical position based on alignment
+        if (newVerticalAlign === 'top') {
+          topPosition = triggerBounds.top + scrollTop - contentHeight - caretSize
+        } else if (newVerticalAlign === 'bottom') {
+          topPosition = triggerBounds.bottom + scrollTop + caretSize
+        }
+
+        // For right alignment, position from the right edge of the trigger
+        if (newHorizontalAlign === 'right') {
+          leftPosition = triggerBounds.right + scrollLeft
+        } else if (newHorizontalAlign === 'center') {
+          leftPosition = triggerBounds.left + scrollLeft + triggerBounds.width / 2
+        }
+
+        setContentPosition({
+          left: leftPosition,
+          top: topPosition,
+          width: triggerBounds.width,
+        })
       }
     },
-    [boundingRef],
+    [boundingRef, horizontalAlign, verticalAlign],
   )
 
   const handleClickOutside = useCallback(
     (e) => {
-      if (contentRef.current.contains(e.target) || triggerRef.current.contains(e.target)) {
+      if (contentRef.current?.contains(e.target) || triggerRef.current?.contains(e.target)) {
         return
       }
 
@@ -144,6 +202,81 @@ export const Popup: React.FC<PopupProps> = (props) => {
     },
     [contentRef, setActive],
   )
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Close popup on Escape key
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        setActive(false)
+        return
+      }
+
+      // Focus trap - handle Tab key
+      if (e.key === 'Tab' && contentRef.current) {
+        const focusableElements = contentRef.current.querySelectorAll(
+          'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        )
+
+        const focusableArray: HTMLElement[] = Array.from(focusableElements)
+        const firstElement = focusableArray[0]
+        const lastElement = focusableArray[focusableArray.length - 1]
+
+        // If no focusable elements in popup, close it and let tab continue
+        if (focusableArray.length === 0) {
+          setActive(false)
+          return
+        }
+
+        // Check if current focus is within the popup content
+        const currentlyFocusedElement = document.activeElement
+        const isInPopup =
+          contentRef.current.contains(currentlyFocusedElement) ||
+          currentlyFocusedElement === contentRef.current
+
+        // If focus is outside popup (or on trigger), bring it to first element
+        if (!isInPopup) {
+          e.preventDefault()
+          firstElement?.focus()
+          return
+        }
+
+        // If shift+tab on first element, go to last
+        if (e.shiftKey && currentlyFocusedElement === firstElement) {
+          e.preventDefault()
+          lastElement?.focus()
+          return
+        }
+
+        // If tab on last element, go to first
+        if (!e.shiftKey && currentlyFocusedElement === lastElement) {
+          e.preventDefault()
+          firstElement?.focus()
+          return
+        }
+      }
+    },
+    [contentRef, setActive],
+  )
+
+  const handleScroll = useCallback(() => {
+    setPosition({ horizontal: true, vertical: true })
+  }, [setPosition])
+
+  const handleResize = useCallback(() => {
+    setPosition({ horizontal: true, vertical: true })
+  }, [setPosition])
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (active) {
+      setPosition({ horizontal: true, vertical: true })
+    }
+  }, [active, setPosition])
 
   useEffect(() => {
     setPosition({ horizontal: true })
@@ -156,24 +289,50 @@ export const Popup: React.FC<PopupProps> = (props) => {
   useEffect(() => {
     if (active) {
       document.addEventListener('mousedown', handleClickOutside)
+      document.addEventListener('keydown', handleKeyDown)
+      window.addEventListener('scroll', handleScroll, true)
+      window.addEventListener('resize', handleResize)
+
+      // Focus first focusable element in popup when opened
+      setTimeout(() => {
+        if (contentRef.current) {
+          const focusableElements = contentRef.current.querySelectorAll(
+            'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          )
+          const firstElement = focusableElements[0] as HTMLElement
+          firstElement?.focus()
+        }
+      }, 0)
     } else {
       document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('scroll', handleScroll, true)
+      window.removeEventListener('resize', handleResize)
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('scroll', handleScroll, true)
+      window.removeEventListener('resize', handleResize)
     }
-  }, [active, handleClickOutside, onToggleOpen])
+  }, [active, handleClickOutside, handleKeyDown, handleResize, handleScroll, onToggleOpen])
 
   useEffect(() => {
     setActive(forceOpen)
   }, [forceOpen, setActive])
 
-  const classes = [
+  const wrapperClasses = [
     baseClass,
     className,
-    `${baseClass}--size-${size}`,
     buttonSize && `${baseClass}--button-size-${buttonSize}`,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const contentClasses = [
+    baseClass,
+    `${baseClass}--size-${size}`,
     `${baseClass}--v-align-${verticalAlign}`,
     `${baseClass}--h-align-${horizontalAlign}`,
     active && `${baseClass}--active`,
@@ -182,47 +341,22 @@ export const Popup: React.FC<PopupProps> = (props) => {
     .filter(Boolean)
     .join(' ')
 
-  return (
-    <div className={classes} id={id}>
-      <div className={`${baseClass}__trigger-wrap`} ref={triggerRef}>
-        {showOnHover ? (
-          <div
-            className={`${baseClass}__on-hover-watch`}
-            onMouseEnter={() => setActive(true)}
-            onMouseLeave={() => setActive(false)}
-            role="button"
-            tabIndex={0}
-          >
-            <PopupTrigger
-              {...{
-                active,
-                button,
-                buttonType,
-                className: buttonClassName,
-                disabled,
-                noBackground,
-                setActive,
-                size: buttonSize,
-              }}
-            />
-          </div>
-        ) : (
-          <PopupTrigger
-            {...{
-              active,
-              button,
-              buttonType,
-              className: buttonClassName,
-              disabled,
-              noBackground,
-              setActive,
-              size: buttonSize,
-            }}
-          />
-        )}
-      </div>
-
-      <div className={`${baseClass}__content`} ref={contentRef}>
+  const popupContent = isMounted && (
+    <div
+      aria-hidden={!active}
+      className={contentClasses}
+      ref={contentRef}
+      role="dialog"
+      style={
+        {
+          '--trigger-width': `${contentPosition.width}px`,
+          left: `${contentPosition.left}px`,
+          position: 'fixed',
+          top: `${contentPosition.top}px`,
+        } as React.CSSProperties
+      }
+    >
+      <div className={`${baseClass}__content`}>
         <div className={`${baseClass}__hide-scrollbar`} ref={intersectionRef}>
           <div className={`${baseClass}__scroll-container`}>
             <div className={`${baseClass}__scroll-content`}>
@@ -235,5 +369,51 @@ export const Popup: React.FC<PopupProps> = (props) => {
         {caret && <div className={`${baseClass}__caret`} />}
       </div>
     </div>
+  )
+
+  return (
+    <>
+      <div className={wrapperClasses} id={id}>
+        <div className={`${baseClass}__trigger-wrap`} ref={triggerRef}>
+          {showOnHover ? (
+            <div
+              className={`${baseClass}__on-hover-watch`}
+              onMouseEnter={() => setActive(true)}
+              onMouseLeave={() => setActive(false)}
+              role="button"
+              tabIndex={0}
+            >
+              <PopupTrigger
+                {...{
+                  active,
+                  button,
+                  buttonType,
+                  className: buttonClassName,
+                  disabled,
+                  noBackground,
+                  setActive,
+                  size: buttonSize,
+                }}
+              />
+            </div>
+          ) : (
+            <PopupTrigger
+              {...{
+                active,
+                button,
+                buttonType,
+                className: buttonClassName,
+                disabled,
+                noBackground,
+                setActive,
+                size: buttonSize,
+              }}
+            />
+          )}
+        </div>
+      </div>
+
+      {isMounted && createPortal(popupContent, document.body)}
+    </>
   )
 }

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -294,7 +294,8 @@ export const Popup: React.FC<PopupProps> = (props) => {
       window.addEventListener('resize', handleResize)
 
       // Focus first focusable element in popup when opened
-      setTimeout(() => {
+      // Use RAF to ensure portal is rendered and painted
+      const rafId = requestAnimationFrame(() => {
         if (contentRef.current) {
           const focusableElements = contentRef.current.querySelectorAll(
             'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
@@ -302,7 +303,11 @@ export const Popup: React.FC<PopupProps> = (props) => {
           const firstElement = focusableElements[0] as HTMLElement
           firstElement?.focus()
         }
-      }, 0)
+      })
+
+      return () => {
+        cancelAnimationFrame(rafId)
+      }
     } else {
       document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleKeyDown)


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11456
Fixes https://github.com/payloadcms/payload/issues/14492

The Popup is now using a portal which means it will always be above everything else when toggled on. This fixes various clipping issues where we can't break out of the parent's Z layer eg in the sidebar. It fixes problems like these:
<img width="890" height="450" alt="image" src="https://github.com/user-attachments/assets/c9fbf388-bac5-4169-a0b0-f83aea8f11f5" />


Now it's portalled so it looks like this
<img width="293" height="267" alt="image" src="https://github.com/user-attachments/assets/c000c8cf-81da-47de-a0f9-c6efe9d03cfa" />

<img width="362" height="313" alt="image" src="https://github.com/user-attachments/assets/d8502899-0aba-4696-8534-d952e9c13b01" />


I've ensured tab order is contained with the contents when its visible.