### PR TITLE
fix: thread `joins` to `replaceWithDraftIfAvailable` and add `joins` property to `db.findVersions`

### DIFF
--- a/packages/db-mongodb/src/utilities/aggregatePaginate.ts
+++ b/packages/db-mongodb/src/utilities/aggregatePaginate.ts
@@ -71,6 +71,12 @@ export const aggregatePaginate = async ({
 
   let countPromise: Promise<null | number> = Promise.resolve(null)
 
+  const sessionParams: { session?: ClientSession } = {}
+
+  if (session) {
+    sessionParams.session = session
+  }
+
   if (pagination !== false && limit) {
     if (useEstimatedCount) {
       countPromise = Model.estimatedDocumentCount(query)
@@ -78,14 +84,14 @@ export const aggregatePaginate = async ({
       const hint = adapter.disableIndexHints !== true ? { _id: 1 } : undefined
       countPromise = Model.countDocuments(query, {
         collation,
-        session,
         ...(hint ? { hint } : {}),
+        ...sessionParams,
       })
     }
   }
 
   const [docs, countResult] = await Promise.all([
-    Model.aggregate(aggregation, { collation, session }),
+    Model.aggregate(aggregation, { collation, ...sessionParams }),
     countPromise,
   ])
 

--- a/packages/drizzle/src/findVersions.ts
+++ b/packages/drizzle/src/findVersions.ts
@@ -9,7 +9,19 @@ import { findMany } from './find/findMany.js'
 
 export const findVersions: FindVersions = async function findVersions(
   this: DrizzleAdapter,
-  { collection, limit, locale, page, pagination, req, select, skip, sort: sortArg, where },
+  {
+    collection,
+    joins = false,
+    limit,
+    locale,
+    page,
+    pagination,
+    req,
+    select,
+    skip,
+    sort: sortArg,
+    where,
+  },
 ) {
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const sort = sortArg !== undefined && sortArg !== null ? sortArg : collectionConfig.defaultSort
@@ -22,8 +34,9 @@ export const findVersions: FindVersions = async function findVersions(
 
   return findMany({
     adapter: this,
+    draftsEnabled: true,
     fields,
-    joins: false,
+    joins,
     limit,
     locale,
     page,
@@ -33,6 +46,7 @@ export const findVersions: FindVersions = async function findVersions(
     skip,
     sort,
     tableName,
+    versions: true,
     where,
   })
 }

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -247,6 +247,7 @@ export const findByIDOperation = async <
         doc: result,
         entity: collectionConfig,
         entityType: 'collection',
+        joins,
         overrideAccess,
         req,
         select,

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -277,6 +277,7 @@ type BaseVersionArgs = {
 
 export type FindVersionsArgs = {
   collection: CollectionSlug
+  joins?: JoinQuery
 } & BaseVersionArgs
 
 export type FindVersions = <T = JsonObject>(

--- a/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
+++ b/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
@@ -3,7 +3,7 @@ import type { SanitizedCollectionConfig, TypeWithID } from '../../collections/co
 import type { AccessResult } from '../../config/types.js'
 import type { FindGlobalVersionsArgs, FindVersionsArgs } from '../../database/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'
-import type { PayloadRequest, SelectType, Where } from '../../types/index.js'
+import type { JoinQuery, PayloadRequest, SelectType, Where } from '../../types/index.js'
 
 import { hasWhereAccessResult } from '../../auth/index.js'
 import { combineQueries } from '../../database/combineQueries.js'
@@ -17,6 +17,7 @@ type Arguments<T> = {
   doc: T
   entity: SanitizedCollectionConfig | SanitizedGlobalConfig
   entityType: 'collection' | 'global'
+  joins?: JoinQuery
   overrideAccess: boolean
   req: PayloadRequest
   select?: SelectType
@@ -27,6 +28,7 @@ export const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
   doc,
   entity,
   entityType,
+  joins,
   req,
   select,
 }: Arguments<T>): Promise<T> => {
@@ -76,6 +78,7 @@ export const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
   const findVersionsArgs: FindGlobalVersionsArgs & FindVersionsArgs = {
     collection: entity.slug,
     global: entity.slug,
+    joins,
     limit: 1,
     locale: locale!,
     pagination: false,

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -839,6 +839,26 @@ describe('Joins Field', () => {
 
       expect(res.docs[0].relatedVersionsMany.docs[0].id).toBe(version.id)
     })
+
+    it('should populate the join field if the version is unpublished and draft: true', async () => {
+      const category = await payload.create({
+        collection: 'categories-versions',
+        data: { title: 'category', _status: 'draft' },
+        draft: true,
+      })
+      const post = await payload.create({
+        collection: 'versions',
+        data: { title: 'post', categoryVersion: category.id },
+        draft: true,
+      })
+      const res = await payload.find({
+        collection: 'categories-versions',
+        // id: category.id,
+        draft: true,
+      })
+      expect(res.docs[0].relatedVersions?.docs[0].id).toBe(post.id)
+      expect(res.docs[0].relatedVersions?.docs[0].title).toBe(post.title)
+    })
   })
 
   describe('REST', () => {


### PR DESCRIPTION
This fixes an issue with a case like this:
* A draft document for collection "categories" has been created. The collection has a join field `relatedPosts`.
* A draft document for collection "posts" has been created with the value of `category` (a relationship field) equal to the ID of the category document
* `findByID({ collection: 'categories' })` - we can get the post document inside `relatedPosts`  fine.
* `findByID({ collection: 'categories', draft: true })` - here we don't have a `relatedPosts` field at all.

However, if we publish the category document, `findByID({ collection: 'categories', draft: true })` will work fine.

The reason behind this bug is because in case of `findByID({ collection: 'categories', draft: true })` when we don't have a published version yet, we use the `replaceWithDraftIfAvailable` function https://github.com/payloadcms/payload/blob/a7cf30dd990021e0e6bf5a37f0fe69d7a904058b/packages/payload/src/collections/operations/findByID.ts#L244-L253 which does not use the `joins` property. Since this function also relies on `db.findVersions` - this PR adds an implementation for the `joins` property to that method as well.