### PR TITLE
fix(ui): app header overflow on mobile

### DIFF
--- a/packages/ui/src/elements/AppHeader/index.scss
+++ b/packages/ui/src/elements/AppHeader/index.scss
@@ -91,8 +91,8 @@
     &__controls-wrapper {
       display: flex;
       align-items: center;
-      flex-grow: 1;
-      width: 100%;
+      flex: 1;
+      min-width: 0;
     }
 
     &__step-nav-wrapper {


### PR DESCRIPTION
### What?
If the step nav's content is too long, then it will overflow the screen on mobile devices. Instead, this portion of the header should grow and shrink as needed, rather than being the full width of the header.

### Why?
I believe this issue was introduced with a change to the menu button.

### How?

- remove `width: 100%` as it is inaccurate to the desired size
- add `min-width: 0` to allow it to shrink
- change `flex-grow: 1` to `flex: 1` to make it take up the available space

Before:

<img width="374" height="41" alt="{D5255587-F9A4-494B-B1CE-DE350C550E6F}" src="https://github.com/user-attachments/assets/5e2f3a4b-08c8-499b-8211-bed83d44e808" />

After:

<img width="374" height="37" alt="{77C3D92D-DC0F-431B-8001-11B21754290C}" src="https://github.com/user-attachments/assets/24fc034b-051b-4888-898e-83a98949d1fc" />