### PR TITLE
fix(richtext-lexical): fix Czech translation for horizontal rule label

### DIFF
--- a/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
+++ b/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
@@ -11,7 +11,7 @@ export const i18n: Partial<GenericLanguages> = {
     label: 'Хоризонтална линия',
   },
   cs: {
-    label: 'Vodorovný pravítko',
+    label: 'Vodorovné pravítko',
   },
   da: {
     label: 'Horisontal Regel',


### PR DESCRIPTION

### What?

Fixes a grammatical error in a translation

### Why?

It's very obvious in UI
