### PR TITLE
docs: remove unused variable from custom field label translation

### DIFF
--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -262,10 +262,7 @@ Additionally, Payload exposes the `t` function in various places, for example in
 ```ts
 // <rootDir>/fields/myField.ts
 
-import type {
-  DefaultTranslationKeys,
-  TFunction,
-} from '@payloadcms/translations'
+import type { TFunction } from '@payloadcms/translations'
 import type { Field } from 'payload'
 
 import { CustomTranslationsKeys } from '../custom-translations'


### PR DESCRIPTION
### What?

There is an unused variable in one of the i18n custom translation examples.

### Why?

Improve overall readability of documentation.

### How?

Remove the unused variable.