### PR TITLE
fix: hide turbopack warnings

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -15,6 +15,43 @@ export const withPayload = (nextConfig = {}, options = {}) => {
     env.NEXT_PUBLIC_ENABLE_ROUTER_CACHE_REFRESH = 'true'
   }
 
+  if (process.env.PAYLOAD_PATCH_TURBOPACK_WARNINGS !== 'false') {
+    // TODO: This warning is thrown because we cannot externalize the entry-point package for client-s3, so we patch the warning to not show it.
+    // We can remove this once Next.js implements https://github.com/vercel/next.js/discussions/76991
+    const turbopackWarningText =
+      'Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.\nTry to install it into the project directory by running'
+
+    // TODO 4.0: Remove this once we drop support for Next.js 15.2.x
+    const turbopackConfigWarningText = "Unrecognized key(s) in object: 'turbopack'"
+
+    const consoleWarn = console.warn
+    console.warn = (...args) => {
+      // Force to disable serverExternalPackages warnings: https://github.com/vercel/next.js/issues/68805
+      if (
+        (typeof args[1] === 'string' && args[1].includes(turbopackWarningText)) ||
+        (typeof args[0] === 'string' && args[0].includes(turbopackWarningText))
+      ) {
+        return
+      }
+
+      // Add Payload-specific message after turbopack config warning in Next.js 15.2.x or lower.
+      // TODO 4.0: Remove this once we drop support for Next.js 15.2.x
+      const hasTurbopackConfigWarning =
+        (typeof args[1] === 'string' && args[1].includes(turbopackConfigWarningText)) ||
+        (typeof args[0] === 'string' && args[0].includes(turbopackConfigWarningText))
+
+      if (hasTurbopackConfigWarning) {
+        consoleWarn(...args)
+        consoleWarn(
+          'Payload: You can safely ignore the "Invalid next.config" warning above. This only occurs on Next.js 15.2.x or lower. We recommend upgrading to a newer version of Next.js to resolve this warning.',
+        )
+        return
+      }
+
+      consoleWarn(...args)
+    }
+  }
+
   const poweredByHeader = {
     key: 'X-Powered-By',
     value: 'Next.js, Payload',

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -43,7 +43,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
       if (hasTurbopackConfigWarning) {
         consoleWarn(...args)
         consoleWarn(
-          'Payload: You can safely ignore the "Invalid next.config" warning above. This only occurs on Next.js 15.2.x or lower. We recommend upgrading to a newer version of Next.js to resolve this warning.',
+          'Payload: You can safely ignore the "Invalid next.config" warning above. This only occurs on Next.js 15.2.x or lower. We recommend upgrading to Next.js 15.4.7 to resolve this warning.',
         )
         return
       }


### PR DESCRIPTION
## Hides external packages warning

If storage-s3 is installed, the following turbopack warning will be thrown:

> Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.\nTry to install it into the project directory by running

We cannot fix this until Next.js implements https://github.com/vercel/next.js/discussions/76991, so this PR hides the warning for now. On Next.js 16, this would be an error, but we can't hide or fix that.

Alternatively, we can fix this in Payload 4.0, by requiring users to install the aws sdk as a peerDependency.

## Throws warning on Next.js 15.2.x

The minimum Next.js version we currently support is 15.2.3. Unfortunately, the Next.js config `turbopack` property was added in 15.3.0. On 15.2.3, the following warning is thrown if you use Payload: `Unrecognized key(s) in object: 'turbopack'`

Unfortunately we cannot remove this property, as Next.js 16 will throw a warning if we do. Instead, this PR throws a new, consecutive warning that prompts the user to bump their Next.js version or explains that this warning can be ignored:

![Screenshot 2025-11-17 at 09 52 21](https://github.com/user-attachments/assets/d9586a79-2094-4c2d-b7ff-8eb478502434)

