### PR TITLE
chore(db-mongodb): export `transform` function

### DIFF
--- a/packages/db-mongodb/package.json
+++ b/packages/db-mongodb/package.json
@@ -29,6 +29,11 @@
       "import": "./src/exports/migration-utils.ts",
       "types": "./src/exports/migration-utils.ts",
       "default": "./src/exports/migration-utils.ts"
+    },
+    "./internal": {
+      "import": "./src/exports/internal.ts",
+      "types": "./src/exports/internal.ts",
+      "default": "./src/exports/internal.ts"
     }
   },
   "main": "./src/index.ts",
@@ -75,6 +80,11 @@
         "import": "./dist/exports/migration-utils.js",
         "types": "./dist/exports/migration-utils.d.ts",
         "default": "./dist/exports/migration-utils.js"
+      },
+      "./internal": {
+        "import": "./dist/exports/internal.js",
+        "types": "./dist/exports/internal.d.ts",
+        "default": "./dist/exports/internal.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/db-mongodb/src/exports/internal.ts
+++ b/packages/db-mongodb/src/exports/internal.ts
@@ -1,0 +1,1 @@
+export { transform } from '../utilities/transform.js'

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -343,4 +343,3 @@ export function mongooseAdapter({
 }
 
 export { compatibilityOptions } from './utilities/compatibilityOptions.js'
-export { transform } from './utilities/transform.js'

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -343,3 +343,4 @@ export function mongooseAdapter({
 }
 
 export { compatibilityOptions } from './utilities/compatibilityOptions.js'
+export { transform } from './utilities/transform.js'

--- a/packages/db-mongodb/src/utilities/transform.ts
+++ b/packages/db-mongodb/src/utilities/transform.ts
@@ -494,6 +494,10 @@ const stripFields = ({
   }
 }
 
+/**
+ * A function that transforms Payload <-> MongoDB data.
+ * @internal - this function may be removed or receive breaking changes in minor releases.
+ */
 export const transform = ({
   $addToSet,
   $inc,


### PR DESCRIPTION
This PR adds an export of the `transform` function from the `@payloadcms/db-mongodb` package which may be useful in case if you want to access Mongoose directly and rely on Payload data format. Note that this is marked as `@internal` so this function may receive breaking changes in the future.