### PR TITLE
fix(ui): prevent text overlap in breadcrumbs

### DIFF
--- a/packages/ui/src/elements/StepNav/index.scss
+++ b/packages/ui/src/elements/StepNav/index.scss
@@ -61,7 +61,15 @@
     span {
       max-width: base(8);
       text-overflow: ellipsis;
+      overflow: hidden;
       white-space: nowrap;
+
+      // Exception: don't truncate modular dashboard elements
+      &:has(.dashboard-breadcrumb-select, .dashboard-breadcrumb-dropdown__editing) {
+        max-width: none;
+        overflow: visible;
+        white-space: normal;
+      }
     }
 
     @include mid-break {


### PR DESCRIPTION
### What?

Text overflow for breadcrumbs regressed during the modular dashboards implementation.

### Why?

`overflow: hidden` was removed from breadcrumbs text, which breaks `text-overflow: ellipsis`.

### How?

Reintroduce `overflow: hidden` to breadcrumbs text, while making an exception for the modular dashboard select/dropdown elements.

I specifically opted for a more verbose scss solution (compared to using something like `span:not(:has())` as I found it was easier to read.

Fixes #15030
