### PR TITLE
fix: use local file read for local upload edits when `serverURL` is set

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -13,6 +13,7 @@ import { FileRetrievalError, FileUploadError, Forbidden, MissingFile } from '../
 import { canResizeImage } from './canResizeImage.js'
 import { checkFileRestrictions } from './checkFileRestrictions.js'
 import { cropImage } from './cropImage.js'
+import { generateFileURL } from './generateFileURL.js'
 import { getExternalFile } from './getExternalFile.js'
 import { getFileByPath } from './getFileByPath.js'
 import { getImageSize } from './getImageSize.js'
@@ -81,7 +82,7 @@ export const generateFileData = async <T>({
     }
   }
 
-  const { sharp } = req.payload.config
+  const { routes, serverURL, sharp } = req.payload.config
 
   let file = req.file
 
@@ -119,8 +120,15 @@ export const generateFileData = async <T>({
       throw new Forbidden(req.t)
     }
 
+    const apiURL = generateFileURL({
+      apiRoute: routes?.api,
+      collectionSlug: collectionConfig.slug,
+      filename,
+      serverURL,
+    })
+
     try {
-      if (url && url.startsWith('/') && !disableLocalStorage) {
+      if (url && url === apiURL && !disableLocalStorage) {
         const filePath = `${staticPath}/${filename}`
         const response = await getFileByPath(filePath)
         file = response

--- a/packages/payload/src/uploads/generateFileURL.ts
+++ b/packages/payload/src/uploads/generateFileURL.ts
@@ -1,0 +1,25 @@
+import type { Config } from '../config/types.js'
+
+import { formatAdminURL } from '../utilities/formatAdminURL.js'
+
+type GenerateFileURLArgs = {
+  apiRoute: NonNullable<Config['routes']>['api']
+  collectionSlug: string
+  filename?: string
+  serverURL: Config['serverURL']
+}
+export const generateFileURL = ({
+  apiRoute,
+  collectionSlug,
+  filename,
+  serverURL,
+}: GenerateFileURLArgs) => {
+  if (filename) {
+    return formatAdminURL({
+      apiRoute: apiRoute || '',
+      path: `/${collectionSlug}/file/${encodeURIComponent(filename)}`,
+      serverURL: serverURL,
+    })
+  }
+  return undefined
+}

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -3,24 +3,8 @@ import type { Config } from '../config/types.js'
 import type { Field } from '../fields/config/types.js'
 import type { UploadConfig } from './types.js'
 
-import { formatAdminURL } from '../utilities/formatAdminURL.js'
+import { generateFileURL } from './generateFileURL.js'
 import { mimeTypeValidator } from './mimeTypeValidator.js'
-
-type GenerateURLArgs = {
-  collectionSlug: string
-  config: Config
-  filename?: string
-}
-const generateURL = ({ collectionSlug, config, filename }: GenerateURLArgs) => {
-  if (filename) {
-    return formatAdminURL({
-      apiRoute: config.routes?.api || '',
-      path: `/${collectionSlug}/file/${encodeURIComponent(filename)}`,
-      serverURL: config.serverURL,
-    })
-  }
-  return undefined
-}
 
 type Options = {
   collection: CollectionConfig
@@ -62,10 +46,11 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
             'sizes' in originalDoc &&
             originalDoc.sizes?.[adminThumbnail]?.filename
           ) {
-            return generateURL({
+            return generateFileURL({
+              apiRoute: config.routes?.api,
               collectionSlug: collection.slug,
-              config,
               filename: originalDoc.sizes?.[adminThumbnail].filename as string,
+              serverURL: config.serverURL,
             })
           }
 
@@ -146,10 +131,11 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
               return value
             }
 
-            return generateURL({
+            return generateFileURL({
+              apiRoute: config.routes?.api,
               collectionSlug: collection.slug,
-              config,
               filename: data?.filename,
+              serverURL: config.serverURL,
             })
           },
         ],
@@ -228,9 +214,10 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
                     const sizeFilename = data?.sizes?.[size.name]?.filename
 
                     if (sizeFilename) {
-                      return formatAdminURL({
-                        apiRoute: config.routes?.api || '',
-                        path: `/${collection.slug}/file/${encodeURIComponent(sizeFilename)}`,
+                      return generateFileURL({
+                        apiRoute: config.routes?.api,
+                        collectionSlug: collection.slug,
+                        filename: sizeFilename,
                         serverURL: config.serverURL,
                       })
                     }


### PR DESCRIPTION
### What?

Fixes `generateFileData` using `getExternalFile` (external fetch) instead of `getFileByPath` (local file read) when getting file details/content for a Payload upload file when `serverURL` is set.

### Why?

Currently, `generateFileData` checks if the file URL starts with a "/" to decide if the file is a file uploaded to Payload. The file URL will start with "/" when `serverURL` is not set. When `serverURL` is set the file URL starts with the `serverURL` value instead of "/", and so `generateFileData` treats the file as an external file.

### How?

Instead of checking if the file URL starts with "/", compare the file URL to what a Payload file URL would be for the given filename.

Fixes https://github.com/payloadcms/payload/issues/14945