### PR TITLE
chore(examples): update astro package.json name

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-payload-monorepo",
+  "name": "astro-payload-monorepo",
   "version": "1.0.0",
   "description": "",
   "keywords": [],


### PR DESCRIPTION
The `astro` example was still using `remix` in its `package.json` name.