### PR TITLE
fix: passes serverURL through to all formatAdminURL calls

### DIFF
--- a/packages/next/src/elements/DocumentHeader/Tabs/Tab/TabLink.tsx
+++ b/packages/next/src/elements/DocumentHeader/Tabs/Tab/TabLink.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { SanitizedConfig } from 'payload'
 
-import { Button } from '@payloadcms/ui'
+import { Button, useConfig } from '@payloadcms/ui'
 import { useParams, usePathname, useSearchParams } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'
 import React from 'react'
@@ -25,6 +25,7 @@ export const DocumentTabLink: React.FC<{
 }) => {
   const pathname = usePathname()
   const params = useParams()
+  const { config } = useConfig()
 
   const searchParams = useSearchParams()
 
@@ -36,6 +37,7 @@ export const DocumentTabLink: React.FC<{
   let docPath = formatAdminURL({
     adminRoute,
     path: `/${isCollection ? 'collections' : 'globals'}/${entitySlug}`,
+    serverURL: config.serverURL,
   })
 
   if (isCollection) {

--- a/packages/next/src/elements/Nav/index.client.tsx
+++ b/packages/next/src/elements/Nav/index.client.tsx
@@ -28,6 +28,7 @@ export const DefaultNavClient: React.FC<{
       },
       folders,
       routes: { admin: adminRoute },
+      serverURL,
     },
   } = useConfig()
 
@@ -36,6 +37,7 @@ export const DefaultNavClient: React.FC<{
   const folderURL = formatAdminURL({
     adminRoute,
     path: foldersRoute,
+    serverURL,
   })
 
   const viewingRootFolderView = pathname.startsWith(folderURL)
@@ -51,12 +53,12 @@ export const DefaultNavClient: React.FC<{
               let id: string
 
               if (type === EntityType.collection) {
-                href = formatAdminURL({ adminRoute, path: `/collections/${slug}` })
+                href = formatAdminURL({ adminRoute, path: `/collections/${slug}`, serverURL })
                 id = `nav-${slug}`
               }
 
               if (type === EntityType.global) {
-                href = formatAdminURL({ adminRoute, path: `/globals/${slug}` })
+                href = formatAdminURL({ adminRoute, path: `/globals/${slug}`, serverURL })
                 id = `nav-global-${slug}`
               }
 

--- a/packages/next/src/utilities/handleAuthRedirect.ts
+++ b/packages/next/src/utilities/handleAuthRedirect.ts
@@ -31,6 +31,7 @@ export const handleAuthRedirect = ({ config, route, searchParams, user }: Args):
   const redirectTo = formatAdminURL({
     adminRoute,
     path: user ? unauthorizedRoute : loginRouteFromConfig,
+    serverURL: config.serverURL,
   })
 
   const parsedLoginRouteSearchParams = qs.parse(redirectTo.split('?')[1] ?? '')

--- a/packages/next/src/views/Account/ResetPreferences/index.tsx
+++ b/packages/next/src/views/Account/ResetPreferences/index.tsx
@@ -2,6 +2,7 @@
 import type { TypedUser } from 'payload'
 
 import { Button, ConfirmationModal, toast, useModal, useTranslation } from '@payloadcms/ui'
+import { formatApiURL } from 'payload/shared'
 import * as qs from 'qs-esm'
 import { Fragment, useCallback } from 'react'
 
@@ -34,13 +35,20 @@ export const ResetPreferences: React.FC<{
     )
 
     try {
-      const res = await fetch(`${apiRoute}/payload-preferences${stringifiedQuery}`, {
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
+      const res = await fetch(
+        formatApiURL({
+          apiRoute,
+          path: `/payload-preferences${stringifiedQuery}`,
+          serverURL: undefined,
+        }),
+        {
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: 'DELETE',
         },
-        method: 'DELETE',
-      })
+      )
 
       const json = await res.json()
       const message = json.message

--- a/packages/next/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.client.tsx
@@ -20,6 +20,7 @@ import {
   useTranslation,
 } from '@payloadcms/ui'
 import { abortAndIgnore, handleAbortRef } from '@payloadcms/ui/shared'
+import { formatApiURL } from 'payload/shared'
 import React, { useEffect } from 'react'
 
 export const CreateFirstUserClient: React.FC<{
@@ -84,7 +85,11 @@ export const CreateFirstUserClient: React.FC<{
 
   return (
     <Form
-      action={`${serverURL}${apiRoute}/${userSlug}/first-register`}
+      action={formatApiURL({
+        apiRoute,
+        path: `/${userSlug}/first-register`,
+        serverURL,
+      })}
       initialState={{
         ...initialState,
         'confirm-password': {

--- a/packages/next/src/views/Dashboard/Default/index.tsx
+++ b/packages/next/src/views/Dashboard/Default/index.tsx
@@ -47,6 +47,7 @@ export function DefaultDashboard(props: DashboardViewServerProps) {
           components: { afterDashboard, beforeDashboard },
         },
         routes: { admin: adminRoute },
+        serverURL,
       },
     },
     payload,
@@ -96,11 +97,16 @@ export function DefaultDashboard(props: DashboardViewServerProps) {
 
                         buttonAriaLabel = t('general:showAllLabel', { label: title })
 
-                        href = formatAdminURL({ adminRoute, path: `/collections/${slug}` })
+                        href = formatAdminURL({
+                          adminRoute,
+                          path: `/collections/${slug}`,
+                          serverURL,
+                        })
 
                         createHREF = formatAdminURL({
                           adminRoute,
                           path: `/collections/${slug}/create`,
+                          serverURL,
                         })
 
                         hasCreatePermission = permissions?.collections?.[slug]?.create
@@ -116,6 +122,7 @@ export function DefaultDashboard(props: DashboardViewServerProps) {
                         href = formatAdminURL({
                           adminRoute,
                           path: `/globals/${slug}`,
+                          serverURL,
                         })
 
                         // Find the lock status for the global

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -22,7 +22,7 @@ import { isEditing as getIsEditing } from '@payloadcms/ui/shared'
 import { buildFormState } from '@payloadcms/ui/utilities/buildFormState'
 import { notFound, redirect } from 'next/navigation.js'
 import { isolateObjectProperty, logError } from 'payload'
-import { formatAdminURL, hasAutosaveEnabled, hasDraftsEnabled } from 'payload/shared'
+import { formatAdminURL, formatApiURL, hasAutosaveEnabled, hasDraftsEnabled } from 'payload/shared'
 import React from 'react'
 
 import type { GenerateEditViewMetadata } from './getMetaBySegment.js'
@@ -274,11 +274,15 @@ export const renderDocument = async ({
 
   const apiQueryParams = `?${formattedParams.toString()}`
 
-  const apiURL = collectionSlug
-    ? `${serverURL}${apiRoute}/${collectionSlug}/${idFromArgs}${apiQueryParams}`
-    : globalSlug
-      ? `${serverURL}${apiRoute}/${globalSlug}${apiQueryParams}`
-      : ''
+  const apiURL = formatApiURL({
+    apiRoute,
+    path: collectionSlug
+      ? `/${collectionSlug}/${idFromArgs}${apiQueryParams}`
+      : globalSlug
+        ? `/${globalSlug}${apiQueryParams}`
+        : '',
+    serverURL,
+  })
 
   let View: ViewToRender = null
 

--- a/packages/next/src/views/ForgotPassword/index.tsx
+++ b/packages/next/src/views/ForgotPassword/index.tsx
@@ -24,6 +24,7 @@ export function ForgotPasswordView({ initPageResult }: AdminViewServerProps) {
       routes: { account: accountRoute, login: loginRoute },
     },
     routes: { admin: adminRoute },
+    serverURL,
   } = config
 
   if (user) {
@@ -38,6 +39,7 @@ export function ForgotPasswordView({ initPageResult }: AdminViewServerProps) {
                     href={formatAdminURL({
                       adminRoute,
                       path: accountRoute,
+                      serverURL,
                     })}
                     prefetch={false}
                   >
@@ -65,6 +67,7 @@ export function ForgotPasswordView({ initPageResult }: AdminViewServerProps) {
         href={formatAdminURL({
           adminRoute,
           path: loginRoute,
+          serverURL,
         })}
         prefetch={false}
       >

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -346,6 +346,7 @@ export const renderListView = async (
     const newDocumentURL = formatAdminURL({
       adminRoute,
       path: `/collections/${collectionSlug}/create`,
+      serverURL: config.serverURL,
     })
 
     const hasCreatePermission = permissions?.collections?.[collectionSlug]?.create

--- a/packages/next/src/views/Login/LoginForm/index.tsx
+++ b/packages/next/src/views/Login/LoginForm/index.tsx
@@ -37,6 +37,7 @@ export const LoginForm: React.FC<{
       user: userSlug,
     },
     routes: { admin: adminRoute, api: apiRoute },
+    serverURL,
   } = config
 
   const collectionConfig = getEntityConfig({ collectionSlug: userSlug })
@@ -109,6 +110,7 @@ export const LoginForm: React.FC<{
         href={formatAdminURL({
           adminRoute,
           path: forgotRoute,
+          serverURL,
         })}
         prefetch={false}
       >

--- a/packages/next/src/views/Login/LoginForm/index.tsx
+++ b/packages/next/src/views/Login/LoginForm/index.tsx
@@ -16,7 +16,7 @@ import {
   useConfig,
   useTranslation,
 } from '@payloadcms/ui'
-import { formatAdminURL, getLoginOptions, getSafeRedirect } from 'payload/shared'
+import { formatAdminURL, formatApiURL, getLoginOptions, getSafeRedirect } from 'payload/shared'
 
 import type { LoginFieldProps } from '../LoginField/index.js'
 
@@ -86,7 +86,11 @@ export const LoginForm: React.FC<{
 
   return (
     <Form
-      action={`${apiRoute}/${userSlug}/login`}
+      action={formatApiURL({
+        apiRoute,
+        path: `/${userSlug}/login`,
+        serverURL,
+      })}
       className={baseClass}
       disableSuccessStatus
       initialState={initialState}

--- a/packages/next/src/views/Logout/LogoutClient.tsx
+++ b/packages/next/src/views/Logout/LogoutClient.tsx
@@ -4,6 +4,7 @@ import {
   LoadingOverlay,
   toast,
   useAuth,
+  useConfig,
   useRouteTransition,
   useTranslation,
 } from '@payloadcms/ui'
@@ -33,6 +34,7 @@ export const LogoutClient: React.FC<{
   const { adminRoute, inactivity, redirect } = props
 
   const { logOut, user } = useAuth()
+  const { config } = useConfig()
 
   const { startRouteTransition } = useRouteTransition()
 
@@ -45,10 +47,12 @@ export const LogoutClient: React.FC<{
   const [loginRoute] = React.useState(() =>
     formatAdminURL({
       adminRoute,
-      path: `/login${inactivity && redirect && redirect.length > 0
+      path: `/login${
+        inactivity && redirect && redirect.length > 0
           ? `?redirect=${encodeURIComponent(redirect)}`
           : ''
-        }`,
+      }`,
+      serverURL: config.serverURL,
     }),
   )
 

--- a/packages/next/src/views/NotFound/index.tsx
+++ b/packages/next/src/views/NotFound/index.tsx
@@ -65,7 +65,7 @@ export const NotFoundPage = async ({
           ignoreQueryPrefix: true,
         }),
       },
-      urlSuffix: `${formatAdminURL({ adminRoute, path: '/not-found' })}${searchParams ? queryString : ''}`,
+      urlSuffix: `${formatAdminURL({ adminRoute, path: '/not-found', serverURL: config.serverURL })}${searchParams ? queryString : ''}`,
     },
   })
 

--- a/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
+++ b/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@payloadcms/ui'
 import { useRouter } from 'next/navigation.js'
 import { type FormState } from 'payload'
-import { formatAdminURL } from 'payload/shared'
+import { formatAdminURL, formatApiURL } from 'payload/shared'
 import React from 'react'
 
 type Args = {
@@ -69,7 +69,11 @@ export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
 
   return (
     <Form
-      action={`${serverURL}${apiRoute}/${userSlug}/reset-password`}
+      action={formatApiURL({
+        apiRoute,
+        path: `/${userSlug}/reset-password`,
+        serverURL,
+      })}
       initialState={initialState}
       method="POST"
       onSuccess={onSuccess}

--- a/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
+++ b/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
@@ -43,10 +43,11 @@ export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
         formatAdminURL({
           adminRoute,
           path: loginRoute,
+          serverURL,
         }),
       )
     }
-  }, [adminRoute, fetchFullUser, history, loginRoute])
+  }, [adminRoute, fetchFullUser, history, loginRoute, serverURL])
 
   const initialState: FormState = {
     'confirm-password': {

--- a/packages/next/src/views/ResetPassword/index.tsx
+++ b/packages/next/src/views/ResetPassword/index.tsx
@@ -43,6 +43,7 @@ export function ResetPassword({ initPageResult, params }: AdminViewServerProps) 
                     href={formatAdminURL({
                       adminRoute,
                       path: accountRoute,
+                      serverURL: config.serverURL,
                     })}
                     prefetch={false}
                   >
@@ -71,6 +72,7 @@ export function ResetPassword({ initPageResult, params }: AdminViewServerProps) 
         href={formatAdminURL({
           adminRoute,
           path: loginRoute,
+          serverURL: config.serverURL,
         })}
         prefetch={false}
       >

--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -160,7 +160,7 @@ export const getRouteData = ({
           return isPathMatchingRoute({
             currentRoute,
             exact: true,
-            path: formatAdminURL({ adminRoute, path: route }),
+            path: formatAdminURL({ adminRoute, path: route, serverURL: config.serverURL }),
           })
         })
 

--- a/packages/next/src/views/Root/index.tsx
+++ b/packages/next/src/views/Root/index.tsx
@@ -66,6 +66,7 @@ export const RootPage = async ({
   const currentRoute = formatAdminURL({
     adminRoute,
     path: Array.isArray(params.segments) ? `/${params.segments.join('/')}` : null,
+    serverURL: config.serverURL,
   })
 
   const segments = Array.isArray(params.segments) ? params.segments : []
@@ -218,7 +219,11 @@ export const RootPage = async ({
     }
   }
 
-  const createFirstUserRoute = formatAdminURL({ adminRoute, path: _createFirstUserRoute })
+  const createFirstUserRoute = formatAdminURL({
+    adminRoute,
+    path: _createFirstUserRoute,
+    serverURL: config.serverURL,
+  })
 
   const usersCollection = config.collections.find(({ slug }) => slug === userSlug)
   const disableLocalStrategy = usersCollection?.auth?.disableLocalStrategy

--- a/packages/next/src/views/Unauthorized/index.tsx
+++ b/packages/next/src/views/Unauthorized/index.tsx
@@ -20,6 +20,7 @@ export function UnauthorizedView({ initPageResult }: AdminViewServerProps) {
             routes: { logout: logoutRoute },
           },
           routes: { admin: adminRoute },
+          serverURL,
         },
       },
       user,
@@ -41,6 +42,7 @@ export function UnauthorizedView({ initPageResult }: AdminViewServerProps) {
         to={formatAdminURL({
           adminRoute,
           path: logoutRoute,
+          serverURL,
         })}
       >
         {i18n.t('authentication:logOut')}

--- a/packages/next/src/views/Verify/index.tsx
+++ b/packages/next/src/views/Verify/index.tsx
@@ -24,6 +24,7 @@ export async function Verify({ initPageResult, params, searchParams }: AdminView
 
   const {
     routes: { admin: adminRoute },
+    serverURL,
   } = config
 
   let textToRender
@@ -45,7 +46,7 @@ export async function Verify({ initPageResult, params, searchParams }: AdminView
     return (
       <ToastAndRedirect
         message={req.t('authentication:emailVerified')}
-        redirectTo={formatAdminURL({ adminRoute, path: '/login' })}
+        redirectTo={formatAdminURL({ adminRoute, path: '/login', serverURL })}
       />
     )
   }

--- a/packages/next/src/views/Version/Default/SetStepNav.tsx
+++ b/packages/next/src/views/Version/Default/SetStepNav.tsx
@@ -32,6 +32,7 @@ export const SetStepNav: React.FC<{
   useEffect(() => {
     const {
       routes: { admin: adminRoute },
+      serverURL,
     } = config
 
     if (collectionConfig) {
@@ -49,6 +50,7 @@ export const SetStepNav: React.FC<{
           url: formatAdminURL({
             adminRoute,
             path: `/collections/${collectionSlug}`,
+            serverURL,
           }),
         },
       ]
@@ -59,6 +61,7 @@ export const SetStepNav: React.FC<{
           url: formatAdminURL({
             adminRoute,
             path: `/collections/${collectionSlug}/trash`,
+            serverURL,
           }),
         })
       }
@@ -69,6 +72,7 @@ export const SetStepNav: React.FC<{
           url: formatAdminURL({
             adminRoute,
             path: docBasePath,
+            serverURL,
           }),
         },
         {
@@ -76,6 +80,7 @@ export const SetStepNav: React.FC<{
           url: formatAdminURL({
             adminRoute,
             path: `${docBasePath}/versions`,
+            serverURL,
           }),
         },
         {
@@ -97,6 +102,7 @@ export const SetStepNav: React.FC<{
           url: formatAdminURL({
             adminRoute,
             path: `/globals/${globalSlug}`,
+            serverURL,
           }),
         },
         {
@@ -104,6 +110,7 @@ export const SetStepNav: React.FC<{
           url: formatAdminURL({
             adminRoute,
             path: `/globals/${globalSlug}/versions`,
+            serverURL,
           }),
         },
         {

--- a/packages/next/src/views/Version/Restore/index.tsx
+++ b/packages/next/src/views/Version/Restore/index.tsx
@@ -74,6 +74,7 @@ export const Restore: React.FC<Props> = ({
       redirectURL = formatAdminURL({
         adminRoute,
         path: `/collections/${collectionConfig.slug}/${originalDocID}`,
+        serverURL,
       })
     }
 
@@ -82,6 +83,7 @@ export const Restore: React.FC<Props> = ({
       redirectURL = formatAdminURL({
         adminRoute,
         path: `/globals/${globalConfig.slug}`,
+        serverURL,
       })
     }
 

--- a/packages/next/src/views/Versions/cells/CreatedAt/index.tsx
+++ b/packages/next/src/views/Versions/cells/CreatedAt/index.tsx
@@ -26,6 +26,7 @@ export const CreatedAtCell: React.FC<CreatedAtCellProps> = ({
     config: {
       admin: { dateFormat },
       routes: { admin: adminRoute },
+      serverURL,
     },
   } = useConfig()
 
@@ -39,6 +40,7 @@ export const CreatedAtCell: React.FC<CreatedAtCellProps> = ({
     to = formatAdminURL({
       adminRoute,
       path: `/collections/${collectionSlug}/${trashedDocPrefix}${docID}/versions/${id}`,
+      serverURL,
     })
   }
 
@@ -46,6 +48,7 @@ export const CreatedAtCell: React.FC<CreatedAtCellProps> = ({
     to = formatAdminURL({
       adminRoute,
       path: `/globals/${globalSlug}/versions/${id}`,
+      serverURL,
     })
   }
 

--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -1,7 +1,7 @@
 import { Gutter, ListQueryProvider, SetDocumentStepNav } from '@payloadcms/ui'
 import { notFound } from 'next/navigation.js'
 import { type DocumentViewServerProps, type PaginatedDocs, type Where } from 'payload'
-import { hasDraftsEnabled, isNumber } from 'payload/shared'
+import { formatApiURL, hasDraftsEnabled, isNumber } from 'payload/shared'
 import React from 'react'
 
 import { fetchLatestVersion, fetchVersions } from '../Version/fetchVersions.js'
@@ -115,9 +115,11 @@ export async function VersionsView(props: DocumentViewServerProps) {
       : Promise.resolve(null),
   ])
 
-  const fetchURL = collectionSlug
-    ? `${serverURL}${apiRoute}/${collectionSlug}/versions`
-    : `${serverURL}${apiRoute}/globals/${globalSlug}/versions`
+  const fetchURL = formatApiURL({
+    apiRoute,
+    path: collectionSlug ? `/${collectionSlug}/versions` : `/${globalSlug}/versions`,
+    serverURL,
+  })
 
   const columns = buildVersionColumns({
     collectionConfig,

--- a/packages/payload/src/exports/shared.ts
+++ b/packages/payload/src/exports/shared.ts
@@ -83,6 +83,7 @@ export { flattenAllFields } from '../utilities/flattenAllFields.js'
 
 export { flattenTopLevelFields } from '../utilities/flattenTopLevelFields.js'
 export { formatAdminURL } from '../utilities/formatAdminURL.js'
+export { formatApiURL } from '../utilities/formatApiURL.js'
 export { formatLabels, toWords } from '../utilities/formatLabels.js'
 export { getBestFitFromSizes } from '../utilities/getBestFitFromSizes.js'
 

--- a/packages/payload/src/utilities/formatApiURL.ts
+++ b/packages/payload/src/utilities/formatApiURL.ts
@@ -1,0 +1,18 @@
+import type { Config } from '../config/types.js'
+
+import { formatAdminURL } from './formatAdminURL.js'
+
+/** Will read the `routes.api` config and appropriately handle `"/"` api paths */
+export const formatApiURL = (args: {
+  apiRoute: NonNullable<Config['routes']>['api']
+  basePath?: string
+  path: '' | `/${string}` | null | undefined
+  serverURL: Config['serverURL']
+}): string => {
+  return formatAdminURL({
+    adminRoute: args.apiRoute,
+    basePath: args.basePath,
+    path: args.path,
+    serverURL: args.serverURL,
+  })
+}

--- a/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
@@ -23,6 +23,7 @@ export const LinkToDocClient: React.FC = () => {
   const href = `${serverURL}${formatAdminURL({
     adminRoute,
     path: `/collections/${value.relationTo || ''}/${value.value || ''}`,
+    serverURL,
   })}`
 
   const hrefToDisplay = `${process.env.NEXT_BASE_PATH || ''}${href}`

--- a/packages/richtext-lexical/src/cell/rscEntry.tsx
+++ b/packages/richtext-lexical/src/cell/rscEntry.tsx
@@ -49,6 +49,7 @@ export const RscEntryLexicalCell: React.FC<LexicalRichTextCellProps> = (props) =
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
   const adminRoute = payload.config.routes.admin
+  const serverURL = payload.config.serverURL
 
   const onClick = onClickFromProps
 
@@ -71,6 +72,7 @@ export const RscEntryLexicalCell: React.FC<LexicalRichTextCellProps> = (props) =
       ? formatAdminURL({
           adminRoute,
           path: `/collections/${collectionConfig?.slug}/${rowData.id}`,
+          serverURL,
         })
       : ''
   }

--- a/packages/richtext-slate/src/cell/rscEntry.tsx
+++ b/packages/richtext-slate/src/cell/rscEntry.tsx
@@ -34,6 +34,7 @@ export const RscEntrySlateCell: React.FC<
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
   const adminRoute = payload.config.routes.admin
+  const serverURL = payload.config.serverURL
 
   const onClick = onClickFromProps
 
@@ -56,6 +57,7 @@ export const RscEntrySlateCell: React.FC<
       ? formatAdminURL({
           adminRoute,
           path: `/collections/${collectionConfig?.slug}/${rowData.id}`,
+          serverURL,
         })
       : ''
   }

--- a/packages/ui/src/elements/AppHeader/index.tsx
+++ b/packages/ui/src/elements/AppHeader/index.tsx
@@ -34,6 +34,7 @@ export function AppHeader({ CustomAvatar, CustomIcon }: Props) {
       },
       localization,
       routes: { admin: adminRoute },
+      serverURL,
     },
   } = useConfig()
 
@@ -96,7 +97,7 @@ export function AppHeader({ CustomAvatar, CustomIcon }: Props) {
             <Link
               aria-label={t('authentication:account')}
               className={`${baseClass}__account`}
-              href={formatAdminURL({ adminRoute, path: accountRoute })}
+              href={formatAdminURL({ adminRoute, path: accountRoute, serverURL })}
               prefetch={false}
               tabIndex={0}
             >

--- a/packages/ui/src/elements/DeleteDocument/index.tsx
+++ b/packages/ui/src/elements/DeleteDocument/index.tsx
@@ -111,10 +111,7 @@ export const DeleteDocument: React.FC<Props> = (props) => {
         if (redirectAfterDelete) {
           return startRouteTransition(() =>
             router.push(
-              formatAdminURL({
-                adminRoute,
-                path: `/collections/${collectionSlug}`,
-              }),
+              formatAdminURL({ adminRoute, path: `/collections/${collectionSlug}`, serverURL }),
             ),
           )
         }

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -124,6 +124,7 @@ export const DocumentControls: React.FC<{
     admin: { dateFormat },
     localization,
     routes: { admin: adminRoute },
+    serverURL,
   } = config
 
   // Settings these in state to avoid hydration issues if there is a mismatch between the server and client
@@ -351,6 +352,7 @@ export const DocumentControls: React.FC<{
                             href={formatAdminURL({
                               adminRoute,
                               path: `/collections/${collectionConfig?.slug}/create`,
+                              serverURL,
                             })}
                             id="action-create"
                           >

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -116,6 +116,7 @@ export const DuplicateDocument: React.FC<Props> = ({
                 formatAdminURL({
                   adminRoute,
                   path: `/collections/${slug}/${doc.id}${localeCode ? `?locale=${localeCode}` : ''}`,
+                  serverURL,
                 }),
               ),
             )

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -5,7 +5,7 @@ import type { SanitizedCollectionConfig } from 'payload'
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
 import { useRouter } from 'next/navigation.js'
-import { formatAdminURL, hasDraftsEnabled } from 'payload/shared'
+import { formatAdminURL, formatApiURL, hasDraftsEnabled } from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
@@ -91,9 +91,13 @@ export const DuplicateDocument: React.FC<Props> = ({
 
       try {
         const res = await requests.post(
-          `${serverURL}${apiRoute}/${slug}/${id}/duplicate${qs.stringify(queryParams, {
-            addQueryPrefix: true,
-          })}`,
+          formatApiURL({
+            apiRoute,
+            path: `/${slug}/${id}/duplicate${qs.stringify(queryParams, {
+              addQueryPrefix: true,
+            })}`,
+            serverURL,
+          }),
           {
             body: JSON.stringify(hasDraftsEnabled(collectionConfig) ? { _status: 'draft' } : {}),
             headers,

--- a/packages/ui/src/elements/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/EditMany/DrawerContent.tsx
@@ -5,7 +5,12 @@ import type { SelectType, Where } from 'payload'
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
 import { useRouter, useSearchParams } from 'next/navigation.js'
-import { combineWhereConstraints, mergeListSearchAndWhere, unflatten } from 'payload/shared'
+import {
+  combineWhereConstraints,
+  formatApiURL,
+  mergeListSearchAndWhere,
+  unflatten,
+} from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
@@ -385,17 +390,29 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
                     {collection?.versions?.drafts ? (
                       <React.Fragment>
                         <SaveDraftButton
-                          action={`${serverURL}${apiRoute}/${collection.slug}${queryString}&draft=true`}
+                          action={formatApiURL({
+                            apiRoute,
+                            path: `/${collection.slug}${queryString}&draft=true`,
+                            serverURL,
+                          })}
                           disabled={selectedFields.length === 0}
                         />
                         <PublishButton
-                          action={`${serverURL}${apiRoute}/${collection.slug}${queryString}&draft=true`}
+                          action={formatApiURL({
+                            apiRoute,
+                            path: `/${collection.slug}${queryString}&draft=true`,
+                            serverURL,
+                          })}
                           disabled={selectedFields.length === 0}
                         />
                       </React.Fragment>
                     ) : (
                       <Submit
-                        action={`${serverURL}${apiRoute}/${collection.slug}${queryString}`}
+                        action={formatApiURL({
+                          apiRoute,
+                          path: `/${collection.slug}${queryString}`,
+                          serverURL,
+                        })}
                         disabled={selectedFields.length === 0}
                       />
                     )}

--- a/packages/ui/src/elements/FolderView/BrowseByFolderButton/index.tsx
+++ b/packages/ui/src/elements/FolderView/BrowseByFolderButton/index.tsx
@@ -17,6 +17,7 @@ export function BrowseByFolderButton({ active }) {
       routes: { browseByFolder: foldersRoute },
     },
     routes: { admin: adminRoute },
+    serverURL,
   } = config
 
   return (
@@ -25,6 +26,7 @@ export function BrowseByFolderButton({ active }) {
       href={formatAdminURL({
         adminRoute,
         path: foldersRoute,
+        serverURL,
       })}
       id="browse-by-folder"
       prefetch={false}

--- a/packages/ui/src/elements/IDLabel/index.tsx
+++ b/packages/ui/src/elements/IDLabel/index.tsx
@@ -19,6 +19,7 @@ export const IDLabel: React.FC<{ className?: string; id: string; prefix?: string
   const {
     config: {
       routes: { admin: adminRoute },
+      serverURL,
     },
   } = useConfig()
 
@@ -28,6 +29,7 @@ export const IDLabel: React.FC<{ className?: string; id: string; prefix?: string
   const docPath = formatAdminURL({
     adminRoute,
     path: `/${collectionSlug ? `collections/${collectionSlug}` : `globals/${globalSlug}`}/${id}`,
+    serverURL,
   })
 
   return (

--- a/packages/ui/src/elements/Logout/index.tsx
+++ b/packages/ui/src/elements/Logout/index.tsx
@@ -26,6 +26,7 @@ export const Logout: React.FC<{
       routes: { logout: logoutRoute },
     },
     routes: { admin: adminRoute },
+    serverURL,
   } = config
 
   return (
@@ -35,6 +36,7 @@ export const Logout: React.FC<{
       href={formatAdminURL({
         adminRoute,
         path: logoutRoute,
+        serverURL,
       })}
       prefetch={false}
       tabIndex={tabIndex}

--- a/packages/ui/src/elements/PermanentlyDeleteButton/index.tsx
+++ b/packages/ui/src/elements/PermanentlyDeleteButton/index.tsx
@@ -95,6 +95,7 @@ export const PermanentlyDeleteButton: React.FC<Props> = (props) => {
               formatAdminURL({
                 adminRoute,
                 path: `/collections/${collectionSlug}/trash`,
+                serverURL,
               }),
             ),
           )

--- a/packages/ui/src/elements/RestoreButton/index.tsx
+++ b/packages/ui/src/elements/RestoreButton/index.tsx
@@ -111,6 +111,7 @@ export const RestoreButton: React.FC<Props> = (props) => {
               formatAdminURL({
                 adminRoute,
                 path: `/collections/${collectionSlug}/${id}`,
+                serverURL,
               }),
             ),
           )

--- a/packages/ui/src/elements/StayLoggedIn/index.tsx
+++ b/packages/ui/src/elements/StayLoggedIn/index.tsx
@@ -24,6 +24,7 @@ export const StayLoggedInModal: React.FC = () => {
       routes: { logout: logoutRoute },
     },
     routes: { admin: adminRoute },
+    serverURL,
   } = config
 
   const { t } = useTranslation()
@@ -35,10 +36,11 @@ export const StayLoggedInModal: React.FC = () => {
         formatAdminURL({
           adminRoute,
           path: logoutRoute,
+          serverURL,
         }),
       ),
     )
-  }, [router, startRouteTransition, adminRoute, logoutRoute])
+  }, [router, startRouteTransition, adminRoute, logoutRoute, serverURL])
 
   const onCancel: OnCancel = useCallback(() => {
     refreshCookie()

--- a/packages/ui/src/elements/Table/DefaultCell/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/index.tsx
@@ -33,6 +33,7 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
   const {
     config: {
       routes: { admin: adminRoute },
+      serverURL,
     },
     getEntityConfig,
   } = useConfig()
@@ -72,6 +73,7 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
         ? formatAdminURL({
             adminRoute,
             path: `/collections/${collectionConfig?.slug}${viewType === 'trash' ? '/trash' : ''}/${encodeURIComponent(rowData.id)}`,
+            serverURL,
           })
         : ''
     }

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -630,6 +630,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
           const docUrl = formatAdminURL({
             adminRoute: config.routes.admin,
             path: `/collections/${collectionSlug}/${id}`,
+            serverURL,
           })
 
           window.open(docUrl, '_blank')
@@ -644,7 +645,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
         })
       }
     },
-    [config.routes.admin],
+    [config.routes.admin, serverURL],
   )
 
   const updateResultsEffectEvent: UpdateResults = useEffectEvent((args) => {

--- a/packages/ui/src/graphics/Account/index.tsx
+++ b/packages/ui/src/graphics/Account/index.tsx
@@ -16,12 +16,13 @@ export const Account = () => {
         routes: { account: accountRoute },
       },
       routes: { admin: adminRoute },
+      serverURL,
     },
   } = useConfig()
 
   const { user } = useAuth()
   const pathname = usePathname()
-  const isOnAccountPage = pathname === formatAdminURL({ adminRoute, path: accountRoute })
+  const isOnAccountPage = pathname === formatAdminURL({ adminRoute, path: accountRoute, serverURL })
 
   if (!user?.email || avatar === 'default') {
     return <DefaultAccountIcon active={isOnAccountPage} />

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -3,7 +3,7 @@ import type { ClientUser, SanitizedPermissions, TypedUser } from 'payload'
 
 import { useModal } from '@faceless-ui/modal'
 import { usePathname, useRouter } from 'next/navigation.js'
-import { formatAdminURL } from 'payload/shared'
+import { formatAdminURL, formatApiURL } from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { createContext, use, useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -198,7 +198,11 @@ export function AuthProvider({
         refreshTokenTimeoutRef.current = setTimeout(async () => {
           try {
             const request = await requests.post(
-              `${serverURL}${apiRoute}/${userSlug}/refresh-token?refresh`,
+              formatApiURL({
+                apiRoute,
+                path: `/${userSlug}/refresh-token?refresh`,
+                serverURL,
+              }),
               {
                 headers: {
                   'Accept-Language': i18n.language,
@@ -235,11 +239,18 @@ export function AuthProvider({
   const refreshCookieAsync = useCallback(
     async (skipSetUser?: boolean): Promise<ClientUser> => {
       try {
-        const request = await requests.post(`${serverURL}${apiRoute}/${userSlug}/refresh-token`, {
-          headers: {
-            'Accept-Language': i18n.language,
+        const request = await requests.post(
+          formatApiURL({
+            apiRoute,
+            path: `/${userSlug}/refresh-token`,
+            serverURL,
+          }),
+          {
+            headers: {
+              'Accept-Language': i18n.language,
+            },
           },
-        })
+        )
 
         if (request.status === 200) {
           const json: UserWithToken = await request.json()
@@ -265,7 +276,13 @@ export function AuthProvider({
     try {
       if (user && user.collection) {
         setNewUser(null)
-        await requests.post(`${serverURL}${apiRoute}/${user.collection}/logout`)
+        await requests.post(
+          formatApiURL({
+            apiRoute,
+            path: `/${user.collection}/logout`,
+            serverURL,
+          }),
+        )
       }
     } catch (_) {
       // fail silently and log the user out in state
@@ -286,11 +303,18 @@ export function AuthProvider({
       )
 
       try {
-        const request = await requests.get(`${serverURL}${apiRoute}/access${params}`, {
-          headers: {
-            'Accept-Language': i18n.language,
+        const request = await requests.get(
+          formatApiURL({
+            apiRoute,
+            path: `/access${params}`,
+            serverURL,
+          }),
+          {
+            headers: {
+              'Accept-Language': i18n.language,
+            },
           },
-        })
+        )
 
         if (request.status === 200) {
           const json: SanitizedPermissions = await request.json()
@@ -307,12 +331,19 @@ export function AuthProvider({
 
   const fetchFullUser = React.useCallback(async () => {
     try {
-      const request = await requests.get(`${serverURL}${apiRoute}/${userSlug}/me`, {
-        credentials: 'include',
-        headers: {
-          'Accept-Language': i18n.language,
+      const request = await requests.get(
+        formatApiURL({
+          apiRoute,
+          path: `/${userSlug}/me`,
+          serverURL,
+        }),
+        {
+          credentials: 'include',
+          headers: {
+            'Accept-Language': i18n.language,
+          },
         },
-      })
+      )
 
       if (request.status === 200) {
         const json: UserWithToken = await request.json()

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -125,12 +125,13 @@ export function AuthProvider({
         formatAdminURL({
           adminRoute,
           path: `${logoutInactivityRoute}${window.location.pathname.startsWith(adminRoute) ? `?redirect=${encodeURIComponent(window.location.pathname)}` : ''}`,
+          serverURL,
         }),
       ),
     )
 
     closeAllModals()
-  }, [router, adminRoute, logoutInactivityRoute, closeAllModals, startRouteTransition])
+  }, [router, adminRoute, logoutInactivityRoute, closeAllModals, startRouteTransition, serverURL])
 
   const revokeTokenAndExpire = useCallback(() => {
     setUserInMemory(null)

--- a/packages/ui/src/providers/Folders/index.tsx
+++ b/packages/ui/src/providers/Folders/index.tsx
@@ -337,6 +337,7 @@ export function FolderProvider({
               formatAdminURL({
                 adminRoute: config.routes.admin,
                 path: `/collections/${collectionSlug}/${docID}`,
+                serverURL,
               }),
             )
             clearSelections()
@@ -351,6 +352,7 @@ export function FolderProvider({
       }
     },
     [
+      serverURL,
       clearSelections,
       config.routes.admin,
       drawerDepth,

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -80,6 +80,7 @@ export function renderCell({
       const defaultURL = formatAdminURL({
         adminRoute,
         path: `/collections/${collectionSlug}${viewType === 'trash' ? '/trash' : ''}/${encodeURIComponent(String(doc.id))}`,
+        serverURL: req.payload.config.serverURL,
       })
 
       const customURL = formatDocURL({

--- a/packages/ui/src/utilities/handleBackToDashboard.tsx
+++ b/packages/ui/src/utilities/handleBackToDashboard.tsx
@@ -5,12 +5,14 @@ import { formatAdminURL } from 'payload/shared'
 type BackToDashboardProps = {
   adminRoute: string
   router: AppRouterInstance
+  serverURL?: string
 }
 
-export const handleBackToDashboard = ({ adminRoute, router }: BackToDashboardProps) => {
+export const handleBackToDashboard = ({ adminRoute, router, serverURL }: BackToDashboardProps) => {
   const redirectRoute = formatAdminURL({
     adminRoute,
     path: '/',
+    serverURL,
   })
   router.push(redirectRoute)
 }

--- a/packages/ui/src/utilities/handleGoBack.tsx
+++ b/packages/ui/src/utilities/handleGoBack.tsx
@@ -6,12 +6,14 @@ type GoBackProps = {
   adminRoute: string
   collectionSlug: string
   router: AppRouterInstance
+  serverURL?: string
 }
 
-export const handleGoBack = ({ adminRoute, collectionSlug, router }: GoBackProps) => {
+export const handleGoBack = ({ adminRoute, collectionSlug, router, serverURL }: GoBackProps) => {
   const redirectRoute = formatAdminURL({
     adminRoute,
     path: collectionSlug ? `/collections/${collectionSlug}` : '/',
+    serverURL,
   })
   router.push(redirectRoute)
 }

--- a/packages/ui/src/views/CollectionFolder/index.tsx
+++ b/packages/ui/src/views/CollectionFolder/index.tsx
@@ -197,6 +197,7 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
                           formatAdminURL({
                             adminRoute: config.routes.admin,
                             path: `/collections/${collectionSlug}/${config.folders.slug}`,
+                            serverURL: config.serverURL,
                           }),
                         )
                       }
@@ -225,6 +226,7 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
                           formatAdminURL({
                             adminRoute: config.routes.admin,
                             path: `/collections/${collectionSlug}/${config.folders.slug}/${crumb.id}`,
+                            serverURL: config.serverURL,
                           }),
                         )
                       }
@@ -243,6 +245,7 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
     collectionSlug,
     config.folders,
     config.routes.admin,
+    config.serverURL,
     drawerDepth,
     i18n,
     labels?.plural,

--- a/packages/ui/src/views/Edit/SetDocumentStepNav/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentStepNav/index.tsx
@@ -41,6 +41,7 @@ export const SetDocumentStepNav: React.FC<{
   const {
     config: {
       routes: { admin: adminRoute },
+      serverURL,
     },
   } = useConfig()
 
@@ -56,6 +57,7 @@ export const SetDocumentStepNav: React.FC<{
             ? formatAdminURL({
                 adminRoute,
                 path: `/collections/${collectionSlug}`,
+                serverURL,
               })
             : undefined,
         })
@@ -68,6 +70,7 @@ export const SetDocumentStepNav: React.FC<{
               ? formatAdminURL({
                   adminRoute,
                   path: `/collections/${collectionSlug}/trash`,
+                  serverURL,
                 })
               : undefined,
           })
@@ -83,6 +86,7 @@ export const SetDocumentStepNav: React.FC<{
                   path: isTrashed
                     ? `/collections/${collectionSlug}/trash/${id}`
                     : `/collections/${collectionSlug}/${id}`,
+                  serverURL,
                 })
               : undefined,
           })
@@ -98,6 +102,7 @@ export const SetDocumentStepNav: React.FC<{
             ? formatAdminURL({
                 adminRoute,
                 path: `/globals/${globalSlug}`,
+                serverURL,
               })
             : undefined,
         })
@@ -126,6 +131,7 @@ export const SetDocumentStepNav: React.FC<{
     title,
     collectionSlug,
     globalSlug,
+    serverURL,
     view,
     isVisible,
   ])

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -121,6 +121,7 @@ export function DefaultEditView({
     config: {
       admin: { user: userSlug },
       routes: { admin: adminRoute },
+      serverURL,
     },
     getEntityConfig,
   } = useConfig()
@@ -321,6 +322,7 @@ export function DefaultEditView({
         const redirectRoute = formatAdminURL({
           adminRoute,
           path: `/collections/${collectionSlug}/${document?.id}${locale ? `?locale=${locale}` : ''}`,
+          serverURL,
         })
 
         startRouteTransition(() => router.push(redirectRoute))
@@ -396,26 +398,22 @@ export function DefaultEditView({
       }
     },
     [
-      reportUpdate,
-      id,
-      entitySlug,
       user,
-      drawerSlug,
       collectionSlug,
       userSlug,
+      id,
       setLastUpdateTime,
       setData,
       onSaveFromContext,
       isEditing,
       depth,
       redirectAfterCreate,
-      setLivePreviewURL,
-      setPreviewURL,
       globalSlug,
       refreshCookieAsync,
       incrementVersionCount,
       adminRoute,
       locale,
+      serverURL,
       startRouteTransition,
       router,
       resetUploadEdits,
@@ -425,11 +423,17 @@ export function DefaultEditView({
       docPermissions,
       operation,
       isLivePreviewEnabled,
-      isPreviewEnabled,
       typeofLivePreviewURL,
+      isPreviewEnabled,
       schemaPathSegments,
+      upload,
       isLockingEnabled,
+      reportUpdate,
+      drawerSlug,
+      entitySlug,
       setDocumentIsLocked,
+      setLivePreviewURL,
+      setPreviewURL,
     ],
   )
 
@@ -558,7 +562,7 @@ export function DefaultEditView({
           )}
           {isLockingEnabled && shouldShowDocumentLockedModal && (
             <DocumentLocked
-              handleGoBack={() => handleGoBack({ adminRoute, collectionSlug, router })}
+              handleGoBack={() => handleGoBack({ adminRoute, collectionSlug, router, serverURL })}
               isActive={shouldShowDocumentLockedModal}
               onReadOnly={() => {
                 setIsReadOnlyForIncomingUser(true)
@@ -584,7 +588,7 @@ export function DefaultEditView({
           )}
           {isLockingEnabled && showTakeOverModal && (
             <DocumentTakeOver
-              handleBackToDashboard={() => handleBackToDashboard({ adminRoute, router })}
+              handleBackToDashboard={() => handleBackToDashboard({ adminRoute, router, serverURL })}
               isActive={showTakeOverModal}
               onReadOnly={() => {
                 setIsReadOnlyForIncomingUser(true)

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -71,6 +71,7 @@ export function DefaultListView(props: ListViewClientProps) {
   const {
     config: {
       routes: { admin: adminRoute },
+      serverURL,
     },
     getEntityConfig,
   } = useConfig()
@@ -127,6 +128,7 @@ export function DefaultListView(props: ListViewClientProps) {
             ? formatAdminURL({
                 adminRoute,
                 path: `/collections/${collectionSlug}`,
+                serverURL,
               })
             : undefined,
       }
@@ -140,7 +142,17 @@ export function DefaultListView(props: ListViewClientProps) {
 
       setStepNav(navItems)
     }
-  }, [adminRoute, setStepNav, labels, isInDrawer, isTrashEnabled, viewType, i18n, collectionSlug])
+  }, [
+    adminRoute,
+    setStepNav,
+    serverURL,
+    labels,
+    isInDrawer,
+    isTrashEnabled,
+    viewType,
+    i18n,
+    collectionSlug,
+  ])
 
   return (
     <Fragment>


### PR DESCRIPTION
Fixes issues with basePath and NextJS. Many of the links created in the admin panel were not passing a `serverURL` through to the `formatAdminURL` helper. 

This PR adds all the missing `serverURL` instances and adds a new helper `formatApiURL` that allows for similar route creation but for api routes.