### PR TITLE
fix(db-*): do not exit process on error during connect

### DIFF
--- a/packages/db-d1-sqlite/src/connect.ts
+++ b/packages/db-d1-sqlite/src/connect.ts
@@ -51,7 +51,7 @@ export const connect: Connect = async function connect(
       this.rejectInitializing()
     }
     console.error(err)
-    process.exit(1)
+    throw new Error(`Error: cannot connect to SQLite: ${message}`)
   }
 
   // Only push schema if not in production

--- a/packages/db-mongodb/src/connect.ts
+++ b/packages/db-mongodb/src/connect.ts
@@ -108,6 +108,6 @@ export const connect: Connect = async function connect(
       err,
       msg,
     })
-    process.exit(1)
+    throw new Error(`Error: cannot connect to MongoDB: ${msg}`)
   }
 }

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -108,7 +108,7 @@ export const connect: Connect = async function connect(
     if (typeof this.rejectInitializing === 'function') {
       this.rejectInitializing()
     }
-    process.exit(1)
+    throw new Error(`Error: cannot connect to Postgres: ${err.message}`)
   }
 
   await this.createExtensions()

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -36,7 +36,7 @@ export const connect: Connect = async function connect(
     if (typeof this.rejectInitializing === 'function') {
       this.rejectInitializing()
     }
-    process.exit(1)
+    throw new Error(`Error: cannot connect to SQLite: ${message}`)
   }
 
   // Only push schema if not in production

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -90,7 +90,7 @@ export const connect: Connect = async function connect(
     if (typeof this.rejectInitializing === 'function') {
       this.rejectInitializing()
     }
-    process.exit(1)
+    throw new Error(`Error: cannot connect to Postgres: ${err.message}`)
   }
 
   await this.createExtensions()

--- a/packages/drizzle/src/transactions/beginTransaction.ts
+++ b/packages/drizzle/src/transactions/beginTransaction.ts
@@ -59,7 +59,7 @@ export const beginTransaction: BeginTransaction = async function beginTransactio
     }
   } catch (err) {
     this.payload.logger.error({ err, msg: `Error: cannot begin transaction: ${err.message}` })
-    process.exit(1)
+    throw new Error(`Error: cannot begin transaction: ${err.message}`)
   }
 
   return id

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1127,12 +1127,12 @@ export const getPayload = async (
     return cached.payload
   }
 
-  if (!cached.promise) {
-    // no need to await options.config here, as it's already awaited in the BasePayload.init
-    cached.promise = new BasePayload().init(options)
-  }
-
   try {
+    if (!cached.promise) {
+      // no need to await options.config here, as it's already awaited in the BasePayload.init
+      cached.promise = new BasePayload().init(options)
+    }
+
     cached.payload = await cached.promise
 
     if (


### PR DESCRIPTION
This PR removes `process.exit(1)` from our exception handlers within db connect methods. When a connection error occurred in vercel fluid compute, it ungracefully shut down the entire compute process.

By re-throwing the error instead, [vercel is able to gracefully handle the error](https://vercel.com/changelog/improved-unhandled-node-js-errors-in-fluid-compute) without shutting down concurrent requests running on the same compute instance.

process.exit(1) [was initially added by this commit](https://github.com/payloadcms/payload/commit/f3fee34d16a43a74732a5f5b58bdec63d07aa4a7#r169957812), however noone was able to recall why it was added.