### PR TITLE
refactor(ui): strongly type render-list server action

### DIFF
--- a/packages/next/src/views/List/handleServerFunction.tsx
+++ b/packages/next/src/views/List/handleServerFunction.tsx
@@ -1,4 +1,5 @@
-import type { CollectionPreferences, ListQuery, ServerFunction, VisibleEntities } from 'payload'
+import type { RenderListServerFnArgs, RenderListServerFnReturnType } from '@payloadcms/ui'
+import type { CollectionPreferences, ServerFunction, VisibleEntities } from 'payload'
 
 import { getClientConfig } from '@payloadcms/ui/utilities/getClientConfig'
 import { headers as getHeaders } from 'next/headers.js'
@@ -7,27 +8,9 @@ import { applyLocaleFiltering } from 'payload/shared'
 
 import { renderListView } from './index.js'
 
-type RenderListResult = {
-  List: React.ReactNode
-  preferences: CollectionPreferences
-}
-
 export const renderListHandler: ServerFunction<
-  {
-    collectionSlug: string
-    disableActions?: boolean
-    disableBulkDelete?: boolean
-    disableBulkEdit?: boolean
-    disableQueryPresets?: boolean
-    documentDrawerSlug: string
-    drawerSlug?: string
-    enableRowSelections: boolean
-    overrideEntityVisibility?: boolean
-    query: ListQuery
-    redirectAfterDelete: boolean
-    redirectAfterDuplicate: boolean
-  },
-  Promise<RenderListResult>
+  RenderListServerFnArgs,
+  Promise<RenderListServerFnReturnType>
 > = async (args) => {
   const {
     collectionSlug,

--- a/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
@@ -6,7 +6,11 @@ import { hoistQueryParamsToAnd } from 'payload/shared'
 import React, { useCallback, useEffect, useState } from 'react'
 
 import type { ListDrawerContextProps, ListDrawerContextType } from '../ListDrawer/Provider.js'
-import type { ListDrawerProps } from './types.js'
+import type {
+  ListDrawerProps,
+  RenderListServerFnArgs,
+  RenderListServerFnReturnType,
+} from './types.js'
 
 import { useDocumentDrawer } from '../../elements/DocumentDrawer/index.js'
 import { useEffectEvent } from '../../hooks/useEffectEvent.js'
@@ -92,10 +96,9 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
         }
 
         if (slug) {
-          const result: { List: React.ReactNode } = (await serverFunction({
+          const result: RenderListServerFnReturnType = (await serverFunction({
             name: 'render-list',
             args: {
-              allowCreate,
               collectionSlug: slug,
               disableBulkDelete: true,
               disableBulkEdit: true,
@@ -104,8 +107,8 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
               enableRowSelections,
               overrideEntityVisibility,
               query: newQuery,
-            },
-          })) as { List: React.ReactNode }
+            } satisfies RenderListServerFnArgs,
+          })) as RenderListServerFnReturnType
 
           setListView(result?.List || null)
         } else {
@@ -123,7 +126,6 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
     [
       serverFunction,
       closeModal,
-      allowCreate,
       drawerSlug,
       isOpen,
       enableRowSelections,

--- a/packages/ui/src/elements/ListDrawer/types.ts
+++ b/packages/ui/src/elements/ListDrawer/types.ts
@@ -1,8 +1,38 @@
-import type { FilterOptionsResult, SanitizedCollectionConfig } from 'payload'
+import type {
+  CollectionPreferences,
+  FilterOptionsResult,
+  ListQuery,
+  SanitizedCollectionConfig,
+} from 'payload'
 import type React from 'react'
 import type { HTMLAttributes } from 'react'
 
 import type { ListDrawerContextProps } from './Provider.js'
+
+/**
+ * @internal - this may change in a minor release
+ */
+export type RenderListServerFnArgs = {
+  collectionSlug: string
+  disableActions?: boolean
+  disableBulkDelete?: boolean
+  disableBulkEdit?: boolean
+  disableQueryPresets?: boolean
+  drawerSlug?: string
+  enableRowSelections: boolean
+  overrideEntityVisibility?: boolean
+  query: ListQuery
+  redirectAfterDelete?: boolean
+  redirectAfterDuplicate?: boolean
+}
+
+/**
+ * @internal - this may change in a minor release
+ */
+export type RenderListServerFnReturnType = {
+  List: React.ReactNode
+  preferences: CollectionPreferences
+}
 
 export type ListDrawerProps = {
   readonly allowCreate?: boolean

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -99,6 +99,8 @@ export { useListDrawer } from '../../elements/ListDrawer/index.js'
 export type {
   ListDrawerProps,
   ListTogglerProps,
+  RenderListServerFnArgs,
+  RenderListServerFnReturnType,
   UseListDrawer,
 } from '../../elements/ListDrawer/types.js'
 export { ListSelection } from '../../views/List/ListSelection/index.js'


### PR DESCRIPTION
The render-list server action call was incorrectly types, resulting in unnecessary arguments being passed into it from the `ListDrawer` component.

This PR fixes the incorrect types, moves the into the ui package so that they can be accessed within it, and strongly types the server function call.