### PR TITLE
fix(templates): add recommended serverExternalPackages to cloudflare

### DIFF
--- a/templates/with-cloudflare-d1/next.config.ts
+++ b/templates/with-cloudflare-d1/next.config.ts
@@ -2,6 +2,10 @@ import { withPayload } from '@payloadcms/next/withPayload'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Packages with Cloudflare Workers (workerd) specific code
+  // Read more: https://opennext.js.org/cloudflare/howtos/workerd
+  serverExternalPackages: ['jose', 'pg-cloudflare'],
+
   // Your Next.js config here
   webpack: (webpackConfig: any) => {
     webpackConfig.resolve.extensionAlias = {


### PR DESCRIPTION
### What?
Adds recommended serverExternalPackages to the Cloudflare template

### Why?
To make packages with cloudflare-specific code work with OpenNext.
More details here: https://opennext.js.org/cloudflare/howtos/workerd

### How?
By adding the serverExternalPackages property to next.config.ts

May fix #14656
Also helps when connecting to Postgres instead of D1 as mentioned in #14181