### PR TITLE
fix(richtext-lexical): export serverInlineBlock modules

### DIFF
--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -864,20 +864,21 @@ export function lexicalEditor(args?: LexicalEditorProps): LexicalRichTextAdapter
 
 export { AlignFeature } from './features/align/server/index.js'
 export { BlockquoteFeature } from './features/blockquote/server/index.js'
-export {
-  $createInlineBlockNode,
-  $isInlineBlockNode,
-  InlineBlockNode,
-} from './features/blocks/client/nodes/InlineBlocksNode.js'
 export { CodeBlock } from './features/blocks/premade/CodeBlock/index.js'
 export { BlocksFeature, type BlocksFeatureProps } from './features/blocks/server/index.js'
-
 export {
   $createServerBlockNode,
   $isServerBlockNode,
   type BlockFields,
   ServerBlockNode,
 } from './features/blocks/server/nodes/BlocksNode.js'
+
+export {
+  $createServerInlineBlockNode,
+  $isServerInlineBlockNode,
+  type InlineBlockFields,
+  ServerInlineBlockNode,
+} from './features/blocks/server/nodes/InlineBlocksNode.js'
 
 export { convertHTMLToLexical } from './features/converters/htmlToLexical/index.js'
 

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -864,6 +864,11 @@ export function lexicalEditor(args?: LexicalEditorProps): LexicalRichTextAdapter
 
 export { AlignFeature } from './features/align/server/index.js'
 export { BlockquoteFeature } from './features/blockquote/server/index.js'
+export {
+  $createInlineBlockNode,
+  $isInlineBlockNode,
+  InlineBlockNode,
+} from './features/blocks/client/nodes/InlineBlocksNode.js'
 export { CodeBlock } from './features/blocks/premade/CodeBlock/index.js'
 export { BlocksFeature, type BlocksFeatureProps } from './features/blocks/server/index.js'
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/pull/14739

Similar to ServerBlockNode and related modules, which we are already exporting. We forgot to export these.

Discord discussion: https://discord.com/channels/967097582721572934/1443201774415777853