### PR TITLE
docs: add graphql multi-field sort note

### DIFF
--- a/docs/queries/sort.mdx
+++ b/docs/queries/sort.mdx
@@ -80,3 +80,15 @@ query {
   }
 }
 ```
+
+To sort by multiple fields in GraphQL, pass a comma-separated list:
+
+```ts
+query {
+  Posts(sort: "priority,-createdAt") {
+    docs {
+      color
+    }
+  }
+}
+```


### PR DESCRIPTION
### What?
Adding a note to the sorting docs that you can sort on multiple fields in the GraphQL endpoint.

### Why?
I was confused about how to do this in the GraphQL API because you can't pass in an array there. Adding a specific note will help future travelers.

**Edit:**
I just reread the docs and see that it's there under the REST API heading. I feel the note still adds something. 
