### PR TITLE
fix(plugin-multi-tenant): refresh tenant selector on create/update

### DIFF
--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -2,7 +2,7 @@
 
 import type { OptionObject } from 'payload'
 
-import { useAuth } from '@payloadcms/ui'
+import { useAuth, useDocumentEvents } from '@payloadcms/ui'
 import { useRouter } from 'next/navigation.js'
 import React, { createContext } from 'react'
 
@@ -42,11 +42,13 @@ export const TenantSelectionProviderClient = ({
   initialValue,
   tenantCookie,
   tenantOptions,
+  tenantsCollectionSlug,
 }: {
   children: React.ReactNode
   initialValue?: number | string
   tenantCookie?: string
   tenantOptions: OptionObject[]
+  tenantsCollectionSlug: string
 }) => {
   const [selectedTenantID, setSelectedTenantID] = React.useState<number | string | undefined>(
     initialValue,
@@ -123,6 +125,16 @@ export const TenantSelectionProviderClient = ({
       router.refresh()
     }
   }, [userID, tenantCookie, deleteCookie, router])
+
+  // Listen for document events to refresh tenant options when tenants are created/updated
+  const { mostRecentUpdate } = useDocumentEvents() as {
+    mostRecentUpdate: { entitySlug: string; id?: number | string; updatedAt: string } | null
+  }
+  React.useEffect(() => {
+    if (mostRecentUpdate?.entitySlug === tenantsCollectionSlug) {
+      router.refresh()
+    }
+  }, [mostRecentUpdate, tenantsCollectionSlug, router])
 
   return (
     <span

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
@@ -65,6 +65,7 @@ export const TenantSelectionProvider = async ({
       initialValue={initialValue}
       tenantCookie={tenantCookie}
       tenantOptions={tenantOptions}
+      tenantsCollectionSlug={tenantsCollectionSlug}
     >
       {children}
     </TenantSelectionProviderClient>


### PR DESCRIPTION
# fix(plugin-multi-tenant): refresh tenant selector on create/update

### What?

This PR fixes an issue where the tenant selector dropdown in the multi-tenant plugin does not update its options list when a new tenant is created or an existing tenant is updated.

**Changes:**

- Added `useDocumentEvents` hook to listen for tenant changes
- Triggers `router.refresh()` when tenants are created or updated
- Passes `tenantsCollectionSlug` to client component to identify events
- Fixes issue where newly created/updated tenants don't appear in dropdown without page reload

### Why?

The `TenantSelectionProviderClient` component receives tenant options as static props from the server-side `TenantSelectionProvider` (RSC). When a tenant is created or updated, there was no mechanism to refetch these options, resulting in a poor user experience where users had to manually reload the browser to see newly created or updated tenants in the selector.

### How?

The fix leverages Payload's existing `useDocumentEvents` hook to listen for document changes:

1. When a tenant is created or updated, the `reportUpdate` function is called (already happening in the Edit view's `onSave` handler)
2. The `TenantSelectionProviderClient` now listens to `mostRecentUpdate` from `useDocumentEvents`
3. When a document update is detected for the tenants collection, `router.refresh()` is triggered
4. This causes the RSC to re-render and fetch the updated tenant options

**Files modified:**

- `packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx` - Added event listener and refresh logic
- `packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx` - Pass `tenantsCollectionSlug` prop

### Testing

1. Navigate to the Payload admin panel
2. Create a new tenant
3. ✅ The tenant selector dropdown immediately shows the new tenant
4. Update an existing tenant's name
5. ✅ The tenant selector reflects the updated name automatically

**Before:** Newly created/updated tenants only appeared after a full page reload

**After:** Tenant selector updates immediately when tenants are created or updated

### Known Limitations

Delete operations do not currently trigger `useDocumentEvents`, so deleted tenants may still appear in the dropdown until a page reload or navigation occurs. This is a broader issue that may require changes to the core Payload UI and is outside the scope of this fix.

Fixes #
