### PR TITLE
fix: add missing beforeDocumentControls custom component key for globals to importmap generation

### DIFF
--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -179,12 +179,13 @@ export const MyGlobal: SanitizedGlobalConfig = {
 
 The following options are available:
 
-| Option            | Description                                                                                                                                                                                                |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SaveButton`      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#savebutton).                                         |
-| `SaveDraftButton` | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#savedraftbutton). |
-| `PublishButton`   | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publishbutton).                                    |
-| `PreviewButton`   | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
+| Option                   | Description                                                                                                                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `beforeDocumentControls` | Inject custom components before the Save / Publish buttons. [More details](../custom-components/edit-view#beforedocumentcontrols).                                                                         |
+| `SaveButton`             | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#savebutton).                                         |
+| `SaveDraftButton`        | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#savedraftbutton). |
+| `PublishButton`          | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publishbutton).                                    |
+| `PreviewButton`          | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/docs/custom-components/edit-view.mdx
+++ b/docs/custom-components/edit-view.mdx
@@ -74,8 +74,8 @@ In addition to swapping out the entire Edit View with a [Custom View](./custom-v
 
 <Banner type="warning">
   **Important:** Collection and Globals are keyed to a different property in the
-  `admin.components` object and have slightly different options. Be sure to use the
-  correct key for the entity you are working with.
+  `admin.components` object and have slightly different options. Be sure to use
+  the correct key for the entity you are working with.
 </Banner>
 
 #### Collections
@@ -135,15 +135,14 @@ export const MyGlobal: GlobalConfig = {
 
 The following options are available:
 
-| Path                     | Description                                                                                                                  |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `beforeDocumentControls` | Inject custom components before the Save / Publish buttons. [More details](#beforedocumentcontrols).                         |
-| `editMenuItems`          | Inject custom components within the 3-dot menu dropdown located in the document control bar. [More details](#editmenuitems). |
-| `SaveButton`             | A button that saves the current document. [More details](#savebutton).                                                       |
-| `SaveDraftButton`        | A button that saves the current document as a draft. [More details](#savedraftbutton).                                       |
-| `PublishButton`          | A button that publishes the current document. [More details](#publishbutton).                                                |
-| `PreviewButton`          | A button that previews the current document. [More details](#previewbutton).                                                 |
-| `Description`            | A description of the Global. [More details](#description).                                                                   |
+| Path                     | Description                                                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `beforeDocumentControls` | Inject custom components before the Save / Publish buttons. [More details](#beforedocumentcontrols). |
+| `SaveButton`             | A button that saves the current document. [More details](#savebutton).                               |
+| `SaveDraftButton`        | A button that saves the current document as a draft. [More details](#savedraftbutton).               |
+| `PublishButton`          | A button that publishes the current document. [More details](#publishbutton).                        |
+| `PreviewButton`          | A button that previews the current document. [More details](#previewbutton).                         |
+| `Description`            | A description of the Global. [More details](#description).                                           |
 
 ### SaveButton
 

--- a/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
@@ -30,7 +30,6 @@ export function iterateGlobals({
     })
 
     addToImportMap(global.admin?.components?.elements?.beforeDocumentControls)
-    addToImportMap(global.admin?.components?.elements?.editMenuItems)
     addToImportMap(global.admin?.components?.elements?.Description)
     addToImportMap(global.admin?.components?.elements?.PreviewButton)
     addToImportMap(global.admin?.components?.elements?.PublishButton)

--- a/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
@@ -29,6 +29,8 @@ export function iterateGlobals({
       imports,
     })
 
+    addToImportMap(global.admin?.components?.elements?.beforeDocumentControls)
+    addToImportMap(global.admin?.components?.elements?.editMenuItems)
     addToImportMap(global.admin?.components?.elements?.Description)
     addToImportMap(global.admin?.components?.elements?.PreviewButton)
     addToImportMap(global.admin?.components?.elements?.PublishButton)


### PR DESCRIPTION
### What?
Add missing `beforeDocumentControls` key for custom components in `admin.components.elements` in globals to importmap generation. Remove `editMenuItems` from globals custom component docs.

### Why?
Adding the custom components does currently not work as stated in the docs (https://payloadcms.com/docs/custom-components/edit-view#globals) as it won't be picked up by `payload generate:importmap`.

### How?
Added missing key to generation. Update docs.