### PR TITLE
fix(plugin-import-export): incorrect user type in Export causing runtime type mismatch

### DIFF
--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -39,7 +39,7 @@ export type Export = {
  * along with the collection name so it can be rehydrated when the job runs.
  */
 export type ExportJobInput = {
-  user: string
+  user: number | string
   userCollection: string
 } & Export
 

--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -33,16 +33,6 @@ export type Export = {
   where?: Where
 }
 
-/**
- * Export input type for job queue serialization.
- * When exports are queued as jobs, the user must be serialized as an ID string
- * along with the collection name so it can be rehydrated when the job runs.
- */
-export type ExportJobInput = {
-  user: number | string
-  userCollection: string
-} & Export
-
 export type CreateExportArgs = {
   /**
    * If true, stream the file instead of saving it

--- a/packages/plugin-import-export/src/export/download.ts
+++ b/packages/plugin-import-export/src/export/download.ts
@@ -18,12 +18,12 @@ export const download = async (req: PayloadRequest, debug = false) => {
     const { collectionSlug } = body.data || {}
 
     req.payload.logger.info(`Download request received ${collectionSlug}`)
-    body.data.user = req.user
 
     const res = await createExport({
       download: true,
       input: { ...body.data, debug },
       req,
+      user: req.user,
     })
 
     return res as Response

--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -1,10 +1,20 @@
 import type { Config, PayloadRequest, TaskConfig, TypedUser } from 'payload'
 
 import type { ImportExportPluginConfig } from '../types.js'
-import type { ExportJobInput } from './createExport.js'
+import type { Export } from './createExport.js'
 
 import { createExport } from './createExport.js'
 import { getFields } from './getFields.js'
+
+/**
+ * Export input type for job queue serialization.
+ * When exports are queued as jobs, the user must be serialized as an ID string
+ * along with the collection name so it can be rehydrated when the job runs.
+ */
+export type ExportJobInput = {
+  user: number | string
+  userCollection: string
+} & Export
 
 export const getCreateCollectionExportTask = (
   config: Config,

--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -8,7 +8,7 @@ import { getFields } from './getFields.js'
 
 /**
  * Export input type for job queue serialization.
- * When exports are queued as jobs, the user must be serialized as an ID string
+ * When exports are queued as jobs, the user must be serialized as an ID string or number
  * along with the collection name so it can be rehydrated when the job runs.
  */
 export type ExportJobInput = {
@@ -48,6 +48,8 @@ export const getCreateCollectionExportTask = (
           id: input.user,
           collection: input.userCollection,
         })) as TypedUser
+
+        req.user = user
       }
 
       if (!user) {

--- a/packages/plugin-import-export/src/getExportCollection.ts
+++ b/packages/plugin-import-export/src/getExportCollection.ts
@@ -86,7 +86,7 @@ export const getExportCollection = ({
         ...doc,
         exportsCollection: collection.slug,
         user: req?.user?.id || req?.user?.user?.id,
-        userCollection: 'users',
+        userCollection: req.payload.config.admin.user,
       }
       await req.payload.jobs.queue({
         input,

--- a/packages/plugin-import-export/src/getExportCollection.ts
+++ b/packages/plugin-import-export/src/getExportCollection.ts
@@ -74,7 +74,7 @@ export const getExportCollection = ({
       }
       const { user } = req
       const debug = pluginConfig.debug
-      await createExport({ input: { ...args.data, debug, user }, req })
+      await createExport({ input: { ...args.data, debug }, req, user })
     })
   } else {
     afterChange.push(async ({ doc, operation, req }) => {


### PR DESCRIPTION
### What?

Separated user serialization concerns from runtime user handling in the export plugin by moving `user` and `userCollection` fields out of the base `Export` type into a new `ExportJobInput` type, and using a separate `user` parameter in `CreateExportArgs`.

### Why?

The `Export` type had `user: string` which was meant for job queue serialization, but when exports ran directly (without job queue), the full user object was being passed where a string was expected. This created a type mismatch that only worked by accident at runtime.

### How?

- Removed `user` and `userCollection` from base `Export` type
- Created `ExportJobInput` type that extends `Export` with serialization fields
- Updated `CreateExportArgs` to accept `user?: TypedUser | null` as separate parameter
- Fixed all call sites to pass user separately instead of in input object
- Added validation to ensure user exists before creating exports
- Job queue handler now strips serialization fields before passing to `createExport`
