### PR TITLE
fix(ui): select/relationship field values have no tooltip on hover

### DIFF
--- a/packages/ui/src/elements/ReactSelect/MultiValueLabel/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/MultiValueLabel/index.tsx
@@ -1,11 +1,14 @@
 'use client'
+import type { OptionLabel } from 'payload'
 import type { MultiValueProps } from 'react-select'
 
+import { getTranslation } from '@payloadcms/translations'
 import React from 'react'
 import { components as SelectComponents } from 'react-select'
 
 import type { Option } from '../types.js'
 
+import { useTranslation } from '../../../providers/Translation/index.js'
 import './index.scss'
 
 const baseClass = 'multi-value-label'
@@ -13,11 +16,14 @@ const baseClass = 'multi-value-label'
 export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
   // @ts-expect-error-next-line// TODO Fix this - moduleResolution 16 breaks our declare module
   const { data, selectProps: { customProps: { draggableProps, editableProps } = {} } = {} } = props
+  const { i18n } = useTranslation()
 
   const className = `${baseClass}__text`
+  const labelText = data.label ? getTranslation(data.label as OptionLabel, i18n) : ''
+  const titleText = typeof labelText === 'string' ? labelText : ''
 
   return (
-    <div className={baseClass}>
+    <div className={baseClass} title={titleText}>
       <SelectComponents.MultiValueLabel
         {...props}
         innerProps={{

--- a/packages/ui/src/elements/ReactSelect/ValueContainer/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/ValueContainer/index.tsx
@@ -1,21 +1,32 @@
 'use client'
+import type { OptionLabel } from 'payload'
 import type { ValueContainerProps } from 'react-select'
 
+import { getTranslation } from '@payloadcms/translations'
 import React from 'react'
 import { components as SelectComponents } from 'react-select'
 
 import type { Option } from '../types.js'
 
+import { useTranslation } from '../../../providers/Translation/index.js'
 import './index.scss'
 
 const baseClass = 'value-container'
 
 export const ValueContainer: React.FC<ValueContainerProps<Option, any>> = (props) => {
   // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
-  const { selectProps: { customProps } = {} } = props
+  const { selectProps: { customProps, value } = {} } = props
+  const { i18n } = useTranslation()
+
+  // Get the title for single-value selects
+  let titleText = ''
+  if (value && !Array.isArray(value) && typeof value === 'object' && 'label' in value) {
+    const labelText = value.label ? getTranslation(value.label as OptionLabel, i18n) : ''
+    titleText = typeof labelText === 'string' ? labelText : ''
+  }
 
   return (
-    <div className={baseClass} ref={customProps?.droppableRef}>
+    <div className={baseClass} ref={customProps?.droppableRef} title={titleText}>
       {customProps?.valueContainerLabel && (
         <span className={`${baseClass}__label`}>{customProps?.valueContainerLabel}</span>
       )}

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
@@ -34,7 +34,7 @@ export const MultiValueLabel: React.FC<
   const hasReadPermission = Boolean(permissions?.collections?.[relationTo]?.read)
 
   return (
-    <div className={baseClass}>
+    <div className={baseClass} title={label || ''}>
       <div className={`${baseClass}__content`}>
         <components.MultiValueLabel
           {...props}

--- a/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
@@ -36,7 +36,7 @@ export const SingleValue: React.FC<
 
   return (
     <SelectComponents.SingleValue {...props} className={baseClass}>
-      <div className={`${baseClass}__label`}>
+      <div className={`${baseClass}__label`} title={label || ''}>
         <div className={`${baseClass}__label-text`}>
           <div className={`${baseClass}__text`}>{children}</div>
           {relationTo && hasReadPermission && allowEdit !== false && (


### PR DESCRIPTION
### What?

Adds native browser tooltips to selected values in Select and Relationship fields, displaying the full value text on hover.

### Why?

Select and Relationship fields truncate long values with `text-overflow: ellipsis`. Users had no way to see the full text on hover, especially problematic for fields with long labels.

### How?

- Added native HTML `title` attributes to display tooltips on hover
- For multi-value fields: added `title` to the wrapper div
- For single-value fields: added `title` to the `ValueContainer` component to ensure tooltips work when hovering over the input element
- Used `getTranslation()` to properly handle localized labels

Fixes #14633 
