### PR TITLE
refactor(db-mongodb,drizzle): reduce race condition window between retrieving and using a session

### DIFF
--- a/packages/db-mongodb/src/count.ts
+++ b/packages/db-mongodb/src/count.ts
@@ -15,10 +15,6 @@ export const count: Count = async function count(
 ) {
   const { collectionConfig, Model } = getCollection({ adapter: this, collectionSlug })
 
-  const options: CountOptions = {
-    session: await getSession(this, req),
-  }
-
   let hasNearConstraint = false
 
   if (where) {
@@ -36,6 +32,10 @@ export const count: Count = async function count(
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0
+
+  const options: CountOptions = {
+    session: await getSession(this, req),
+  }
 
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding

--- a/packages/db-mongodb/src/countGlobalVersions.ts
+++ b/packages/db-mongodb/src/countGlobalVersions.ts
@@ -15,10 +15,6 @@ export const countGlobalVersions: CountGlobalVersions = async function countGlob
 ) {
   const { globalConfig, Model } = getGlobal({ adapter: this, globalSlug, versions: true })
 
-  const options: CountOptions = {
-    session: await getSession(this, req),
-  }
-
   let hasNearConstraint = false
 
   if (where) {
@@ -35,6 +31,10 @@ export const countGlobalVersions: CountGlobalVersions = async function countGlob
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0
+
+  const options: CountOptions = {
+    session: await getSession(this, req),
+  }
 
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding

--- a/packages/db-mongodb/src/countVersions.ts
+++ b/packages/db-mongodb/src/countVersions.ts
@@ -19,10 +19,6 @@ export const countVersions: CountVersions = async function countVersions(
     versions: true,
   })
 
-  const options: CountOptions = {
-    session: await getSession(this, req),
-  }
-
   let hasNearConstraint = false
 
   if (where) {
@@ -39,6 +35,10 @@ export const countVersions: CountVersions = async function countVersions(
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0
+
+  const options: CountOptions = {
+    session: await getSession(this, req),
+  }
 
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding

--- a/packages/db-mongodb/src/create.ts
+++ b/packages/db-mongodb/src/create.ts
@@ -15,12 +15,6 @@ export const create: Create = async function create(
 ) {
   const { collectionConfig, customIDType, Model } = getCollection({ adapter: this, collectionSlug })
 
-  const options: CreateOptions = {
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
-  }
-
   let doc
 
   if (!data.createdAt) {
@@ -45,6 +39,12 @@ export const create: Create = async function create(
       )
       throw error
     }
+  }
+
+  const options: CreateOptions = {
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
   }
 
   try {

--- a/packages/db-mongodb/src/createGlobalVersion.ts
+++ b/packages/db-mongodb/src/createGlobalVersion.ts
@@ -22,12 +22,6 @@ export const createGlobalVersion: CreateGlobalVersion = async function createGlo
 ) {
   const { globalConfig, Model } = getGlobal({ adapter: this, globalSlug, versions: true })
 
-  const options = {
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
-  }
-
   const data = {
     autosave,
     createdAt,
@@ -49,6 +43,12 @@ export const createGlobalVersion: CreateGlobalVersion = async function createGlo
     fields,
     operation: 'write',
   })
+
+  const options = {
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
+  }
 
   let [doc] = await Model.create([data], options, req)
 

--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -27,12 +27,6 @@ export const createVersion: CreateVersion = async function createVersion(
     versions: true,
   })
 
-  const options = {
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
-  }
-
   const data = {
     autosave,
     createdAt,
@@ -55,6 +49,12 @@ export const createVersion: CreateVersion = async function createVersion(
     fields,
     operation: 'write',
   })
+
+  const options = {
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
+  }
 
   let [doc] = await Model.create([data], options, req)
 

--- a/packages/db-mongodb/src/deleteMany.ts
+++ b/packages/db-mongodb/src/deleteMany.ts
@@ -14,16 +14,16 @@ export const deleteMany: DeleteMany = async function deleteMany(
 ) {
   const { collectionConfig, Model } = getCollection({ adapter: this, collectionSlug })
 
-  const options: DeleteOptions = {
-    session: await getSession(this, req),
-  }
-
   const query = await buildQuery({
     adapter: this,
     collectionSlug,
     fields: collectionConfig.flattenedFields,
     where,
   })
+
+  const options: DeleteOptions = {
+    session: await getSession(this, req),
+  }
 
   await Model.deleteMany(query, options)
 }

--- a/packages/db-mongodb/src/deleteOne.ts
+++ b/packages/db-mongodb/src/deleteOne.ts
@@ -15,6 +15,13 @@ export const deleteOne: DeleteOne = async function deleteOne(
 ) {
   const { collectionConfig, Model } = getCollection({ adapter: this, collectionSlug })
 
+  const query = await buildQuery({
+    adapter: this,
+    collectionSlug,
+    fields: collectionConfig.flattenedFields,
+    where,
+  })
+
   const options: MongooseUpdateQueryOptions = {
     projection: buildProjectionFromSelect({
       adapter: this,
@@ -23,13 +30,6 @@ export const deleteOne: DeleteOne = async function deleteOne(
     }),
     session: await getSession(this, req),
   }
-
-  const query = await buildQuery({
-    adapter: this,
-    collectionSlug,
-    fields: collectionConfig.flattenedFields,
-    where,
-  })
 
   if (returning === false) {
     await Model.deleteOne(query, options)?.lean()

--- a/packages/db-mongodb/src/deleteVersions.ts
+++ b/packages/db-mongodb/src/deleteVersions.ts
@@ -36,14 +36,14 @@ export const deleteVersions: DeleteVersions = async function deleteVersions(
     throw new APIError('Either collection or globalSlug must be passed.')
   }
 
-  const session = await getSession(this, req)
-
   const query = await buildQuery({
     adapter: this,
     fields,
     locale,
     where,
   })
+
+  const session = await getSession(this, req)
 
   await VersionsModel.deleteMany(query, { session })
 }

--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -34,8 +34,6 @@ export const find: Find = async function find(
 ) {
   const { collectionConfig, Model } = getCollection({ adapter: this, collectionSlug })
 
-  const session = await getSession(this, req)
-
   let hasNearConstraint = false
 
   if (where) {
@@ -65,6 +63,8 @@ export const find: Find = async function find(
     locale,
     where,
   })
+
+  const session = await getSession(this, req)
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0

--- a/packages/db-mongodb/src/findDistinct.ts
+++ b/packages/db-mongodb/src/findDistinct.ts
@@ -16,8 +16,6 @@ export const findDistinct: FindDistinct = async function (this: MongooseAdapter,
     collectionSlug: args.collection,
   })
 
-  const session = await getSession(this, args.req)
-
   const { where = {} } = args
 
   let sortAggregation: PipelineStage[] = []
@@ -201,6 +199,8 @@ export const findDistinct: FindDistinct = async function (this: MongooseAdapter,
       },
     },
   ]
+
+  const session = await getSession(this, args.req)
 
   const getValues = async () => {
     return Model.aggregate(pipeline, { session }).then((res) =>

--- a/packages/db-mongodb/src/findGlobal.ts
+++ b/packages/db-mongodb/src/findGlobal.ts
@@ -18,6 +18,15 @@ export const findGlobal: FindGlobal = async function findGlobal(
   const { globalConfig, Model } = getGlobal({ adapter: this, globalSlug })
 
   const fields = globalConfig.flattenedFields
+
+  const query = await buildQuery({
+    adapter: this,
+    fields,
+    globalSlug,
+    locale,
+    where: combineQueries({ globalType: { equals: globalSlug } }, where),
+  })
+
   const options: QueryOptions = {
     lean: true,
     select: buildProjectionFromSelect({
@@ -27,14 +36,6 @@ export const findGlobal: FindGlobal = async function findGlobal(
     }),
     session: await getSession(this, req),
   }
-
-  const query = await buildQuery({
-    adapter: this,
-    fields,
-    globalSlug,
-    locale,
-    where: combineQueries({ globalType: { equals: globalSlug } }, where),
-  })
 
   const doc: any = await Model.findOne(query, {}, options)
 

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -31,13 +31,6 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
 
   const versionFields = buildVersionGlobalFields(this.payload.config, globalConfig, true)
 
-  const session = await getSession(this, req)
-  const options: QueryOptions = {
-    limit,
-    session,
-    skip,
-  }
-
   let hasNearConstraint = false
 
   if (where) {
@@ -63,6 +56,13 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     locale,
     where,
   })
+
+  const session = await getSession(this, req)
+  const options: QueryOptions = {
+    limit,
+    session,
+    skip,
+  }
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0

--- a/packages/db-mongodb/src/findOne.ts
+++ b/packages/db-mongodb/src/findOne.ts
@@ -19,12 +19,6 @@ export const findOne: FindOne = async function findOne(
 ) {
   const { collectionConfig, Model } = getCollection({ adapter: this, collectionSlug })
 
-  const session = await getSession(this, req)
-  const options: AggregateOptions & QueryOptions = {
-    lean: true,
-    session,
-  }
-
   const query = await buildQuery({
     adapter: this,
     collectionSlug,
@@ -49,6 +43,12 @@ export const findOne: FindOne = async function findOne(
     projection,
     query,
   })
+
+  const session = await getSession(this, req)
+  const options: AggregateOptions & QueryOptions = {
+    lean: true,
+    session,
+  }
 
   let doc
   if (aggregate) {

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -33,13 +33,6 @@ export const findVersions: FindVersions = async function findVersions(
     versions: true,
   })
 
-  const session = await getSession(this, req)
-  const options: QueryOptions = {
-    limit,
-    session,
-    skip,
-  }
-
   let hasNearConstraint = false
 
   if (where) {
@@ -67,6 +60,13 @@ export const findVersions: FindVersions = async function findVersions(
     locale,
     where,
   })
+
+  const session = await getSession(this, req)
+  const options: QueryOptions = {
+    limit,
+    session,
+    skip,
+  }
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -36,10 +36,6 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     versions: true,
   })
 
-  const options: QueryOptions = {
-    session: await getSession(this, req),
-  }
-
   let hasNearConstraint
   let sort
 
@@ -78,6 +74,12 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     fields,
     select,
   })
+
+  const session = await getSession(this, req)
+  const options: QueryOptions = {
+    session,
+  }
+
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount =
     hasNearConstraint || !versionQuery || Object.keys(versionQuery).length === 0

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -16,6 +16,8 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
 
   const fields = globalConfig.fields
 
+  transform({ adapter: this, data, fields, globalSlug, operation: 'write' })
+
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
     lean: true,
@@ -29,8 +31,6 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
     // Timestamps are manually added by the write transform
     timestamps: false,
   }
-
-  transform({ adapter: this, data, fields, globalSlug, operation: 'write' })
 
   if (returning === false) {
     await Model.updateOne({ globalType: globalSlug }, data, options)

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -30,6 +30,16 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
 
   const fields = buildVersionGlobalFields(this.payload.config, globalConfig)
   const flattenedFields = buildVersionGlobalFields(this.payload.config, globalConfig, true)
+
+  const query = await buildQuery({
+    adapter: this,
+    fields: flattenedFields,
+    locale,
+    where: whereToUse,
+  })
+
+  transform({ adapter: this, data: versionData, fields, operation: 'write' })
+
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
     lean: true,
@@ -43,15 +53,6 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
     // Timestamps are manually added by the write transform
     timestamps: false,
   }
-
-  const query = await buildQuery({
-    adapter: this,
-    fields: flattenedFields,
-    locale,
-    where: whereToUse,
-  })
-
-  transform({ adapter: this, data: versionData, fields, operation: 'write' })
 
   if (returning === false) {
     await Model.updateOne(query, versionData, options)

--- a/packages/db-mongodb/src/updateJobs.ts
+++ b/packages/db-mongodb/src/updateJobs.ts
@@ -36,14 +36,6 @@ export const updateJobs: UpdateJobs = async function updateMany(
     timestamps: true,
   })
 
-  const options: MongooseUpdateQueryOptions = {
-    lean: true,
-    new: true,
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
-  }
-
   let query = await buildQuery({
     adapter: this,
     collectionSlug: collectionConfig.slug,
@@ -86,6 +78,14 @@ export const updateJobs: UpdateJobs = async function updateMany(
   if (Object.keys(updateOps).length) {
     updateOps.$set = updateData
     updateData = updateOps
+  }
+
+  const options: MongooseUpdateQueryOptions = {
+    lean: true,
+    new: true,
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
   }
 
   let result: Job[] = []

--- a/packages/db-mongodb/src/updateMany.ts
+++ b/packages/db-mongodb/src/updateMany.ts
@@ -48,20 +48,6 @@ export const updateMany: UpdateMany = async function updateMany(
     })
   }
 
-  const options: MongooseUpdateQueryOptions = {
-    ...optionsArgs,
-    lean: true,
-    new: true,
-    projection: buildProjectionFromSelect({
-      adapter: this,
-      fields: collectionConfig.flattenedFields,
-      select,
-    }),
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
-  }
-
   let query = await buildQuery({
     adapter: this,
     collectionSlug,
@@ -103,6 +89,20 @@ export const updateMany: UpdateMany = async function updateMany(
   if (Object.keys(updateOps).length) {
     updateOps.$set = data
     data = updateOps
+  }
+
+  const options: MongooseUpdateQueryOptions = {
+    ...optionsArgs,
+    lean: true,
+    new: true,
+    projection: buildProjectionFromSelect({
+      adapter: this,
+      fields: collectionConfig.flattenedFields,
+      select,
+    }),
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
   }
 
   try {

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -28,20 +28,6 @@ export const updateOne: UpdateOne = async function updateOne(
   const where = id ? { id: { equals: id } } : whereArg
   const fields = collectionConfig.fields
 
-  const options: MongooseUpdateQueryOptions = {
-    ...optionsArgs,
-    lean: true,
-    new: true,
-    projection: buildProjectionFromSelect({
-      adapter: this,
-      fields: collectionConfig.flattenedFields,
-      select,
-    }),
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
-  }
-
   const query = await buildQuery({
     adapter: this,
     collectionSlug,
@@ -87,6 +73,20 @@ export const updateOne: UpdateOne = async function updateOne(
   if (Object.keys(updateOps).length) {
     updateOps.$set = updateData
     updateData = updateOps
+  }
+
+  const options: MongooseUpdateQueryOptions = {
+    ...optionsArgs,
+    lean: true,
+    new: true,
+    projection: buildProjectionFromSelect({
+      adapter: this,
+      fields: collectionConfig.flattenedFields,
+      select,
+    }),
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
   }
 
   try {

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -35,6 +35,15 @@ export const updateVersion: UpdateVersion = async function updateVersion(
 
   const flattenedFields = buildVersionCollectionFields(this.payload.config, collectionConfig, true)
 
+  const query = await buildQuery({
+    adapter: this,
+    fields: flattenedFields,
+    locale,
+    where: whereToUse,
+  })
+
+  transform({ adapter: this, data: versionData, fields, operation: 'write' })
+
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
     lean: true,
@@ -48,15 +57,6 @@ export const updateVersion: UpdateVersion = async function updateVersion(
     // Timestamps are manually added by the write transform
     timestamps: false,
   }
-
-  const query = await buildQuery({
-    adapter: this,
-    fields: flattenedFields,
-    locale,
-    where: whereToUse,
-  })
-
-  transform({ adapter: this, data: versionData, fields, operation: 'write' })
 
   if (returning === false) {
     await Model.updateOne(query, versionData, options)

--- a/packages/drizzle/src/count.ts
+++ b/packages/drizzle/src/count.ts
@@ -15,8 +15,6 @@ export const count: Count = async function count(
 
   const tableName = this.tableNameMap.get(toSnakeCase(collectionConfig.slug))
 
-  const db = await getTransaction(this, req)
-
   const { joins, where } = buildQuery({
     adapter: this,
     fields: collectionConfig.flattenedFields,
@@ -24,6 +22,8 @@ export const count: Count = async function count(
     tableName,
     where: whereArg,
   })
+
+  const db = await getTransaction(this, req)
 
   const countResult = await this.countDistinct({
     db,

--- a/packages/drizzle/src/countGlobalVersions.ts
+++ b/packages/drizzle/src/countGlobalVersions.ts
@@ -20,8 +20,6 @@ export const countGlobalVersions: CountGlobalVersions = async function countGlob
     `_${toSnakeCase(globalConfig.slug)}${this.versionsSuffix}`,
   )
 
-  const db = await getTransaction(this, req)
-
   const fields = buildVersionGlobalFields(this.payload.config, globalConfig, true)
 
   const { joins, where } = buildQuery({
@@ -31,6 +29,8 @@ export const countGlobalVersions: CountGlobalVersions = async function countGlob
     tableName,
     where: whereArg,
   })
+
+  const db = await getTransaction(this, req)
 
   const countResult = await this.countDistinct({
     db,

--- a/packages/drizzle/src/countVersions.ts
+++ b/packages/drizzle/src/countVersions.ts
@@ -18,8 +18,6 @@ export const countVersions: CountVersions = async function countVersions(
     `_${toSnakeCase(collectionConfig.slug)}${this.versionsSuffix}`,
   )
 
-  const db = await getTransaction(this, req)
-
   const fields = buildVersionCollectionFields(this.payload.config, collectionConfig, true)
 
   const { joins, where } = buildQuery({
@@ -29,6 +27,8 @@ export const countVersions: CountVersions = async function countVersions(
     tableName,
     where: whereArg,
   })
+
+  const db = await getTransaction(this, req)
 
   const countResult = await this.countDistinct({
     db,

--- a/packages/drizzle/src/create.ts
+++ b/packages/drizzle/src/create.ts
@@ -11,10 +11,11 @@ export const create: Create = async function create(
   this: DrizzleAdapter,
   { collection: collectionSlug, data, req, returning, select },
 ) {
-  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
+
+  const db = await getTransaction(this, req)
 
   const result = await upsertRow({
     adapter: this,

--- a/packages/drizzle/src/createGlobal.ts
+++ b/packages/drizzle/src/createGlobal.ts
@@ -11,12 +11,13 @@ export async function createGlobal<T extends Record<string, unknown>>(
   this: DrizzleAdapter,
   { slug, data, req, returning }: CreateGlobalArgs,
 ): Promise<T> {
-  const db = await getTransaction(this, req)
   const globalConfig = this.payload.globals.config.find((config) => config.slug === slug)
 
   const tableName = this.tableNameMap.get(toSnakeCase(globalConfig.slug))
 
   data.createdAt = new Date().toISOString()
+
+  const db = await getTransaction(this, req)
 
   const result = await upsertRow<{ globalType: string } & T>({
     adapter: this,

--- a/packages/drizzle/src/createGlobalVersion.ts
+++ b/packages/drizzle/src/createGlobalVersion.ts
@@ -24,10 +24,11 @@ export async function createGlobalVersion<T extends JsonObject = JsonObject>(
     versionData,
   }: CreateGlobalVersionArgs,
 ): Promise<TypeWithVersion<T>> {
-  const db = await getTransaction(this, req)
   const global = this.payload.globals.config.find(({ slug }) => slug === globalSlug)
 
   const tableName = this.tableNameMap.get(`_${toSnakeCase(global.slug)}${this.versionsSuffix}`)
+
+  const db = await getTransaction(this, req)
 
   const result = await upsertRow<TypeWithVersion<T>>({
     adapter: this,

--- a/packages/drizzle/src/createVersion.ts
+++ b/packages/drizzle/src/createVersion.ts
@@ -25,7 +25,6 @@ export async function createVersion<T extends JsonObject = JsonObject>(
     versionData,
   }: CreateVersionArgs<T>,
 ): Promise<TypeWithVersion<T>> {
-  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
   const defaultTableName = toSnakeCase(collection.slug)
 
@@ -46,6 +45,8 @@ export async function createVersion<T extends JsonObject = JsonObject>(
     updatedAt,
     version,
   }
+
+  const db = await getTransaction(this, req)
 
   const result = await upsertRow<TypeWithVersion<T>>({
     adapter: this,

--- a/packages/drizzle/src/deleteMany.ts
+++ b/packages/drizzle/src/deleteMany.ts
@@ -13,7 +13,6 @@ export const deleteMany: DeleteMany = async function deleteMany(
   this: DrizzleAdapter,
   { collection, req, where: whereArg },
 ) {
-  const db = await getTransaction(this, req)
   const collectionConfig = this.payload.collections[collection].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collectionConfig.slug))
@@ -54,6 +53,8 @@ export const deleteMany: DeleteMany = async function deleteMany(
       result.docs.map((doc) => doc.id),
     )
   }
+
+  const db = await getTransaction(this, req)
 
   await this.deleteWhere({
     db,

--- a/packages/drizzle/src/deleteOne.ts
+++ b/packages/drizzle/src/deleteOne.ts
@@ -15,7 +15,6 @@ export const deleteOne: DeleteOne = async function deleteOne(
   this: DrizzleAdapter,
   { collection: collectionSlug, req, returning, select, where: whereArg },
 ) {
-  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
@@ -29,6 +28,8 @@ export const deleteOne: DeleteOne = async function deleteOne(
     tableName,
     where: whereArg,
   })
+
+  const db = await getTransaction(this, req)
 
   const selectDistinctResult = await selectDistinct({
     adapter: this,

--- a/packages/drizzle/src/deleteVersions.ts
+++ b/packages/drizzle/src/deleteVersions.ts
@@ -13,8 +13,6 @@ export const deleteVersions: DeleteVersions = async function deleteVersion(
   this: DrizzleAdapter,
   { collection: collectionSlug, globalSlug, locale, req, where: where },
 ) {
-  const db = await getTransaction(this, req)
-
   let tableName: string
   let fields: FlattenedField[]
 
@@ -53,6 +51,8 @@ export const deleteVersions: DeleteVersions = async function deleteVersion(
   })
 
   if (ids.length > 0) {
+    const db = await getTransaction(this, req)
+
     await this.deleteWhere({
       db,
       tableName,

--- a/packages/drizzle/src/find/findMany.ts
+++ b/packages/drizzle/src/find/findMany.ts
@@ -37,7 +37,6 @@ export const findMany = async function find({
   versions,
   where: whereArg,
 }: Args) {
-  const db = await getTransaction(adapter, req)
   let limit = limitArg
   let totalDocs: number
   let totalPages: number
@@ -95,6 +94,8 @@ export const findMany = async function find({
       }
     }
   }
+
+  const db = await getTransaction(adapter, req)
 
   const selectDistinctResult = await selectDistinct({
     adapter,

--- a/packages/drizzle/src/findDistinct.ts
+++ b/packages/drizzle/src/findDistinct.ts
@@ -9,7 +9,6 @@ import { getTransaction } from './utilities/getTransaction.js'
 import { DistinctSymbol } from './utilities/rawConstraint.js'
 
 export const findDistinct: FindDistinct = async function (this: DrizzleAdapter, args) {
-  const db = await getTransaction(this, args.req)
   const collectionConfig: SanitizedCollectionConfig =
     this.payload.collections[args.collection].config
   const page = args.page || 1
@@ -35,6 +34,8 @@ export const findDistinct: FindDistinct = async function (this: DrizzleAdapter, 
   })
 
   orderBy.pop()
+
+  const db = await getTransaction(this, args.req)
 
   const selectDistinctResult = await selectDistinct({
     adapter: this,

--- a/packages/drizzle/src/updateGlobal.ts
+++ b/packages/drizzle/src/updateGlobal.ts
@@ -11,10 +11,10 @@ export async function updateGlobal<T extends Record<string, unknown>>(
   this: DrizzleAdapter,
   { slug, data, req, returning, select }: UpdateGlobalArgs,
 ): Promise<T> {
-  const db = await getTransaction(this, req)
   const globalConfig = this.payload.globals.config.find((config) => config.slug === slug)
   const tableName = this.tableNameMap.get(toSnakeCase(globalConfig.slug))
 
+  const db = await getTransaction(this, req)
   const existingGlobal = await db.query[tableName].findFirst({})
 
   const result = await upsertRow<{ globalType: string } & T>({

--- a/packages/drizzle/src/updateGlobalVersion.ts
+++ b/packages/drizzle/src/updateGlobalVersion.ts
@@ -27,7 +27,6 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
     where: whereArg,
   }: UpdateGlobalVersionArgs<T>,
 ): Promise<TypeWithVersion<T>> {
-  const db = await getTransaction(this, req)
   const globalConfig: SanitizedGlobalConfig = this.payload.globals.config.find(
     ({ slug }) => slug === global,
   )
@@ -46,6 +45,8 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
     tableName,
     where: whereToUse,
   })
+
+  const db = await getTransaction(this, req)
 
   const result = await upsertRow<TypeWithVersion<T>>({
     id,

--- a/packages/drizzle/src/updateJobs.ts
+++ b/packages/drizzle/src/updateJobs.ts
@@ -23,7 +23,6 @@ export const updateJobs: UpdateJobs = async function updateMany(
   const whereToUse: Where = id ? { id: { equals: id } } : whereArg
   const limit = id ? 1 : limitArg
 
-  const db = await getTransaction(this, req)
   const collection = this.payload.collections['payload-jobs'].config
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
   const sort = sortArg !== undefined && sortArg !== null ? sortArg : collection.defaultSort
@@ -34,6 +33,8 @@ export const updateJobs: UpdateJobs = async function updateMany(
   })
 
   if (useOptimizedUpsertRow && id) {
+    const db = await getTransaction(this, req)
+
     const result = await upsertRow({
       id,
       adapter: this,
@@ -63,6 +64,8 @@ export const updateJobs: UpdateJobs = async function updateMany(
   if (!jobs.docs.length) {
     return []
   }
+
+  const db = await getTransaction(this, req)
 
   const results = []
 

--- a/packages/drizzle/src/updateMany.ts
+++ b/packages/drizzle/src/updateMany.ts
@@ -25,7 +25,6 @@ export const updateMany: UpdateMany = async function updateMany(
     where: whereToUse,
   },
 ) {
-  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
 
@@ -39,6 +38,8 @@ export const updateMany: UpdateMany = async function updateMany(
     tableName,
     where: whereToUse,
   })
+
+  const db = await getTransaction(this, req)
 
   let idsToUpdate: (number | string)[] = []
 

--- a/packages/drizzle/src/updateOne.ts
+++ b/packages/drizzle/src/updateOne.ts
@@ -25,10 +25,11 @@ export const updateOne: UpdateOne = async function updateOne(
     where: whereArg,
   },
 ) {
-  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
   let idToUpdate = id
+
+  const db = await getTransaction(this, req)
 
   if (!idToUpdate) {
     const { joins, selectFields, where } = buildQuery({

--- a/packages/drizzle/src/updateVersion.ts
+++ b/packages/drizzle/src/updateVersion.ts
@@ -27,7 +27,6 @@ export async function updateVersion<T extends JsonObject = JsonObject>(
     where: whereArg,
   }: UpdateVersionArgs<T>,
 ): Promise<TypeWithVersion<T>> {
-  const db = await getTransaction(this, req)
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const whereToUse = whereArg || { id: { equals: id } }
   const tableName = this.tableNameMap.get(
@@ -43,6 +42,8 @@ export async function updateVersion<T extends JsonObject = JsonObject>(
     tableName,
     where: whereToUse,
   })
+
+  const db = await getTransaction(this, req)
 
   const result = await upsertRow<TypeWithVersion<T>>({
     id,


### PR DESCRIPTION
## Description

Moves `getSession` (MongoDB) and `getTransaction` (Drizzle) calls to immediately before database operations.

## Why

When sessions are retrieved early in a function but used much later, there's a race condition window: if a parallel operation commits/ends that session before we use it, we get `MongoExpiredSessionError`. By retrieving the session right before use, we minimize this window.

This alone significantly reduced transaction errors in #14651. By retrieving sessions closer to use, if a parallel operation commits the transaction before we retrieve it, we get `undefined` instead of an expired session. Operations then run without a session (which succeeds) rather than attempting to use an expired session (which errors).

**Example:**

```ts
// Before - 50+ line window where session could be ended by parallel operation
const session = await getSession(this, req)
const query = await buildQuery(...)     // Line 1
transform(data)                         // Line 2
// ... 48 more lines
await Model.find(query, { session })    // Line 50 - session might be expired!
```

```ts
// After - retrieve right before use
const query = await buildQuery(...)
transform(data)
const session = await getSession(this, req)  // Get it now
await Model.find(query, { session })         // Use immediately
```