### PR TITLE
feat(plugin-ecommerce): support Mollie as payment adapter

### DIFF
--- a/docs/ecommerce/overview.mdx
+++ b/docs/ecommerce/overview.mdx
@@ -3,7 +3,7 @@ title: Ecommerce Overview
 label: Overview
 order: 10
 desc: Add ecommerce functionality to your Payload CMS application with this plugin.
-keywords: plugins, ecommerce, stripe, plugin, payload, cms, shop, payments
+keywords: plugins, ecommerce, stripe, mollie, plugin, payload, cms, shop, payments
 ---
 
 ![https://www.npmjs.com/package/@payloadcms/plugin-ecommerce](https://img.shields.io/npm/v/@payloadcms/plugin-ecommerce)

--- a/docs/ecommerce/payments.mdx
+++ b/docs/ecommerce/payments.mdx
@@ -3,7 +3,7 @@ title: Payment Adapters
 label: Payment Adapters
 order: 40
 desc: Add ecommerce functionality to your Payload CMS application with this plugin.
-keywords: plugins, ecommerce, stripe, plugin, payload, cms, shop, payments
+keywords: plugins, ecommerce, stripe, mollie, plugin, payload, cms, shop, payments
 ---
 
 A deeper look into the payment adapter pattern used by the Ecommerce Plugin, and how to create your own.
@@ -11,6 +11,7 @@ A deeper look into the payment adapter pattern used by the Ecommerce Plugin, and
 The current list of supported payment adapters are:
 
 - [Stripe](#stripe)
+- [Mollie](#mollie)
 
 ## REST API
 
@@ -131,6 +132,114 @@ import { stripeAdapterClient } from '@payloadcms/plugin-ecommerce/payments/strip
     stripeAdapterClient({
       publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || '',
     }),
+  ]}
+>
+  {children}
+</EcommerceProvider>
+```
+
+Then you can use the `usePayments` hook to access the `initiatePayment` and `confirmOrder` functions, see the [Frontend docs](./frontend#usePayments) for more details.
+
+## Mollie
+
+Currently the Mollie adapter supports one-time purchases. To use Mollie, you will need to install the Mollie package:
+
+```bash
+  pnpm add @mollie/api-client
+```
+
+We recommend at least `18.5.0` to ensure compatibility with the plugin.
+
+Then, in your `plugins` array of your [Payload Config](https://payloadcms.com/docs/configuration/overview), call the plugin with:
+
+```ts
+import { ecommercePlugin } from '@payloadcms/plugin-ecommerce'
+import { mollieAdapter } from '@payloadcms/plugin-ecommerce/payments/mollie'
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  // Payload config...
+  plugins: [
+    ecommercePlugin({
+      // rest of config...
+      payments: {
+        paymentMethods: [
+          mollieAdapter({
+            apiKey: process.env.MOLLIE_API_KEY,
+          }),
+        ],
+      },
+    }),
+  ],
+})
+```
+
+### Configuration
+
+The Mollie payment adapter takes the following configuration options:
+
+| Option   | Type     | Description                                                                                                                                                                                      |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| apiKey   | `string` | Your Mollie API Key, found in the [Mollie Dashboard](https://www.mollie.com/dashboard/settings/profiles).                                                                                        |
+| webhooks | `object` | (Optional) An object where the keys are Mollie payment statuses and the values are functions that will be called when that event is received. See [Webhooks](#mollie-webhooks) for more details. |
+
+### Mollie Webhooks
+
+You can also add your own webhooks to handle [payment status updates from Mollie](https://docs.mollie.com/reference/webhooks). This is optional and the plugin internally does not use webhooks for any core functionality. It receives the following arguments:
+
+| Argument | Type             | Description                     |
+| -------- | ---------------- | ------------------------------- |
+| payment  | `Payment`        | The Mollie payment object       |
+| req      | `PayloadRequest` | The Payload request object      |
+| mollie   | `MollieClient`   | The initialized Mollie instance |
+
+You can add a webhook like so:
+
+```ts
+import { ecommercePlugin } from '@payloadcms/plugin-ecommerce'
+import { mollieAdapter } from '@payloadcms/plugin-ecommerce/payments/mollie'
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  // Payload config...
+  plugins: [
+    ecommercePlugin({
+      // rest of config...
+      payments: {
+        paymentMethods: [
+          mollieAdapter({
+            apiKey: process.env.MOLLIE_API_KEY,
+            webhooks: {
+              paid: ({ payment, req }) => {
+                console.log(payment)
+                req.payload.logger.info('Payment has been fully paid')
+              },
+            },
+          }),
+        ],
+      },
+    }),
+  ],
+})
+```
+
+To use webhooks during local development you need to forward them with a local tunnel.
+
+Please refer to the [Mollie Docs](https://docs.mollie.com/docs/magento-2-test-and-go-live#get-status-updates-in-local-test-environments) for more information.
+
+### Frontend usage
+
+Unlike Stripe, the Mollie payment adapter does not have a client side SDK implemented. You will still need to load the `mollieAdapterClient` for other values to apply.
+
+Wrap your application in the provider and pass in the Mollie adapter:
+
+```ts
+import { EcommerceProvider } from '@payloadcms/plugin-ecommerce/client/react'
+import { mollieAdapterClient } from '@payloadcms/plugin-ecommerce/payments/mollie'
+
+<EcommerceProvider
+  paymentMethods={[
+    mollieAdapterClient({}),
   ]}
 >
   {children}
@@ -405,8 +514,8 @@ The client side adapter should implement the `PaymentAdapterClient` interface:
 
 And for the args use the `PaymentAdapterClientArgs` type:
 
-| Property | Type     | Description                                                       |
-| -------- | -------- | ----------------------------------------------------------------- |
+| Property | Type     | Description                                                        |
+| -------- | -------- | ------------------------------------------------------------------ |
 | `label`  | `string` | (Optional) Allow overriding the default UI label for this adapter. |
 
 ## Best Practices

--- a/docs/ecommerce/payments.mdx
+++ b/docs/ecommerce/payments.mdx
@@ -178,10 +178,11 @@ export default buildConfig({
 
 The Mollie payment adapter takes the following configuration options:
 
-| Option   | Type     | Description                                                                                                                                                                                      |
-| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| apiKey   | `string` | Your Mollie API Key, found in the [Mollie Dashboard](https://www.mollie.com/dashboard/settings/profiles).                                                                                        |
-| webhooks | `object` | (Optional) An object where the keys are Mollie payment statuses and the values are functions that will be called when that event is received. See [Webhooks](#mollie-webhooks) for more details. |
+| Option        | Type       | Description                                                                                                                                                                                      |
+| ------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| apiKey        | `string`   | Your Mollie API Key, found in the [Mollie Dashboard](https://www.mollie.com/dashboard/settings/profiles).                                                                                        |
+| createPayment | `function` | (Optional) A function that returns custom values for the payment object such as custom description, webhook url or success/cancellation url.                                                     |
+| webhooks      | `object`   | (Optional) An object where the keys are Mollie payment statuses and the values are functions that will be called when that event is received. See [Webhooks](#mollie-webhooks) for more details. |
 
 ### Mollie Webhooks
 
@@ -209,6 +210,14 @@ export default buildConfig({
         paymentMethods: [
           mollieAdapter({
             apiKey: process.env.MOLLIE_API_KEY,
+            createPayment: ({ amount, currency, customer }) => {
+              return {
+                // This url must be publicly reachable. It's recommended to use a local tunnel during development.
+                webhookUrl: 'https://example.com/api/mollie/webhooks',
+                // additional props...
+                // see https://docs.mollie.com/reference/create-payment
+              }
+            },
             webhooks: {
               paid: ({ payment, req }) => {
                 console.log(payment)

--- a/packages/plugin-ecommerce/package.json
+++ b/packages/plugin-ecommerce/package.json
@@ -41,6 +41,11 @@
       "types": "./src/exports/payments/stripe.ts",
       "default": "./src/exports/payments/stripe.ts"
     },
+    "./payments/mollie": {
+      "import": "./src/exports/payments/mollie.ts",
+      "types": "./src/exports/payments/mollie.ts",
+      "default": "./src/exports/payments/mollie.ts"
+    },
     "./rsc": {
       "import": "./src/exports/rsc.ts",
       "types": "./src/exports/rsc.ts",
@@ -83,6 +88,7 @@
     "qs-esm": "7.0.2"
   },
   "devDependencies": {
+    "@mollie/api-client": "4.3.3",
     "@payloadcms/eslint-config": "workspace:*",
     "@payloadcms/next": "workspace:*",
     "@types/json-schema": "7.0.15",
@@ -112,6 +118,11 @@
         "import": "./dist/exports/payments/stripe.js",
         "types": "./dist/exports/payments/stripe.d.ts",
         "default": "./dist/exports/payments/stripe.js"
+      },
+      "./payments/mollie": {
+        "import": "./dist/exports/payments/mollie.js",
+        "types": "./dist/exports/payments/mollie.d.ts",
+        "default": "./dist/exports/payments/mollie.js"
       },
       "./rsc": {
         "import": "./dist/exports/rsc.js",

--- a/packages/plugin-ecommerce/src/exports/payments/mollie.ts
+++ b/packages/plugin-ecommerce/src/exports/payments/mollie.ts
@@ -1,0 +1,1 @@
+export { mollieAdapter, mollieAdapterClient } from '../../payments/adapters/mollie/index.js'

--- a/packages/plugin-ecommerce/src/payments/adapters/mollie/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/mollie/confirmOrder.ts
@@ -1,0 +1,137 @@
+import { createMollieClient } from '@mollie/api-client'
+
+import type { PaymentAdapter } from '../../../types/index.js'
+import type { MollieAdapterArgs } from './index.js'
+
+import { getOrCreateMollieCustomer } from './utils.js'
+
+type Props = {
+  apiKey: MollieAdapterArgs['apiKey']
+}
+
+export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confirmOrder'] =
+  (props) =>
+  async ({
+    customersSlug = 'users',
+    data,
+    ordersSlug = 'orders',
+    req,
+    transactionsSlug = 'transactions',
+  }) => {
+    const payload = req.payload
+    const { apiKey } = props || {}
+
+    const customerEmail = data.customerEmail
+
+    const paymentID = data.paymentID as string
+
+    if (!apiKey) {
+      throw new Error('Mollie API key is required')
+    }
+
+    if (!paymentID) {
+      throw new Error('Payment ID is required')
+    }
+
+    if (!customerEmail || typeof customerEmail !== 'string') {
+      throw new Error('A valid customer email is required to confirm an order.')
+    }
+
+    const mollie = createMollieClient({
+      apiKey,
+    })
+
+    try {
+      const customer = await getOrCreateMollieCustomer({
+        customerEmail,
+        customersSlug,
+        mollie,
+        payload,
+      })
+
+      // Find our existing transaction by the payment intent ID
+      const transactionsResults = await payload.find({
+        collection: transactionsSlug,
+        where: {
+          'mollie.paymentID': {
+            equals: paymentID,
+          },
+        },
+      })
+
+      const transaction = transactionsResults.docs[0]
+
+      if (!transactionsResults.totalDocs || !transaction) {
+        throw new Error('No transaction found for the provided Payment ID')
+      }
+
+      // Verify the payment intent exists and retrieve it
+      const payment = await mollie.payments.get(paymentID)
+      const metadata = payment.metadata as
+        | {
+            cartID?: string
+            cartItemsSnapshot?: string
+            shippingAddress?: string
+          }
+        | undefined
+
+      const cartID = metadata?.cartID
+      const cartItemsSnapshot = metadata?.cartItemsSnapshot
+        ? JSON.parse(metadata.cartItemsSnapshot)
+        : undefined
+
+      const shippingAddress = metadata?.shippingAddress
+        ? JSON.parse(metadata.shippingAddress)
+        : undefined
+
+      if (!cartID) {
+        throw new Error('Cart ID not found in the Payment metadata')
+      }
+
+      if (!cartItemsSnapshot || !Array.isArray(cartItemsSnapshot)) {
+        throw new Error('Cart items snapshot not found or invalid in the Payment metadata')
+      }
+
+      const order = await payload.create({
+        collection: ordersSlug,
+        data: {
+          amount: Number(payment.amount.value) * 100,
+          currency: payment.amount.currency,
+          ...(req.user ? { customer: req.user.id } : { customerEmail }),
+          items: cartItemsSnapshot,
+          shippingAddress,
+          status: 'processing',
+          transactions: [transaction.id],
+        },
+      })
+
+      const timestamp = new Date().toISOString()
+
+      await payload.update({
+        id: cartID,
+        collection: 'carts',
+        data: {
+          purchasedAt: timestamp,
+        },
+      })
+
+      await payload.update({
+        id: transaction.id,
+        collection: transactionsSlug,
+        data: {
+          order: order.id,
+          status: 'succeeded',
+        },
+      })
+
+      return {
+        message: 'Payment confirmed successfully',
+        orderID: order.id,
+        transactionID: transaction.id,
+      }
+    } catch (error) {
+      payload.logger.error(error, 'Error confirming payment with Mollie')
+
+      throw new Error(error instanceof Error ? error.message : 'Unknown error confirming payment')
+    }
+  }

--- a/packages/plugin-ecommerce/src/payments/adapters/mollie/endpoints/webhooks.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/mollie/endpoints/webhooks.ts
@@ -1,0 +1,57 @@
+import type { MollieOptions, Payment as MolliePayment } from '@mollie/api-client'
+import type { Endpoint } from 'payload'
+
+import { createMollieClient } from '@mollie/api-client'
+
+import type { MollieAdapterArgs } from '../index.js'
+
+type Props = { webhooks?: MollieAdapterArgs['webhooks'] } & Pick<MollieOptions, 'apiKey'>
+
+export const webhooksEndpoint: (props: Props) => Endpoint = (props) => {
+  const { apiKey, webhooks } = props || {}
+
+  const handler: Endpoint['handler'] = async (req) => {
+    let returnStatus = 200
+
+    if (apiKey && req.formData) {
+      const mollie = createMollieClient({
+        apiKey,
+      })
+
+      const body = await req.formData()
+      const paymentId = body.get('id')
+
+      if (paymentId && typeof paymentId === 'string') {
+        let payment: MolliePayment | undefined
+
+        try {
+          payment = await mollie.payments.get(paymentId)
+        } catch (err: unknown) {
+          const msg: string = err instanceof Error ? err.message : JSON.stringify(err)
+          req.payload.logger.error(`Error retrieving Mollie payment: ${msg}`)
+          returnStatus = 400
+        }
+
+        if (typeof webhooks === 'object' && payment) {
+          const webhookEventHandler = webhooks[payment.status]
+
+          if (typeof webhookEventHandler === 'function') {
+            await webhookEventHandler({
+              mollie,
+              payment,
+              req,
+            })
+          }
+        }
+      }
+    }
+
+    return Response.json({ received: true }, { status: returnStatus })
+  }
+
+  return {
+    handler,
+    method: 'post',
+    path: '/webhooks',
+  }
+}

--- a/packages/plugin-ecommerce/src/payments/adapters/mollie/index.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/mollie/index.ts
@@ -56,7 +56,7 @@ export type MollieAdapterArgs = {
 } & PaymentAdapterArgs
 
 export const mollieAdapter: (props: MollieAdapterArgs) => PaymentAdapter = (props) => {
-  const { apiKey, groupOverrides, webhooks } = props
+  const { apiKey, createPayment, groupOverrides, webhooks } = props
   const label = props?.label || 'Mollie'
 
   const baseFields: Field[] = [
@@ -99,6 +99,7 @@ export const mollieAdapter: (props: MollieAdapterArgs) => PaymentAdapter = (prop
     group: groupField,
     initiatePayment: initiatePayment({
       apiKey,
+      createPayment,
     }),
     label,
   }

--- a/packages/plugin-ecommerce/src/payments/adapters/mollie/index.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/mollie/index.ts
@@ -1,0 +1,106 @@
+import type {
+  createMollieClient,
+  MollieClient,
+  Payment as MolliePayment,
+  PaymentStatus as MolliePaymentStatus,
+} from '@mollie/api-client'
+import type { Field, GroupField, PayloadRequest } from 'payload'
+
+import type {
+  PaymentAdapter,
+  PaymentAdapterArgs,
+  PaymentAdapterClient,
+  PaymentAdapterClientArgs,
+} from '../../../types/index.js'
+
+import { confirmOrder } from './confirmOrder.js'
+import { webhooksEndpoint } from './endpoints/webhooks.js'
+import { initiatePayment } from './initiatePayment.js'
+
+type MollieWebhookHandler = (args: {
+  mollie: MollieClient
+  payment: MolliePayment
+  req: PayloadRequest
+}) => Promise<void> | void
+
+type MollieWebhookHandlers = {
+  /**
+   * The payment status to handle (e.g., paid, failed, etc.).
+   */
+  [paymentStatus in MolliePaymentStatus]: MollieWebhookHandler
+}
+
+export type MollieAdapterArgs = {
+  apiKey: string
+  webhooks?: MollieWebhookHandlers
+} & PaymentAdapterArgs
+
+export const mollieAdapter: (props: MollieAdapterArgs) => PaymentAdapter = (props) => {
+  const { apiKey, groupOverrides, webhooks } = props
+  const label = props?.label || 'Mollie'
+
+  const baseFields: Field[] = [
+    {
+      name: 'customerID',
+      type: 'text',
+      label: 'Mollie Customer ID',
+    },
+    {
+      name: 'paymentID',
+      type: 'text',
+      label: 'Mollie Payment ID',
+    },
+  ]
+
+  const groupField: GroupField = {
+    name: 'mollie',
+    type: 'group',
+    ...groupOverrides,
+    admin: {
+      condition: (data) => {
+        const path = 'paymentMethod'
+
+        return data?.[path] === 'mollie'
+      },
+      ...groupOverrides?.admin,
+    },
+    fields:
+      groupOverrides?.fields && typeof groupOverrides?.fields === 'function'
+        ? groupOverrides.fields({ defaultFields: baseFields })
+        : baseFields,
+  }
+
+  return {
+    name: 'mollie',
+    confirmOrder: confirmOrder({
+      apiKey,
+    }),
+    endpoints: [webhooksEndpoint({ apiKey, webhooks })],
+    group: groupField,
+    initiatePayment: initiatePayment({
+      apiKey,
+    }),
+    label,
+  }
+}
+
+// Placeholder for client side adapter
+// Mollie has no client side SDK yet
+export type MollieAdapterClientArgs = {} & PaymentAdapterClientArgs
+
+export const mollieAdapterClient: (props: MollieAdapterClientArgs) => PaymentAdapterClient = (
+  props,
+) => {
+  return {
+    name: 'mollie',
+    confirmOrder: true,
+    initiatePayment: true,
+    label: 'Card',
+  }
+}
+
+export type InitiatePaymentReturnType = {
+  href: string
+  message: string
+  paymentID: string
+}

--- a/packages/plugin-ecommerce/src/payments/adapters/mollie/index.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/mollie/index.ts
@@ -1,9 +1,11 @@
 import type {
   createMollieClient,
   MollieClient,
+  Customer as MollieCustomer,
   Payment as MolliePayment,
   PaymentStatus as MolliePaymentStatus,
 } from '@mollie/api-client'
+import type { CreateParameters } from '@mollie/api-client/dist/types/binders/payments/parameters.js'
 import type { Field, GroupField, PayloadRequest } from 'payload'
 
 import type {
@@ -30,8 +32,26 @@ type MollieWebhookHandlers = {
   [paymentStatus in MolliePaymentStatus]: MollieWebhookHandler
 }
 
+type CreatePaymentParameters = Partial<Omit<CreateParameters, 'amount' | 'customerId'>>
+
 export type MollieAdapterArgs = {
   apiKey: string
+  createPayment?: (args: {
+    /**
+     * The amount of the payment in cents.
+     * @example 1000 (10.00 USD)
+     */
+    amount: number
+    /**
+     * The currency of the payment.
+     * @example 'USD'
+     */
+    currency: string
+    /**
+     * The Mollie customer object.
+     */
+    customer: MollieCustomer
+  }) => CreatePaymentParameters | Promise<CreatePaymentParameters>
   webhooks?: MollieWebhookHandlers
 } & PaymentAdapterArgs
 

--- a/packages/plugin-ecommerce/src/payments/adapters/mollie/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/mollie/initiatePayment.ts
@@ -1,0 +1,123 @@
+import { createMollieClient } from '@mollie/api-client'
+
+import type { PaymentAdapter } from '../../../types/index.js'
+import type { InitiatePaymentReturnType, MollieAdapterArgs } from './index.js'
+
+import { getOrCreateMollieCustomer } from './utils.js'
+
+type Props = {
+  apiKey: MollieAdapterArgs['apiKey']
+}
+
+export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['initiatePayment'] =
+  (props) =>
+  async ({ customersSlug = 'users', data, req, transactionsSlug }) => {
+    const payload = req.payload
+    const { apiKey } = props || {}
+
+    const customerEmail = data.customerEmail
+    const currency = data.currency
+    const cart = data.cart
+    const amount = cart.subtotal
+    const billingAddressFromData = data.billingAddress
+    const shippingAddressFromData = data.shippingAddress
+
+    if (!apiKey) {
+      throw new Error('Mollie API key is required.')
+    }
+
+    if (!currency) {
+      throw new Error('Currency is required.')
+    }
+
+    if (!cart || !cart.items || cart.items.length === 0) {
+      throw new Error('Cart is empty or not provided.')
+    }
+
+    if (!customerEmail || typeof customerEmail !== 'string') {
+      throw new Error('A valid customer email is required to make a purchase.')
+    }
+
+    if (!amount || typeof amount !== 'number' || amount <= 0) {
+      throw new Error('A valid amount is required to initiate a payment.')
+    }
+
+    const mollie = createMollieClient({
+      apiKey,
+    })
+
+    try {
+      const customer = await getOrCreateMollieCustomer({
+        customerEmail,
+        customersSlug,
+        mollie,
+        payload,
+      })
+
+      const flattenedCart = cart.items.map((item) => {
+        const productID = typeof item.product === 'object' ? item.product.id : item.product
+        const variantID = item.variant
+          ? typeof item.variant === 'object'
+            ? item.variant.id
+            : item.variant
+          : undefined
+
+        return {
+          product: productID,
+          quantity: item.quantity,
+          variant: variantID,
+        }
+      })
+
+      const shippingAddressAsString = JSON.stringify(shippingAddressFromData)
+
+      const payment = await mollie.payments.create({
+        amount: {
+          // Must be in format '10.00' as string
+          value: (amount / 100).toFixed(2),
+          // Must be a valid ISO 4217 currency code
+          currency: currency.toUpperCase(),
+        },
+        // This will appear on the customer's bank statement
+        // Use the cart ID as a description for now
+        customerId: customer.id,
+        description: `${cart.id}`,
+        metadata: {
+          cartID: cart.id,
+          cartItemsSnapshot: JSON.stringify(flattenedCart),
+          shippingAddress: shippingAddressAsString,
+        },
+      })
+
+      // Create a transaction for the payment intent in the database
+      const transaction = await payload.create({
+        collection: transactionsSlug,
+        data: {
+          ...(req.user ? { customer: req.user.id } : { customerEmail }),
+          amount: Number(payment.amount.value) * 100,
+          billingAddress: billingAddressFromData,
+          cart: cart.id,
+          currency: payment.amount.currency,
+          items: flattenedCart,
+          mollie: {
+            customerID: customer.id,
+            paymentID: payment.id,
+          },
+          paymentMethod: 'mollie',
+          status: 'pending',
+        },
+      })
+
+      const returnData: InitiatePaymentReturnType = {
+        href: payment._links.checkout?.href || '',
+        message: 'Payment initiated successfully',
+        paymentID: payment.id,
+      }
+
+      return returnData
+    } catch (error) {
+      payload.logger.error(error, 'Error initiating payment with Mollie')
+
+      throw new Error(error instanceof Error ? error.message : 'Unknown error initiating payment')
+    }
+  }

--- a/packages/plugin-ecommerce/src/payments/adapters/mollie/utils.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/mollie/utils.ts
@@ -1,0 +1,75 @@
+import type { MollieClient, Customer as MollieCustomer } from '@mollie/api-client'
+import type { Payload } from 'payload'
+
+import { MollieApiError } from '@mollie/api-client'
+
+/**
+ * Retrieves or creates a Mollie customer by email.
+ */
+export const getOrCreateMollieCustomer = async ({
+  customerEmail,
+  customersSlug,
+  mollie,
+  payload,
+}: {
+  customerEmail: string
+  customersSlug: string
+  mollie: MollieClient
+  payload: Payload
+}): Promise<MollieCustomer> => {
+  // Since Mollie does not support querying customers by email,
+  // we need to query the customers collection in Payload.
+  const customerResults = await payload.find({
+    collection: customersSlug,
+    depth: 0,
+    limit: 1,
+    select: {
+      mollieCustomerID: true,
+    },
+    where: {
+      email: {
+        equals: customerEmail,
+      },
+    },
+  })
+
+  const payloadCustomer = customerResults.docs[0]
+  const mollieCustomerID = payloadCustomer?.mollieCustomerID as string | undefined
+
+  let customer: MollieCustomer | undefined
+  if (mollieCustomerID) {
+    try {
+      customer = await mollie.customers.get(mollieCustomerID)
+    } catch (error) {
+      if (error instanceof MollieApiError && error.statusCode === 404) {
+        // Customer not found, continue and try to create a new one
+        customer = undefined
+      } else {
+        // Rethrow the error to be handled by the caller
+        throw error
+      }
+    }
+  }
+
+  if (!customer) {
+    // Create a new customer if it doesn't exist
+    customer = await mollie.customers.create({
+      email: customerEmail,
+    })
+
+    // Link the customer to the customer document in Payload
+    await payload.update({
+      collection: customersSlug,
+      data: {
+        mollieCustomerID: customer.id,
+      },
+      where: {
+        email: {
+          equals: customerEmail,
+        },
+      },
+    })
+  }
+
+  return customer
+}


### PR DESCRIPTION
### What?

This PR adds basic support for Mollie as payment adapter to the ecommerce plugin.

### Why?

Currently, only Stripe is supported for taking payments. However, Mollie is one of the largest PSPs in the European Economic Area. 

We can utilise the existing adapter pattern and create a new adapter that supports one-time payments in a similiar way.

### How?

The current adapter configuration is cloned and tailored to the Mollie ecosystem. 

There are some important changes/limitations to note:
- Mollie's webhooks only send payment status updates - they need to be fetched and there is no webhook secret. The implementation of the webhook handler differs slightly.
- Mollie's webhook endpoint needs to be publicly reachable even during development. A local tunnel is required for testing. A hint must be placed in the docs.
- Payments must have a valid description that appears on bank statement.
- Mollie does not support querying customers via email directly. A field must be added to the payload customers collection (missing docs / maybe better solution?).
- Currently, there is no client side SDK. 
- A custom hook `createPayment` was introduced to bypass above limitations.


This pull request is just for basic support and may need some additional changes. There are more options that can be passed to the Mollie client, but only `apiKey` is implemented for now.
