### PR TITLE
fix(next): merge user serverExternalPackages in withPayload

### DIFF
--- a/packages/next/src/withPayload/withPayload.ts
+++ b/packages/next/src/withPayload/withPayload.ts
@@ -81,6 +81,7 @@ export const withPayload = (
       ]
     },
     serverExternalPackages: [
+      ...(nextConfig.serverExternalPackages || []),
       // WHY: without externalizing graphql, a graphql version error will be thrown
       // during runtime ("Ensure that there is only one instance of \"graphql\" in the node_modules\ndirectory.")
       'graphql',


### PR DESCRIPTION
Merge user's `serverExternalPackages` with Payload's defaults in `withPayload()`.

Currently user-defined `serverExternalPackages` are ignored:

```js
const nextConfig = {
  serverExternalPackages: ['@node-rs/xxhash', 'prettier'], // ignored
}
export default withPayload(nextConfig)
```

Fix: spread user packages before Payload's defaults.
