### PR TITLE
feat: add augmentable interfaces for collection and global custom properties

### DIFF
--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -35,6 +35,8 @@ import type {
 } from '../../fields/config/types.js'
 import type { CollectionFoldersConfiguration } from '../../folders/types.js'
 import type {
+  CollectionAdminCustom,
+  CollectionCustom,
   CollectionSlug,
   JsonObject,
   RequestContext,
@@ -383,7 +385,7 @@ export type CollectionAdminOptions = {
     }
   }
   /** Extension point to add your custom data. Available in server and client. */
-  custom?: Record<string, any>
+  custom?: CollectionAdminCustom
   /**
    * Default columns to show in list view
    */
@@ -506,7 +508,7 @@ export type CollectionConfig<TSlug extends CollectionSlug = any> = {
    */
   auth?: boolean | IncomingAuthType
   /** Extension point to add your custom data. Server only. */
-  custom?: Record<string, any>
+  custom?: CollectionCustom
   /**
    * Used to override the default naming of the database table or collection with your using a function or string
    * @WARNING: If you change this property with existing data, you will need to handle the renaming of the table in your database or by using migrations

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -23,7 +23,14 @@ import type {
 } from '../../config/types.js'
 import type { DBIdentifierName } from '../../database/types.js'
 import type { Field, FlattenedField } from '../../fields/config/types.js'
-import type { GlobalSlug, RequestContext, TypedGlobal, TypedGlobalSelect } from '../../index.js'
+import type {
+  GlobalAdminCustom,
+  GlobalCustom,
+  GlobalSlug,
+  RequestContext,
+  TypedGlobal,
+  TypedGlobalSelect,
+} from '../../index.js'
 import type { PayloadRequest, SelectIncludeType, Where } from '../../types/index.js'
 import type { IncomingGlobalVersions, SanitizedGlobalVersions } from '../../versions/types.js'
 
@@ -134,7 +141,7 @@ export type GlobalAdminOptions = {
     }
   }
   /** Extension point to add your custom data. Available in server and client. */
-  custom?: Record<string, any>
+  custom?: GlobalAdminCustom
   /**
    * Custom description for collection
    */
@@ -179,7 +186,7 @@ export type GlobalConfig<TSlug extends GlobalSlug = any> = {
   }
   admin?: GlobalAdminOptions
   /** Extension point to add your custom data. Server only. */
-  custom?: Record<string, any>
+  custom?: GlobalCustom
   /**
    * Customize the SQL table name
    */

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1459,6 +1459,14 @@ export {
 
 export interface FieldCustom extends Record<string, any> {}
 
+export interface CollectionCustom extends Record<string, any> {}
+
+export interface CollectionAdminCustom extends Record<string, any> {}
+
+export interface GlobalCustom extends Record<string, any> {}
+
+export interface GlobalAdminCustom extends Record<string, any> {}
+
 export { sanitizeFields } from './fields/config/sanitize.js'
 
 export type {

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -212,7 +212,7 @@ declare module 'payload' {
     'plugin-import-export'?: {
       /**
        * When `true` the field is **completely excluded** from the import-export plugin:
-       * - It will not appear in the “Fields to export” selector.
+       * - It will not appear in the "Fields to export" selector.
        * - It is hidden from the preview list when no specific fields are chosen.
        * - Its data is omitted from the final CSV / JSON export.
        * @default false
@@ -222,6 +222,16 @@ declare module 'payload' {
        * Custom function used to modify the outgoing csv data by manipulating the data, siblingData or by returning the desired value
        */
       toCSV?: ToCSVFunction
+    }
+  }
+
+  export interface CollectionAdminCustom {
+    'plugin-import-export'?: {
+      /**
+       * Array of field paths that are disabled for import/export.
+       * These paths are collected from fields marked with `custom['plugin-import-export'].disabled = true`.
+       */
+      disabledFields?: string[]
     }
   }
 }


### PR DESCRIPTION
### What?

Adds augmentable interfaces for the `custom` property on collections and globals:
- `CollectionCustom` 
- `CollectionAdminCustom` 
- `GlobalCustom` 
- `GlobalAdminCustom`

Also updates `plugin-import-export` to use `CollectionAdminCustom` for its internal storage.

### Why?

Fields already have `FieldCustom` which plugins can augment for type-safe custom config. Collections and globals were still using `Record<string, any>` directly, so there was no way to get proper types when building plugins that need collection/global-level configuration.

This made it annoying to build well-typed plugins since you'd lose all type safety and autocomplete at the collection/global level.

### How?

- Added the four interfaces (same pattern as `FieldCustom` - empty interfaces extending `Record<string, any>`)
- Updated the type definitions in `collections/config/types.ts` and `globals/config/types.ts` to use them
- Updated `plugin-import-export` to augment `CollectionAdminCustom` so it gets proper types for the `disabledFields` array it stores

Fixes #14724 

