### PR TITLE
fix: should exclude svg files from file buffer mime validation

### DIFF
--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -90,8 +90,9 @@ export const checkFileRestrictions = async ({
     let detected = await fileTypeFromBuffer(file.data)
     const typeFromExtension = file.name.split('.').pop() || ''
 
-    // Handle SVG files as they are not detected by `file-type`
+    // Handle SVG files that are detected as XML due to <?xml declarations
     if (
+      detected?.mime === 'application/xml' &&
       configMimeTypes.some(
         (type) => type.includes('image/') && (type.includes('svg') || type === 'image/*'),
       )

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -151,6 +151,24 @@ describe('Collections - Uploads', () => {
         expect(doc.height).toBeDefined()
       })
 
+      it('should upload svg in an image mimetype restricted collection', async () => {
+        const filePath = path.join(dirname, './image.svg')
+        const formData = new FormData()
+        const { file, handle } = await createStreamableFile(filePath)
+        formData.append('file', file)
+
+        const response = await restClient.POST(`/any-images`, {
+          body: formData,
+          file,
+        })
+
+        const { doc } = await response.json()
+        await handle.close()
+
+        expect(response.status).toBe(201)
+        expect(doc.mimeType).toEqual('image/svg+xml')
+      })
+
       it('should have valid image url', async () => {
         const formData = new FormData()
         const filePath = path.join(dirname, './image.svg')


### PR DESCRIPTION
### What?
Fix bug of `svg` files throwing an error when `mimeTypes: ['image/*']` is set.

### Why?
We recently added an additional mime type check on the buffer however the `file-buffer` package that we use to detect file type does not support svgs.

### How?
Updates `expectsDetectableType` logic to exclude svgs.

Fixes #14743

