### PR TITLE
fix(plugin-multi-tenant): moves getGlobalViewRedirect from utilities to rsc exports

### DIFF
--- a/packages/plugin-multi-tenant/src/exports/rsc.ts
+++ b/packages/plugin-multi-tenant/src/exports/rsc.ts
@@ -1,3 +1,4 @@
 export { GlobalViewRedirect } from '../components/GlobalViewRedirect/index.js'
 export { TenantSelector } from '../components/TenantSelector/index.js'
 export { TenantSelectionProvider } from '../providers/TenantSelectionProvider/index.js'
+export { getGlobalViewRedirect } from '../utilities/getGlobalViewRedirect.js'

--- a/packages/plugin-multi-tenant/src/exports/utilities.ts
+++ b/packages/plugin-multi-tenant/src/exports/utilities.ts
@@ -1,6 +1,5 @@
 export { defaults } from '../defaults.js'
 export { filterDocumentsByTenants as getTenantListFilter } from '../filters/filterDocumentsByTenants.js'
-export { getGlobalViewRedirect } from '../utilities/getGlobalViewRedirect.js'
 export { getTenantAccess } from '../utilities/getTenantAccess.js'
 export { getTenantFromCookie } from '../utilities/getTenantFromCookie.js'
 export { getUserTenantIDs } from '../utilities/getUserTenantIDs.js'

--- a/test/plugin-multi-tenant/config.ts
+++ b/test/plugin-multi-tenant/config.ts
@@ -1,4 +1,5 @@
 import { multiTenantPlugin } from '@payloadcms/plugin-multi-tenant'
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
 const filename = fileURLToPath(import.meta.url)
@@ -6,7 +7,6 @@ const dirname = path.dirname(filename)
 
 import type { Config as ConfigType } from './payload-types.js'
 
-import { getTenantFromCookie } from '../../packages/plugin-multi-tenant/src/utilities/getTenantFromCookie.js'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { AutosaveGlobal } from './collections/AutosaveGlobal.js'
 import { Menu } from './collections/Menu.js'


### PR DESCRIPTION
After upgrading Next an error surfaced: `Error: Invariant: AsyncLocalStorage accessed in runtime where it is not available`. The `getGlobalViewRedirect` uses Next's `unauthorized` function and should be exported from the rsc directory.