### PR TITLE
fix(next): unhandled error in renderListView server function when no user present

### DIFF
--- a/packages/next/src/views/List/handleServerFunction.tsx
+++ b/packages/next/src/views/List/handleServerFunction.tsx
@@ -3,7 +3,13 @@ import type { CollectionPreferences, ServerFunction, VisibleEntities } from 'pay
 
 import { getClientConfig } from '@payloadcms/ui/utilities/getClientConfig'
 import { headers as getHeaders } from 'next/headers.js'
-import { canAccessAdmin, getAccessResults, isEntityHidden, parseCookies } from 'payload'
+import {
+  canAccessAdmin,
+  getAccessResults,
+  isEntityHidden,
+  parseCookies,
+  UnauthorizedError,
+} from 'payload'
 import { applyLocaleFiltering } from 'payload/shared'
 
 import { renderListView } from './index.js'
@@ -32,6 +38,10 @@ export const renderListHandler: ServerFunction<
       user,
     },
   } = args
+
+  if (!req.user) {
+    throw new UnauthorizedError()
+  }
 
   const headers = await getHeaders()
 


### PR DESCRIPTION
Previously, the following error may be thrown when no `user` is present on the `req`:

```ts
 TypeError: Cannot read properties of null (reading 'collection')
    at renderListHandler (packages/next/src/views/List/handleServerFunction.tsx:66:28)
    at async Server.<anonymous> (test/dev.ts:129:5)
  64 |           {
  65 |             'user.relationTo': {
> 66 |               equals: user.collection,
     |                            ^
  67 |             },
  68 |           },
  69 |           { {
  digest: '4059983158'
}
 POST /admin/collections/with-list-drawer 500 in 164ms (compile: 2ms, render: 162ms)
```

I'm seeing it thrown a lot in our test suites, likely because it's logging out the user while a previous request is still going on.

This PR explicitly throws an `UnauthorizedError` before the server function tries to access properties on the `user` object.