### PR TITLE
chore: getLocalizedPaths should filter fields with locale-like names

### DIFF
--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -136,17 +136,21 @@ export function getLocalizedPaths({
         }
 
         const nextSegment = pathSegments[i + 1]!
+        const currentFieldIsLocalized = fieldShouldBeLocalized({
+          field: matchedField,
+          parentIsLocalized: _parentIsLocalized!,
+        })
+
         const nextSegmentIsLocale =
-          localizationConfig && localizationConfig.localeCodes.includes(nextSegment)
+          localizationConfig &&
+          localizationConfig.localeCodes.includes(nextSegment) &&
+          currentFieldIsLocalized
 
         if (nextSegmentIsLocale) {
           // Skip the next iteration, because it's a locale
           i += 1
           currentPath = `${currentPath}.${nextSegment}`
-        } else if (
-          localizationConfig &&
-          fieldShouldBeLocalized({ field: matchedField, parentIsLocalized: _parentIsLocalized! })
-        ) {
+        } else if (localizationConfig && currentFieldIsLocalized) {
           currentPath = `${currentPath}.${locale}`
         }
 

--- a/test/localization/collections/NoLocalizedFields/index.ts
+++ b/test/localization/collections/NoLocalizedFields/index.ts
@@ -13,5 +13,21 @@ export const NoLocalizedFieldsCollection: CollectionConfig = {
       type: 'text',
       localized: false,
     },
+    {
+      type: 'group',
+      name: 'group',
+      fields: [
+        {
+          name: 'en',
+          type: 'group',
+          fields: [
+            {
+              name: 'text',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    },
   ],
 }

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -23,6 +23,7 @@ import { initPayloadInt } from '../helpers/initPayloadInt.js'
 import { arrayCollectionSlug } from './collections/Array/index.js'
 import { groupSlug } from './collections/Group/index.js'
 import { nestedToArrayAndBlockCollectionSlug } from './collections/NestedToArrayAndBlock/index.js'
+import { noLocalizedFieldsCollectionSlug } from './collections/NoLocalizedFields/index.js'
 import { tabSlug } from './collections/Tab/index.js'
 import {
   allFieldsLocalizedSlug,
@@ -3576,6 +3577,32 @@ describe('Localization', () => {
       expect((allLocalesDoc.g1 as any).en.g2.g2a1).toHaveLength(2)
       expect((allLocalesDoc.g1 as any).en.g2.g2a1[0].text).toBe('EN Deep 1')
       expect((allLocalesDoc.g1 as any).es).toBeUndefined()
+    })
+  })
+
+  describe('Localization like fields', () => {
+    it('should not localize fields that merely resemble localization fields', async () => {
+      const doc = await payload.create({
+        collection: noLocalizedFieldsCollectionSlug,
+        data: {
+          text: 'title',
+          group: {
+            en: {
+              text: 'some text',
+            },
+          },
+        },
+      })
+
+      const queriedDoc = await payload.find({
+        collection: noLocalizedFieldsCollectionSlug,
+        where: {
+          'group.en.text': { equals: 'some text' },
+        },
+      })
+
+      expect(queriedDoc.docs).toHaveLength(1)
+      expect(queriedDoc.docs[0]!.id).toBe(doc.id)
     })
   })
 })

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -487,6 +487,11 @@ export interface User {
 export interface NoLocalizedField {
   id: string;
   text?: string | null;
+  group?: {
+    en?: {
+      text?: string | null;
+    };
+  };
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -1299,6 +1304,15 @@ export interface LocalizedPostsSelect<T extends boolean = true> {
  */
 export interface NoLocalizedFieldsSelect<T extends boolean = true> {
   text?: T;
+  group?:
+    | T
+    | {
+        en?:
+          | T
+          | {
+              text?: T;
+            };
+      };
   updatedAt?: T;
   createdAt?: T;
   _status?: T;


### PR DESCRIPTION
### What?
Ensures `getLocalizedPaths` doesn't falsely detect fields with locale-like names as a localized field.

### Why?
In the function we are determining if the next segment is a locale based on whether the segment of the field path matches a locale:
```ts
const nextSegmentIsLocale = localizationConfig && localizationConfig.localeCodes.includes(nextSegment)
```

If you have locale `en` and a nested field with `name: 'en'`, the function will mistake it for a locale key regardless of whether the field is localized.

### How?
Uses the existing `fieldShouldBeLocalized` function to check whether the field is localized in addition to the other checks.