### PR TITLE
fix: cannot read private member #headers error on Node.js 24 when using isolateObjectProperty

### DIFF
--- a/packages/payload/src/utilities/isolateObjectProperty.spec.ts
+++ b/packages/payload/src/utilities/isolateObjectProperty.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import { isolateObjectProperty } from './isolateObjectProperty.js'
+
+describe('isolateObjectProperty', () => {
+  describe('basic isolation behavior', () => {
+    it('should isolate specified property from the original object', () => {
+      const original = { a: 1, b: 2 }
+      const proxy = isolateObjectProperty(original, 'a')
+
+      proxy.a = 100
+
+      expect(proxy.a).toBe(100)
+      expect(original.a).toBe(1) // Original unchanged
+    })
+
+    it('should share non-isolated properties with the original object', () => {
+      const original = { a: 1, b: 2 }
+      const proxy = isolateObjectProperty(original, 'a')
+
+      proxy.b = 200
+
+      expect(proxy.b).toBe(200)
+      expect(original.b).toBe(200) // Original also changed
+    })
+
+    it('should support isolating multiple properties', () => {
+      const original = { a: 1, b: 2, c: 3 }
+      const proxy = isolateObjectProperty(original, ['a', 'b'])
+
+      proxy.a = 100
+      proxy.b = 200
+
+      expect(proxy.a).toBe(100)
+      expect(proxy.b).toBe(200)
+      expect(original.a).toBe(1)
+      expect(original.b).toBe(2)
+    })
+
+    it('should support deleting isolated properties', () => {
+      const original: Record<string, any> = { a: 1, b: 2 }
+      const proxy = isolateObjectProperty(original, 'a')
+
+      delete proxy.a
+
+      expect('a' in proxy).toBe(false)
+      expect('a' in original).toBe(true) // Original still has it
+    })
+
+    it('should support "in" operator for isolated properties', () => {
+      const original: Record<string, any> = { a: 1, b: 2 }
+      const proxy = isolateObjectProperty(original, 'a')
+
+      expect('a' in proxy).toBe(true)
+      expect('b' in proxy).toBe(true)
+
+      delete proxy.a
+      expect('a' in proxy).toBe(false)
+    })
+  })
+
+  describe('private field access (Node 24+ compatibility)', () => {
+    /**
+     * Class with private fields to test that the proxy correctly handles
+     * getters/setters that access private fields (Node 24+ compatibility).
+     */
+    class ObjectWithPrivateFields {
+      #privateValue: string
+
+      constructor(value: string) {
+        this.#privateValue = value
+      }
+
+      get value(): string {
+        return this.#privateValue
+      }
+
+      set value(newValue: string) {
+        this.#privateValue = newValue
+      }
+    }
+
+    it('should allow reading properties via getters that access private fields when not isolated', () => {
+      const original = new ObjectWithPrivateFields('secret')
+
+      expect(original.value).toBe('secret')
+    })
+
+    it('should allow reading properties via getters that access private fields', () => {
+      const original = new ObjectWithPrivateFields('secret')
+      const proxy = isolateObjectProperty(original, 'nonExistentKey' as keyof typeof original)
+
+      // This would throw "Cannot read private member" if receiver is wrong
+      expect(proxy.value).toBe('secret')
+    })
+
+    it('should allow writing properties via setters that access private fields', () => {
+      const original = new ObjectWithPrivateFields('secret')
+      const proxy = isolateObjectProperty(original, 'nonExistentKey' as keyof typeof original)
+
+      // This would throw "Cannot write private member" if receiver is wrong
+      proxy.value = 'updated'
+
+      expect(proxy.value).toBe('updated')
+      expect(original.value).toBe('updated')
+    })
+
+    it('should work with Headers-like objects (simulating Request.headers)', () => {
+      // Simulate a Request-like object with headers
+      class MockRequest {
+        #headers: Headers
+
+        constructor() {
+          this.#headers = new Headers({ 'content-type': 'application/json' })
+        }
+
+        get headers(): Headers {
+          return this.#headers
+        }
+      }
+
+      const request = new MockRequest()
+      const proxy = isolateObjectProperty(request, 'nonExistentKey' as keyof typeof request)
+
+      // This simulates what happens in createLocalReq when checking req.headers
+      expect(proxy.headers).toBeInstanceOf(Headers)
+      expect(proxy.headers.get('content-type')).toBe('application/json')
+    })
+  })
+})

--- a/packages/payload/src/utilities/isolateObjectProperty.ts
+++ b/packages/payload/src/utilities/isolateObjectProperty.ts
@@ -17,7 +17,11 @@ export function isolateObjectProperty<T extends object>(object: T, key: (keyof T
       return Reflect.deleteProperty(keys.includes(p as keyof T) ? delegate : target, p)
     },
     get(target, p, receiver) {
-      return Reflect.get(keys.includes(p as keyof T) ? delegate : target, p, receiver)
+      if (keys.includes(p as keyof T)) {
+        return Reflect.get(delegate, p, receiver)
+      }
+      // Use target as receiver to preserve private field access (e.g., Request#headers in Node 24+)
+      return Reflect.get(target, p, target)
     },
     has(target, p) {
       return Reflect.has(keys.includes(p as keyof T) ? delegate : target, p)

--- a/packages/payload/src/utilities/isolateObjectProperty.ts
+++ b/packages/payload/src/utilities/isolateObjectProperty.ts
@@ -26,14 +26,13 @@ export function isolateObjectProperty<T extends object>(object: T, key: (keyof T
     has(target, p) {
       return Reflect.has(keys.includes(p as keyof T) ? delegate : target, p)
     },
-    set(target, p, newValue, receiver) {
+    set(target, p, newValue, _receiver) {
       if (keys.includes(p as keyof T)) {
         // in case of transactionID we must ignore any receiver, because
         // "If provided and target does not have a setter for propertyKey, the property will be set on receiver instead."
         return Reflect.set(delegate, p, newValue)
-      } else {
-        return Reflect.set(target, p, newValue, receiver)
       }
+      return Reflect.set(target, p, newValue, target)
     },
   }
   return new Proxy(object, handler)


### PR DESCRIPTION
Fixes `TypeError: Cannot read private member #headers` in Node 24. This error occurred [when calling createLocalReq with existing `req.headers`](https://github.com/payloadcms/payload/blob/main/packages/payload/src/utilities/createLocalReq.ts#L125). Happened in a few int tests if we run them using Node 24 (we currently run tests using Node 23 so this never errored in CI).

**Root cause:**

Node 24's `Request` uses private class fields (`#headers`). When accessing properties through our Proxy, the getter's execution context was incorrectly bound to the Proxy instead of the original object, preventing access to private fields.

```ts
class Request {
  #headers: Headers
  get headers() {
    // private properties can be accessed from within the class
    return this.#headers
  }
}

const req = new Request()
const proxy = isolateObjectProperty(req, 'transactionID')

// The getter runs as `this.#headers` - but what is `this`?
// Before fix: `this` = proxy (doesn't have #headers) -> TypeError
// After fix: `this` = original req (owns #headers) -> Works
proxy.headers
```

**The fix:**

For non-isolated properties, the Proxy now correctly delegates to the original object's context. This matches the behavior as if no Proxy was used - which is the intended design, since the Proxy should be transparent for everything except the isolated properties (usually `transactionID`).