### PR TITLE
fix: use hasDraftsEnabled utility instead of direct check

### DIFF
--- a/packages/next/src/views/Document/getDocumentPermissions.tsx
+++ b/packages/next/src/views/Document/getDocumentPermissions.tsx
@@ -46,7 +46,7 @@ export const getDocumentPermissions = async (args: {
         req,
       })
 
-      if (collectionConfig.versions?.drafts) {
+      if (hasDraftsEnabled(collectionConfig)) {
         hasPublishPermission = (
           await docAccessOperation({
             id,

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -171,7 +171,7 @@ export const updateOperation = async <
 
     let docs
 
-    if (collectionConfig.versions?.drafts && shouldSaveDraft) {
+    if (hasDraftsEnabled(collectionConfig) && shouldSaveDraft) {
       const versionsWhere = appendVersionToQueryKey(fullWhere)
 
       await validateQueryPaths({

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -5,7 +5,7 @@ import type { SanitizedCollectionConfig } from 'payload'
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
 import { useRouter } from 'next/navigation.js'
-import { formatAdminURL } from 'payload/shared'
+import { formatAdminURL, hasDraftsEnabled } from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
@@ -95,7 +95,7 @@ export const DuplicateDocument: React.FC<Props> = ({
             addQueryPrefix: true,
           })}`,
           {
-            body: JSON.stringify(collectionConfig.versions?.drafts ? { _status: 'draft' } : {}),
+            body: JSON.stringify(hasDraftsEnabled(collectionConfig) ? { _status: 'draft' } : {}),
             headers,
           },
         )


### PR DESCRIPTION
Replaces direct checks of `collectionConfig.versions?.drafts` with the `hasDraftsEnabled` utility function for consistency across document permissions, update operations, and duplicate document functionality.