### PR TITLE
test: fix auth e2e test suite flakiness

### DIFF
--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -30,7 +30,7 @@ const dirname = path.dirname(filename)
 
 let payload: PayloadTestSDK<Config>
 
-const { beforeAll, afterAll, describe } = test
+const { beforeAll, beforeEach, afterAll, describe } = test
 
 const headers = {
   'Content-Type': 'application/json',
@@ -52,17 +52,17 @@ describe('Auth', () => {
     context = await browser.newContext()
     page = await context.newPage()
     initPageConsoleErrorCatch(page)
+
+    await ensureCompilationIsDone({ page, serverURL, noAutoLogin: true })
   })
 
   describe('create first user', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       await reInitializeDB({
         serverURL,
         snapshotKey: 'create-first-user',
         deleteOnly: true,
       })
-
-      await ensureCompilationIsDone({ page, serverURL, noAutoLogin: true })
 
       await payload.delete({
         collection: slug,
@@ -167,8 +167,6 @@ describe('Auth', () => {
         snapshotKey: 'auth',
         deleteOnly: false,
       })
-
-      await ensureCompilationIsDone({ page, serverURL, noAutoLogin: true })
 
       await login({ page, serverURL })
     })


### PR DESCRIPTION
The `"richText field should should not be readOnly in create first user view"` test was expecting no user to exist. However, the previous test added a user, and the test suite was not reset in between tests.

The only way this test passed was after waiting to retry, during which the database was reset. This test consistently fails at least one time.

Additionally, every time the auth test suite starts up, it would spam the console with errors, as we were not waiting for compilation to be done.

Example: https://github.com/payloadcms/payload/actions/runs/19444977200/job/55637794191 (it looks like this for every single test run)

Both issues are fixed in this PR.