### PR TITLE
fix(ui): query preset crash with empty filters in postgres/sqlite

### DIFF
--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -669,6 +669,15 @@ export const traverseFields = <T extends Record<string, unknown>>({
           return
         }
 
+        case 'json':
+        case 'richText': {
+          if (fieldData === null) {
+            val = undefined
+          }
+
+          break
+        }
+
         case 'number': {
           if (typeof fieldData === 'string') {
             val = Number.parseFloat(fieldData)

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -669,15 +669,6 @@ export const traverseFields = <T extends Record<string, unknown>>({
           return
         }
 
-        case 'json':
-        case 'richText': {
-          if (fieldData === null) {
-            val = undefined
-          }
-
-          break
-        }
-
         case 'number': {
           if (typeof fieldData === 'string') {
             val = Number.parseFloat(fieldData)

--- a/packages/ui/src/elements/QueryPresets/cells/WhereCell/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/cells/WhereCell/index.tsx
@@ -9,13 +9,13 @@ const transformWhereToNaturalLanguage = (where: Where): string => {
     const orQuery = where.or[0]
     const andQuery = orQuery?.and?.[0]
 
-    if (!andQuery) {
+    if (!andQuery || typeof andQuery !== 'object') {
       return 'No where query'
     }
 
     const key = Object.keys(andQuery)[0]
 
-    if (!andQuery[key]) {
+    if (!key || !andQuery[key] || typeof andQuery[key] !== 'object') {
       return 'No where query'
     }
 

--- a/packages/ui/src/elements/QueryPresets/fields/WhereField/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/fields/WhereField/index.tsx
@@ -23,9 +23,13 @@ const transformWhereToNaturalLanguage = (
   }
 
   const renderCondition = (condition: any): React.ReactNode => {
+    if (!condition || typeof condition !== 'object') {
+      return 'No where query'
+    }
+
     const key = Object.keys(condition)[0]
 
-    if (!condition[key]) {
+    if (!key || !condition[key] || typeof condition[key] !== 'object') {
       return 'No where query'
     }
 

--- a/packages/ui/src/providers/ListQuery/sanitizeQuery.ts
+++ b/packages/ui/src/providers/ListQuery/sanitizeQuery.ts
@@ -16,7 +16,12 @@ export const sanitizeQuery = (toSanitize: ListQuery): ListQuery => {
       delete sanitized[key]
     }
 
-    if (key === 'where' && typeof value === 'object' && !Object.keys(value as Where).length) {
+    if (
+      key === 'where' &&
+      typeof value === 'object' &&
+      value !== null &&
+      !Object.keys(value as Where).length
+    ) {
       delete sanitized[key]
     }
 

--- a/test/query-presets/e2e.spec.ts
+++ b/test/query-presets/e2e.spec.ts
@@ -394,6 +394,65 @@ describe('Query Presets', () => {
     ).toBeVisible()
   })
 
+  test('can create and view preset with no filters or columns', async () => {
+    await page.goto(pagesUrl.list)
+
+    const presetTitle = 'Empty Preset'
+
+    // Create a new preset without setting any filters or columns
+    await page.locator('#create-new-preset').click()
+    const modal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
+    await expect(modal).toBeVisible()
+    await modal.locator('input[name="title"]').fill(presetTitle)
+
+    const currentURL = page.url()
+    await saveDocAndAssert(page)
+    await expect(modal).toBeHidden()
+
+    await page.waitForURL(() => page.url() !== currentURL)
+
+    await expect(
+      page.locator('button#select-preset', {
+        hasText: exactText(presetTitle),
+      }),
+    ).toBeVisible()
+
+    // Open the edit modal to verify where/columns fields handle null values
+    await page.locator('#edit-preset').click()
+    const editModal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
+    await expect(editModal).toBeVisible()
+
+    // Verify the Where field displays "No where query" instead of crashing
+    const whereFieldContent = editModal.locator('.query-preset-where-field .value-wrapper')
+    await expect(whereFieldContent).toBeVisible()
+    await expect(whereFieldContent).toContainText('No where query')
+
+    // Verify the Columns field displays "No columns selected" instead of crashing
+    const columnsFieldContent = editModal.locator('.query-preset-columns-field .value-wrapper')
+    await expect(columnsFieldContent).toBeVisible()
+    await expect(columnsFieldContent).toContainText('No columns selected')
+
+    await editModal.locator('button.doc-drawer__header-close').click()
+    await expect(editModal).toBeHidden()
+
+    await openQueryPresetDrawer({ page })
+    const drawer = page.locator('[id^=list-drawer_0_]')
+    await expect(drawer).toBeVisible()
+
+    const presetRow = drawer.locator('tbody tr', {
+      has: page.locator(`button:has-text("${presetTitle}")`),
+    })
+
+    await expect(presetRow).toBeVisible()
+
+    // Column order: title (0), isShared (1), access (2), where (3), columns (4)
+    const whereCell = presetRow.locator('td').nth(3)
+    await expect(whereCell).toContainText('No where query')
+
+    const columnsCell = presetRow.locator('td').nth(4)
+    await expect(columnsCell).toContainText('No columns selected')
+  })
+
   test('only shows query presets related to the underlying collection', async () => {
     // no results on `posts` collection
     const postsURL = new AdminUrlUtil(serverURL, 'posts')

--- a/test/query-presets/e2e.spec.ts
+++ b/test/query-presets/e2e.spec.ts
@@ -149,6 +149,65 @@ describe('Query Presets', () => {
     }
   })
 
+  test('can create and view preset with no filters or columns', async () => {
+    await page.goto(pagesUrl.list)
+
+    const presetTitle = 'Empty Preset'
+
+    // Create a new preset without setting any filters or columns
+    await page.locator('#create-new-preset').click()
+    const modal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
+    await expect(modal).toBeVisible()
+    await modal.locator('input[name="title"]').fill(presetTitle)
+
+    const currentURL = page.url()
+    await saveDocAndAssert(page)
+    await expect(modal).toBeHidden()
+
+    await page.waitForURL(() => page.url() !== currentURL)
+
+    await expect(
+      page.locator('button#select-preset', {
+        hasText: exactText(presetTitle),
+      }),
+    ).toBeVisible()
+
+    // Open the edit modal to verify where/columns fields handle null values
+    await page.locator('#edit-preset').click()
+    const editModal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
+    await expect(editModal).toBeVisible()
+
+    // Verify the Where field displays "No where query" instead of crashing
+    const whereFieldContent = editModal.locator('.query-preset-where-field .value-wrapper')
+    await expect(whereFieldContent).toBeVisible()
+    await expect(whereFieldContent).toContainText('No where query')
+
+    // Verify the Columns field displays "No columns selected" instead of crashing
+    const columnsFieldContent = editModal.locator('.query-preset-columns-field .value-wrapper')
+    await expect(columnsFieldContent).toBeVisible()
+    await expect(columnsFieldContent).toContainText('No columns selected')
+
+    await editModal.locator('button.doc-drawer__header-close').click()
+    await expect(editModal).toBeHidden()
+
+    await openQueryPresetDrawer({ page })
+    const drawer = page.locator('[id^=list-drawer_0_]')
+    await expect(drawer).toBeVisible()
+
+    const presetRow = drawer.locator('tbody tr', {
+      has: page.locator(`button:has-text("${presetTitle}")`),
+    })
+
+    await expect(presetRow).toBeVisible()
+
+    // Column order: title (0), isShared (1), access (2), where (3), columns (4)
+    const whereCell = presetRow.locator('td').nth(3)
+    await expect(whereCell).toContainText('No where query')
+
+    const columnsCell = presetRow.locator('td').nth(4)
+    await expect(columnsCell).toContainText('No columns selected')
+  })
+
   test('should select preset and apply filters', async () => {
     await page.goto(pagesUrl.list)
 
@@ -392,65 +451,6 @@ describe('Query Presets', () => {
         hasText: exactText(presetTitle),
       }),
     ).toBeVisible()
-  })
-
-  test('can create and view preset with no filters or columns', async () => {
-    await page.goto(pagesUrl.list)
-
-    const presetTitle = 'Empty Preset'
-
-    // Create a new preset without setting any filters or columns
-    await page.locator('#create-new-preset').click()
-    const modal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
-    await expect(modal).toBeVisible()
-    await modal.locator('input[name="title"]').fill(presetTitle)
-
-    const currentURL = page.url()
-    await saveDocAndAssert(page)
-    await expect(modal).toBeHidden()
-
-    await page.waitForURL(() => page.url() !== currentURL)
-
-    await expect(
-      page.locator('button#select-preset', {
-        hasText: exactText(presetTitle),
-      }),
-    ).toBeVisible()
-
-    // Open the edit modal to verify where/columns fields handle null values
-    await page.locator('#edit-preset').click()
-    const editModal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
-    await expect(editModal).toBeVisible()
-
-    // Verify the Where field displays "No where query" instead of crashing
-    const whereFieldContent = editModal.locator('.query-preset-where-field .value-wrapper')
-    await expect(whereFieldContent).toBeVisible()
-    await expect(whereFieldContent).toContainText('No where query')
-
-    // Verify the Columns field displays "No columns selected" instead of crashing
-    const columnsFieldContent = editModal.locator('.query-preset-columns-field .value-wrapper')
-    await expect(columnsFieldContent).toBeVisible()
-    await expect(columnsFieldContent).toContainText('No columns selected')
-
-    await editModal.locator('button.doc-drawer__header-close').click()
-    await expect(editModal).toBeHidden()
-
-    await openQueryPresetDrawer({ page })
-    const drawer = page.locator('[id^=list-drawer_0_]')
-    await expect(drawer).toBeVisible()
-
-    const presetRow = drawer.locator('tbody tr', {
-      has: page.locator(`button:has-text("${presetTitle}")`),
-    })
-
-    await expect(presetRow).toBeVisible()
-
-    // Column order: title (0), isShared (1), access (2), where (3), columns (4)
-    const whereCell = presetRow.locator('td').nth(3)
-    await expect(whereCell).toContainText('No where query')
-
-    const columnsCell = presetRow.locator('td').nth(4)
-    await expect(columnsCell).toContainText('No columns selected')
   })
 
   test('only shows query presets related to the underlying collection', async () => {

--- a/test/query-presets/int.spec.ts
+++ b/test/query-presets/int.spec.ts
@@ -803,5 +803,43 @@ describe('Query Presets', () => {
         ],
       })
     })
+
+    it('should handle empty where and columns fields', async () => {
+      const result = await payload.create({
+        collection: queryPresetsCollectionSlug,
+        user: adminUser,
+        overrideAccess: false,
+        data: {
+          title: 'Empty Where and Columns',
+          // Not including where or columns at all
+          access: {
+            read: {
+              constraint: 'everyone',
+            },
+            update: {
+              constraint: 'everyone',
+            },
+            delete: {
+              constraint: 'everyone',
+            },
+          },
+          relatedCollection: 'pages',
+        },
+      })
+
+      expect(result.where).toBeUndefined()
+      expect(result.columns).toBeUndefined()
+
+      const fetched = await payload.findByID({
+        collection: queryPresetsCollectionSlug,
+        depth: 0,
+        user: adminUser,
+        overrideAccess: false,
+        id: result.id,
+      })
+
+      expect(fetched.where).toBeUndefined()
+      expect(fetched.columns).toBeUndefined()
+    })
   })
 })

--- a/test/query-presets/int.spec.ts
+++ b/test/query-presets/int.spec.ts
@@ -827,8 +827,8 @@ describe('Query Presets', () => {
         },
       })
 
-      expect(result.where).toBeUndefined()
-      expect(result.columns).toBeUndefined()
+      expect(result.where == null).toBe(true)
+      expect(result.columns == null).toBe(true)
 
       const fetched = await payload.findByID({
         collection: queryPresetsCollectionSlug,
@@ -838,8 +838,8 @@ describe('Query Presets', () => {
         id: result.id,
       })
 
-      expect(fetched.where).toBeUndefined()
-      expect(fetched.columns).toBeUndefined()
+      expect(fetched.where == null).toBe(true)
+      expect(fetched.columns == null).toBe(true)
     })
   })
 })

--- a/test/query-presets/payload-types.ts
+++ b/test/query-presets/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     pages: Page;
     posts: Post;
     users: User;
+    'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -80,6 +81,7 @@ export interface Config {
     pages: PagesSelect<false> | PagesSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -88,6 +90,7 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
+  fallbackLocale: null;
   globals: {};
   globalsSelect: {};
   locale: null;
@@ -166,23 +169,31 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
   id: string;
-  document?:
-    | ({
-        relationTo: 'pages';
-        value: string | Page;
-      } | null)
-    | ({
-        relationTo: 'posts';
-        value: string | Post;
-      } | null)
-    | ({
-        relationTo: 'users';
-        value: string | User;
-      } | null);
+  document?: {
+    relationTo: 'users';
+    value: string | User;
+  } | null;
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
@@ -317,6 +328,14 @@ export interface UsersSelect<T extends boolean = true> {
         createdAt?: T;
         expiresAt?: T;
       };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?

Fixes a crash when creating query presets with no filters (`where`) or columns in Postgres/SQLite.

### Why?

When you save a query preset without any `where` filters or `columns`, SQL databases store these as `NULL`. When the UI tries to render or sanitize these presets, it calls `Object.keys()` on null values and crashes with `TypeError: Cannot convert undefined or null to object`.

This only happens in Postgres/SQLite because MongoDB doesn't store missing fields at all - they just come back as `undefined`. SQL databases explicitly store `NULL` values.

### How?

Added null checks before calling `Object.keys()` in three places:
- `sanitizeQuery.ts` - The main fix that prevents the crash when loading presets
- `WhereField` component - Defensive check when rendering the where field
- `WhereCell` component - Defensive check when rendering the where cell in tables

Fixes #14719 
