### PR TITLE
feat(ui): add listSelectionItems custom component

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -203,16 +203,17 @@ export const MyCollection: CollectionConfig = {
 
 The following options are available:
 
-| Option            | Description                                                                                                                                                                        |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `afterList`       | An array of components to inject _after_ the built-in List View. [More details](../custom-components/list-view#afterlist).                                                         |
-| `afterListTable`  | An array of components to inject _after_ the built-in List View's table. [More details](../custom-components/list-view#afterlisttable).                                            |
-| `beforeList`      | An array of components to inject _before_ the built-in List View. [More details](../custom-components/list-view#beforelist).                                                       |
-| `beforeListTable` | An array of components to inject _before_ the built-in List View's table. [More details](../custom-components/list-view#beforelisttable).                                          |
-| `listMenuItems`   | An array of components to render within a menu next to the List Controls (after the Columns and Filters options)                                                                   |
-| `Description`     | A component to render below the Collection label in the List View. An alternative to the `admin.description` property. [More details](../custom-components/list-view#description). |
-| `edit`            | Override specific components within the Edit View. [More details](#edit-view-options).                                                                                             |
-| `views`           | Override or create new views within the Admin Panel. [More details](../custom-components/custom-views).                                                                            |
+| Option               | Description                                                                                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `afterList`          | An array of components to inject _after_ the built-in List View. [More details](../custom-components/list-view#afterlist).                                                         |
+| `afterListTable`     | An array of components to inject _after_ the built-in List View's table. [More details](../custom-components/list-view#afterlisttable).                                            |
+| `beforeList`         | An array of components to inject _before_ the built-in List View. [More details](../custom-components/list-view#beforelist).                                                       |
+| `beforeListTable`    | An array of components to inject _before_ the built-in List View's table. [More details](../custom-components/list-view#beforelisttable).                                          |
+| `listMenuItems`      | An array of components to render within a menu next to the List Controls (after the Columns and Filters options).                                                                  |
+| `listSelectionItems` | An array of components to render within the List Selection menu. [More details](../custom-components/list-view#listselectionitems).                                                |
+| `Description`        | A component to render below the Collection label in the List View. An alternative to the `admin.description` property. [More details](../custom-components/list-view#description). |
+| `edit`               | Override specific components within the Edit View. [More details](#edit-view-options).                                                                                             |
+| `views`              | Override or create new views within the Admin Panel. [More details](../custom-components/custom-views).                                                                            |
 
 #### Edit View Options
 

--- a/docs/custom-components/list-view.mdx
+++ b/docs/custom-components/list-view.mdx
@@ -88,14 +88,15 @@ export const MyCollection: CollectionConfig = {
 
 The following options are available:
 
-| Path              | Description                                                                                                               |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `beforeList`      | An array of custom components to inject before the list of documents in the List View. [More details](#beforelist).       |
-| `beforeListTable` | An array of custom components to inject before the table of documents in the List View. [More details](#beforelisttable). |
-| `afterList`       | An array of custom components to inject after the list of documents in the List View. [More details](#afterlist).         |
-| `afterListTable`  | An array of custom components to inject after the table of documents in the List View. [More details](#afterlisttable).   |
-| `listMenuItems`   | An array of components to render within a menu next to the List Controls (after the Columns and Filters options)          |
-| `Description`     | A component to render a description of the Collection. [More details](#description).                                      |
+| Path                 | Description                                                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `beforeList`         | An array of custom components to inject before the list of documents in the List View. [More details](#beforelist).       |
+| `beforeListTable`    | An array of custom components to inject before the table of documents in the List View. [More details](#beforelisttable). |
+| `afterList`          | An array of custom components to inject after the list of documents in the List View. [More details](#afterlist).         |
+| `afterListTable`     | An array of custom components to inject after the table of documents in the List View. [More details](#afterlisttable).   |
+| `listMenuItems`      | An array of components to render within a menu next to the List Controls (after the Columns and Filters options).         |
+| `listSelectionItems` | An array of components to render within the List Selection menu. [More details](#listselectionitems).                     |
+| `Description`        | A component to render a description of the Collection. [More details](#description).                                      |
 
 ### beforeList
 
@@ -278,6 +279,61 @@ import type { AfterListTableClientProps } from 'payload'
 
 export function MyAfterListTableComponent(props: AfterListTableClientProps) {
   return <div>This is a custom afterListTable component (Client)</div>
+}
+```
+
+### listSelectionItems
+
+The `listSelectionItems` property allows you to add custom action buttons to the list selection menu. These components will appear when one or more documents are selected.
+
+To add `listSelectionItems` components, use the `components.listSelectionItems` property in your [Collection Config](../configuration/collections):
+
+```ts
+import type { CollectionConfig } from 'payload'
+
+export const MyCollection: CollectionConfig = {
+  // ...
+  admin: {
+    components: {
+      // highlight-start
+      listSelectionItems: ['/path/to/MyListSelectionItemsComponent'],
+      // highlight-end
+    },
+  },
+}
+```
+
+Here's an example of a custom `ListSelectionItems` component:
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import type { ListSelectionItemsServerProps } from 'payload'
+
+export function MyListSelectionItemsComponent(
+  props: ListSelectionItemsServerProps,
+) {
+  return <div>This is a custom listSelectionItems component (Server)</div>
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import type { ListSelectionItemsClientProps } from 'payload'
+import { ListSelectionButton } from '@payloadcms/ui'
+
+export function MyListSelectionItemsComponent(
+  props: ListSelectionItemsClientProps,
+) {
+  return (
+    <ListSelectionButton>
+      This is a custom listSelectionItems component (Client)
+    </ListSelectionButton>
+  )
 }
 ```
 

--- a/packages/next/src/views/List/renderListViewSlots.tsx
+++ b/packages/next/src/views/List/renderListViewSlots.tsx
@@ -6,6 +6,8 @@ import type {
   BeforeListServerPropsOnly,
   BeforeListTableClientProps,
   BeforeListTableServerPropsOnly,
+  ListSelectionItemsClientProps,
+  ListSelectionItemsServerPropsOnly,
   ListViewServerPropsOnly,
   ListViewSlots,
   ListViewSlotSharedClientProps,
@@ -57,6 +59,19 @@ export const renderListViewSlots = ({
         Component: listMenuItems,
         importMap: payload.importMap,
         serverProps,
+      }),
+    ]
+  }
+
+  const listSelectionItems = collectionConfig.admin.components?.listSelectionItems
+
+  if (Array.isArray(listSelectionItems)) {
+    result.listSelectionItems = [
+      RenderServerComponent({
+        clientProps: clientProps satisfies ListSelectionItemsClientProps,
+        Component: listSelectionItems,
+        importMap: payload.importMap,
+        serverProps: serverProps satisfies ListSelectionItemsServerPropsOnly,
       }),
     ]
   }

--- a/packages/payload/src/admin/elements/ListSelectionItems.ts
+++ b/packages/payload/src/admin/elements/ListSelectionItems.ts
@@ -1,0 +1,10 @@
+import type { ServerProps } from '../../config/types.js'
+
+export type ListSelectionItemsClientProps = {
+  collectionSlug: string
+}
+
+export type ListSelectionItemsServerPropsOnly = {} & ServerProps
+
+export type ListSelectionItemsServerProps = ListSelectionItemsClientProps &
+  ListSelectionItemsServerPropsOnly

--- a/packages/payload/src/admin/types.ts
+++ b/packages/payload/src/admin/types.ts
@@ -59,6 +59,11 @@ export type {
   EditMenuItemsServerProps,
   EditMenuItemsServerPropsOnly,
 } from './elements/EditMenuItems.js'
+export type {
+  ListSelectionItemsClientProps,
+  ListSelectionItemsServerProps,
+  ListSelectionItemsServerPropsOnly,
+} from './elements/ListSelectionItems.js'
 export type { NavGroupPreferences, NavPreferences } from './elements/Nav.js'
 export type {
   PreviewButtonClientProps,

--- a/packages/payload/src/admin/views/list.ts
+++ b/packages/payload/src/admin/views/list.ts
@@ -17,6 +17,7 @@ export type ListViewSlots = {
   BeforeListTable?: React.ReactNode
   Description?: React.ReactNode
   listMenuItems?: React.ReactNode[]
+  listSelectionItems?: React.ReactNode[]
   Table: React.ReactNode | React.ReactNode[]
 }
 

--- a/packages/payload/src/bin/generateImportMap/iterateCollections.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateCollections.ts
@@ -30,6 +30,7 @@ export function iterateCollections({
     })
 
     addToImportMap(collection.admin?.components?.afterList)
+    addToImportMap(collection.admin?.components?.listSelectionItems)
     addToImportMap(collection.admin?.components?.listMenuItems)
     addToImportMap(collection.admin?.components?.afterListTable)
     addToImportMap(collection.admin?.components?.beforeList)

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -442,6 +442,7 @@ export type CollectionAdminOptions = {
       Upload?: CustomUpload
     }
     listMenuItems?: CustomComponent[]
+    listSelectionItems?: CustomComponent[]
     views?: {
       /**
        * Replace, modify, or add new "document" views.

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -98,6 +98,7 @@ export { HydrateAuthProvider } from '../../elements/HydrateAuthProvider/index.js
 export { Locked } from '../../elements/Locked/index.js'
 export { ListControls } from '../../elements/ListControls/index.js'
 export { useListDrawer } from '../../elements/ListDrawer/index.js'
+export { ListSelectionButton } from '../../elements/ListSelection/index.js'
 export type {
   ListDrawerProps,
   ListTogglerProps,

--- a/packages/ui/src/views/List/ListHeader/index.tsx
+++ b/packages/ui/src/views/List/ListHeader/index.tsx
@@ -34,6 +34,7 @@ export type ListHeaderProps = {
   i18n: I18nClient
   isBulkUploadEnabled: boolean
   isTrashEnabled?: boolean
+  listSelectionItems?: React.ReactNode[]
   newDocumentURL: string
   onBulkUploadSuccess?: () => void
   /** @deprecated This prop will be removed in the next major version.
@@ -61,6 +62,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
   i18n,
   isBulkUploadEnabled,
   isTrashEnabled,
+  listSelectionItems,
   newDocumentURL,
   onBulkUploadSuccess,
   openBulkUpload,
@@ -113,6 +115,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
             disableBulkEdit={disableBulkEdit}
             key="list-selection"
             label={getTranslation(collectionConfig?.labels?.plural, i18n)}
+            ListSelectionItems={listSelectionItems}
             showSelectAllAcrossPages={!isGroupingBy}
             viewType={viewType}
           />

--- a/packages/ui/src/views/List/ListSelection/index.tsx
+++ b/packages/ui/src/views/List/ListSelection/index.tsx
@@ -17,6 +17,7 @@ export type ListSelectionProps = {
   disableBulkDelete?: boolean
   disableBulkEdit?: boolean
   label: string
+  ListSelectionItems?: React.ReactNode[]
   modalPrefix?: string
   showSelectAllAcrossPages?: boolean
   viewType?: ViewTypes
@@ -28,6 +29,7 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
   disableBulkDelete,
   disableBulkEdit,
   label,
+  ListSelectionItems,
   modalPrefix,
   showSelectAllAcrossPages = true,
   viewType,
@@ -104,6 +106,7 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
             viewType={viewType}
           />
         ),
+        ...(ListSelectionItems || []),
       ].filter(Boolean)}
     />
   )

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -50,6 +50,7 @@ export function DefaultListView(props: ListViewClientProps) {
     hasCreatePermission: hasCreatePermissionFromProps,
     hasDeletePermission,
     listMenuItems,
+    listSelectionItems,
     newDocumentURL,
     queryPreset,
     queryPresetPermissions,
@@ -184,6 +185,7 @@ export function DefaultListView(props: ListViewClientProps) {
                 i18n={i18n}
                 isBulkUploadEnabled={isBulkUploadEnabled && !upload.hideFileInputOnCreate}
                 isTrashEnabled={isTrashEnabled}
+                listSelectionItems={listSelectionItems}
                 newDocumentURL={newDocumentURL}
                 openBulkUpload={openBulkUpload}
                 smallBreak={smallBreak}
@@ -251,6 +253,7 @@ export function DefaultListView(props: ListViewClientProps) {
                           disableBulkDelete={disableBulkDelete}
                           disableBulkEdit={disableBulkEdit}
                           label={getTranslation(collectionConfig.labels.plural, i18n)}
+                          ListSelectionItems={listSelectionItems}
                           showSelectAllAcrossPages={!isGroupingBy}
                         />
                         <div className={`${baseClass}__list-selection-actions`}>

--- a/test/admin/collections/ListSelectionItems.ts
+++ b/test/admin/collections/ListSelectionItems.ts
@@ -1,0 +1,22 @@
+import type { CollectionConfig } from 'payload'
+
+import { listSelectionItemsSlug } from '../slugs.js'
+
+export const ListSelectionItems: CollectionConfig = {
+  slug: listSelectionItemsSlug,
+  admin: {
+    components: {
+      listSelectionItems: [
+        {
+          path: '/components/ListSelectionItems/index.js#ListSelectionItemClient',
+        },
+      ],
+    },
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}

--- a/test/admin/components/ListSelectionItems/index.tsx
+++ b/test/admin/components/ListSelectionItems/index.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { ListSelectionButton } from '@payloadcms/ui'
+
+export const ListSelectionItemClient = () => {
+  return (
+    <ListSelectionButton id="list-selection-custom-component">
+      List selection custom component
+    </ListSelectionButton>
+  )
+}

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -21,6 +21,7 @@ import { CollectionGroup2A } from './collections/Group2A.js'
 import { CollectionGroup2B } from './collections/Group2B.js'
 import { CollectionHidden } from './collections/Hidden.js'
 import { ListDrawer } from './collections/ListDrawer.js'
+import { ListSelectionItems } from './collections/ListSelectionItems.js'
 import { ListViewSelectAPI } from './collections/ListViewSelectAPI/index.js'
 import { Localized } from './collections/Localized.js'
 import { CollectionNoApiView } from './collections/NoApiView.js'
@@ -199,6 +200,7 @@ export default buildConfigWithDefaults({
     EditMenuItems,
     FormatDocURL,
     BaseListFilter,
+    ListSelectionItems,
     with300Documents,
     ListDrawer,
     Placeholder,

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -22,6 +22,7 @@ import {
   formatDocURLCollectionSlug,
   geoCollectionSlug,
   listDrawerSlug,
+  listSelectionItemsSlug,
   placeholderCollectionSlug,
   postsCollectionSlug,
   virtualsSlug,
@@ -81,6 +82,7 @@ describe('List View', () => {
   let user: any
   let virtualsUrl: AdminUrlUtil
   let noTimestampsUrl: AdminUrlUtil
+  let listSelectionItemsUrl: AdminUrlUtil
 
   let serverURL: string
   let adminRoutes: ReturnType<typeof getRoutes>
@@ -108,6 +110,7 @@ describe('List View', () => {
     formatDocURLUrl = new AdminUrlUtil(serverURL, formatDocURLCollectionSlug)
     virtualsUrl = new AdminUrlUtil(serverURL, virtualsSlug)
     noTimestampsUrl = new AdminUrlUtil(serverURL, noTimestampsSlug)
+    listSelectionItemsUrl = new AdminUrlUtil(serverURL, listSelectionItemsSlug)
     const context = await browser.newContext()
     page = await context.newPage()
     initPageConsoleErrorCatch(page)
@@ -273,6 +276,24 @@ describe('List View', () => {
           hasText: exactText('AfterList custom component'),
         }),
       ).toBeVisible()
+    })
+
+    test('should render custom listSelectionItems component', async () => {
+      await payload.create({
+        collection: listSelectionItemsSlug,
+        data: { title: 'Test Document' },
+      })
+
+      await page.goto(listSelectionItemsUrl.list)
+      await page.waitForURL(listSelectionItemsUrl.list)
+
+      const selectRow = page.locator('.row-1 .cell-_select input')
+      await expect(selectRow).toBeVisible()
+      await selectRow.click()
+
+      const customListSelection = page.locator('#list-selection-custom-component')
+      await expect(customListSelection).toBeVisible()
+      await expect(customListSelection).toContainText('List selection custom component')
     })
   })
 

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -90,6 +90,7 @@ export interface Config {
     'edit-menu-items': EditMenuItem;
     'format-doc-url': FormatDocUrl;
     'base-list-filters': BaseListFilter;
+    'list-selection-items': ListSelectionItem;
     with300documents: With300Document;
     'with-list-drawer': WithListDrawer;
     placeholder: Placeholder;
@@ -130,6 +131,7 @@ export interface Config {
     'edit-menu-items': EditMenuItemsSelect<false> | EditMenuItemsSelect<true>;
     'format-doc-url': FormatDocUrlSelect<false> | FormatDocUrlSelect<true>;
     'base-list-filters': BaseListFiltersSelect<false> | BaseListFiltersSelect<true>;
+    'list-selection-items': ListSelectionItemsSelect<false> | ListSelectionItemsSelect<true>;
     with300documents: With300DocumentsSelect<false> | With300DocumentsSelect<true>;
     'with-list-drawer': WithListDrawerSelect<false> | WithListDrawerSelect<true>;
     placeholder: PlaceholderSelect<false> | PlaceholderSelect<true>;
@@ -560,6 +562,16 @@ export interface BaseListFilter {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "list-selection-items".
+ */
+export interface ListSelectionItem {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "with300documents".
  */
 export interface With300Document {
@@ -783,6 +795,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'base-list-filters';
         value: string | BaseListFilter;
+      } | null)
+    | ({
+        relationTo: 'list-selection-items';
+        value: string | ListSelectionItem;
       } | null)
     | ({
         relationTo: 'with300documents';
@@ -1204,6 +1220,15 @@ export interface BaseListFiltersSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "list-selection-items_select".
+ */
+export interface ListSelectionItemsSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "with300documents_select".
  */
 export interface With300DocumentsSelect<T extends boolean = true> {
@@ -1558,6 +1583,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore 
+  // @ts-ignore
   export interface GeneratedTypes extends Config {}
 }

--- a/test/admin/slugs.ts
+++ b/test/admin/slugs.ts
@@ -72,3 +72,4 @@ export const globalSlugs = [
 ]
 export const with300DocumentsSlug = 'with300documents'
 export const editMenuItemsSlug = 'edit-menu-items'
+export const listSelectionItemsSlug = 'list-selection-items'


### PR DESCRIPTION
### What?

Adds a new custom component called `listSelectionItems` that can be used in the list view.

I had attempted to implement this in a previous [PR](https://github.com/payloadcms/payload/pull/11719) but closed it. I have decided to resurface it due to popular demand with some changes to match the flows of other existing custom components.

### Why?

To increase flexibility and customization for users who may want to apply additional functionality to bulk selected documents.

### How?

Added the `listSelectionItems` slot into the `ListSelection` component.