### PR TITLE
test: fix flaky toast assertions in draft validation tests

### DIFF
--- a/test/field-error-states/e2e.spec.ts
+++ b/test/field-error-states/e2e.spec.ts
@@ -102,7 +102,7 @@ describe('Field Error States', () => {
       await page.goto(validateDraftsOn.create)
       await page.locator('#field-title').fill('Test Document')
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-success').first()).toBeVisible()
+      await expect(page.locator('.payload-toast-container .toast-success')).toBeVisible()
 
       await page.waitForURL(/\/admin\/collections\/validate-drafts-on\/[a-zA-Z0-9]+/)
 
@@ -111,20 +111,22 @@ describe('Field Error States', () => {
       await page.locator('#field-validatedField').fill('This will fail')
 
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-error').first()).toBeVisible()
+      const errorToast = page.locator('.payload-toast-container .toast-error').first()
+      await expect(errorToast).toBeVisible()
+      await errorToast.locator('button[aria-label="Close toast"]').click()
 
       const saveDraftButton = page.locator('#action-save-draft')
       await expect(saveDraftButton).toBeEnabled()
 
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-error').first()).toBeVisible()
+      await expect(page.locator('.payload-toast-container .toast-error')).toBeVisible()
     })
 
     test('should keep save draft button enabled after successful save when form is modified again', async () => {
       await page.goto(validateDraftsOn.create)
       await page.locator('#field-title').fill('Test Document')
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-success').first()).toBeVisible()
+      await expect(page.locator('.payload-toast-container .toast-success')).toBeVisible()
 
       await page.locator('#field-title').fill('Modified Document')
 

--- a/test/field-error-states/e2e.spec.ts
+++ b/test/field-error-states/e2e.spec.ts
@@ -102,7 +102,7 @@ describe('Field Error States', () => {
       await page.goto(validateDraftsOn.create)
       await page.locator('#field-title').fill('Test Document')
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-success')).toBeVisible()
+      await expect(page.locator('.payload-toast-container .toast-success').first()).toBeVisible()
 
       await page.waitForURL(/\/admin\/collections\/validate-drafts-on\/[a-zA-Z0-9]+/)
 
@@ -111,20 +111,20 @@ describe('Field Error States', () => {
       await page.locator('#field-validatedField').fill('This will fail')
 
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-error')).toBeVisible()
+      await expect(page.locator('.payload-toast-container .toast-error').first()).toBeVisible()
 
       const saveDraftButton = page.locator('#action-save-draft')
       await expect(saveDraftButton).toBeEnabled()
 
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-error')).toBeVisible()
+      await expect(page.locator('.payload-toast-container .toast-error').first()).toBeVisible()
     })
 
     test('should keep save draft button enabled after successful save when form is modified again', async () => {
       await page.goto(validateDraftsOn.create)
       await page.locator('#field-title').fill('Test Document')
       await page.click('#action-save-draft')
-      await expect(page.locator('.payload-toast-container .toast-success')).toBeVisible()
+      await expect(page.locator('.payload-toast-container .toast-success').first()).toBeVisible()
 
       await page.locator('#field-title').fill('Modified Document')
 


### PR DESCRIPTION
### What?

The test "should keep save draft button enabled after validation failure on update" was intermittently failing in CI with:

```
Error: strict mode violation: locator('.payload-toast-container .toast-error') resolved to 2 elements
```

This occurred because the test clicks the save draft button twice in quick succession to verify it remains enabled after validation failures. In slower CI environments, both error toasts were visible simultaneously, causing Playwright's strict mode to fail.
