### PR TITLE
fix(db-mongodb): fix projection handling for relationship fields in GraphQL queries with select

### DIFF
--- a/packages/db-mongodb/src/utilities/buildProjectionFromSelect.ts
+++ b/packages/db-mongodb/src/utilities/buildProjectionFromSelect.ts
@@ -185,6 +185,20 @@ const traverseFields = ({
         break
       }
 
+      case 'relationship':
+      case 'upload': {
+        // When a relationship/upload field is selected with nested fields (for population), we still need to include the raw
+        // field value in the projection so that population can work. The nested select is handled by the population logic.
+        addFieldToProjection({
+          adapter,
+          databaseSchemaPath,
+          field,
+          parentIsLocalized,
+          projection,
+        })
+        break
+      }
+
       default:
         break
     }

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -2302,6 +2302,146 @@ describe('Select', () => {
       expect(richTextSlateRel.value).toMatchObject(homePage)
     })
 
+    it('graphQL - should return relationship fields when using select flag', async () => {
+      // Create a related document first
+      const rel = await payload.create({ collection: 'rels', data: { text: 'graphql-rel-test' } })
+
+      // Create a post with the relationship
+      const testPost = await payload.create({
+        collection: 'posts',
+        depth: 0,
+        data: {
+          text: 'graphql-select-test',
+          number: 42,
+          hasOne: rel.id,
+          hasMany: [rel.id],
+        },
+      })
+
+      // eslint-disable-next-line jest/no-conditional-in-test
+      const testPostId = typeof testPost.id === 'string' ? `"${testPost.id}"` : testPost.id
+
+      // Query with select: true to enable the GraphQL select optimization
+      // This is the scenario from issue #14467 where relationship fields were returned as empty arrays
+      const query = `query {
+        Posts(where: { id: { equals: ${testPostId} } }, select: true) {
+          docs {
+            id
+            text
+            hasOne {
+              id
+              text
+            }
+            hasMany {
+              id
+              text
+            }
+          }
+        }
+      }`
+
+      const response = await restClient
+        .GRAPHQL_POST({
+          body: JSON.stringify({ query }),
+        })
+        .then((res) => res.json())
+
+      const doc = response.data?.Posts?.docs?.[0]
+
+      expect(doc).toBeDefined()
+      expect(doc.id).toBe(testPost.id)
+      expect(doc.text).toBe('graphql-select-test')
+
+      expect(doc.hasOne).toBeDefined()
+      expect(doc.hasOne.id).toBe(rel.id)
+      expect(doc.hasOne.text).toBe('graphql-rel-test')
+
+      expect(doc.hasMany).toBeDefined()
+      expect(doc.hasMany).toHaveLength(1)
+      expect(doc.hasMany[0].id).toBe(rel.id)
+      expect(doc.hasMany[0].text).toBe('graphql-rel-test')
+
+      // Cleanup
+      await payload.delete({ collection: 'posts', id: testPost.id })
+      await payload.delete({ collection: 'rels', id: rel.id })
+    })
+
+    it('graphQL - should return polymorphic relationship fields when using select flag', async () => {
+      // Create a related document
+      const rel = await payload.create({ collection: 'rels', data: { text: 'graphql-poly-test' } })
+
+      // Create a post with polymorphic relationships
+      const testPost = await payload.create({
+        collection: 'posts',
+        depth: 0,
+        data: {
+          text: 'graphql-poly-select-test',
+          number: 43,
+          hasOnePoly: { relationTo: 'rels', value: rel.id },
+          hasManyPoly: [{ relationTo: 'rels', value: rel.id }],
+        },
+      })
+
+      // eslint-disable-next-line jest/no-conditional-in-test
+      const testPostId = typeof testPost.id === 'string' ? `"${testPost.id}"` : testPost.id
+
+      // Query with select: true
+      const query = `query {
+        Posts(where: { id: { equals: ${testPostId} } }, select: true) {
+          docs {
+            id
+            text
+            hasOnePoly {
+              relationTo
+              value {
+                ...on Rel {
+                  id
+                  text
+                }
+              }
+            }
+            hasManyPoly {
+              relationTo
+              value {
+                ...on Rel {
+                  id
+                  text
+                }
+              }
+            }
+          }
+        }
+      }`
+
+      const response = await restClient
+        .GRAPHQL_POST({
+          body: JSON.stringify({ query }),
+        })
+        .then((res) => res.json())
+
+      const doc = response.data?.Posts?.docs?.[0]
+
+      expect(doc).toBeDefined()
+      expect(doc.id).toBe(testPost.id)
+
+      // Polymorphic hasOne
+      expect(doc.hasOnePoly).toBeDefined()
+      expect(doc.hasOnePoly.relationTo).toBe('rels')
+      expect(doc.hasOnePoly.value.id).toBe(rel.id)
+      expect(doc.hasOnePoly.value.text).toBe('graphql-poly-test')
+
+      // Polymorphic hasMany
+      expect(doc.hasManyPoly).toBeDefined()
+      expect(doc.hasManyPoly).toHaveLength(1)
+      expect(doc.hasManyPoly[0].relationTo).toBe('rels')
+      expect(doc.hasManyPoly[0].value.id).toBe(rel.id)
+      expect(doc.hasManyPoly[0].value.text).toBe('graphql-poly-test')
+
+      // Cleanup
+      await payload.delete({ collection: 'posts', id: testPost.id })
+      await payload.delete({ collection: 'rels', id: rel.id })
+    })
+
     it('local API - should populate and override defaultSelect select shape from the populate arg', async () => {
       const result = await payload.findByID({
         populate: {


### PR DESCRIPTION
 ### What? 
Fix GraphQL API select flag returning empty arrays for relationship and upload fields when using MongoDB. 

### Why? 
When using the GraphQL API with `select: true`, relationship fields were being returned as empty arrays instead of the actual populated data. This issue only affected MongoDB, not SQLite/Postgres. 
The root cause was in `buildProjectionFromSelect.ts`. When GraphQL builds a select object, it creates nested objects for relationship fields (e.g., `{ hasOne: { id: true, text: true } }`) to indicate which fields should be selected from the populated relationship. However, the MongoDB projection builder only checked for `select[field.name] === true` at line 65, which doesn't match when the value is an object. The relationship fields then fell through to the switch statement which had no case for relationship or upload types, causing them to be silently skipped from the projection. Without the relationship field in the MongoDB projection, the document was returned without the relationship IDs, so the population phase had nothing to populate - resulting in empty arrays. 

### How? 
Added a switch case for relationship and upload field types in `buildProjectionFromSelect.ts` that adds the field to the MongoDB projection. This ensures the raw relationship IDs are included in the query result, allowing the population logic to work correctly. 

Also added two GraphQL integration tests that verify relationship fields (both regular and polymorphic) are properly returned when using the select flag.

Fixes https://github.com/payloadcms/payload/issues/14467
