### PR TITLE
fix(next): status component incorrectly shows as published status on new documents saved as drafts when readVersions permissions are false

### DIFF
--- a/packages/next/src/views/Document/getVersions.ts
+++ b/packages/next/src/views/Document/getVersions.ts
@@ -60,7 +60,8 @@ export const getVersions = async ({
   const shouldFetchVersions = Boolean(versionsConfig && docPermissions?.readVersions)
 
   if (!shouldFetchVersions) {
-    const hasPublishedDoc = Boolean((collectionConfig && id) || globalConfig)
+    // Without readVersions permission, determine published status from the _status field
+    const hasPublishedDoc = doc?._status !== 'draft'
 
     return {
       hasPublishedDoc,

--- a/test/versions/collections/DraftsNoReadVersions.ts
+++ b/test/versions/collections/DraftsNoReadVersions.ts
@@ -1,0 +1,30 @@
+import type { CollectionConfig } from 'payload'
+
+import { draftsNoReadVersionsSlug } from '../slugs.js'
+
+const DraftsNoReadVersions: CollectionConfig = {
+  slug: draftsNoReadVersionsSlug,
+  access: {
+    readVersions: () => false,
+  },
+  admin: {
+    defaultColumns: ['title', 'createdAt', '_status'],
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+    },
+  ],
+  versions: {
+    drafts: true,
+  },
+}
+
+export default DraftsNoReadVersions

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -11,6 +11,7 @@ import CustomIDs from './collections/CustomIDs.js'
 import { Diff } from './collections/Diff/index.js'
 import DisablePublish from './collections/DisablePublish.js'
 import DraftPosts from './collections/Drafts.js'
+import DraftsNoReadVersions from './collections/DraftsNoReadVersions.js'
 import DraftWithChangeHook from './collections/DraftsWithChangeHook.js'
 import DraftWithMax from './collections/DraftsWithMax.js'
 import DraftsWithValidate from './collections/DraftsWithValidate.js'
@@ -47,6 +48,7 @@ export default buildConfigWithDefaults({
     AutosaveWithMultiSelectPosts,
     AutosaveWithDraftValidate,
     DraftPosts,
+    DraftsNoReadVersions,
     DraftWithMax,
     DraftWithChangeHook,
     DraftsWithValidate,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -63,6 +63,7 @@ import {
   disablePublishSlug,
   draftCollectionSlug,
   draftGlobalSlug,
+  draftsNoReadVersionsSlug,
   draftWithChangeHookCollectionSlug,
   draftWithMaxCollectionSlug,
   draftWithMaxGlobalSlug,
@@ -96,6 +97,7 @@ describe('Versions', () => {
   let customIDURL: AdminUrlUtil
   let postURL: AdminUrlUtil
   let errorOnUnpublishURL: AdminUrlUtil
+  let draftsNoReadVersionsURL: AdminUrlUtil
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
@@ -134,6 +136,7 @@ describe('Versions', () => {
       customIDURL = new AdminUrlUtil(serverURL, customIDSlug)
       postURL = new AdminUrlUtil(serverURL, postCollectionSlug)
       errorOnUnpublishURL = new AdminUrlUtil(serverURL, errorOnUnpublishSlug)
+      draftsNoReadVersionsURL = new AdminUrlUtil(serverURL, draftsNoReadVersionsSlug)
     })
 
     test('collection — should show "has published version" status in list view when draft is saved after publish', async () => {
@@ -935,6 +938,54 @@ describe('Versions', () => {
 
         expect(scanResults.totalFocusableElements).toBeGreaterThan(0)
         expect(scanResults.elementsWithoutIndicators).toBe(0)
+      })
+    })
+
+    describe('without readVersions permission', () => {
+      test('should show Draft status when creating and saving a new draft document', async () => {
+        await page.goto(draftsNoReadVersionsURL.create)
+        await page.locator('#field-title').fill('Test Draft Title')
+        await page.locator('#field-description').fill('Test Draft Description')
+
+        await saveDocAndAssert(page, '#action-save-draft')
+
+        await expect(page.locator('.doc-controls__status .status__value')).toContainText('Draft')
+
+        await expect(page.locator('#action-unpublish')).toBeHidden()
+      })
+
+      test('should show Published status after publishing a draft document', async () => {
+        await page.goto(draftsNoReadVersionsURL.create)
+        await page.locator('#field-title').fill('Test Publish Title')
+        await page.locator('#field-description').fill('Test Publish Description')
+
+        await saveDocAndAssert(page, '#action-save-draft')
+
+        await expect(page.locator('.doc-controls__status .status__value')).toContainText('Draft')
+
+        await page.locator('#action-save').click()
+
+        await expect(page.locator('.doc-controls__status .status__value')).toContainText(
+          'Published',
+        )
+
+        await expect(page.locator('#action-unpublish')).toBeVisible()
+      })
+
+      test('should maintain Draft status when saving draft multiple times', async () => {
+        await page.goto(draftsNoReadVersionsURL.create)
+        await page.locator('#field-title').fill('Test Multiple Saves')
+        await page.locator('#field-description').fill('Initial Description')
+
+        await saveDocAndAssert(page, '#action-save-draft')
+
+        await expect(page.locator('.doc-controls__status .status__value')).toContainText('Draft')
+
+        await page.locator('#field-description').fill('Updated Description')
+        await saveDocAndAssert(page, '#action-save-draft')
+
+        await expect(page.locator('.doc-controls__status .status__value')).toContainText('Draft')
+        await expect(page.locator('#action-unpublish')).toBeHidden()
       })
     })
   })

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -74,6 +74,7 @@ export interface Config {
     'autosave-multi-select-posts': AutosaveMultiSelectPost;
     'autosave-with-validate-posts': AutosaveWithValidatePost;
     'draft-posts': DraftPost;
+    'drafts-no-read-versions': DraftsNoReadVersion;
     'draft-with-max-posts': DraftWithMaxPost;
     'draft-posts-with-change-hook': DraftPostsWithChangeHook;
     'draft-with-validate-posts': DraftWithValidatePost;
@@ -101,6 +102,7 @@ export interface Config {
     'autosave-multi-select-posts': AutosaveMultiSelectPostsSelect<false> | AutosaveMultiSelectPostsSelect<true>;
     'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'draft-posts': DraftPostsSelect<false> | DraftPostsSelect<true>;
+    'drafts-no-read-versions': DraftsNoReadVersionsSelect<false> | DraftsNoReadVersionsSelect<true>;
     'draft-with-max-posts': DraftWithMaxPostsSelect<false> | DraftWithMaxPostsSelect<true>;
     'draft-posts-with-change-hook': DraftPostsWithChangeHookSelect<false> | DraftPostsWithChangeHookSelect<true>;
     'draft-with-validate-posts': DraftWithValidatePostsSelect<false> | DraftWithValidatePostsSelect<true>;
@@ -122,6 +124,7 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es' | 'de') | ('en' | 'es' | 'de')[];
   globals: {
     'autosave-global': AutosaveGlobal;
     'autosave-with-draft-button-global': AutosaveWithDraftButtonGlobal;
@@ -308,6 +311,18 @@ export interface AutosaveMultiSelectPost {
 export interface AutosaveWithValidatePost {
   id: string;
   title: string;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "drafts-no-read-versions".
+ */
+export interface DraftsNoReadVersion {
+  id: string;
+  title: string;
+  description?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -776,6 +791,10 @@ export interface PayloadLockedDocument {
         value: string | DraftPost;
       } | null)
     | ({
+        relationTo: 'drafts-no-read-versions';
+        value: string | DraftsNoReadVersion;
+      } | null)
+    | ({
         relationTo: 'draft-with-max-posts';
         value: string | DraftWithMaxPost;
       } | null)
@@ -961,6 +980,17 @@ export interface DraftPostsSelect<T extends boolean = true> {
       };
   relation?: T;
   restrictedToUpdate?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "drafts-no-read-versions_select".
+ */
+export interface DraftsNoReadVersionsSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -9,6 +9,8 @@ export const customIDSlug = 'custom-ids'
 
 export const draftCollectionSlug = 'draft-posts'
 
+export const draftsNoReadVersionsSlug = 'drafts-no-read-versions'
+
 export const draftWithValidateCollectionSlug = 'draft-with-validate-posts'
 export const draftWithMaxCollectionSlug = 'draft-with-max-posts'
 


### PR DESCRIPTION
### What?

Fixes incorrect `status` display when creating and saving new draft documents in collections where users don't have readVersions permission.

### Why?

The `getVersions` function was incorrectly assuming any document with an ID is published, causing the Status component to show "Published" for newly created drafts. This happens when `readVersions` permission is disabled because the code takes an early return path that doesn't query the versions collection.

### How?

- Changed the early return logic in `getVersions.ts` to check the document's `_status` field directly
- Returns `hasPublishedDoc = false` only when `_status === 'draft'`, otherwise `true`