### PR TITLE
feat(plugin-mcp): adds a PayloadRequest to custom tool, prompt, and resource handlers

### DIFF
--- a/docs/plugins/mcp.mdx
+++ b/docs/plugins/mcp.mdx
@@ -196,7 +196,9 @@ tools: [
   {
     name: 'getPostScores',
     description: 'Get useful scores about content in posts',
-    handler: async (args, { payload }) => {
+    handler: async (args, req) => {
+      const { payload } = req
+
       const stats = await payload.find({
         collection: 'posts',
         where: {
@@ -204,6 +206,9 @@ tools: [
             greater_than: args.since,
           },
         },
+        req,
+        overrideAccess: false,
+        user: req.user,
       })
 
       return {

--- a/docs/plugins/mcp.mdx
+++ b/docs/plugins/mcp.mdx
@@ -154,7 +154,7 @@ resources: [
     description: 'Company content creation guidelines',
     uri: 'guidelines://company',
     mimeType: 'text/markdown',
-    handler: (uri) => ({
+    handler: (uri, req) => ({
       contents: [
         {
           uri: uri.href,
@@ -171,7 +171,7 @@ resources: [
     description: 'Access user profile information',
     uri: new ResourceTemplate('users://profile/{userId}', { list: undefined }),
     mimeType: 'application/json',
-    handler: async (uri, { userId }) => {
+    handler: async (uri, { userId }, req) => {
       // Fetch user data from your system
       const userData = await getUserById(userId)
       return {

--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -57,7 +57,7 @@ export const initializeMCPHandler = (pluginOptions: PluginMCPServerConfig) => {
         payload.logger.info('[payload-mcp] API Key is valid')
       }
 
-      return docs[0] as MCPAccessSettings
+      return docs[0] as unknown as MCPAccessSettings
     }
 
     const mcpAccessSettings = pluginOptions.overrideAuth

--- a/packages/plugin-mcp/src/mcp/helpers/fileValidation.ts
+++ b/packages/plugin-mcp/src/mcp/helpers/fileValidation.ts
@@ -202,14 +202,14 @@ function getWorkflowConfig(importedModule: Record<string, unknown>): undefined |
  * Validate collection configuration structure
  */
 function validateCollectionConfig(config: CollectionConfig): ValidationResult<CollectionConfig> {
-  if (!config || typeof config !== 'object') {
+  if (!config) {
     return {
       error: 'Collection config is not a valid object',
       success: false,
     }
   }
 
-  if (!config.slug || typeof config.slug !== 'string') {
+  if (!config.slug) {
     return {
       error: 'Collection config must have a valid slug property',
       success: false,
@@ -220,7 +220,7 @@ function validateCollectionConfig(config: CollectionConfig): ValidationResult<Co
   if (config.fields) {
     for (let i = 0; i < config.fields.length; i++) {
       const field = config.fields[i] as Record<string, unknown>
-      if (!field || typeof field !== 'object') {
+      if (!field) {
         return {
           error: `Field at index ${i} is not a valid object`,
           success: false,
@@ -228,7 +228,7 @@ function validateCollectionConfig(config: CollectionConfig): ValidationResult<Co
       }
 
       // Check if field has type property
-      if ('type' in field && field.type && typeof field.type !== 'string') {
+      if ('type' in field && field.type) {
         return {
           error: `Field at index ${i} has invalid type property`,
           success: false,
@@ -244,21 +244,21 @@ function validateCollectionConfig(config: CollectionConfig): ValidationResult<Co
  * Validate task configuration structure
  */
 function validateTaskConfig(config: TaskConfig): ValidationResult<TaskConfig> {
-  if (!config || typeof config !== 'object') {
+  if (!config) {
     return {
       error: 'Task config is not a valid object',
       success: false,
     }
   }
 
-  if (!config.slug || typeof config.slug !== 'string') {
+  if (!config.slug) {
     return {
       error: 'Task config must have a valid slug property',
       success: false,
     }
   }
 
-  if (!config.handler || typeof config.handler !== 'function') {
+  if (!config.handler) {
     return {
       error: 'Task config must have a valid handler function',
       success: false,
@@ -266,7 +266,7 @@ function validateTaskConfig(config: TaskConfig): ValidationResult<TaskConfig> {
   }
 
   // Validate optional properties
-  if (config.retries !== undefined && (typeof config.retries !== 'number' || config.retries < 0)) {
+  if (config.retries !== undefined && config.retries < 0) {
     return {
       error: 'Task config retries must be a non-negative number',
       success: false,
@@ -277,21 +277,21 @@ function validateTaskConfig(config: TaskConfig): ValidationResult<TaskConfig> {
   if (config.inputSchema && Array.isArray(config.inputSchema)) {
     for (let i = 0; i < config.inputSchema.length; i++) {
       const field = config.inputSchema[i]
-      if (!field || typeof field !== 'object') {
+      if (!field) {
         return {
           error: `Input schema field at index ${i} is not a valid object`,
           success: false,
         }
       }
 
-      if (!field.name || typeof field.name !== 'string') {
+      if (!field.name) {
         return {
           error: `Input schema field at index ${i} must have a valid name property`,
           success: false,
         }
       }
 
-      if (!field.type || typeof field.type !== 'string') {
+      if (!field.type) {
         return {
           error: `Input schema field at index ${i} must have a valid type property`,
           success: false,
@@ -303,21 +303,21 @@ function validateTaskConfig(config: TaskConfig): ValidationResult<TaskConfig> {
   if (config.outputSchema && Array.isArray(config.outputSchema)) {
     for (let i = 0; i < config.outputSchema.length; i++) {
       const field = config.outputSchema[i]
-      if (!field || typeof field !== 'object') {
+      if (!field) {
         return {
           error: `Output schema field at index ${i} is not a valid object`,
           success: false,
         }
       }
 
-      if (!field.name || typeof field.name !== 'string') {
+      if (!field.name) {
         return {
           error: `Output schema field at index ${i} must have a valid name property`,
           success: false,
         }
       }
 
-      if (!field.type || typeof field.type !== 'string') {
+      if (!field.type) {
         return {
           error: `Output schema field at index ${i} must have a valid type property`,
           success: false,
@@ -333,21 +333,21 @@ function validateTaskConfig(config: TaskConfig): ValidationResult<TaskConfig> {
  * Validate workflow configuration structure
  */
 function validateWorkflowConfig(config: WorkflowConfig): ValidationResult<WorkflowConfig> {
-  if (!config || typeof config !== 'object') {
+  if (!config) {
     return {
       error: 'Workflow config is not a valid object',
       success: false,
     }
   }
 
-  if (!config.slug || typeof config.slug !== 'string') {
+  if (!config.slug) {
     return {
       error: 'Workflow config must have a valid slug property',
       success: false,
     }
   }
 
-  if (!config.handler || typeof config.handler !== 'function') {
+  if (!config.handler) {
     return {
       error: 'Workflow config must have a valid handler function',
       success: false,
@@ -355,14 +355,14 @@ function validateWorkflowConfig(config: WorkflowConfig): ValidationResult<Workfl
   }
 
   // Validate optional properties
-  if (config.queue && typeof config.queue !== 'string') {
+  if (config.queue) {
     return {
       error: 'Workflow config queue must be a string',
       success: false,
     }
   }
 
-  if (config.retries !== undefined && (typeof config.retries !== 'number' || config.retries < 0)) {
+  if (config.retries !== undefined && config.retries < 0) {
     return {
       error: 'Workflow config retries must be a non-negative number',
       success: false,
@@ -373,21 +373,21 @@ function validateWorkflowConfig(config: WorkflowConfig): ValidationResult<Workfl
   if (config.inputSchema && Array.isArray(config.inputSchema)) {
     for (let i = 0; i < config.inputSchema.length; i++) {
       const field = config.inputSchema[i]
-      if (!field || typeof field !== 'object') {
+      if (!field) {
         return {
           error: `Input schema field at index ${i} is not a valid object`,
           success: false,
         }
       }
 
-      if (!field.name || typeof field.name !== 'string') {
+      if (!field.name) {
         return {
           error: `Input schema field at index ${i} must have a valid name property`,
           success: false,
         }
       }
 
-      if (!field.type || typeof field.type !== 'string') {
+      if (!field.type) {
         return {
           error: `Input schema field at index ${i} must have a valid type property`,
           success: false,

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig, CollectionSlug, PayloadRequest } from 'payload'
+import type { CollectionConfig, CollectionSlug, PayloadRequest, TypedUser } from 'payload'
 import type { z } from 'zod'
 
 import { type ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -192,7 +192,11 @@ export type PluginMCPServerConfig = {
       /**
        * Set the handler of the tool. This is the function that will be called when the tool is used.
        */
-      handler: (args: Record<string, unknown>) => Promise<{
+      handler: (
+        args: Record<string, unknown>,
+        req: PayloadRequest,
+        _extra: unknown,
+      ) => Promise<{
         content: Array<{
           text: string
           type: 'text'
@@ -309,6 +313,7 @@ export type MCPAccessSettings = {
   'payload-mcp-prompt'?: Record<string, boolean>
   'payload-mcp-resource'?: Record<string, boolean>
   'payload-mcp-tool'?: Record<string, boolean>
+  user: TypedUser
 } & Record<string, unknown>
 
 export type FieldDefinition = {

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -135,7 +135,29 @@ export type PluginMCPServerConfig = {
       /**
        * Set the handler of the prompt. This is the function that will be called when the prompt is used.
        */
-      handler: (...args: any) => any
+      handler: (
+        args: Record<string, unknown>,
+        req: PayloadRequest,
+        _extra: unknown,
+      ) =>
+        | {
+            messages: Array<{
+              content: {
+                text: string
+                type: 'text'
+              }
+              role: 'assistant' | 'user'
+            }>
+          }
+        | Promise<{
+            messages: Array<{
+              content: {
+                text: string
+                type: 'text'
+              }
+              role: 'assistant' | 'user'
+            }>
+          }>
       /**
        * Set the function name of the prompt.
        */
@@ -157,8 +179,21 @@ export type PluginMCPServerConfig = {
       description: string
       /**
        * Set the handler of the resource. This is the function that will be called when the resource is used.
+       * The handler can have either 3 arguments (when no args are passed) or 4 arguments (when args are passed).
        */
-      handler: (...args: any) => any
+      handler: (...args: any[]) =>
+        | {
+            contents: Array<{
+              text: string
+              uri: string
+            }>
+          }
+        | Promise<{
+            contents: Array<{
+              text: string
+              uri: string
+            }>
+          }>
       /**
        * Set the mime type of the resource.
        * example: 'text/plain'
@@ -196,12 +231,21 @@ export type PluginMCPServerConfig = {
         args: Record<string, unknown>,
         req: PayloadRequest,
         _extra: unknown,
-      ) => Promise<{
-        content: Array<{
-          text: string
-          type: 'text'
-        }>
-      }>
+      ) =>
+        | {
+            content: Array<{
+              text: string
+              type: 'text'
+            }>
+            role?: string
+          }
+        | Promise<{
+            content: Array<{
+              text: string
+              type: 'text'
+            }>
+            role?: string
+          }>
       /**
        * Set the name of the tool. This is the name that will be used to identify the tool. LLMs will interperate the name to determine when to use the tool.
        */

--- a/packages/plugin-mcp/src/utils/convertCollectionSchemaToZod.ts
+++ b/packages/plugin-mcp/src/utils/convertCollectionSchemaToZod.ts
@@ -30,6 +30,5 @@ export const convertCollectionSchemaToZod = (schema: JSONSchema4) => {
    * 5. No user input or external data is involved in the schema generation process
    */
   // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  const zodSchema = new Function('z', `return ${transpileResult.outputText}`)(z)
-  return zodSchema
+  return new Function('z', `return ${transpileResult.outputText}`)(z)
 }

--- a/test/plugin-mcp/collections/ModifiedPrompts.ts
+++ b/test/plugin-mcp/collections/ModifiedPrompts.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from 'payload'
+
+export const ModifiedPrompts: CollectionConfig = {
+  slug: 'modified-prompts',
+  fields: [
+    {
+      name: 'original',
+      type: 'textarea',
+      admin: {
+        description: 'The original prompt',
+      },
+      required: true,
+    },
+    {
+      name: 'modified',
+      type: 'textarea',
+      admin: {
+        description: 'The modified prompt',
+      },
+      required: true,
+    },
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: {
+        description: 'The user sent the prompt to modify',
+      },
+      required: true,
+    },
+  ],
+}

--- a/test/plugin-mcp/collections/ReturnedResources.ts
+++ b/test/plugin-mcp/collections/ReturnedResources.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from 'payload'
+
+export const ReturnedResources: CollectionConfig = {
+  slug: 'returned-resources',
+  fields: [
+    {
+      name: 'uri',
+      type: 'text',
+      admin: {
+        description: 'The URI of the resource',
+      },
+      required: true,
+    },
+    {
+      name: 'content',
+      type: 'textarea',
+      admin: {
+        description: 'The content of the resource',
+      },
+      required: true,
+    },
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: {
+        description: 'The user sent the prompt to modify',
+      },
+      required: true,
+    },
+  ],
+}

--- a/test/plugin-mcp/collections/Rolls.ts
+++ b/test/plugin-mcp/collections/Rolls.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from 'payload'
+
+export const Rolls: CollectionConfig = {
+  slug: 'rolls',
+  fields: [
+    {
+      name: 'sides',
+      type: 'number',
+      admin: {
+        description: 'The number of sides on the die that was rolled',
+      },
+      required: true,
+    },
+    {
+      name: 'result',
+      type: 'number',
+      admin: {
+        description: 'The result of the die roll',
+      },
+      required: true,
+    },
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: {
+        description: 'The user who rolled the die',
+      },
+      required: true,
+    },
+  ],
+}

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -8,6 +8,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Media } from './collections/Media.js'
 import { Posts } from './collections/Posts.js'
 import { Products } from './collections/Products.js'
+import { Rolls } from './collections/Rolls.js'
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
@@ -20,7 +21,7 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media, Posts, Products],
+  collections: [Users, Media, Posts, Products, Rolls],
   onInit: seed,
   plugins: [
     mcpPlugin({
@@ -110,9 +111,28 @@ export default buildConfigWithDefaults({
           {
             name: 'diceRoll',
             description: 'Rolls a virtual dice with a specified number of sides',
-            handler: (args: Record<string, unknown>) => {
+            handler: async (args: Record<string, unknown>, req) => {
               const sides = (args.sides as number) || 6
               const result = Math.floor(Math.random() * sides) + 1
+              const payload = req.payload
+
+              payload.logger.info(
+                `Dice Roll MCP Tool rolled a ${args.sides} sided die and got a ${result}`,
+              )
+
+              await payload.create({
+                collection: 'rolls',
+                data: {
+                  sides,
+                  result,
+                  user: req.user?.id,
+                },
+                req,
+                overrideAccess: false,
+                user: req.user,
+                draft: true,
+              })
+
               return Promise.resolve({
                 content: [
                   {

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -6,8 +6,10 @@ import { z } from 'zod'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Media } from './collections/Media.js'
+import { ModifiedPrompts } from './collections/ModifiedPrompts.js'
 import { Posts } from './collections/Posts.js'
 import { Products } from './collections/Products.js'
+import { ReturnedResources } from './collections/ReturnedResources.js'
 import { Rolls } from './collections/Rolls.js'
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
@@ -21,7 +23,7 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media, Posts, Products, Rolls],
+  collections: [Users, Media, Posts, Products, Rolls, ModifiedPrompts, ReturnedResources],
   onInit: seed,
   plugins: [
     mcpPlugin({
@@ -160,17 +162,45 @@ export default buildConfigWithDefaults({
             argsSchema: { message: z.string() },
             description: 'Creates a prompt to process a message',
             title: 'Echo Prompt',
-            handler: ({ message }: { message: string }) => ({
-              messages: [
-                {
-                  content: {
-                    type: 'text',
-                    text: `Please process this message: ${message}`,
-                  },
-                  role: 'user',
+            handler: async ({ message }, req) => {
+              const { payload } = req
+
+              payload.logger.info(`Echo Prompt was sent: ${message}`)
+
+              const modifiedPrompt = `This prompt was sent: ${message}`
+
+              await payload.create({
+                collection: 'modified-prompts',
+                data: {
+                  original: message as string,
+                  modified: modifiedPrompt,
+                  user: req.user?.id,
                 },
-              ],
-            }),
+                req,
+                overrideAccess: false,
+                user: req.user,
+                draft: true,
+              })
+
+              return {
+                messages: [
+                  {
+                    content: {
+                      type: 'text',
+                      text: modifiedPrompt,
+                    },
+                    role: 'user',
+                  },
+                  {
+                    content: {
+                      type: 'text',
+                      text: `This prompt was sent by userId: ${req.user?.id}`,
+                    },
+                    role: 'assistant',
+                  },
+                ],
+              }
+            },
           },
         ],
         resources: [
@@ -178,14 +208,38 @@ export default buildConfigWithDefaults({
           {
             name: 'data',
             description: 'Data is a resource that contains special data.',
-            handler: (uri) => ({
-              contents: [
-                {
+            handler: async (uri, req) => {
+              const payload = req.payload
+
+              payload.logger.info(`Data resource was requested`)
+
+              const text = 'My special data.'
+              await payload.create({
+                collection: 'returned-resources',
+                data: {
                   uri: uri.href,
-                  text: 'My special data.',
+                  content: text,
+                  user: req.user?.id,
                 },
-              ],
-            }),
+                req,
+                overrideAccess: false,
+                user: req.user,
+                draft: true,
+              })
+
+              return {
+                contents: [
+                  {
+                    uri: uri.href,
+                    text,
+                  },
+                  {
+                    uri: uri.href,
+                    text: `This was requested by user: ${req.user?.id}`,
+                  },
+                ],
+              }
+            },
             mimeType: 'text/plain',
             title: 'Data',
             uri: 'data://app',
@@ -194,14 +248,38 @@ export default buildConfigWithDefaults({
           {
             name: 'dataByID',
             description: 'Data is a resource that contains special data.',
-            handler: (uri, { id }) => ({
-              contents: [
-                {
+            handler: async (uri, { id }, req) => {
+              const payload = req.payload
+
+              payload.logger.info(`Data by ID resource was requested`)
+
+              const text = `My special data for ID: ${id}`
+              await payload.create({
+                collection: 'returned-resources',
+                data: {
                   uri: uri.href,
-                  text: `My special data for ID: ${id}`,
+                  content: text,
+                  user: req.user?.id,
                 },
-              ],
-            }),
+                req,
+                overrideAccess: false,
+                user: req.user,
+                draft: true,
+              })
+
+              return {
+                contents: [
+                  {
+                    uri: uri.href,
+                    text,
+                  },
+                  {
+                    uri: uri.href,
+                    text: `This was requested by user: ${req.user?.id}`,
+                  },
+                ],
+              }
+            },
             mimeType: 'text/plain',
             title: 'Data By ID',
             uri: new ResourceTemplate('data://app/{id}', { list: undefined }),

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -358,8 +358,6 @@ describe('@payloadcms/plugin-mcp', () => {
     })
 
     const roll = docs?.[0]
-
-    expect(docs).toHaveLength(1)
     expect(roll?.sides).toBe(6)
     expect(roll?.result).toBeDefined()
     // @ts-expect-error - doc.user is a string | User

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -288,6 +288,141 @@ describe('@payloadcms/plugin-mcp', () => {
     expect(json.result.prompts[0].arguments[0].required).toBe(true)
   })
 
+  it('should get echo prompt', async () => {
+    const apiKey = await getApiKey()
+    const response = await restClient.POST('/mcp', {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'prompts/get',
+        params: {
+          name: 'echo',
+          arguments: {
+            message: 'Hello, world!',
+          },
+        },
+      }),
+    })
+
+    const json = await parseStreamResponse(response)
+
+    expect(json).toBeDefined()
+    expect(json.result).toBeDefined()
+    expect(json.result.messages).toHaveLength(2)
+    expect(json.result.messages[0].content.type).toBe('text')
+    expect(json.result.messages[0].content.text).toContain('This prompt was sent: Hello, world!')
+    expect(json.result.messages[1].content.type).toBe('text')
+    expect(json.result.messages[1].content.text).toContain(
+      `This prompt was sent by userId: ${userId}`,
+    )
+
+    const { docs } = await payload.find({
+      collection: 'modified-prompts',
+      where: {
+        user: {
+          equals: userId,
+        },
+      },
+    })
+
+    const modifiedPrompt = docs?.[0]
+    expect(modifiedPrompt?.original).toBe('Hello, world!')
+    expect(modifiedPrompt?.modified).toBe('This prompt was sent: Hello, world!')
+    // @ts-expect-error - doc.user is a string | User
+    expect(modifiedPrompt?.user?.id).toBe(userId)
+  })
+
+  it('should read the data resource', async () => {
+    const apiKey = await getApiKey()
+    const response = await restClient.POST('/mcp', {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'resources/read',
+        params: {
+          uri: 'data://app',
+        },
+      }),
+    })
+
+    const json = await parseStreamResponse(response)
+
+    expect(json).toBeDefined()
+    expect(json.result).toBeDefined()
+    expect(json.result.contents).toHaveLength(2)
+    expect(json.result.contents[0].uri).toBe('data://app')
+    expect(json.result.contents[0].text).toContain('My special data.')
+    expect(json.result.contents[1].text).toContain(`This was requested by user: ${userId}`)
+
+    const { docs } = await payload.find({
+      collection: 'returned-resources',
+      where: {
+        user: {
+          equals: userId,
+        },
+      },
+    })
+
+    const returnedResource = docs?.[0]
+    expect(returnedResource?.uri).toBe('data://app')
+    expect(returnedResource?.content).toBe('My special data.')
+    // @ts-expect-error - doc.user is a string | User
+    expect(returnedResource?.user?.id).toBe(userId)
+  })
+
+  it('should read the dataByID resource', async () => {
+    const apiKey = await getApiKey()
+    const response = await restClient.POST('/mcp', {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'resources/read',
+        params: {
+          uri: 'data://app/1',
+        },
+      }),
+    })
+
+    const json = await parseStreamResponse(response)
+
+    expect(json).toBeDefined()
+    expect(json.result).toBeDefined()
+    expect(json.result.contents).toHaveLength(2)
+    expect(json.result.contents[0].uri).toBe('data://app/1')
+    expect(json.result.contents[0].text).toContain('My special data for ID: 1')
+    expect(json.result.contents[1].text).toContain(`This was requested by user: ${userId}`)
+
+    const { docs } = await payload.find({
+      collection: 'returned-resources',
+      where: {
+        user: {
+          equals: userId,
+        },
+      },
+    })
+
+    const returnedResource = docs?.[0]
+    expect(returnedResource?.uri).toBe('data://app/1')
+    expect(returnedResource?.content).toBe('My special data for ID: 1')
+    // @ts-expect-error - doc.user is a string | User
+    expect(returnedResource?.user?.id).toBe(userId)
+  })
+
   it('should call diceRoll', async () => {
     const apiKey = await getApiKey()
     const response = await restClient.POST('/mcp', {
@@ -319,34 +454,6 @@ describe('@payloadcms/plugin-mcp', () => {
     expect(json.result.content[0].text).toContain('**Result:**')
     expect(json.result.content[0].text).toContain('🎲 You rolled a **')
     expect(json.result.content[0].text).toContain('** on a 6-sided die!')
-  })
-
-  it('should call diceRoll and create a document in the rolls collection with a user relationship set to the current user', async () => {
-    const apiKey = await getApiKey()
-    const response = await restClient.POST('/mcp', {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        Accept: 'application/json, text/event-stream',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'tools/call',
-        params: {
-          name: 'diceRoll',
-          arguments: {
-            sides: 6,
-          },
-        },
-      }),
-    })
-
-    const json = await parseStreamResponse(response)
-
-    expect(json).toBeDefined()
-    expect(json.result).toBeDefined()
-    expect(json.result.content).toHaveLength(1)
 
     const { docs } = await payload.find({
       collection: 'rolls',

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -72,6 +72,7 @@ export interface Config {
     media: Media;
     posts: Post;
     products: Product;
+    rolls: Roll;
     'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -84,6 +85,7 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     products: ProductsSelect<false> | ProductsSelect<true>;
+    rolls: RollsSelect<false> | RollsSelect<true>;
     'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -220,6 +222,27 @@ export interface Product {
   title?: string | null;
   description?: string | null;
   price?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rolls".
+ */
+export interface Roll {
+  id: string;
+  /**
+   * The number of sides on the die that was rolled
+   */
+  sides: number;
+  /**
+   * The result of the die roll
+   */
+  result: number;
+  /**
+   * The user who rolled the die
+   */
+  user: string | User;
   updatedAt: string;
   createdAt: string;
 }
@@ -422,6 +445,10 @@ export interface PayloadLockedDocument {
         value: string | Product;
       } | null)
     | ({
+        relationTo: 'rolls';
+        value: string | Roll;
+      } | null)
+    | ({
         relationTo: 'payload-mcp-api-keys';
         value: string | PayloadMcpApiKey;
       } | null);
@@ -539,6 +566,17 @@ export interface ProductsSelect<T extends boolean = true> {
   title?: T;
   description?: T;
   price?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rolls_select".
+ */
+export interface RollsSelect<T extends boolean = true> {
+  sides?: T;
+  result?: T;
+  user?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -73,6 +73,8 @@ export interface Config {
     posts: Post;
     products: Product;
     rolls: Roll;
+    'modified-prompts': ModifiedPrompt;
+    'returned-resources': ReturnedResource;
     'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -86,6 +88,8 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     products: ProductsSelect<false> | ProductsSelect<true>;
     rolls: RollsSelect<false> | RollsSelect<true>;
+    'modified-prompts': ModifiedPromptsSelect<false> | ModifiedPromptsSelect<true>;
+    'returned-resources': ReturnedResourcesSelect<false> | ReturnedResourcesSelect<true>;
     'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -241,6 +245,48 @@ export interface Roll {
   result: number;
   /**
    * The user who rolled the die
+   */
+  user: string | User;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "modified-prompts".
+ */
+export interface ModifiedPrompt {
+  id: string;
+  /**
+   * The original prompt
+   */
+  original: string;
+  /**
+   * The modified prompt
+   */
+  modified: string;
+  /**
+   * The user sent the prompt to modify
+   */
+  user: string | User;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "returned-resources".
+ */
+export interface ReturnedResource {
+  id: string;
+  /**
+   * The URI of the resource
+   */
+  uri: string;
+  /**
+   * The content of the resource
+   */
+  content: string;
+  /**
+   * The user sent the prompt to modify
    */
   user: string | User;
   updatedAt: string;
@@ -449,6 +495,14 @@ export interface PayloadLockedDocument {
         value: string | Roll;
       } | null)
     | ({
+        relationTo: 'modified-prompts';
+        value: string | ModifiedPrompt;
+      } | null)
+    | ({
+        relationTo: 'returned-resources';
+        value: string | ReturnedResource;
+      } | null)
+    | ({
         relationTo: 'payload-mcp-api-keys';
         value: string | PayloadMcpApiKey;
       } | null);
@@ -576,6 +630,28 @@ export interface ProductsSelect<T extends boolean = true> {
 export interface RollsSelect<T extends boolean = true> {
   sides?: T;
   result?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "modified-prompts_select".
+ */
+export interface ModifiedPromptsSelect<T extends boolean = true> {
+  original?: T;
+  modified?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "returned-resources_select".
+ */
+export interface ReturnedResourcesSelect<T extends boolean = true> {
+  uri?: T;
+  content?: T;
   user?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
In order to be able to use the payload object or the same access control strategy in our custom tools without having to do additional lookups, we now included a `req` in the custom tool handlers.

- Adds a `req` to the custom tool handlers.

Previously handlers did not include a `req` argument:
```ts
handler: async (args: Record<string, unknown>) => {}
```

Now they do!
```ts
handler: async (args: Record<string, unknown>, req:PayloadRequest, _extra) => {}
```

