### PR TITLE
fix(next): turbopack build version check not working for 16.1.1 canaries

### DIFF
--- a/packages/next/src/withPayload/withPayload.utils.ts
+++ b/packages/next/src/withPayload/withPayload.utils.ts
@@ -129,7 +129,7 @@ export function supportsTurbopackExternalizeTransitiveDependencies(
       return true
     }
     if (minor === 1) {
-      // 16.1.1+ and canaries always supports this feature
+      // 16.1.1+ and canaries support this feature
       if (patch > 0) {
         return true
       }

--- a/packages/next/src/withPayload/withPayload.utils.ts
+++ b/packages/next/src/withPayload/withPayload.utils.ts
@@ -114,7 +114,7 @@ export function supportsTurbopackExternalizeTransitiveDependencies(
     return false
   }
 
-  const { canaryVersion, major, minor } = version
+  const { canaryVersion, major, minor, patch } = version
 
   if (major === undefined || minor === undefined) {
     return false
@@ -129,11 +129,15 @@ export function supportsTurbopackExternalizeTransitiveDependencies(
       return true
     }
     if (minor === 1) {
+      // 16.1.1+ and canaries always supports this feature
+      if (patch > 0) {
+        return true
+      }
       if (canaryVersion !== undefined) {
         // 16.1.0-canary.3+
         return canaryVersion >= 3
       } else {
-        // Assume that Next.js 16.1 inherits support for this feature from the canary release
+        // Next.js 16.1.0
         return true
       }
     }

--- a/packages/next/src/withPayload/withPayloadLegacy.ts
+++ b/packages/next/src/withPayload/withPayloadLegacy.ts
@@ -48,7 +48,7 @@ export const withPayloadLegacy = (nextConfig: NextConfig = {}): NextConfig => {
 
   if (isBuild && (isTurbopackNextjs15 || isTurbopackNextjs16)) {
     throw new Error(
-      'Your Next.js and Payload versions do not support using Turbopack for production builds. Please upgrade to Next.js 16.1.0 or, if not yet released, the latest canary release.',
+      'Your Next.js version does not support using Turbopack for production builds. The *minimum* Next.js version required for Turbopack Builds is 16.1.0. Please upgrade to the latest supported Next.js version to resolve this error.',
     )
   }
 


### PR DESCRIPTION
Currently, turbopack build is disabled for Next.js 16.1.1-canary.1 due to an incorrect version check. This PR fixes this version check to allow turbopack build on all newer Next.js canaries.