### PR TITLE
feat(ui): enhance LeaveWithoutSaving component with popstate navigation handling

### DIFF
--- a/packages/ui/src/elements/LeaveWithoutSaving/index.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/index.tsx
@@ -43,12 +43,14 @@ export const LeaveWithoutSaving: React.FC<LeaveWithoutSavingProps> = ({
 
   const handleAccept = useCallback(() => {
     closeModal(modalSlug)
+    setHasAccepted(false)
   }, [closeModal, modalSlug])
 
   usePreventLeave({ hasAccepted, onAccept: handleAccept, onPrevent: handlePrevent, prevent })
 
   const onCancel: OnCancel = useCallback(() => {
     closeModal(modalSlug)
+    setHasAccepted(false)
   }, [closeModal, modalSlug])
 
   const handleConfirm = useCallback(async () => {

--- a/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
@@ -78,6 +78,8 @@ export const usePreventLeave = ({
 
   const router = useRouter()
   const cancelledURL = useRef<string>('')
+  // Track if we're handling a popstate (back/forward) navigation
+  const isPopstateNavigation = useRef<boolean>(false)
 
   // check when page is about to be changed
   useEffect(() => {
@@ -128,6 +130,7 @@ export const usePreventLeave = ({
           if (isPageLeaving && prevent && (!onPrevent ? !window.confirm(message) : true)) {
             // Keep a reference of the href
             cancelledURL.current = newUrl
+            isPopstateNavigation.current = false
 
             // Cancel the route change
             event.preventDefault()
@@ -153,14 +156,63 @@ export const usePreventLeave = ({
       document.removeEventListener('click', handleClick, true)
     }
   }, [onPrevent, prevent, message])
+  // Handle browser back/forward button navigation (popstate events)
+  useEffect(() => {
+    if (!prevent) return
+
+    // This prevents creating a fake back button when user landed directly on this page
+    const hasBackHistory = window.history.length > 1
+
+    if (!hasBackHistory) return
+
+    window.history.pushState(null, '', window.location.href)
+
+    function handlePopstate() {
+
+      window.history.pushState(null, '', window.location.href)
+
+      isPopstateNavigation.current = true
+
+      if (!onPrevent) {
+        if (window.confirm(message)) {
+          if (onAccept) {
+            onAccept()
+          }
+          // When the user clicks back, they pop this entry instead of leaving, allowing us to show a confirmation. If they confirm, we use history.go(-2) to skip both fake entries.
+          window.history.go(-2)
+        }
+        return
+      }
+
+      onPrevent()
+    }
+
+    // Add the global popstate event listener
+    window.addEventListener('popstate', handlePopstate)
+
+    return () => {
+      // Remove the global popstate event listener
+      window.removeEventListener('popstate', handlePopstate)
+    }
+  }, [prevent, onPrevent, onAccept, message])
 
   useEffect(() => {
-    if (hasAccepted && cancelledURL.current) {
+    if (hasAccepted) {
       if (onAccept) {
         onAccept()
       }
 
-      startRouteTransition(() => router.push(cancelledURL.current))
+      if (isPopstateNavigation.current) {
+        isPopstateNavigation.current = false
+        // For back button navigation, go back in history
+        window.history.go(-2)
+      } else if (cancelledURL.current) {
+        const url = cancelledURL.current
+        cancelledURL.current = ''
+
+        // For click navigation, push to the cancelled URL
+        startRouteTransition(() => router.push(url))
+      }
     }
   }, [hasAccepted, onAccept, router, startRouteTransition])
 }


### PR DESCRIPTION
### What?

Added support for handling browser back/forward navigation in the LeaveWithoutSaving component.

### Why?

To improve user experience by preventing accidental navigation away from the page without confirmation when using the browser's back and forward buttons.

### How?

Implemented a popstate event listener that prompts the user for confirmation when navigating away, and adjusted the route handling logic accordingly.

Additionally, ensured that the hasAccepted state is reset when the modal is closed or canceled.

Fixes #14957

### Video Demo

#### Before

https://github.com/user-attachments/assets/8056a89e-d40e-47ac-ab1f-c9068c536637

#### After

https://github.com/user-attachments/assets/a652eae8-2735-4200-bb66-ad1d462b93ad


<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
