### PR TITLE
test: adjust test targeting to wait for input

### DIFF
--- a/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -1068,12 +1068,16 @@ describe('lexicalBlocks', () => {
 
       await conditionalArrayBlock.locator('.btn__label:has-text("Add Columns2")').first().click()
       await expect(
-        conditionalArrayBlock.locator('.array-field__draggable-rows #columns2-row-0'),
+        conditionalArrayBlock.locator(
+          '.array-field__draggable-rows #columns2-row-0 input[type="text"]',
+        ),
       ).toBeVisible()
 
       await conditionalArrayBlock.locator('.btn__label:has-text("Add Columns2")').first().click()
       await expect(
-        conditionalArrayBlock.locator('.array-field__draggable-rows #columns2-row-1'),
+        conditionalArrayBlock.locator(
+          '.array-field__draggable-rows #columns2-row-1 input[type="text"]',
+        ),
       ).toBeVisible()
 
       await conditionalArrayBlock


### PR DESCRIPTION
Adjust the lexical test to wait for nested inputs to be visible before rapidly adding another row.