### PR TITLE
fix(next): use fileURLToPath for cross-platform path resolution

### DIFF
--- a/packages/next/src/withPayload/withPayload.utils.ts
+++ b/packages/next/src/withPayload/withPayload.utils.ts
@@ -26,6 +26,7 @@
  */
 
 import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
 
 function _parseInt(input: string | undefined): number {
   return parseInt(input || '', 10)
@@ -86,7 +87,9 @@ export function getNextjsVersion(): SemVer | undefined {
     if (typeof import.meta?.resolve === 'function') {
       // ESM environment - use import.meta.resolve
       const pkgUrl = import.meta.resolve('next/package.json')
-      pkgPath = new URL(pkgUrl).pathname
+      // Use fileURLToPath for proper cross-platform path handling (Windows, macOS, Linux)
+      // new URL().pathname returns '/C:/path' on Windows which causes path resolution issues
+      pkgPath = fileURLToPath(pkgUrl)
     } else {
       // CJS environment - use require.resolve
       pkgPath = require.resolve('next/package.json')


### PR DESCRIPTION
Fixes #14880

## Summary

Fixes a bug where `getNextjsVersion()` fails to read the Next.js package.json on Windows systems, causing errors like:
Error: ENOENT: no such file or directory, open 'F:\F:\data...\next\package.json'