### PR TITLE
perf(graphql): optimized join count when docs are not needed

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -444,6 +444,16 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           throw new Error('GraphQL with array of join.field.collection is not implemented')
         }
 
+        if (count && limit === 0) {
+          return await req.payload.count({
+            collection,
+            depth: 0,
+            overrideAccess: false,
+            req,
+            where: fullWhere,
+          })
+        }
+
         const { docs, totalDocs } = await req.payload.find({
           collection,
           depth: 0,


### PR DESCRIPTION
### What?
Optimizes the count of a join field when the goal is just to retrieve the count value (i.e. limit: 0). 

### Why?
Generates 1 database query instead of two when the goal is just to retrieve the count value.

### How?
By using payload.count() instead of payload.find()