### PR TITLE
chore(templates): strengthen types in preview url gen

### DIFF
--- a/docs/admin/preview.mdx
+++ b/docs/admin/preview.mdx
@@ -49,11 +49,11 @@ The following arguments are provided to the `preview` function:
 
 The `options` object contains the following properties:
 
-| Path         | Description                                           |
-| ------------ | ----------------------------------------------------- |
-| **`locale`** | The current locale of the Document being edited.      |
-| **`req`**    | The Payload Request object.                           |
-| **`token`**  | The JWT token of the currently authenticated user.    |
+| Path         | Description                                        |
+| ------------ | -------------------------------------------------- |
+| **`locale`** | The current locale of the Document being edited.   |
+| **`req`**    | The Payload Request object.                        |
+| **`token`**  | The JWT token of the currently authenticated user. |
 
 If your application requires a fully qualified URL, such as within deploying to Vercel Preview Deployments, you can use the `req` property to build this URL:
 
@@ -108,7 +108,7 @@ Then, create an API route that verifies the preview secret, authenticates the us
 `/app/preview/route.ts`
 
 ```ts
-import type { CollectionSlug, PayloadRequest } from 'payload'
+import type { PayloadRequest } from 'payload'
 import { getPayload } from 'payload'
 
 import { draftMode } from 'next/headers'
@@ -130,8 +130,6 @@ export async function GET(
   const { searchParams } = new URL(req.url)
 
   const path = searchParams.get('path')
-  const collection = searchParams.get('collection') as CollectionSlug
-  const slug = searchParams.get('slug')
   const previewSecret = searchParams.get('previewSecret')
 
   if (previewSecret !== process.env.PREVIEW_SECRET) {
@@ -140,7 +138,7 @@ export async function GET(
     })
   }
 
-  if (!path || !collection || !slug) {
+  if (!path) {
     return new Response('Insufficient search params', { status: 404 })
   }
 

--- a/examples/draft-preview/src/app/(app)/preview/route.ts
+++ b/examples/draft-preview/src/app/(app)/preview/route.ts
@@ -1,34 +1,30 @@
-import type { CollectionSlug, PayloadRequest } from 'payload'
+import type { PayloadRequest } from 'payload'
 import { getPayload } from 'payload'
 
 import { draftMode } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { NextRequest } from 'next/server'
 
 import configPromise from '@payload-config'
 
-export async function GET(
-  req: {
-    cookies: {
-      get: (name: string) => {
-        value: string
-      }
-    }
-  } & Request,
-): Promise<Response> {
+export type PreviewSearchParams = {
+  path: string
+  previewSecret: string
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
   const payload = await getPayload({ config: configPromise })
 
   const { searchParams } = new URL(req.url)
 
   const path = searchParams.get('path')
-  const collection = searchParams.get('collection') as CollectionSlug
-  const slug = searchParams.get('slug')
   const previewSecret = searchParams.get('previewSecret')
 
   if (previewSecret !== process.env.PREVIEW_SECRET) {
     return new Response('You are not allowed to preview this page', { status: 403 })
   }
 
-  if (!path || !collection || !slug) {
+  if (!path) {
     return new Response('Insufficient search params', { status: 404 })
   }
 

--- a/examples/draft-preview/src/collections/Pages/index.ts
+++ b/examples/draft-preview/src/collections/Pages/index.ts
@@ -5,6 +5,7 @@ import { loggedIn } from './access/loggedIn'
 import { publishedOrLoggedIn } from './access/publishedOrLoggedIn'
 import { formatSlug } from './hooks/formatSlug'
 import { revalidatePage } from './hooks/revalidatePage'
+import { PreviewSearchParams } from '@/app/(app)/preview/route'
 
 export const Pages: CollectionConfig = {
   slug: 'pages',
@@ -18,11 +19,9 @@ export const Pages: CollectionConfig = {
     defaultColumns: ['title', 'slug', 'updatedAt'],
     preview: ({ slug, collection }: { slug: string; collection: CollectionSlug }) => {
       const encodedParams = new URLSearchParams({
-        slug,
-        collection,
         path: `/${slug}`,
         previewSecret: process.env.PREVIEW_SECRET || '',
-      })
+      } satisfies PreviewSearchParams)
 
       return `${process.env.NEXT_PUBLIC_SERVER_URL}/preview?${encodedParams.toString()}`
     },

--- a/templates/ecommerce/src/app/(app)/next/preview/route.ts
+++ b/templates/ecommerce/src/app/(app)/next/preview/route.ts
@@ -1,26 +1,30 @@
-import type { CollectionSlug, PayloadRequest } from 'payload'
+import type { PayloadRequest } from 'payload'
 import { getPayload } from 'payload'
 
 import { draftMode } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { NextRequest } from 'next/server'
 
 import configPromise from '@payload-config'
 
-export async function GET(req: Request): Promise<Response> {
+export type PreviewSearchParams = {
+  path: string
+  previewSecret: string
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
   const payload = await getPayload({ config: configPromise })
 
   const { searchParams } = new URL(req.url)
 
   const path = searchParams.get('path')
-  const collection = searchParams.get('collection') as CollectionSlug
-  const slug = searchParams.get('slug')
   const previewSecret = searchParams.get('previewSecret')
 
   if (previewSecret !== process.env.PREVIEW_SECRET) {
     return new Response('You are not allowed to preview this page', { status: 403 })
   }
 
-  if (!path || !collection || !slug) {
+  if (!path) {
     return new Response('Insufficient search params', { status: 404 })
   }
 

--- a/templates/ecommerce/src/utilities/generatePreviewPath.ts
+++ b/templates/ecommerce/src/utilities/generatePreviewPath.ts
@@ -1,7 +1,8 @@
+import { PreviewSearchParams } from '@/app/(frontend)/next/preview/route'
 import { PayloadRequest, CollectionSlug } from 'payload'
 
 const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
-  products: '/products',
+  posts: '/posts',
   pages: '',
 }
 
@@ -12,17 +13,17 @@ type Props = {
 }
 
 export const generatePreviewPath = ({ collection, slug }: Props) => {
-  // Allow empty strings, e.g. for the homepage
   if (slug === undefined || slug === null) {
     return null
   }
 
+  // Encode to support slugs with special characters
+  const encodedSlug = encodeURIComponent(slug)
+
   const encodedParams = new URLSearchParams({
-    slug,
-    collection,
-    path: `${collectionPrefixMap[collection]}/${slug}`,
+    path: `${collectionPrefixMap[collection]}/${encodedSlug}`,
     previewSecret: process.env.PREVIEW_SECRET || '',
-  })
+  } satisfies PreviewSearchParams)
 
   const url = `/next/preview?${encodedParams.toString()}`
 

--- a/templates/website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/website/src/app/(frontend)/next/preview/route.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, PayloadRequest } from 'payload'
+import type { PayloadRequest } from 'payload'
 import { getPayload } from 'payload'
 
 import { draftMode } from 'next/headers'
@@ -7,21 +7,24 @@ import { NextRequest } from 'next/server'
 
 import configPromise from '@payload-config'
 
+export type PreviewSearchParams = {
+  path: string
+  previewSecret: string
+}
+
 export async function GET(req: NextRequest): Promise<Response> {
   const payload = await getPayload({ config: configPromise })
 
   const { searchParams } = new URL(req.url)
 
   const path = searchParams.get('path')
-  const collection = searchParams.get('collection') as CollectionSlug
-  const slug = searchParams.get('slug')
   const previewSecret = searchParams.get('previewSecret')
 
   if (previewSecret !== process.env.PREVIEW_SECRET) {
     return new Response('You are not allowed to preview this page', { status: 403 })
   }
 
-  if (!path || !collection || !slug) {
+  if (!path) {
     return new Response('Insufficient search params', { status: 404 })
   }
 

--- a/templates/website/src/utilities/generatePreviewPath.ts
+++ b/templates/website/src/utilities/generatePreviewPath.ts
@@ -1,3 +1,4 @@
+import { PreviewSearchParams } from '@/app/(frontend)/next/preview/route'
 import { PayloadRequest, CollectionSlug } from 'payload'
 
 const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
@@ -12,7 +13,6 @@ type Props = {
 }
 
 export const generatePreviewPath = ({ collection, slug }: Props) => {
-  // Allow empty strings, e.g. for the homepage
   if (slug === undefined || slug === null) {
     return null
   }
@@ -21,11 +21,9 @@ export const generatePreviewPath = ({ collection, slug }: Props) => {
   const encodedSlug = encodeURIComponent(slug)
 
   const encodedParams = new URLSearchParams({
-    slug: encodedSlug,
-    collection,
     path: `${collectionPrefixMap[collection]}/${encodedSlug}`,
     previewSecret: process.env.PREVIEW_SECRET || '',
-  })
+  } satisfies PreviewSearchParams)
 
   const url = `/next/preview?${encodedParams.toString()}`
 

--- a/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, PayloadRequest } from 'payload'
+import type { PayloadRequest } from 'payload'
 import { getPayload } from 'payload'
 
 import { draftMode } from 'next/headers'
@@ -7,21 +7,24 @@ import { NextRequest } from 'next/server'
 
 import configPromise from '@payload-config'
 
+export type PreviewSearchParams = {
+  path: string
+  previewSecret: string
+}
+
 export async function GET(req: NextRequest): Promise<Response> {
   const payload = await getPayload({ config: configPromise })
 
   const { searchParams } = new URL(req.url)
 
   const path = searchParams.get('path')
-  const collection = searchParams.get('collection') as CollectionSlug
-  const slug = searchParams.get('slug')
   const previewSecret = searchParams.get('previewSecret')
 
   if (previewSecret !== process.env.PREVIEW_SECRET) {
     return new Response('You are not allowed to preview this page', { status: 403 })
   }
 
-  if (!path || !collection || !slug) {
+  if (!path) {
     return new Response('Insufficient search params', { status: 404 })
   }
 

--- a/templates/with-vercel-website/src/utilities/generatePreviewPath.ts
+++ b/templates/with-vercel-website/src/utilities/generatePreviewPath.ts
@@ -1,3 +1,4 @@
+import { PreviewSearchParams } from '@/app/(frontend)/next/preview/route'
 import { PayloadRequest, CollectionSlug } from 'payload'
 
 const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
@@ -12,7 +13,6 @@ type Props = {
 }
 
 export const generatePreviewPath = ({ collection, slug }: Props) => {
-  // Allow empty strings, e.g. for the homepage
   if (slug === undefined || slug === null) {
     return null
   }
@@ -21,11 +21,9 @@ export const generatePreviewPath = ({ collection, slug }: Props) => {
   const encodedSlug = encodeURIComponent(slug)
 
   const encodedParams = new URLSearchParams({
-    slug: encodedSlug,
-    collection,
     path: `${collectionPrefixMap[collection]}/${encodedSlug}`,
     previewSecret: process.env.PREVIEW_SECRET || '',
-  })
+  } satisfies PreviewSearchParams)
 
   const url = `/next/preview?${encodedParams.toString()}`
 


### PR DESCRIPTION
The templates have no safety between the frontends entering and exiting draft mode, and the endpoints that handle those requests.

We need to ensure that the search params that the endpoint relies on, e.g. `path`, are typed in the requests that send them.