### PR TITLE
feat(sdk): add proper error handling

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -699,7 +699,16 @@ export type FetchAPIFileUploadOptions = {
   useTempFiles?: boolean | undefined
 } & Partial<BusboyConfig>
 
-export type ErrorResult = { data?: any; errors: unknown[]; stack?: string }
+export type ErrorResult = {
+  data?: any
+  errors: {
+    data?: Record<string, unknown>
+    field?: string
+    message?: string
+    name?: string
+  }[]
+  stack?: string
+}
 
 export type AfterErrorResult = {
   graphqlResult?: GraphQLFormattedError

--- a/packages/payload/src/utilities/formatErrors.ts
+++ b/packages/payload/src/utilities/formatErrors.ts
@@ -18,9 +18,9 @@ export const formatErrors = (incoming: { [key: string]: unknown } | APIError): E
       return {
         errors: [
           {
-            name: incoming.name,
-            data: incoming.data,
-            message: incoming.message,
+            name: incoming.name as string,
+            data: incoming.data as Record<string, unknown>,
+            message: incoming.message as string,
           },
         ],
       }
@@ -52,7 +52,7 @@ export const formatErrors = (incoming: { [key: string]: unknown } | APIError): E
       return {
         errors: [
           {
-            message: incoming.message,
+            message: incoming.message as string,
           },
         ],
       }

--- a/packages/sdk/src/collections/findByID.ts
+++ b/packages/sdk/src/collections/findByID.ts
@@ -78,17 +78,13 @@ export async function findByID<
       path: `/${options.collection}/${options.id}`,
     })
 
-    if (response.ok) {
-      return response.json()
-    } else {
-      throw new Error()
-    }
-  } catch {
+    return response.json()
+  } catch (err) {
     if (options.disableErrors) {
       // @ts-expect-error generic nullable
       return null
     }
 
-    throw new Error(`Error retrieving the document ${options.collection}/${options.id}`)
+    throw err
   }
 }

--- a/packages/sdk/src/collections/findVersionByID.ts
+++ b/packages/sdk/src/collections/findVersionByID.ts
@@ -79,17 +79,13 @@ export async function findVersionByID<
       path: `/${options.collection}/versions/${options.id}`,
     })
 
-    if (response.ok) {
-      return response.json()
-    } else {
-      throw new Error()
-    }
-  } catch {
+    return response.json()
+  } catch (err) {
     if (options.disableErrors) {
       // @ts-expect-error generic nullable
       return null
     }
 
-    throw new Error(`Error retrieving the version document ${options.collection}/${options.id}`)
+    throw err
   }
 }

--- a/packages/sdk/src/errors/PayloadSDKError.ts
+++ b/packages/sdk/src/errors/PayloadSDKError.ts
@@ -1,0 +1,37 @@
+import type { ErrorResult } from 'payload'
+
+/**
+ * Error class for SDK API errors.
+ * Contains the HTTP status code and error details from the API response.
+ */
+export class PayloadSDKError extends Error {
+  /**
+   * The error data from the API response.
+   * For ValidationError, this contains `collection`, `global`, and `errors` array.
+   */
+  errors: ErrorResult['errors']
+
+  /** The response object */
+  response: Response
+
+  /** HTTP status code */
+  status: number
+
+  constructor({
+    errors,
+    message,
+    response,
+    status,
+  }: {
+    errors: ErrorResult['errors']
+    message: string
+    response: Response
+    status: number
+  }) {
+    super(message)
+    this.name = 'PayloadSDKError'
+    this.status = status
+    this.errors = errors
+    this.response = response
+  }
+}

--- a/packages/sdk/src/globals/findVersionByID.ts
+++ b/packages/sdk/src/globals/findVersionByID.ts
@@ -67,17 +67,13 @@ export async function findGlobalVersionByID<
       path: `/globals/${options.slug}/versions/${options.id}`,
     })
 
-    if (response.ok) {
-      return response.json()
-    } else {
-      throw new Error()
-    }
-  } catch {
+    return response.json()
+  } catch (err) {
     if (options.disableErrors) {
       // @ts-expect-error generic nullable
       return null
     }
 
-    throw new Error(`Error retrieving the version document ${options.slug}/${options.id}`)
+    throw err
   }
 }

--- a/test/sdk/collections/Emails.ts
+++ b/test/sdk/collections/Emails.ts
@@ -1,0 +1,20 @@
+import type { CollectionConfig } from 'payload'
+
+export const emailsSlug = 'emails'
+
+export const EmailsCollection: CollectionConfig = {
+  slug: emailsSlug,
+  access: { create: () => true, update: () => true, delete: () => true, read: () => true },
+  fields: [
+    {
+      name: 'email',
+      type: 'email',
+      unique: true,
+      required: true,
+    },
+    {
+      name: 'name',
+      type: 'text',
+    },
+  ],
+}

--- a/test/sdk/config.ts
+++ b/test/sdk/config.ts
@@ -5,6 +5,7 @@ const dirname = path.dirname(filename)
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
+import { EmailsCollection } from './collections/Emails.js'
 import { PostsCollection } from './collections/Posts.js'
 import { Users } from './collections/Users.js'
 
@@ -17,6 +18,7 @@ export default buildConfigWithDefaults({
   collections: [
     Users,
     PostsCollection,
+    EmailsCollection,
     {
       access: { create: () => true, read: () => true, update: () => true },
       slug: 'media',

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -324,7 +324,7 @@ describe('@payloadcms/sdk', () => {
     const createdEmailIDs: (number | string)[] = []
 
     afterEach(async () => {
-      await payload.delete({ collection: 'emails', where: { id: { exists: true } } })
+      await payload.db.deleteMany({ collection: 'emails', where: { id: { exists: true } } })
     })
 
     it('should throw PayloadSDKError on validation error (duplicate unique field)', async () => {
@@ -352,8 +352,7 @@ describe('@payloadcms/sdk', () => {
       expect(thrownError!.status).toBe(400)
       expect(thrownError!.errors).toBeDefined()
       expect(thrownError!.errors.length).toBeGreaterThan(0)
-      // @ts-expect-error
-      expect(thrownError!.errors[0].name).toBe('ValidationError')
+      expect(thrownError!.errors[0]?.name).toBe('ValidationError')
       expect(thrownError!.message).toBeTruthy()
     })
 

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -321,8 +321,6 @@ describe('@payloadcms/sdk', () => {
   })
 
   describe('Error Handling', () => {
-    const createdEmailIDs: (number | string)[] = []
-
     afterEach(async () => {
       await payload.db.deleteMany({ collection: 'emails', where: { id: { exists: true } } })
     })
@@ -330,12 +328,10 @@ describe('@payloadcms/sdk', () => {
     it('should throw PayloadSDKError on validation error (duplicate unique field)', async () => {
       const testEmail = 'unique-test@example.com'
 
-      const firstDoc = await payload.create({
+      await payload.create({
         collection: emailsSlug,
         data: { email: testEmail },
       })
-
-      createdEmailIDs.push(firstDoc.id)
 
       let thrownError: null | PayloadSDKError = null
 
@@ -393,19 +389,15 @@ describe('@payloadcms/sdk', () => {
       const testEmail = 'update-error-test@example.com'
       const testEmail2 = 'update-error-test2@example.com'
 
-      const doc1 = await payload.create({
+      await payload.create({
         collection: emailsSlug,
         data: { email: testEmail },
       })
-
-      createdEmailIDs.push(doc1.id)
 
       const doc2 = await payload.create({
         collection: emailsSlug,
         data: { email: testEmail2 },
       })
-
-      createdEmailIDs.push(doc2.id)
 
       try {
         await sdk.update({
@@ -462,12 +454,10 @@ describe('@payloadcms/sdk', () => {
     it('should have error data for ValidationError', async () => {
       const testEmail = 'validation-data-test@example.com'
 
-      const doc = await payload.create({
+      await payload.create({
         collection: emailsSlug,
         data: { email: testEmail },
       })
-
-      createdEmailIDs.push(doc.id)
 
       let thrownError: null | PayloadSDKError = null
 

--- a/test/sdk/payload-types.ts
+++ b/test/sdk/payload-types.ts
@@ -6,14 +6,72 @@
  * and re-run `payload generate:types` to regenerate this file.
  */
 
+/**
+ * Supported timezones in IANA format.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "supportedTimezones".
+ */
+export type SupportedTimezones =
+  | 'Pacific/Midway'
+  | 'Pacific/Niue'
+  | 'Pacific/Honolulu'
+  | 'Pacific/Rarotonga'
+  | 'America/Anchorage'
+  | 'Pacific/Gambier'
+  | 'America/Los_Angeles'
+  | 'America/Tijuana'
+  | 'America/Denver'
+  | 'America/Phoenix'
+  | 'America/Chicago'
+  | 'America/Guatemala'
+  | 'America/New_York'
+  | 'America/Bogota'
+  | 'America/Caracas'
+  | 'America/Santiago'
+  | 'America/Buenos_Aires'
+  | 'America/Sao_Paulo'
+  | 'Atlantic/South_Georgia'
+  | 'Atlantic/Azores'
+  | 'Atlantic/Cape_Verde'
+  | 'Europe/London'
+  | 'Europe/Berlin'
+  | 'Africa/Lagos'
+  | 'Europe/Athens'
+  | 'Africa/Cairo'
+  | 'Europe/Moscow'
+  | 'Asia/Riyadh'
+  | 'Asia/Dubai'
+  | 'Asia/Baku'
+  | 'Asia/Karachi'
+  | 'Asia/Tashkent'
+  | 'Asia/Calcutta'
+  | 'Asia/Dhaka'
+  | 'Asia/Almaty'
+  | 'Asia/Jakarta'
+  | 'Asia/Bangkok'
+  | 'Asia/Shanghai'
+  | 'Asia/Singapore'
+  | 'Asia/Tokyo'
+  | 'Asia/Seoul'
+  | 'Australia/Brisbane'
+  | 'Australia/Sydney'
+  | 'Pacific/Guam'
+  | 'Pacific/Noumea'
+  | 'Pacific/Auckland'
+  | 'Pacific/Fiji';
+
 export interface Config {
   auth: {
     users: UserAuthOperations;
   };
+  blocks: {};
   collections: {
     users: User;
     posts: Post;
+    emails: Email;
     media: Media;
+    'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -22,7 +80,9 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
+    emails: EmailsSelect<false> | EmailsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -30,6 +90,7 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es' | 'de') | ('en' | 'es' | 'de')[];
   globals: {
     global: Global;
   };
@@ -78,6 +139,13 @@ export interface User {
   hash?: string | null;
   loginAttempts?: number | null;
   lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
   password?: string | null;
 }
 /**
@@ -93,6 +161,17 @@ export interface Post {
     text?: string | null;
     number?: number | null;
   };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "emails".
+ */
+export interface Email {
+  id: string;
+  email: string;
+  name?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -116,6 +195,23 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -128,6 +224,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'posts';
         value: string | Post;
+      } | null)
+    | ({
+        relationTo: 'emails';
+        value: string | Email;
       } | null)
     | ({
         relationTo: 'media';
@@ -189,6 +289,13 @@ export interface UsersSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -209,6 +316,16 @@ export interface PostsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "emails_select".
+ */
+export interface EmailsSelect<T extends boolean = true> {
+  email?: T;
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
@@ -223,6 +340,14 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
DO NOT MERGE BEFORE #15147 

Fixes #14495

The SDK now throws a proper `PayloadSDKError` class on failed API requests instead of either returning undefined or a generic `Error`. Error handling is centralized in the `request()` method, which adds error handling for operations where it was previously missing (like `create`, `update`, `delete`, `find`, etc.).

**Changes:**
- Added `PayloadSDKError` class with `status`, `errors`, `response`, and `message` properties
- Centralized error handling in `request()` - all operations now properly throw on failed responses. Previously, some operations (like `findByID`) just threw a generic Error that did not explain what actually went wrong and some operations (like `create`) did not throw an error at all and simply returned undefined.
- Lots of new int tests

**Usage:**
```ts
import { PayloadSDKError } from '@payloadcms/sdk'

try {
  await sdk.create({ collection: 'posts', data: { ... } })
} catch (err) {
  if (err instanceof PayloadSDKError) {
    console.log(err.status)  // 400
    console.log(err.errors)  // [{ name: 'ValidationError', message: '...', data: {...} }]
  }
}
```