### PR TITLE
fix: remove tilde imports in scss files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm lint -- --quiet
 
       - name: Lint SCSS
-        run: pnpm run lint:scss
+        run: pnpm run lint:styles
 
   build:
     needs: changes

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "lint": "turbo run lint --log-order=grouped --continue --filter \"!blank\" --filter \"!website\" --filter \"!ecommerce\"",
     "lint-staged": "lint-staged",
     "lint:fix": "turbo run lint:fix --log-order=grouped --continue --filter \"!blank\" --filter \"!website\" --filter \"!ecommerce\"",
-    "lint:scss": "stylelint \"packages/ui/src/**/*.scss\"",
+    "lint:styles": "stylelint \"**/*.scss\"",
     "obliterate-playwright-cache-macos": "rm -rf ~/Library/Caches/ms-playwright && find /System/Volumes/Data/private/var/folders -type d -name 'playwright*' -exec rm -rf {} +",
     "prepare": "husky",
     "prepare-run-test-against-prod": "pnpm bf && rm -rf test/packed && rm -rf test/node_modules && rm -rf app && rm -f test/pnpm-lock.yaml && pnpm run script:pack --all --no-build --dest test/packed && pnpm runts test/setupProd.ts && cd test && pnpm i --ignore-workspace && cd ..",

--- a/packages/next/src/elements/DocumentHeader/Tabs/Tab/index.scss
+++ b/packages/next/src/elements/DocumentHeader/Tabs/Tab/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .doc-tab {

--- a/packages/next/src/elements/DocumentHeader/Tabs/index.scss
+++ b/packages/next/src/elements/DocumentHeader/Tabs/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .doc-tabs {

--- a/packages/next/src/elements/DocumentHeader/index.scss
+++ b/packages/next/src/elements/DocumentHeader/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .doc-header {

--- a/packages/next/src/elements/Nav/NavWrapper/index.scss
+++ b/packages/next/src/elements/Nav/NavWrapper/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .nav {

--- a/packages/next/src/elements/Nav/SettingsMenuButton/index.scss
+++ b/packages/next/src/elements/Nav/SettingsMenuButton/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .settings-menu-button {

--- a/packages/next/src/elements/Nav/index.scss
+++ b/packages/next/src/elements/Nav/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .nav {

--- a/packages/next/src/templates/Default/Wrapper/index.scss
+++ b/packages/next/src/templates/Default/Wrapper/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .template-default {

--- a/packages/next/src/templates/Default/index.scss
+++ b/packages/next/src/templates/Default/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .template-default {

--- a/packages/next/src/templates/Minimal/index.scss
+++ b/packages/next/src/templates/Minimal/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .template-minimal {

--- a/packages/next/src/views/API/RenderJSON/index.scss
+++ b/packages/next/src/views/API/RenderJSON/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 $tab-width: 24px;
 

--- a/packages/next/src/views/API/index.scss
+++ b/packages/next/src/views/API/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .query-inspector {

--- a/packages/next/src/views/Account/Settings/index.scss
+++ b/packages/next/src/views/Account/Settings/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .payload-settings {

--- a/packages/next/src/views/CreateFirstUser/index.scss
+++ b/packages/next/src/views/CreateFirstUser/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .create-first-user {

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .modular-dashboard {

--- a/packages/next/src/views/Logout/index.scss
+++ b/packages/next/src/views/Logout/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .logout {

--- a/packages/next/src/views/NotFound/index.scss
+++ b/packages/next/src/views/NotFound/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .not-found {

--- a/packages/next/src/views/ResetPassword/index.scss
+++ b/packages/next/src/views/ResetPassword/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .reset-password__wrap {

--- a/packages/next/src/views/Unauthorized/index.scss
+++ b/packages/next/src/views/Unauthorized/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .unauthorized {

--- a/packages/next/src/views/Version/Default/index.scss
+++ b/packages/next/src/views/Version/Default/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .view-version {

--- a/packages/next/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.scss
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .diff-collapser {

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Relationship/index.scss
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Relationship/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .relationship-diff-container .field-diff-content {

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Upload/index.scss
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Upload/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .upload-diff-container .field-diff-content {

--- a/packages/next/src/views/Version/RenderFieldsToDiff/index.scss
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .render-field-diffs {

--- a/packages/next/src/views/Version/Restore/index.scss
+++ b/packages/next/src/views/Version/Restore/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .restore-version {

--- a/packages/next/src/views/Version/SelectComparison/VersionDrawer/index.scss
+++ b/packages/next/src/views/Version/SelectComparison/VersionDrawer/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .version-drawer {

--- a/packages/next/src/views/Version/SelectComparison/index.scss
+++ b/packages/next/src/views/Version/SelectComparison/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .compare-version {

--- a/packages/next/src/views/Version/VersionPillLabel/index.scss
+++ b/packages/next/src/views/Version/VersionPillLabel/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .version-pill-label {

--- a/packages/next/src/views/Versions/index.scss
+++ b/packages/next/src/views/Versions/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .versions {

--- a/packages/plugin-import-export/src/components/ExportListMenuItem/index.scss
+++ b/packages/plugin-import-export/src/components/ExportListMenuItem/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .export-list-menu-item {

--- a/packages/richtext-lexical/src/features/blocks/client/component/index.scss
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .LexicalEditorTheme__block {

--- a/packages/richtext-lexical/src/features/blocks/client/componentInline/index.scss
+++ b/packages/richtext-lexical/src/features/blocks/client/componentInline/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .LexicalEditorTheme__inlineBlock {

--- a/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/Collapse/index.scss
+++ b/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/Collapse/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .code-block-collapse-button {
   all: unset;

--- a/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/FloatingCollapse/index.scss
+++ b/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/FloatingCollapse/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .code-block-floating-collapse-button {
   all: unset;

--- a/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/index.scss
+++ b/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .payload-richtext-code-block.collapsible--collapsed {
   .rah-static {

--- a/packages/richtext-lexical/src/features/debug/testRecorder/client/plugin/index.scss
+++ b/packages/richtext-lexical/src/features/debug/testRecorder/client/plugin/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .test-recorder-output {

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TableActionMenuPlugin/index.scss
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TableActionMenuPlugin/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .table-cell-action-button-container {

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .LexicalEditorTheme {

--- a/packages/richtext-lexical/src/features/horizontalRule/client/plugin/index.scss
+++ b/packages/richtext-lexical/src/features/horizontalRule/client/plugin/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .LexicalEditorTheme__hr {

--- a/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/index.scss
+++ b/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .link-editor {

--- a/packages/richtext-lexical/src/features/relationship/client/components/index.scss
+++ b/packages/richtext-lexical/src/features/relationship/client/components/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .LexicalEditorTheme__relationship {

--- a/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.scss
+++ b/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   html[data-theme='dark'] {

--- a/packages/richtext-lexical/src/features/toolbars/inline/client/Toolbar/index.scss
+++ b/packages/richtext-lexical/src/features/toolbars/inline/client/Toolbar/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .inline-toolbar-popup {

--- a/packages/richtext-lexical/src/features/toolbars/shared/ToolbarButton/index.scss
+++ b/packages/richtext-lexical/src/features/toolbars/shared/ToolbarButton/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .toolbar-popup__button {

--- a/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/index.scss
+++ b/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .toolbar-popup__dropdown {

--- a/packages/richtext-lexical/src/features/upload/client/component/index.scss
+++ b/packages/richtext-lexical/src/features/upload/client/component/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .LexicalEditorTheme__upload {

--- a/packages/richtext-lexical/src/field/Diff/converters/listitem/index.scss
+++ b/packages/richtext-lexical/src/field/Diff/converters/listitem/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .lexical-diff {

--- a/packages/richtext-lexical/src/field/Diff/converters/relationship/index.scss
+++ b/packages/richtext-lexical/src/field/Diff/converters/relationship/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .lexical-diff .lexical-relationship-diff {

--- a/packages/richtext-lexical/src/field/Diff/converters/unknown/index.scss
+++ b/packages/richtext-lexical/src/field/Diff/converters/unknown/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .lexical-diff .lexical-unknown-diff {

--- a/packages/richtext-lexical/src/field/Diff/converters/upload/index.scss
+++ b/packages/richtext-lexical/src/field/Diff/converters/upload/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .lexical-diff {

--- a/packages/richtext-lexical/src/field/Diff/index.scss
+++ b/packages/richtext-lexical/src/field/Diff/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .lexical-diff .field-diff-content {

--- a/packages/richtext-lexical/src/field/index.scss
+++ b/packages/richtext-lexical/src/field/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-lexical {

--- a/packages/richtext-lexical/src/lexical/LexicalEditor.scss
+++ b/packages/richtext-lexical/src/lexical/LexicalEditor.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-lexical {

--- a/packages/richtext-lexical/src/lexical/plugins/DecoratorPlugin/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/DecoratorPlugin/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   [data-lexical-decorator='true'] {

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-lexical--show-gutter {

--- a/packages/richtext-lexical/src/lexical/plugins/SlashMenu/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/SlashMenu/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .slash-menu-popup {

--- a/packages/richtext-lexical/src/lexical/plugins/handles/AddBlockHandlePlugin/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/handles/AddBlockHandlePlugin/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .add-block-menu {

--- a/packages/richtext-lexical/src/lexical/plugins/handles/DraggableBlockPlugin/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/handles/DraggableBlockPlugin/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .draggable-block-menu {

--- a/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
+++ b/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .LexicalEditorTheme {

--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 $lexical-contenteditable-top-padding: 8px;
 $lexical-contenteditable-bottom-padding: 8px;

--- a/packages/richtext-slate/src/field/buttons.scss
+++ b/packages/richtext-slate/src/field/buttons.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text__button {

--- a/packages/richtext-slate/src/field/elements/blockquote/index.scss
+++ b/packages/richtext-slate/src/field/elements/blockquote/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-blockquote {

--- a/packages/richtext-slate/src/field/elements/link/Element/index.scss
+++ b/packages/richtext-slate/src/field/elements/link/Element/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-link {

--- a/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.scss
+++ b/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-link-edit-modal {

--- a/packages/richtext-slate/src/field/elements/ol/index.scss
+++ b/packages/richtext-slate/src/field/elements/ol/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-ol {

--- a/packages/richtext-slate/src/field/elements/relationship/Button/index.scss
+++ b/packages/richtext-slate/src/field/elements/relationship/Button/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .relationship-rich-text-button {

--- a/packages/richtext-slate/src/field/elements/relationship/Element/index.scss
+++ b/packages/richtext-slate/src/field/elements/relationship/Element/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-relationship {

--- a/packages/richtext-slate/src/field/elements/ul/index.scss
+++ b/packages/richtext-slate/src/field/elements/ul/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-ul {

--- a/packages/richtext-slate/src/field/elements/upload/Button/index.scss
+++ b/packages/richtext-slate/src/field/elements/upload/Button/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .upload-rich-text-button {

--- a/packages/richtext-slate/src/field/elements/upload/Element/index.scss
+++ b/packages/richtext-slate/src/field/elements/upload/Element/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text-upload {

--- a/packages/richtext-slate/src/field/icons/IndentLeft/index.scss
+++ b/packages/richtext-slate/src/field/icons/IndentLeft/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .icon--indent-left {

--- a/packages/richtext-slate/src/field/icons/IndentRight/index.scss
+++ b/packages/richtext-slate/src/field/icons/IndentRight/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .icon--indent-right {

--- a/packages/richtext-slate/src/field/icons/Link/index.scss
+++ b/packages/richtext-slate/src/field/icons/Link/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .icon--link {

--- a/packages/richtext-slate/src/field/icons/Relationship/index.scss
+++ b/packages/richtext-slate/src/field/icons/Relationship/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .icon--relationship {

--- a/packages/richtext-slate/src/field/icons/Upload/index.scss
+++ b/packages/richtext-slate/src/field/icons/Upload/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .icon--upload {

--- a/packages/richtext-slate/src/field/index.scss
+++ b/packages/richtext-slate/src/field/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 @layer payload-default {
   .rich-text {

--- a/templates/ecommerce/src/components/BeforeDashboard/index.scss
+++ b/templates/ecommerce/src/components/BeforeDashboard/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .dashboard .before-dashboard {
   margin-bottom: base(1.5);

--- a/templates/website/src/components/AdminBar/index.scss
+++ b/templates/website/src/components/AdminBar/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .admin-bar {
   @include small-break {

--- a/templates/website/src/components/BeforeDashboard/index.scss
+++ b/templates/website/src/components/BeforeDashboard/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .dashboard .before-dashboard {
   margin-bottom: base(1.5);

--- a/templates/with-vercel-website/src/components/AdminBar/index.scss
+++ b/templates/with-vercel-website/src/components/AdminBar/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .admin-bar {
   @include small-break {

--- a/templates/with-vercel-website/src/components/BeforeDashboard/index.scss
+++ b/templates/with-vercel-website/src/components/BeforeDashboard/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .dashboard .before-dashboard {
   margin-bottom: base(1.5);

--- a/test/admin/components/views/CustomDefault/index.scss
+++ b/test/admin/components/views/CustomDefault/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .custom-default-view {
   &__login-btn {

--- a/test/admin/components/views/CustomMinimal/index.scss
+++ b/test/admin/components/views/CustomMinimal/index.scss
@@ -1,4 +1,4 @@
-@import '~@payloadcms/ui/scss';
+@import '@payloadcms/ui/src/scss/styles';
 
 .custom-minimal-view {
   &__login-btn {


### PR DESCRIPTION
### Problem

The tilde (`~`) prefix in SCSS imports (e.g., `@import '~@payloadcms/ui/scss'`) is a **Webpack-specific convention**, not a standard Sass feature. This causes compilation errors when:

1. **Files are published to npm** (like `@payloadcms/ui/dist/*.scss`) and consumed without Webpack
2. **Modern bundlers** (Turbopack, Vite, native Sass compilers) don't recognize this syntax
3. **Windows environments** have stricter path resolution, making the issue more visible

### Root Cause

The issue was exposed by PR #13683 (Modular Dashboards - Widgets) which introduced `CollectionCards` widget. This was the first widget in `packages/ui/src/widgets/` that:
- Used `@import '~@payloadcms/ui/scss'`
- Was copied without compilation to `dist/`
- Was published to npm
- A Windows user attempted to use it → compilation failed

PR #15028 fixed the files inside the UI package because they are copied instead of compiled by Webpack. However, [a user has reported](https://github.com/payloadcms/payload/pull/15028#issuecomment-3715911638) after that PR was merged having issues with another tilde inside the `/templates` folder. I am not sure why that import has started causing problems now, since it has been there for a long time (maybe using turbopack instead of webpack?), but it seems best to cut the problem at the root and simply not use the tilde, which is not standard Sass syntax.

### Linter Improvements

Expanded the `lint:scss` command to cover the entire monorepo, instead of just the ui package.

### Technical Details

#### Package.json exports vs Sass imports

The `@payloadcms/ui` package.json defines:
```json
"./scss": {
  "import": "./src/scss/styles.scss"
}
```
However, **exports are for JavaScript/TypeScript only**. Sass compilers don't resolve package.json exports. That's why we use the direct path:
```sass
@import '@payloadcms/ui/src/scss/styles';  // Direct to physical file
```
This works because modern bundlers (Next.js, Webpack, Vite) configure Sass's `loadPaths` to include `node_modules`.

### Related Issues & PRs

- Extends PR #15028 to cover entire monorepo

### References

- **Webpack sass-loader** - [GitHub](https://github.com/webpack-contrib/sass-loader) - Documents that tilde is a Webpack convention, not Sass
- **Angular deprecation** - [Stack Overflow](https://stackoverflow.com/questions/73853771/) - Industry trend moving away from tilde

### Future Work

- Consider migrating from `@import` to `@use` (Sass module system) - separate PR. Sass has deprecated `import` in favor of `use` ([source](https://sass-lang.com/blog/import-is-deprecated/)). The official `sass-migrator` tool can automate this migration when we decide to do it.