### PR TITLE
fix: add missing beforeInput and afterInput properties to UploadAdmin type

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1018,6 +1018,8 @@ type SharedUploadPropertiesClient = FieldBaseClient &
 type UploadAdmin = {
   allowCreate?: boolean
   components?: {
+    afterInput?: CustomComponent[]
+    beforeInput?: CustomComponent[]
     Error?: CustomComponent<
       RelationshipFieldErrorClientComponent | RelationshipFieldErrorServerComponent
     >


### PR DESCRIPTION
### What?

This PR adds the missing `beforeInput` and `afterInput` properties to the `UploadAdmin` type so that the type definition reflects the actual supported admin props for upload fields.

### Why?

Although upload fields [already support `beforeInput` and `afterInput`](https://github.com/payloadcms/payload/blob/fb93cd13bcd66dca3777826fc420a941d3cb75ab/packages/ui/src/fields/Upload/index.tsx#L51) in practice, these props are currently not included in the `UploadAdmin` TypeScript type. This leads to type errors or the need for type assertions when trying to use them. Aligning the type definition with the existing runtime behavior improves DX and keeps the admin field types consistent, similar to what was done for RichTextField in #12889.

### How?

Extended the UploadAdmin type to include the `beforeInput` and `afterInput` properties.