### PR TITLE
feat: Optional Email Sterilization

### DIFF
--- a/packages/payload/src/auth/baseFields/email.ts
+++ b/packages/payload/src/auth/baseFields/email.ts
@@ -13,7 +13,7 @@ export const emailFieldConfig: EmailField = {
   hooks: {
     beforeChange: [
       ({ value, field }) => {
-        if (value && 'steralize' in field && field.steralize) {
+        if (value && 'sterilize' in field && field.sterilize) {
           return value.toLowerCase().trim()
         }
       },
@@ -23,5 +23,5 @@ export const emailFieldConfig: EmailField = {
   required: true,
   unique: true,
   validate: email,
-  steralize: true,
+  sterilize: true,
 }

--- a/packages/payload/src/auth/baseFields/email.ts
+++ b/packages/payload/src/auth/baseFields/email.ts
@@ -12,8 +12,8 @@ export const emailFieldConfig: EmailField = {
   },
   hooks: {
     beforeChange: [
-      ({ value }) => {
-        if (value) {
+      ({ value, field }) => {
+        if (value && 'steralize' in field && field.steralize) {
           return value.toLowerCase().trim()
         }
       },
@@ -23,4 +23,5 @@ export const emailFieldConfig: EmailField = {
   required: true,
   unique: true,
   validate: email,
+  steralize: true,
 }

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -674,7 +674,8 @@ export type EmailField = {
     placeholder?: Record<string, string> | string
   } & FieldAdmin
   type: 'email'
-  validate?: EmailFieldValidation
+  validate?: EmailFieldValidation,
+  steralize?: boolean
 } & Omit<FieldBase, 'validate'>
 
 export type EmailFieldClient = {

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -675,7 +675,7 @@ export type EmailField = {
   } & FieldAdmin
   type: 'email'
   validate?: EmailFieldValidation,
-  steralize?: boolean
+  sterilize?: boolean
 } & Omit<FieldBase, 'validate'>
 
 export type EmailFieldClient = {


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change
-->


### What?
A small but valuable change for people who need to encrypt data.

### Why?
Currently there is no way (to mine and other's knowledge) to bypass the beforeChange hook for the email field within an auth collection. This makes it impossible for people to encrypt the field as it will lowercase and trim the encryption.

### How?
Added `sterilize?: boolean` to the `EmailField` type so people can conditionally turn on and off the beforeChange hook that payload automatically injects into the email field.

### Pictures of changed code
The changes are very small so the files changed should be pretty clear, but here are some screenshots!

#### After of email field and hook:
<img width="715" height="544" alt="Screenshot 2025-12-02 at 7 01 06 PM" src="https://github.com/user-attachments/assets/0aab3bd6-b923-47ba-8c0e-8687470945a4" /> 

#### After of the email field's type:
<img width="694" height="282" alt="Screenshot 2025-12-02 at 7 01 21 PM" src="https://github.com/user-attachments/assets/a6b57325-975e-4023-928c-17d0d834811c" />