### PR TITLE
fix(ui): preserve beforeInput/afterInput components in bulk edit

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -49,7 +49,13 @@ export const renderField: RenderFieldMethod = ({
   schemaPath,
   siblingData,
 }) => {
-  const requiresRender = renderAllFields || !lastRenderedPath || lastRenderedPath !== path
+  // Fields with beforeInput/afterInput need custom components created, so they require render
+  const hasBeforeOrAfterInput =
+    fieldConfig.admin?.components &&
+    ('beforeInput' in fieldConfig.admin.components || 'afterInput' in fieldConfig.admin.components)
+
+  const requiresRender =
+    renderAllFields || !lastRenderedPath || lastRenderedPath !== path || hasBeforeOrAfterInput
 
   if (!requiresRender && fieldConfig.type !== 'array' && fieldConfig.type !== 'blocks') {
     return
@@ -327,7 +333,7 @@ export const renderField: RenderFieldMethod = ({
               clientProps,
               Component: fieldConfig.admin.components.afterInput,
               importMap: req.payload.importMap,
-              key: 'field.admin.components.afterInput',
+              key: `field.admin.components.afterInput.${path}`,
               serverProps,
             })
           : 'Mock'
@@ -339,7 +345,7 @@ export const renderField: RenderFieldMethod = ({
               clientProps,
               Component: fieldConfig.admin.components.beforeInput,
               importMap: req.payload.importMap,
-              key: 'field.admin.components.beforeInput',
+              key: `field.admin.components.beforeInput.${path}`,
               serverProps,
             })
           : 'Mock'

--- a/test/bulk-edit/collections/Posts/index.ts
+++ b/test/bulk-edit/collections/Posts/index.ts
@@ -25,6 +25,36 @@ export const PostsCollection: CollectionConfig = {
       type: 'textarea',
     },
     {
+      name: 'fieldWithBeforeInputA1',
+      type: 'text',
+      label: 'Field With Before Input A1',
+      admin: {
+        components: {
+          beforeInput: ['/components/BeforeInputA.js#BeforeInputA'],
+        },
+      },
+    },
+    {
+      name: 'fieldWithBeforeInputA2',
+      type: 'text',
+      label: 'Field With Before Input A2',
+      admin: {
+        components: {
+          beforeInput: ['/components/BeforeInputA.js#BeforeInputA'],
+        },
+      },
+    },
+    {
+      name: 'fieldWithBeforeInputB',
+      type: 'text',
+      label: 'Field With Before Input B',
+      admin: {
+        components: {
+          beforeInput: ['/components/BeforeInputB.js#BeforeInputB'],
+        },
+      },
+    },
+    {
       name: 'defaultValueField',
       type: 'text',
       defaultValue: 'This is a default value',

--- a/test/bulk-edit/components/BeforeInputA.tsx
+++ b/test/bulk-edit/components/BeforeInputA.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import React from 'react'
+
+export const BeforeInputA: React.FC = () => {
+  return (
+    <div className="before-input-a" data-testid="before-input-a">
+      #before-input-a
+    </div>
+  )
+}

--- a/test/bulk-edit/components/BeforeInputB.tsx
+++ b/test/bulk-edit/components/BeforeInputB.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import React from 'react'
+
+export const BeforeInputB: React.FC = () => {
+  return (
+    <div className="before-input-b" data-testid="before-input-b">
+      #before-input-b
+    </div>
+  )
+}

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -683,6 +683,39 @@ test.describe('Bulk Edit', () => {
       .poll(() => updatedDoc?.tabTab?.tabTabArray?.[0]?.tabTabArrayText)
       .toEqual('nestedText')
   })
+
+  test('should preserve beforeInput components when selecting multiple fields', async () => {
+    await deleteAllPosts()
+    await createPost({ title: 'Post 1' })
+
+    await page.goto(postsUrl.list)
+
+    const { modal } = await selectAllAndEditMany(page)
+
+    // Select multiple fields with beforeInput components
+    await selectInput({
+      selectLocator: modal.locator('.field-select'),
+      options: [
+        'Field With Before Input A1',
+        'Field With Before Input A2',
+        'Field With Before Input B',
+      ],
+      multiSelect: true,
+    })
+
+    // All fields should be visible
+    await expect(modal.locator('#field-fieldWithBeforeInputA1')).toBeVisible()
+    await expect(modal.locator('#field-fieldWithBeforeInputA2')).toBeVisible()
+    await expect(modal.locator('#field-fieldWithBeforeInputB')).toBeVisible()
+
+    // All beforeInput components should be visible (2 of type A, 1 of type B)
+    const beforeInputsA = modal.locator('[data-testid="before-input-a"]')
+    await expect(beforeInputsA).toHaveCount(2)
+
+    const beforeInputB = modal.locator('[data-testid="before-input-b"]')
+    await expect(beforeInputB).toHaveCount(1)
+    await expect(beforeInputB).toBeVisible()
+  })
 })
 
 async function selectFieldToEdit(

--- a/test/bulk-edit/payload-types.ts
+++ b/test/bulk-edit/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     posts: Post;
     tabs: Tab;
+    'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -78,6 +79,7 @@ export interface Config {
   collectionsSelect: {
     posts: PostsSelect<false> | PostsSelect<true>;
     tabs: TabsSelect<false> | TabsSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -86,6 +88,7 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
+  fallbackLocale: null;
   globals: {};
   globalsSelect: {};
   locale: null;
@@ -123,6 +126,9 @@ export interface Post {
   id: string;
   title?: string | null;
   description?: string | null;
+  fieldWithBeforeInputA1?: string | null;
+  fieldWithBeforeInputA2?: string | null;
+  fieldWithBeforeInputB?: string | null;
   defaultValueField?: string | null;
   group?: {
     defaultValueField?: string | null;
@@ -173,6 +179,23 @@ export interface Tab {
   };
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -266,6 +289,9 @@ export interface PayloadMigration {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   description?: T;
+  fieldWithBeforeInputA1?: T;
+  fieldWithBeforeInputA2?: T;
+  fieldWithBeforeInputB?: T;
   defaultValueField?: T;
   group?:
     | T
@@ -322,6 +348,14 @@ export interface TabsSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
## Summary

- Fixes a bug where `beforeInput` and `afterInput` components would disappear from the bulk edit UI when additional fields were selected
- Fields with these custom components are now properly preserved by ensuring they always require rendering in the form state
- Adds unique React keys for each component instance to prevent rendering conflicts
