### PR TITLE
test: fix console logs not appearing on vitest

### DIFF
--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,6 +1,3 @@
-import console from 'console'
-global.console = console
-
 import dotenv from 'dotenv'
 dotenv.config()
 


### PR DESCRIPTION
We had some legacy jest code in our vitest.setup.console.ts. On jest it was necessary to make console logs more readable - however on vitest this is no longer necessary, in fact it makes the console logs disappear.

This PR fixes it by removing that legacy jest code