### PR TITLE
fix: correct precedence when building urlToUse in createLocalReq

### DIFF
--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -44,7 +44,9 @@ const attachFakeURLProperties = (req: Partial<PayloadRequest>, urlSuffix?: strin
       urlToUse = req.url
     } else if (req.payload?.config?.serverURL) {
       const base = req.payload.config.serverURL.replace(/\/+$/, '')
-      const suffix = urlSuffix?.startsWith('/') ? urlSuffix : `/${urlSuffix || ''}`
+      const suffix = urlSuffix
+        ? (urlSuffix.startsWith('/') ? urlSuffix : `/${urlSuffix}`)
+        : ''
       urlToUse = `${base}${suffix}`
     } else {
       urlToUse = fallbackURL

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -38,10 +38,17 @@ const attachFakeURLProperties = (req: Partial<PayloadRequest>, urlSuffix?: strin
 
     const fallbackURL = `http://${req.host || 'localhost'}${urlSuffix || ''}`
 
-    const urlToUse =
-      req?.url || req.payload?.config?.serverURL
-        ? `${req.payload?.config.serverURL}${urlSuffix || ''}`
-        : fallbackURL
+    let urlToUse: string
+    
+    if (req?.url) {
+      urlToUse = req.url
+    } else if (req.payload?.config?.serverURL) {
+      const base = req.payload.config.serverURL.replace(/\/+$/, '')
+      const suffix = urlSuffix?.startsWith('/') ? urlSuffix : `/${urlSuffix || ''}`
+      urlToUse = `${base}${suffix}`
+    } else {
+      urlToUse = fallbackURL
+    }
 
     try {
       urlObject = new URL(urlToUse)


### PR DESCRIPTION
This appears to be a new error produced with the latest update of next.

Occurs when front end is using a simple <Link> component for example <Link href="/admin"> to send a user to the payloadcms backend. This throws a new error. This only occurs with links to the /admin page.

```
[20:11:25] ERROR: Failed to create URL object from URL: http://localhost:3000http://localhost:3000/admin, falling back to http://localhost:3000http://localhost:3000/admin
⨯ TypeError: Invalid URL
    at ignore-listed frames {
  code: 'ERR_INVALID_URL',
  input: 'http://localhost:3000http://localhost:3000/admin',
  digest: '1079054744'
}

node_modules\.pnpm\@payloadcms+next@3.68.3_@ty_5c4107aa334225014c648de0038e6397\node_modules\@payloadcms\next\src\utilities\initReq.ts (103:25) @ <anonymous> 101 | const { req: reqOverrides, ...optionsOverrides } = overrides || {} 102 | > 103 | const req = await createLocalReq( | ^ 104 | { 105 | req: { 106 | headers,
```

Fixes #14900