### PR TITLE
fix(ui): ensure block error css only gets applied to the affected block

### DIFF
--- a/packages/ui/src/fields/Blocks/index.scss
+++ b/packages/ui/src/fields/Blocks/index.scss
@@ -107,6 +107,12 @@
       .blocks-field__heading-with-error {
         color: var(--theme-error-750);
       }
+
+      .blocks-field__row--no-errors {
+        .section-title__input {
+          color: var(--theme-text);
+        }
+      }
     }
   }
 
@@ -115,6 +121,12 @@
       .section-title__input,
       .blocks-field__heading-with-error {
         color: var(--theme-error-500);
+      }
+
+      .blocks-field__row--no-errors {
+        .section-title__input {
+          color: var(--theme-text);
+        }
       }
     }
   }

--- a/packages/ui/src/fields/Blocks/index.scss
+++ b/packages/ui/src/fields/Blocks/index.scss
@@ -108,8 +108,10 @@
         color: var(--theme-error-750);
       }
 
-      .blocks-field__row--no-errors {
-        .section-title__input {
+      .blocks-field__row--no-errors,
+      .blocks-field--has-no-error {
+        .section-title__input,
+        .blocks-field__heading-with-error {
           color: var(--theme-text);
         }
       }
@@ -123,8 +125,10 @@
         color: var(--theme-error-500);
       }
 
-      .blocks-field__row--no-errors {
-        .section-title__input {
+      .blocks-field__row--no-errors,
+      .blocks-field--has-no-error {
+        .section-title__input,
+        .blocks-field__heading-with-error {
           color: var(--theme-text);
         }
       }

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -324,6 +324,20 @@ describe('Block fields', () => {
     )
   })
 
+  test('should only apply error styling to block with error', async () => {
+    await page.goto(url.create)
+
+    const firstBlockTextInput = page.locator('#field-blocks__0__text')
+    await firstBlockTextInput.fill('')
+
+    await page.click('#action-save')
+
+    const blockNameInput = page.locator('#blocks-row-1 input#blocks\\.1\\.blockName').first()
+
+    await expect(blockNameInput).toHaveValue('Second block')
+    await expect(blockNameInput).not.toHaveCSS('color', 'rgb(123, 41, 39)')
+  })
+
   describe('row manipulation', () => {
     test('moving rows should immediately move custom row labels', async () => {
       await page.goto(url.create)


### PR DESCRIPTION
### What?
Ensures block field error styles only get applied to the block containing the error.

### Why?
Currently, error styles are applied at the top level of a block component, which overrides nested components that have the `--no-errors` class. This leads to blocks without errors incorrectly displaying error styling.

### How?
Updates css to respect block elements with `--no-errors` within blocks with errors.

**Reported by client.**