### PR TITLE
chore: add full field path to field sanitize errors

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -799,7 +799,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           depth = args.depth
         }
         if (!field?.editor) {
-          throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+          throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
         }
 
         if (typeof field?.editor === 'function') {

--- a/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -263,7 +263,7 @@ const buildVersionField = ({
   let CustomComponent = customDiffComponents?.[field.type]
   if (field?.type === 'richText') {
     if (!field?.editor) {
-      throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+      throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
     }
 
     if (typeof field?.editor === 'function') {

--- a/packages/payload/src/errors/DuplicateFieldName.ts
+++ b/packages/payload/src/errors/DuplicateFieldName.ts
@@ -1,9 +1,12 @@
 import { APIError } from './APIError.js'
 
 export class DuplicateFieldName extends APIError {
-  constructor(fieldName: string) {
+  constructor(fieldName: string, collectionName?: string, blockFieldName?: string) {
+    const collectionString = collectionName ? ` in collection '${collectionName}'` : ''
+    const blockFieldString = blockFieldName ? ` in field '${blockFieldName}'` : ''
+    const contextString = collectionString + blockFieldString
     super(
-      `A field with the name '${fieldName}' was found multiple times on the same level. Field names must be unique.`,
+      `A field with the name '${fieldName}' was found multiple times on the same level${contextString}. Field names must be unique.`,
     )
   }
 }

--- a/packages/payload/src/errors/DuplicateFieldName.ts
+++ b/packages/payload/src/errors/DuplicateFieldName.ts
@@ -1,12 +1,9 @@
 import { APIError } from './APIError.js'
 
 export class DuplicateFieldName extends APIError {
-  constructor(fieldName: string, collectionName?: string, blockFieldName?: string) {
-    const collectionString = collectionName ? ` in collection '${collectionName}'` : ''
-    const blockFieldString = blockFieldName ? ` in field '${blockFieldName}'` : ''
-    const contextString = collectionString + blockFieldString
+  constructor(fieldPath: string) {
     super(
-      `A field with the name '${fieldName}' was found multiple times on the same level${contextString}. Field names must be unique.`,
+      `A field with path '${fieldPath}' was found multiple times on the same level. Field names must be unique.`,
     )
   }
 }

--- a/packages/payload/src/errors/InvalidFieldJoin.ts
+++ b/packages/payload/src/errors/InvalidFieldJoin.ts
@@ -3,9 +3,9 @@ import type { JoinField } from '../fields/config/types.js'
 import { APIError } from './APIError.js'
 
 export class InvalidFieldJoin extends APIError {
-  constructor(field: JoinField) {
+  constructor(field: JoinField, fieldPath: string) {
     super(
-      `Invalid join field ${field.name}. The config does not have a field '${field.on}' in collection '${field.collection}'.`,
+      `Invalid join field with path ${fieldPath}. The config does not have a field '${field.on}' in collection '${field.collection}'.`,
     )
   }
 }

--- a/packages/payload/src/errors/InvalidFieldName.ts
+++ b/packages/payload/src/errors/InvalidFieldName.ts
@@ -1,11 +1,9 @@
-import type { FieldAffectingData } from '../fields/config/types.js'
-
 import { APIError } from './APIError.js'
 
 export class InvalidFieldName extends APIError {
-  constructor(field: FieldAffectingData, fieldName: string) {
+  constructor(fieldPath: string, fieldName: string) {
     super(
-      `Field ${field.label} has invalid name '${fieldName}'. Field names can not include periods (.) and must be alphanumeric.`,
+      `Field at path ${fieldPath} has invalid name '${fieldName}'. Field names can not include periods (.) and must be alphanumeric.`,
     )
   }
 }

--- a/packages/payload/src/errors/InvalidFieldRelationship.ts
+++ b/packages/payload/src/errors/InvalidFieldRelationship.ts
@@ -1,9 +1,7 @@
-import type { RelationshipField, UploadField } from '../fields/config/types.js'
-
 import { APIError } from './APIError.js'
 
 export class InvalidFieldRelationship extends APIError {
-  constructor(field: RelationshipField | UploadField, relationship: string) {
-    super(`Field ${field.label} has invalid relationship '${relationship}'.`)
+  constructor(fieldPath: string, relationship: string) {
+    super(`Field with path ${fieldPath} has invalid relationship '${relationship}'.`)
   }
 }

--- a/packages/payload/src/errors/MissingEditorProp.ts
+++ b/packages/payload/src/errors/MissingEditorProp.ts
@@ -1,9 +1,18 @@
 import { APIError } from './APIError.js'
 
+type MissingEditorPropArgs =
+  | {
+      fieldName: string
+    }
+  | {
+      fieldPath: string
+    }
+
 export class MissingEditorProp extends APIError {
-  constructor(fieldPath: string) {
+  constructor(args: MissingEditorPropArgs) {
+    const nameOrPath = 'fieldName' in args ? `name ${args.fieldName}` : `path ${args.fieldPath}`
     super(
-      `RichText field with path ${fieldPath} is missing the editor prop. For sub-richText fields, the editor props is required, as it would otherwise create infinite recursion.`,
+      `RichText field with ${nameOrPath} is missing the editor prop. For sub-richText fields, the editor props is required, as it would otherwise create infinite recursion.`,
     )
   }
 }

--- a/packages/payload/src/errors/MissingEditorProp.ts
+++ b/packages/payload/src/errors/MissingEditorProp.ts
@@ -1,12 +1,9 @@
-import type { Field } from '../fields/config/types.js'
-
-import { fieldAffectsData } from '../fields/config/types.js'
 import { APIError } from './APIError.js'
 
 export class MissingEditorProp extends APIError {
-  constructor(field: Field) {
+  constructor(fieldPath: string) {
     super(
-      `RichText field${fieldAffectsData(field) ? ` "${field.name}"` : ''} is missing the editor prop. For sub-richText fields, the editor props is required, as it would otherwise create infinite recursion.`,
+      `RichText field with path ${fieldPath} is missing the editor prop. For sub-richText fields, the editor props is required, as it would otherwise create infinite recursion.`,
     )
   }
 }

--- a/packages/payload/src/errors/ReservedFieldName.ts
+++ b/packages/payload/src/errors/ReservedFieldName.ts
@@ -3,7 +3,7 @@ import type { FieldAffectingData } from '../fields/config/types.js'
 import { APIError } from './APIError.js'
 
 export class ReservedFieldName extends APIError {
-  constructor(field: FieldAffectingData, fieldName: string) {
-    super(`Field ${field.label} has reserved name '${fieldName}'.`)
+  constructor(fieldPath: string, fieldName: string) {
+    super(`Field ${fieldPath} has reserved name '${fieldName}'.`)
   }
 }

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -388,7 +388,7 @@ export const createClientField = ({
 
     case 'richText': {
       if (!incomingField?.editor) {
-        throw new MissingEditorProp(incomingField) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        throw new MissingEditorProp({ fieldName: incomingField.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
       if (typeof incomingField?.editor === 'function') {

--- a/packages/payload/src/fields/config/sanitize.spec.ts
+++ b/packages/payload/src/fields/config/sanitize.spec.ts
@@ -21,7 +21,9 @@ import { describe, it, expect } from 'vitest'
 
 describe('sanitizeFields', () => {
   const config = {} as Config
-  const collectionConfig = {} as CollectionConfig
+  const collectionConfig = {
+    slug: 'example-collection',
+  } as CollectionConfig
 
   it('should throw on missing type field', async () => {
     const fields: Field[] = [
@@ -75,14 +77,21 @@ describe('sanitizeFields', () => {
       },
     ]
 
-    await expect(async () => {
+    let error: Error | null = null
+    try {
       await sanitizeFields({
         config,
         collectionConfig,
         fields,
         validRelationships: [],
       })
-    }).rejects.toThrow(DuplicateFieldName)
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeInstanceOf(DuplicateFieldName)
+    expect(error?.message).toBe(
+      "A field with the name 'someField' was found multiple times on the same level in collection 'example-collection'. Field names must be unique.",
+    )
   })
 
   it('should throw on duplicate block slug', async () => {
@@ -113,14 +122,21 @@ describe('sanitizeFields', () => {
       },
     ]
 
-    await expect(async () => {
+    let error: Error | null = null
+    try {
       await sanitizeFields({
         config,
         collectionConfig,
         fields,
         validRelationships: [],
       })
-    }).rejects.toThrow(DuplicateFieldName)
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeInstanceOf(DuplicateFieldName)
+    expect(error?.message).toBe(
+      "A field with the name 'block' was found multiple times on the same level in collection 'example-collection' in field 'blocks'. Field names must be unique.",
+    )
   })
 
   describe('auto-labeling', () => {

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -231,7 +231,7 @@ export const sanitizeFields = async ({
 
     if (fieldAffectsData) {
       if (existingFieldNames.has(field.name)) {
-        throw new DuplicateFieldName(field.name)
+        throw new DuplicateFieldName(field.name, collectionConfig?.slug)
       } else if (!['blockName', 'id'].includes(field.name)) {
         existingFieldNames.add(field.name)
       }
@@ -320,7 +320,7 @@ export const sanitizeFields = async ({
         const blockSlug = typeof block === 'string' ? block : block.slug
 
         if (blockSlugs.includes(blockSlug)) {
-          throw new DuplicateFieldName(blockSlug)
+          throw new DuplicateFieldName(blockSlug, collectionConfig?.slug, field.name)
         }
 
         blockSlugs.push(blockSlug)

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -179,8 +179,15 @@ export const sanitizeFields = async ({
     }
 
     if (field.type === 'join') {
-      // TODO - come back to this
-      sanitizeJoinField({ config, field, joinPath, joins, parentIsLocalized, polymorphicJoins })
+      sanitizeJoinField({
+        config,
+        field,
+        joinPath,
+        joins,
+        parentIsLocalized,
+        pathToField,
+        polymorphicJoins,
+      })
     }
 
     if (field.type === 'relationship' || field.type === 'upload') {

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -9,7 +9,6 @@ import type {
 import type { Config, SanitizedConfig } from '../../config/types.js'
 import type { GlobalConfig } from '../../globals/config/types.js'
 import type { Field } from './types.js'
-import { fieldAffectsData as _fieldAffectsData, fieldIsLocalized, tabHasName } from './types.js'
 
 import {
   DuplicateFieldName,
@@ -36,6 +35,7 @@ import {
   reservedVerifyFieldNames,
 } from './reservedFieldNames.js'
 import { sanitizeJoinField } from './sanitizeJoinField.js'
+import { fieldAffectsData as _fieldAffectsData, fieldIsLocalized, tabHasName } from './types.js'
 
 type Args = {
   collectionConfig?: CollectionConfig

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -56,7 +56,7 @@ type Args = {
   /**
    *  Keep track of the path to this field so we can log the full field path on errors
    */
-  pathToField: string[]
+  pathToField?: string[]
   polymorphicJoins?: SanitizedJoin[]
   /**
    * If true, a richText field will require an editor property to be set, as the sanitizeFields function will not add it from the payload config if not present.
@@ -302,7 +302,7 @@ export const sanitizeFields = async ({
             // config.editor should be sanitized at this point
             field.editor = _config.editor
           } else {
-            throw new MissingEditorProp(pathToFieldString) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+            throw new MissingEditorProp({ fieldPath: pathToFieldString }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
           }
         }
 

--- a/packages/payload/src/fields/config/sanitizeJoinField.ts
+++ b/packages/payload/src/fields/config/sanitizeJoinField.ts
@@ -13,6 +13,7 @@ export const sanitizeJoinField = ({
   joinPath,
   joins,
   parentIsLocalized,
+  pathToField: incomingPathToField,
   polymorphicJoins,
   validateOnly,
 }: {
@@ -21,6 +22,7 @@ export const sanitizeJoinField = ({
   joinPath?: string
   joins?: SanitizedJoins
   parentIsLocalized: boolean
+  pathToField: string[]
   polymorphicJoins?: SanitizedJoin[]
   validateOnly?: boolean
 }) => {
@@ -52,6 +54,7 @@ export const sanitizeJoinField = ({
         joinPath,
         joins,
         parentIsLocalized,
+        pathToField: [...incomingPathToField, sanitizedField.name],
         polymorphicJoins,
         validateOnly: true,
       })
@@ -64,11 +67,13 @@ export const sanitizeJoinField = ({
     return
   }
 
+  const pathToFieldString = incomingPathToField.join(' > ')
+
   const joinCollection = config.collections?.find(
     (collection) => collection.slug === field.collection,
   )
   if (!joinCollection) {
-    throw new InvalidFieldJoin(field)
+    throw new InvalidFieldJoin(field, pathToFieldString)
   }
 
   const relationshipField = getFieldByPath({
@@ -80,7 +85,7 @@ export const sanitizeJoinField = ({
     !relationshipField ||
     (relationshipField.field.type !== 'relationship' && relationshipField.field.type !== 'upload')
   ) {
-    throw new InvalidFieldJoin(join.field)
+    throw new InvalidFieldJoin(join.field, pathToFieldString)
   }
 
   if (relationshipField.pathHasLocalized) {

--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -265,7 +265,7 @@ export const promise = async ({
 
     case 'richText': {
       if (!field?.editor) {
-        throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
       if (typeof field.editor === 'function') {

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -237,7 +237,7 @@ export const promise = async ({
 
     case 'richText': {
       if (!field?.editor) {
-        throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
       if (typeof field?.editor === 'function') {
         throw new Error('Attempted to access unsanitized rich text editor.')
@@ -777,7 +777,7 @@ export const promise = async ({
 
     case 'richText': {
       if (!field?.editor) {
-        throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
       if (typeof field?.editor === 'function') {

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -537,7 +537,7 @@ export const promise = async ({
 
     case 'richText': {
       if (!field?.editor) {
-        throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
       if (typeof field?.editor === 'function') {

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -496,7 +496,7 @@ export const promise = async <T>({
 
     case 'richText': {
       if (!field?.editor) {
-        throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
       if (typeof field?.editor === 'function') {

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -624,7 +624,7 @@ export function fieldsToJSONSchema(
           }
           case 'richText': {
             if (!field?.editor) {
-              throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+              throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
             }
             if (typeof field.editor === 'function') {
               throw new Error('Attempted to access unsanitized rich text editor.')

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -242,7 +242,7 @@ export const renderField: RenderFieldMethod = ({
   switch (fieldConfig.type) {
     case 'richText': {
       if (!fieldConfig?.editor) {
-        throw new MissingEditorProp(fieldConfig) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        throw new MissingEditorProp({ fieldName: fieldConfig.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
       if (typeof fieldConfig?.editor === 'function') {

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -162,7 +162,7 @@ export function renderCell({
 
   if (serverField?.type === 'richText') {
     if (!serverField?.editor) {
-      throw new MissingEditorProp(serverField) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+      throw new MissingEditorProp({ fieldName: serverField.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
     }
 
     if (typeof serverField?.editor === 'function') {

--- a/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
+++ b/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
@@ -103,7 +103,7 @@ export const traverseFields = ({
 
       case 'richText': {
         if (!field?.editor) {
-          throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+          throw new MissingEditorProp({ fieldName: field.name }) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
         }
 
         if (typeof field.editor === 'function') {


### PR DESCRIPTION
### What?

Add full field path to field config sanitize errors.

### Why?

Helps locate where the incorrect configuration is. I am currently getting an error message 

```
"A field with the name 'folder' was found multiple times on the same level. Field names must be unique." 
```

and I'm unsure which collection is causing the issue. 

### How?

Pass the full path to the field through, and concatenate with ' > ' to display the full path.
