### PR TITLE
fix(templates): fix mobile menu auth buttons overflow in ecommerce template

### DIFF
--- a/templates/ecommerce/src/components/Header/MobileMenu.tsx
+++ b/templates/ecommerce/src/components/Header/MobileMenu.tsx
@@ -94,12 +94,12 @@ export function MobileMenu({ menu }: Props) {
         ) : (
           <div>
             <h2 className="text-xl mb-4">My account</h2>
-            <div className="flex items-center gap-2 mt-4">
-              <Button asChild className="w-full" variant="outline">
+            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+              <Button asChild className="w-full sm:flex-1" variant="outline">
                 <Link href="/login">Log in</Link>
               </Button>
-              <span>or</span>
-              <Button asChild className="w-full">
+              <span className="text-center text-sm text-muted-foreground sm:text-base">or</span>
+              <Button asChild className="w-full sm:flex-1">
                 <Link href="/create-account">Create an account</Link>
               </Button>
             </div>


### PR DESCRIPTION
…template

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
Fix mobile header sheet layout in the ecommerce template so the auth buttons no longer overflow the drawer on narrow screens.

### Why?
The login/create-account buttons were rendered in a horizontal `flex` row while each button had `w-full`. In a narrow sheet (`w-3/4` + padding), the row could not shrink both full‑width buttons, causing horizontal overflow and one button to appear outside the sheet.

### How?
- Updated the auth button container to use a column layout on small screens.
- Keep the row layout from `sm` and up.
- Use `sm:flex-1` so both buttons share available width at larger sizes.
- Adjusted the “or” label style to align with the new responsive layout.

Fixes #15019

#### Before
<img width="787" height="888" alt="image" src="https://github.com/user-attachments/assets/14c6f4d9-ace9-4d68-9705-9db455fe580d" />

#### After
<img width="670" height="888" alt="image" src="https://github.com/user-attachments/assets/6323d73f-ee14-4f63-aed6-159c71bb4248" />
