### PR TITLE
docs: fix beforeChange field hook documentation to reflect actual behaviour

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -118,9 +118,7 @@ stored in a consistent format in the database.
 
 ### beforeChange
 
-Immediately following validation, `beforeChange` hooks will run within `create` and `update` operations. At this stage,
-you can be confident that the field data that will be saved to the document is valid in accordance to your field
-validations.
+Immediately before validation, beforeChange hooks will run during create and update operations. At this stage, the data should be treated as unvalidated user input. There is no guarantee that required fields exist or that fields are in the correct format. As such, using this data for side effects requires manual validation. You can optionally modify the shape of the data to be saved.
 
 ```ts
 import type { Field } from 'payload'


### PR DESCRIPTION
The current documentation is incorrect as `beforeChange` field hooks are called before field validation runs.

This updates the documentation for the `beforeChange` field hook to match the documentation for the `beforeChange` collection hook.

Related: https://github.com/payloadcms/payload/pull/12651