### PR TITLE
fix(ui): relationship add button unsafe permissions property access

### DIFF
--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -193,7 +193,7 @@ export const AddNewRelation: React.FC<Props> = ({
             render={({ close: closePopup }) => (
               <PopupList.ButtonGroup>
                 {relatedCollections.map((relatedCollection) => {
-                  if (permissions.collections[relatedCollection?.slug].create) {
+                  if (permissions.collections[relatedCollection?.slug]?.create) {
                     return (
                       <PopupList.Button
                         className={`${baseClass}__relation-button--${relatedCollection?.slug}`}


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
Fix crashing due to unsafe permissions property access in `AddNewRelation` by safely checking that a collection’s permissions exist before reading its `create` property.

### Why?
Accessing `permissions.collections[slug].create` throws and breaks the UI when a collection’s permissions entry is missing.
This happens for example when collection‑level access control makes that collection inaccessible.

### How?
Change the condition to use optional chaining on the permissions, aligning with usage elsewhere in the codebase:
- Before: `permissions.collections[relatedCollection?.slug].create`
- After: `permissions.collections[relatedCollection?.slug]?.create`

