### PR TITLE
fix(ui): duplicate should duplicate as draft by default

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -130,7 +130,6 @@ export const createOperation = async <
         id: duplicateFromID,
         collectionConfig,
         draftArg: isSavingDraft,
-        isSavingDraft,
         overrideAccess,
         req,
         selectedLocales,

--- a/packages/payload/src/duplicateDocument/index.ts
+++ b/packages/payload/src/duplicateDocument/index.ts
@@ -17,7 +17,6 @@ type GetDuplicateDocumentArgs = {
   collectionConfig: SanitizedCollectionConfig
   draftArg?: boolean
   id: number | string
-  isSavingDraft?: boolean
   overrideAccess?: boolean
   req: PayloadRequest
   selectedLocales?: string[]
@@ -26,7 +25,6 @@ export const getDuplicateDocumentData = async ({
   id,
   collectionConfig,
   draftArg,
-  isSavingDraft,
   overrideAccess,
   req,
   selectedLocales,
@@ -95,11 +93,6 @@ export const getDuplicateDocumentData = async ({
     overrideAccess: overrideAccess!,
     req,
   })
-
-  // for version enabled collections, override the current status with draft, unless draft is explicitly set to false
-  if (isSavingDraft) {
-    duplicatedFromDocWithLocales._status = 'draft'
-  }
 
   const duplicatedFromDoc = await afterRead({
     collection: collectionConfig,

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -95,7 +95,7 @@ export const DuplicateDocument: React.FC<Props> = ({
             addQueryPrefix: true,
           })}`,
           {
-            body: JSON.stringify({}),
+            body: JSON.stringify(collectionConfig.versions?.drafts ? { _status: 'draft' } : {}),
             headers,
           },
         )

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -431,6 +431,31 @@ describe('Versions', () => {
       })
     })
 
+    describe('Duplicate', () => {
+      it('should duplicate a versioned document as a draft', async () => {
+        const originalDoc = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            description: 'Original description',
+            title: 'Original Title',
+            _status: 'published',
+          },
+          draft: false,
+        })
+
+        const duplicatedDoc = await payload.create({
+          duplicateFromID: originalDoc.id,
+          collection: draftCollectionSlug,
+          data: {
+            _status: 'draft',
+          },
+          draft: true,
+        })
+
+        expect(duplicatedDoc._status).toBe('draft')
+      })
+    })
+
     describe('Query operations', () => {
       beforeAll(async () => {
         // Create test data for query-only tests (pagination, sorting)


### PR DESCRIPTION
When duplicating documents it should duplicate as draft when drafts are enabled. It is odd behavior to duplicate a published document and have the copy immediately be published.