### PR TITLE
feat(richtext-lexical): add align support to upload nodes

### DIFF
--- a/packages/richtext-lexical/src/features/upload/client/component/index.scss
+++ b/packages/richtext-lexical/src/features/upload/client/component/index.scss
@@ -11,6 +11,27 @@
     font-family: var(--font-body);
     margin-block: base(0.5);
 
+    // Alignment support using :has() selector
+    &:has([data-align='center']) {
+      width: fit-content;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    &:has([data-align='right']),
+    &:has([data-align='end']) {
+      width: fit-content;
+      margin-left: auto;
+      margin-right: 0;
+    }
+
+    &:has([data-align='left']),
+    &:has([data-align='start']) {
+      width: fit-content;
+      margin-left: 0;
+      margin-right: auto;
+    }
+
     &:hover {
       border: 1px solid var(--theme-elevation-150);
     }

--- a/packages/richtext-lexical/src/features/upload/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/component/index.tsx
@@ -44,6 +44,7 @@ export const UploadComponent: React.FC<ElementProps> = (props) => {
   const {
     className: baseClass,
     data: { fields, relationTo, value },
+    format,
     nodeKey,
   } = props
 
@@ -106,7 +107,7 @@ export const UploadComponent: React.FC<ElementProps> = (props) => {
   }, [editor, nodeKey])
 
   const updateUpload = useCallback(
-    (data: Data) => {
+    (_data: Data) => {
       setParams({
         ...initialParams,
         cacheBust, // do this to get the usePayloadAPI to re-fetch the data even though the URL string hasn't changed
@@ -150,6 +151,7 @@ export const UploadComponent: React.FC<ElementProps> = (props) => {
   return (
     <div
       className={`${baseClass}__contents ${baseClass}__contents--${aspectRatio}`}
+      data-align={format || undefined}
       data-filename={data?.filename}
       ref={uploadRef}
     >

--- a/test/lexical/collections/_LexicalFullyFeatured/e2e.spec.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/e2e.spec.ts
@@ -64,6 +64,29 @@ describe('Lexical Fully Featured', () => {
     await expect(paragraph).toHaveText('')
   })
 
+  test('ensure upload node can be aligned', async ({ page }) => {
+    await lexical.slashCommand('upload')
+    await lexical.drawer.locator('.list-drawer__header').getByText('Create New').click()
+    await lexical.drawer.getByText('Paste URL').click()
+    const url =
+      'https://raw.githubusercontent.com/payloadcms/website/refs/heads/main/public/images/universal-truth.jpg'
+    await lexical.drawer.locator('.file-field__remote-file').fill(url)
+    await lexical.drawer.getByText('Add file').click()
+    await lexical.save('drawer')
+    const img = lexical.editor.locator('img').first()
+    await img.click()
+    const imgBoxBeforeCenter = await img.boundingBox()
+    await expect(() => {
+      expect(imgBoxBeforeCenter?.x).toBeLessThan(150)
+    }).toPass({ timeout: 100 })
+    await page.getByLabel('align dropdown').click()
+    await page.getByLabel('Align Center').click()
+    const imgBoxAfterCenter = await img.boundingBox()
+    await expect(() => {
+      expect(imgBoxAfterCenter?.x).toBeGreaterThan(150)
+    }).toPass({ timeout: 100 })
+  })
+
   test('ControlOrMeta+A inside input should select all the text inside the input', async ({
     page,
   }) => {


### PR DESCRIPTION

DecoratorBlock already had a `__format` property. The format in which it was stored in Lexical was inconsistent with that of ElementNode, and the `FORMAT_ELEMENT_COMMAND` command was simply ignoring it.

I fixed the problem with a Lexical plugin within AlignFeature.


After
<img width="944" height="659" alt="image" src="https://github.com/user-attachments/assets/65d255ee-e973-44bc-bb57-f9888090f2c7" />
