### PR TITLE
docs: update screenshot for fields/rich-text

### DIFF
--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -12,12 +12,11 @@ Consistent with Payload's goal of making you learn as little of Payload as possi
 
 Instead, you can invest your time and effort into learning the underlying open-source tools that will allow you to apply your learnings elsewhere as well.
 
-<LightDarkImage
-  alt="Shows a Rich Text field in the Payload Admin Panel"
+<PayloadMedia
+  mediaID="694343f20b5443302f1ac8ea"
   caption="Admin Panel screenshot of a Rich Text field"
-  srcDark="https://payloadcms.com/images/docs/fields/richtext-dark.png"
-  srcLight="https://payloadcms.com/images/docs/fields/richtext.png"
 />
+
 
 ## Config Options
 

--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -13,7 +13,7 @@ Consistent with Payload's goal of making you learn as little of Payload as possi
 Instead, you can invest your time and effort into learning the underlying open-source tools that will allow you to apply your learnings elsewhere as well.
 
 <PayloadMedia
-  mediaID="694343f20b5443302f1ac8ea"
+  mediaID="69444ac1cca4069327f4fad2"
   caption="Admin Panel screenshot of a Rich Text field"
 />
 


### PR DESCRIPTION
Updates the screenshot to use lexical instead of slate.

Before: https://payloadcms.com/docs/fields/rich-text
After: https://payloadcms.com/docs/dynamic/fields/rich-text?branch=AlessioGr-patch-1