### PR TITLE
fix: add beforeOperation hook in findVersions collections operations

### DIFF
--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -55,6 +55,42 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
 
   try {
     // /////////////////////////////////////
+    // beforeOperation - Collection
+    // /////////////////////////////////////
+
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection.config,
+            context: args.req!.context,
+            operation: 'read',
+            req: args.req!,
+          })) || args
+      }
+    }
+
+    const {
+      collection: { config: collectionConfig },
+      collection,
+      depth,
+      limit,
+      overrideAccess,
+      page,
+      pagination = true,
+      populate,
+      select: incomingSelect,
+      showHiddenFields,
+      sort: incomingSort,
+      trash = false,
+      where,
+    } = args
+
+    const req = args.req!
+    const { fallbackLocale, locale, payload } = req
+
+    // /////////////////////////////////////
     // Access
     // /////////////////////////////////////
 


### PR DESCRIPTION
### What?

Fixes the beforeOperation collection hook being called when using the findVersions operation, just as it is for the standard find operation.

### Why?

Previously, the beforeOperation hook was only triggered for standard find operations, but not for findVersions. This led to inconsistent behavior, as custom logic (such as access control, logging, or argument modification) defined in beforeOperation would not run when querying document versions. This PR brings parity and predictability to hook execution across both operations.

### How?

The logic for invoking the beforeOperation hook (as seen in find.ts) was added to findVersions.ts.
Now, when findVersions is called, all registered beforeOperation hooks are executed with the correct arguments before the main operation logic runs.

Fixes 
https://github.com/payloadcms/payload/issues/14726

