### PR TITLE
fix(ui): shows minRowsProp instead of minRows

### DIFF
--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -455,7 +455,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
               {showMinRows && (
                 <Banner type="error">
                   {t('validation:requiresAtLeast', {
-                    count: minRows,
+                    count: minRowsProp ?? minRows,
                     label:
                       getTranslation(minRows > 1 ? labels.plural : labels.singular, i18n) ||
                       t(minRows > 1 ? 'general:rows' : 'general:row'),

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -67,7 +67,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
 
   const schemaPath = schemaPathFromProps ?? name
 
-  const minRows = (minRowsProp ?? required) ? 1 : 0
+  const minRows = minRowsProp ?? (required ? 1 : 0)
 
   const { setDocFieldPreferences } = useDocumentInfo()
   const {
@@ -455,7 +455,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
               {showMinRows && (
                 <Banner type="error">
                   {t('validation:requiresAtLeast', {
-                    count: minRowsProp ?? minRows,
+                    count: minRows,
                     label:
                       getTranslation(minRows > 1 ? labels.plural : labels.singular, i18n) ||
                       t(minRows > 1 ? 'general:rows' : 'general:row'),


### PR DESCRIPTION
Initially:
<img width="958" height="135" alt="image" src="https://github.com/user-attachments/assets/098cbe10-5f4b-4d66-bc59-8d6ba5567382" />


Now says the _total_ number of rows required in the validation message which matches the config `minRows` property:

<img width="964" height="128" alt="image" src="https://github.com/user-attachments/assets/ec334cf1-265d-4134-b67c-fb84008fcac8" />

# Array Field
```ts
{
  name: 'arrayWithMinRows',
  fields: [
    {
      name: 'text',
      type: 'text',
    },
  ],
  minRows: 2, // <---
  type: 'array',
  required: true,
},
```
