### PR TITLE
fix(plugin-mcp): adds collection and strategy to user

### DIFF
--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -64,13 +64,13 @@ export const initializeMCPHandler = (pluginOptions: PluginMCPServerConfig) => {
       }
 
       const user = docs[0]?.user as TypedUser
-      user.collection =
+      const customUserCollection =
         typeof pluginOptions.userCollection === 'string'
           ? pluginOptions.userCollection
-          : (pluginOptions.userCollection?.slug as CollectionSlug) || ('users' as CollectionSlug)
+          : pluginOptions.userCollection?.slug
+      user.collection = customUserCollection ?? 'users'
       user._strategy = 'mcp-api-key' as const
 
-      console.log(user)
       return docs[0] as unknown as MCPAccessSettings
     }
 

--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -1,5 +1,11 @@
 import crypto from 'crypto'
-import { type PayloadHandler, UnauthorizedError, type Where } from 'payload'
+import {
+  type CollectionSlug,
+  type PayloadHandler,
+  type TypedUser,
+  UnauthorizedError,
+  type Where,
+} from 'payload'
 
 import type { MCPAccessSettings, PluginMCPServerConfig } from '../types.js'
 
@@ -57,6 +63,14 @@ export const initializeMCPHandler = (pluginOptions: PluginMCPServerConfig) => {
         payload.logger.info('[payload-mcp] API Key is valid')
       }
 
+      const user = docs[0]?.user as TypedUser
+      user.collection =
+        typeof pluginOptions.userCollection === 'string'
+          ? pluginOptions.userCollection
+          : (pluginOptions.userCollection?.slug as CollectionSlug) || ('users' as CollectionSlug)
+      user._strategy = 'mcp-api-key' as const
+
+      console.log(user)
       return docs[0] as unknown as MCPAccessSettings
     }
 

--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -1,11 +1,5 @@
 import crypto from 'crypto'
-import {
-  type CollectionSlug,
-  type PayloadHandler,
-  type TypedUser,
-  UnauthorizedError,
-  type Where,
-} from 'payload'
+import { type PayloadHandler, type TypedUser, UnauthorizedError, type Where } from 'payload'
 
 import type { MCPAccessSettings, PluginMCPServerConfig } from '../types.js'
 


### PR DESCRIPTION
Fixes: https://github.com/payloadcms/payload/issues/14923

Correctly adds `collectionSlug` and `_strategy` to the `user` when using MCP operations.
