### PR TITLE
fix: add beforeDocumentControls to globals generate importmap

### DIFF
--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -179,12 +179,14 @@ export const MyGlobal: SanitizedGlobalConfig = {
 
 The following options are available:
 
-| Option            | Description                                                                                                                                                                                                |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SaveButton`      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#savebutton).                                         |
-| `SaveDraftButton` | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#savedraftbutton). |
-| `PublishButton`   | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publishbutton).                                    |
-| `PreviewButton`   | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
+| Option                   | Description                                                                                                                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `beforeDocumentControls` | Inject custom components before the Save button. [More details](../custom-components/edit-view#beforedocumentcontrols).                                                                                    |
+| `Description`            | A component to render below the Global label in the Edit View. [More details](../custom-components/edit-view#description).                                                                                 |
+| `SaveButton`             | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#savebutton).                                         |
+| `SaveDraftButton`        | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#savedraftbutton). |
+| `PublishButton`          | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publishbutton).                                    |
+| `PreviewButton`          | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
@@ -29,6 +29,7 @@ export function iterateGlobals({
       imports,
     })
 
+    addToImportMap(global.admin?.components?.elements?.beforeDocumentControls)
     addToImportMap(global.admin?.components?.elements?.Description)
     addToImportMap(global.admin?.components?.elements?.PreviewButton)
     addToImportMap(global.admin?.components?.elements?.PublishButton)


### PR DESCRIPTION
### What?

When adding `beforeDocumentControls`  as a custom component to a global, it does not get picked up by the import map, even when running `generate:importmap`.

### Why?

`beforeDocumentControls` is missing from `addToImportMap` in `iterateGlobals`.

### How?

Adds `beforeDocumentControls` to `addToImportMap` in `iterateGlobals`.

While doing this I've used the opportunity to add `Description` to the globals custom component documentation as it was missing.

Fixes #15035 