### PR TITLE
refactor(next): remove unnecessary react hooks from DefaultTemplate rsc

### DIFF
--- a/packages/next/src/templates/Default/index.tsx
+++ b/packages/next/src/templates/Default/index.tsx
@@ -94,34 +94,18 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
     user,
   }
 
-  const {
-    Actions,
-  }: {
-    Actions: Record<string, React.ReactNode>
-  } = {
-    Actions: viewActions
-      ? viewActions.reduce((acc, action) => {
-          if (action) {
-            if (typeof action === 'object') {
-              acc[action.path] = RenderServerComponent({
-                clientProps,
-                Component: action,
-                importMap: payload.importMap,
-                serverProps,
-              })
-            } else {
-              acc[action] = RenderServerComponent({
-                clientProps,
-                Component: action,
-                importMap: payload.importMap,
-                serverProps,
-              })
-            }
-          }
-
-          return acc
-        }, {})
-      : undefined,
+  const Actions: Record<string, React.ReactNode> = {}
+  for (const action of viewActions ?? []) {
+    if (!action) {
+      continue
+    }
+    const key = typeof action === 'object' ? action.path : action
+    Actions[key] = RenderServerComponent({
+      clientProps,
+      Component: action,
+      importMap: payload.importMap,
+      serverProps,
+    })
   }
 
   const NavComponent = RenderServerComponent({

--- a/packages/next/src/templates/Default/index.tsx
+++ b/packages/next/src/templates/Default/index.tsx
@@ -69,72 +69,60 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
     } = {},
   } = payload.config || {}
 
-  const clientProps = React.useMemo(() => {
-    return {
-      documentSubViewType,
-      viewType,
-      visibleEntities,
-    }
-  }, [documentSubViewType, viewType, visibleEntities])
+  const clientProps = {
+    documentSubViewType,
+    viewType,
+    visibleEntities,
+  }
 
-  const serverProps = React.useMemo<ServerProps>(
-    () => ({
-      collectionSlug,
-      docID,
-      globalSlug,
-      i18n,
-      locale,
-      params,
-      payload,
-      permissions,
-      req,
-      searchParams,
-      user,
-    }),
-    [
-      i18n,
-      locale,
-      params,
-      payload,
-      permissions,
-      searchParams,
-      user,
-      globalSlug,
-      collectionSlug,
-      docID,
-      req,
-    ],
-  )
+  const serverProps: {
+    collectionSlug: string
+    docID: number | string
+    globalSlug: string
+    req: PayloadRequest
+  } & ServerProps = {
+    collectionSlug,
+    docID,
+    globalSlug,
+    i18n,
+    locale,
+    params,
+    payload,
+    permissions,
+    req,
+    searchParams,
+    user,
+  }
 
-  const { Actions } = React.useMemo<{
+  const {
+    Actions,
+  }: {
     Actions: Record<string, React.ReactNode>
-  }>(() => {
-    return {
-      Actions: viewActions
-        ? viewActions.reduce((acc, action) => {
-            if (action) {
-              if (typeof action === 'object') {
-                acc[action.path] = RenderServerComponent({
-                  clientProps,
-                  Component: action,
-                  importMap: payload.importMap,
-                  serverProps,
-                })
-              } else {
-                acc[action] = RenderServerComponent({
-                  clientProps,
-                  Component: action,
-                  importMap: payload.importMap,
-                  serverProps,
-                })
-              }
+  } = {
+    Actions: viewActions
+      ? viewActions.reduce((acc, action) => {
+          if (action) {
+            if (typeof action === 'object') {
+              acc[action.path] = RenderServerComponent({
+                clientProps,
+                Component: action,
+                importMap: payload.importMap,
+                serverProps,
+              })
+            } else {
+              acc[action] = RenderServerComponent({
+                clientProps,
+                Component: action,
+                importMap: payload.importMap,
+                serverProps,
+              })
             }
+          }
 
-            return acc
-          }, {})
-        : undefined,
-    }
-  }, [payload, serverProps, viewActions, clientProps])
+          return acc
+        }, {})
+      : undefined,
+  }
 
   const NavComponent = RenderServerComponent({
     clientProps,


### PR DESCRIPTION
This remove unnecessary useMemo react hooks from `DefaultTemplate`. `DefaultTemplate` is a React Server Component, so those hooks didn't do anything and shouldn't be used.