### PR TITLE
feat(kv-redis): add optional TTL for automatic cache invalidation

### DIFF
--- a/packages/kv-redis/README.md
+++ b/packages/kv-redis/README.md
@@ -18,7 +18,7 @@ export default buildConfig({
   kv: redisKVAdapter({
     // Redis connection URL. Defaults to process.env.REDIS_URL
     redisURL: 'redis://localhost:6379',
-    // Optional prefix for Redis keys to isolate the store. Defaults to 'payload-kv'
+    // Optional prefix for Redis keys to isolate the store. Defaults to 'payload-kv:'
     keyPrefix: 'kv-storage',
     // Optional TTL configuration for automatic expiration by key prefix
     ttl: [

--- a/packages/kv-redis/README.md
+++ b/packages/kv-redis/README.md
@@ -20,6 +20,13 @@ export default buildConfig({
     redisURL: 'redis://localhost:6379',
     // Optional prefix for Redis keys to isolate the store. Defaults to 'payload-kv'
     keyPrefix: 'kv-storage',
+    // Optional TTL resolver automatic cache invalidation
+    resolveTTL: (key) => {
+      // Set different TTLs based on key patterns
+      if (key.startsWith('session:')) return 3600
+      if (key.startsWith('cache:')) return 300
+      return undefined // No TTL for other keys
+    }
   }),
 })
 ```

--- a/packages/kv-redis/README.md
+++ b/packages/kv-redis/README.md
@@ -20,13 +20,12 @@ export default buildConfig({
     redisURL: 'redis://localhost:6379',
     // Optional prefix for Redis keys to isolate the store. Defaults to 'payload-kv'
     keyPrefix: 'kv-storage',
-    // Optional TTL resolver automatic cache invalidation
-    resolveTTL: (key) => {
-      // Set different TTLs based on key patterns
-      if (key.startsWith('session:')) return 3600
-      if (key.startsWith('cache:')) return 300
-      return undefined // No TTL for other keys
-    }
+    // Optional TTL configuration for automatic expiration by key prefix
+    ttl: [
+      { prefix: 'session:', ttl: 3600 },
+      { prefix: 'cache:', ttl: 300 },
+      { prefix: 'temp:', ttl: 60 },
+    ]
   }),
 })
 ```

--- a/packages/kv-redis/src/index.ts
+++ b/packages/kv-redis/src/index.ts
@@ -11,7 +11,7 @@ export type TTLConfig = TTLRule[]
 
 export class RedisKVAdapter implements KVAdapter {
   redisClient: Redis
-  resolveTTL?: (key: string) => number | undefined
+  resolveTTL?: (redisKey: string) => number | undefined
 
   constructor(
     readonly keyPrefix: string,
@@ -21,9 +21,9 @@ export class RedisKVAdapter implements KVAdapter {
     this.redisClient = new Redis(redisURL)
 
     if (ttlConfig) {
-      this.resolveTTL = (key: string) => {
+      this.resolveTTL = (redisKey: string) => {
         for (const rule of ttlConfig) {
-          if (key.startsWith(rule.prefix)) {
+          if (redisKey.startsWith(rule.prefix)) {
             return rule.ttl
           }
         }
@@ -72,7 +72,7 @@ export class RedisKVAdapter implements KVAdapter {
   async set(key: string, data: KVStoreValue): Promise<void> {
     const redisKey = `${this.keyPrefix}${key}`
     const value = JSON.stringify(data)
-    const ttl = this.resolveTTL?.(key)
+    const ttl = this.resolveTTL?.(redisKey)
 
     if (ttl && ttl > 0) {
       await this.redisClient.set(redisKey, value, 'EX', ttl)

--- a/packages/kv-redis/src/index.ts
+++ b/packages/kv-redis/src/index.ts
@@ -2,11 +2,28 @@ import type { KVAdapter, KVAdapterResult, KVStoreValue } from 'payload'
 
 import { Redis } from 'ioredis'
 
+/**
+ * Configuration rule for automatic TTL-based cache invalidation.
+ */
 export type TTLRule = {
+  /**
+   * Key prefix to match against (e.g., 'session:', 'cache:').
+   *
+   * This prefix is checked against the full Redis key (including any adapter-level
+   * `keyPrefix`) before that `keyPrefix` is applied to the user-provided key.
+   */
   prefix: string
+  /**
+   * Time-to-live in seconds for keys matching this rule.
+   *
+   * Must be a positive integer; non-positive values disable TTL for the matching keys.
+   */
   ttl: number
 }
 
+/**
+ * Collection of TTL rules mapping Redis key prefixes to their respective TTLs.
+ */
 export type TTLConfig = TTLRule[]
 
 export class RedisKVAdapter implements KVAdapter {


### PR DESCRIPTION
This adds optional redis TTL support to the redis KV adapter.

The adapter can now be configured with TTL rules based on key prefixes. When a key matches a configured rule, the value is written using Redis SET … EX, ensuring automatic expiration at the storage layer.

Keys that do not match any rule remain persistent.