### PR TITLE
feat: add support for additional IANA timezones, custom UTC offsets and overriding the timezone field

### DIFF
--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -266,3 +266,43 @@ You can customise the available list of timezones in the [global admin config](.
 Dates without a specific time are normalised to 12:00 in the selected timezone.
 
 </Banner>
+
+### Manual Offsets
+
+In addition to IANA timezone names (like `America/New_York`), you can also use fixed UTC offsets in the `±HH:mm` format:
+
+```ts
+{
+  name: 'eventTime',
+  type: 'date',
+  timezone: {
+    supportedTimezones: [
+      { label: 'UTC+5:30 (India)', value: '+05:30' },
+      { label: 'UTC-8 (Pacific)', value: '-08:00' },
+      { label: 'UTC+0', value: '+00:00' },
+    ],
+  },
+}
+```
+
+You can also mix IANA timezones with manual offsets:
+
+```ts
+{
+  name: 'scheduledAt',
+  type: 'date',
+  timezone: {
+    supportedTimezones: [
+      { label: 'New York', value: 'America/New_York' },
+      { label: 'UTC+5:30', value: '+05:30' },
+      { label: 'UTC', value: 'UTC' },
+    ],
+  },
+}
+```
+
+<Banner type="warning">
+  Manual UTC offsets are fixed and do not account for daylight saving time (DST)
+  adjustments. If you need automatic DST handling, use IANA timezone names
+  instead (e.g., `America/New_York` rather than `-05:00`).
+</Banner>

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -304,7 +304,7 @@ The `override` function receives an object with `baseField` (the default timezon
   config so that the right validations are run against your timezones.
 </Banner>
 
-### Manual Offsets
+### Custom UTC Offsets
 
 In addition to IANA timezone names (like `America/New_York`), you can also use fixed UTC offsets in the `±HH:mm` format:
 
@@ -322,7 +322,7 @@ In addition to IANA timezone names (like `America/New_York`), you can also use f
 }
 ```
 
-You can also mix IANA timezones with manual offsets:
+You can also mix IANA timezones with custom UTC offsets:
 
 ```ts
 {
@@ -338,8 +338,8 @@ You can also mix IANA timezones with manual offsets:
 }
 ```
 
-<Banner type="warning">
-  Manual UTC offsets are fixed and do not account for daylight saving time (DST)
+<Banner type="info">
+  Custom UTC offsets are fixed and do not account for daylight saving time (DST)
   adjustments. If you need automatic DST handling, use IANA timezone names
   instead (e.g., `America/New_York` rather than `-05:00`).
 </Banner>

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -306,3 +306,33 @@ You can also mix IANA timezones with manual offsets:
   adjustments. If you need automatic DST handling, use IANA timezone names
   instead (e.g., `America/New_York` rather than `-05:00`).
 </Banner>
+
+#### GraphQL Enum Names
+
+When using offset timezones with GraphQL, the offset values are transformed to valid GraphQL enum names using the `_TZOFFSET_` prefix:
+
+| Offset Value | GraphQL Enum Name       |
+| ------------ | ----------------------- |
+| `+05:30`     | `_TZOFFSET_PLUS_05_30`  |
+| `-08:00`     | `_TZOFFSET_MINUS_08_00` |
+| `+00:00`     | `_TZOFFSET_PLUS_00_00`  |
+
+Similarly, IANA timezone names are also transformed (e.g., `America/New_York` becomes `America_New_York`).
+
+```graphql
+# Query returns the enum name
+query {
+  Event {
+    scheduledAt_tz # Returns "_TZOFFSET_PLUS_05_30"
+  }
+}
+
+# Mutations use the enum name
+mutation {
+  createEvent(data: { scheduledAt_tz: _TZOFFSET_PLUS_05_30 }) {
+    scheduledAt_tz
+  }
+}
+```
+
+The actual value (`+05:30`) is stored in the database and returned by the REST API.

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -238,11 +238,12 @@ This will add a dropdown to the date picker that allows users to select a timezo
 
 You can customise the available list of timezones in the [global admin config](../admin/overview#timezones) or on the field config itself which accepts the following config as well:
 
-| Property             | Description                                                               |
-| -------------------- | ------------------------------------------------------------------------- |
-| `defaultTimezone`    | A value for the default timezone to be set.                               |
-| `supportedTimezones` | An array of supported timezones with label and value object.              |
-| `required`           | If true, the timezone selection will be required even if the date is not. |
+| Property             | Description                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| `defaultTimezone`    | A value for the default timezone to be set.                                              |
+| `supportedTimezones` | An array of supported timezones with label and value object.                             |
+| `required`           | If true, the timezone selection will be required even if the date is not.                |
+| `override`           | A function to customize the generated timezone field. [More details](#timezone-override) |
 
 ```ts
 {
@@ -265,6 +266,42 @@ You can customise the available list of timezones in the [global admin config](.
 
 Dates without a specific time are normalised to 12:00 in the selected timezone.
 
+</Banner>
+
+### Timezone Override
+
+The `override` function allows you to customize the auto-generated timezone select field at a granular level. This is useful when you need to modify admin options like visibility, descriptions, or other field properties.
+
+```ts
+{
+  name: 'publishedAt',
+  type: 'date',
+  label: 'Published At',
+  timezone: {
+    override: ({ baseField }) => ({
+      ...baseField,
+      admin: {
+        ...baseField.admin,
+        disableListColumn: true, // Hide from list view columns
+      },
+    }),
+  },
+}
+```
+
+The `override` function receives an object with `baseField` (the default timezone select field) and must return a valid field configuration. The base field includes:
+
+- `name`: The timezone field name (e.g., `publishedAt_tz`)
+- `type`: Always `'select'`
+- `options`: The available timezone options
+- `defaultValue`: The default timezone value
+- `required`: Whether the timezone is required
+- `label`: Auto-generated from the parent field's label (e.g., "Published At Tz")
+- `admin.hidden`: `true` by default
+
+<Banner type="info">
+  We recommend changing the available options only via the supportedTimezones
+  config so that the right validations are run against your timezones.
 </Banner>
 
 ### Manual Offsets

--- a/packages/graphql/src/utilities/formatName.spec.ts
+++ b/packages/graphql/src/utilities/formatName.spec.ts
@@ -14,4 +14,47 @@ describe('formatName', () => {
   `('should convert accented character: $char', ({ char, expected }) => {
     expect(formatName(char)).toEqual(expected)
   })
+
+  describe('UTC offset handling', () => {
+    it.each`
+      offset      | expected
+      ${'+00:00'} | ${'_TZOFFSET_PLUS_00_00'}
+      ${'+05:30'} | ${'_TZOFFSET_PLUS_05_30'}
+      ${'+05:45'} | ${'_TZOFFSET_PLUS_05_45'}
+      ${'+08:00'} | ${'_TZOFFSET_PLUS_08_00'}
+      ${'+12:00'} | ${'_TZOFFSET_PLUS_12_00'}
+      ${'+14:00'} | ${'_TZOFFSET_PLUS_14_00'}
+      ${'-00:00'} | ${'_TZOFFSET_MINUS_00_00'}
+      ${'-03:30'} | ${'_TZOFFSET_MINUS_03_30'}
+      ${'-05:00'} | ${'_TZOFFSET_MINUS_05_00'}
+      ${'-08:00'} | ${'_TZOFFSET_MINUS_08_00'}
+      ${'-12:00'} | ${'_TZOFFSET_MINUS_12_00'}
+    `('should convert UTC offset $offset to $expected', ({ offset, expected }) => {
+      expect(formatName(offset)).toEqual(expected)
+    })
+
+    it('should not collide between positive and negative offsets', () => {
+      const plusFive = formatName('+05:00')
+      const minusFive = formatName('-05:00')
+      expect(plusFive).not.toEqual(minusFive)
+      expect(plusFive).toEqual('_TZOFFSET_PLUS_05_00')
+      expect(minusFive).toEqual('_TZOFFSET_MINUS_05_00')
+    })
+
+    it('should not treat IANA timezone names as offsets', () => {
+      // These should use standard formatting, not UTC offset formatting
+      expect(formatName('America/New_York')).toEqual('America_New_York')
+      expect(formatName('Europe/London')).toEqual('Europe_London')
+      expect(formatName('Asia/Tokyo')).toEqual('Asia_Tokyo')
+    })
+
+    it('should not treat partial offset patterns as offsets', () => {
+      // These don't match the strict ±HH:mm pattern, so they use standard formatting
+      expect(formatName('+5')).toEqual('_5')
+      expect(formatName('+05')).toEqual('_05')
+      expect(formatName('+0530')).toEqual('_0530')
+      // 05:30 without sign is not a UTC offset, starts with number so gets _ prefix
+      expect(formatName('05:30')).toEqual('_05:30')
+    })
+  })
 })

--- a/packages/graphql/src/utilities/formatName.ts
+++ b/packages/graphql/src/utilities/formatName.ts
@@ -1,7 +1,16 @@
+import { formatUtcOffset } from './formatUtcOffset.js'
+
 const numbers = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
 export const formatName = (string: string): string => {
   let sanitizedString = String(string)
+
+  // Check if this is a UTC offset (e.g., +05:30, -08:00)
+  // These need special handling to avoid collisions
+  const utcOffsetName = formatUtcOffset(sanitizedString)
+  if (utcOffsetName) {
+    return utcOffsetName
+  }
 
   const firstLetter = sanitizedString.substring(0, 1)
 

--- a/packages/graphql/src/utilities/formatUtcOffset.spec.ts
+++ b/packages/graphql/src/utilities/formatUtcOffset.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatUtcOffset } from './formatUtcOffset.js'
+
+describe('formatUtcOffset', () => {
+  describe('valid UTC offsets', () => {
+    it.each([
+      ['+00:00', '_TZOFFSET_PLUS_00_00'],
+      ['+05:30', '_TZOFFSET_PLUS_05_30'],
+      ['+05:45', '_TZOFFSET_PLUS_05_45'],
+      ['+08:00', '_TZOFFSET_PLUS_08_00'],
+      ['+09:30', '_TZOFFSET_PLUS_09_30'],
+      ['+12:00', '_TZOFFSET_PLUS_12_00'],
+      ['+14:00', '_TZOFFSET_PLUS_14_00'],
+    ])('should convert positive offset %s to %s', (offset, expected) => {
+      expect(formatUtcOffset(offset)).toEqual(expected)
+    })
+
+    it.each([
+      ['-00:00', '_TZOFFSET_MINUS_00_00'],
+      ['-03:30', '_TZOFFSET_MINUS_03_30'],
+      ['-05:00', '_TZOFFSET_MINUS_05_00'],
+      ['-08:00', '_TZOFFSET_MINUS_08_00'],
+      ['-09:30', '_TZOFFSET_MINUS_09_30'],
+      ['-12:00', '_TZOFFSET_MINUS_12_00'],
+    ])('should convert negative offset %s to %s', (offset, expected) => {
+      expect(formatUtcOffset(offset)).toEqual(expected)
+    })
+  })
+
+  describe('non-offset values', () => {
+    it.each(['UTC', 'America/New_York', 'Europe/London', 'Asia/Tokyo', 'Pacific/Auckland'])(
+      'should return null for IANA timezone: %s',
+      (timezone) => {
+        expect(formatUtcOffset(timezone)).toBeNull()
+      },
+    )
+
+    it.each(['+5', '-8', '+05', '-08', '+0530', '-0800', '05:30', '0530', 'invalid', ''])(
+      'should return null for non-standard format: %s',
+      (value) => {
+        expect(formatUtcOffset(value)).toBeNull()
+      },
+    )
+  })
+
+  describe('uniqueness', () => {
+    it('should produce unique names for positive and negative offsets', () => {
+      const testCases = [
+        ['+05:00', '-05:00'],
+        ['+08:00', '-08:00'],
+        ['+00:00', '-00:00'],
+        ['+12:00', '-12:00'],
+      ]
+
+      for (const [positive, negative] of testCases) {
+        const positiveName = formatUtcOffset(positive)
+        const negativeName = formatUtcOffset(negative)
+        expect(positiveName).not.toEqual(negativeName)
+      }
+    })
+
+    it('should produce unique names for different hour offsets', () => {
+      const offsets = ['+05:00', '+06:00', '+07:00', '+08:00']
+      const names = offsets.map(formatUtcOffset)
+      const uniqueNames = new Set(names)
+      expect(uniqueNames.size).toEqual(offsets.length)
+    })
+
+    it('should produce unique names for different minute offsets', () => {
+      const offsets = ['+05:00', '+05:15', '+05:30', '+05:45']
+      const names = offsets.map(formatUtcOffset)
+      const uniqueNames = new Set(names)
+      expect(uniqueNames.size).toEqual(offsets.length)
+    })
+  })
+})

--- a/packages/graphql/src/utilities/formatUtcOffset.ts
+++ b/packages/graphql/src/utilities/formatUtcOffset.ts
@@ -1,0 +1,24 @@
+/**
+ * Converts a UTC offset string to a GraphQL-safe enum name.
+ * Uses `_TZOFFSET_` prefix to avoid conflicts with user-defined enum values.
+ *
+ * Examples:
+ * - '+05:30' → '_TZOFFSET_PLUS_05_30'
+ * - '-08:00' → '_TZOFFSET_MINUS_08_00'
+ * - '+00:00' → '_TZOFFSET_PLUS_00_00'
+ *
+ * @returns The GraphQL-safe name, or null if not a UTC offset
+ */
+export const formatUtcOffset = (value: string): null | string => {
+  // Match UTC offset pattern: ±HH:mm
+  const match = value.match(/^([+-])(\d{2}):(\d{2})$/)
+  if (!match) {
+    return null
+  }
+
+  const sign = match[1] === '+' ? 'PLUS' : 'MINUS'
+  const hours = match[2]
+  const minutes = match[3]
+
+  return `_TZOFFSET_${sign}_${hours}_${minutes}`
+}

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -34,6 +34,7 @@ import { getDefaultJobsCollection, jobsCollectionSlug } from '../queues/config/c
 import { getJobStatsGlobal } from '../queues/config/global.js'
 import { flattenBlock } from '../utilities/flattenAllFields.js'
 import { hasScheduledPublishEnabled } from '../utilities/getVersionsConfig.js'
+import { validateTimezones } from '../utilities/validateTimezones.js'
 import { getSchedulePublishTask } from '../versions/schedule/job.js'
 import { addDefaultsToConfig } from './defaults.js'
 import { setupOrderable } from './orderable/index.js'
@@ -89,9 +90,9 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
   }
 
   if (sanitizedConfig?.admin?.timezones) {
-    if (typeof sanitizedConfig?.admin?.timezones?.supportedTimezones === 'function') {
+    if (typeof configToSanitize?.admin?.timezones?.supportedTimezones === 'function') {
       sanitizedConfig.admin.timezones.supportedTimezones =
-        sanitizedConfig.admin.timezones.supportedTimezones({ defaultTimezones })
+        configToSanitize.admin.timezones.supportedTimezones({ defaultTimezones })
     }
 
     if (!sanitizedConfig?.admin?.timezones?.supportedTimezones) {
@@ -102,16 +103,10 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
       supportedTimezones: defaultTimezones,
     }
   }
-  // Timezones supported by the Intl API
-  const _internalSupportedTimezones = Intl.supportedValuesOf('timeZone')
 
-  // We're casting here because it's already been sanitised above but TS still thinks it could be a function
-  ;(sanitizedConfig.admin!.timezones.supportedTimezones as Timezone[]).forEach((timezone) => {
-    if (timezone.value !== 'UTC' && !_internalSupportedTimezones.includes(timezone.value)) {
-      throw new InvalidConfiguration(
-        `Timezone ${timezone.value} is not supported by the current runtime via the Intl API.`,
-      )
-    }
+  validateTimezones({
+    source: 'admin.timezones.supportedTimezones',
+    timezones: sanitizedConfig.admin!.timezones.supportedTimezones as Timezone[],
   })
 
   return sanitizedConfig as unknown as Partial<SanitizedConfig>

--- a/packages/payload/src/fields/baseFields/timezone/baseField.ts
+++ b/packages/payload/src/fields/baseFields/timezone/baseField.ts
@@ -1,11 +1,9 @@
+import type { StaticLabel } from '../../../config/types.js'
 import type { SelectField } from '../../config/types.js'
 
-export const baseTimezoneField: (args: Partial<SelectField>) => SelectField = ({
-  name,
-  defaultValue,
-  options,
-  required,
-}) => {
+export const baseTimezoneField: (
+  args: { label?: StaticLabel } & Partial<SelectField>,
+) => SelectField = ({ name, defaultValue, label, options, required }) => {
   return {
     name: name!,
     type: 'select',
@@ -13,6 +11,7 @@ export const baseTimezoneField: (args: Partial<SelectField>) => SelectField = ({
       hidden: true,
     },
     defaultValue,
+    label,
     options: options!,
     required,
   }

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -11,6 +11,7 @@ import type {
   BlocksFieldClient,
   ClientBlock,
   ClientField,
+  DateFieldClient,
   Field,
   FieldBase,
   JoinFieldClient,
@@ -325,6 +326,21 @@ export const createClientField = ({
           i18n,
           importMap,
         }) as ClientBlock[]
+      }
+
+      break
+    }
+
+    case 'date': {
+      // Strip the `override` function from timezone config as it cannot be serialized
+      if (
+        incomingField.timezone &&
+        typeof incomingField.timezone === 'object' &&
+        'override' in incomingField.timezone
+      ) {
+        const field = clientField as DateFieldClient
+        const { override: _, ...timezoneConfigWithoutOverride } = incomingField.timezone
+        field.timezone = timezoneConfigWithoutOverride
       }
 
       break

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -437,14 +437,25 @@ export const sanitizeFields = async ({
         defaultTimezone = options[0].value
       }
 
+      // Generate label for timezone field
+      // Use parent field's label + ' Tz' if it's a simple string, otherwise fallback to name
+      const timezoneLabel = typeof field.label === 'string' ? `${field.label} Tz` : toWords(name)
+
       // Need to set the options here manually so that any database enums are generated correctly
       // The UI component will import the options from the config
-      const timezoneField = baseTimezoneField({
+      const baseField = baseTimezoneField({
         name,
         defaultValue: defaultTimezone,
+        label: timezoneLabel,
         options,
         required,
       })
+
+      // Apply override if provided
+      const timezoneField =
+        typeof field.timezone === 'object' && typeof field.timezone.override === 'function'
+          ? field.timezone.override({ baseField })
+          : baseField
 
       fields.splice(++i, 0, timezoneField)
     }

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -22,6 +22,7 @@ import { ReservedFieldName } from '../../errors/ReservedFieldName.js'
 import { flattenAllFields } from '../../utilities/flattenAllFields.js'
 import { formatLabels, toWords } from '../../utilities/formatLabels.js'
 import { getFieldByPath } from '../../utilities/getFieldByPath.js'
+import { validateTimezones } from '../../utilities/validateTimezones.js'
 import { baseBlockFields } from '../baseFields/baseBlockFields.js'
 import { baseIDField } from '../baseFields/baseIDField.js'
 import { baseTimezoneField } from '../baseFields/timezone/baseField.js'
@@ -426,6 +427,11 @@ export const sanitizeFields = async ({
         typeof supportedTimezones === 'function'
           ? supportedTimezones({ defaultTimezones })
           : supportedTimezones
+
+      validateTimezones({
+        source: `field "${field.name}" timezone.supportedTimezones`,
+        timezones: options,
+      })
 
       if (options && options.length === 1 && options[0]?.value) {
         defaultTimezone = options[0].value

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -725,13 +725,39 @@ export type CheckboxFieldClient = {
 } & FieldBaseClient &
   Pick<CheckboxField, 'type'>
 
-type DateFieldTimezoneConfig = {
+type DateFieldTimezoneConfigBase = {
   /**
    * Make only the timezone required in the admin interface. This means a timezone is always required to be selected.
    */
   required?: boolean
   supportedTimezones?: Timezone[]
 } & Pick<TimezonesConfig, 'defaultTimezone'>
+
+type DateFieldTimezoneConfig = {
+  /**
+   * A function used to override the timezone field at a granular level.
+   * Passes the base select field to you to manipulate beyond the exposed options.
+   * @example
+   * ```ts
+   * {
+   *   type: 'date',
+   *   name: 'publishedAt',
+   *   timezone: {
+   *     override: ({ baseField }) => ({
+   *       ...baseField,
+   *       admin: {
+   *         ...baseField.admin,
+   *         hidden: false,
+   *       },
+   *     }),
+   *   },
+   * }
+   * ```
+   */
+  override?: (args: { baseField: SelectField }) => Field
+} & DateFieldTimezoneConfigBase
+
+type DateFieldTimezoneConfigClient = DateFieldTimezoneConfigBase
 
 export type DateField = {
   admin?: {
@@ -755,8 +781,13 @@ export type DateField = {
 export type DateFieldClient = {
   // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
   admin?: AdminClient & Pick<DateField['admin'], 'date' | 'placeholder'>
+  /**
+   * Enable timezone selection in the admin interface.
+   * Note: The `override` function is stripped on the client.
+   */
+  timezone?: DateFieldTimezoneConfigClient | true
 } & FieldBaseClient &
-  Pick<DateField, 'timezone' | 'type'>
+  Pick<DateField, 'type'>
 
 export type GroupBase = {
   admin?: {

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -12,6 +12,7 @@ import { fieldAffectsData } from '../fields/config/types.js'
 import { generateJobsJSONSchemas } from '../queues/config/generateJobsJSONSchemas.js'
 import { formatNames } from './formatLabels.js'
 import { getCollectionIDFieldTypes } from './getCollectionIDFieldTypes.js'
+import { optionsAreEqual } from './optionsAreEqual.js'
 
 const fieldIsRequired = (field: FlattenedField): boolean => {
   const isConditional = Boolean(field?.admin && field?.admin?.condition)
@@ -662,8 +663,15 @@ export function fieldsToJSONSchema(
             const isTimezoneField =
               previousField?.type === 'date' && previousField.timezone && field.name.includes('_tz')
 
+            // Check if the timezone field's options match the global config's supported timezones
+            const hasMatchingGlobalTimezones =
+              isTimezoneField &&
+              config &&
+              optionsAreEqual(field.options, config.admin?.timezones?.supportedTimezones)
+
             // Timezone selects should reference the supportedTimezones definition
-            if (isTimezoneField) {
+            // only if the field's options match the global config
+            if (isTimezoneField && hasMatchingGlobalTimezones) {
               fieldSchema = {
                 $ref: `#/definitions/supportedTimezones`,
               }

--- a/packages/payload/src/utilities/optionsAreEqual.spec.ts
+++ b/packages/payload/src/utilities/optionsAreEqual.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+
+import { optionsAreEqual } from './optionsAreEqual.js'
+
+describe('optionsAreEqual', () => {
+  describe('with string options', () => {
+    it('should return true for identical string arrays', () => {
+      expect(optionsAreEqual(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(true)
+    })
+
+    it('should return true for same values in different order', () => {
+      expect(optionsAreEqual(['a', 'b', 'c'], ['c', 'a', 'b'])).toBe(true)
+    })
+
+    it('should return false for different values', () => {
+      expect(optionsAreEqual(['a', 'b'], ['a', 'c'])).toBe(false)
+    })
+
+    it('should return false for different lengths', () => {
+      expect(optionsAreEqual(['a', 'b'], ['a', 'b', 'c'])).toBe(false)
+    })
+  })
+
+  describe('with object options', () => {
+    it('should return true for identical object arrays', () => {
+      const options1 = [
+        { label: 'Option A', value: 'a' },
+        { label: 'Option B', value: 'b' },
+      ]
+      const options2 = [
+        { label: 'Option A', value: 'a' },
+        { label: 'Option B', value: 'b' },
+      ]
+      expect(optionsAreEqual(options1, options2)).toBe(true)
+    })
+
+    it('should return true for same values with different labels', () => {
+      const options1 = [
+        { label: 'First Label', value: 'a' },
+        { label: 'Second Label', value: 'b' },
+      ]
+      const options2 = [
+        { label: 'Different Label A', value: 'a' },
+        { label: 'Different Label B', value: 'b' },
+      ]
+      expect(optionsAreEqual(options1, options2)).toBe(true)
+    })
+
+    it('should return true for same values in different order', () => {
+      const options1 = [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+      ]
+      const options2 = [
+        { label: 'B', value: 'b' },
+        { label: 'A', value: 'a' },
+      ]
+      expect(optionsAreEqual(options1, options2)).toBe(true)
+    })
+
+    it('should return false for different values', () => {
+      const options1 = [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+      ]
+      const options2 = [
+        { label: 'A', value: 'a' },
+        { label: 'C', value: 'c' },
+      ]
+      expect(optionsAreEqual(options1, options2)).toBe(false)
+    })
+  })
+
+  describe('with mixed string and object options', () => {
+    it('should return true when string and object have same value', () => {
+      const options1 = ['a', 'b']
+      const options2 = [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+      ]
+      expect(optionsAreEqual(options1, options2)).toBe(true)
+    })
+
+    it('should return false when values differ', () => {
+      const options1 = ['a', 'b']
+      const options2 = [
+        { label: 'A', value: 'a' },
+        { label: 'C', value: 'c' },
+      ]
+      expect(optionsAreEqual(options1, options2)).toBe(false)
+    })
+  })
+
+  describe('with timezone-like options', () => {
+    it('should return true for identical timezone options', () => {
+      const globalTimezones = [
+        { label: 'New York', value: 'America/New_York' },
+        { label: 'Los Angeles', value: 'America/Los_Angeles' },
+        { label: 'London', value: 'Europe/London' },
+      ]
+      const fieldTimezones = [
+        { label: 'New York', value: 'America/New_York' },
+        { label: 'Los Angeles', value: 'America/Los_Angeles' },
+        { label: 'London', value: 'Europe/London' },
+      ]
+      expect(optionsAreEqual(globalTimezones, fieldTimezones)).toBe(true)
+    })
+
+    it('should return false for custom offset timezones vs IANA timezones', () => {
+      const globalTimezones = [
+        { label: 'New York', value: 'America/New_York' },
+        { label: 'Los Angeles', value: 'America/Los_Angeles' },
+      ]
+      const fieldTimezones = [
+        { label: 'UTC+5:30', value: '+05:30' },
+        { label: 'UTC-8', value: '-08:00' },
+      ]
+      expect(optionsAreEqual(globalTimezones, fieldTimezones)).toBe(false)
+    })
+
+    it('should return false for mixed IANA and offset vs pure IANA', () => {
+      const globalTimezones = [
+        { label: 'New York', value: 'America/New_York' },
+        { label: 'London', value: 'Europe/London' },
+      ]
+      const fieldTimezones = [
+        { label: 'New York', value: 'America/New_York' },
+        { label: 'UTC+5:30', value: '+05:30' },
+      ]
+      expect(optionsAreEqual(globalTimezones, fieldTimezones)).toBe(false)
+    })
+
+    it('should return false for subset of global timezones', () => {
+      const globalTimezones = [
+        { label: 'New York', value: 'America/New_York' },
+        { label: 'Los Angeles', value: 'America/Los_Angeles' },
+        { label: 'London', value: 'Europe/London' },
+      ]
+      const fieldTimezones = [{ label: 'New York', value: 'America/New_York' }]
+      expect(optionsAreEqual(globalTimezones, fieldTimezones)).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should return true for both undefined', () => {
+      expect(optionsAreEqual(undefined, undefined)).toBe(true)
+    })
+
+    it('should return false for one undefined', () => {
+      expect(optionsAreEqual(['a'], undefined)).toBe(false)
+      expect(optionsAreEqual(undefined, ['a'])).toBe(false)
+    })
+
+    it('should return true for both empty arrays', () => {
+      expect(optionsAreEqual([], [])).toBe(true)
+    })
+
+    it('should return false for empty vs non-empty', () => {
+      expect(optionsAreEqual([], ['a'])).toBe(false)
+      expect(optionsAreEqual(['a'], [])).toBe(false)
+    })
+
+    it('should handle duplicate values in source (uses Set)', () => {
+      // If there are duplicates, the Set will dedupe them
+      // So ['a', 'a', 'b'] becomes Set{'a', 'b'} with size 2
+      // and ['a', 'b'] becomes Set{'a', 'b'} with size 2
+      // But the arrays have different lengths, so they're not equal
+      expect(optionsAreEqual(['a', 'a', 'b'], ['a', 'b'])).toBe(false)
+    })
+  })
+})

--- a/packages/payload/src/utilities/optionsAreEqual.ts
+++ b/packages/payload/src/utilities/optionsAreEqual.ts
@@ -1,0 +1,47 @@
+import type { Option } from '../fields/config/types.js'
+
+/**
+ * Extracts the value from an option-like object or string.
+ */
+const getOptionValue = (option: Option): string => {
+  if (typeof option === 'string') {
+    return option
+  }
+  return option.value
+}
+
+/**
+ * Compares two arrays of options by their values.
+ * Returns true if both arrays contain the same values (order-independent).
+ */
+export const optionsAreEqual = (
+  options1: Option[] | undefined,
+  options2: Option[] | undefined,
+): boolean => {
+  if (!options1 && !options2) {
+    return true
+  }
+
+  if (!options1 || !options2) {
+    return false
+  }
+
+  if (options1.length !== options2.length) {
+    return false
+  }
+
+  const values1 = new Set(options1.map(getOptionValue))
+  const values2 = new Set(options2.map(getOptionValue))
+
+  if (values1.size !== values2.size) {
+    return false
+  }
+
+  for (const value of values1) {
+    if (!values2.has(value)) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/packages/payload/src/utilities/validateTimezones.spec.ts
+++ b/packages/payload/src/utilities/validateTimezones.spec.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+
+import { InvalidConfiguration } from '../errors/index.js'
+import { validateTimezones } from './validateTimezones.js'
+
+describe('validateTimezones', () => {
+  describe('valid timezones', () => {
+    it('should accept UTC timezone', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: 'UTC', value: 'UTC' }],
+        }),
+      ).not.toThrow()
+    })
+
+    it.each([
+      'America/New_York',
+      'America/Los_Angeles',
+      'America/Chicago',
+      'Europe/London',
+      'Europe/Paris',
+      'Europe/Berlin',
+      'Asia/Tokyo',
+      'Asia/Shanghai',
+      'Asia/Singapore',
+      'Australia/Sydney',
+      'Pacific/Auckland',
+    ])('should accept valid IANA timezone: %s', (timezone) => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: timezone, value: timezone }],
+        }),
+      ).not.toThrow()
+    })
+
+    it('should accept multiple valid timezones', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [
+            { label: 'New York', value: 'America/New_York' },
+            { label: 'London', value: 'Europe/London' },
+            { label: 'Tokyo', value: 'Asia/Tokyo' },
+          ],
+        }),
+      ).not.toThrow()
+    })
+
+    it('should accept empty array', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [],
+        }),
+      ).not.toThrow()
+    })
+
+    it('should accept undefined timezones', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: undefined,
+        }),
+      ).not.toThrow()
+    })
+  })
+
+  describe('invalid timezones', () => {
+    it('should throw for completely invalid timezone', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: 'Invalid', value: 'Invalid/Timezone' }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it('should throw for made up timezone', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: 'Fake', value: 'Fake/Place' }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it('should throw for empty string timezone value', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: 'Empty', value: '' }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it('should throw for random string timezone', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: 'Random', value: 'not-a-timezone' }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+  })
+
+  describe('misspelled timezones', () => {
+    it.each([
+      ['Asian/Tokyo', 'Asia/Tokyo'],
+      ['Asian/Shanghai', 'Asia/Shanghai'],
+      ['Asian/Singapore', 'Asia/Singapore'],
+      ['Asian/Seoul', 'Asia/Seoul'],
+      ['Asian/Bangkok', 'Asia/Bangkok'],
+    ])('should throw for misspelled "Asian/" instead of "Asia/": %s', (misspelled) => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: misspelled, value: misspelled }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it.each([
+      ['Americas/New_York', 'America/New_York'],
+      ['Americas/Los_Angeles', 'America/Los_Angeles'],
+      ['Americas/Chicago', 'America/Chicago'],
+    ])('should throw for misspelled "Americas/" instead of "America/": %s', (misspelled) => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: misspelled, value: misspelled }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it.each([
+      ['Europ/London', 'Europe/London'],
+      ['Euorpe/Paris', 'Europe/Paris'],
+      ['Europa/Berlin', 'Europe/Berlin'],
+    ])('should throw for misspelled Europe region: %s', (misspelled) => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: misspelled, value: misspelled }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it.each([
+      ['Australa/Sydney', 'Australia/Sydney'],
+      ['Austrlia/Melbourne', 'Australia/Melbourne'],
+    ])('should throw for misspelled Australia region: %s', (misspelled) => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: misspelled, value: misspelled }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it.each([
+      ['Pacific/Aukland', 'Pacific/Auckland'],
+      ['Pacfic/Auckland', 'Pacific/Auckland'],
+    ])('should throw for misspelled Pacific region or city: %s', (misspelled) => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: misspelled, value: misspelled }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it.each([
+      'America/NewYork', // missing underscore
+      'America/New-York', // hyphen instead of underscore
+      'America/newyork', // missing underscore and wrong case for city
+    ])('should throw for incorrectly formatted city name: %s', (misspelled) => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: misspelled, value: misspelled }],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    // Note: Intl API is case-insensitive, so lowercase versions like 'america/new_york' are valid
+    it('should accept lowercase timezone (Intl API is case-insensitive)', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: 'lowercase', value: 'america/new_york' }],
+        }),
+      ).not.toThrow()
+    })
+  })
+
+  describe('error messages', () => {
+    it('should include timezone value in error message', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [{ label: 'Bad', value: 'Invalid/Zone' }],
+        }),
+      ).toThrow(/Invalid\/Zone/)
+    })
+
+    it('should include source in error message when provided', () => {
+      expect(() =>
+        validateTimezones({
+          source: 'admin.timezones.supportedTimezones',
+          timezones: [{ label: 'Bad', value: 'Invalid/Zone' }],
+        }),
+      ).toThrow(/admin\.timezones\.supportedTimezones/)
+    })
+
+    it('should include field name in source for field-level errors', () => {
+      expect(() =>
+        validateTimezones({
+          source: 'field "publishedAt" timezone.supportedTimezones',
+          timezones: [{ label: 'Bad', value: 'Asian/Tokyo' }],
+        }),
+      ).toThrow(/field "publishedAt"/)
+    })
+  })
+
+  describe('mixed valid and invalid timezones', () => {
+    it('should throw when array contains at least one invalid timezone', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [
+            { label: 'New York', value: 'America/New_York' },
+            { label: 'Invalid', value: 'Asian/Tokyo' }, // misspelled
+            { label: 'London', value: 'Europe/London' },
+          ],
+        }),
+      ).toThrow(InvalidConfiguration)
+    })
+
+    it('should throw on first invalid timezone encountered', () => {
+      expect(() =>
+        validateTimezones({
+          timezones: [
+            { label: 'First Invalid', value: 'Fake/First' },
+            { label: 'Second Invalid', value: 'Fake/Second' },
+          ],
+        }),
+      ).toThrow(/Fake\/First/)
+    })
+  })
+})

--- a/packages/payload/src/utilities/validateTimezones.spec.ts
+++ b/packages/payload/src/utilities/validateTimezones.spec.ts
@@ -231,4 +231,129 @@ describe('validateTimezones', () => {
       ).toThrow(/Fake\/First/)
     })
   })
+
+  describe('UTC offset timezones', () => {
+    describe('valid UTC offsets', () => {
+      it.each([
+        '+00:00',
+        '-00:00',
+        '+05:30',
+        '-08:00',
+        '+12:00',
+        '-12:00',
+        '+14:00', // max positive offset (Line Islands)
+        '+09:30', // half-hour offset
+        '+05:45', // 45-minute offset (Nepal)
+      ])('should accept valid HH:mm format offset: %s', (offset) => {
+        expect(() =>
+          validateTimezones({
+            timezones: [{ label: `UTC${offset}`, value: offset }],
+          }),
+        ).not.toThrow()
+      })
+
+      it('should accept mixed IANA and offset timezones', () => {
+        expect(() =>
+          validateTimezones({
+            timezones: [
+              { label: 'New York', value: 'America/New_York' },
+              { label: 'UTC+5:30', value: '+05:30' },
+              { label: 'UTC', value: 'UTC' },
+              { label: 'UTC-8', value: '-08:00' },
+            ],
+          }),
+        ).not.toThrow()
+      })
+    })
+
+    describe('invalid UTC offsets', () => {
+      it.each(['+0530', '-0800', '+0000', '+1200', '+00', '-08', '+9', '-5'])(
+        'should throw for non-HH:mm format offset: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `Invalid ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+
+      it.each(['+15:00', '-13:00', '+25:00', '-20:00'])(
+        'should throw for out of range hour offset: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `Invalid ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+
+      it.each(['+05:60', '-08:99', '+12:75', '+00:61'])(
+        'should throw for invalid minutes in offset: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `Invalid ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+
+      it.each(['05:30', '0800', '12', '530'])(
+        'should throw for offset missing sign: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `Missing sign ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+
+      it.each(['++05:30', '--08:00', '+-05:30', '-+08:00'])(
+        'should throw for malformed sign in offset: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `Malformed ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+
+      it.each(['+ 05:30', '- 08:00', '+05 :30', '+05: 30'])(
+        'should throw for offset with spaces: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `Spaced ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+
+      it.each(['+5:', '+:30', ':', '+:', '-:'])(
+        'should throw for incomplete offset format: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `Incomplete ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+
+      it.each(['+05:30:00', '+05:30:30', '-08:00:00'])(
+        'should throw for offset with seconds: %s',
+        (offset) => {
+          expect(() =>
+            validateTimezones({
+              timezones: [{ label: `With seconds ${offset}`, value: offset }],
+            }),
+          ).toThrow(InvalidConfiguration)
+        },
+      )
+    })
+  })
 })

--- a/packages/payload/src/utilities/validateTimezones.ts
+++ b/packages/payload/src/utilities/validateTimezones.ts
@@ -1,0 +1,66 @@
+import type { Timezone } from '../config/types.js'
+
+import { InvalidConfiguration } from '../errors/index.js'
+
+type ValidateTimezonesArgs = {
+  /**
+   * The source of the timezones for error messaging
+   */
+  source?: string
+  /**
+   * Array of timezones to validate
+   */
+  timezones: Timezone[] | undefined
+}
+
+/**
+ * Checks if a timezone is supported by the current runtime.
+ * Uses Intl.DateTimeFormat as the primary check since it tests actual usability,
+ * with Intl.supportedValuesOf as a secondary check for environments that support it.
+ */
+const isTimezoneSupported = (timezoneValue: string): boolean => {
+  // UTC is always supported
+  if (timezoneValue === 'UTC') {
+    return true
+  }
+
+  // Primary check: attempt to create a DateTimeFormat with the timezone
+  // This is the most reliable check as it tests actual usability
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezoneValue })
+    return true
+  } catch {
+    // DateTimeFormat failed, timezone is not supported
+  }
+
+  // Secondary check: verify against supportedValuesOf if available
+  if (typeof Intl.supportedValuesOf === 'function') {
+    const supportedTimezones = Intl.supportedValuesOf('timeZone')
+    if (supportedTimezones.includes(timezoneValue)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Validates that all provided timezones are supported by the current runtime's Intl API.
+ * Uses both Intl.DateTimeFormat and Intl.supportedValuesOf for comprehensive validation.
+ *
+ * @throws InvalidConfiguration if an unsupported timezone is found
+ */
+export const validateTimezones = ({ source, timezones }: ValidateTimezonesArgs): void => {
+  if (!timezones?.length) {
+    return
+  }
+
+  for (const timezone of timezones) {
+    if (!isTimezoneSupported(timezone.value)) {
+      const sourceText = source ? ` in ${source}` : ''
+      throw new InvalidConfiguration(
+        `Timezone ${timezone.value}${sourceText} is not supported by the current runtime via the Intl API.`,
+      )
+    }
+  }
+}

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -790,6 +790,31 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
       }).toPass({ timeout: 10000, intervals: [100] })
     })
 
+    test('date field with hidden timezone column should display date correctly in list view', async () => {
+      await page.goto(url.list)
+
+      // The date field value should still be displayed correctly
+      const dateTimeLocator = page.locator('.cell-dateWithTimezoneWithDisabledColumns').first()
+
+      await expect(async () => {
+        // The date is 2027-08-12T14:00:00.000Z with America/New_York timezone
+        // In New York (UTC-4 in summer), this should display as 10:00 AM
+        await expect(dateTimeLocator).toHaveText('August 12th 2027, 10:00 AM')
+      }).toPass({ timeout: 10000, intervals: [100] })
+
+      // The timezone column should NOT be visible (hidden via disableListColumn override)
+      const timezoneColumnCell = page.locator('.cell-dateWithTimezoneWithDisabledColumns_tz')
+      await expect(timezoneColumnCell).toHaveCount(0)
+
+      await page.locator('.list-controls__toggle-columns').click()
+
+      const dateColumnOption = page.locator('#dateWithTimezoneWithDisabledColumns')
+      await expect(dateColumnOption).toBeVisible()
+
+      const timezoneColumnOption = page.locator('#dateWithTimezoneWithDisabledColumns_tz')
+      await expect(timezoneColumnOption).toBeHidden()
+    })
+
     test('creates the expected UTC value when the selected timezone is UTC', async () => {
       const expectedDateInput = 'Jan 1, 2025 6:00 PM'
       const expectedUTCValue = '2025-01-01T18:00:00.000Z'

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -597,6 +597,98 @@ describe('Date', () => {
     })
   })
 
+  describe('dates with offset timezones', () => {
+    test('can see UTC offset timezone options in picker', async () => {
+      await page.goto(url.create)
+
+      const dropdownControlSelector = `#field-dateWithOffsetTimezone .rs__control`
+
+      await page.click(dropdownControlSelector)
+
+      // Check for UTC+5:30 (India) option
+      const indiaOption = page.locator(
+        `#field-dateWithOffsetTimezone .rs__menu .rs__option:has-text("UTC+5:30 (India)")`,
+      )
+      await expect(indiaOption).toBeVisible()
+
+      // Check for UTC-8 (PST) option
+      const pstOption = page.locator(
+        `#field-dateWithOffsetTimezone .rs__menu .rs__option:has-text("UTC-8 (PST)")`,
+      )
+      await expect(pstOption).toBeVisible()
+
+      // Check for UTC+0 option
+      const utcOption = page.locator(
+        `#field-dateWithOffsetTimezone .rs__menu .rs__option:has-text("UTC+0")`,
+      )
+      await expect(utcOption).toBeVisible()
+    })
+
+    // Note: The 'can select offset timezone and save document' test has been moved to
+    // createTimezoneContextTests to verify it works across different browser timezone contexts
+
+    test('can see mixed IANA and offset timezone options', async () => {
+      await page.goto(url.create)
+
+      const dropdownControlSelector = `#field-dateWithMixedTimezones .rs__control`
+
+      await page.click(dropdownControlSelector)
+
+      // Check for IANA timezone option
+      const newYorkOption = page.locator(
+        `#field-dateWithMixedTimezones .rs__menu .rs__option:has-text("New York")`,
+      )
+      await expect(newYorkOption).toBeVisible()
+
+      // Check for UTC offset option
+      const offsetOption = page.locator(
+        `#field-dateWithMixedTimezones .rs__menu .rs__option:text-is("UTC+5:30")`,
+      )
+      await expect(offsetOption).toBeVisible()
+
+      // Check for UTC option
+      const utcOption = page.locator(
+        `#field-dateWithMixedTimezones .rs__menu .rs__option:text-is("UTC")`,
+      )
+      await expect(utcOption).toBeVisible()
+    })
+
+    test('default offset timezone is pre-selected', async () => {
+      await page.goto(url.create)
+
+      const selectedTimezoneSelector = `#field-dateWithOffsetTimezone .rs__value-container`
+      const selectedTimezone = page.locator(selectedTimezoneSelector)
+
+      // Default is +05:30 which has label "UTC+5:30 (India)"
+      await expect(selectedTimezone).toContainText('UTC+5:30 (India)')
+    })
+
+    test('changing offset timezone updates displayed date value', async () => {
+      const {
+        docs: [existingDoc],
+      } = await payload.find({
+        collection: dateFieldsSlug,
+      })
+
+      await page.goto(url.edit(existingDoc!.id))
+
+      const dateTimeLocator = page.locator(
+        '#field-dateWithOffsetTimezone .react-datepicker-wrapper input',
+      )
+
+      const initialDateValue = await dateTimeLocator.inputValue()
+
+      const dropdownControlSelector = `#field-dateWithOffsetTimezone .rs__control`
+      const timezoneOptionSelector = `#field-dateWithOffsetTimezone .rs__menu .rs__option:has-text("UTC-8 (PST)")`
+
+      await page.click(dropdownControlSelector)
+      await page.click(timezoneOptionSelector)
+
+      // Date value should change to reflect the new timezone
+      await expect(dateTimeLocator).not.toHaveValue(initialDateValue)
+    })
+  })
+
   describe('A11y', () => {
     test.fixme('Edit view should have no accessibility violations', async ({}, testInfo) => {
       await page.goto(url.create)
@@ -1006,6 +1098,209 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
       // Verify the stored values are as expected
       expect(existingDoc?.dayAndTimeWithTimezoneReadOnly).toEqual(expectedReadOnlyUTCValue)
       expect(existingDoc?.dayAndTimeWithTimezoneReadOnly_tz).toEqual(expectedReadOnlyTimezoneValue)
+    })
+    describe('offset timezone handling', () => {
+      test('offset timezone saves correct UTC value regardless of browser context', async () => {
+        // This test verifies that UTC offset conversion is independent of browser timezone
+        // Input: Jan 1, 2025 6:00 PM with +05:30 selected
+        // Expected UTC: 2025-01-01T12:30:00.000Z (should be same in ALL browser contexts)
+        const expectedDateInput = 'Jan 1, 2025 6:00 PM'
+        const expectedUTCValue = '2025-01-01T12:30:00.000Z'
+        const expectedTimezone = '+05:30'
+
+        await page.goto(url.create)
+
+        const dateField = page.locator('#field-default input')
+        await dateField.fill('01/01/2025')
+
+        // Fill required dayAndTimeWithTimezone field
+        const requiredDateWithTz = page.locator(
+          '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+        )
+        await requiredDateWithTz.fill('01/01/2025 10:00 AM')
+
+        const requiredTzDropdown = `#field-dayAndTimeWithTimezone .rs__control`
+        const requiredTzOption = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Tokyo")`
+        await page.click(requiredTzDropdown)
+        await page.click(requiredTzOption)
+
+        // Set up the offset timezone field
+        const dateTimeLocator = page.locator(
+          '#field-dateWithOffsetTimezone .react-datepicker-wrapper input',
+        )
+
+        const dropdownControlSelector = `#field-dateWithOffsetTimezone .rs__control`
+        const timezoneOptionSelector = `#field-dateWithOffsetTimezone .rs__menu .rs__option:has-text("UTC+5:30 (India)")`
+
+        await page.click(dropdownControlSelector)
+        await page.click(timezoneOptionSelector)
+        await dateTimeLocator.fill(expectedDateInput)
+
+        await saveDocAndAssert(page)
+
+        const docID = page.url().split('/').pop()
+
+        // eslint-disable-next-line payload/no-flaky-assertions
+        expect(docID).toBeTruthy()
+
+        const {
+          docs: [existingDoc],
+        } = await payload.find({
+          collection: dateFieldsSlug,
+          where: {
+            id: {
+              equals: docID,
+            },
+          },
+        })
+
+        // The UTC value should be identical regardless of browser timezone context
+        // eslint-disable-next-line payload/no-flaky-assertions
+        expect(existingDoc?.dateWithOffsetTimezone).toEqual(expectedUTCValue)
+        expect(existingDoc?.dateWithOffsetTimezone_tz).toEqual(expectedTimezone)
+      })
+
+      test('negative offset timezone saves correct UTC value regardless of browser context', async () => {
+        // Input: Jan 1, 2025 6:00 PM with -08:00 selected
+        // Expected UTC: 2025-01-02T02:00:00.000Z (6PM + 8 hours = 2AM next day)
+        const expectedDateInput = 'Jan 1, 2025 6:00 PM'
+        const expectedUTCValue = '2025-01-02T02:00:00.000Z'
+        const expectedTimezone = '-08:00'
+
+        await page.goto(url.create)
+
+        const dateField = page.locator('#field-default input')
+        await dateField.fill('01/01/2025')
+
+        // Fill required dayAndTimeWithTimezone field
+        const requiredDateWithTz = page.locator(
+          '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+        )
+        await requiredDateWithTz.fill('01/01/2025 10:00 AM')
+
+        const requiredTzDropdown = `#field-dayAndTimeWithTimezone .rs__control`
+        const requiredTzOption = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Tokyo")`
+        await page.click(requiredTzDropdown)
+        await page.click(requiredTzOption)
+
+        // Set up the offset timezone field with negative offset
+        const dateTimeLocator = page.locator(
+          '#field-dateWithOffsetTimezone .react-datepicker-wrapper input',
+        )
+
+        const dropdownControlSelector = `#field-dateWithOffsetTimezone .rs__control`
+        const timezoneOptionSelector = `#field-dateWithOffsetTimezone .rs__menu .rs__option:has-text("UTC-8 (PST)")`
+
+        await page.click(dropdownControlSelector)
+        await page.click(timezoneOptionSelector)
+        await dateTimeLocator.fill(expectedDateInput)
+
+        await saveDocAndAssert(page)
+
+        const docID = page.url().split('/').pop()
+
+        // eslint-disable-next-line payload/no-flaky-assertions
+        expect(docID).toBeTruthy()
+
+        const {
+          docs: [existingDoc],
+        } = await payload.find({
+          collection: dateFieldsSlug,
+          where: {
+            id: {
+              equals: docID,
+            },
+          },
+        })
+
+        // eslint-disable-next-line payload/no-flaky-assertions
+        expect(existingDoc?.dateWithOffsetTimezone).toEqual(expectedUTCValue)
+        expect(existingDoc?.dateWithOffsetTimezone_tz).toEqual(expectedTimezone)
+      })
+
+      test('switching between IANA and offset timezone works correctly', async () => {
+        // Test the mixed timezone field that supports both IANA and offset formats
+        const expectedDateInput = 'Jan 1, 2025 6:00 PM'
+
+        await page.goto(url.create)
+
+        const dateField = page.locator('#field-default input')
+        await dateField.fill('01/01/2025')
+
+        // Fill required dayAndTimeWithTimezone field
+        const requiredDateWithTz = page.locator(
+          '#field-dayAndTimeWithTimezone .react-datepicker-wrapper input',
+        )
+        await requiredDateWithTz.fill('01/01/2025 10:00 AM')
+
+        const requiredTzDropdown = `#field-dayAndTimeWithTimezone .rs__control`
+        const requiredTzOption = `#field-dayAndTimeWithTimezone .rs__menu .rs__option:has-text("Tokyo")`
+        await page.click(requiredTzDropdown)
+        await page.click(requiredTzOption)
+
+        // Set up the mixed timezone field - first with IANA timezone
+        const dateTimeLocator = page.locator(
+          '#field-dateWithMixedTimezones .react-datepicker-wrapper input',
+        )
+        const dropdownControlSelector = `#field-dateWithMixedTimezones .rs__control`
+
+        // Select IANA timezone first
+        const ianaOptionSelector = `#field-dateWithMixedTimezones .rs__menu .rs__option:has-text("New York")`
+        await page.click(dropdownControlSelector)
+        await page.click(ianaOptionSelector)
+        await dateTimeLocator.fill(expectedDateInput)
+
+        // Now switch to offset timezone
+        const offsetOptionSelector = `#field-dateWithMixedTimezones .rs__menu .rs__option:text-is("UTC+5:30")`
+        await page.click(dropdownControlSelector)
+        await page.click(offsetOptionSelector)
+
+        await saveDocAndAssert(page)
+
+        const docID = page.url().split('/').pop()
+
+        // eslint-disable-next-line payload/no-flaky-assertions
+        expect(docID).toBeTruthy()
+
+        const {
+          docs: [existingDoc],
+        } = await payload.find({
+          collection: dateFieldsSlug,
+          where: {
+            id: {
+              equals: docID,
+            },
+          },
+        })
+
+        // Should have saved with the offset timezone
+        expect(existingDoc?.dateWithMixedTimezones_tz).toEqual('+05:30')
+      })
+
+      test('offset timezone display is independent of browser timezone', async () => {
+        // Create a doc with a known offset timezone value
+        const doc = await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            default: '2025-01-01T00:00:00.000Z',
+            dayAndTimeWithTimezone: '2025-01-01T01:00:00.000Z',
+            dayAndTimeWithTimezone_tz: 'Asia/Tokyo',
+            // 2025-01-01T12:30:00.000Z with +05:30 should display as Jan 1, 2025 6:00 PM
+            dateWithOffsetTimezone: '2025-01-01T12:30:00.000Z',
+            dateWithOffsetTimezone_tz: '+05:30',
+          },
+        })
+
+        await page.goto(url.edit(doc.id))
+
+        const dateTimeLocator = page.locator(
+          '#field-dateWithOffsetTimezone .react-datepicker-wrapper input',
+        )
+
+        // The displayed value should be 6:00 PM regardless of browser timezone
+        // because offset timezones are absolute (not affected by browser TZ)
+        await expect(dateTimeLocator).toHaveValue('Jan 1, 2025 6:00 PM')
+      })
     })
   })
 }

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -14,6 +14,7 @@ const DateFields: CollectionConfig = {
       'dayAndTimeWithTimezone',
       'timezoneGroup.dayAndTime',
       'dayAndTimeWithTimezoneFixed',
+      'dateWithTimezoneWithDisabledColumns',
     ],
   },
   fields: [
@@ -227,6 +228,25 @@ const DateFields: CollectionConfig = {
           { label: 'UTC+5:30', value: '+05:30' },
           { label: 'UTC', value: 'UTC' },
         ],
+      },
+    },
+    {
+      name: 'dateWithTimezoneWithDisabledColumns',
+      type: 'date',
+      timezone: {
+        override: ({ baseField }) => ({
+          ...baseField,
+          admin: {
+            ...baseField.admin,
+            disableListColumn: true,
+            description: 'This timezone field was customized via override',
+          },
+        }),
+      },
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
       },
     },
   ],

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -195,6 +195,40 @@ const DateFields: CollectionConfig = {
         },
       ],
     },
+    {
+      name: 'dateWithOffsetTimezone',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+      timezone: {
+        defaultTimezone: '+05:30',
+        supportedTimezones: [
+          { label: 'UTC+5:30 (India)', value: '+05:30' },
+          { label: 'UTC-8 (PST)', value: '-08:00' },
+          { label: 'UTC+0', value: '+00:00' },
+        ],
+      },
+    },
+    {
+      name: 'dateWithMixedTimezones',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+      timezone: {
+        defaultTimezone: 'America/New_York',
+        supportedTimezones: [
+          { label: 'New York', value: 'America/New_York' },
+          { label: 'UTC+5:30', value: '+05:30' },
+          { label: 'UTC', value: 'UTC' },
+        ],
+      },
+    },
   ],
 }
 

--- a/test/fields/collections/Date/shared.ts
+++ b/test/fields/collections/Date/shared.ts
@@ -37,4 +37,7 @@ export const dateDoc: Partial<DateField> = {
   // Mixed IANA + offset timezones - 2027-08-12 10:00 AM in America/New_York (UTC-4 in summer) = 14:00 UTC
   dateWithMixedTimezones: '2027-08-12T14:00:00.000+00:00',
   dateWithMixedTimezones_tz: 'America/New_York',
+  // Date with timezone where timezone column is hidden via override
+  dateWithTimezoneWithDisabledColumns: '2027-08-12T14:00:00.000+00:00',
+  dateWithTimezoneWithDisabledColumns_tz: 'America/New_York',
 }

--- a/test/fields/collections/Date/shared.ts
+++ b/test/fields/collections/Date/shared.ts
@@ -31,4 +31,10 @@ export const dateDoc: Partial<DateField> = {
   dayAndTimeWithTimezoneReadOnly: '2027-08-12T01:00:00.000+00:00',
   dayAndTimeWithTimezoneReadOnly_tz: 'Asia/Tokyo',
   dayAndTimeWithTimezoneFixed: '2025-10-29T20:00:00.000+00:00',
+  // UTC offset timezone tests - 2027-08-12 10:00 AM in UTC+5:30 (India) = 04:30 UTC
+  dateWithOffsetTimezone: '2027-08-12T04:30:00.000+00:00',
+  dateWithOffsetTimezone_tz: '+05:30',
+  // Mixed IANA + offset timezones - 2027-08-12 10:00 AM in America/New_York (UTC-4 in summer) = 14:00 UTC
+  dateWithMixedTimezones: '2027-08-12T14:00:00.000+00:00',
+  dateWithMixedTimezones_tz: 'America/New_York',
 }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -3702,7 +3702,7 @@ describe('Fields', () => {
 
         const query = `
           query {
-            DateField(id: "${doc.id}") {
+            DateField(id: ${typeof doc.id === 'string' ? `"${doc.id}"` : doc.id}) {
               dateWithOffsetTimezone
               dateWithOffsetTimezone_tz
             }
@@ -3734,7 +3734,7 @@ describe('Fields', () => {
 
         const query = `
           query {
-            DateField(id: "${doc.id}") {
+            DateField(id: ${typeof doc.id === 'string' ? `"${doc.id}"` : doc.id}) {
               dateWithOffsetTimezone_tz
             }
           }
@@ -3760,7 +3760,7 @@ describe('Fields', () => {
 
         const query = `
           query {
-            DateField(id: "${doc.id}") {
+            DateField(id: ${typeof doc.id === 'string' ? `"${doc.id}"` : doc.id}) {
               dateWithMixedTimezones
               dateWithMixedTimezones_tz
             }
@@ -3856,7 +3856,7 @@ describe('Fields', () => {
         const mutation = `
           mutation {
             updateDateField(
-              id: "${doc.id}",
+              id: ${typeof doc.id === 'string' ? `"${doc.id}"` : doc.id},
               data: {
                 dateWithOffsetTimezone_tz: _TZOFFSET_MINUS_08_00
               }
@@ -3890,7 +3890,7 @@ describe('Fields', () => {
         const mutation = `
           mutation {
             updateDateField(
-              id: "${doc.id}",
+              id: ${typeof doc.id === 'string' ? `"${doc.id}"` : doc.id},
               data: {
                 dateWithMixedTimezones_tz: _TZOFFSET_PLUS_05_30
               }
@@ -3925,7 +3925,7 @@ describe('Fields', () => {
         const mutation = `
           mutation {
             updateDateField(
-              id: "${doc.id}",
+              id: ${typeof doc.id === 'string' ? `"${doc.id}"` : doc.id},
               data: {
                 dateWithMixedTimezones_tz: America_New_York
               }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -33,6 +33,7 @@ import {
   blockFieldsSlug,
   checkboxFieldsSlug,
   collapsibleFieldsSlug,
+  dateFieldsSlug,
   groupFieldsSlug,
   numberFieldsSlug,
   relationshipFieldsSlug,
@@ -778,8 +779,10 @@ describe('Fields', () => {
       if (res.totalDocs > 10) {
         // This is where postgres might fail! selectDistinct actually removed some rows here, because it distincts by:
         // not only ID, but also created_at, updated_at, items_date
+        // eslint-disable-next-line vitest/no-conditional-expect
         expect(res.docs).toHaveLength(10)
       } else {
+        // eslint-disable-next-line vitest/no-conditional-expect
         expect(res.docs.length).toBeLessThanOrEqual(res.totalDocs)
       }
     })
@@ -994,6 +997,7 @@ describe('Fields', () => {
 
         expect(result).toBeFalsy()
       } catch (error) {
+        // eslint-disable-next-line vitest/no-conditional-expect
         expect((error as Error).message).toBe(
           'The following field is invalid: Select with filtered options',
         )
@@ -3533,6 +3537,490 @@ describe('Fields', () => {
       })
 
       expect(result.docs).toHaveLength(1)
+    })
+  })
+
+  describe('date fields with timezones', () => {
+    it('should create document with UTC offset timezone', async () => {
+      const doc = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithOffsetTimezone: '2027-08-12T04:30:00.000Z',
+          dateWithOffsetTimezone_tz: '+05:30',
+        },
+        draft: true,
+      })
+
+      expect(doc.dateWithOffsetTimezone).toEqual('2027-08-12T04:30:00.000Z')
+      expect(doc.dateWithOffsetTimezone_tz).toEqual('+05:30')
+    })
+
+    it('should update timezone from IANA to offset', async () => {
+      const doc = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithMixedTimezones: '2027-08-12T14:00:00.000Z',
+          dateWithMixedTimezones_tz: 'America/New_York',
+        },
+        draft: true,
+      })
+
+      expect(doc.dateWithMixedTimezones_tz).toEqual('America/New_York')
+
+      const updated = await payload.update({
+        id: doc.id,
+        collection: dateFieldsSlug,
+        data: {
+          dateWithMixedTimezones_tz: '+05:30',
+        },
+      })
+
+      expect(updated.dateWithMixedTimezones_tz).toEqual('+05:30')
+    })
+
+    it('should query documents by timezone field', async () => {
+      await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithOffsetTimezone: '2027-08-12T04:30:00.000Z',
+          dateWithOffsetTimezone_tz: '+05:30',
+        },
+        draft: true,
+      })
+
+      await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithOffsetTimezone: '2027-08-12T08:00:00.000Z',
+          dateWithOffsetTimezone_tz: '-08:00',
+        },
+        draft: true,
+      })
+
+      const indiaTimezoneResults = await payload.find({
+        collection: dateFieldsSlug,
+        where: {
+          dateWithOffsetTimezone_tz: {
+            equals: '+05:30',
+          },
+        },
+      })
+
+      expect(indiaTimezoneResults.docs.length).toBeGreaterThanOrEqual(1)
+      expect(
+        indiaTimezoneResults.docs.every((doc) => doc.dateWithOffsetTimezone_tz === '+05:30'),
+      ).toBe(true)
+    })
+
+    it('should store mixed IANA and offset timezones correctly', async () => {
+      const doc = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithMixedTimezones: '2027-08-12T14:00:00.000Z',
+          dateWithMixedTimezones_tz: 'America/New_York',
+        },
+        draft: true,
+      })
+
+      expect(doc.dateWithMixedTimezones_tz).toEqual('America/New_York')
+
+      // Create another doc with offset timezone
+      const doc2 = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithMixedTimezones: '2027-08-12T04:30:00.000Z',
+          dateWithMixedTimezones_tz: '+05:30',
+        },
+        draft: true,
+      })
+
+      expect(doc2.dateWithMixedTimezones_tz).toEqual('+05:30')
+    })
+
+    it('should handle different offset formats consistently', async () => {
+      // Test HH:mm format
+      const doc1 = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithOffsetTimezone: '2027-08-12T04:30:00.000Z',
+          dateWithOffsetTimezone_tz: '+05:30',
+        },
+        draft: true,
+      })
+
+      expect(doc1.dateWithOffsetTimezone_tz).toEqual('+05:30')
+
+      // Test negative offset
+      const doc2 = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithOffsetTimezone: '2027-08-12T16:00:00.000Z',
+          dateWithOffsetTimezone_tz: '-08:00',
+        },
+        draft: true,
+      })
+
+      expect(doc2.dateWithOffsetTimezone_tz).toEqual('-08:00')
+
+      // Test zero offset
+      const doc3 = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dateDoc,
+          dateWithOffsetTimezone: '2027-08-12T10:00:00.000Z',
+          dateWithOffsetTimezone_tz: '+00:00',
+        },
+        draft: true,
+      })
+
+      expect(doc3.dateWithOffsetTimezone_tz).toEqual('+00:00')
+    })
+
+    describe('GraphQL timezone operations', () => {
+      // Note: GraphQL enums serialize to their NAME (e.g., '_TZOFFSET_PLUS_05_30'), not their VALUE (e.g., '+05:30')
+      // This is standard GraphQL behavior. UTC offsets are transformed to GraphQL-safe names:
+      // +05:30 → _TZOFFSET_PLUS_05_30, -08:00 → _TZOFFSET_MINUS_08_00, America/New_York → America_New_York
+
+      it('should read UTC offset timezone via GraphQL query', async () => {
+        const doc = await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithOffsetTimezone: '2027-08-12T04:30:00.000Z',
+            dateWithOffsetTimezone_tz: '+05:30',
+          },
+          draft: true,
+        })
+
+        const query = `
+          query {
+            DateField(id: "${doc.id}") {
+              dateWithOffsetTimezone
+              dateWithOffsetTimezone_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        const result = await response.json()
+
+        if (result.errors) {
+          console.error('GraphQL errors:', JSON.stringify(result.errors, null, 2))
+        }
+        expect(result.errors).toBeUndefined()
+        expect(result.data.DateField.dateWithOffsetTimezone).toEqual('2027-08-12T04:30:00.000Z')
+        // GraphQL returns enum NAME, not VALUE
+        expect(result.data.DateField.dateWithOffsetTimezone_tz).toEqual('_TZOFFSET_PLUS_05_30')
+      })
+
+      it('should read negative UTC offset timezone via GraphQL query', async () => {
+        const doc = await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithOffsetTimezone: '2027-08-12T16:00:00.000Z',
+            dateWithOffsetTimezone_tz: '-08:00',
+          },
+          draft: true,
+        })
+
+        const query = `
+          query {
+            DateField(id: "${doc.id}") {
+              dateWithOffsetTimezone_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        const result = await response.json()
+
+        expect(result.errors).toBeUndefined()
+        expect(result.data.DateField.dateWithOffsetTimezone_tz).toEqual('_TZOFFSET_MINUS_08_00')
+      })
+
+      it('should read mixed IANA and offset timezones via GraphQL query', async () => {
+        const doc = await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithMixedTimezones: '2027-08-12T14:00:00.000Z',
+            dateWithMixedTimezones_tz: 'America/New_York',
+          },
+          draft: true,
+        })
+
+        const query = `
+          query {
+            DateField(id: "${doc.id}") {
+              dateWithMixedTimezones
+              dateWithMixedTimezones_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        const result = await response.json()
+
+        expect(result.errors).toBeUndefined()
+        // GraphQL returns enum NAME (America_New_York), not VALUE (America/New_York)
+        expect(result.data.DateField.dateWithMixedTimezones_tz).toEqual('America_New_York')
+      })
+
+      it('should create document with UTC offset timezone via GraphQL mutation', async () => {
+        const mutation = `
+          mutation {
+            createDateField(
+              data: {
+                default: "2027-08-12T10:00:00.000Z",
+                dayAndTimeWithTimezone: "2027-08-12T01:00:00.000Z",
+                dayAndTimeWithTimezone_tz: Asia_Tokyo,
+                dayAndTimeWithTimezoneRequired_tz: America_New_York,
+                dateWithOffsetTimezone: "2027-08-12T04:30:00.000Z",
+                dateWithOffsetTimezone_tz: _TZOFFSET_PLUS_05_30
+              }
+            ) {
+              id
+              dateWithOffsetTimezone
+              dateWithOffsetTimezone_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({ query: mutation }),
+        })
+        const result = await response.json()
+
+        if (result.errors) {
+          console.error('GraphQL errors:', JSON.stringify(result.errors, null, 2))
+        }
+        expect(result.errors).toBeUndefined()
+        expect(result.data.createDateField.dateWithOffsetTimezone_tz).toEqual(
+          '_TZOFFSET_PLUS_05_30',
+        )
+      })
+
+      it('should create document with negative UTC offset via GraphQL mutation', async () => {
+        const mutation = `
+          mutation {
+            createDateField(
+              data: {
+                default: "2027-08-12T10:00:00.000Z",
+                dayAndTimeWithTimezone: "2027-08-12T01:00:00.000Z",
+                dayAndTimeWithTimezone_tz: Asia_Tokyo,
+                dayAndTimeWithTimezoneRequired_tz: America_New_York,
+                dateWithOffsetTimezone: "2027-08-12T16:00:00.000Z",
+                dateWithOffsetTimezone_tz: _TZOFFSET_MINUS_08_00
+              }
+            ) {
+              id
+              dateWithOffsetTimezone_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({ query: mutation }),
+        })
+        const result = await response.json()
+
+        if (result.errors) {
+          console.error('GraphQL errors:', JSON.stringify(result.errors, null, 2))
+        }
+        expect(result.errors).toBeUndefined()
+        expect(result.data.createDateField.dateWithOffsetTimezone_tz).toEqual(
+          '_TZOFFSET_MINUS_08_00',
+        )
+      })
+
+      it('should update timezone from one offset to another via GraphQL mutation', async () => {
+        const doc = await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithOffsetTimezone: '2027-08-12T04:30:00.000Z',
+            dateWithOffsetTimezone_tz: '+05:30',
+          },
+          draft: true,
+        })
+
+        const mutation = `
+          mutation {
+            updateDateField(
+              id: "${doc.id}",
+              data: {
+                dateWithOffsetTimezone_tz: _TZOFFSET_MINUS_08_00
+              }
+            ) {
+              dateWithOffsetTimezone_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({ query: mutation }),
+        })
+        const result = await response.json()
+
+        expect(result.errors).toBeUndefined()
+        expect(result.data.updateDateField.dateWithOffsetTimezone_tz).toEqual(
+          '_TZOFFSET_MINUS_08_00',
+        )
+      })
+
+      it('should update mixed timezone field from IANA to offset via GraphQL mutation', async () => {
+        const doc = await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithMixedTimezones: '2027-08-12T14:00:00.000Z',
+            dateWithMixedTimezones_tz: 'America/New_York',
+          },
+        })
+
+        const mutation = `
+          mutation {
+            updateDateField(
+              id: "${doc.id}",
+              data: {
+                dateWithMixedTimezones_tz: _TZOFFSET_PLUS_05_30
+              }
+            ) {
+              dateWithMixedTimezones_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({ query: mutation }),
+        })
+        const result = await response.json()
+
+        expect(result.errors).toBeUndefined()
+        expect(result.data.updateDateField.dateWithMixedTimezones_tz).toEqual(
+          '_TZOFFSET_PLUS_05_30',
+        )
+      })
+
+      it('should update mixed timezone field from offset to IANA via GraphQL mutation', async () => {
+        const doc = await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithMixedTimezones: '2027-08-12T04:30:00.000Z',
+            dateWithMixedTimezones_tz: '+05:30',
+          },
+          draft: true,
+        })
+
+        const mutation = `
+          mutation {
+            updateDateField(
+              id: "${doc.id}",
+              data: {
+                dateWithMixedTimezones_tz: America_New_York
+              }
+            ) {
+              dateWithMixedTimezones_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({ query: mutation }),
+        })
+        const result = await response.json()
+
+        expect(result.errors).toBeUndefined()
+        expect(result.data.updateDateField.dateWithMixedTimezones_tz).toEqual('America_New_York')
+      })
+
+      it('should query documents by offset timezone field via GraphQL', async () => {
+        // Create documents with different timezones
+        await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithOffsetTimezone: '2027-08-12T04:30:00.000Z',
+            dateWithOffsetTimezone_tz: '+05:30',
+          },
+          draft: true,
+        })
+
+        await payload.create({
+          collection: dateFieldsSlug,
+          data: {
+            ...dateDoc,
+            dateWithOffsetTimezone: '2027-08-12T16:00:00.000Z',
+            dateWithOffsetTimezone_tz: '-08:00',
+          },
+          draft: true,
+        })
+
+        const query = `
+          query {
+            DateFields(where: { dateWithOffsetTimezone_tz: { equals: _TZOFFSET_PLUS_05_30 } }) {
+              docs {
+                dateWithOffsetTimezone_tz
+              }
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        const result = await response.json()
+
+        expect(result.errors).toBeUndefined()
+        expect(result.data.DateFields.docs.length).toBeGreaterThanOrEqual(1)
+        expect(
+          result.data.DateFields.docs.every(
+            (doc: { dateWithOffsetTimezone_tz: string }) =>
+              doc.dateWithOffsetTimezone_tz === '_TZOFFSET_PLUS_05_30',
+          ),
+        ).toBe(true)
+      })
+
+      it('should handle UTC+00:00 offset via GraphQL', async () => {
+        const mutation = `
+          mutation {
+            createDateField(
+              data: {
+                default: "2027-08-12T10:00:00.000Z",
+                dayAndTimeWithTimezone: "2027-08-12T01:00:00.000Z",
+                dayAndTimeWithTimezone_tz: Asia_Tokyo,
+                dayAndTimeWithTimezoneRequired_tz: America_New_York,
+                dateWithOffsetTimezone: "2027-08-12T10:00:00.000Z",
+                dateWithOffsetTimezone_tz: _TZOFFSET_PLUS_00_00
+              }
+            ) {
+              id
+              dateWithOffsetTimezone_tz
+            }
+          }
+        `
+
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({ query: mutation }),
+        })
+        const result = await response.json()
+
+        if (result.errors) {
+          console.error('GraphQL errors:', JSON.stringify(result.errors, null, 2))
+        }
+        expect(result.errors).toBeUndefined()
+        expect(result.data.createDateField.dateWithOffsetTimezone_tz).toEqual(
+          '_TZOFFSET_PLUS_00_00',
+        )
+      })
     })
   })
 })

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1036,6 +1036,8 @@ export interface DateField {
   dateWithOffsetTimezone_tz?: ('+05:30' | '-08:00' | '+00:00') | null;
   dateWithMixedTimezones?: string | null;
   dateWithMixedTimezones_tz?: ('America/New_York' | '+05:30' | 'UTC') | null;
+  dateWithTimezoneWithDisabledColumns?: string | null;
+  dateWithTimezoneWithDisabledColumns_tz?: SupportedTimezones;
   updatedAt: string;
   createdAt: string;
 }
@@ -2834,6 +2836,8 @@ export interface DateFieldsSelect<T extends boolean = true> {
   dateWithOffsetTimezone_tz?: T;
   dateWithMixedTimezones?: T;
   dateWithMixedTimezones_tz?: T;
+  dateWithTimezoneWithDisabledColumns?: T;
+  dateWithTimezoneWithDisabledColumns_tz?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1001,7 +1001,7 @@ export interface DateField {
   dayAndTimeWithTimezone: string;
   dayAndTimeWithTimezone_tz: SupportedTimezones;
   dayAndTimeWithTimezoneFixed?: string | null;
-  dayAndTimeWithTimezoneFixed_tz?: SupportedTimezones;
+  dayAndTimeWithTimezoneFixed_tz?: 'Europe/London' | null;
   dayAndTimeWithTimezoneRequired?: string | null;
   dayAndTimeWithTimezoneRequired_tz: SupportedTimezones;
   dayAndTimeWithTimezoneReadOnly?: string | null;
@@ -1032,6 +1032,10 @@ export interface DateField {
         id?: string | null;
       }[]
     | null;
+  dateWithOffsetTimezone?: string | null;
+  dateWithOffsetTimezone_tz?: ('+05:30' | '-08:00' | '+00:00') | null;
+  dateWithMixedTimezones?: string | null;
+  dateWithMixedTimezones_tz?: ('America/New_York' | '+05:30' | 'UTC') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -2826,6 +2830,10 @@ export interface DateFieldsSelect<T extends boolean = true> {
         date?: T;
         id?: T;
       };
+  dateWithOffsetTimezone?: T;
+  dateWithOffsetTimezone_tz?: T;
+  dateWithMixedTimezones?: T;
+  dateWithMixedTimezones_tz?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
This PR is quite extensive and comes with several bugfixes and new features as listed.

### Additional IANA timezones

Previously we were only checking the `supportedValuesOf` for validating the IANA timezones however this list of names is not comprehensive, nor is it canonical for what's supported by the runtime. We now check the `DateTimeFormat` API as well which means timezones like `Asia/Ho_Chi_Minh` and `Asia/Saigon` are both supported.

### Custom UTC offsets support

In addition to IANA timezone names (like `America/New_York`), you can also use fixed UTC offsets in the `±HH:mm` format:

```ts
{
  name: 'eventTime',
  type: 'date',
  timezone: {
    supportedTimezones: [
      { label: 'UTC+5:30 (India)', value: '+05:30' },
      { label: 'UTC-8 (Pacific)', value: '-08:00' },
      { label: 'UTC+0', value: '+00:00' },
    ],
  },
}
```

NOTE: Since GraphQL does not allow special symbols like +- in the enums we format them to _TZOFFSET_MINUS_05_00. The `_TZOFFSET_` prefix is to ensure that we show this is an internal enum and avoid potential conflicts for any custom enums.

### Overriding the timezone field

You can now override the timezone field via `override` on timezone config:

```ts
{
  name: 'publishedAt',
  type: 'date',
  label: 'Published At',
  timezone: {
    override: ({ baseField }) => ({
      ...baseField,
      admin: {
        ...baseField.admin,
        disableListColumn: true, // Hide from list view columns
      },
    }),
  },
}
```

### Bugfixes

- The timezone field can now correctly inherit or display a formatted label from the parent, for label functions or complex translations you should use the override as above
- The timezone field can now be hidden from list column
- Types are now generated correctly per field if they have their own timezones, previously it was assigned to the global SupportedTimezones list
- Field's own timezones are now run through validation as well