### PR TITLE
fix: simplify import/export types

### DIFF
--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -17,10 +17,9 @@ import { getSelect } from './getSelect.js'
 export type CreateExportArgs = {
   debug?: boolean
   /**
-   * If true, stream the file instead of saving it
+   * The fields on the export document
    */
-  download?: boolean
-  input: (
+  doc: (
     | {
         exportsCollection?: never
         id?: never
@@ -31,6 +30,10 @@ export type CreateExportArgs = {
       }
   ) &
     Omit<MockExportCollectionData, 'id'>
+  /**
+   * If true, stream the file instead of saving it
+   */
+  download?: boolean
   req: PayloadRequest
   user?: null | TypedUser
 }
@@ -39,7 +42,7 @@ export const createExport = async (args: CreateExportArgs) => {
   const {
     download,
     debug = false,
-    input: {
+    doc: {
       id,
       name: nameArg,
       collectionSlug,

--- a/packages/plugin-import-export/src/export/download.ts
+++ b/packages/plugin-import-export/src/export/download.ts
@@ -2,6 +2,8 @@ import type { PayloadRequest } from 'payload'
 
 import { APIError } from 'payload'
 
+import type { MockExportCollectionData } from '../types.js'
+
 import { createExport } from './createExport.js'
 
 export const download = async (req: PayloadRequest, debug = false) => {
@@ -15,13 +17,15 @@ export const download = async (req: PayloadRequest, debug = false) => {
       throw new APIError('Request data is required.')
     }
 
-    const { collectionSlug } = body.data || {}
+    const data = body.data as MockExportCollectionData
+    const { collectionSlug } = data || {}
 
     req.payload.logger.info(`Download request received ${collectionSlug}`)
 
     const res = await createExport({
+      debug,
       download: true,
-      input: { ...body.data, debug },
+      input: { ...data },
       req,
       user: req.user,
     })

--- a/packages/plugin-import-export/src/export/download.ts
+++ b/packages/plugin-import-export/src/export/download.ts
@@ -24,8 +24,8 @@ export const download = async (req: PayloadRequest, debug = false) => {
 
     const res = await createExport({
       debug,
+      doc: { ...data },
       download: true,
-      input: { ...data },
       req,
       user: req.user,
     })

--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -52,9 +52,9 @@ export const getCreateCollectionExportTask = (
       }
 
       // Strip out user and userCollection from input - they're only needed for rehydration
-      const { user: _userId, userCollection: _userCollection, ...exportInput } = input
+      const { doc, user: _userId, userCollection: _userCollection } = input
 
-      await createExport({ input: exportInput, req, user })
+      await createExport({ doc, req, user })
 
       return {
         output: {},

--- a/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
+++ b/packages/plugin-import-export/src/export/getCreateExportCollectionTask.ts
@@ -1,7 +1,6 @@
 import type { Config, PayloadRequest, TaskConfig, TypedUser } from 'payload'
 
-import type { ImportExportPluginConfig } from '../types.js'
-import type { Export } from './createExport.js'
+import type { ExportJobInputData, ImportExportPluginConfig } from '../types.js'
 
 import { createExport } from './createExport.js'
 import { getFields } from './getFields.js'
@@ -11,16 +10,12 @@ import { getFields } from './getFields.js'
  * When exports are queued as jobs, the user must be serialized as an ID string or number
  * along with the collection name so it can be rehydrated when the job runs.
  */
-export type ExportJobInput = {
-  user: number | string
-  userCollection: string
-} & Export
 
 export const getCreateCollectionExportTask = (
   config: Config,
   pluginConfig?: ImportExportPluginConfig,
 ): TaskConfig<{
-  input: ExportJobInput
+  input: ExportJobInputData
   output: object
 }> => {
   const inputSchema = getFields(config, pluginConfig).concat(
@@ -40,7 +35,7 @@ export const getCreateCollectionExportTask = (
 
   return {
     slug: 'createCollectionExport',
-    handler: async ({ input, req }: { input: ExportJobInput; req: PayloadRequest }) => {
+    handler: async ({ input, req }: { input: ExportJobInputData; req: PayloadRequest }) => {
       let user: TypedUser | undefined
 
       if (input.userCollection && input.user) {

--- a/packages/plugin-import-export/src/getExportCollection.ts
+++ b/packages/plugin-import-export/src/getExportCollection.ts
@@ -5,7 +5,12 @@ import type {
   Config,
 } from 'payload'
 
-import type { CollectionOverride, ImportExportPluginConfig } from './types.js'
+import type {
+  CollectionOverride,
+  ExportJobInputData,
+  ImportExportPluginConfig,
+  MockExportCollectionData,
+} from './types.js'
 
 import { createExport } from './export/createExport.js'
 import { download } from './export/download.js'
@@ -74,7 +79,12 @@ export const getExportCollection = ({
       }
       const { user } = req
       const debug = pluginConfig.debug
-      await createExport({ input: { ...args.data, debug }, req, user })
+      await createExport({
+        debug,
+        input: { ...(args.data as MockExportCollectionData) },
+        req,
+        user,
+      })
     })
   } else {
     afterChange.push(async ({ doc, operation, req }) => {
@@ -82,7 +92,7 @@ export const getExportCollection = ({
         return
       }
 
-      const input = {
+      const input: ExportJobInputData = {
         ...doc,
         exportsCollection: collection.slug,
         user: req?.user?.id || req?.user?.user?.id,

--- a/packages/plugin-import-export/src/getExportCollection.ts
+++ b/packages/plugin-import-export/src/getExportCollection.ts
@@ -81,7 +81,7 @@ export const getExportCollection = ({
       const debug = pluginConfig.debug
       await createExport({
         debug,
-        input: { ...(args.data as MockExportCollectionData) },
+        doc: { ...(args.data as MockExportCollectionData) },
         req,
         user,
       })
@@ -93,7 +93,7 @@ export const getExportCollection = ({
       }
 
       const input: ExportJobInputData = {
-        ...doc,
+        doc,
         exportsCollection: collection.slug,
         user: req?.user?.id || req?.user?.user?.id,
         userCollection: req.payload.config.admin.user,

--- a/packages/plugin-import-export/src/types.ts
+++ b/packages/plugin-import-export/src/types.ts
@@ -114,7 +114,8 @@ export type MockExportCollectionData = {
 }
 
 export type ExportJobInputData = {
+  doc: MockExportCollectionData
   exportsCollection: string
   user?: null | number | string
   userCollection: string
-} & MockExportCollectionData
+}

--- a/packages/plugin-import-export/src/types.ts
+++ b/packages/plugin-import-export/src/types.ts
@@ -77,3 +77,44 @@ export type ToCSVFunction = (args: {
    */
   value: unknown
 }) => unknown
+
+export type MockExportCollectionData = {
+  collectionSlug: string
+  createdAt: string
+  drafts?: ('no' | 'yes') | null
+  fields?: null | string[]
+  filename?: null | string
+  filesize?: null | number
+  focalX?: null | number
+  focalY?: null | number
+  format?: ('csv' | 'json') | null
+  height?: null | number
+  id: string
+  limit?: null | number
+  locale?: ('all' | 'de' | 'en' | 'es') | null
+  mimeType?: null | string
+  name?: null | string
+  page?: null | number
+  selectionToUse?: ('all' | 'currentFilters' | 'currentSelection') | null
+  sort?: null | string
+  sortOrder?: ('asc' | 'desc') | null
+  thumbnailURL?: null | string
+  updatedAt: string
+  url?: null | string
+  where?:
+    | {
+        [k: string]: unknown
+      }
+    | boolean
+    | null
+    | number
+    | string
+    | unknown[]
+  width?: null | number
+}
+
+export type ExportJobInputData = {
+  exportsCollection: string
+  user?: null | number | string
+  userCollection: string
+} & MockExportCollectionData


### PR DESCRIPTION
Creates a helper type that can be used within the plugin since in a real project you would have generated types for collections that you could use. Here we just needed to mock a data type for the exports collection. The type comes from a generated export in the test collection.
