### PR TITLE
fix: count versions should allow querying on localized fields

### DIFF
--- a/packages/payload/src/collections/operations/countVersions.ts
+++ b/packages/payload/src/collections/operations/countVersions.ts
@@ -50,7 +50,7 @@ export const countVersionsOperation = async <TSlug extends CollectionSlug>(
       where,
     } = args
 
-    const { payload } = req!
+    const { locale, payload } = req!
 
     // /////////////////////////////////////
     // Access
@@ -90,6 +90,7 @@ export const countVersionsOperation = async <TSlug extends CollectionSlug>(
 
     result = await payload.db.countVersions({
       collection: collectionConfig.slug,
+      locale: locale!,
       req,
       where: fullWhere,
     })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -32,6 +32,7 @@ import {
   englishTitle,
   hungarianLocale,
   localizedDateFieldsSlug,
+  localizedDraftsSlug,
   localizedPostsSlug,
   localizedSortSlug,
   portugueseLocale,
@@ -3615,6 +3616,28 @@ describe('Localization', () => {
 
       expect(queriedDoc.docs).toHaveLength(1)
       expect(queriedDoc.docs[0]!.id).toBe(doc.id)
+    })
+  })
+
+  describe('localized queries', () => {
+    it('should count versions with query on localized field', async () => {
+      await payload.create({
+        collection: localizedDraftsSlug,
+        data: {
+          title: 'Localized Drafts EN',
+        },
+        locale: defaultLocale,
+      })
+
+      const result2 = await payload.countVersions({
+        collection: localizedDraftsSlug,
+        where: {
+          'version.title': {
+            equals: 'Localized Drafts EN',
+          },
+        },
+      })
+      expect(result2.totalDocs).toBe(1)
     })
   })
 })


### PR DESCRIPTION
`payload.countVersions` was not passing the locale through, so it was not possible to query on localized fields without querying on the localized path. This differs from how the find operation works.