### PR TITLE
fix: get field by path for blocks

### DIFF
--- a/packages/payload/src/utilities/getFieldByPath.spec.ts
+++ b/packages/payload/src/utilities/getFieldByPath.spec.ts
@@ -60,6 +60,30 @@ const fields = flattenAllFields({
         },
       ],
     },
+    {
+      type: 'blocks',
+      name: 'blocks',
+      blocks: [
+        {
+          slug: 'block1',
+          fields: [
+            {
+              name: 'text1',
+              type: 'text',
+            },
+          ],
+        },
+        {
+          slug: 'block2',
+          fields: [
+            {
+              name: 'text2',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    },
   ],
 })
 
@@ -104,5 +128,14 @@ describe('getFieldByPath', () => {
     expect(assert_7.field).toBe((fields[3] as any).flattenedFields[0].flattenedFields[0])
     expect(assert_7.pathHasLocalized).toBe(true)
     expect(assert_7.localizedPath).toBe('tab.localizedArray.<locale>.text')
+  })
+
+  it('gets field nested within block', () => {
+    const fieldInBlock = getFieldByPath({ fields, path: 'blocks.block2.text2' })
+    expect(fieldInBlock?.field).toBeDefined()
+
+    const sourceField = (fields[4] as any).blocks?.[1].flattenedFields?.[0]
+    expect(sourceField).toBeDefined()
+    expect(fieldInBlock?.field).toBe(sourceField)
   })
 })

--- a/packages/payload/src/utilities/getFieldByPath.ts
+++ b/packages/payload/src/utilities/getFieldByPath.ts
@@ -2,10 +2,9 @@ import type { SanitizedConfig } from '../config/types.js'
 import type { FlattenedField } from '../fields/config/types.js'
 
 /**
- * Get the field from by its path.
- * Can accept nested paths, e.g: group.title, array.group.title
- * If there were any localized on the path, pathHasLocalized will be true and localizedPath will look like:
- * group.<locale>.title // group is localized here
+ * Get the field by its schema path, e.g. group.title, array.group.title
+ * If there were any localized on the path, `pathHasLocalized` will be true and `localizedPath` will look like:
+ * `group.<locale>.title` // group is localized here
  */
 export const getFieldByPath = ({
   config,
@@ -18,6 +17,9 @@ export const getFieldByPath = ({
   fields: FlattenedField[]
   includeRelationships?: boolean
   localizedPath?: string
+  /**
+   * The schema path, e.g. `array.group.title`
+   */
   path: string
 }): {
   field: FlattenedField
@@ -34,6 +36,7 @@ export const getFieldByPath = ({
 
   while (segments.length > 0) {
     const segment = segments.shift()
+
     localizedPath = `${localizedPath ? `${localizedPath}.` : ''}${segment}`
     const field = currentFields.find((each) => each.name === segment)
 
@@ -68,19 +71,25 @@ export const getFieldByPath = ({
       }
     }
 
-    if ('blocks' in field) {
-      for (const block of field.blocks) {
-        const maybeField = getFieldByPath({
+    if ('blocks' in field && segments.length > 0) {
+      const blockSlug = segments[0]
+      const block = field.blocks.find((b) => b.slug === blockSlug)
+
+      if (block) {
+        segments.shift()
+        localizedPath = `${localizedPath}.${blockSlug}`
+
+        if (segments.length === 0) {
+          return null
+        }
+
+        return getFieldByPath({
           config,
           fields: block.flattenedFields,
           includeRelationships,
           localizedPath,
-          path: [...segments].join('.'),
+          path: segments.join('.'),
         })
-
-        if (maybeField) {
-          return maybeField
-        }
       }
     }
 


### PR DESCRIPTION
It's currently not possible to use `getFieldByPath` to find a field nested within a block.

For example:

```ts
// This return undefined
const fieldInBlock = getFieldByPath({
  path: 'blocks.block2.text2' ,
  fields: [
    {
      type: 'blocks',
      name: 'blocks',
      blocks: [
        {
          slug: 'block1',
          fields: [
            {
              name: 'text1',
              type: 'text',
            },
          ],
        },
        {
          slug: 'block2',
          fields: [
            {
              name: 'text2',
              type: 'text',
            },
          ],
        },
      ],
    }
  ]
})
```

This is because the function is ignoring block slugs and looping over each block's fields until one is found. Except they are never found because the path is not trimmed for the next iteration. If the same field exists across different blocks, I would also imagine the wrong schema could get matched.