### PR TITLE
fix: ensure restoreAsDraft only updates the published doc when draft is false

### DIFF
--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -262,13 +262,15 @@ export const restoreVersionOperation = async <
     result.updatedAt = new Date().toISOString()
     // Ensure status respects restoreAsDraft arg
     result._status = draftArg ? 'draft' : result._status
-    result = await req.payload.db.updateOne({
-      id: parentDocID,
-      collection: collectionConfig.slug,
-      data: result,
-      req,
-      select,
-    })
+    if (!draftArg) {
+      result = await req.payload.db.updateOne({
+        id: parentDocID,
+        collection: collectionConfig.slug,
+        data: result,
+        req,
+        select,
+      })
+    }
 
     // /////////////////////////////////////
     // Save restored doc as a new version

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -306,6 +306,7 @@ describe('Versions', () => {
 
       await expect(page.locator('#field-title')).toHaveValue('v2')
       await page.goto(`${savedDocURL}/api`)
+      await page.locator('#field-draft').check()
       const values = page.locator('.query-inspector__value')
       const count = await values.count()
 


### PR DESCRIPTION
### What?
Updates the `restoreVersion` logic to ensure restoring as a draft does not overwrite the currently published data.

### Why?
If you have a published doc, then save a draft, you expect to be able to access the published data by `draft: false` and the draft by `draft:true`. When you restore a version as a draft, the same behavior is expected.

However, in the `restoreVersion` operation, we are updating the main doc even if you are restoring as a draft. This overwrites the published data, so now you will see draft data returned regardless of querying with `draft: true/false`.

### How?
When restoring a version as a draft, we only need to save a new version. The main doc should only be updated when restoring as published. 

This change checks `(!draftArg)` before running the `updateOne` on the main doc.

#### Reported by client.