### PR TITLE
fix: improves upload security for PDFs and SVGs

### DIFF
--- a/packages/payload/src/uploads/validateSvg.ts
+++ b/packages/payload/src/uploads/validateSvg.ts
@@ -6,7 +6,6 @@ export function validateSvg(buffer: Buffer): boolean {
   try {
     const content = buffer.toString('utf8')
 
-    // Dangerous patterns that should not be present in uploaded SVGs
     const dangerousPatterns = [
       // Script tags
       /<script[\s>]/i,
@@ -46,86 +45,14 @@ export function validateSvg(buffer: Buffer): boolean {
       /<!\[CDATA\[[\s\S]*<script/i,
     ]
 
-    // Check for dangerous patterns
     for (const pattern of dangerousPatterns) {
       if (pattern.test(content)) {
         return false
       }
     }
 
-    // Additional validation: check for suspicious attribute combinations
-    // Multiple event handlers or unusual nesting often indicates malicious intent
-    const eventHandlerCount = (content.match(/\son\w+\s*=/gi) || []).length
-    if (eventHandlerCount > 0) {
-      return false
-    }
-
-    // Check for data URIs that might contain executable content
-    const dataUriMatches = content.match(/data:[^;,]+/gi) || []
-    for (const dataUri of dataUriMatches) {
-      const mimeType = dataUri.toLowerCase()
-      // Only allow safe image formats in data URIs
-      if (
-        !mimeType.includes('image/png') &&
-        !mimeType.includes('image/jpeg') &&
-        !mimeType.includes('image/jpg') &&
-        !mimeType.includes('image/gif') &&
-        !mimeType.includes('image/webp') &&
-        !mimeType.includes('image/svg+xml')
-      ) {
-        return false
-      }
-    }
-
-    // Validate that use/image hrefs don't point to dangerous protocols
-    const hrefMatches = content.match(/(?:href|src|data|xlink:href)\s*=\s*["'][^"']+["']/gi) || []
-    for (const hrefMatch of hrefMatches) {
-      const hrefValue = hrefMatch.match(/["']([^"']+)["']/)?.[1]?.toLowerCase() || ''
-
-      // Block dangerous protocols
-      if (
-        hrefValue.startsWith('javascript:') ||
-        hrefValue.startsWith('data:text/html') ||
-        hrefValue.startsWith('vbscript:') ||
-        hrefValue.startsWith('file:')
-      ) {
-        return false
-      }
-    }
-
-    // Check for excessive nesting (potential DoS or obfuscation)
-    const nestingDepth = calculateMaxNestingDepth(content)
-    if (nestingDepth > 100) {
-      return false
-    }
-
     return true
   } catch (_error) {
-    // If any error occurs during validation, reject as unsafe
     return false
   }
-}
-
-/**
- * Calculate maximum nesting depth of XML/SVG elements
- * Helps detect overly complex or malicious structures
- */
-function calculateMaxNestingDepth(content: string): number {
-  let maxDepth = 0
-  let currentDepth = 0
-
-  // Simple depth calculation based on opening/closing tags
-  const tagPattern = /<\/?[\w:-]+/g
-  const matches = content.match(tagPattern) || []
-
-  for (const match of matches) {
-    if (match.startsWith('</')) {
-      currentDepth--
-    } else {
-      currentDepth++
-      maxDepth = Math.max(maxDepth, currentDepth)
-    }
-  }
-
-  return maxDepth
 }

--- a/packages/payload/src/uploads/validateSvg.ts
+++ b/packages/payload/src/uploads/validateSvg.ts
@@ -1,0 +1,131 @@
+/**
+ * Validate SVG content for security vulnerabilities
+ * Detects and blocks malicious patterns commonly used in SVG-based attacks
+ */
+export function validateSvg(buffer: Buffer): boolean {
+  try {
+    const content = buffer.toString('utf8')
+
+    // Dangerous patterns that should not be present in uploaded SVGs
+    const dangerousPatterns = [
+      // Script tags
+      /<script[\s>]/i,
+      /<\/script>/i,
+
+      // Event handlers (onclick, onload, onerror, etc.)
+      /\son\w+\s*=/i,
+
+      // JavaScript URLs
+      /javascript:/i,
+      /data:text\/html/i,
+
+      // Foreign objects (can embed HTML)
+      /<foreignObject[\s>]/i,
+
+      // Embedded iframes
+      /<iframe[\s>]/i,
+
+      // Embedded objects and embeds
+      /<object[\s>]/i,
+      /<embed[\s>]/i,
+
+      // Base64 encoded scripts (common obfuscation technique)
+      /data:image\/svg\+xml;base64,[\w+/]*PHNjcmlwdA/i, // <script in base64
+
+      // XLink href with javascript (deprecated but still dangerous)
+      /xlink:href\s*=\s*["']javascript:/i,
+
+      // Import statements
+      /@import/i,
+
+      // External resource references that could be dangerous
+      /<!ENTITY/i,
+      /<!DOCTYPE[^>]*\[/i, // DOCTYPE with internal subset
+
+      // Attempt to use CDATA to hide scripts
+      /<!\[CDATA\[[\s\S]*<script/i,
+    ]
+
+    // Check for dangerous patterns
+    for (const pattern of dangerousPatterns) {
+      if (pattern.test(content)) {
+        return false
+      }
+    }
+
+    // Additional validation: check for suspicious attribute combinations
+    // Multiple event handlers or unusual nesting often indicates malicious intent
+    const eventHandlerCount = (content.match(/\son\w+\s*=/gi) || []).length
+    if (eventHandlerCount > 0) {
+      return false
+    }
+
+    // Check for data URIs that might contain executable content
+    const dataUriMatches = content.match(/data:[^;,]+/gi) || []
+    for (const dataUri of dataUriMatches) {
+      const mimeType = dataUri.toLowerCase()
+      // Only allow safe image formats in data URIs
+      if (
+        !mimeType.includes('image/png') &&
+        !mimeType.includes('image/jpeg') &&
+        !mimeType.includes('image/jpg') &&
+        !mimeType.includes('image/gif') &&
+        !mimeType.includes('image/webp') &&
+        !mimeType.includes('image/svg+xml')
+      ) {
+        return false
+      }
+    }
+
+    // Validate that use/image hrefs don't point to dangerous protocols
+    const hrefMatches = content.match(/(?:href|src|data|xlink:href)\s*=\s*["'][^"']+["']/gi) || []
+    for (const hrefMatch of hrefMatches) {
+      const hrefValue = hrefMatch.match(/["']([^"']+)["']/)?.[1]?.toLowerCase() || ''
+
+      // Block dangerous protocols
+      if (
+        hrefValue.startsWith('javascript:') ||
+        hrefValue.startsWith('data:text/html') ||
+        hrefValue.startsWith('vbscript:') ||
+        hrefValue.startsWith('file:')
+      ) {
+        return false
+      }
+    }
+
+    // Check for excessive nesting (potential DoS or obfuscation)
+    const nestingDepth = calculateMaxNestingDepth(content)
+    if (nestingDepth > 100) {
+      return false
+    }
+
+    return true
+  } catch (_error) {
+    // If any error occurs during validation, reject as unsafe
+    return false
+  }
+}
+
+/**
+ * Calculate maximum nesting depth of XML/SVG elements
+ * Helps detect overly complex or malicious structures
+ */
+function calculateMaxNestingDepth(content: string): number {
+  let maxDepth = 0
+  let currentDepth = 0
+
+  // Simple depth calculation based on opening/closing tags
+  const tagPattern = /<\/?[\w:-]+/g
+  const matches = content.match(tagPattern) || []
+
+  for (const match of matches) {
+    if (match.startsWith('</')) {
+      currentDepth--
+    } else {
+      currentDepth++
+      maxDepth = Math.max(maxDepth, currentDepth)
+    }
+  }
+
+  return maxDepth
+}

--- a/packages/payload/src/utilities/validateMimeType.ts
+++ b/packages/payload/src/utilities/validateMimeType.ts
@@ -1,23 +1,9 @@
-export const validateMimeType = (
-  mimeType: string,
-  allowedMimeTypes: string[],
-  ext?: boolean,
-): boolean => {
-  const cleanedMimeTypes = allowedMimeTypes.map((v) => v.replace('*', ''))
+export const validateMimeType = (mimeType: string, allowedMimeTypes: string[]): boolean => {
   if (allowedMimeTypes.length === 0) {
     return true
   }
 
-  const startsWithMatch = cleanedMimeTypes.some((cleanedMimeType) =>
-    mimeType.startsWith(cleanedMimeType),
-  )
-  if (startsWithMatch) {
-    return true
-  }
+  const cleanedMimeTypes = allowedMimeTypes.map((v) => v.replace('*', ''))
 
-  if (ext) {
-    return cleanedMimeTypes.some((cleanedMimeType) => cleanedMimeType.includes(mimeType))
-  }
-
-  return false
+  return cleanedMimeTypes.some((cleanedMimeType) => mimeType.startsWith(cleanedMimeType))
 }

--- a/packages/payload/src/utilities/validateMimeType.ts
+++ b/packages/payload/src/utilities/validateMimeType.ts
@@ -1,4 +1,23 @@
-export const validateMimeType = (mimeType: string, allowedMimeTypes: string[]): boolean => {
+export const validateMimeType = (
+  mimeType: string,
+  allowedMimeTypes: string[],
+  ext?: boolean,
+): boolean => {
   const cleanedMimeTypes = allowedMimeTypes.map((v) => v.replace('*', ''))
-  return cleanedMimeTypes.some((cleanedMimeType) => mimeType.startsWith(cleanedMimeType))
+  if (allowedMimeTypes.length === 0) {
+    return true
+  }
+
+  const startsWithMatch = cleanedMimeTypes.some((cleanedMimeType) =>
+    mimeType.startsWith(cleanedMimeType),
+  )
+  if (startsWithMatch) {
+    return true
+  }
+
+  if (ext) {
+    return cleanedMimeTypes.some((cleanedMimeType) => cleanedMimeType.includes(mimeType))
+  }
+
+  return false
 }

--- a/test/uploads/corrupt.svg
+++ b/test/uploads/corrupt.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400"
+viewBox="0 0 124 124" fill="none">
+<rect width="124" height="124" rx="24" fill="#000000"/>
+<script type="text/javascript">
+alert(window.location);
+</script>
+</svg>

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -287,6 +287,21 @@ describe('Collections - Uploads', () => {
         expect(response.status).toBe(400)
       })
 
+      it('should not allow html file to be uploaded to PDF only collection', async () => {
+        const formData = new FormData()
+        const filePath = path.join(dirname, './test.html')
+        const { file, handle } = await createStreamableFile(filePath, 'application/pdf')
+        formData.append('file', file)
+        formData.append('contentType', 'application/pdf')
+
+        const response = await restClient.POST(`/${pdfOnlySlug}`, {
+          body: formData,
+        })
+        await handle.close()
+
+        expect(response.status).toBe(400)
+      })
+
       it('should not allow invalid mimeType to be created', async () => {
         const formData = new FormData()
         const filePath = path.join(dirname, './image.jpg')
@@ -296,6 +311,20 @@ describe('Collections - Uploads', () => {
         formData.append('contentType', 'image/png')
 
         const response = await restClient.POST(`/${restrictedMimeTypesSlug}`, {
+          body: formData,
+        })
+        await handle.close()
+
+        expect(response.status).toBe(400)
+      })
+
+      it('should not allow corrupted SVG to be created', async () => {
+        const formData = new FormData()
+        const filePath = path.join(dirname, './corrupt.svg')
+        const { file, handle } = await createStreamableFile(filePath)
+        formData.append('file', file)
+
+        const response = await restClient.POST(`/${svgOnlySlug}`, {
           body: formData,
         })
         await handle.close()

--- a/test/uploads/test.html
+++ b/test/uploads/test.html
@@ -1,0 +1,1 @@
+<div>hello</div>


### PR DESCRIPTION
#### What?
Improves upload security by closing validation gaps for `PDF` and `SVG` files, preventing malicious files from bypassing MIME type restrictions.

#### Why?

- **PDFs**: Corrupted PDFs with a manipulated content type could bypass detection when no `fileTypeFromBuffer` was undefined, allowing unauthorized file types pass.

- **SVGs**: SVGs can contain malicious scripts that execute when rendered, currently we do not check the SVG for anything potentially harmful

#### How?
- Added extension validation: If the PDF returns no buffer, we have an additional check on the `ext` which closes the validation gap 
- Added SVG sanitization: New `validateSvg` utility checks for attack elements including scripts, event handlers, foreign objects, iframes etc