### PR TITLE
fix(ui): equals filter shows no results when value is cleared

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -74,7 +74,7 @@ export const Condition: React.FC<Props> = (props) => {
     valueOptions = reducedField.field.options
   }
 
-  const updateValue = useEffectEvent(async (debouncedValue) => {
+  const updateValue = useEffectEvent(async (debouncedValue: Value) => {
     if (operator) {
       await updateCondition({
         type: 'value',
@@ -82,7 +82,7 @@ export const Condition: React.FC<Props> = (props) => {
         field: reducedField,
         operator,
         orIndex,
-        value: debouncedValue === null ? '' : debouncedValue,
+        value: debouncedValue === null || debouncedValue === '' ? undefined : debouncedValue,
       })
     }
   })

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -745,10 +745,8 @@ describe('List View', () => {
     test('should show all documents when equals filter value is cleared', async () => {
       await page.goto(postsUrl.list)
 
-      // Verify we start with 2 posts
       await expect(page.locator(tableRowLocator)).toHaveCount(2)
 
-      // Add a filter with a value
       const { whereBuilder } = await addListFilter({
         page,
         fieldLabel: 'Title',
@@ -759,10 +757,8 @@ describe('List View', () => {
       // Wait for filter to be applied
       await page.waitForTimeout(500)
 
-      // Should now show only 1 post
       await expect(page.locator(tableRowLocator)).toHaveCount(1)
 
-      // Clear the filter value
       const valueInput = whereBuilder.locator('.condition__value >> input')
       await valueInput.clear()
 

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -742,6 +742,37 @@ describe('List View', () => {
       await expect(valueInput).toHaveValue('Test')
     })
 
+    test('should show all documents when equals filter value is cleared', async () => {
+      await page.goto(postsUrl.list)
+
+      // Verify we start with 2 posts
+      await expect(page.locator(tableRowLocator)).toHaveCount(2)
+
+      // Add a filter with a value
+      const { whereBuilder } = await addListFilter({
+        page,
+        fieldLabel: 'Title',
+        operatorLabel: 'equals',
+        value: 'post1',
+      })
+
+      // Wait for filter to be applied
+      await page.waitForTimeout(500)
+
+      // Should now show only 1 post
+      await expect(page.locator(tableRowLocator)).toHaveCount(1)
+
+      // Clear the filter value
+      const valueInput = whereBuilder.locator('.condition__value >> input')
+      await valueInput.clear()
+
+      // Wait for debounce
+      await page.waitForTimeout(500)
+
+      // Should now show all 2 posts again (not 0 posts)
+      await expect(page.locator(tableRowLocator)).toHaveCount(2)
+    })
+
     test('should still show second filter if two filters exist and first filter is removed', async () => {
       await page.goto(postsUrl.list)
 

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -98,6 +98,7 @@ export interface Config {
     'list-view-select-api': ListViewSelectApi;
     virtuals: Virtual;
     'no-timestamps': NoTimestamp;
+    'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -135,6 +136,7 @@ export interface Config {
     'list-view-select-api': ListViewSelectApiSelect<false> | ListViewSelectApiSelect<true>;
     virtuals: VirtualsSelect<false> | VirtualsSelect<true>;
     'no-timestamps': NoTimestampsSelect<false> | NoTimestampsSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -142,6 +144,7 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | ('es' | 'en') | ('es' | 'en')[];
   globals: {
     'hidden-global': HiddenGlobal;
     'not-in-view-global': NotInViewGlobal;
@@ -636,6 +639,23 @@ export interface Virtual {
 export interface NoTimestamp {
   id: string;
   title?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1226,6 +1246,14 @@ export interface VirtualsSelect<T extends boolean = true> {
  */
 export interface NoTimestampsSelect<T extends boolean = true> {
   title?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?

Fixes a bug where clearing the value of an 'equals' filter in the collection list view would show no results (or only documents with empty string values) instead of showing all documents.

### Why?

When a user cleared a filter value using backspace or delete, the WhereBuilder was converting the `null` value to an empty string `''`. This caused the query to become `equals=''`, which filtered for documents where the field equals an empty string, rather than treating it as "no filter" and showing all documents.

This was inconsistent with the initial behavior when a filter is first added without a value, where all documents are displayed.

### How?

Updated the `updateValue` function to pass `undefined` instead of an empty string when the debounced value is `null` or empty:

```typescript
value: debouncedValue === null || debouncedValue === '' ? undefined : debouncedValue,
```

Fixes #14627 
