### PR TITLE
feat: improve type safety for siblingData in field types

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -160,7 +160,7 @@ import type {
   UploadFieldSingleValidation,
 } from '../validations.js'
 
-export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSiblingData = TData> = {
+export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSiblingData = any> = {
   /**
    * The data of the nearest parent block. If the field is not within a block, `blockData` will be equal to `undefined`.
    */
@@ -228,11 +228,11 @@ export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSibling
   value?: TValue
 }
 
-export type FieldHook<TData extends TypeWithID = any, TValue = any, TSiblingData = TData> = (
+export type FieldHook<TData extends TypeWithID = any, TValue = any, TSiblingData = any> = (
   args: FieldHookArgs<TData, TValue, TSiblingData>,
 ) => Promise<TValue> | TValue
 
-export type FieldAccessArgs<TData extends TypeWithID = any, TSiblingData = TData> = {
+export type FieldAccessArgs<TData extends TypeWithID = any, TSiblingData = any> = {
   /**
    * The data of the nearest parent block. If the field is not within a block, `blockData` will be equal to `undefined`.
    */
@@ -257,12 +257,12 @@ export type FieldAccessArgs<TData extends TypeWithID = any, TSiblingData = TData
   siblingData?: Partial<StripRelationships<TSiblingData>>
 }
 
-export type FieldAccess<TData extends TypeWithID = any, TSiblingData = TData> = (
+export type FieldAccess<TData extends TypeWithID = any, TSiblingData = any> = (
   args: FieldAccessArgs<TData, TSiblingData>,
 ) => boolean | Promise<boolean>
 
 //TODO: In 4.0, we should replace the three parameters of the condition function with a single, named parameter object
-export type Condition<TData extends TypeWithID = any, TSiblingData = TData> = (
+export type Condition<TData extends TypeWithID = any, TSiblingData = any> = (
   /**
    * The top-level document data
    */
@@ -310,7 +310,7 @@ export type StripRelationships<T> = {
     : Extract<T[K], null | undefined> | ExtractID<T[K]>
 }
 
-export type FilterOptionsProps<TData = any> = {
+export type FilterOptionsProps<TData = any, TSiblingData = any> = {
   /**
    * The data of the nearest parent block. Will be `undefined` if the field is not within a block or when called on a `Filter` component within the list view.
    */
@@ -320,7 +320,7 @@ export type FilterOptionsProps<TData = any> = {
    */
   data: TData
   /**
-   * The `id` of the current document being edited. Will be undefined during the `create` operation or when called on a `Filter` component within the list view.
+   * The `id` of the current document being edited. Will be s during the `create` operation or when called on a `Filter` component within the list view.
    */
   id: number | string
   /**
@@ -331,7 +331,7 @@ export type FilterOptionsProps<TData = any> = {
   /**
    * An object containing document data that is scoped to only fields within the same parent of this field. Will be an empty object when called on a `Filter` component within the list view.
    */
-  siblingData: Partial<StripRelationships<TData>>
+  siblingData: Partial<StripRelationships<TSiblingData>>
   /**
    * An object containing the currently authenticated user.
    */

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -320,7 +320,7 @@ export type FilterOptionsProps<TData = any, TSiblingData = any> = {
    */
   data: TData
   /**
-   * The `id` of the current document being edited. Will be s during the `create` operation or when called on a `Filter` component within the list view.
+   * The `id` of the current document being edited. Will be undefined during the `create` operation or when called on a `Filter` component within the list view.
    */
   id: number | string
   /**

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -201,7 +201,7 @@ export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSibling
   /** The document before changes were applied, only in `afterChange` hooks. */
   previousDoc?: TData
   /** The sibling data of the document before changes being applied, only in `beforeChange`, `beforeValidate`, `beforeDuplicate` and `afterChange` field hooks. */
-  previousSiblingDoc?: TSiblingData
+  previousSiblingDoc?: Partial<StripRelationships<TSiblingData>>
   /** The previous value of the field, before changes, only in `beforeChange`, `afterChange`, `beforeDuplicate` and `beforeValidate` field hooks. */
   previousValue?: TValue
   /** The Express request object. It is mocked for Local API operations. */

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -306,8 +306,8 @@ type ExtractID<T> = T extends { id: unknown } ? never : T
  */
 export type StripRelationships<T> = {
   [K in keyof T]: T[K] extends (infer U)[] | null | undefined
-    ? ExtractID<U>[] | Extract<T[K], null | undefined>
-    : ExtractID<T[K]> | Extract<T[K], null | undefined>
+    ? Extract<T[K], null | undefined> | ExtractID<U>[]
+    : Extract<T[K], null | undefined> | ExtractID<T[K]>
 }
 
 export type FilterOptionsProps<TData = any> = {


### PR DESCRIPTION
### Summary
Improves TypeScript type safety for `siblingData` across field configuration types by introducing a StripRelationships utility type that removes populated relationship objects, keeping the ID type (`number` or `string`) base on database config.


```typescript
const siblingData = {
  creator: 1,                    // Relationship field
  _status: 'draft',
  title:"abc",
  updatedAt: '2025-12-11T07:52:22.115Z',
  createdAt: '2025-12-11T07:13:24.433Z',
  attributes: [3, 2],            // Relationship hasMany
  description: {                 // RichText field
    root: {
      type: 'root',
      children: [...],
    }
  },
}

} // RichText field


// Before (Incorrect Types)
type SiblingData = {
  [key: string]: any
} | undefined

// Or with Partial<TData>:
type SiblingData = {
  creator: number | User | undefined      // ❌ Includes populated object
  attributes?: (number | Attribute)[]     // ❌ Includes populated objects
  ...
}


// After (Correct Types)

type SiblingData = {
  id: number | undefined
  creator: number | undefined              // ✅ ID only
  title: string | undefined
  description: {
    [k: string]: unknown
    root: {
      type: string
      children: { type: any; version: number }[]
      direction: 'rtl' | 'ltr' | null
      format: '' | 'center' | 'left' | 'right' | 'start' | 'end' | 'justify'
      indent: number
      version: number
    }
  } | undefined
  attributes?: number[] | null             // ✅ IDs only
  updatedAt: string | undefined
  createdAt: string | undefined
   _status?: "draft" | "published" | null
}
```

