### PR TITLE
docs: Lexical custom server feature not using absolute import path

### DIFF
--- a/docs/rich-text/custom-features.mdx
+++ b/docs/rich-text/custom-features.mdx
@@ -416,7 +416,7 @@ import { createServerFeature } from '@payloadcms/richtext-lexical'
 
 export const MyFeature = createServerFeature({
   feature: {
-    ClientFeature: './path/to/feature.client#MyClientFeature',
+    ClientFeature: '@/path/to/feature.client#MyClientFeature',
   },
   key: 'myFeature',
   dependenciesPriority: ['otherFeature'],


### PR DESCRIPTION
I was following the instructions for adding a Lexical rich text custom feature and I had the problem that it was not showing in the admin panel within the Lexical editor. Following the [Payload example](https://github.com/payloadcms/payload/blob/main/packages/richtext-lexical/src/features/paragraph/server/index.ts), I noticed that an absolute path is used and the documentation ([here](https://payloadcms.com/docs/rich-text/custom-features#adding-a-client-feature-to-the-server-feature)) suggests a relative one. This fixed the issue. 

Please let me know if I am mistaken or if there is a better way to suggest not using a relative path to the `ClientFeature` component.