### PR TITLE
fix: type TypeWithVersion missing latest property

### DIFF
--- a/packages/payload/src/versions/types.ts
+++ b/packages/payload/src/versions/types.ts
@@ -122,6 +122,7 @@ export type SanitizedGlobalVersions = {
 export type TypeWithVersion<T> = {
   createdAt: string
   id: string
+  latest?: boolean
   parent: number | string
   publishedLocale?: string
   snapshot?: boolean


### PR DESCRIPTION
### What?

Adds the missing `latest?: boolean` property to the `TypeWithVersion<T>` type definition.

### Why?

The `latest` property is set by database adapters when creating and updating versions (both collection and global versions), and is included in the version field schema when drafts are enabled. However, it was missing from the TypeScript type definition, causing type errors when consumers try to access this property on version documents.

### How?

Added `latest?: boolean` as an optional property to the `TypeWithVersion<T>` type. The property is optional because it's only present when drafts are enabled in the version configuration.

Fixes #14624 