### PR TITLE
fix: remove init of transaction for global doc access

### DIFF
--- a/packages/payload/src/globals/operations/docAccess.ts
+++ b/packages/payload/src/globals/operations/docAccess.ts
@@ -27,7 +27,6 @@ export const docAccessOperation = async (args: Arguments): Promise<SanitizedGlob
   }
 
   try {
-    const shouldCommit = await initTransaction(req)
     const result = await getEntityPermissions({
       id: undefined,
       blockReferencesPermissions: {},
@@ -38,9 +37,7 @@ export const docAccessOperation = async (args: Arguments): Promise<SanitizedGlob
       operations: globalOperations,
       req,
     })
-    if (shouldCommit) {
-      await commitTransaction(req)
-    }
+
     const sanitizedPermissions = sanitizePermissions({
       globals: {
         [globalConfig.slug]: result,


### PR DESCRIPTION
When getting the globals doc permissions we were creating a transaction. This was causing transaction errors to occur where the session was closed already due to a promise.All() during [renderDocument](https://github.com/payloadcms/payload/blob/802a21afea066542a08bbd9fbd8f386f58a94e3d/packages/next/src/views/Document/index.tsx#L170)

This change makes it so we no longer create the transaction as is normal for all other db read operations.
