### PR TITLE
fix(richtext-lexical,ui): make uploadNode default to `alt` user-defined values.

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Upload/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Upload/index.tsx
@@ -279,6 +279,9 @@ const UploadDocumentDiff = (args: {
     id = uploadDoc
   }
 
+  const alt =
+    (value && typeof value === 'object' && (value as { alt?: string }).alt) || filename || ''
+
   return (
     <div
       className={`${baseClass}`}
@@ -288,7 +291,7 @@ const UploadDocumentDiff = (args: {
     >
       <div className={`${baseClass}__card`}>
         <div className={`${baseClass}__thumbnail`}>
-          {thumbnailSRC?.length ? <img alt={filename} src={thumbnailSRC} /> : <File />}
+          {thumbnailSRC?.length ? <img alt={alt} src={thumbnailSRC} /> : <File />}
         </div>
         {pillLabel && (
           <div className={`${baseClass}__pill`} data-enable-match="false">

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/converters/upload.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/converters/upload.ts
@@ -27,6 +27,8 @@ export const UploadHTMLConverterAsync: HTMLConvertersAsync<SerializedUploadNode>
       return ''
     }
 
+    const alt = (node.fields?.alt as string) || (uploadDoc as { alt?: string })?.alt || ''
+
     const url = uploadDoc.url
 
     // 1) If upload is NOT an image, return a link
@@ -38,7 +40,7 @@ export const UploadHTMLConverterAsync: HTMLConvertersAsync<SerializedUploadNode>
     if (!uploadDoc.sizes || !Object.keys(uploadDoc.sizes).length) {
       return `
         <img${providedStyleTag}
-          alt="${uploadDoc.filename}"
+          alt="${alt}"
           height="${uploadDoc.height}"
           src="${url}"
           width="${uploadDoc.width}"
@@ -75,7 +77,7 @@ export const UploadHTMLConverterAsync: HTMLConvertersAsync<SerializedUploadNode>
 
     pictureHTML += `
       <img
-        alt="${uploadDoc.filename}"
+        alt="${alt}"
         height="${uploadDoc.height}"
         src="${url}"
         width="${uploadDoc.width}"

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/sync/converters/upload.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/sync/converters/upload.ts
@@ -21,6 +21,8 @@ export const UploadHTMLConverter: HTMLConverters<SerializedUploadNode> = {
       return ''
     }
 
+    const alt = (node.fields?.alt as string) || (uploadDoc as { alt?: string })?.alt || ''
+
     const url = uploadDoc.url
 
     // 1) If upload is NOT an image, return a link
@@ -32,7 +34,7 @@ export const UploadHTMLConverter: HTMLConverters<SerializedUploadNode> = {
     if (!uploadDoc.sizes || !Object.keys(uploadDoc.sizes).length) {
       return `
         <img${providedStyleTag}
-          alt="${uploadDoc.filename}"
+          alt="${alt}"
           height="${uploadDoc.height}"
           src="${url}"
           width="${uploadDoc.width}"
@@ -69,7 +71,7 @@ export const UploadHTMLConverter: HTMLConverters<SerializedUploadNode> = {
 
     pictureHTML += `
       <img
-        alt="${uploadDoc.filename}"
+        alt="${alt}"
         height="${uploadDoc.height}"
         src="${url}"
         width="${uploadDoc.width}"

--- a/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/converters/upload.tsx
@@ -14,6 +14,8 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
 
     const uploadDoc = uploadNode.value as FileData & TypeWithID
 
+    const alt = (uploadNode.fields?.alt as string) || (uploadDoc as { alt?: string })?.alt || ''
+
     const url = uploadDoc.url
 
     /**
@@ -31,9 +33,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
      * If the upload is a simple image with no different sizes, return a simple img tag
      */
     if (!uploadDoc.sizes || !Object.keys(uploadDoc.sizes).length) {
-      return (
-        <img alt={uploadDoc.filename} height={uploadDoc.height} src={url} width={uploadDoc.width} />
-      )
+      return <img alt={alt} height={uploadDoc.height} src={url} width={uploadDoc.width} />
     }
 
     /**
@@ -71,13 +71,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
 
     // Add the default img tag
     pictureJSX.push(
-      <img
-        alt={uploadDoc?.filename}
-        height={uploadDoc?.height}
-        key={'image'}
-        src={url}
-        width={uploadDoc?.width}
-      />,
+      <img alt={alt} height={uploadDoc?.height} key={'image'} src={url} width={uploadDoc?.width} />,
     )
     return <picture>{pictureJSX}</picture>
   },

--- a/packages/richtext-lexical/src/features/upload/server/index.ts
+++ b/packages/richtext-lexical/src/features/upload/server/index.ts
@@ -177,6 +177,11 @@ export const UploadFeature = createServerFeature<
 
                   const url = getAbsoluteURL(uploadDocument?.value?.url ?? '', req?.payload)
 
+                  const alt =
+                    (node.fields?.alt as string) ||
+                    (uploadDocument?.value as { alt?: string })?.alt ||
+                    ''
+
                   /**
                    * If the upload is not an image, return a link to the upload
                    */
@@ -191,7 +196,7 @@ export const UploadFeature = createServerFeature<
                     !uploadDocument?.value?.sizes ||
                     !Object.keys(uploadDocument?.value?.sizes).length
                   ) {
-                    return `<img src="${url}" alt="${uploadDocument?.value?.filename}" width="${uploadDocument?.value?.width}"  height="${uploadDocument?.value?.height}"/>`
+                    return `<img src="${url}" alt="${alt}" width="${uploadDocument?.value?.width}"  height="${uploadDocument?.value?.height}"/>`
                   }
 
                   /**
@@ -220,7 +225,7 @@ export const UploadFeature = createServerFeature<
                   }
 
                   // Add the default img tag
-                  pictureHTML += `<img src="${url}" alt="Image" width="${uploadDocument.value?.width}" height="${uploadDocument.value?.height}">`
+                  pictureHTML += `<img src="${url}" alt="${alt}" width="${uploadDocument.value?.width}" height="${uploadDocument.value?.height}">`
                   pictureHTML += '</picture>'
                   return pictureHTML
                 } else {

--- a/packages/richtext-lexical/src/field/Diff/converters/upload/index.tsx
+++ b/packages/richtext-lexical/src/field/Diff/converters/upload/index.tsx
@@ -18,7 +18,7 @@ const baseClass = 'lexical-upload-diff'
 export const UploadDiffHTMLConverterAsync: (args: {
   i18n: I18nClient
   req: PayloadRequest
-}) => HTMLConvertersAsync<SerializedUploadNode> = ({ i18n, req }) => {
+}) => HTMLConvertersAsync<SerializedUploadNode> = () => {
   return {
     upload: async ({ node, populate, providedCSSString }) => {
       const uploadNode = node as UploadDataImproved
@@ -42,7 +42,7 @@ export const UploadDiffHTMLConverterAsync: (args: {
         return ''
       }
 
-      const relatedCollection = req.payload.collections[uploadNode.relationTo]?.config
+      const alt = (node.fields?.alt as string) || (uploadDoc as { alt?: string })?.alt || ''
 
       const thumbnailSRC: string =
         ('thumbnailURL' in uploadDoc && (uploadDoc?.thumbnailURL as string)) || uploadDoc?.url || ''
@@ -66,11 +66,7 @@ export const UploadDiffHTMLConverterAsync: (args: {
         >
           <div className={`${baseClass}__card`}>
             <div className={`${baseClass}__thumbnail`}>
-              {thumbnailSRC?.length ? (
-                <img alt={uploadDoc?.filename} src={thumbnailSRC} />
-              ) : (
-                <File />
-              )}
+              {thumbnailSRC?.length ? <img alt={alt} src={thumbnailSRC} /> : <File />}
             </div>
             <div className={`${baseClass}__info`} data-enable-match="false">
               <strong>{uploadDoc?.filename}</strong>

--- a/packages/richtext-slate/src/field/elements/upload/Element/index.tsx
+++ b/packages/richtext-slate/src/field/elements/upload/Element/index.tsx
@@ -136,6 +136,8 @@ const UploadElementComponent: React.FC<{ enabledCollectionSlugs?: string[] }> = 
   const relatedFieldSchemaPath = `${uploadFieldsSchemaPath}.${relatedCollection.slug}`
   const customFieldsMap = fieldProps.componentMap[relatedFieldSchemaPath]
 
+  const alt = (data as { alt?: string })?.alt || data?.filename || ''
+
   return (
     <div
       className={[baseClass, selected && focused && `${baseClass}--selected`]
@@ -148,7 +150,7 @@ const UploadElementComponent: React.FC<{ enabledCollectionSlugs?: string[] }> = 
         <div className={`${baseClass}__topRow`}>
           {/* TODO: migrate to use Thumbnail component */}
           <div className={`${baseClass}__thumbnail`}>
-            {thumbnailSRC ? <img alt={data?.filename} src={thumbnailSRC} /> : <File />}
+            {thumbnailSRC ? <img alt={alt} src={thumbnailSRC} /> : <File />}
           </div>
           <div className={`${baseClass}__topRowRightPanel`}>
             <div className={`${baseClass}__collectionLabel`}>

--- a/packages/ui/src/elements/PreviewSizes/index.tsx
+++ b/packages/ui/src/elements/PreviewSizes/index.tsx
@@ -33,6 +33,7 @@ const sortSizes = (sizes: FilesSizesWithUrl, imageSizes: SanitizedUploadConfig['
 
 type PreviewSizeCardProps = {
   active: boolean
+  alt: string
   meta: FileInfo
   name: string
   onClick?: () => void
@@ -41,6 +42,7 @@ type PreviewSizeCardProps = {
 const PreviewSizeCard: React.FC<PreviewSizeCardProps> = ({
   name,
   active,
+  alt,
   meta,
   onClick,
   previewSrc,
@@ -63,7 +65,7 @@ const PreviewSizeCard: React.FC<PreviewSizeCardProps> = ({
       tabIndex={0}
     >
       <div className={`${baseClass}__image`}>
-        <img alt={meta.filename} src={previewSrc} />
+        <img alt={alt} src={previewSrc} />
       </div>
       <div className={`${baseClass}__sizeMeta`}>
         <div className={`${baseClass}__sizeName`}>{name}</div>
@@ -84,6 +86,8 @@ export type PreviewSizesProps = {
 export const PreviewSizes: React.FC<PreviewSizesProps> = ({ doc, imageCacheTag, uploadConfig }) => {
   const { imageSizes } = uploadConfig
   const { sizes } = doc
+
+  const alt = (doc as { alt?: string })?.alt || doc.filename || ''
 
   const [orderedSizes, setOrderedSizes] = useState<FilesSizesWithUrl>(() =>
     sortSizes(sizes, imageSizes),
@@ -126,12 +130,13 @@ export const PreviewSizes: React.FC<PreviewSizesProps> = ({ doc, imageCacheTag, 
           <div className={`${baseClass}__sizeName`}>{selectedSize || originalFilename}</div>
           <FileMeta {...(selectedSize ? orderedSizes[selectedSize] : originalImage)} />
         </div>
-        <img alt={doc.filename} className={`${baseClass}__preview`} src={mainPreviewSrc} />
+        <img alt={alt} className={`${baseClass}__preview`} src={mainPreviewSrc} />
       </div>
       <div className={`${baseClass}__listWrap`}>
         <div className={`${baseClass}__list`}>
           <PreviewSizeCard
             active={!selectedSize}
+            alt={alt}
             meta={originalImage}
             name={originalFilename}
             onClick={() => setSelectedSize(null)}
@@ -146,6 +151,7 @@ export const PreviewSizes: React.FC<PreviewSizesProps> = ({ doc, imageCacheTag, 
               return (
                 <PreviewSizeCard
                   active={selected}
+                  alt={alt}
                   key={key}
                   meta={val}
                   name={key}


### PR DESCRIPTION
Fix #14780

There are 2 ways a user can add fields to UploadNode within richtext:
```ts
// 1. Media Collection
export const Media: CollectionConfig = {
  slug: 'media',
  fields: [
    { name: 'alt', type: 'text' }  // ← Default alt for the image
  ],
  upload: true,
}

// 2. UploadFeature in Lexical (Per-instance override)
UploadFeature({
  collections: {
    media: {
      fields: [
        { name: 'alt', type: 'text' }  // ← Context-specific alt per usage
      ]
    }
  }
})
```
This PR updates all upload converters (JSX, HTML async/sync, Slate, and UI components) to intelligently resolve the `alt` attribute with the following priority:

1. **UploadFeature `fields.alt`** - Context-specific override
2. **Media collection `alt`** - Default from document
3. **Empty string** - Accessibility fallback (instead of using filename)

This prevents users from having to manually override converters to achieve proper alt text handling.

**Implementation note:** Type assertions are required since both `alt` fields are user-defined and don't exist in the core types at compile time.