### PR TITLE
perf: optimized collection create when versions are enabled

### DIFF
--- a/packages/drizzle/src/createVersion.ts
+++ b/packages/drizzle/src/createVersion.ts
@@ -27,8 +27,13 @@ export async function createVersion<T extends JsonObject = JsonObject>(
   }: CreateVersionArgs<T>,
 ): Promise<TypeWithVersion<T>> {
   const collection = this.payload.collections[collectionSlug].config
-  const defaultTableName = toSnakeCase(collection.slug)
+  if (collection.versions.drafts) {
+    if (typeof select === 'object') {
+      select.updatedAt = true
+    }
+  }
 
+  const defaultTableName = toSnakeCase(collection.slug)
   const tableName = this.tableNameMap.get(`_${defaultTableName}${this.versionsSuffix}`)
 
   const version = { ...versionData }
@@ -54,6 +59,7 @@ export async function createVersion<T extends JsonObject = JsonObject>(
     data,
     db,
     fields: buildVersionCollectionFields(this.payload.config, collection, true),
+    ignoreResult: returning === false ? 'idOnly' : undefined,
     operation: 'create',
     req,
     select,
@@ -70,7 +76,7 @@ export async function createVersion<T extends JsonObject = JsonObject>(
         SET latest = false
         WHERE ${table.id} != ${result.id}
           AND ${table.parent} = ${parent}
-          AND ${table.updatedAt} < ${result.updatedAt}
+          AND ${table.updatedAt} < ${result.updatedAt || updatedAt}
       `,
     })
   }

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -287,6 +287,7 @@ export const createOperation = async <
         payload,
         publishSpecificLocale,
         req,
+        returning: false,
       })
     }
 

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -21,6 +21,7 @@ type Args<T extends JsonObject = JsonObject> = {
   payload: Payload
   publishSpecificLocale?: string
   req?: PayloadRequest
+  returning?: boolean
   select?: SelectType
   snapshot?: any
 }
@@ -36,6 +37,7 @@ export const saveVersion = async <TData extends JsonObject = JsonObject>({
   payload,
   publishSpecificLocale,
   req,
+  returning,
   select,
   snapshot,
 }: Args<TData>): Promise<JsonObject> => {
@@ -136,6 +138,7 @@ export const saveVersion = async <TData extends JsonObject = JsonObject>({
         parent: collection ? id : undefined,
         publishedLocale: publishSpecificLocale || undefined,
         req,
+        returning,
         select: getQueryDraftsSelect({ select }),
         updatedAt: now,
         versionData,
@@ -189,6 +192,9 @@ export const saveVersion = async <TData extends JsonObject = JsonObject>({
       payload,
       req,
     })
+  }
+  if (returning === false) {
+    return {}
   }
 
   let createdVersion = (result as any).version

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -26,7 +26,16 @@ type Args<T extends JsonObject = JsonObject> = {
   snapshot?: any
 }
 
-export const saveVersion = async <TData extends JsonObject = JsonObject>({
+export async function saveVersion<TData extends JsonObject = JsonObject>(
+  args: { returning: false } & Args<TData>,
+): Promise<null>
+export async function saveVersion<TData extends JsonObject = JsonObject>(
+  args: { returning: true } & Args<TData>,
+): Promise<JsonObject>
+export async function saveVersion<TData extends JsonObject = JsonObject>(
+  args: Omit<Args<TData>, 'returning'>,
+): Promise<JsonObject>
+export async function saveVersion<TData extends JsonObject = JsonObject>({
   id,
   autosave,
   collection,
@@ -40,7 +49,7 @@ export const saveVersion = async <TData extends JsonObject = JsonObject>({
   returning,
   select,
   snapshot,
-}: Args<TData>): Promise<JsonObject> => {
+}: Args<TData>): Promise<JsonObject | null> {
   let result: JsonObject | undefined
   let createNewVersion = true
   const now = new Date().toISOString()
@@ -194,7 +203,7 @@ export const saveVersion = async <TData extends JsonObject = JsonObject>({
     })
   }
   if (returning === false) {
-    return {}
+    return null
   }
 
   let createdVersion = (result as any).version

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1,8 +1,8 @@
-import type { JsonObject, Payload } from 'payload'
+import type { JsonObject, Payload} from 'payload';
 
 import { schedulePublishHandler } from '@payloadcms/ui/utilities/schedulePublishHandler'
 import path from 'path'
-import { createLocalReq, ValidationError } from 'payload'
+import { createLocalReq, saveVersion, ValidationError  } from 'payload'
 import { wait } from 'payload/shared'
 import * as qs from 'qs-esm'
 import { fileURLToPath } from 'url'
@@ -428,6 +428,28 @@ describe('Versions', () => {
           where: { id: { equals: post.id } },
         })
         expect(await getVersionsCount()).toBe(2)
+      })
+
+      it('should return null when saving a version with returning:false', async () => {
+        const collection = autosaveCollectionSlug
+        const collectionConfig = payload.collections[autosaveCollectionSlug].config
+
+        const post = await payload.create({
+          collection,
+          data: { description: 'description' },
+          draft: true,
+        })
+
+        const result = await saveVersion({
+          id: post.id,
+          collection: collectionConfig,
+          docWithLocales: post,
+          operation: 'create',
+          payload,
+          returning: false,
+        })
+
+        expect(result).toBeNull()
       })
     })
 


### PR DESCRIPTION
### What?
Optimized the collection create operation when versions are enabled.

### Why?
To reduce the total request time when creating a new entry on a collection with versions enabled.

### How?
By passing returning=false to the saveVersion method, as the result is not needed. Also updated drizzle's createVersion operation to ignore the result when returning==false. This saves multiple database queries, specially on collections with relationships and other complex fields, as it no longer needs to load the new entry after creation.