### PR TITLE
fix(ui): ensures modal closes on route change

### DIFF
--- a/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
+++ b/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
@@ -2,7 +2,7 @@
 
 import { useModal } from '@faceless-ui/modal'
 import { usePathname } from 'next/navigation.js'
-import { useEffect } from 'react'
+import { useEffectEvent, useRef } from 'react'
 
 export function CloseModalOnRouteChange() {
   const { closeAllModals } = useModal()

--- a/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
+++ b/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
@@ -8,9 +8,20 @@ export function CloseModalOnRouteChange() {
   const { closeAllModals } = useModal()
   const pathname = usePathname()
 
-  useEffect(() => {
+  const closeAllModalsEffectEvent = useEffectEvent(() => {
     closeAllModals()
-  }, [pathname, closeAllModals])
+  })
+
+  const initialRenderRef = useRef(true)
+
+  useEffect(() => {
+    if (initialRenderRef.current) {
+      initialRenderRef.current = false
+      return
+    }
+
+    closeAllModalsEffectEvent()
+  }, [pathname])
 
   return null
 }

--- a/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
+++ b/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
@@ -2,7 +2,7 @@
 
 import { useModal } from '@faceless-ui/modal'
 import { usePathname } from 'next/navigation.js'
-import { useRef, useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { useEffectEvent } from '../../hooks/useEffectEvent.js'
 

--- a/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
+++ b/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useModal } from '@faceless-ui/modal'
+import { usePathname } from 'next/navigation.js'
+import { useEffect } from 'react'
+
+export function CloseModalOnRouteChange() {
+  const { closeAllModals } = useModal()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    closeAllModals()
+  }, [pathname, closeAllModals])
+
+  return null
+}

--- a/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
+++ b/packages/ui/src/elements/CloseModalOnRouteChange/index.tsx
@@ -2,7 +2,9 @@
 
 import { useModal } from '@faceless-ui/modal'
 import { usePathname } from 'next/navigation.js'
-import { useEffectEvent, useRef } from 'react'
+import { useRef, useEffect } from 'react'
+
+import { useEffectEvent } from '../../hooks/useEffectEvent.js'
 
 export function CloseModalOnRouteChange() {
   const { closeAllModals } = useModal()

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -16,6 +16,7 @@ import React from 'react'
 
 import type { Theme } from '../Theme/index.js'
 
+import { CloseModalOnRouteChange } from '../../elements/CloseModalOnRouteChange/index.js'
 import { LoadingOverlayProvider } from '../../elements/LoadingOverlay/index.js'
 import { NavProvider } from '../../elements/Nav/context.js'
 import { StayLoggedInModal } from '../../elements/StayLoggedIn/index.js'
@@ -101,6 +102,7 @@ export const RootProvider: React.FC<Props> = ({
                     <ScrollInfoProvider>
                       <SearchParamsProvider>
                         <ModalProvider classPrefix="payload" transTime={0} zIndex="var(--z-modal)">
+                          <CloseModalOnRouteChange />
                           <AuthProvider permissions={permissions} user={user}>
                             <PreferencesProvider>
                               <ThemeProvider theme={theme}>

--- a/test/admin-root/e2e.spec.ts
+++ b/test/admin-root/e2e.spec.ts
@@ -145,4 +145,16 @@ test.describe('Admin Panel (Root)', () => {
     await page.goto(`${url.admin}/custom-view`)
     await expect(page.locator('#custom-view')).toBeVisible()
   })
+
+  test('should close modal on route change', async () => {
+    await page.goto(url.create)
+    const textField = page.locator('#field-text')
+    await textField.fill('updated')
+    await page.click('a[aria-label="Account"]')
+    const modal = page.locator('div.payload__modal-container')
+    await expect(modal).toBeVisible()
+
+    await page.goBack()
+    await expect(modal).toBeHidden()
+  })
 })

--- a/test/fields-relationship/collections/Relationship/index.ts
+++ b/test/fields-relationship/collections/Relationship/index.ts
@@ -24,6 +24,11 @@ export const Relationship: CollectionConfig = {
   },
   fields: [
     {
+      name: 'relationToSelf',
+      relationTo: slug,
+      type: 'relationship',
+    },
+    {
       name: 'relationship',
       relationTo: relationOneSlug,
       type: 'relationship',

--- a/test/fields-relationship/payload-types.ts
+++ b/test/fields-relationship/payload-types.ts
@@ -81,6 +81,7 @@ export interface Config {
     podcasts: Podcast;
     'mixed-media': MixedMedia;
     'versioned-relationship-field': VersionedRelationshipField;
+    'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -102,6 +103,7 @@ export interface Config {
     podcasts: PodcastsSelect<false> | PodcastsSelect<true>;
     'mixed-media': MixedMediaSelect<false> | MixedMediaSelect<true>;
     'versioned-relationship-field': VersionedRelationshipFieldSelect<false> | VersionedRelationshipFieldSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -110,6 +112,7 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | 'en' | 'en'[];
   globals: {};
   globalsSelect: {};
   locale: 'en';
@@ -145,6 +148,7 @@ export interface UserAuthOperations {
  */
 export interface FieldsRelationship {
   id: string;
+  relationToSelf?: (string | null) | FieldsRelationship;
   relationship?: (string | null) | RelationOne;
   relationshipHasMany?: (string | RelationOne)[] | null;
   relationshipMultiple?:
@@ -383,6 +387,23 @@ export interface VersionedRelationshipField {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -519,6 +540,7 @@ export interface PayloadMigration {
  * via the `definition` "fields-relationship_select".
  */
 export interface FieldsRelationshipSelect<T extends boolean = true> {
+  relationToSelf?: T;
   relationship?: T;
   relationshipHasMany?: T;
   relationshipMultiple?: T;
@@ -668,6 +690,14 @@ export interface VersionedRelationshipFieldSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?
Adds fix to ensure modal fully closes when navigating back/forwards in the browser.

### Why?
Currently if the modal is open and you navigate back in the browser, the modal content gets closed but the container remains visible, due to this you cannot click anything in the admin panel.

### How?
Adds a `closeModalOnRouteChange` component as described in the `faceless-ui` package [here](https://facelessui.com/docs/modal/routing#closemodalonroutechange).

#### NOTE
We have a similar PR [here](https://github.com/payloadcms/payload/pull/14721). Decided to merge efforts into this one, tests moved from other PR into this one.

Reported by client.
