### PR TITLE
fix: remove "all" from JSDoc comment on supported http methods in endpoints

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -346,7 +346,7 @@ export type Endpoint = {
    * Compatible with Web Request/Response Model
    */
   handler: PayloadHandler
-  /** HTTP method (or "all") */
+  /** HTTP method */
   method: 'connect' | 'delete' | 'get' | 'head' | 'options' | 'patch' | 'post' | 'put'
   /**
    * Pattern that should match the path of the incoming request


### PR DESCRIPTION
Removes the suggestion that "all" is a supported HTTP method in endpoints since it's not supported and it's not a valid method either.

Closes https://github.com/payloadcms/payload/issues/14732