### PR TITLE
test: ensure vitest vscode extension env variables match CI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,11 @@
   "bun.test.filePattern": "bun.test.ts",
   "playwright.env": {
     "NODE_OPTIONS": "--no-deprecation --no-experimental-strip-types"
+  },
+  "vitest.nodeEnv": {
+    // Ensure the node options match the ones we use for pnpm test:int. Otherwise, the behavior
+    // of the test run buttons in vscode will be different from CI, which can result to tests passing
+    // locally, and suddenly failing in CI.
+    "NODE_OPTIONS": "--no-deprecation --no-experimental-strip-types"
   }
 }


### PR DESCRIPTION
Previously, pressing the vitest run button in vs code would run the tests with Node.js type stripping enabled, while running `pnpm test:int` would disable Node.js type stripping. This actually caused some tests to pass locally for me, while they were failing in CI.

This PR fixes this by ensuring the vitest vscode extension uses the exact same env variables as the test:int script