### PR TITLE
ci: fix ERR_PNPM_NO_MATCHING_VERSION errors that happen shortly after publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -621,6 +621,11 @@ jobs:
           mongodb-version: 6.0
         if: matrix.database == 'mongodb'
 
+      # Avoid "ERR_PNPM_NO_MATCHING_VERSION" errors shortly after a new version is published
+      - name: Clear pnpm metadata cache
+        run: pnpm store prune
+        if: matrix.template != 'plugin'
+
       - name: Build Template
         run: |
           pnpm run script:pack --dest templates/${{ matrix.template }}

--- a/tools/scripts/src/build-template-with-local-pkgs.ts
+++ b/tools/scripts/src/build-template-with-local-pkgs.ts
@@ -52,6 +52,9 @@ async function main() {
 
   await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJsonObj, null, 2))
 
+  // Configure pnpm to retry npm registry fetches to handle CDN propagation delays
+  execSync('pnpm config set fetch-retries 3', execOpts)
+
   execSync('pnpm add ./*.tgz --ignore-workspace', execOpts)
   execSync('pnpm install --ignore-workspace', execOpts)
 


### PR DESCRIPTION
If a CI run is performed shortly after a new version is published, it often will get a `ERR_PNPM_NO_MATCHING_VERSION` error because there is a mismatch between what version is hard-coded in the package.json files vs. what is being pulled from the registry. This attempts to clear the registry cache in an attempt to avoid this.

[Example CI run](https://github.com/payloadcms/payload/actions/runs/19342920774/job/55336211250#step:13:14801) of this happening.