### PR TITLE
feat(db-mongodb): add afterCreateConnection and afterOpenConnection hooks

### DIFF
--- a/packages/db-mongodb/src/connect.ts
+++ b/packages/db-mongodb/src/connect.ts
@@ -37,9 +37,16 @@ export const connect: Connect = async function connect(
   try {
     if (!this.connection) {
       this.connection = await mongoose.createConnection(urlToConnect, connectionOptions).asPromise()
+      if (this.afterCreateConnection) {
+        await this.afterCreateConnection(this)
+      }
     }
 
     await this.connection.openUri(urlToConnect, connectionOptions)
+
+    if (this.afterOpenConnection) {
+      await this.afterOpenConnection(this)
+    }
 
     if (this.useAlternativeDropDatabase) {
       if (this.connection.db) {
@@ -70,9 +77,7 @@ export const connect: Connect = async function connect(
       await new Promise((resolve) => setTimeout(resolve, 2000))
     }
 
-    const client = this.connection.getClient()
-
-    if (!client.options.replicaSet) {
+    if (!this.connection.getClient().options.replicaSet) {
       this.transactionOptions = false
       this.beginTransaction = defaultBeginTransaction()
     }

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -67,6 +67,8 @@ import { upsert } from './upsert.js'
 export type { MigrateDownArgs, MigrateUpArgs } from './types.js'
 
 export interface Args {
+  afterCreateConnection?: (adapter: MongooseAdapter) => Promise<void> | void
+  afterOpenConnection?: (adapter: MongooseAdapter) => Promise<void> | void
   /**
    * By default, Payload strips all additional keys from MongoDB data that don't exist
    * in the Payload schema. If you have some data that you want to include to the result
@@ -173,6 +175,8 @@ export interface Args {
 }
 
 export type MongooseAdapter = {
+  afterCreateConnection?: (adapter: MongooseAdapter) => Promise<void> | void
+  afterOpenConnection?: (adapter: MongooseAdapter) => Promise<void> | void
   collections: {
     [slug: string]: CollectionModel
   }
@@ -236,6 +240,8 @@ declare module 'payload' {
 }
 
 export function mongooseAdapter({
+  afterCreateConnection,
+  afterOpenConnection,
   allowAdditionalKeys = false,
   allowIDOnCreate = false,
   autoPluralization = true,
@@ -262,6 +268,8 @@ export function mongooseAdapter({
       name: 'mongoose',
 
       // Mongoose-specific
+      afterCreateConnection,
+      afterOpenConnection,
       autoPluralization,
       collections: {},
       // @ts-expect-error initialize without a connection

--- a/packages/db-mongodb/src/init.ts
+++ b/packages/db-mongodb/src/init.ts
@@ -18,10 +18,14 @@ import { buildSchema } from './models/buildSchema.js'
 import { getBuildQueryPlugin } from './queries/getBuildQueryPlugin.js'
 import { getDBName } from './utilities/getDBName.js'
 
-export const init: Init = function init(this: MongooseAdapter) {
+export const init: Init = async function init(this: MongooseAdapter) {
   // Always create a scoped, **unopened** connection object
   // (no URI here; models compile per-connection and do not require an open socket)
   this.connection ??= mongoose.createConnection()
+
+  if (this.afterCreateConnection) {
+    await this.afterCreateConnection(this)
+  }
 
   this.payload.config.collections.forEach((collection: SanitizedCollectionConfig) => {
     const schemaOptions = this.collectionsSchemaOptions?.[collection.slug]


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14547

This PR exposes `afterCreateConnection` and `afterOpenConnection` hooks through the db-mongodb adapter args.

## Use-case

These lifecycle hooks allow developers to perform additional setup logic after a MongoDB connection or pool has been created or opened - for example, to enable [connection pooling in Vercel Functions](https://vercel.com/guides/connection-pooling-with-functions)￼:

```ts
export const databaseAdapter = mongooseAdapter({
  // ...
  afterOpenConnection: async (adapter) => {
    const client = adapter.connection.getClient()
    attachDatabasePool(client);
  },
})
```