### PR TITLE
test: update outdated hardcoded postgres connection strings

### DIFF
--- a/test/access-control/config.postgreslogs.ts
+++ b/test/access-control/config.postgreslogs.ts
@@ -1,5 +1,6 @@
-/* eslint-disable no-restricted-exports */
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+/* eslint-disable no-restricted-exports */
+import { defaultPostgresUrl } from '../generateDatabaseAdapter.js'
 import { getConfig } from './getConfig.js'
 
 const config = getConfig()
@@ -8,7 +9,7 @@ import { postgresAdapter } from '@payloadcms/db-postgres'
 
 export const databaseAdapter = postgresAdapter({
   pool: {
-    connectionString: process.env.POSTGRES_URL || 'postgres://127.0.0.1:5432/payloadtests',
+    connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || defaultPostgresUrl,
   },
   logger: true,
 })

--- a/test/database/config.postgreslogs.ts
+++ b/test/database/config.postgreslogs.ts
@@ -1,5 +1,6 @@
-/* eslint-disable no-restricted-exports */
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+/* eslint-disable no-restricted-exports */
+import { defaultPostgresUrl } from '../generateDatabaseAdapter.js'
 import { getConfig } from './getConfig.js'
 
 const config = getConfig()
@@ -8,7 +9,7 @@ import { postgresAdapter } from '@payloadcms/db-postgres'
 
 export const databaseAdapter = postgresAdapter({
   pool: {
-    connectionString: process.env.POSTGRES_URL || 'postgres://127.0.0.1:5432/payloadtests',
+    connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || defaultPostgresUrl,
   },
   logger: true,
 })

--- a/test/generateDatabaseAdapter.ts
+++ b/test/generateDatabaseAdapter.ts
@@ -13,6 +13,8 @@ const mongooseAdapterArgs = `
       'mongodb://payload:payload@localhost:27018/payload?authSource=admin&directConnection=true&replicaSet=rs0',
 `
 
+export const defaultPostgresUrl = 'postgres://payload:payload@127.0.0.1:5433/payload'
+
 export const allDatabaseAdapters = {
   mongodb: `
   import { mongooseAdapter } from '@payloadcms/db-mongodb'
@@ -63,7 +65,7 @@ export const allDatabaseAdapters = {
 
   export const databaseAdapter = postgresAdapter({
     pool: {
-      connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || 'postgres://payload:payload@127.0.0.1:5433/payload',
+      connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || '${defaultPostgresUrl}',
     },
   })`,
   'postgres-custom-schema': `
@@ -71,7 +73,7 @@ export const allDatabaseAdapters = {
 
   export const databaseAdapter = postgresAdapter({
     pool: {
-      connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || 'postgres://payload:payload@127.0.0.1:5433/payload',
+      connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || '${defaultPostgresUrl}',
     },
     schemaName: 'custom',
   })`,
@@ -81,7 +83,7 @@ export const allDatabaseAdapters = {
   export const databaseAdapter = postgresAdapter({
     idType: 'uuid',
     pool: {
-      connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || 'postgres://payload:payload@127.0.0.1:5433/payload',
+      connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || '${defaultPostgresUrl}',
     },
   })`,
   'postgres-read-replica': `

--- a/test/queues/config.postgreslogs.ts
+++ b/test/queues/config.postgreslogs.ts
@@ -1,5 +1,6 @@
-/* eslint-disable no-restricted-exports */
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+/* eslint-disable no-restricted-exports */
+import { defaultPostgresUrl } from '../generateDatabaseAdapter.js'
 import { getConfig } from './getConfig.js'
 
 const config = getConfig()
@@ -8,7 +9,7 @@ import { postgresAdapter } from '@payloadcms/db-postgres'
 
 export const databaseAdapter = postgresAdapter({
   pool: {
-    connectionString: process.env.POSTGRES_URL || 'postgres://127.0.0.1:5432/payloadtests',
+    connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || defaultPostgresUrl,
   },
   logger: true,
 })

--- a/test/queues/postgres-logs.int.spec.ts
+++ b/test/queues/postgres-logs.int.spec.ts
@@ -31,7 +31,7 @@ describePostgres('queues - postgres logs', () => {
   })
 
   afterAll(async () => {
-    await payload.destroy()
+    await payload?.destroy()
   })
 
   it('ensure running jobs uses minimal db calls', async () => {

--- a/test/select/config.postgreslogs.ts
+++ b/test/select/config.postgreslogs.ts
@@ -1,5 +1,6 @@
-/* eslint-disable no-restricted-exports */
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+/* eslint-disable no-restricted-exports */
+import { defaultPostgresUrl } from '../generateDatabaseAdapter.js'
 import { getConfig } from './getConfig.js'
 
 const config = getConfig()
@@ -8,7 +9,7 @@ import { postgresAdapter } from '@payloadcms/db-postgres'
 
 export const databaseAdapter = postgresAdapter({
   pool: {
-    connectionString: process.env.POSTGRES_URL || 'postgres://127.0.0.1:5432/payloadtests',
+    connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL || defaultPostgresUrl,
   },
   logger: true,
 })


### PR DESCRIPTION
There are a few hardcoded postgres connection strings that still reference the old postgres URLs. This PR updates them to matches the connection URL used in our default generated db adapter.