### PR TITLE
docs: fix duplicate anchor links

### DIFF
--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -40,7 +40,7 @@ This page is divided into two parts: first, the settings of the Blocks Field, an
 
 ## Block Field
 
-### Config Options
+### Block Config Options
 
 | Option                 | Description                                                                                                                                                                                                                                                                                             |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -65,7 +65,7 @@ This page is divided into two parts: first, the settings of the Blocks Field, an
 
 _\* An asterisk denotes that a property is required._
 
-### Admin Options
+### Block Admin Options
 
 To customize the appearance and behavior of the Blocks Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 


### PR DESCRIPTION
- renames Config options to Block config options
- renames Admin options to Block admin options

Fixes #14912