### PR TITLE
refactor: add relative flag to formatAdminURL util

### DIFF
--- a/packages/next/src/views/Root/getRouteData.ts
+++ b/packages/next/src/views/Root/getRouteData.ts
@@ -160,7 +160,12 @@ export const getRouteData = ({
           return isPathMatchingRoute({
             currentRoute,
             exact: true,
-            path: formatAdminURL({ adminRoute, path: route }),
+            path: formatAdminURL({
+              adminRoute,
+              path: route,
+              relative: true,
+              serverURL: config.serverURL,
+            }),
           })
         })
 

--- a/packages/next/src/views/Root/index.tsx
+++ b/packages/next/src/views/Root/index.tsx
@@ -67,6 +67,8 @@ export const RootPage = async ({
   const currentRoute = formatAdminURL({
     adminRoute,
     path: Array.isArray(params.segments) ? `/${params.segments.join('/')}` : null,
+    relative: true,
+    serverURL: config.serverURL,
   })
 
   const segments = Array.isArray(params.segments) ? params.segments : []
@@ -224,7 +226,12 @@ export const RootPage = async ({
   const usersCollection = config.collections.find(({ slug }) => slug === userSlug)
   const disableLocalStrategy = usersCollection?.auth?.disableLocalStrategy
 
-  const createFirstUserRoute = formatAdminURL({ adminRoute, path: _createFirstUserRoute })
+  const createFirstUserRoute = formatAdminURL({
+    adminRoute,
+    path: _createFirstUserRoute,
+    relative: true,
+    serverURL: config.serverURL,
+  })
 
   if (disableLocalStrategy && currentRoute === createFirstUserRoute) {
     redirect(adminRoute)

--- a/packages/payload/src/utilities/formatAdminURL.spec.ts
+++ b/packages/payload/src/utilities/formatAdminURL.spec.ts
@@ -3,206 +3,204 @@ import { formatAdminURL } from './formatAdminURL.js'
 describe('formatAdminURL', () => {
   const serverURL = 'https://example.com'
 
+  const defaultAdminRoute = '/admin'
+  const rootAdminRoute = '/'
+
+  const dummyPath = '/collections/posts'
+
   describe('relative URLs', () => {
-    it('should return relative path when relative=true', () => {
+    it('should ignore `serverURL` when relative=true', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
-        path: '/collections/posts',
+        adminRoute: defaultAdminRoute,
+        path: dummyPath,
         serverURL,
         relative: true,
       })
-      expect(result).toBe('/admin/collections/posts')
+
+      expect(result).toBe(`${defaultAdminRoute}${dummyPath}`)
     })
 
-    it('should return relative path when no serverURL provided', () => {
+    it('should force relative URL when `serverURL` is omitted', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
-        path: '/collections/posts',
+        adminRoute: defaultAdminRoute,
+        path: dummyPath,
+        relative: false,
       })
-      expect(result).toBe('/admin/collections/posts')
-    })
 
-    it('should return "/" when no paths provided and relative=true', () => {
-      const result = formatAdminURL({
-        adminRoute: null,
-        relative: true,
-      })
-      expect(result).toBe('/')
+      expect(result).toBe(`${defaultAdminRoute}${dummyPath}`)
     })
   })
 
   describe('absolute URLs', () => {
     it('should return absolute URL with serverURL', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
-        path: '/collections/posts',
+        adminRoute: defaultAdminRoute,
+        path: dummyPath,
         serverURL,
       })
-      expect(result).toBe('https://example.com/admin/collections/posts')
+
+      expect(result).toBe(`${serverURL}${defaultAdminRoute}${dummyPath}`)
     })
 
     it('should handle serverURL with trailing slash', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
+        adminRoute: defaultAdminRoute,
         path: '/collections/posts',
         serverURL: 'https://example.com/',
       })
+
       expect(result).toBe('https://example.com/admin/collections/posts')
     })
 
     it('should handle serverURL with subdirectory', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
+        adminRoute: defaultAdminRoute,
         path: '/collections/posts',
         serverURL: 'https://example.com/api/v1',
       })
+
       expect(result).toBe('https://example.com/admin/collections/posts')
     })
   })
 
-  describe('adminRoute handling', () => {
-    it('should handle adminRoute="/"', () => {
+  describe('admin route handling', () => {
+    it('should return relative URL for adminRoute="/", no path, no `serverURL`', () => {
       const result = formatAdminURL({
-        adminRoute: '/',
+        adminRoute: rootAdminRoute,
+        relative: true,
+      })
+
+      expect(result).toBe('/')
+    })
+
+    it('should handle relative URL for adminRoute="/", with path, no `serverURL`', () => {
+      const result = formatAdminURL({
+        adminRoute: rootAdminRoute,
+        path: dummyPath,
+        relative: true,
+      })
+
+      expect(result).toBe(dummyPath)
+    })
+
+    it('should return absolute URL for adminRoute="/", no path, with `serverURL`', () => {
+      const result = formatAdminURL({
+        adminRoute: rootAdminRoute,
         serverURL,
       })
+
       expect(result).toBe('https://example.com/')
     })
 
-    it('should handle adminRoute="/" with path', () => {
+    it('should handle absolute URL for adminRoute="/", with path and `serverURL`', () => {
       const result = formatAdminURL({
-        adminRoute: '/',
-        path: '/collections/posts',
+        adminRoute: rootAdminRoute,
         serverURL,
+        path: dummyPath,
       })
-      expect(result).toBe('https://example.com/collections/posts')
-    })
 
-    it('should handle adminRoute="/admin"', () => {
-      const result = formatAdminURL({
-        adminRoute: '/admin',
-        serverURL,
-      })
-      expect(result).toBe('https://example.com/admin')
-    })
-
-    it('should handle adminRoute="/custom-admin"', () => {
-      const result = formatAdminURL({
-        adminRoute: '/custom-admin',
-        path: '/dashboard',
-        serverURL,
-      })
-      expect(result).toBe('https://example.com/custom-admin/dashboard')
-    })
-
-    it('should handle null adminRoute', () => {
-      const result = formatAdminURL({
-        adminRoute: undefined,
-        path: '/collections/posts',
-        serverURL,
-      })
-      expect(result).toBe('https://example.com/collections/posts')
+      expect(result).toBe(`${serverURL}${dummyPath}`)
     })
   })
 
-  describe('basePath handling', () => {
+  describe('base path handling', () => {
     it('should include basePath in URL', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
+        adminRoute: defaultAdminRoute,
         basePath: '/v1',
-        path: '/collections/posts',
+        path: dummyPath,
         serverURL,
       })
-      expect(result).toBe('https://example.com/v1/admin/collections/posts')
+
+      expect(result).toBe(`${serverURL}/v1${defaultAdminRoute}${dummyPath}`)
     })
 
     it('should handle basePath with adminRoute="/"', () => {
       const result = formatAdminURL({
-        adminRoute: '/',
-        basePath: '/api',
+        adminRoute: rootAdminRoute,
+        basePath: '/v1',
         serverURL,
       })
-      expect(result).toBe('https://example.com/api')
+
+      expect(result).toBe(`${serverURL}/v1`)
     })
 
     it('should handle basePath with no adminRoute', () => {
       const result = formatAdminURL({
         adminRoute: undefined,
-        basePath: '/api',
-        path: '/collections',
+        basePath: '/v1',
+        path: dummyPath,
         serverURL,
       })
-      expect(result).toBe('https://example.com/api/collections')
+
+      expect(result).toBe(`${serverURL}/v1${dummyPath}`)
+    })
+
+    it('should handle empty basePath', () => {
+      const result = formatAdminURL({
+        adminRoute: defaultAdminRoute,
+        basePath: '',
+        path: dummyPath,
+        serverURL,
+      })
+
+      expect(result).toBe(`${serverURL}${defaultAdminRoute}${dummyPath}`)
     })
   })
 
   describe('path handling', () => {
     it('should handle empty string path', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
+        adminRoute: defaultAdminRoute,
         path: '',
         serverURL,
       })
-      expect(result).toBe('https://example.com/admin')
+
+      expect(result).toBe(`${serverURL}${defaultAdminRoute}`)
     })
 
     it('should handle null path', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
+        adminRoute: defaultAdminRoute,
         path: null,
         serverURL,
       })
-      expect(result).toBe('https://example.com/admin')
+      expect(result).toBe(`${serverURL}${defaultAdminRoute}`)
     })
 
     it('should handle undefined path', () => {
       const result = formatAdminURL({
-        adminRoute: '/admin',
+        adminRoute: defaultAdminRoute,
         path: undefined,
         serverURL,
       })
-      expect(result).toBe('https://example.com/admin')
+
+      expect(result).toBe(`${serverURL}${defaultAdminRoute}`)
     })
 
     it('should handle path with query parameters', () => {
+      const path = `${dummyPath}?page=2`
+
       const result = formatAdminURL({
-        adminRoute: '/admin',
-        path: '/collections/posts?page=2',
+        adminRoute: defaultAdminRoute,
+        path,
         serverURL,
       })
-      expect(result).toBe('https://example.com/admin/collections/posts?page=2')
+
+      expect(result).toBe(`${serverURL}${defaultAdminRoute}${path}`)
     })
   })
 
   describe('edge cases', () => {
-    it('should handle empty basePath', () => {
-      const result = formatAdminURL({
-        adminRoute: '/admin',
-        basePath: '',
-        path: '/collections/posts',
-        serverURL,
-      })
-      expect(result).toBe('https://example.com/admin/collections/posts')
-    })
-
-    it('should return "/" for minimal relative config', () => {
+    it('should return "/" when given minimal args', () => {
       const result = formatAdminURL({
         adminRoute: undefined,
         basePath: '',
         path: '',
         relative: true,
       })
-      expect(result).toBe('/')
-    })
 
-    it('should handle complex nested paths', () => {
-      const result = formatAdminURL({
-        adminRoute: '/admin',
-        basePath: '/api/v2',
-        path: '/collections/posts/edit/123',
-        serverURL,
-      })
-      expect(result).toBe('https://example.com/api/v2/admin/collections/posts/edit/123')
+      expect(result).toBe('/')
     })
   })
 })

--- a/packages/payload/src/utilities/formatAdminURL.spec.ts
+++ b/packages/payload/src/utilities/formatAdminURL.spec.ts
@@ -1,0 +1,208 @@
+import { formatAdminURL } from './formatAdminURL.js'
+
+describe('formatAdminURL', () => {
+  const serverURL = 'https://example.com'
+
+  describe('relative URLs', () => {
+    it('should return relative path when relative=true', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: '/collections/posts',
+        serverURL,
+        relative: true,
+      })
+      expect(result).toBe('/admin/collections/posts')
+    })
+
+    it('should return relative path when no serverURL provided', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: '/collections/posts',
+      })
+      expect(result).toBe('/admin/collections/posts')
+    })
+
+    it('should return "/" when no paths provided and relative=true', () => {
+      const result = formatAdminURL({
+        adminRoute: null,
+        relative: true,
+      })
+      expect(result).toBe('/')
+    })
+  })
+
+  describe('absolute URLs', () => {
+    it('should return absolute URL with serverURL', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: '/collections/posts',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/admin/collections/posts')
+    })
+
+    it('should handle serverURL with trailing slash', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: '/collections/posts',
+        serverURL: 'https://example.com/',
+      })
+      expect(result).toBe('https://example.com/admin/collections/posts')
+    })
+
+    it('should handle serverURL with subdirectory', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: '/collections/posts',
+        serverURL: 'https://example.com/api/v1',
+      })
+      expect(result).toBe('https://example.com/admin/collections/posts')
+    })
+  })
+
+  describe('adminRoute handling', () => {
+    it('should handle adminRoute="/"', () => {
+      const result = formatAdminURL({
+        adminRoute: '/',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/')
+    })
+
+    it('should handle adminRoute="/" with path', () => {
+      const result = formatAdminURL({
+        adminRoute: '/',
+        path: '/collections/posts',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/collections/posts')
+    })
+
+    it('should handle adminRoute="/admin"', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/admin')
+    })
+
+    it('should handle adminRoute="/custom-admin"', () => {
+      const result = formatAdminURL({
+        adminRoute: '/custom-admin',
+        path: '/dashboard',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/custom-admin/dashboard')
+    })
+
+    it('should handle null adminRoute', () => {
+      const result = formatAdminURL({
+        adminRoute: undefined,
+        path: '/collections/posts',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/collections/posts')
+    })
+  })
+
+  describe('basePath handling', () => {
+    it('should include basePath in URL', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        basePath: '/v1',
+        path: '/collections/posts',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/v1/admin/collections/posts')
+    })
+
+    it('should handle basePath with adminRoute="/"', () => {
+      const result = formatAdminURL({
+        adminRoute: '/',
+        basePath: '/api',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/api')
+    })
+
+    it('should handle basePath with no adminRoute', () => {
+      const result = formatAdminURL({
+        adminRoute: undefined,
+        basePath: '/api',
+        path: '/collections',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/api/collections')
+    })
+  })
+
+  describe('path handling', () => {
+    it('should handle empty string path', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: '',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/admin')
+    })
+
+    it('should handle null path', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: null,
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/admin')
+    })
+
+    it('should handle undefined path', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: undefined,
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/admin')
+    })
+
+    it('should handle path with query parameters', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        path: '/collections/posts?page=2',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/admin/collections/posts?page=2')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty basePath', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        basePath: '',
+        path: '/collections/posts',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/admin/collections/posts')
+    })
+
+    it('should return "/" for minimal relative config', () => {
+      const result = formatAdminURL({
+        adminRoute: undefined,
+        basePath: '',
+        path: '',
+        relative: true,
+      })
+      expect(result).toBe('/')
+    })
+
+    it('should handle complex nested paths', () => {
+      const result = formatAdminURL({
+        adminRoute: '/admin',
+        basePath: '/api/v2',
+        path: '/collections/posts/edit/123',
+        serverURL,
+      })
+      expect(result).toBe('https://example.com/api/v2/admin/collections/posts/edit/123')
+    })
+  })
+})

--- a/packages/payload/src/utilities/formatAdminURL.ts
+++ b/packages/payload/src/utilities/formatAdminURL.ts
@@ -3,22 +3,37 @@ import type { Config } from '../config/types.js'
 /** Will read the `routes.admin` config and appropriately handle `"/"` admin paths */
 export const formatAdminURL = (args: {
   adminRoute: NonNullable<Config['routes']>['admin']
+  /**
+   * The subpath of your application, if specified.
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath
+   * @example '/docs'
+   */
   basePath?: string
-  path: '' | `/${string}` | null | undefined
+  path?: '' | `/${string}` | null
+  /**
+   * Return a relative URL, e.g. ignore `serverURL`.
+   * Useful for route-matching, etc.
+   */
+  relative?: boolean
   serverURL?: Config['serverURL']
 }): string => {
-  const { adminRoute, basePath = '', path: pathFromArgs, serverURL } = args
-  const path = pathFromArgs || ''
+  const { adminRoute, basePath = '', path = '', relative = false, serverURL } = args
 
-  if (adminRoute) {
-    if (adminRoute === '/') {
-      if (!path) {
-        return `${serverURL || ''}${basePath}${adminRoute}`
-      }
-    } else {
-      return `${serverURL || ''}${basePath}${adminRoute}${path}`
-    }
+  const pathSegments = [basePath]
+
+  if (adminRoute && adminRoute !== '/') {
+    pathSegments.push(adminRoute)
   }
 
-  return `${serverURL || ''}${basePath}${path}`
+  if (path && !(adminRoute === '/' && !path)) {
+    pathSegments.push(path)
+  }
+
+  const pathname = pathSegments.join('') || '/'
+
+  if (relative || !serverURL) {
+    return pathname
+  }
+
+  return new URL(pathname, serverURL).toString()
 }

--- a/packages/payload/src/utilities/formatAdminURL.ts
+++ b/packages/payload/src/utilities/formatAdminURL.ts
@@ -1,22 +1,29 @@
 import type { Config } from '../config/types.js'
 
-/** Will read the `routes.admin` config and appropriately handle `"/"` admin paths */
-export const formatAdminURL = (args: {
-  adminRoute: NonNullable<Config['routes']>['admin']
-  /**
-   * The subpath of your application, if specified.
-   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath
-   * @example '/docs'
-   */
-  basePath?: string
-  path?: '' | `/${string}` | null
-  /**
-   * Return a relative URL, e.g. ignore `serverURL`.
-   * Useful for route-matching, etc.
-   */
-  relative?: boolean
-  serverURL?: Config['serverURL']
-}): string => {
+/**
+ * This function builds correct URLs for admin panel routing.
+ * Its primary responsibilities are:
+ * 1. Read from your `routes.admin` config and appropriately handle `"/"` admin paths
+ * 2. Prepend the `basePath` from your Next.js config, if specified
+ * 3. Return relative or absolute URLs, as needed
+ */
+export const formatAdminURL = (
+  args: {
+    adminRoute: NonNullable<Config['routes']>['admin']
+    /**
+     * The subpath of your application, if specified.
+     * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath
+     * @example '/docs'
+     */
+    basePath?: string
+    path?: '' | `/${string}` | null
+    /**
+     * Return a relative URL, e.g. ignore `serverURL`.
+     * Useful for route-matching, etc.
+     */
+    relative?: boolean
+  } & Pick<Config, 'serverURL'>,
+): string => {
   const { adminRoute, basePath = '', path = '', relative = false, serverURL } = args
 
   const pathSegments = [basePath]


### PR DESCRIPTION
Adds a `relative` flag to the `formatAdminURL` util.

There are cases where this function can produce a fully qualified URL, like for client-side routing, and other times when it must remain relative, like when matching routes.

This flag differentiates these two behaviors declaratively so we don't have to rely on the omission of `serverURL`.

```ts
const result = formatAdminURL({
  adminRoute: '/admin',
  basePath: '/v1',
  path: '/collections/posts',
  serverURL: 'http://payloadcms.com',
  relative: true,
})

// returns '/v1/admin/collections/posts'
```

Related: https://github.com/payloadcms/payload/pull/14919 and https://github.com/payloadcms/payload/pull/14907