### PR TITLE
docs: update collection access control reference link on collection config page

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -96,7 +96,7 @@ Fields define the schema of the Documents within a Collection. To learn more, go
 
 ### Access Control
 
-[Collection Access Control](../access-control/overview) determines what a user can and cannot do with any given Document within a Collection. To learn more, go to the [Access Control](../access-control/overview) documentation.
+[Collection Access Control](../access-control/collections) determines what a user can and cannot do with any given Document within a Collection. To learn more, go to the [Access Control](../access-control/overview) documentation.
 
 ### Hooks
 


### PR DESCRIPTION
The link despite written as "Collection Access Control", currently point to the general Access Control page and not the dedicated page for Collection Access Control. On the same paragraph there's also a reference to the Access Control page and makes it confusing.
This replace the link to point to the dedicated Collection Access Control page.