### PR TITLE
refactor: replace deprecated url.parse api usage

### DIFF
--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -1,5 +1,3 @@
-import url from 'url'
-
 import type { Collection } from '../../collections/config/types.js'
 import type { Document, PayloadRequest } from '../../types/index.js'
 
@@ -64,8 +62,9 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
       throw new Forbidden(args.req.t)
     }
 
-    const parsedURL = url.parse(args.req.url!)
-    const isGraphQL = parsedURL.pathname === config.routes.graphQL
+    const pathname = new URL(args.req.url!).pathname
+
+    const isGraphQL = pathname === config.routes.graphQL
 
     let user = await req.payload.db.findOne<any>({
       collection: collectionConfig.slug,


### PR DESCRIPTION
Replaces `URL.parse()` usage which is now deprecated with `new URL()`. Fixes https://github.com/payloadcms/payload/issues/14978