### PR TITLE
fix(ui): prevent NaN page parameter in polymorphic relationship pagination

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -227,7 +227,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
             if (search !== searchArg) {
               lastLoadedPageToUse = 1
             } else {
-              lastLoadedPageToUse = lastLoadedPageArg[relation] + 1
+              lastLoadedPageToUse = (lastLoadedPageArg[relation] || 0) + 1
             }
             await priorRelation
 

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -285,29 +285,28 @@ describe('Relationship Field', () => {
   })
 
   test('should paginate polymorphic relationship correctly and not send NaN page parameter', async () => {
-    // Create 15 docs for each relation type
     const relationOneIDs: string[] = []
     const relationTwoIDs: string[] = []
 
-    // Create 15 relationOne docs
+    // Create 15 relationOne docs to simulate pagination in the dropdown
     for (let i = 0; i < 15; i++) {
-      const doc = (await payload.create({
+      const doc = await payload.create({
         collection: relationOneSlug,
         data: {
           name: `relation-one-${i}`,
         },
-      })) as any
+      })
       relationOneIDs.push(doc.id)
     }
 
-    // Create 15 relationTwo docs
+    // Create 15 relationOne docs to simulate pagination in the dropdown
     for (let i = 0; i < 15; i++) {
-      const doc = (await payload.create({
+      const doc = await payload.create({
         collection: relationTwoSlug,
         data: {
           name: `relation-two-${i}`,
         },
-      })) as any
+      })
       relationTwoIDs.push(doc.id)
     }
 
@@ -315,43 +314,31 @@ describe('Relationship Field', () => {
 
     const field = page.locator('#field-relationshipHasManyMultiple')
 
-    // Click to open dropdown
     await field.click({ delay: 100 })
 
-    // Wait for initial options to load and menu to be visible
     const menu = page.locator('.rs__menu-list')
     await expect(menu).toBeVisible()
     await wait(300)
 
-    // Verify we have some initial options
     const options = page.locator('.rs__option')
     await expect(options.first()).toBeVisible()
 
-    // Scroll to the bottom multiple times to trigger pagination for both collection types
-    // First scroll loads more relationOne docs
-    await menu.evaluate((node) => {
-      node.scrollTop = node.scrollHeight
-    })
-    await wait(500)
+    // Hover over the menu and use mouse wheel to scroll and trigger pagination
+    await menu.hover()
 
-    // Second scroll should trigger loading more relationTwo docs (page 2)
-    await menu.evaluate((node) => {
-      node.scrollTop = node.scrollHeight
-    })
-    await wait(500)
+    // Scroll down multiple times using mouse wheel to trigger onMenuScrollToBottom
+    for (let i = 0; i < 5; i++) {
+      await menu.hover()
+      await page.mouse.wheel(0, 500)
+      await wait(300)
+    }
 
-    // Third scroll to ensure we've loaded page 2 of relationTwo
-    await menu.evaluate((node) => {
-      node.scrollTop = node.scrollHeight
-    })
-    await wait(500)
-
-    // Check that we can see the 11th doc from relationTwo (which would be on page 2)
+    // Check that we can see the 14th doc from relationTwo (which would be on page 2)
     // Before the fix, page 2 of relationTwo wouldn't load because page parameter was NaN
-    const eleventhRelationTwoDoc = relationTwoIDs[10] // Index 10 = 11th doc (page 2, item 1)
+    const fourteenthRelationTwoDoc = relationTwoIDs[13] // Index 13 = 14th doc (page 2, item 4)
 
-    // The 11th relationTwo doc should be visible in the dropdown
-    await expect(options.locator(`text=${eleventhRelationTwoDoc}`)).toBeVisible()
+    // The 14th relationTwo doc should be visible in the dropdown
+    await expect(options.locator(`text=${fourteenthRelationTwoDoc}`)).toBeVisible()
   })
 
   test('should duplicate document with relationships', async () => {


### PR DESCRIPTION
### What

Fixed pagination bug in polymorphic relationship fields where the second collection type would fail to load additional pages due to sending `page=NaN` in the request.

### Why

When paginating through a polymorphic relationship dropdown, `lastLoadedPageArg[relation]` was `undefined` for collections that hadn't been loaded yet. This caused the page parameter to become `NaN` (`undefined + 1 = NaN`), breaking pagination for subsequent collection types.

### How

Added a fallback to default to `0` when the relation hasn't been paginated yet:

```typescript
lastLoadedPageToUse = (lastLoadedPageArg[relation] || 0) + 1
```

Fixes #14754 