### PR TITLE
feat: retain cause for upload fetch errors

### DIFF
--- a/packages/payload/src/errors/FileRetrievalError.ts
+++ b/packages/payload/src/errors/FileRetrievalError.ts
@@ -4,13 +4,15 @@ import { status as httpStatus } from 'http-status'
 
 import { APIError } from './APIError.js'
 
-export class FileRetrievalError extends APIError {
-  constructor(t?: TFunction, message?: string) {
+export class FileRetrievalError<
+  TData extends null | object = { [key: string]: unknown } | null,
+> extends APIError<TData> {
+  constructor(t?: TFunction, message?: string, cause?: TData) {
     let msg = t ? t('error:problemUploadingFile') : 'There was a problem while retrieving the file.'
 
     if (message) {
       msg += ` ${message}`
     }
-    super(msg, httpStatus.INTERNAL_SERVER_ERROR)
+    super(msg, httpStatus.INTERNAL_SERVER_ERROR, cause)
   }
 }

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -141,7 +141,9 @@ export const generateFileData = async <T>({
         overwriteExistingFiles = true
       }
     } catch (err: unknown) {
-      throw new FileRetrievalError(req.t, err instanceof Error ? err.message : undefined)
+      const message = err instanceof Error ? err.message : String(err)
+      const cause = err instanceof Error && err.cause instanceof Error ? err.cause : undefined
+      throw new FileRetrievalError(req.t, message, cause)
     }
   }
 

--- a/packages/payload/src/uploads/safeFetch.ts
+++ b/packages/payload/src/uploads/safeFetch.ts
@@ -88,22 +88,15 @@ export const safeFetch = async (...args: Parameters<typeof undiciFetch>) => {
     })
   } catch (error) {
     if (error instanceof Error) {
-      if (error.cause instanceof Error && error.cause.message.includes('unsafe')) {
-        // Errors thrown from within interceptors always have 'fetch error' as the message
-        // The desired message we want to bubble up is in the cause
-        throw new Error(error.cause.message)
-      } else {
-        let stringifiedUrl: string | undefined = undefined
-        if (typeof unverifiedUrl === 'string') {
-          stringifiedUrl = unverifiedUrl
-        } else if (unverifiedUrl instanceof URL) {
-          stringifiedUrl = unverifiedUrl.toString()
-        } else if (unverifiedUrl instanceof Request) {
-          stringifiedUrl = unverifiedUrl.url
-        }
-
-        throw new Error(`Failed to fetch from ${stringifiedUrl}, ${error.message}`)
+      let stringifiedUrl: string | undefined = undefined
+      if (typeof unverifiedUrl === 'string') {
+        stringifiedUrl = unverifiedUrl
+      } else if (unverifiedUrl instanceof URL) {
+        stringifiedUrl = unverifiedUrl.toString()
+      } else if (unverifiedUrl instanceof Request) {
+        stringifiedUrl = unverifiedUrl.url
       }
+      error.message += ` (safeFetch: ${stringifiedUrl})`
     }
     throw error
   }

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -872,15 +872,15 @@ describe('Collections - Uploads', () => {
     describe('filters', () => {
       it.each`
         url                                  | collection            | errorContains
-        ${'http://127.0.0.1/file.png'}       | ${mediaSlug}          | ${'unsafe'}
-        ${'http://[::1]/file.png'}           | ${mediaSlug}          | ${'unsafe'}
-        ${'http://10.0.0.1/file.png'}        | ${mediaSlug}          | ${'unsafe'}
-        ${'http://192.168.1.1/file.png'}     | ${mediaSlug}          | ${'unsafe'}
-        ${'http://172.16.0.1/file.png'}      | ${mediaSlug}          | ${'unsafe'}
-        ${'http://169.254.1.1/file.png'}     | ${mediaSlug}          | ${'unsafe'}
-        ${'http://224.0.0.1/file.png'}       | ${mediaSlug}          | ${'unsafe'}
-        ${'http://0.0.0.0/file.png'}         | ${mediaSlug}          | ${'unsafe'}
-        ${'http://255.255.255.255/file.png'} | ${mediaSlug}          | ${'unsafe'}
+        ${'http://127.0.0.1/file.png'}       | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://[::1]/file.png'}           | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://10.0.0.1/file.png'}        | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://192.168.1.1/file.png'}     | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://172.16.0.1/file.png'}      | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://169.254.1.1/file.png'}     | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://224.0.0.1/file.png'}       | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://0.0.0.0/file.png'}         | ${mediaSlug}          | ${'safeFetch'}
+        ${'http://255.255.255.255/file.png'} | ${mediaSlug}          | ${'safeFetch'}
         ${'http://127.0.0.1/file.png'}       | ${allowListMediaSlug} | ${'There was a problem while uploading the file.'}
         ${'http://[::1]/file.png'}           | ${allowListMediaSlug} | ${'There was a problem while uploading the file.'}
         ${'http://10.0.0.1/file.png'}        | ${allowListMediaSlug} | ${'There was a problem while uploading the file.'}
@@ -960,7 +960,7 @@ describe('Collections - Uploads', () => {
         ).rejects.toThrow(
           expect.objectContaining({
             name: 'FileRetrievalError',
-            message: expect.not.stringContaining('unsafe'),
+            message: expect.not.stringContaining('safeFetch'),
           }),
         )
       })
@@ -978,7 +978,7 @@ describe('Collections - Uploads', () => {
         ).rejects.toThrow(
           expect.objectContaining({
             name: 'FileRetrievalError',
-            message: expect.not.stringContaining('unsafe'),
+            message: expect.not.stringContaining('safeFetch'),
           }),
         )
       })


### PR DESCRIPTION
### What?

Ensure the cause for upload fetch errors (`error.cause`) is retained so that it gets surfaced/printed at the server console.

### Why?

The error message for errors thrown by `fetch` (e.g. network connectivity issues, SSL certificate errors, etc.) is very generic (basically "fetch failed"); the actual error message/code is in `error.cause`. The current error handling for upload fetches discards the cause, making it very difficult to debug fetch errors.

### How?

This updates `FileRetrievalError` to accept the error cause as a parameter (passing it as the `data` parameter of `APIError`), and updates the try/catch clauses in `safeFetch` and `generateFileData` to pass the error cause to `FileRetrievalError`.