### PR TITLE
fix: sub-folders not showing up in browse-by-folder view due to wrong empty check in query

### DIFF
--- a/packages/ui/src/utilities/getFolderResultsComponentAndData.tsx
+++ b/packages/ui/src/utilities/getFolderResultsComponentAndData.tsx
@@ -117,7 +117,7 @@ export const getFolderResultsComponentAndData = async ({
                 // if the folderType is not set, it means it accepts all collections and should appear in the results
                 {
                   folderType: {
-                    exists: false,
+                    equals: [],
                   },
                 },
               ],


### PR DESCRIPTION
### What?
Sub folders don't show up when creating them or browsing through the browse-by-folder/select folder view.

### Why?
As there is currently no way to navigate through sub folders in either the global browse-by-folder without having to set the "folder" filter first or when selecting a sub-folder from a collection.

### How?
As the result returns an empty array if there are no collections assigned, I've changed the query to check for `equals: []` instead of `exists: false`. This might be related to https://github.com/payloadcms/payload/issues/12072.

### Before

https://github.com/user-attachments/assets/1d7b7d73-6aeb-4a46-b9a8-2d75653e356c

### After

https://github.com/user-attachments/assets/4c35528f-38e8-4f47-8e58-a1315a28b95a


