### PR TITLE
fix(templates): improve cli detection in cloudflare template

### DIFF
--- a/templates/with-cloudflare-d1/src/payload.config.ts
+++ b/templates/with-cloudflare-d1/src/payload.config.ts
@@ -1,6 +1,7 @@
+import fs from 'fs'
+import path from 'path'
 import { sqliteD1Adapter } from '@payloadcms/db-d1-sqlite'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
-import path from 'path'
 import { buildConfig } from 'payload'
 import { fileURLToPath } from 'url'
 import { CloudflareContext, getCloudflareContext } from '@opennextjs/cloudflare'
@@ -12,8 +13,9 @@ import { Media } from './collections/Media'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+const realpath = (value: string) => (fs.existsSync(value) ? fs.realpathSync(value) : undefined)
 
-const isCLI = process.argv.some((value) => value.match(/^(generate|migrate):?/))
+const isCLI = process.argv.some((value) => realpath(value).endsWith(path.join('payload', 'bin.js')))
 const isProduction = process.env.NODE_ENV === 'production'
 
 const cloudflare =


### PR DESCRIPTION
### What?
Improves the CLI detection in the Cloudflare template

### Why?
To also support running scripts via `payload run`

### How?
By looking for Payload's bin.js inside process.argv instead of just looking for the generate/migrate commands.

Discord discussion: https://discord.com/channels/967097582721572934/1439728398405468291
