### PR TITLE
feat(next): add experimentalTurbopackBuild option

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -2,6 +2,8 @@
  * @param {import('next').NextConfig} nextConfig
  * @param {Object} [options] - Optional configuration options
  * @param {boolean} [options.devBundleServerPackages] - Whether to bundle server packages in development mode. @default false
+ * @param {boolean} [options.experimentalTurbopackBuild] - Allow Turbopack production builds on Next 15/16 (experimental, may increase server bundle size).
+ *   May require adding your database adapter, `@payloadcms/drizzle`, `drizzle-kit`, `esbuild`, and `thread-stream` to `serverExternalPackages` in next.config. @default false
  *
  * @returns {import('next').NextConfig}
  * */
@@ -56,9 +58,16 @@ export const withPayload = (nextConfig = {}, options = {}) => {
   const isTurbopackNextjs15 = process.env.TURBOPACK === '1'
   const isTurbopackNextjs16 = process.env.TURBOPACK === 'auto'
 
-  if (isBuild && (isTurbopackNextjs15 || isTurbopackNextjs16)) {
+  if (
+    isBuild &&
+    (isTurbopackNextjs15 || isTurbopackNextjs16) &&
+    !options.experimentalTurbopackBuild
+  ) {
     throw new Error(
-      'Payload does not support using Turbopack for production builds. If you are using Next.js 16, please use `next build --webpack` instead.',
+      'Payload does not support using Turbopack for production builds. If you are using Next.js 16, please use `next build --webpack` instead. ' +
+        'Alternatively, you can pass `experimentalTurbopackBuild: true` to withPayload() to bypass this check. ' +
+        'Note: this is experimental and may increase server bundle size. ' +
+        'See https://github.com/payloadcms/payload/pull/14696 for details.',
     )
   }
 


### PR DESCRIPTION
### What?

Adds an `experimentalTurbopackBuild` option to `withPayload()` that allows users to bypass the Turbopack production build check introduced in #14696.

### Why?

PR #14696 disabled Turbopack for production builds due to concerns about bundle size increases. However, some users may prefer the significantly faster build times Turbopack offers and are willing to accept the trade-off.

**Build comparison on a real-world Payload project (Next.js 16, Payload 3.64.0):**

| Metric | Turbopack | Webpack | Difference |
|--------|-----------|---------|------------|
| Compile time | 9.1s | 24.2s | **Turbopack 2.6x faster** |
| `.next/server` | 888M | 693M | Webpack 22% smaller |
| `.next/static` | 11M | 10M | ~same |

The server bundle is ~28% larger with Turbopack, but build times are significantly faster. This PR gives users the choice rather than blocking Turbopack entirely.

### How?

- Added `experimentalTurbopackBuild` option to `withPayload()` options
- When `true`, bypasses the Turbopack build check
- Updated error message to inform users about the option
- JSDoc documents the option and notes that users may need to add packages to `serverExternalPackages`

**Usage:**
```js
// next.config.mjs
export default withPayload(nextConfig, { experimentalTurbopackBuild: true })
// Users may also need to add the following to their next.config.mjs:
serverExternalPackages: [
  '@payloadcms/db-postgres', // or your database adapter
  '@payloadcms/drizzle',
  'drizzle-kit',
  'esbuild',
  'thread-stream',
],
```

Related:
[PR: 14696](https://github.com/payloadcms/payload/pull/14696)
[Issue: 14786](https://github.com/payloadcms/payload/issues/14786)

