### PR TITLE
fix(ui): fully close modals on route navigation

### DIFF
--- a/packages/ui/src/elements/IDLabel/index.tsx
+++ b/packages/ui/src/elements/IDLabel/index.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useModal } from '@faceless-ui/modal'
 import React from 'react'
 
 import './index.scss'
@@ -7,6 +8,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { formatAdminURL } from '../../utilities/formatAdminURL.js'
 import { sanitizeID } from '../../utilities/sanitizeID.js'
+import { useDocumentDrawerContext } from '../DocumentDrawer/Provider.js'
 import { useDrawerDepth } from '../Drawer/index.js'
 
 const baseClass = 'id-label'
@@ -24,17 +26,31 @@ export const IDLabel: React.FC<{ className?: string; id: string; prefix?: string
 
   const { collectionSlug, globalSlug } = useDocumentInfo()
   const drawerDepth = useDrawerDepth()
+  const { drawerSlug } = useDocumentDrawerContext()
+  const { closeModal } = useModal()
 
   const docPath = formatAdminURL({
     adminRoute,
     path: `/${collectionSlug ? `collections/${collectionSlug}` : `globals/${globalSlug}`}/${id}`,
   })
 
+  const onClick = React.useCallback(() => {
+    if (drawerSlug) {
+      closeModal(drawerSlug)
+    }
+  }, [drawerSlug, closeModal])
+
   return (
     <div className={[baseClass, className].filter(Boolean).join(' ')} title={id}>
       {prefix}
       &nbsp;
-      {drawerDepth > 1 ? <Link href={docPath}>{sanitizeID(id)}</Link> : sanitizeID(id)}
+      {drawerDepth > 1 ? (
+        <Link href={docPath} onClick={onClick}>
+          {sanitizeID(id)}
+        </Link>
+      ) : (
+        sanitizeID(id)
+      )}
     </div>
   )
 }

--- a/packages/ui/src/elements/IDLabel/index.tsx
+++ b/packages/ui/src/elements/IDLabel/index.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { useModal } from '@faceless-ui/modal'
 import React from 'react'
 
 import './index.scss'
@@ -8,7 +7,6 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { formatAdminURL } from '../../utilities/formatAdminURL.js'
 import { sanitizeID } from '../../utilities/sanitizeID.js'
-import { useDocumentDrawerContext } from '../DocumentDrawer/Provider.js'
 import { useDrawerDepth } from '../Drawer/index.js'
 
 const baseClass = 'id-label'
@@ -26,31 +24,17 @@ export const IDLabel: React.FC<{ className?: string; id: string; prefix?: string
 
   const { collectionSlug, globalSlug } = useDocumentInfo()
   const drawerDepth = useDrawerDepth()
-  const { drawerSlug } = useDocumentDrawerContext()
-  const { closeModal } = useModal()
 
   const docPath = formatAdminURL({
     adminRoute,
     path: `/${collectionSlug ? `collections/${collectionSlug}` : `globals/${globalSlug}`}/${id}`,
   })
 
-  const onClick = React.useCallback(() => {
-    if (drawerSlug) {
-      closeModal(drawerSlug)
-    }
-  }, [drawerSlug, closeModal])
-
   return (
     <div className={[baseClass, className].filter(Boolean).join(' ')} title={id}>
       {prefix}
       &nbsp;
-      {drawerDepth > 1 ? (
-        <Link href={docPath} onClick={onClick}>
-          {sanitizeID(id)}
-        </Link>
-      ) : (
-        sanitizeID(id)
-      )}
+      {drawerDepth > 1 ? <Link href={docPath}>{sanitizeID(id)}</Link> : sanitizeID(id)}
     </div>
   )
 }

--- a/packages/ui/src/elements/ModalCleanup/index.tsx
+++ b/packages/ui/src/elements/ModalCleanup/index.tsx
@@ -1,0 +1,16 @@
+import { useModal } from '@faceless-ui/modal'
+import { usePathname } from 'next/navigation.js'
+import React from 'react'
+
+export const ModalCleanup: React.FC = () => {
+  const { closeAllModals } = useModal()
+  const pathname = usePathname()
+
+  React.useEffect(() => {
+    return () => {
+      closeAllModals()
+    }
+  }, [closeAllModals, pathname])
+
+  return null
+}

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -17,6 +17,7 @@ import React from 'react'
 import type { Theme } from '../Theme/index.js'
 
 import { LoadingOverlayProvider } from '../../elements/LoadingOverlay/index.js'
+import { ModalCleanup } from '../../elements/ModalCleanup/index.js'
 import { NavProvider } from '../../elements/Nav/context.js'
 import { StayLoggedInModal } from '../../elements/StayLoggedIn/index.js'
 import { StepNavProvider } from '../../elements/StepNav/index.js'
@@ -116,6 +117,7 @@ export const RootProvider: React.FC<Props> = ({
                                                 id={dndContextID}
                                               >
                                                 {children}
+                                                <ModalCleanup />
                                               </DndContext>
                                             </UploadHandlersProvider>
                                           </NavProvider>

--- a/test/fields-relationship/collections/Relationship/index.ts
+++ b/test/fields-relationship/collections/Relationship/index.ts
@@ -24,6 +24,11 @@ export const Relationship: CollectionConfig = {
   },
   fields: [
     {
+      name: 'relationToSelf',
+      relationTo: slug,
+      type: 'relationship',
+    },
+    {
       name: 'relationship',
       relationTo: relationOneSlug,
       type: 'relationship',

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -575,6 +575,55 @@ describe('Relationship Field', () => {
     await expect(documentDrawer).toBeVisible()
   })
 
+  test('should open document from drawer by clicking on ID Label', async () => {
+    const relatedDoc = await payload.create({
+      collection: relationOneSlug,
+      data: {
+        name: 'Drawer ID Label',
+      },
+    })
+    const doc = await payload.create({
+      collection: slug,
+      data: {
+        relationship: relatedDoc.id,
+      },
+    })
+
+    await page.goto(url.edit(doc.id))
+
+    const relationshipDrawerTrigger = page.locator(
+      '#field-relationship button.relationship--single-value__drawer-toggler',
+    )
+    await expect(relationshipDrawerTrigger).toBeVisible()
+
+    await relationshipDrawerTrigger.click()
+
+    const documentDrawer = page.locator('[id^=doc-drawer_relation-one_1_]')
+    await expect(documentDrawer).toBeVisible()
+
+    const idLabel = documentDrawer.locator('.id-label')
+    await expect(idLabel).toBeVisible()
+
+    await idLabel.locator('a').click()
+
+    const closedModalLocator = page.locator(
+      '.payload__modal-container.payload__modal-container--exitDone',
+    )
+
+    await expect(closedModalLocator).toBeVisible()
+
+    await Promise.all([
+      payload.delete({
+        collection: relationOneSlug,
+        id: relatedDoc.id,
+      }),
+      payload.delete({
+        collection: slug,
+        id: doc.id,
+      }),
+    ])
+  })
+
   test('should open document drawer and append newly created docs onto the parent field', async () => {
     await page.goto(url.edit(docWithExistingRelations.id))
     await wait(300)

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -588,29 +588,44 @@ describe('Relationship Field', () => {
         relationship: relatedDoc.id,
       },
     })
+    await payload.update({
+      collection: slug,
+      id: doc.id,
+      data: {
+        relationToSelf: doc.id,
+      },
+    })
 
     await page.goto(url.edit(doc.id))
+    // open first drawer (self-relation)
+    const selfRelationTrigger = page.locator(
+      '#field-relationToSelf button.relationship--single-value__drawer-toggler',
+    )
+    await expect(selfRelationTrigger).toBeVisible()
+    await selfRelationTrigger.click()
 
-    const relationshipDrawerTrigger = page.locator(
+    const drawer1 = page.locator('[id^=doc-drawer_fields-relationship_1_]')
+    await expect(drawer1).toBeVisible()
+
+    // open nested drawer (relation field inside self-relation)
+    const relationshipDrawerTrigger = drawer1.locator(
       '#field-relationship button.relationship--single-value__drawer-toggler',
     )
     await expect(relationshipDrawerTrigger).toBeVisible()
-
     await relationshipDrawerTrigger.click()
 
-    const documentDrawer = page.locator('[id^=doc-drawer_relation-one_1_]')
-    await expect(documentDrawer).toBeVisible()
+    const drawer2 = page.locator('[id^=doc-drawer_relation-one_2_]')
+    await expect(drawer2).toBeVisible()
 
-    const idLabel = documentDrawer.locator('.id-label')
+    const idLabel = drawer2.locator('.id-label')
     await expect(idLabel).toBeVisible()
-
     await idLabel.locator('a').click()
 
     const closedModalLocator = page.locator(
       '.payload__modal-container.payload__modal-container--exitDone',
     )
 
-    await expect(closedModalLocator).toBeVisible()
+    await expect(closedModalLocator).toHaveCount(1)
 
     await Promise.all([
       payload.delete({

--- a/test/fields-relationship/payload-types.ts
+++ b/test/fields-relationship/payload-types.ts
@@ -81,6 +81,7 @@ export interface Config {
     podcasts: Podcast;
     'mixed-media': MixedMedia;
     'versioned-relationship-field': VersionedRelationshipField;
+    'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -102,6 +103,7 @@ export interface Config {
     podcasts: PodcastsSelect<false> | PodcastsSelect<true>;
     'mixed-media': MixedMediaSelect<false> | MixedMediaSelect<true>;
     'versioned-relationship-field': VersionedRelationshipFieldSelect<false> | VersionedRelationshipFieldSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -145,6 +147,7 @@ export interface UserAuthOperations {
  */
 export interface FieldsRelationship {
   id: string;
+  relationToSelf?: (string | null) | FieldsRelationship;
   relationship?: (string | null) | RelationOne;
   relationshipHasMany?: (string | RelationOne)[] | null;
   relationshipMultiple?:
@@ -383,6 +386,23 @@ export interface VersionedRelationshipField {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -519,6 +539,7 @@ export interface PayloadMigration {
  * via the `definition` "fields-relationship_select".
  */
 export interface FieldsRelationshipSelect<T extends boolean = true> {
+  relationToSelf?: T;
   relationship?: T;
   relationshipHasMany?: T;
   relationshipMultiple?: T;
@@ -668,6 +689,14 @@ export interface VersionedRelationshipFieldSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Using Link navigation causes the modal container to not fully unmount.
