### PR TITLE
feat: add groupBy support to query presets

### DIFF
--- a/packages/payload/src/query-presets/config.ts
+++ b/packages/payload/src/query-presets/config.ts
@@ -14,7 +14,7 @@ export const getQueryPresetsConfig = (config: Config): CollectionConfig => ({
   slug: queryPresetsCollectionSlug,
   access: getAccess(config),
   admin: {
-    defaultColumns: ['title', 'isShared', 'access', 'where', 'columns'],
+    defaultColumns: ['title', 'isShared', 'access', 'where', 'columns', 'groupBy'],
     hidden: true,
     useAsTitle: 'title',
   },
@@ -93,6 +93,17 @@ export const getQueryPresetsConfig = (config: Config): CollectionConfig => ({
 
         return true
       },
+    },
+    {
+      name: 'groupBy',
+      type: 'text',
+      admin: {
+        components: {
+          Cell: '@payloadcms/ui#QueryPresetsGroupByCell',
+          Field: '@payloadcms/ui#QueryPresetsGroupByField',
+        },
+      },
+      label: 'Group By',
     },
     {
       name: 'relatedCollection',

--- a/packages/payload/src/query-presets/types.ts
+++ b/packages/payload/src/query-presets/types.ts
@@ -20,6 +20,7 @@ export type QueryPreset = {
     }
   }
   columns: CollectionPreferences['columns']
+  groupBy?: string
   id: number | string
   isShared: boolean
   relatedCollection: CollectionSlug

--- a/packages/ui/src/elements/QueryPresets/QueryPresetBar/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/QueryPresetBar/index.tsx
@@ -83,6 +83,7 @@ export const QueryPresetBar: React.FC<{
       await refineListData(
         {
           columns: preset.columns ? transformColumnsToSearchParams(preset.columns) : undefined,
+          groupBy: preset.groupBy || '',
           preset: preset.id,
           where: preset.where,
         },
@@ -96,6 +97,7 @@ export const QueryPresetBar: React.FC<{
     await refineListData(
       {
         columns: [],
+        groupBy: '',
         preset: '',
         where: {},
       },
@@ -141,6 +143,7 @@ export const QueryPresetBar: React.FC<{
       await fetch(`${apiRoute}/payload-query-presets/${activePreset.id}`, {
         body: JSON.stringify({
           columns: transformColumnsToPreferences(query.columns),
+          groupBy: query.groupBy,
           where: query.where,
         }),
         credentials: 'include',
@@ -178,6 +181,7 @@ export const QueryPresetBar: React.FC<{
     apiRoute,
     activePreset?.id,
     query.columns,
+    query.groupBy,
     query.where,
     t,
     presetConfig?.labels?.singular,
@@ -216,6 +220,7 @@ export const QueryPresetBar: React.FC<{
                 await refineListData(
                   {
                     columns: transformColumnsToSearchParams(activePreset.columns),
+                    groupBy: activePreset.groupBy || '',
                     where: activePreset.where,
                   },
                   false,
@@ -263,6 +268,7 @@ export const QueryPresetBar: React.FC<{
       <CreateNewPresetDrawer
         initialData={{
           columns: transformColumnsToPreferences(query.columns),
+          groupBy: query.groupBy,
           relatedCollection: collectionSlug,
           where: query.where,
         }}

--- a/packages/ui/src/elements/QueryPresets/cells/GroupByCell/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/cells/GroupByCell/index.tsx
@@ -1,9 +1,48 @@
 import type { DefaultCellComponentProps } from 'payload'
 
 import { toWords } from 'payload/shared'
-import React from 'react'
+import React, { useMemo } from 'react'
 
-export const QueryPresetsGroupByCell: React.FC<DefaultCellComponentProps> = ({ cellData }) => {
+import { useAuth } from '../../../../providers/Auth/index.js'
+import { useConfig } from '../../../../providers/Config/index.js'
+import { useTranslation } from '../../../../providers/Translation/index.js'
+import { reduceFieldsToOptions } from '../../../../utilities/reduceFieldsToOptions.js'
+
+export const QueryPresetsGroupByCell: React.FC<DefaultCellComponentProps> = ({
+  cellData,
+  rowData,
+}) => {
+  const { i18n } = useTranslation()
+  const { permissions } = useAuth()
+  const { config } = useConfig()
+
+  // Get the related collection from the row data
+  const relatedCollection = rowData?.relatedCollection as string
+
+  // Get the collection config for the related collection
+  const collectionConfig = useMemo(() => {
+    if (!relatedCollection) {
+      return null
+    }
+
+    return config.collections?.find((col) => col.slug === relatedCollection)
+  }, [relatedCollection, config.collections])
+
+  // Reduce fields to options to get proper labels
+  const reducedFields = useMemo(() => {
+    if (!collectionConfig) {
+      return []
+    }
+
+    const fieldPermissions = permissions?.collections?.[relatedCollection]?.fields
+
+    return reduceFieldsToOptions({
+      fieldPermissions,
+      fields: collectionConfig.fields,
+      i18n,
+    })
+  }, [collectionConfig, permissions, relatedCollection, i18n])
+
   if (!cellData || typeof cellData !== 'string') {
     return <div>No group by selected</div>
   }
@@ -12,9 +51,13 @@ export const QueryPresetsGroupByCell: React.FC<DefaultCellComponentProps> = ({ c
   const fieldName = isDescending ? cellData.slice(1) : cellData
   const direction = isDescending ? 'descending' : 'ascending'
 
+  // Find the field option to get the proper label
+  const fieldOption = reducedFields.find((field) => field.value === fieldName)
+  const displayLabel = fieldOption?.label || toWords(fieldName)
+
   return (
     <div>
-      {toWords(fieldName)} ({direction})
+      {displayLabel} ({direction})
     </div>
   )
 }

--- a/packages/ui/src/elements/QueryPresets/cells/GroupByCell/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/cells/GroupByCell/index.tsx
@@ -1,0 +1,20 @@
+import type { DefaultCellComponentProps } from 'payload'
+
+import { toWords } from 'payload/shared'
+import React from 'react'
+
+export const QueryPresetsGroupByCell: React.FC<DefaultCellComponentProps> = ({ cellData }) => {
+  if (!cellData || typeof cellData !== 'string') {
+    return <div>No group by selected</div>
+  }
+
+  const isDescending = cellData.startsWith('-')
+  const fieldName = isDescending ? cellData.slice(1) : cellData
+  const direction = isDescending ? 'descending' : 'ascending'
+
+  return (
+    <div>
+      {toWords(fieldName)} ({direction})
+    </div>
+  )
+}

--- a/packages/ui/src/elements/QueryPresets/fields/GroupByField/index.scss
+++ b/packages/ui/src/elements/QueryPresets/fields/GroupByField/index.scss
@@ -1,0 +1,17 @@
+@import '../../../../scss/styles';
+
+@layer payload-default {
+  .query-preset-group-by-field {
+    .field-label {
+      margin-bottom: calc(var(--base) / 2);
+    }
+
+    .value-wrapper {
+      background-color: var(--theme-elevation-50);
+      padding: var(--base);
+      display: flex;
+      flex-wrap: wrap;
+      gap: calc(var(--base) / 2);
+    }
+  }
+}

--- a/packages/ui/src/elements/QueryPresets/fields/GroupByField/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/fields/GroupByField/index.tsx
@@ -2,10 +2,14 @@
 import type { TextFieldClientComponent } from 'payload'
 
 import { toWords } from 'payload/shared'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { FieldLabel } from '../../../../fields/FieldLabel/index.js'
 import { useField } from '../../../../forms/useField/index.js'
+import { useAuth } from '../../../../providers/Auth/index.js'
+import { useConfig } from '../../../../providers/Config/index.js'
+import { useTranslation } from '../../../../providers/Translation/index.js'
+import { reduceFieldsToOptions } from '../../../../utilities/reduceFieldsToOptions.js'
 import { Pill } from '../../../Pill/index.js'
 import './index.scss'
 
@@ -13,6 +17,37 @@ export const QueryPresetsGroupByField: TextFieldClientComponent = ({
   field: { label, required },
 }) => {
   const { path, value } = useField()
+  const { i18n } = useTranslation()
+  const { permissions } = useAuth()
+  const { config } = useConfig()
+
+  // Get the relatedCollection from the document data
+  const relatedCollectionField = useField({ path: 'relatedCollection' })
+  const relatedCollection = relatedCollectionField.value as string
+
+  // Get the collection config for the related collection
+  const collectionConfig = useMemo(() => {
+    if (!relatedCollection) {
+      return null
+    }
+
+    return config.collections?.find((col) => col.slug === relatedCollection)
+  }, [relatedCollection, config.collections])
+
+  // Reduce fields to options to get proper labels
+  const reducedFields = useMemo(() => {
+    if (!collectionConfig) {
+      return []
+    }
+
+    const fieldPermissions = permissions?.collections?.[relatedCollection]?.fields
+
+    return reduceFieldsToOptions({
+      fieldPermissions,
+      fields: collectionConfig.fields,
+      i18n,
+    })
+  }, [collectionConfig, permissions, relatedCollection, i18n])
 
   const renderGroupBy = (groupByValue: string) => {
     if (!groupByValue) {
@@ -23,9 +58,13 @@ export const QueryPresetsGroupByField: TextFieldClientComponent = ({
     const fieldName = isDescending ? groupByValue.slice(1) : groupByValue
     const direction = isDescending ? 'descending' : 'ascending'
 
+    // Find the field option to get the proper label
+    const fieldOption = reducedFields.find((field) => field.value === fieldName)
+    const displayLabel = fieldOption?.label || toWords(fieldName)
+
     return (
       <Pill pillStyle="always-white" size="small">
-        <b>{toWords(fieldName)}</b> ({direction})
+        <b>{displayLabel}</b> ({direction})
       </Pill>
     )
   }

--- a/packages/ui/src/elements/QueryPresets/fields/GroupByField/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/fields/GroupByField/index.tsx
@@ -1,0 +1,39 @@
+'use client'
+import type { TextFieldClientComponent } from 'payload'
+
+import { toWords } from 'payload/shared'
+import React from 'react'
+
+import { FieldLabel } from '../../../../fields/FieldLabel/index.js'
+import { useField } from '../../../../forms/useField/index.js'
+import { Pill } from '../../../Pill/index.js'
+import './index.scss'
+
+export const QueryPresetsGroupByField: TextFieldClientComponent = ({
+  field: { label, required },
+}) => {
+  const { path, value } = useField()
+
+  const renderGroupBy = (groupByValue: string) => {
+    if (!groupByValue) {
+      return 'No group by selected'
+    }
+
+    const isDescending = groupByValue.startsWith('-')
+    const fieldName = isDescending ? groupByValue.slice(1) : groupByValue
+    const direction = isDescending ? 'descending' : 'ascending'
+
+    return (
+      <Pill pillStyle="always-white" size="small">
+        <b>{toWords(fieldName)}</b> ({direction})
+      </Pill>
+    )
+  }
+
+  return (
+    <div className="field-type query-preset-group-by-field">
+      <FieldLabel as="h3" label={label} path={path} required={required} />
+      <div className="value-wrapper">{renderGroupBy(value as string)}</div>
+    </div>
+  )
+}

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -32,8 +32,10 @@ export { OrderableTable } from '../../elements/Table/OrderableTable.js'
 export { QueryPresetsColumnsCell } from '../../elements/QueryPresets/cells/ColumnsCell/index.js'
 export { QueryPresetsWhereCell } from '../../elements/QueryPresets/cells/WhereCell/index.js'
 export { QueryPresetsAccessCell } from '../../elements/QueryPresets/cells/AccessCell/index.js'
+export { QueryPresetsGroupByCell } from '../../elements/QueryPresets/cells/GroupByCell/index.js'
 export { QueryPresetsColumnField } from '../../elements/QueryPresets/fields/ColumnsField/index.js'
 export { QueryPresetsWhereField } from '../../elements/QueryPresets/fields/WhereField/index.js'
+export { QueryPresetsGroupByField } from '../../elements/QueryPresets/fields/GroupByField/index.js'
 
 // elements
 export { ConfirmationModal } from '../../elements/ConfirmationModal/index.js'

--- a/test/group-by/collections/Posts/index.ts
+++ b/test/group-by/collections/Posts/index.ts
@@ -11,6 +11,7 @@ export const PostsCollection: CollectionConfig = {
     groupBy: true,
     defaultColumns: ['title', 'category', 'createdAt', 'updatedAt'],
   },
+  enableQueryPresets: true,
   trash: true,
   fields: [
     {

--- a/test/group-by/e2e.spec.ts
+++ b/test/group-by/e2e.spec.ts
@@ -19,6 +19,7 @@ import {
   ensureCompilationIsDone,
   exactText,
   initPageConsoleErrorCatch,
+  saveDocAndAssert,
   selectTableRow,
 } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
@@ -923,4 +924,129 @@ test.describe('Group By', () => {
       },
     }) as unknown as Promise<Post>
   }
+
+  test.describe('Query Presets with Virtual Fields', () => {
+    test('should display virtual field label in preset drawer when groupBy is saved', async () => {
+      await page.goto(url.list)
+
+      // Add group by virtual field
+      const { groupByContainer } = await openGroupBy(page)
+      const field = groupByContainer.locator('#group-by--field-select')
+      await field.click()
+      await field
+        .locator('.rs__option', {
+          hasText: exactText('Virtual Title From Page'),
+        })
+        .click()
+
+      await expect(field.locator('.react-select--single-value')).toHaveText(
+        'Virtual Title From Page',
+      )
+      await expect(page).toHaveURL(/&groupBy=page\.title/)
+
+      // Create a new preset with this groupBy
+      await page.locator('#create-new-preset').click()
+      const modal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
+      await expect(modal).toBeVisible()
+
+      const presetTitle = 'Virtual Field Preset'
+      await modal.locator('input[name="title"]').fill(presetTitle)
+
+      // Check that the groupBy field shows the proper label (not "page.title")
+      const groupByField = modal.locator('.query-preset-group-by-field .value-wrapper')
+      await expect(groupByField).toBeVisible()
+      await expect(groupByField).toContainText('Virtual Title From Page')
+      await expect(groupByField).toContainText('ascending')
+
+      await saveDocAndAssert(page)
+      await expect(modal).toBeHidden()
+
+      await expect(page).toHaveURL(/groupBy=page\.title/)
+    })
+
+    test('should display virtual field label in preset list cell', async () => {
+      await page.goto(url.list)
+
+      await payload.create({
+        collection: 'payload-query-presets',
+        data: {
+          access: {
+            delete: { constraint: 'onlyMe' },
+            read: { constraint: 'onlyMe' },
+            update: { constraint: 'onlyMe' },
+          },
+          groupBy: 'page.title',
+          isShared: false,
+          relatedCollection: postsSlug,
+          title: 'Virtual Field Cell Test',
+          where: {},
+        },
+        user,
+      })
+
+      // Open the preset drawer
+      await page.click('button#select-preset')
+      const drawer = page.locator('dialog[id^="list-drawer_0_"]')
+      await expect(drawer).toBeVisible()
+
+      // Find the row with our preset in the drawer
+      const presetRow = drawer.locator('tbody tr', {
+        has: page.locator('button:has-text("Virtual Field Cell Test")'),
+      })
+      await expect(presetRow).toBeVisible()
+
+      // Check the groupBy cell displays the proper label (not "page.title")
+      const groupByCell = presetRow.locator('td.cell-groupBy')
+      await expect(groupByCell).toBeVisible()
+      await expect(groupByCell).toContainText('Virtual Title From Page')
+      await expect(groupByCell).toContainText('ascending')
+    })
+
+    test('should display virtual field label when editing a preset', async () => {
+      await page.goto(url.list)
+
+      const presetTitle = 'Virtual Field Edit Test'
+      await payload.create({
+        collection: 'payload-query-presets',
+        data: {
+          access: {
+            delete: { constraint: 'onlyMe' },
+            read: { constraint: 'onlyMe' },
+            update: { constraint: 'onlyMe' },
+          },
+          groupBy: '-page.title',
+          isShared: false,
+          relatedCollection: postsSlug,
+          title: presetTitle,
+          where: {},
+        },
+        user,
+      })
+
+      // Select the preset to make it active
+      await page.locator('button#select-preset').click()
+      const drawer = page.locator('[id^=list-drawer_0_]')
+      await expect(drawer).toBeVisible()
+
+      await drawer
+        .locator('tbody tr td button', {
+          hasText: exactText(presetTitle),
+        })
+        .first()
+        .click()
+
+      await expect(drawer).toBeHidden()
+
+      // Now open the edit preset drawer
+      await page.locator('#edit-preset').click()
+      const editModal = page.locator('[id^=doc-drawer_payload-query-presets_0_]')
+      await expect(editModal).toBeVisible()
+
+      // Check that the groupBy field shows the proper label with descending direction
+      const groupByField = editModal.locator('.query-preset-group-by-field .value-wrapper')
+      await expect(groupByField).toBeVisible()
+      await expect(groupByField).toContainText('Virtual Title From Page')
+      await expect(groupByField).toContainText('descending')
+    })
+  })
 })

--- a/test/group-by/payload-types.ts
+++ b/test/group-by/payload-types.ts
@@ -77,6 +77,7 @@ export interface Config {
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
+    'payload-query-presets': PayloadQueryPreset;
   };
   collectionsJoins: {};
   collectionsSelect: {
@@ -90,10 +91,12 @@ export interface Config {
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
+    'payload-query-presets': PayloadQueryPresetsSelect<false> | PayloadQueryPresetsSelect<true>;
   };
   db: {
     defaultIDType: string;
   };
+  fallbackLocale: null;
   globals: {};
   globalsSelect: {};
   locale: null;
@@ -355,6 +358,55 @@ export interface PayloadMigration {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-query-presets".
+ */
+export interface PayloadQueryPreset {
+  id: string;
+  title: string;
+  isShared?: boolean | null;
+  access?: {
+    read?: {
+      constraint?: ('everyone' | 'onlyMe' | 'specificUsers') | null;
+      users?: (string | User)[] | null;
+    };
+    update?: {
+      constraint?: ('everyone' | 'onlyMe' | 'specificUsers') | null;
+      users?: (string | User)[] | null;
+    };
+    delete?: {
+      constraint?: ('everyone' | 'onlyMe' | 'specificUsers') | null;
+      users?: (string | User)[] | null;
+    };
+  };
+  where?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  columns?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  groupBy?: string | null;
+  relatedCollection: 'posts';
+  /**
+   * This is a temporary field used to determine if updating the preset would remove the user's access to it. When `true`, this record will be deleted after running the preset's `validate` function.
+   */
+  isTemp?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "pages_select".
  */
 export interface PagesSelect<T extends boolean = true> {
@@ -512,6 +564,43 @@ export interface PayloadPreferencesSelect<T extends boolean = true> {
 export interface PayloadMigrationsSelect<T extends boolean = true> {
   name?: T;
   batch?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-query-presets_select".
+ */
+export interface PayloadQueryPresetsSelect<T extends boolean = true> {
+  title?: T;
+  isShared?: T;
+  access?:
+    | T
+    | {
+        read?:
+          | T
+          | {
+              constraint?: T;
+              users?: T;
+            };
+        update?:
+          | T
+          | {
+              constraint?: T;
+              users?: T;
+            };
+        delete?:
+          | T
+          | {
+              constraint?: T;
+              users?: T;
+            };
+      };
+  where?: T;
+  columns?: T;
+  groupBy?: T;
+  relatedCollection?: T;
+  isTemp?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/query-presets/collections/Posts/index.ts
+++ b/test/query-presets/collections/Posts/index.ts
@@ -6,6 +6,7 @@ export const Posts: CollectionConfig = {
   slug: postsSlug,
   admin: {
     useAsTitle: 'text',
+    groupBy: true,
   },
   enableQueryPresets: true,
   lockDocuments: false,

--- a/test/query-presets/helpers/togglePreset.ts
+++ b/test/query-presets/helpers/togglePreset.ts
@@ -33,13 +33,13 @@ export async function clearSelectedPreset({ page }: { page: Page }) {
   const queryPresetsControl = page.locator('button#select-preset')
   const clearButton = queryPresetsControl.locator('#clear-preset')
 
-  if (await clearButton.isVisible()) {
-    await clearButton.click()
-  }
+  // Wait for the clear button to be visible and click it
+  await expect(clearButton).toBeVisible()
+  await clearButton.click()
 
-  // columns can either be omitted or an empty string after being cleared
-  const regex = /columns=(?:\[\]|$)/
-
+  // Wait for preset parameter to be cleared from URL
+  // Other params like columns, groupBy may be temporarily empty strings before being removed
+  const regex = /preset=/
   await page.waitForURL((url) => !regex.test(url.search), {
     timeout: TEST_TIMEOUT_LONG,
   })

--- a/test/query-presets/payload-types.ts
+++ b/test/query-presets/payload-types.ts
@@ -278,6 +278,7 @@ export interface PayloadQueryPreset {
     | number
     | boolean
     | null;
+  groupBy?: string | null;
   relatedCollection: 'pages' | 'posts';
   /**
    * This is a temporary field used to determine if updating the preset would remove the user's access to it. When `true`, this record will be deleted after running the preset's `validate` function.
@@ -402,6 +403,7 @@ export interface PayloadQueryPresetsSelect<T extends boolean = true> {
       };
   where?: T;
   columns?: T;
+  groupBy?: T;
   relatedCollection?: T;
   isTemp?: T;
   updatedAt?: T;


### PR DESCRIPTION
### What?

Adds `groupBy` field support to query presets. Presets now save, apply, and clear groupBy state when switching between presets.

### Why?

Previously, `groupBy` settings would persist when switching between presets. GroupBy was not being saved as part of the preset configuration, so users couldn't save their preferred grouping with a preset.

### How?

Added `groupBy?: string` to the `QueryPreset` type and updated the preset collection config to include the field. 

Modified `QueryPresetBar` to handle groupBy when selecting, deselecting, resetting, saving, or creating presets. 

Created custom Field and Cell components to display groupBy values in the admin UI. 

#### Preset creation with group-by added
<img width="711" height="684" alt="Screenshot 2025-12-03 at 3 15 03 PM" src="https://github.com/user-attachments/assets/5fe6ee88-6ed7-40f6-b190-df6b2e89460c" />

#### Preset collection list view with group-by preset
<img width="2233" height="537" alt="Screenshot 2025-12-03 at 3 15 26 PM" src="https://github.com/user-attachments/assets/a56645fc-9106-4885-8c54-0e000c429499" />

#### Preset creation without group-by
<img width="1250" height="704" alt="Screenshot 2025-12-03 at 3 15 48 PM" src="https://github.com/user-attachments/assets/3438585b-7aa9-4336-9101-2fab59733480" />
