### PR TITLE
docs: update link for MDN docs on cookies in requests

### DIFF
--- a/docs/authentication/cookies.mdx
+++ b/docs/authentication/cookies.mdx
@@ -32,7 +32,7 @@ const response = await fetch('http://localhost:3000/api/pages', {
 const pages = await response.json()
 ```
 
-For more about including cookies in requests from your app to your Payload API, [read the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Sending_a_request_with_credentials_included).
+For more about including cookies in requests from your app to your Payload API, [read the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials).
 
 <Banner type="success">
   **Tip:** To make sure you have a Payload cookie set properly in your browser


### PR DESCRIPTION
### What?

Update link to MDN docs section about credentials in fetch requests

### Why?

The heading in MDN docs changed

### How?

(no related issue)