### PR TITLE
fix(ui): use portals for popup to prevent clipping, improve keyboard navigation

### DIFF
--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -7,7 +7,7 @@ import React, { Fragment, useEffect, useRef, useState } from 'react'
 
 import type { ListControlsProps } from './types.js'
 
-import { Popup } from '../../elements/Popup/index.js'
+import { Popup, PopupList } from '../../elements/Popup/index.js'
 import { useUseTitleField } from '../../hooks/useUseAsTitle.js'
 import { ChevronIcon } from '../../icons/Chevron/index.js'
 import { Dots } from '../../icons/Dots/index.js'
@@ -210,9 +210,11 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
               size="small"
               verticalAlign="bottom"
             >
-              {listMenuItems.map((item, i) => (
-                <Fragment key={`list-menu-item-${i}`}>{item}</Fragment>
-              ))}
+              <PopupList.ButtonGroup>
+                {listMenuItems.map((item, i) => (
+                  <Fragment key={`list-menu-item-${i}`}>{item}</Fragment>
+                ))}
+              </PopupList.ButtonGroup>
             </Popup>
           ),
         ].filter(Boolean)}

--- a/packages/ui/src/elements/Popup/PopupButtonList/index.scss
+++ b/packages/ui/src/elements/Popup/PopupButtonList/index.scss
@@ -47,6 +47,7 @@
       &:hover,
       &:focus-visible,
       &:focus-within {
+        outline: none;
         background-color: var(--popup-button-highlight);
       }
     }

--- a/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
+++ b/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
@@ -12,7 +12,7 @@ export type PopupTriggerProps = {
   className?: string
   disabled?: boolean
   noBackground?: boolean
-  setActive: (active: boolean) => void
+  setActive: (active: boolean, viaKeyboard?: boolean) => void
   size?: 'large' | 'medium' | 'small' | 'xsmall'
 }
 
@@ -30,9 +30,16 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
     .filter(Boolean)
     .join(' ')
 
-  const handleClick = React.useCallback(() => {
-    setActive(!active)
-  }, [active, setActive])
+  const handleClick = () => {
+    setActive(!active, false)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      setActive(!active, true)
+    }
+  }
 
   if (buttonType === 'none') {
     return null
@@ -43,11 +50,7 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
       <div
         className={classes}
         onClick={handleClick}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            handleClick()
-          }
-        }}
+        onKeyDown={handleKeyDown}
         role="button"
         tabIndex={0}
       >
@@ -61,11 +64,7 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
       className={classes}
       disabled={disabled}
       onClick={handleClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') {
-          handleClick()
-        }
-      }}
+      onKeyDown={handleKeyDown}
       tabIndex={0}
       type="button"
     >

--- a/packages/ui/src/elements/Popup/index.scss
+++ b/packages/ui/src/elements/Popup/index.scss
@@ -2,13 +2,6 @@
 
 @layer payload-default {
   .popup {
-    --popup-button-highlight: var(--theme-elevation-200);
-    --popup-bg: var(--theme-input-bg);
-    --popup-text: var(--theme-text);
-    --popup-caret-size: 10px;
-    --popup-x-padding: calc(var(--base) * 0.33);
-    --popup-padding: calc(var(--base) * 0.5);
-    --button-size-offset: -8px;
     position: relative;
 
     &__trigger-wrap {
@@ -18,248 +11,65 @@
       cursor: pointer;
     }
 
-    &__content {
-      position: absolute;
-      background: var(--popup-bg);
-      opacity: 0;
-      visibility: hidden;
-      pointer-events: none;
-      z-index: var(--z-popup);
-      max-width: calc(100vw - #{$baseline});
-      color: var(--popup-text);
-      border-radius: 4px;
-      padding-left: var(--popup-padding);
-      padding-right: var(--popup-padding);
-      min-width: var(--popup-width, auto);
+    &__on-hover-watch {
+      display: contents;
+    }
+  }
+
+  .popup__content {
+    --popup-caret-size: 8px;
+
+    position: absolute;
+    z-index: var(--z-popup);
+    background: var(--theme-input-bg);
+    color: var(--theme-text);
+    border-radius: 4px;
+    padding: calc(var(--base) * 0.5);
+    min-width: 150px;
+    max-width: calc(100vw - var(--base));
+    @include shadow-lg;
+
+    &.popup--size-xsmall {
+      min-width: 80px;
+    }
+    &.popup--size-small {
+      min-width: 100px;
+    }
+    &.popup--size-large {
+      min-width: 200px;
+    }
+    &.popup--size-fit-content {
+      min-width: fit-content;
     }
 
-    &__hide-scrollbar {
-      overflow: hidden;
-    }
-
-    &__scroll-container {
-      overflow-y: auto;
-      white-space: nowrap;
-      width: calc(100% + var(--scrollbar-width));
-      padding-top: var(--popup-padding);
-      padding-bottom: var(--popup-padding);
-      max-height: calc(var(--base) * 10);
-      overflow-y: auto;
-    }
-
-    &__scroll-content {
-      width: calc(100% - var(--scrollbar-width));
-    }
-
-    &--show-scrollbar {
-      .popup__scroll-container,
-      .popup__scroll-content {
-        width: 100%;
+    &.popup--show-scrollbar {
+      .popup__scroll-container {
+        overflow-y: auto;
       }
     }
+  }
 
-    &:focus,
-    &:active {
-      outline: none;
+  .popup__scroll-container {
+    overflow-y: auto;
+    max-height: calc(var(--base) * 10);
+  }
+
+  .popup__caret {
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: var(--popup-caret-size) solid transparent;
+    left: var(--caret-left, 16px);
+    transform: translateX(-50%);
+
+    .popup--v-bottom & {
+      top: calc(var(--popup-caret-size) * -2);
+      border-bottom-color: var(--theme-input-bg);
     }
 
-    ////////////////////////////////
-    // SIZE
-    ////////////////////////////////
-
-    &--size-xsmall {
-      --popup-width: 80px;
-      .popup__content {
-        @include shadow-sm;
-      }
-    }
-
-    &--size-small {
-      --popup-width: 100px;
-      .popup__content {
-        @include shadow-m;
-      }
-    }
-
-    &--size-medium {
-      --popup-width: 150px;
-      .popup__content {
-        @include shadow-lg;
-      }
-    }
-
-    &--size-large {
-      --popup-width: 200px;
-      .popup__content {
-        @include shadow-lg;
-      }
-    }
-
-    ////////////////////////////////
-    /// BUTTON SIZE
-    ////////////////////////////////
-
-    &--button-size-xsmall {
-      --button-size-offset: -12px;
-    }
-
-    &--button-size-small {
-      --button-size-offset: -8px;
-    }
-
-    &--button-size-medium {
-      --button-size-offset: -4px;
-    }
-
-    &--button-size-large {
-      --button-size-offset: 0px;
-    }
-
-    ////////////////////////////////
-    // HORIZONTAL ALIGNMENT
-    ////////////////////////////////
-    [dir='rtl'] &--h-align-left {
-      .popup__caret {
-        right: var(--popup-padding);
-        left: unset;
-      }
-    }
-    &--h-align-left {
-      .popup__caret {
-        left: var(--popup-padding);
-      }
-    }
-    &--h-align-center {
-      .popup__content {
-        left: 50%;
-        transform: translateX(-50%);
-      }
-
-      .popup__caret {
-        left: 50%;
-        transform: translateX(-50%);
-      }
-    }
-
-    [dir='rtl'] &--h-align-right {
-      .popup__content {
-        right: unset;
-        left: 0;
-      }
-
-      .popup__caret {
-        right: unset;
-        left: var(--popup-padding);
-      }
-    }
-
-    &--h-align-right {
-      .popup__content {
-        right: var(--button-size-offset);
-      }
-
-      .popup__caret {
-        right: var(--popup-padding);
-      }
-    }
-
-    ////////////////////////////////
-    // VERTICAL ALIGNMENT
-    ////////////////////////////////
-
-    &__caret {
-      position: absolute;
-      border: var(--popup-caret-size) solid transparent;
-    }
-
-    &--v-align-top {
-      .popup__content {
-        @include shadow-lg;
-        bottom: calc(100% + var(--popup-caret-size));
-      }
-
-      .popup__caret {
-        top: calc(100% - 1px);
-        border-top-color: var(--popup-bg);
-      }
-    }
-
-    &--v-align-bottom {
-      .popup__content {
-        @include shadow-lg-top;
-        top: calc(100% + var(--popup-caret-size));
-      }
-
-      .popup__caret {
-        bottom: calc(100% - 1px);
-        border-bottom-color: var(--popup-bg);
-      }
-    }
-
-    ////////////////////////////////
-    // ACTIVE
-    ////////////////////////////////
-
-    &--active {
-      .popup__content {
-        opacity: 1;
-        visibility: visible;
-        pointer-events: all;
-      }
-    }
-
-    @include mid-break {
-      --popup-padding: calc(var(--base) * 0.25);
-
-      &--h-align-center {
-        .popup__content {
-          left: 50%;
-          transform: translateX(-0%);
-        }
-
-        .popup__caret {
-          left: 50%;
-          transform: translateX(-0%);
-        }
-      }
-
-      &--h-align-right {
-        .popup__content {
-          right: 0;
-        }
-
-        .popup__caret {
-          right: var(--popup-padding);
-        }
-      }
-
-      &--force-h-align-left {
-        .popup__content {
-          left: 0;
-          right: unset;
-          transform: unset;
-        }
-
-        .popup__caret {
-          left: var(--popup-padding);
-          right: unset;
-          transform: unset;
-        }
-      }
-
-      &--force-h-align-right {
-        .popup__content {
-          right: 0;
-          left: unset;
-          transform: unset;
-        }
-
-        .popup__caret {
-          right: var(--popup-padding);
-          left: unset;
-          transform: unset;
-        }
-      }
+    .popup--v-top & {
+      bottom: calc(var(--popup-caret-size) * -2);
+      border-top-color: var(--theme-input-bg);
     }
   }
 }

--- a/packages/ui/src/elements/Popup/index.scss
+++ b/packages/ui/src/elements/Popup/index.scss
@@ -42,17 +42,20 @@
     &.popup--size-fit-content {
       min-width: fit-content;
     }
-
-    &.popup--show-scrollbar {
-      .popup__scroll-container {
-        overflow-y: auto;
-      }
-    }
   }
 
   .popup__scroll-container {
     overflow-y: auto;
     max-height: calc(var(--base) * 10);
+
+    &:not(.popup__scroll-container--show-scrollbar) {
+      scrollbar-width: none; // Firefox
+      -ms-overflow-style: none; // IE/Edge
+
+      &::-webkit-scrollbar {
+        display: none; // Chrome/Safari/Opera
+      }
+    }
   }
 
   .popup__caret {

--- a/packages/ui/src/elements/Popup/index.scss
+++ b/packages/ui/src/elements/Popup/index.scss
@@ -16,6 +16,10 @@
     }
   }
 
+  .popup__hidden-content {
+    display: none;
+  }
+
   .popup__content {
     --popup-caret-size: 8px;
     --popup-button-highlight: var(--theme-elevation-150);

--- a/packages/ui/src/elements/Popup/index.scss
+++ b/packages/ui/src/elements/Popup/index.scss
@@ -18,6 +18,7 @@
 
   .popup__content {
     --popup-caret-size: 8px;
+    --popup-button-highlight: var(--theme-elevation-150);
 
     position: absolute;
     z-index: var(--z-popup);

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -77,6 +77,12 @@ export const Popup: React.FC<PopupProps> = (props) => {
 
   const popupRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLDivElement>(null)
+
+  /**
+   * Keeps track of whether the popup was opened via keyboard.
+   * This is used to determine whether to autofocus the first element in the popup.
+   * If the popup was opened via mouse, we do not want to autofocus the first element.
+   */
   const openedViaKeyboardRef = useRef(false)
   const [active, setActiveInternal] = useState(initActive)
   const [isOnTop, setIsOnTop] = useState(verticalAlign === 'top')

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -34,6 +34,12 @@ export type PopupProps = {
   onToggleOpen?: (active: boolean) => void
   render?: (args: { close: () => void }) => React.ReactNode
   showOnHover?: boolean
+  /**
+   * By default, the scrollbar is hidden. If you want to show it, set this to true.
+   * In both cases, the container is still scrollable.
+   *
+   * @default false
+   */
   showScrollbar?: boolean
   size?: 'fit-content' | 'large' | 'medium' | 'small'
   verticalAlign?: 'bottom' | 'top'
@@ -261,14 +267,15 @@ export const Popup: React.FC<PopupProps> = (props) => {
             className={[
               `${baseClass}__content`,
               `${baseClass}--size-${size}`,
-              showScrollbar && `${baseClass}--show-scrollbar`,
               isOnTop ? `${baseClass}--v-top` : `${baseClass}--v-bottom`,
             ]
               .filter(Boolean)
               .join(' ')}
             ref={popupRef}
           >
-            <div className={`${baseClass}__scroll-container`}>
+            <div
+              className={`${baseClass}__scroll-container${showScrollbar ? ` ${baseClass}__scroll-container--show-scrollbar` : ''}`}
+            >
               {render?.({ close: () => setActive(false) })}
               {children}
             </div>

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -12,6 +12,24 @@ import { PopupTrigger } from './PopupTrigger/index.js'
 
 const baseClass = 'popup'
 
+/**
+ * Selector for all elements the browser considers tabbable.
+ */
+const TABBABLE_SELECTOR = [
+  'a[href]',
+  'button:not(:disabled)',
+  'input:not(:disabled):not([type="hidden"])',
+  'select:not(:disabled)',
+  'textarea:not(:disabled)',
+  '[tabindex]',
+  '[contenteditable]:not([contenteditable="false"])',
+  'audio[controls]',
+  'video[controls]',
+  'summary',
+]
+  .map((s) => `${s}:not([tabindex="-1"])`)
+  .join(', ')
+
 export type PopupProps = {
   backgroundColor?: CSSProperties['backgroundColor']
   boundingRef?: React.RefObject<HTMLElement>
@@ -259,11 +277,7 @@ export const Popup: React.FC<PopupProps> = (props) => {
     }
 
     if (e.key === 'Tab' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-      const focusable = Array.from(
-        popup.querySelectorAll<HTMLElement>(
-          '.popup-button-list__button:not(.popup-button-list__disabled)',
-        ),
-      )
+      const focusable = Array.from(popup.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR))
       if (focusable.length === 0) {
         return
       }
@@ -316,9 +330,7 @@ export const Popup: React.FC<PopupProps> = (props) => {
     if (openedViaKeyboardRef.current) {
       // Use requestAnimationFrame to ensure DOM is ready.
       requestAnimationFrame(() => {
-        const firstFocusable = popup.querySelector<HTMLElement>(
-          '.popup-button-list__button:not(.popup-button-list__disabled)',
-        )
+        const firstFocusable = popup.querySelector<HTMLElement>(TABBABLE_SELECTOR)
         firstFocusable?.focus()
       })
     }

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -368,6 +368,7 @@ export const Popup: React.FC<PopupProps> = (props) => {
             ]
               .filter(Boolean)
               .join(' ')}
+            data-popup-id={id || undefined}
             ref={popupRef}
           >
             <div

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -301,6 +301,20 @@ export const Popup: React.FC<PopupProps> = (props) => {
   })
 
   // /////////////////////////////////////
+  // Click Handler for Actionable Elements
+  // Closes popup when buttons/links inside are clicked (includes Enter/Space activation).
+  // /////////////////////////////////////
+
+  const handleActionableClick = useEffectEvent((e: MouseEvent) => {
+    const target = e.target as HTMLElement
+    // Check if the clicked element or any ancestor is an actionable element
+    const actionable = target.closest('button, a[href], [role="button"], [role="menuitem"]')
+    if (actionable && popupRef.current?.contains(actionable)) {
+      setActive(false)
+    }
+  })
+
+  // /////////////////////////////////////
   // Effect: Setup/Teardown position and focus management
   // /////////////////////////////////////
 
@@ -346,12 +360,14 @@ export const Popup: React.FC<PopupProps> = (props) => {
     window.addEventListener('scroll', updatePosition, { capture: true, passive: true })
     document.addEventListener('mousedown', handleClickOutside)
     document.addEventListener('keydown', handleKeyDown)
+    popup.addEventListener('click', handleActionableClick)
 
     return () => {
       window.removeEventListener('resize', updatePosition)
       window.removeEventListener('scroll', updatePosition, { capture: true })
       document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleKeyDown)
+      popup.removeEventListener('click', handleActionableClick)
     }
   }, [active])
 

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -358,29 +358,40 @@ export const Popup: React.FC<PopupProps> = (props) => {
         )}
       </div>
 
-      {active &&
-        createPortal(
-          <div
-            className={[
-              `${baseClass}__content`,
-              `${baseClass}--size-${size}`,
-              isOnTop ? `${baseClass}--v-top` : `${baseClass}--v-bottom`,
-            ]
-              .filter(Boolean)
-              .join(' ')}
-            data-popup-id={id || undefined}
-            ref={popupRef}
-          >
+      {typeof document !== 'undefined'
+        ? // We need to make sure the popup is part of the DOM (although invisible), even if it's not active.
+          // This ensures that components within the popup, like modals, do not unmount when the popup closes.
+          // Otherwise, modals opened from the popup will close unexpectedly when clicking within the modal, since
+          // that closes the popup due to the click outside handler.
+          createPortal(
             <div
-              className={`${baseClass}__scroll-container${showScrollbar ? ` ${baseClass}__scroll-container--show-scrollbar` : ''}`}
+              className={
+                active
+                  ? [
+                      `${baseClass}__content`,
+                      `${baseClass}--size-${size}`,
+                      isOnTop ? `${baseClass}--v-top` : `${baseClass}--v-bottom`,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')
+                  : // Do not share any class names between active and disabled popups, to make sure
+                    // tests do not accidentally target inactive popups.
+                    `${baseClass}__hidden-content`
+              }
+              data-popup-id={id || undefined}
+              ref={popupRef}
             >
-              {render?.({ close: () => setActive(false) })}
-              {children}
-            </div>
-            {caret && <div className={`${baseClass}__caret`} />}
-          </div>,
-          document.body,
-        )}
+              <div
+                className={`${baseClass}__scroll-container${showScrollbar ? ` ${baseClass}__scroll-container--show-scrollbar` : ''}`}
+              >
+                {render?.({ close: () => setActive(false) })}
+                {children}
+              </div>
+              {caret && <div className={`${baseClass}__caret`} />}
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   )
 }

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -99,8 +99,14 @@ export const Popup: React.FC<PopupProps> = (props) => {
    * If the popup was opened via mouse, we do not want to autofocus the first element.
    */
   const openedViaKeyboardRef = useRef(false)
+  const [mounted, setMounted] = useState(false)
   const [active, setActiveInternal] = useState(initActive)
   const [isOnTop, setIsOnTop] = useState(verticalAlign === 'top')
+
+  // Track when component is mounted to avoid SSR/client hydration mismatch
+  useEffect(() => {
+    setMounted(true)
+  }, [])
 
   const setActive = useCallback(
     (isActive: boolean, viaKeyboard = false) => {
@@ -358,7 +364,7 @@ export const Popup: React.FC<PopupProps> = (props) => {
         )}
       </div>
 
-      {typeof document !== 'undefined'
+      {mounted
         ? // We need to make sure the popup is part of the DOM (although invisible), even if it's not active.
           // This ensures that components within the popup, like modals, do not unmount when the popup closes.
           // Otherwise, modals opened from the popup will close unexpectedly when clicking within the modal, since

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -45,6 +45,12 @@ export type PopupProps = {
   verticalAlign?: 'bottom' | 'top'
 }
 
+/**
+ * Component that renders a popup, as well as a button that triggers the popup.
+ *
+ * The popup is rendered in a portal, and is automatically positioned above / below the trigger,
+ * depending on the verticalAlign prop and the space available.
+ */
 export const Popup: React.FC<PopupProps> = (props) => {
   const {
     id,

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -177,9 +177,8 @@ export const Popup: React.FC<PopupProps> = (props) => {
         return
       }
 
-      // Focus trap - handle ALL tab navigation ourselves, to also support buttons
-      // that are skipped by the browser.
-      if (e.key === 'Tab') {
+      // Focus trap and arrow key navigation
+      if (e.key === 'Tab' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
         const focusable = Array.from(getFocusableElements())
         if (focusable.length === 0) {
           return
@@ -188,16 +187,17 @@ export const Popup: React.FC<PopupProps> = (props) => {
         e.preventDefault()
 
         const currentIndex = focusable.findIndex((el) => el === document.activeElement)
+        const goBackward = e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)
 
         let nextIndex: number
         if (currentIndex === -1) {
           // Nothing in popup focused, focus first/last based on direction
-          nextIndex = e.shiftKey ? focusable.length - 1 : 0
-        } else if (e.shiftKey) {
-          // Shift+Tab - go backwards, wrap to end
+          nextIndex = goBackward ? focusable.length - 1 : 0
+        } else if (goBackward) {
+          // Go backwards, wrap to end
           nextIndex = currentIndex === 0 ? focusable.length - 1 : currentIndex - 1
         } else {
-          // Tab - go forwards, wrap to start
+          // Go forwards, wrap to start
           nextIndex = currentIndex === focusable.length - 1 ? 0 : currentIndex + 1
         }
 

--- a/packages/ui/src/scss/app.scss
+++ b/packages/ui/src/scss/app.scss
@@ -31,7 +31,8 @@
     --style-radius-m: #{$style-radius-m};
     --style-radius-l: #{$style-radius-l};
 
-    --z-popup: 10;
+    // --z-popup needs to be higher than --z-modal to ensure the popup is displayed when modal is open
+    --z-popup: 60;
     --z-nav: 20;
     --z-modal: 30;
     --z-status: 40;

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -766,7 +766,7 @@ describe('Document View', () => {
       await expect(threeDotMenu).toBeVisible()
       await threeDotMenu.click()
 
-      const customEditMenuItem = page.locator('.popup-button-list__button', {
+      const customEditMenuItem = page.locator('.popup__content .popup-button-list__button', {
         hasText: 'Custom Edit Menu Item',
       })
 

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -782,7 +782,7 @@ describe('Document View', () => {
       await expect(threeDotMenu).toBeVisible()
       await threeDotMenu.click()
 
-      const popup = page.locator('.popup--active .popup__content')
+      const popup = page.locator('.popup__content')
       await expect(popup).toBeVisible()
 
       const customEditMenuItem = popup.getByRole('link', {
@@ -801,7 +801,7 @@ describe('Document View', () => {
       await expect(threeDotMenu).toBeVisible()
       await threeDotMenu.click()
 
-      const popup = page.locator('.popup--active .popup__content')
+      const popup = page.locator('.popup__content')
       await expect(popup).toBeVisible()
 
       const customEditMenuItem = popup.getByRole('link', {

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -535,21 +535,17 @@ describe('General', () => {
       const gearButton = page.locator('.nav__controls .popup#settings-menu .popup-button')
       await gearButton.click()
 
+      const popupButtons = page.locator(
+        '[data-popup-id="settings-menu"] .popup-button-list__button',
+      )
+
       // Check for the first group of buttons
-      await expect(
-        page.locator('.popup#settings-menu .popup-button-list__button').first(),
-      ).toContainText('System Settings')
-      await expect(
-        page.locator('.popup#settings-menu .popup-button-list__button').nth(1),
-      ).toContainText('View Logs')
+      await expect(popupButtons.first()).toContainText('System Settings')
+      await expect(popupButtons.nth(1)).toContainText('View Logs')
 
       // Check for the second group of buttons
-      await expect(
-        page.locator('.popup#settings-menu .popup-button-list__button').nth(2),
-      ).toContainText('Manage Users')
-      await expect(
-        page.locator('.popup#settings-menu .popup-button-list__button').nth(3),
-      ).toContainText('View Activity')
+      await expect(popupButtons.nth(2)).toContainText('Manage Users')
+      await expect(popupButtons.nth(3)).toContainText('View Activity')
     })
 
     test('breadcrumbs — should navigate from list to dashboard', async () => {

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -783,7 +783,7 @@ describe('General', () => {
     })
 
     test('should allow custom translation of locale labels', async () => {
-      const selectOptionClass = '.localizer .popup-button-list__button'
+      const selectOptionClass = '.popup-button-list__button'
       const localizerButton = page.locator('.localizer .popup-button')
       const localeListItem1 = page.locator(selectOptionClass).nth(0)
 

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -783,7 +783,7 @@ describe('General', () => {
     })
 
     test('should allow custom translation of locale labels', async () => {
-      const selectOptionClass = '.popup-button-list__button'
+      const selectOptionClass = '.popup__content .popup-button-list__button'
       const localizerButton = page.locator('.localizer .popup-button')
       const localeListItem1 = page.locator(selectOptionClass).nth(0)
 

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -525,7 +525,7 @@ describe('General', () => {
       await openNav(page)
       const gearButton = page.locator('.nav__controls .popup#settings-menu .popup-button')
       await gearButton.click()
-      const popupContent = page.locator('.popup#settings-menu .popup__content')
+      const popupContent = page.locator('.popup__content')
       await expect(popupContent).toBeVisible()
     })
 

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -1525,8 +1525,7 @@ describe('List View', () => {
 
       await page.goto(postsUrl.list)
       await page.locator('.per-page .popup-button').click()
-      await page.locator('.per-page .popup-button').click()
-      const options = page.locator('.per-page button.per-page__button')
+      const options = page.locator('.popup__content button.per-page__button')
       await expect(options).toHaveCount(3)
       await expect(options.nth(0)).toContainText('5')
       await expect(options.nth(1)).toContainText('10')
@@ -1567,7 +1566,7 @@ describe('List View', () => {
       await page.locator('.per-page .popup-button').click()
 
       await page
-        .locator('.per-page button.per-page__button', {
+        .locator('.popup__content button.per-page__button', {
           hasText: '15',
         })
         .click()

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -256,9 +256,12 @@ describe('List View', () => {
       await kebabMenu.click()
 
       await expect(
-        page.locator('.popup-button-list').locator('div', {
-          hasText: 'listMenuItems',
-        }),
+        page
+          .locator('.popup-button-list')
+          .locator('div', {
+            hasText: 'listMenuItems',
+          })
+          .first(),
       ).toBeVisible()
     })
 

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -485,7 +485,7 @@ describe('Array', () => {
       )
       await arrayFieldPopupBtn.click()
       const disabledCopyBtn = page.locator(
-        '#field-collapsedArray .popup.clipboard-action__popup .popup__content div.popup-button-list__disabled:has-text("Copy Field")',
+        '.popup__content div.popup-button-list__disabled:has-text("Copy Field")',
       )
       await expect(disabledCopyBtn).toBeVisible()
     })
@@ -502,7 +502,7 @@ describe('Array', () => {
       await expect(popupBtn).toBeVisible()
       await popupBtn.click()
       const disabledPasteBtn = page.locator(
-        '#field-readOnly .popup.clipboard-action__popup .popup__content div.popup-button-list__disabled:has-text("Paste Field")',
+        '.popup__content div.popup-button-list__disabled:has-text("Paste Field")',
       )
       await expect(disabledPasteBtn).toBeVisible()
     })

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -502,7 +502,7 @@ describe('Block fields', () => {
       )
       await popupBtn.click()
       const disabledCopyBtn = page.locator(
-        '#field-i18nBlocks .popup.clipboard-action__popup .popup__content div.popup-button-list__disabled:has-text("Copy Field")',
+        '.popup__content div.popup-button-list__disabled:has-text("Copy Field")',
       )
       await expect(disabledCopyBtn).toBeVisible()
     })
@@ -519,7 +519,7 @@ describe('Block fields', () => {
       await expect(popupBtn).toBeVisible()
       await popupBtn.click()
       const disabledPasteBtn = page.locator(
-        '#field-readOnly .popup.clipboard-action__popup .popup__content div.popup-button-list__disabled:has-text("Paste Field")',
+        '.popup__content div.popup-button-list__disabled:has-text("Paste Field")',
       )
       await expect(disabledPasteBtn).toBeVisible()
     })

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -491,8 +491,8 @@ describe('relationship', () => {
       })
       const drawer1Content = page.locator('[id^=doc-drawer_text-fields_1_] .drawer__content')
       const originalDrawerID = await drawer1Content.locator('.id-label').textContent()
-      await openDocControls(drawer1Content)
-      await drawer1Content.locator('#action-create').click()
+      await openDocControls(drawer1Content, page)
+      await page.locator('.popup__content #action-create').click()
       await wait(1000) // wait for /form-state to return
       const title = 'Created from drawer'
       await drawer1Content.locator('#field-text').fill(title)
@@ -551,8 +551,8 @@ describe('relationship', () => {
       const originalText = 'Text'
       await drawer1Content.locator('#field-text').fill(originalText)
       await saveDocAndAssert(page, '[id^=doc-drawer_text-fields_1_] .drawer__content #action-save')
-      await openDocControls(drawer1Content)
-      await drawer1Content.locator('#action-duplicate').click()
+      await openDocControls(drawer1Content, page)
+      await page.locator('.popup__content #action-duplicate').click()
       const duplicateID = drawer1Content.locator('.id-label')
       await expect(duplicateID).not.toHaveText(originalID)
       await page.locator('[id^=doc-drawer_text-fields_1_] .drawer__close').click()
@@ -608,8 +608,8 @@ describe('relationship', () => {
 
       const drawer1Content = page.locator('[id^=doc-drawer_text-fields_1_] .drawer__content')
       const originalID = await drawer1Content.locator('.id-label').textContent()
-      await openDocControls(drawer1Content)
-      await drawer1Content.locator('#action-delete').click()
+      await openDocControls(drawer1Content, page)
+      await page.locator('.popup__content #action-delete').click()
 
       await page
         .locator('[id^=delete-].payload__modal-item.confirmation-modal[open] button#confirm-action')

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -82,7 +82,7 @@ describe('relationship', () => {
     await loadCreatePage()
     await openCreateDocDrawer({ page, fieldSelector: '#field-relationship' })
     await page
-      .locator('#field-relationship .relationship-add-new__relation-button--text-fields')
+      .locator('.popup__content .relationship-add-new__relation-button--text-fields')
       .click()
     const textField = page.locator('.drawer__content #field-text')
     await expect(textField).toBeEnabled()
@@ -105,7 +105,7 @@ describe('relationship', () => {
 
     // Select the SECOND collection (array-fields) instead of the first (text-fields)
     await page
-      .locator('#field-relationship .relationship-add-new__relation-button--array-fields')
+      .locator('.popup__content .relationship-add-new__relation-button--array-fields')
       .click()
 
     await page.locator('[id^=doc-drawer_array-fields_1_] #action-save').click()
@@ -331,7 +331,7 @@ describe('relationship', () => {
     // First fill out the relationship field, as it's required
     await openCreateDocDrawer({ page, fieldSelector: '#field-relationship' })
     await page
-      .locator('#field-relationship .relationship-add-new__relation-button--text-fields')
+      .locator('.popup__content .relationship-add-new__relation-button--text-fields')
       .click()
 
     await page.locator('.drawer__content #field-text').fill('something')

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -207,7 +207,7 @@ test.describe('Folders', () => {
       await expect(createDocButton).toBeVisible()
       await createDocButton.click()
       const postButton = page
-        .locator('.popup--active')
+        .locator('.popup__content')
         .locator('.popup-button-list__button', { hasText: 'Post' })
       await expect(postButton).toBeVisible()
       await postButton.click()
@@ -290,7 +290,7 @@ test.describe('Folders', () => {
         hasText: 'Create New',
       })
       await createNewDropdown.click()
-      const createFolderButton = page.locator('.popup-button-list__button').first()
+      const createFolderButton = page.locator('.popup__content .popup-button-list__button').first()
       await createFolderButton.click()
       await createFolderDoc({
         page,
@@ -300,7 +300,9 @@ test.describe('Folders', () => {
       await expect(page.locator('.folder-file-card__name')).toHaveText('Nested Folder')
 
       await createNewDropdown.click()
-      const createPostButton = page.locator('.popup-button-list__button', { hasText: 'Post' })
+      const createPostButton = page.locator('.popup__content .popup-button-list__button', {
+        hasText: 'Post',
+      })
       await createPostButton.click()
 
       const postTitleInput = page.locator('input[id="field-title"]')
@@ -612,10 +614,9 @@ test.describe('Folders', () => {
         hasText: 'Create New',
       })
       await createNewDropdown.click()
-      const createFolderButton = page.locator(
-        '.list-header__title-actions .popup-button-list__button',
-        { hasText: 'Folder' },
-      )
+      const createFolderButton = page.locator('.popup__content .popup-button-list__button', {
+        hasText: 'Folder',
+      })
       await createFolderButton.click()
 
       const drawer = page.locator('dialog .collection-edit--payload-folders')
@@ -671,12 +672,9 @@ test.describe('Folders', () => {
       )
       await expect(folderDropdown).toBeVisible()
       await folderDropdown.click()
-      const createFolderButton = page.locator(
-        '.list-header__title-actions .popup-button-list__button',
-        {
-          hasText: 'Folder',
-        },
-      )
+      const createFolderButton = page.locator('.popup__content .popup-button-list__button', {
+        hasText: 'Folder',
+      })
       await createFolderButton.click()
 
       const drawer = page.locator('dialog .collection-edit--payload-folders')
@@ -709,10 +707,9 @@ test.describe('Folders', () => {
         hasText: 'Create New',
       })
       await createNewDropdown.click()
-      const createFolderButton = page.locator(
-        '.list-header__title-actions .popup-button-list__button',
-        { hasText: 'Folder' },
-      )
+      const createFolderButton = page.locator('.popup__content .popup-button-list__button', {
+        hasText: 'Folder',
+      })
       await createFolderButton.click()
 
       const drawer = page.locator('dialog .collection-edit--payload-folders')

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -219,7 +219,7 @@ export async function openCreateDocDrawer(page: Page, fieldSelector: string): Pr
 
 export async function openLocaleSelector(page: Page): Promise<void> {
   const button = page.locator('.localizer button.popup-button')
-  const popup = page.locator('.localizer .popup.popup--active')
+  const popup = page.locator('.popup__content')
 
   if (!(await popup.isVisible())) {
     await button.click()
@@ -228,7 +228,7 @@ export async function openLocaleSelector(page: Page): Promise<void> {
 }
 
 export async function closeLocaleSelector(page: Page): Promise<void> {
-  const popup = page.locator('.localizer .popup.popup--active')
+  const popup = page.locator('.popup__content')
 
   if (await popup.isVisible()) {
     await page.click('body', { position: { x: 0, y: 0 } })
@@ -240,14 +240,12 @@ export async function changeLocale(page: Page, newLocale: string) {
   await openLocaleSelector(page)
 
   const currentlySelectedLocale = await page
-    .locator(
-      `.localizer .popup.popup--active .popup-button-list__button--selected .localizer__locale-code`,
-    )
+    .locator(`.popup__content .popup-button-list__button--selected .localizer__locale-code`)
     .textContent()
 
   if (currentlySelectedLocale !== `(${newLocale})`) {
     const localeToSelect = page
-      .locator('.localizer .popup.popup--active .popup-button-list__button')
+      .locator('.popup__content .popup-button-list__button')
       .locator('.localizer__locale-code', {
         hasText: `${newLocale}`,
       })

--- a/test/helpers/e2e/copyPasteField.ts
+++ b/test/helpers/e2e/copyPasteField.ts
@@ -31,8 +31,8 @@ export async function copyPasteField({
   await popupBtn.click()
 
   const actionBtnSelector = rowAction
-    ? `#${fieldName}-row-${rowIndex} .popup__content .popup-button-list button.array-actions__${action}`
-    : `.popup.clipboard-action__popup .popup__content .popup-button-list button:has-text("${isCopy ? 'Copy' : 'Paste'} Field")`
+    ? `.popup__content .popup-button-list button.array-actions__${action}`
+    : `.popup__content .popup-button-list button:has-text("${isCopy ? 'Copy' : 'Paste'} Field")`
   const actionBtn = field.locator(actionBtnSelector).first()
   await expect(actionBtn).toBeVisible()
   await actionBtn.click()

--- a/test/helpers/e2e/copyPasteField.ts
+++ b/test/helpers/e2e/copyPasteField.ts
@@ -33,7 +33,7 @@ export async function copyPasteField({
   const actionBtnSelector = rowAction
     ? `.popup__content .popup-button-list button.array-actions__${action}`
     : `.popup__content .popup-button-list button:has-text("${isCopy ? 'Copy' : 'Paste'} Field")`
-  const actionBtn = field.locator(actionBtnSelector).first()
+  const actionBtn = page.locator(actionBtnSelector).first()
   await expect(actionBtn).toBeVisible()
   await actionBtn.click()
 

--- a/test/helpers/e2e/fields/array/openArrayRowActions.ts
+++ b/test/helpers/e2e/fields/array/openArrayRowActions.ts
@@ -26,7 +26,7 @@ export const openArrayRowActions = async (
     .locator(`#field-${fieldName} #${formattedRowID}-row-${rowIndex} .array-actions`)
     .first()
 
-  const popupContentLocator = rowActions.locator('.popup__content')
+  const popupContentLocator = page.locator('.popup__content')
 
   if (await popupContentLocator.isVisible()) {
     throw new Error(`Row actions for field "${fieldName}" at index ${rowIndex} are already open.`)

--- a/test/helpers/e2e/live-preview/selectLivePreviewBreakpoint.ts
+++ b/test/helpers/e2e/live-preview/selectLivePreviewBreakpoint.ts
@@ -21,7 +21,7 @@ export const selectLivePreviewBreakpoint = async (page: Page, breakpointLabel: s
 
   await expect(breakpointSelector).toContainText(breakpointLabel)
 
-  const option = page.locator('.popup__content button.popup-button-list__button--selected')
+  const option = page.locator('.live-preview-toolbar-controls__breakpoint button.popup-button')
 
   await expect(option).toHaveText(breakpointLabel)
 }

--- a/test/helpers/e2e/live-preview/selectLivePreviewBreakpoint.ts
+++ b/test/helpers/e2e/live-preview/selectLivePreviewBreakpoint.ts
@@ -15,15 +15,13 @@ export const selectLivePreviewBreakpoint = async (page: Page, breakpointLabel: s
   await breakpointSelector.first().click()
 
   await page
-    .locator(`.live-preview-toolbar-controls__breakpoint button.popup-button-list__button`)
+    .locator('.popup__content .popup-button-list__button')
     .filter({ hasText: breakpointLabel })
     .click()
 
   await expect(breakpointSelector).toContainText(breakpointLabel)
 
-  const option = page.locator(
-    '.live-preview-toolbar-controls__breakpoint button.popup-button-list__button--selected',
-  )
+  const option = page.locator('.popup__content button.popup-button-list__button--selected')
 
   await expect(option).toHaveText(breakpointLabel)
 }

--- a/test/helpers/e2e/live-preview/selectLivePreviewZoom.ts
+++ b/test/helpers/e2e/live-preview/selectLivePreviewZoom.ts
@@ -5,7 +5,7 @@ import { POLL_TOPASS_TIMEOUT } from 'playwright.config.js'
 import { expect } from 'playwright/test'
 
 export const selectLivePreviewZoom = async (page: Page, zoomLabel: string) => {
-  const zoomSelector = page.locator('.live-preview-toolbar-controls__zoom button.popup-button')
+  const zoomSelector = page.locator('.popup__content button.popup-button')
 
   await expect(() => expect(zoomSelector).toBeTruthy()).toPass({
     timeout: POLL_TOPASS_TIMEOUT,
@@ -13,21 +13,16 @@ export const selectLivePreviewZoom = async (page: Page, zoomLabel: string) => {
 
   await zoomSelector.first().click()
 
-  const zoomOption = page.locator(
-    '.live-preview-toolbar-controls__zoom button.popup-button-list__button',
-    {
-      hasText: exactText(zoomLabel),
-    },
-  )
+  const zoomOption = page.locator('.popup__content button.popup-button-list__button', {
+    hasText: exactText(zoomLabel),
+  })
 
   expect(zoomOption).toBeTruthy()
   await zoomOption.click()
 
   await expect(zoomSelector).toContainText(zoomLabel)
 
-  const option = page.locator(
-    '.live-preview-toolbar-controls__zoom button.popup-button-list__button--selected',
-  )
+  const option = page.locator('.popup__content button.popup-button-list__button--selected')
 
   await expect(option).toHaveText(zoomLabel)
 }

--- a/test/helpers/e2e/live-preview/selectLivePreviewZoom.ts
+++ b/test/helpers/e2e/live-preview/selectLivePreviewZoom.ts
@@ -5,7 +5,7 @@ import { POLL_TOPASS_TIMEOUT } from 'playwright.config.js'
 import { expect } from 'playwright/test'
 
 export const selectLivePreviewZoom = async (page: Page, zoomLabel: string) => {
-  const zoomSelector = page.locator('.popup__content button.popup-button')
+  const zoomSelector = page.locator('.live-preview-toolbar-controls__zoom button.popup-button')
 
   await expect(() => expect(zoomSelector).toBeTruthy()).toPass({
     timeout: POLL_TOPASS_TIMEOUT,
@@ -21,8 +21,4 @@ export const selectLivePreviewZoom = async (page: Page, zoomLabel: string) => {
   await zoomOption.click()
 
   await expect(zoomSelector).toContainText(zoomLabel)
-
-  const option = page.locator('.popup__content button.popup-button-list__button--selected')
-
-  await expect(option).toHaveText(zoomLabel)
 }

--- a/test/helpers/e2e/openDocControls.ts
+++ b/test/helpers/e2e/openDocControls.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 
 export async function openDocControls(page: Locator | Page): Promise<void> {
-  await page.locator('.doc-controls__popup >> .popup-button').click()
+  await page.locator('.doc-controls__popup .popup-button').click()
   await expect(page.locator('.popup__content')).toBeVisible()
 }

--- a/test/helpers/e2e/openDocControls.ts
+++ b/test/helpers/e2e/openDocControls.ts
@@ -2,5 +2,5 @@ import { expect, type Locator, type Page } from '@playwright/test'
 
 export async function openDocControls(page: Locator | Page): Promise<void> {
   await page.locator('.doc-controls__popup >> .popup-button').click()
-  await expect(page.locator('.doc-controls__popup >> .popup__content')).toBeVisible()
+  await expect(page.locator('.popup__content')).toBeVisible()
 }

--- a/test/helpers/e2e/openDocControls.ts
+++ b/test/helpers/e2e/openDocControls.ts
@@ -1,6 +1,9 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 
-export async function openDocControls(page: Locator | Page): Promise<void> {
+export async function openDocControls(
+  page: Locator | Page,
+  mainPage?: Locator | Page,
+): Promise<void> {
   await page.locator('.doc-controls__popup .popup-button').click()
-  await expect(page.locator('.popup__content')).toBeVisible()
+  await expect((mainPage ?? page).locator('.popup__content')).toBeVisible()
 }

--- a/test/helpers/folders/applyBrowseByFolderTypeFilter.ts
+++ b/test/helpers/folders/applyBrowseByFolderTypeFilter.ts
@@ -16,14 +16,14 @@ export const applyBrowseByFolderTypeFilter = async ({
   let typePill = page.locator('.search-bar__actions .checkbox-popup.popup--active', {
     hasText: 'Type',
   })
-  const isActive = (await typePill.count()) > 0
+  const isActive = (await page.locator('.popup__content').count()) > 0
 
   if (!isActive) {
     typePill = page.locator('.search-bar__actions .checkbox-popup', { hasText: 'Type' })
     await typePill.locator('.popup-button', { hasText: 'Type' }).click()
   }
 
-  await typePill.locator('.field-label', { hasText: type.label }).click()
+  await page.locator('.popup__content .field-label', { hasText: type.label }).click()
 
   await page.waitForURL((urlStr) => {
     try {

--- a/test/helpers/folders/createFolder.ts
+++ b/test/helpers/folders/createFolder.ts
@@ -20,7 +20,7 @@ export async function createFolder({
       hasText: 'Create',
     })
     await folderDropdown.click()
-    const createFolderButton = titleActionsLocator.locator('.popup-button-list__button', {
+    const createFolderButton = page.locator('.popup__content .popup-button-list__button', {
       hasText: 'Folder',
     })
     await createFolderButton.click()

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -472,7 +472,7 @@ describe('Join Field', () => {
     const popupButton = drawer.locator('.doc-controls__popup button.popup-button')
     await expect(popupButton).toBeVisible()
     await popupButton.click()
-    const deleteButton = drawer.locator('#action-delete')
+    const deleteButton = page.locator('.popup__content #action-delete')
     await expect(deleteButton).toBeVisible()
     await deleteButton.click()
     const deleteConfirmModal = page.locator('dialog[id^="delete-"][open]')
@@ -630,7 +630,9 @@ describe('Join Field', () => {
     const addNewPopupBtn = joinField.locator('.relationship-table__add-new-polymorphic')
     await expect(addNewPopupBtn).toBeVisible()
     await addNewPopupBtn.click()
-    const pageOption = joinField.locator('.relationship-table__relation-button--example-pages')
+    const pageOption = page.locator(
+      '.popup__content .relationship-table__relation-button--example-pages',
+    )
     await expect(pageOption).toHaveText('Example Page')
     await pageOption.click()
     await page.locator('.drawer__content input#field-title').fill('Some new page')

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -1442,9 +1442,9 @@ describe('lexicalMain', () => {
 
     // Move block 1 to the end
     await page.locator('#blocks-row-0 .array-actions__button').click()
-    await expect(page.locator('#blocks-row-0 .popup__content')).toBeVisible()
+    await expect(page.locator('.popup__content')).toBeVisible()
 
-    await page.locator('#blocks-row-0 .popup__content').getByText('Move Down').click()
+    await page.locator('.popup__content').getByText('Move Down').click()
 
     await expect(page.locator('#blocks-row-0 .LexicalEditorTheme__paragraph')).toContainText('2')
     await expect(page.locator('#blocks-row-0 .section-title__input')).toHaveValue('2') // block name

--- a/test/lexical/collections/RichText/e2e.spec.ts
+++ b/test/lexical/collections/RichText/e2e.spec.ts
@@ -309,7 +309,7 @@ describe('Rich Text', () => {
 
       // Open link popup
       await page.locator('#field-richText span >> text="render links"').click()
-      const popup = page.locator('.popup--active .rich-text-link__popup')
+      const popup = page.locator('.popup__content .rich-text-link__popup')
       await expect(popup).toBeVisible()
       await expect(popup.locator('a')).toHaveAttribute('href', 'https://payloadcms.com')
 
@@ -333,7 +333,7 @@ describe('Rich Text', () => {
 
       // Open link popup
       await page.locator('#field-richText span >> text="link to relationships"').click()
-      const popup = page.locator('.popup--active .rich-text-link__popup')
+      const popup = page.locator('.popup__content .rich-text-link__popup')
       await expect(popup).toBeVisible()
       await expect(popup.locator('a')).toHaveAttribute(
         'href',
@@ -418,7 +418,7 @@ describe('Rich Text', () => {
       await wait(500)
       const editBlock = page.locator('#blocks-row-0 .popup-button')
       await editBlock.click()
-      const removeButton = page.locator('#blocks-row-0').getByRole('button', { name: 'Remove' })
+      const removeButton = page.locator('.popup__content').getByRole('button', { name: 'Remove' })
       await expect(removeButton).toBeVisible()
       await wait(500)
       await removeButton.click()

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -155,7 +155,7 @@ describe('Localization', () => {
 
       await page.locator('.localizer button.popup-button').first().click()
 
-      await expect(page.locator('.localizer .popup')).toHaveClass(/popup--active/)
+      await expect(page.locator('.popup__content')).toBeVisible()
 
       const activeOption = page.locator(`.popup__content .popup-button-list__button--selected`)
 

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -121,14 +121,15 @@ describe('Localization', () => {
       await page.goto(url.create)
       await expect(page.locator('.localizer.app-header__localizer')).toBeVisible()
       await page.locator('.localizer >> button').first().click()
-      await expect(page.locator('.localizer .popup.popup--active')).toBeVisible()
+      await expect(page.locator('.popup__content')).toBeVisible()
     })
 
     test('should filter locale with filterAvailableLocales', async () => {
       await page.goto(url.create)
       await expect(page.locator('.localizer.app-header__localizer')).toBeVisible()
       await page.locator('.localizer >> button').first().click()
-      await expect(page.locator('.localizer .popup.popup--active')).not.toContainText('FILTERED')
+      await expect(page.locator('.popup__content')).toBeVisible()
+      await expect(page.locator('.popup__content')).not.toContainText('FILTERED')
     })
 
     test('should filter version locale selector with filterAvailableLocales', async () => {
@@ -156,9 +157,7 @@ describe('Localization', () => {
 
       await expect(page.locator('.localizer .popup')).toHaveClass(/popup--active/)
 
-      const activeOption = page.locator(
-        `.localizer .popup.popup--active .popup-button-list__button--selected`,
-      )
+      const activeOption = page.locator(`.popup__content .popup-button-list__button--selected`)
 
       await expect(activeOption).toBeVisible()
       const tagName = await activeOption.evaluate((node) => node.tagName)
@@ -545,7 +544,7 @@ describe('Localization', () => {
       await openLocaleSelector(page)
 
       const localeToSelect = page
-        .locator('.localizer .popup.popup--active .popup-button-list__button')
+        .locator('.popup__content .popup-button-list__button')
         .locator('.localizer__locale-code', {
           hasText: `${spanishLocale}`,
         })

--- a/test/plugin-multi-tenant/e2e.spec.ts
+++ b/test/plugin-multi-tenant/e2e.spec.ts
@@ -719,8 +719,8 @@ async function openAssignTenantModal({
   }
 
   // Open the assign tenant modal
-  const docControlsPopup = page.locator('.doc-controls__popup')
-  const docControlsButton = docControlsPopup.locator('.popup-button')
+  const docControlsPopup = page.locator('.popup__content')
+  const docControlsButton = page.locator('.doc-controls__popup .popup-button')
   await expect(docControlsButton).toBeVisible()
   await docControlsButton.click()
 

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -175,7 +175,7 @@ describe('Trash', () => {
         await expect(threeDotMenu).toBeVisible()
         await threeDotMenu.click()
 
-        await page.locator('.doc-controls__popup #action-delete').click()
+        await page.locator('.popup__content #action-delete').click()
         await expect(page.locator('#delete-forever')).toBeHidden()
       })
 
@@ -186,7 +186,7 @@ describe('Trash', () => {
         await expect(threeDotMenu).toBeVisible()
         await threeDotMenu.click()
 
-        await page.locator('.doc-controls__popup #action-delete').click()
+        await page.locator('.popup__content #action-delete').click()
         await expect(page.locator('#delete-forever')).toBeVisible()
       })
 
@@ -197,7 +197,7 @@ describe('Trash', () => {
         await expect(threeDotMenuOne).toBeVisible()
         await threeDotMenuOne.click()
 
-        await page.locator('.doc-controls__popup #action-delete').click()
+        await page.locator('.popup__content #action-delete').click()
 
         // Check the checkbox to delete permanently
         await page.locator('#delete-forever').check()
@@ -214,7 +214,7 @@ describe('Trash', () => {
         await expect(threeDotMenuTwo).toBeVisible()
         await threeDotMenuTwo.click()
 
-        await page.locator('.doc-controls__popup #action-delete').click()
+        await page.locator('.popup__content #action-delete').click()
 
         // Skip the checkbox to delete permanently and default to trashing
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1200,7 +1200,7 @@ describe('Versions', () => {
       const publishOptions = page.locator('.doc-controls__controls .popup')
       await publishOptions.click()
 
-      const publishSpecificLocale = page.locator('.doc-controls__controls .popup__content')
+      const publishSpecificLocale = page.locator('.popup__content')
 
       await expect(publishSpecificLocale).toContainText('English')
     })
@@ -1644,7 +1644,7 @@ describe('Versions', () => {
       const publishOptions = page.locator('.doc-controls__controls .popup')
       await publishOptions.click()
 
-      const publishSpecificLocale = page.locator('.doc-controls__controls .popup__content')
+      const publishSpecificLocale = page.locator('.popup__content')
 
       await expect(publishSpecificLocale).toContainText('English')
     })

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -2369,7 +2369,7 @@ describe('Versions', () => {
       await publishDropdown.click()
 
       const schedulePublishButton = page.locator(
-        '.popup-button-list__button:has-text("Schedule Publish")',
+        '.popup__content .popup-button-list__button:has-text("Schedule Publish")',
       )
       await schedulePublishButton.click()
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11456
Fixes https://github.com/payloadcms/payload/issues/14492
Fixes https://github.com/payloadcms/payload/issues/14744
Fixes https://github.com/payloadcms/payload/issues/14965

Previously, the Popup contents were displayed relative to the Popup trigger button. This caused the Popup contents to be hidden if the parent element has `overflow: hidden`, which was the case for doc_controls on smaller screen sizes (this PR adds an e2e test that previously failed).

This PR refactors the Popup component to use `createPortal`, rendering the popup content directly to `document.body` to avoid clipping issues.


## Before

https://github.com/user-attachments/assets/c1cc341a-2295-45b6-89d0-7e89866e5bfd

## After

https://github.com/user-attachments/assets/2eb0d8b5-105e-468b-bd66-8ef8261a6306



While refactoring, I also improved the keyboard navigation for popups:

| Feature | Before | After |
|---------|--------|-------|
| Tab cycling | Exited popup after last button | Cycles and goes back to first button |
| Escape key | Did nothing | Closes popup and returns focus to trigger |
| Arrow keys | Scrolled the page | Navigates between buttons (↑/↓) |
| Button focus styling | Bad | Good |
| `<a>` elements | Skipped during navigation | Included in keyboard navigation |


## Keyboard navigation before

https://github.com/user-attachments/assets/9d212c90-7759-42cf-ad37-d7ee7dc64c5d

## Keyboard navigation after

https://github.com/user-attachments/assets/dbc7d647-b58b-4e5b-928c-a6f3fdab6348

