### PR TITLE
feat: allow to specify payload instance cache key in `handleEndpoints`

### DIFF
--- a/packages/payload/src/utilities/createPayloadRequest.ts
+++ b/packages/payload/src/utilities/createPayloadRequest.ts
@@ -18,6 +18,7 @@ type Args = {
   params?: {
     collection: string
   }
+  payloadInstanceCacheKey?: string
   request: Request
 }
 
@@ -25,10 +26,15 @@ export const createPayloadRequest = async ({
   canSetHeaders,
   config: configPromise,
   params,
+  payloadInstanceCacheKey,
   request,
 }: Args): Promise<PayloadRequest> => {
   const cookies = parseCookies(request.headers)
-  const payload = await getPayload({ config: configPromise, cron: true })
+  const payload = await getPayload({
+    config: configPromise,
+    cron: true,
+    key: payloadInstanceCacheKey,
+  })
 
   const { config } = payload
   const localization = config.localization

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -63,12 +63,14 @@ export const handleEndpoints = async ({
   basePath = '',
   config: incomingConfig,
   path,
+  payloadInstanceCacheKey,
   request,
 }: {
   basePath?: string
   config: Promise<SanitizedConfig> | SanitizedConfig
   /** Override path from the request */
   path?: string
+  payloadInstanceCacheKey?: string
   request: Request
 }): Promise<Response> => {
   let handler!: PayloadHandler
@@ -122,6 +124,7 @@ export const handleEndpoints = async ({
       basePath,
       config: incomingConfig,
       path,
+      payloadInstanceCacheKey,
       request: req,
     })
 
@@ -129,7 +132,12 @@ export const handleEndpoints = async ({
   }
 
   try {
-    req = await createPayloadRequest({ canSetHeaders: true, config: incomingConfig, request })
+    req = await createPayloadRequest({
+      canSetHeaders: true,
+      config: incomingConfig,
+      payloadInstanceCacheKey,
+      request,
+    })
 
     if (req.method?.toLowerCase() === 'options') {
       return Response.json(


### PR DESCRIPTION
This PR extends https://github.com/payloadcms/payload/pull/13603 with allowing you to specify `payloadInstanceCacheKey` inside `handleEndpoints` and `createPayloadRequest`.