### PR TITLE
test: deflakes localization e2e suite

### DIFF
--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -2,7 +2,6 @@ import type { BrowserContext, Page } from '@playwright/test'
 import type { GeneratedTypes } from 'helpers/sdk/types.js'
 
 import { expect, test } from '@playwright/test'
-import { englishLocale } from 'globals/config.js'
 import { addArrayRow } from 'helpers/e2e/fields/array/index.js'
 import { addBlock } from 'helpers/e2e/fields/blocks/addBlock.js'
 import { navigateToDoc } from 'helpers/e2e/navigateToDoc.js'
@@ -440,7 +439,7 @@ describe('Localization', () => {
 
       await openCopyToLocaleDrawer(page)
       await setToLocale(page, 'English')
-      await runCopy({ page, toLocale: englishLocale })
+      await runCopy({ page, toLocale: defaultLocale })
 
       await expect(arrayField).toHaveValue(sampleText)
     })

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Page } from '@playwright/test'
 import type { GeneratedTypes } from 'helpers/sdk/types.js'
 
 import { expect, test } from '@playwright/test'
+import { englishLocale } from 'globals/config.js'
 import { addArrayRow } from 'helpers/e2e/fields/array/index.js'
 import { addBlock } from 'helpers/e2e/fields/blocks/addBlock.js'
 import { navigateToDoc } from 'helpers/e2e/navigateToDoc.js'
@@ -38,6 +39,7 @@ import {
   arrayWithFallbackCollectionSlug,
   defaultLocale,
   englishTitle,
+  hungarianLocale,
   localizedDraftsSlug,
   localizedPostsSlug,
   relationshipLocalizedSlug,
@@ -404,7 +406,7 @@ describe('Localization', () => {
       await createAndSaveDoc(page, url, { title })
       await openCopyToLocaleDrawer(page)
       await setToLocale(page, 'Spanish')
-      await runCopy(page)
+      await runCopy({ page, toLocale: spanishLocale })
       await expect(page.locator('#field-title')).toHaveValue(title)
       await changeLocale(page, defaultLocale)
     })
@@ -419,7 +421,7 @@ describe('Localization', () => {
 
       await openCopyToLocaleDrawer(page)
       await setToLocale(page, 'Spanish')
-      await runCopy(page)
+      await runCopy({ page, toLocale: spanishLocale })
 
       await expect(richTextField).toContainText(richTextContent)
     })
@@ -438,7 +440,7 @@ describe('Localization', () => {
 
       await openCopyToLocaleDrawer(page)
       await setToLocale(page, 'English')
-      await runCopy(page)
+      await runCopy({ page, toLocale: englishLocale })
 
       await expect(arrayField).toHaveValue(sampleText)
     })
@@ -465,7 +467,7 @@ describe('Localization', () => {
       await setToLocale(page, 'Spanish')
       const overwriteCheckbox = page.locator('#field-overwriteExisting')
       await expect(overwriteCheckbox).not.toBeChecked()
-      await runCopy(page)
+      await runCopy({ page, toLocale: spanishLocale })
 
       await expect(page.locator('#field-title')).toHaveValue(spanishTitle)
       await expect(page.locator('#field-description')).toHaveValue('Spanish description')
@@ -482,7 +484,7 @@ describe('Localization', () => {
       await setToLocale(page, 'Spanish')
       const overwriteCheckbox = page.locator('#field-overwriteExisting')
       await overwriteCheckbox.click()
-      await runCopy(page)
+      await runCopy({ page, toLocale: spanishLocale })
       await expect(page.locator('#field-title')).toHaveValue(englishTitle)
       await changeLocale(page, defaultLocale)
     })
@@ -508,7 +510,7 @@ describe('Localization', () => {
 
       await openCopyToLocaleDrawer(page)
       await setToLocale(page, 'Spanish')
-      await runCopy(page)
+      await runCopy({ page, toLocale: spanishLocale })
       await expect(page.locator('#field-title')).toHaveValue(title)
 
       const regexPattern = /locale=es/
@@ -516,7 +518,7 @@ describe('Localization', () => {
 
       await openCopyToLocaleDrawer(page)
       await setToLocale(page, 'Hungarian')
-      await runCopy(page)
+      await runCopy({ page, toLocale: hungarianLocale })
       await expect(page.locator('#field-title')).toHaveValue(title)
     })
 
@@ -797,8 +799,11 @@ async function fillValues(data: Partial<LocalizedPost>) {
   }
 }
 
-async function runCopy(page) {
+async function runCopy({ page, toLocale }: { page: Page; toLocale: string }) {
   await page.locator('.copy-locale-data__sub-header button').click()
+
+  const regexPattern = new RegExp(`locale=${toLocale}`)
+  await expect(page).toHaveURL(regexPattern)
 }
 
 async function createAndSaveDoc(page, url, values) {


### PR DESCRIPTION
The localization e2e suite would use the `runCopy` helper function which copies data from 1 locale to another  locale and then navigates to that locale. 

Tests would fail intermittently because they did not wait for that route change to happen. Scenarios would arise where the request took longer than the next `changeLocale` call which changes the locale and navigates to that locale.

So it looked like:
- `runCopy` is called **but has not finished**
- `changeLocale` runs and navigates user to new locale
- `runCopy` finishes and navigates to the locale it copied to