### PR TITLE
chore: ignore

### DIFF
--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -67,6 +67,7 @@ describe('collections-rest', () => {
       expect(result.docs).toEqual(expect.arrayContaining(expectedDocs))
     })
 
+    // a
     it('should count', async () => {
       await createPost()
       await createPost()


### PR DESCRIPTION
Test e2e on 2.x