### PR TITLE
refactor: deprecate returning failed state from job queue handlers

### DIFF
--- a/packages/payload/src/queues/config/types/taskTypes.ts
+++ b/packages/payload/src/queues/config/types/taskTypes.ts
@@ -10,7 +10,13 @@ export type TaskHandlerResult<
   TTaskSlugOrInputOutput extends keyof TypedJobs['tasks'] | TaskInputOutput,
 > =
   | {
+      /**
+       * @deprecated Returning `state: 'failed'` is deprecated. Throw an error instead.
+       */
       errorMessage?: string
+      /**
+       * @deprecated Returning `state: 'failed'` is deprecated. Throw an error instead.
+       */
       state: 'failed'
     }
   | {
@@ -53,7 +59,7 @@ export type TaskHandler<
   TWorkflowSlug extends keyof TypedJobs['workflows'] = string,
 > = (
   args: TaskHandlerArgs<TTaskSlugOrInputOutput, TWorkflowSlug>,
-) => Promise<TaskHandlerResult<TTaskSlugOrInputOutput>> | TaskHandlerResult<TTaskSlugOrInputOutput>
+) => MaybePromise<TaskHandlerResult<TTaskSlugOrInputOutput>>
 
 /**
  * @todo rename to TaskSlug in 4.0, similar to CollectionSlug
@@ -116,7 +122,13 @@ export type RunInlineTaskFunction = <TTaskInput extends object, TTaskOutput exte
       tasks: RunTaskFunctions
     }) => MaybePromise<
       | {
+          /**
+           * @deprecated Returning `state: 'failed'` is deprecated. Throw an error instead.
+           */
           errorMessage?: string
+          /**
+           * @deprecated Returning `state: 'failed'` is deprecated. Throw an error instead.
+           */
           state: 'failed'
         }
       | {
@@ -140,7 +152,7 @@ export type TaskCallbackArgs = {
 export type ShouldRestoreFn = (
   args: { taskStatus: SingleTaskStatus<string> } & Omit<TaskCallbackArgs, 'taskStatus'>,
 ) => boolean | Promise<boolean>
-export type TaskCallbackFn = (args: TaskCallbackArgs) => Promise<void> | void
+export type TaskCallbackFn = (args: TaskCallbackArgs) => MaybePromise<void>
 
 export type RetryConfig = {
   /**


### PR DESCRIPTION
This PR deprecates returning `{ state: 'failed' }`, which unnecessarily inflates the API.

**Reasons:**
- It duplicates existing behavior, making the API and docs more confusing.
- It creates ambiguity about which approach developers should use.
- It increases maintenance cost.
- Throwing errors is more flexible: for example, cancelling a job from a task handler currently requires throwing `JobCancelledError`, which cannot be done via a return value.


# Migration Example

## Before

```ts
import type { TaskConfig } from 'payload'

export const ReturnCustomErrorTask: TaskConfig<'ReturnCustomError'> = {
  retries: 0,
  slug: 'ReturnCustomError',
  inputSchema: [],
  outputSchema: [],
  handler: ({ input }) => {
    return {
      state: 'failed',
      errorMessage: 'oh no! this failed'
    }
  },
}
```

## After

```ts
import type { TaskConfig } from 'payload'

export const ReturnCustomErrorTask: TaskConfig<'ReturnCustomError'> = {
  retries: 0,
  slug: 'ReturnCustomError',
  inputSchema: [],
  outputSchema: [],
  handler: ({ input }) => {
    throw new Error('oh no! this failed')
  },
}
```