### PR TITLE
chore: narrow down files affected by vitest lint rules

### DIFF
--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -232,17 +232,15 @@ export const rootEslintConfig = [
     files: ['**/*.tsx'],
   },
   {
-    name: 'Unit Tests',
+    name: 'Unit and Integration Tests',
     plugins: {
-      vitest
+      vitest,
     },
     rules: {
       ...vitest.configs.recommended.rules,
     },
-    files: [
-      '**/*.spec.ts',
-      '!**/*.e2e.spec.ts',
-    ],
+    files: ['**/*.spec.ts'],
+    ignores: ['**/*.e2e.spec.ts'],
   },
   {
     name: 'Payload Config',
@@ -257,6 +255,7 @@ export const rootEslintConfig = [
   {
     name: 'React Compiler',
     ...reactCompiler.configs.recommended,
+    files: ['**/*.tsx'],
   },
 ]
 


### PR DESCRIPTION
The previous glob pattern was incorrect and caused _all_ files to be included, which is not what we want.

The new config entry uses `ignores` to ensure all .spec.ts that are **not** .e2e.spec.ts files are targeted.