### PR TITLE
fix(richtext-lexical): blocksFeature with relationship exposes other tenants

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/server/index.ts
+++ b/packages/richtext-lexical/src/features/blocks/server/index.ts
@@ -9,6 +9,7 @@ import type {
 
 import { fieldsToJSONSchema, flattenAllFields, sanitizeFields } from 'payload'
 
+import { applyBaseFilterToFields } from '../../../utilities/applyBaseFilterToFields.js'
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { createNode } from '../../typeUtilities.js'
 import { blockPopulationPromiseHOC } from './graphQLPopulationPromise.js'
@@ -58,7 +59,11 @@ export const BlocksFeature = createServerFeature<BlocksFeatureProps, BlocksFeatu
           `Block not found for slug: ${typeof _block === 'string' ? _block : _block?.slug}`,
         )
       }
-      blockConfigs.push(block)
+      // Apply baseFilter to relationship fields in the block
+      blockConfigs.push({
+        ...block,
+        fields: applyBaseFilterToFields(block.fields, _config),
+      })
     }
 
     const inlineBlockConfigs: Block[] = []
@@ -71,7 +76,11 @@ export const BlocksFeature = createServerFeature<BlocksFeatureProps, BlocksFeatu
           `Block not found for slug: ${typeof _block === 'string' ? _block : _block?.slug}`,
         )
       }
-      inlineBlockConfigs.push(block)
+      // Apply baseFilter to relationship fields in the block
+      inlineBlockConfigs.push({
+        ...block,
+        fields: applyBaseFilterToFields(block.fields, _config),
+      })
     }
 
     return {

--- a/packages/richtext-lexical/src/utilities/applyBaseFilterToFields.ts
+++ b/packages/richtext-lexical/src/utilities/applyBaseFilterToFields.ts
@@ -1,0 +1,109 @@
+import type { Block, Field, SanitizedConfig, TypedUser } from 'payload'
+
+/**
+ * Recursively applies baseFilter from collection config to relationship fields
+ * within blocks. This ensures that relationship drawers in blocks respect
+ * collection-level filters like multi-tenant filtering.
+ *
+ * Based on the fix from PR #13229 for LinkFeature
+ */
+export function applyBaseFilterToFields(fields: Field[], config: SanitizedConfig): Field[] {
+  return fields.map((field) => {
+    // Handle relationship fields
+    if (field.type === 'relationship') {
+      const relationshipField = field
+
+      // Store the original filterOptions
+      const originalFilterOptions = relationshipField.filterOptions
+
+      // Create new filterOptions that includes baseFilter
+      relationshipField.filterOptions = async (args) => {
+        const { relationTo, req, user } = args
+
+        // Call original filterOptions if it exists
+        const originalResult =
+          typeof originalFilterOptions === 'function'
+            ? await originalFilterOptions(args)
+            : (originalFilterOptions ?? true)
+
+        // If original filter returns false, respect that
+        if (originalResult === false) {
+          return false
+        }
+
+        // Get the collection's admin config
+        const admin = config.collections.find(({ slug }) => slug === relationTo)?.admin
+
+        // Check if collection is hidden
+        const hidden = admin?.hidden
+        if (typeof hidden === 'function' && hidden({ user } as { user: TypedUser })) {
+          return false
+        }
+
+        // Apply baseFilter (with backwards compatibility for baseListFilter)
+        const baseFilter = admin?.baseFilter ?? admin?.baseListFilter
+        const baseFilterResult = await baseFilter?.({
+          limit: 0,
+          page: 1,
+          req,
+          sort: 'id',
+        })
+
+        // If no baseFilter, return original result
+        if (!baseFilterResult) {
+          return originalResult
+        }
+
+        // If original result is true, just return the baseFilter
+        if (originalResult === true) {
+          return baseFilterResult
+        }
+
+        // Combine original and baseFilter results
+        return {
+          and: [originalResult, baseFilterResult],
+        }
+      }
+
+      return relationshipField
+    }
+
+    // Recursively process nested fields
+    if ('fields' in field && field.fields) {
+      return {
+        ...field,
+        fields: applyBaseFilterToFields(field.fields, config),
+      }
+    }
+
+    // Handle tabs
+    if (field.type === 'tabs' && 'tabs' in field) {
+      return {
+        ...field,
+        tabs: field.tabs.map((tab) => ({
+          ...tab,
+          fields: applyBaseFilterToFields(tab.fields, config),
+        })),
+      }
+    }
+
+    // Handle blocks
+    if (field.type === 'blocks') {
+      const blocks = (field.blockReferences ?? field.blocks ?? []) as Block[]
+      return {
+        ...field,
+        blocks: blocks.map((block) => {
+          if (typeof block === 'string') {
+            return block
+          }
+          return {
+            ...block,
+            fields: applyBaseFilterToFields(block.fields, config),
+          }
+        }),
+      }
+    }
+
+    return field
+  })
+}

--- a/packages/richtext-lexical/src/utilities/applyBaseFilterToFields.ts
+++ b/packages/richtext-lexical/src/utilities/applyBaseFilterToFields.ts
@@ -1,5 +1,7 @@
 import type { Block, Field, SanitizedConfig, TypedUser } from 'payload'
 
+import { combineWhereConstraints } from 'payload/shared'
+
 /**
  * Recursively applies baseFilter from collection config to relationship fields
  * within blocks. This ensures that relationship drawers in blocks respect
@@ -60,9 +62,7 @@ export function applyBaseFilterToFields(fields: Field[], config: SanitizedConfig
         }
 
         // Combine original and baseFilter results
-        return {
-          and: [originalResult, baseFilterResult],
-        }
+        return combineWhereConstraints([originalResult, baseFilterResult], 'and')
       }
 
       return relationshipField

--- a/test/plugin-multi-tenant/collections/MenuItems.ts
+++ b/test/plugin-multi-tenant/collections/MenuItems.ts
@@ -1,6 +1,7 @@
 import type { Access, CollectionConfig, Where } from 'payload'
 
 import { getUserTenantIDs } from '@payloadcms/plugin-multi-tenant/utilities'
+import { BlocksFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
 
 import { menuItemsSlug, notTenantedSlug, relationshipsSlug } from '../shared.js'
 
@@ -96,6 +97,25 @@ export const MenuItems: CollectionConfig = {
     {
       name: 'content',
       type: 'richText',
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [
+          ...defaultFeatures,
+          BlocksFeature({
+            blocks: [
+              {
+                slug: 'block-with-relationship',
+                fields: [
+                  {
+                    name: 'relationship',
+                    type: 'relationship',
+                    relationTo: 'food-menu',
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
     },
     {
       name: 'polymorphicRelationship',

--- a/test/plugin-multi-tenant/e2e.spec.ts
+++ b/test/plugin-multi-tenant/e2e.spec.ts
@@ -416,6 +416,45 @@ test.describe('Multi Tenant', () => {
       await expect(page.getByText('Chorizo Con Queso')).toBeVisible()
       await expect(page.getByText('Pretzel Bites')).toBeHidden()
     })
+
+    test('should filter relationship fields in Lexical BlocksFeature', async () => {
+      await loginClientSide({
+        data: credentials.admin,
+        page,
+        serverURL,
+      })
+      await page.goto(menuItemsURL.create)
+      await selectDocumentTenant({
+        page,
+        payload,
+        tenant: 'Blue Dog',
+      })
+
+      // Fill in the required name field
+      await page.fill('#field-name', 'Test Menu Item')
+
+      // Find the bug-repro richtext field and insert a block
+      const rte = page.locator('.rich-text-lexical [data-lexical-editor="true"]')
+      await rte.click()
+      await rte.focus()
+
+      // Open slash menu and insert block
+      await page.keyboard.type('/')
+      await expect(page.locator('.slash-menu-popup')).toBeVisible()
+      await page.getByText('Block With Relationship').click()
+
+      // Wait for block to be inserted
+      await expect(page.locator('.LexicalEditorTheme__block')).toBeVisible()
+
+      // Open the relationship field in the block
+      await page.locator('.LexicalEditorTheme__block .rs__input').click()
+
+      // Should only show Blue Dog Menu, not Steel Cat Menu or others
+      await expect(page.getByText('Blue Dog Menu')).toBeVisible()
+      await expect(page.getByText('Steel Cat Menu')).toBeHidden()
+      await expect(page.getByText('Anchor Bar Menu')).toBeHidden()
+      await expect(page.locator('.rs__menu')).toHaveCount(1)
+    })
   })
 
   test.describe('Globals', () => {


### PR DESCRIPTION
Fixes #14823

The issue is essentially the same problem that PR #13229 fixed, but for a different Lexical feature:

| PR #13229 | PR #14985 (this one) |
| --- | --- |
| Link Feature with internal links | BlocksFeature with relationship fields inside blocks |
| Relationship to documents exposes other tenants | Relationship inside blocks exposes other tenants |

## Root Cause

The multi tenant plugin applies tenant filters to relationship fields using `addFilterOptionsToFields()`, which only runs on collection fields. However:

- BlocksFeature defines blocks via feature props rather than collection fields  
- These blocks are processed independently through `sanitizeFields()`  
- Relationship fields inside blocks never receive the collection baseFilter

