### PR TITLE
fix(plugin-multi-tenant): auto assign tenant when autosave is enabled

### DIFF
--- a/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
@@ -32,6 +32,7 @@ const fieldValidation =
 
 type Args = {
   debug?: boolean
+  isDraftsEnabled?: boolean
   name: string
   overrides?: RootTenantFieldConfigOverrides
   tenantsArrayFieldName: string
@@ -42,6 +43,7 @@ type Args = {
 export const tenantField = ({
   name = defaults.tenantFieldName,
   debug,
+  isDraftsEnabled,
   overrides: _overrides = {},
   tenantsArrayFieldName = defaults.tenantsArrayFieldName,
   tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
@@ -101,6 +103,15 @@ export const tenantField = ({
             },
           })
           return isValidTenant ? tenantFromCookie : null
+        }
+        if (req.user && isDraftsEnabled) {
+          const userTenants = getUserTenantIDs(req.user, {
+            tenantsArrayFieldName,
+            tenantsArrayTenantFieldName,
+          })
+          if (userTenants.length > 0) {
+            return userTenants[0]
+          }
         }
         return null
       }),

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -190,6 +190,11 @@ export const multiTenantPlugin =
             tenantField({
               name: tenantFieldName,
               debug: pluginConfig.debug,
+              isDraftsEnabled: Boolean(
+                collection.versions &&
+                  typeof collection.versions === 'object' &&
+                  collection.versions.drafts,
+              ),
               overrides: pluginConfig.collections[collection.slug]?.tenantFieldOverrides
                 ? pluginConfig.collections[collection.slug]?.tenantFieldOverrides
                 : pluginConfig.tenantField || {},
@@ -376,6 +381,11 @@ export const multiTenantPlugin =
             tenantField({
               name: tenantFieldName,
               debug: pluginConfig.debug,
+              isDraftsEnabled: Boolean(
+                collection.versions &&
+                  typeof collection.versions === 'object' &&
+                  collection.versions.drafts,
+              ),
               overrides: pluginConfig.collections[collection.slug]?.tenantFieldOverrides
                 ? pluginConfig.collections[collection.slug]?.tenantFieldOverrides
                 : pluginConfig.tenantField || {},


### PR DESCRIPTION
When autosave is enabled, mutli-tenant would not auto-assign the tenant since we implemented the modal overlay allowing you to select the tenant for the new document. When autosave is enabled the doc saves and redirects to the edit view, but the user is unable to set the tenant in the modal because it does not show. So then the user would not have access to the document because there was no assigned tenant. 

This fix auto-assigns a tenant when autosave is enabled on a collection.