### PR TITLE
feat: add support for custom slugify functions from payload config

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -101,6 +101,7 @@ The following options are available:
 | **`i18n`**                 | Internationalization configuration. Pass all i18n languages you'd like the admin UI to support. Defaults to English-only. [More details](./i18n).                                              |
 | **`secret`** \*            | A secure, unguessable string that Payload will use for any encryption workflows - for example, password salt / hashing.                                                                        |
 | **`sharp`**                | If you would like Payload to offer cropping, focal point selection, and automatic media resizing, install and pass the Sharp module to the config here.                                        |
+| **`slugify`**              | Override the default slugify function for all slug fields. Can be overridden at field level. [More details](#custom-slugify-function).                                                         |
 | **`typescript`**           | Configure TypeScript settings here. [More details](#typescript).                                                                                                                               |
 
 _\* An asterisk denotes that a property is required._
@@ -249,6 +250,45 @@ export default buildConfig({
   // highlight-end
 })
 ```
+
+## Custom Slugify Function
+
+You can override the default slugify function for all slug fields across your application. This is useful when you need special character encoding, additional language support, or consistent slug formatting across all collections.
+
+The config-level `slugify` function can be overridden at the field level if needed.
+
+```ts
+import { buildConfig } from 'payload'
+import slugify from 'slugify'
+
+export default buildConfig({
+  // ...
+  // highlight-start
+  slugify: ({ valueToSlugify }) =>
+    slugify(valueToSlugify, {
+      lower: true,
+      strict: true,
+      // ...additional `slugify` options here
+    }),
+  // highlight-end
+})
+```
+
+The following args are provided to the custom `slugify` function:
+
+| Argument         | Type             | Description                                      |
+| ---------------- | ---------------- | ------------------------------------------------ |
+| `valueToSlugify` | `string`         | The value of the field specified in `useAsSlug`. |
+| `data`           | `object`         | The full document data being saved.              |
+| `req`            | `PayloadRequest` | The Payload request object.                      |
+
+**Priority order:**
+
+1. Field-level `slugify` (if defined)
+2. Config-level `slugify` (if defined)
+3. Default `slugify` function
+
+For more details on field-level overrides, see the [Slug Field documentation](../fields/text#custom-slugify-function).
 
 ## TypeScript
 

--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -249,9 +249,11 @@ export const ExampleCollection: CollectionConfig = {
 
 ### Custom Slugify Function
 
-You can also override the default slugify function of the slug field. This is necessary if the slug requires special treatment, such as character encoding, additional language support, etc.
+You can override the default slugify function of the slug field. This is necessary if the slug requires special treatment, such as character encoding, additional language support, etc.
 
-This functions receives the value of the `useAsSlug` field as `valueToSlugify` and must return a string.
+You can also set a global default slugify function in the [Payload Config](../configuration/overview#custom-slugify-function) that will apply to all slug fields across your application. Field-level slugify will override the config-level setting.
+
+This function receives the value of the `useAsSlug` field as `valueToSlugify` and must return a string.
 
 For example, if you wanted to use the [`slugify`](https://www.npmjs.com/package/slugify) package, you could do something like this:
 

--- a/packages/next/src/utilities/slugify.ts
+++ b/packages/next/src/utilities/slugify.ts
@@ -46,12 +46,16 @@ export const slugifyHandler: ServerFunction<
     path,
   })
 
-  const customSlugify = (
+  const fieldLevelSlugify = (
     typeof field?.custom?.slugify === 'function' ? field.custom.slugify : undefined
   ) as Slugify
 
-  const result = customSlugify
-    ? await customSlugify({ data, req, valueToSlugify })
+  const configLevelSlugify = req.payload.config.slugify
+
+  const slugifyToUse = fieldLevelSlugify || configLevelSlugify
+
+  const result = slugifyToUse
+    ? await slugifyToUse({ data, req, valueToSlugify })
     : defaultSlugify(valueToSlugify)
 
   return result

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -38,6 +38,7 @@ export type ServerOnlyRootProperties = keyof Pick<
   | 'queryPresets'
   | 'secret'
   | 'sharp'
+  | 'slugify'
   | 'typescript'
 >
 
@@ -80,6 +81,7 @@ export const serverOnlyConfigProperties: readonly Partial<ServerOnlyRootProperti
   'editor',
   'plugins',
   'sharp',
+  'slugify',
   'onInit',
   'secret',
   'hooks',

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -39,6 +39,7 @@ import type {
 import type { DatabaseAdapterResult } from '../database/types.js'
 import type { EmailAdapter, SendEmailOptions } from '../email/types.js'
 import type { ErrorName } from '../errors/types.js'
+import type { Slugify } from '../fields/baseFields/slug/index.js'
 import type { RootFoldersConfiguration } from '../folders/types.js'
 import type { GlobalConfig, Globals, SanitizedGlobalConfig } from '../globals/config/types.js'
 import type {
@@ -1305,6 +1306,13 @@ export type Config = {
    *
    */
   sharp?: SharpDependency
+  /**
+   * Provide a custom slugify function to be used as the default for all slug fields.
+   * Can be overridden at the field level by passing a `slugify` function to `slugField()`.
+   *
+   * @see https://payloadcms.com/docs/fields/text#slug-field
+   */
+  slugify?: Slugify
   /** Send anonymous telemetry data about general usage. */
   telemetry?: boolean
   /** Control how typescript interfaces are generated from your collections. */

--- a/packages/payload/src/fields/baseFields/slug/generateSlug.ts
+++ b/packages/payload/src/fields/baseFields/slug/generateSlug.ts
@@ -11,7 +11,7 @@ type HookArgs = {
   Required<Pick<SlugFieldArgs, 'useAsSlug'>>
 
 const slugify = ({
-  customSlugify,
+  customSlugify: fieldLevelSlugify,
   data,
   req,
   valueToSlugify,
@@ -21,6 +21,9 @@ const slugify = ({
   req: PayloadRequest
   valueToSlugify?: string
 }) => {
+  const configLevelSlugify = req.payload.config.slugify
+  const customSlugify = fieldLevelSlugify || configLevelSlugify
+
   if (customSlugify) {
     return customSlugify({ data, req, valueToSlugify })
   }


### PR DESCRIPTION
### What?
Adds support for custom slugify functions in the Payload Config. With the option to override it at field level.

### Why?
https://github.com/payloadcms/payload/pull/14117 added support for custom slugify functions on field level, which is very useful but it makes the user have to add their custom slugify function to every single place they need a slug field. By setting it in the payload config instead, it's just done once for all slug fields across the cms.

### How?
Added slugify property to the main `Config` type
Updated `generateSlug.ts` to check for config-level slugify with priority order.
Updated slugifyHandler server function to access config-level slugify via req.payload.config.slugify
Added slugify to server-only config properties to prevent client-side errors

Can be used like this:
```ts
// payload.config.ts
slugify: ({ valueToSlugify }) => slugify(valueToSlugify, {
  // ...additional `slugify` options here
})
```

**Priority order:**
1. Field-level slugify (if defined)
2. Config-level slugify (if defined)
3. Default slugify function

### Example with config level and field level slugify
```ts
// payload.config.ts
slugify: ({ valueToSlugify }) => {
  return `config-${valueToSlugify?.toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g, '')}`
},
```

<img width="433" height="199" alt="screenshot-slugify" src="https://github.com/user-attachments/assets/69cdc3e3-3cb4-4d14-8b80-9aa307ce5e30" />