### PR TITLE
fix(translations): correct French translation for 'move' action

### DIFF
--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -350,7 +350,7 @@ export const frTranslations: DefaultTranslationsObject = {
     locales: 'Paramètres régionaux',
     menu: 'Menu',
     moreOptions: "Plus d'options",
-    move: 'Déplacez-vous',
+    move: 'Déplacer',
     moveConfirm:
       'Vous êtes sur le point de déplacer {{count}} {{label}} vers <1>{{destination}}</1>. Êtes-vous sûr ?',
     moveCount: 'Déplacez {{count}} {{label}}',


### PR DESCRIPTION
- [X] I did review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md).

### What?
Changed the French translation of the 'move' action from `Déplacez-vous﻿` to `Déplacer`.

### Why?
The original translation translates to "move yourself," which sounds awkward. The corrected version is the standard translation that French-speaking users expect to see in interfaces.