### PR TITLE
fix: req.transactionID stays a promise even if beginTransaction returns null

### DIFF
--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -22,14 +22,16 @@ export async function initTransaction(
   }
   if (typeof payload.db.beginTransaction === 'function') {
     // create a new transaction
-    req.transactionID = payload.db.beginTransaction().then((transactionID) => {
-      if (transactionID) {
-        req.transactionID = transactionID
-      }
+    const promise = payload.db.beginTransaction()
+    req.transactionID = promise as Promise<number | string>
+    const transactionID = await promise
 
-      return transactionID!
-    })
-    return !!(await req.transactionID)
+    if (transactionID) {
+      req.transactionID = transactionID
+    } else {
+      req.transactionID = undefined
+    }
+    return !!req.transactionID
   }
   return false
 }

--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -26,7 +26,7 @@ export async function initTransaction(
     req.transactionID = promise as Promise<number | string>
     const transactionID = await promise
 
-    if (transactionID) {
+    if (typeof transactionID === 'string' || typeof transactionID === 'number') {
       req.transactionID = transactionID
     } else {
       req.transactionID = undefined


### PR DESCRIPTION
If the db is incorrectly configured, `beginTransaction` can return null.

Previously, if this happens, `req.transactionID` still remains as a promise after `initTransaction` is called. This makes no sense, as the promise has long been resolved - we know it will be null.

This PR fixes this behavior, by assigning it to `undefined` if no `transactionID` is returned.