### PR TITLE
fix(drizzle): unique field errors were not thrown as ValidationErrors

### DIFF
--- a/packages/drizzle/src/upsertRow/handleUpsertError.ts
+++ b/packages/drizzle/src/upsertRow/handleUpsertError.ts
@@ -1,0 +1,89 @@
+import type { PayloadRequest } from 'payload'
+
+import { ValidationError } from 'payload'
+
+import type { DrizzleAdapter } from '../types.js'
+
+type HandleUpsertErrorArgs = {
+  adapter: DrizzleAdapter
+  error: unknown
+  id?: number | string
+  req?: Partial<PayloadRequest>
+  tableName: string
+}
+
+/**
+ * Handles unique constraint violation errors from PostgreSQL and SQLite,
+ * converting them to Payload ValidationErrors.
+ * Re-throws non-constraint errors unchanged.
+ */
+export const handleUpsertError = ({
+  id,
+  adapter,
+  error: caughtError,
+  req,
+  tableName,
+}: HandleUpsertErrorArgs): never => {
+  let error: any = caughtError
+  if (typeof caughtError === 'object' && caughtError !== null && 'cause' in caughtError) {
+    error = caughtError.cause
+  }
+
+  // PostgreSQL: 23505, SQLite: SQLITE_CONSTRAINT_UNIQUE
+  if (error?.code === '23505' || error?.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+    let fieldName: null | string = null
+
+    if (error.code === '23505') {
+      // PostgreSQL - extract field name from constraint
+      if (adapter.fieldConstraints?.[tableName]?.[error.constraint]) {
+        fieldName = adapter.fieldConstraints[tableName][error.constraint]
+      } else {
+        const replacement = `${tableName}_`
+        if (error.constraint?.includes(replacement)) {
+          const replacedConstraint = error.constraint.replace(replacement, '')
+          if (replacedConstraint && adapter.fieldConstraints[tableName]?.[replacedConstraint]) {
+            fieldName = adapter.fieldConstraints[tableName][replacedConstraint]
+          }
+        }
+      }
+
+      if (!fieldName && error.detail) {
+        // Extract from detail: "Key (field)=(value) already exists."
+        const regex = /Key \(([^)]+)\)=\(([^)]+)\)/
+        const match: string[] = error.detail.match(regex)
+        if (match && match[1]) {
+          fieldName = match[1]
+        }
+      }
+    } else if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      // SQLite - extract from message: "UNIQUE constraint failed: table.field"
+      const regex = /UNIQUE constraint failed: ([^.]+)\.([^.]+)/
+      const match: string[] = error.message?.match(regex)
+      if (match && match[2]) {
+        if (adapter.fieldConstraints[tableName]) {
+          fieldName = adapter.fieldConstraints[tableName][`${match[2]}_idx`]
+        }
+        if (!fieldName) {
+          fieldName = match[2]
+        }
+      }
+    }
+
+    throw new ValidationError(
+      {
+        id,
+        errors: [
+          {
+            message: req?.t ? req.t('error:valueMustBeUnique') : 'Value must be unique',
+            path: fieldName,
+          },
+        ],
+        req,
+      },
+      req?.t,
+    )
+  }
+
+  // Re-throw non-constraint errors
+  throw caughtError
+}

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -3,7 +3,6 @@ import type { SelectedFields } from 'drizzle-orm/sqlite-core'
 import type { TypeWithID } from 'payload'
 
 import { and, desc, eq, isNull, or } from 'drizzle-orm'
-import { ValidationError } from 'payload'
 
 import type { BlockRowToInsert } from '../transform/write/types.js'
 import type { Args } from './types.js'
@@ -22,6 +21,7 @@ import { transform } from '../transform/read/index.js'
 import { transformForWrite } from '../transform/write/index.js'
 import { deleteExistingArrayRows } from './deleteExistingArrayRows.js'
 import { deleteExistingRowsByPath } from './deleteExistingRowsByPath.js'
+import { handleUpsertError } from './handleUpsertError.js'
 import { insertArrays } from './insertArrays.js'
 import { shouldUseOptimizedUpsertRow } from './shouldUseOptimizedUpsertRow.js'
 
@@ -57,65 +57,116 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
 
   let insertedRow: Record<string, unknown> = { id }
   if (id && shouldUseOptimizedUpsertRow({ data, fields })) {
-    const transformedForWrite = transformForWrite({
-      adapter,
-      data,
-      enableAtomicWrites: true,
-      fields,
-      tableName,
-    })
-    const { row } = transformedForWrite
-    const { arraysToPush } = transformedForWrite
-
-    const drizzle = db as LibSQLDatabase
-
-    // First, handle $push arrays
-
-    if (arraysToPush && Object.keys(arraysToPush)?.length) {
-      await insertArrays({
+    try {
+      const transformedForWrite = transformForWrite({
         adapter,
-        arrays: [arraysToPush],
-        db,
-        parentRows: [insertedRow],
-        uuidMap: {},
+        data,
+        enableAtomicWrites: true,
+        fields,
+        tableName,
       })
-    }
+      const { row } = transformedForWrite
+      const { arraysToPush } = transformedForWrite
 
-    // If row.updatedAt is not set, delete it to avoid triggering hasDataToUpdate. `updatedAt` may be explicitly set to null to
-    // disable triggering hasDataToUpdate.
-    if (typeof row.updatedAt === 'undefined' || row.updatedAt === null) {
-      delete row.updatedAt
-    }
+      const drizzle = db as LibSQLDatabase
 
-    const hasDataToUpdate = row && Object.keys(row)?.length
+      // First, handle $push arrays
 
-    // Then, handle regular row update
-    if (ignoreResult) {
-      if (hasDataToUpdate) {
-        // Only update row if there is something to update.
-        // Example: if the data only consists of a single $push, calling insertArrays is enough - we don't need to update the row.
-        await drizzle
+      if (arraysToPush && Object.keys(arraysToPush)?.length) {
+        await insertArrays({
+          adapter,
+          arrays: [arraysToPush],
+          db,
+          parentRows: [insertedRow],
+          uuidMap: {},
+        })
+      }
+
+      // If row.updatedAt is not set, delete it to avoid triggering hasDataToUpdate. `updatedAt` may be explicitly set to null to
+      // disable triggering hasDataToUpdate.
+      if (typeof row.updatedAt === 'undefined' || row.updatedAt === null) {
+        delete row.updatedAt
+      }
+
+      const hasDataToUpdate = row && Object.keys(row)?.length
+
+      // Then, handle regular row update
+      if (ignoreResult) {
+        if (hasDataToUpdate) {
+          // Only update row if there is something to update.
+          // Example: if the data only consists of a single $push, calling insertArrays is enough - we don't need to update the row.
+          await drizzle
+            .update(adapter.tables[tableName])
+            .set(row)
+            .where(eq(adapter.tables[tableName].id, id))
+        }
+        return ignoreResult === 'idOnly' ? ({ id } as T) : null
+      }
+
+      const findManyArgs = buildFindManyArgs({
+        adapter,
+        depth: 0,
+        fields,
+        joinQuery: false,
+        select,
+        tableName,
+      })
+
+      const findManyKeysLength = Object.keys(findManyArgs).length
+      const hasOnlyColumns = Object.keys(findManyArgs.columns || {}).length > 0
+
+      if (!hasDataToUpdate) {
+        // Nothing to update => just fetch current row and return
+        findManyArgs.where = eq(adapter.tables[tableName].id, insertedRow.id)
+
+        const doc = await db.query[tableName].findFirst(findManyArgs)
+
+        return transform<T>({
+          adapter,
+          config: adapter.payload.config,
+          data: doc,
+          fields,
+          joinQuery: false,
+          tableName,
+        })
+      }
+
+      if (findManyKeysLength === 0 || hasOnlyColumns) {
+        // Optimization - No need for joins => can simply use returning(). This is optimal for very simple collections
+        // without complex fields that live in separate tables like blocks, arrays, relationships, etc.
+
+        const selectedFields: SelectedFields = {}
+        if (hasOnlyColumns) {
+          for (const [column, enabled] of Object.entries(findManyArgs.columns)) {
+            if (enabled) {
+              selectedFields[column] = adapter.tables[tableName][column]
+            }
+          }
+        }
+
+        const docs = await drizzle
           .update(adapter.tables[tableName])
           .set(row)
           .where(eq(adapter.tables[tableName].id, id))
+          .returning(Object.keys(selectedFields).length ? selectedFields : undefined)
+
+        return transform<T>({
+          adapter,
+          config: adapter.payload.config,
+          data: docs[0],
+          fields,
+          joinQuery: false,
+          tableName,
+        })
       }
-      return ignoreResult === 'idOnly' ? ({ id } as T) : null
-    }
 
-    const findManyArgs = buildFindManyArgs({
-      adapter,
-      depth: 0,
-      fields,
-      joinQuery: false,
-      select,
-      tableName,
-    })
+      // DB Update that needs the result, potentially with joins => need to update first, then find. returning() does not work with joins.
 
-    const findManyKeysLength = Object.keys(findManyArgs).length
-    const hasOnlyColumns = Object.keys(findManyArgs.columns || {}).length > 0
+      await drizzle
+        .update(adapter.tables[tableName])
+        .set(row)
+        .where(eq(adapter.tables[tableName].id, id))
 
-    if (!hasDataToUpdate) {
-      // Nothing to update => just fetch current row and return
       findManyArgs.where = eq(adapter.tables[tableName].id, insertedRow.id)
 
       const doc = await db.query[tableName].findFirst(findManyArgs)
@@ -128,56 +179,9 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         joinQuery: false,
         tableName,
       })
+    } catch (error) {
+      handleUpsertError({ id, adapter, error, req, tableName })
     }
-
-    if (findManyKeysLength === 0 || hasOnlyColumns) {
-      // Optimization - No need for joins => can simply use returning(). This is optimal for very simple collections
-      // without complex fields that live in separate tables like blocks, arrays, relationships, etc.
-
-      const selectedFields: SelectedFields = {}
-      if (hasOnlyColumns) {
-        for (const [column, enabled] of Object.entries(findManyArgs.columns)) {
-          if (enabled) {
-            selectedFields[column] = adapter.tables[tableName][column]
-          }
-        }
-      }
-
-      const docs = await drizzle
-        .update(adapter.tables[tableName])
-        .set(row)
-        .where(eq(adapter.tables[tableName].id, id))
-        .returning(Object.keys(selectedFields).length ? selectedFields : undefined)
-
-      return transform<T>({
-        adapter,
-        config: adapter.payload.config,
-        data: docs[0],
-        fields,
-        joinQuery: false,
-        tableName,
-      })
-    }
-
-    // DB Update that needs the result, potentially with joins => need to update first, then find. returning() does not work with joins.
-
-    await drizzle
-      .update(adapter.tables[tableName])
-      .set(row)
-      .where(eq(adapter.tables[tableName].id, id))
-
-    findManyArgs.where = eq(adapter.tables[tableName].id, insertedRow.id)
-
-    const doc = await db.query[tableName].findFirst(findManyArgs)
-
-    return transform<T>({
-      adapter,
-      config: adapter.payload.config,
-      data: doc,
-      fields,
-      joinQuery: false,
-      tableName,
-    })
   }
   // Split out the incoming data into the corresponding:
   // base row, locales, relationships, blocks, and arrays
@@ -717,86 +721,8 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         })
       }
     }
-
-    // //////////////////////////////////
-    // Error Handling
-    // //////////////////////////////////
-  } catch (caughtError) {
-    // Unique constraint violation error
-    // '23505' is the code for PostgreSQL, and 'SQLITE_CONSTRAINT_UNIQUE' is for SQLite
-
-    let error = caughtError
-    if (typeof caughtError === 'object' && 'cause' in caughtError) {
-      error = caughtError.cause
-    }
-
-    if (error.code === '23505' || error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
-      let fieldName: null | string = null
-      // We need to try and find the right constraint for the field but if we can't we fallback to a generic message
-      if (error.code === '23505') {
-        // For PostgreSQL, we can try to extract the field name from the error constraint
-        if (adapter.fieldConstraints?.[tableName]?.[error.constraint]) {
-          fieldName = adapter.fieldConstraints[tableName]?.[error.constraint]
-        } else {
-          const replacement = `${tableName}_`
-
-          if (error.constraint.includes(replacement)) {
-            const replacedConstraint = error.constraint.replace(replacement, '')
-
-            if (replacedConstraint && adapter.fieldConstraints[tableName]?.[replacedConstraint]) {
-              fieldName = adapter.fieldConstraints[tableName][replacedConstraint]
-            }
-          }
-        }
-
-        if (!fieldName) {
-          // Last case scenario we extract the key and value from the detail on the error
-          const detail = error.detail
-          const regex = /Key \(([^)]+)\)=\(([^)]+)\)/
-          const match: string[] = detail.match(regex)
-
-          if (match && match[1]) {
-            const key = match[1]
-
-            fieldName = key
-          }
-        }
-      } else if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
-        /**
-         * For SQLite, we can try to extract the field name from the error message
-         * The message typically looks like:
-         * "UNIQUE constraint failed: table_name.field_name"
-         */
-        const regex = /UNIQUE constraint failed: ([^.]+)\.([^.]+)/
-        const match: string[] = error.message.match(regex)
-
-        if (match && match[2]) {
-          if (adapter.fieldConstraints[tableName]) {
-            fieldName = adapter.fieldConstraints[tableName][`${match[2]}_idx`]
-          }
-
-          if (!fieldName) {
-            fieldName = match[2]
-          }
-        }
-      }
-
-      throw new ValidationError(
-        {
-          id,
-          errors: [
-            {
-              message: req?.t ? req.t('error:valueMustBeUnique') : 'Value must be unique',
-              path: fieldName,
-            },
-          ],
-          req,
-        },
-        req?.t,
-      )
-    } else {
-      throw error
-    }
+  } catch (error) {
+    handleUpsertError({ id, adapter, error, req, tableName })
   }
 
   if (ignoreResult === 'idOnly') {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1720,7 +1720,6 @@ describe('database', () => {
       await payload.db.collections['relationships-migration'].deleteMany({})
       await payload.db.versions['relationships-migration'].deleteMany({})
     })
-
   })
 
   describe('schema', () => {
@@ -3865,6 +3864,36 @@ describe('database', () => {
         collection: 'unique-fields',
         data: {
           slugField: 'unique-text',
+        },
+      })
+    } catch (e) {
+      expect((e as ValidationError).message).toEqual('The following field is invalid: slugField')
+    }
+  })
+
+  it('should throw unique constraint errors in optimized update path', async () => {
+    await payload.create({
+      collection: 'unique-fields',
+      data: {
+        slugField: 'optimized-unique-1',
+      },
+    })
+
+    const doc2 = await payload.create({
+      collection: 'unique-fields',
+      data: {
+        slugField: 'optimized-unique-2',
+      },
+    })
+
+    // This update goes through the optimized path (shouldUseOptimizedUpsertRow) in db-drizzle
+    // because it's a simple field update with an existing ID
+    try {
+      await payload.update({
+        collection: 'unique-fields',
+        id: doc2.id,
+        data: {
+          slugField: 'optimized-unique-1', // Try to set to doc1's unique value
         },
       })
     } catch (e) {

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -124,7 +124,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es' | 'uk') | ('en' | 'es' | 'uk')[];
   globals: {
@@ -173,7 +173,7 @@ export interface UserAuthOperations {
  * via the `definition` "noTimeStamps".
  */
 export interface NoTimeStamp {
-  id: string;
+  id: number;
   title?: string | null;
 }
 /**
@@ -181,12 +181,12 @@ export interface NoTimeStamp {
  * via the `definition` "categories".
  */
 export interface Category {
-  id: string;
+  id: number;
   title?: string | null;
-  simple?: (string | null) | Simple;
+  simple?: (number | null) | Simple;
   hideout?: {
     camera1?: {
-      time1Image?: (string | null) | Post;
+      time1Image?: (number | null) | Post;
     };
   };
   updatedAt: string;
@@ -198,7 +198,7 @@ export interface Category {
  * via the `definition` "simple".
  */
 export interface Simple {
-  id: string;
+  id: number;
   text?: string | null;
   number?: number | null;
   updatedAt: string;
@@ -209,9 +209,9 @@ export interface Simple {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   title: string;
-  category?: (string | null) | Category;
+  category?: (number | null) | Category;
   categoryID?:
     | {
         [k: string]: unknown;
@@ -223,16 +223,16 @@ export interface Post {
     | null;
   categoryTitle?: string | null;
   categorySimpleText?: string | null;
-  categories?: (string | Category)[] | null;
+  categories?: (number | Category)[] | null;
   categoriesCustomID?: (number | CategoriesCustomId)[] | null;
   categoryPoly?: {
     relationTo: 'categories';
-    value: string | Category;
+    value: number | Category;
   } | null;
   categoryPolyMany?:
     | {
         relationTo: 'categories';
-        value: string | Category;
+        value: number | Category;
       }[]
     | null;
   categoryCustomID?: (number | null) | CategoriesCustomId;
@@ -240,11 +240,11 @@ export interface Post {
     | (
         | {
             relationTo: 'categories';
-            value: string | Category;
+            value: number | Category;
           }
         | {
             relationTo: 'simple';
-            value: string | Simple;
+            value: number | Simple;
           }
       )[]
     | null;
@@ -252,11 +252,11 @@ export interface Post {
     | (
         | {
             relationTo: 'categories';
-            value: string | Category;
+            value: number | Category;
           }
         | {
             relationTo: 'simple';
-            value: string | Simple;
+            value: number | Simple;
           }
       )[]
     | null;
@@ -284,11 +284,11 @@ export interface Post {
       | (
           | {
               relationTo: 'categories';
-              value: string | Category;
+              value: number | Category;
             }
           | {
               relationTo: 'simple';
-              value: string | Simple;
+              value: number | Simple;
             }
         )[]
       | null;
@@ -350,7 +350,7 @@ export interface CategoriesCustomId {
  * via the `definition` "error-on-unnamed-fields".
  */
 export interface ErrorOnUnnamedField {
-  id: string;
+  id: number;
   groupWithinUnnamedTab: {
     text: string;
   };
@@ -362,7 +362,7 @@ export interface ErrorOnUnnamedField {
  * via the `definition` "default-values".
  */
 export interface DefaultValue {
-  id: string;
+  id: number;
   title?: string | null;
   defaultValue?: string | null;
   array?:
@@ -389,7 +389,7 @@ export interface DefaultValue {
  * via the `definition` "relation-a".
  */
 export interface RelationA {
-  id: string;
+  id: number;
   title?: string | null;
   richText?: {
     root: {
@@ -414,9 +414,9 @@ export interface RelationA {
  * via the `definition` "relation-b".
  */
 export interface RelationB {
-  id: string;
+  id: number;
   title?: string | null;
-  relationship?: (string | null) | RelationA;
+  relationship?: (number | null) | RelationA;
   richText?: {
     root: {
       type: string;
@@ -440,14 +440,14 @@ export interface RelationB {
  * via the `definition` "pg-migrations".
  */
 export interface PgMigration {
-  id: string;
-  relation1?: (string | null) | RelationA;
+  id: number;
+  relation1?: (number | null) | RelationA;
   myArray?:
     | {
-        relation2?: (string | null) | RelationB;
+        relation2?: (number | null) | RelationB;
         mySubArray?:
           | {
-              relation3?: (string | null) | RelationB;
+              relation3?: (number | null) | RelationB;
               id?: string | null;
             }[]
           | null;
@@ -455,12 +455,12 @@ export interface PgMigration {
       }[]
     | null;
   myGroup?: {
-    relation4?: (string | null) | RelationB;
+    relation4?: (number | null) | RelationB;
   };
   myBlocks?:
     | {
-        relation5?: (string | null) | RelationA;
-        relation6?: (string | null) | RelationB;
+        relation5?: (number | null) | RelationA;
+        relation6?: (number | null) | RelationB;
         id?: string | null;
         blockName?: string | null;
         blockType: 'myBlock';
@@ -474,10 +474,10 @@ export interface PgMigration {
  * via the `definition` "custom-schema".
  */
 export interface CustomSchema {
-  id: string;
+  id: number;
   text?: string | null;
   localizedText?: string | null;
-  relationship?: (string | RelationA)[] | null;
+  relationship?: (number | RelationA)[] | null;
   select?: ('a' | 'b' | 'c')[] | null;
   radio?: ('a' | 'b' | 'c') | null;
   array?:
@@ -505,7 +505,7 @@ export interface CustomSchema {
  * via the `definition` "places".
  */
 export interface Place {
-  id: string;
+  id: number;
   country?: string | null;
   city?: string | null;
   updatedAt: string;
@@ -516,7 +516,7 @@ export interface Place {
  * via the `definition` "virtual-relations".
  */
 export interface VirtualRelation {
-  id: string;
+  id: number;
   postTitle?: string | null;
   postsTitles?: string[] | null;
   postCategoriesTitles?: string[] | null;
@@ -542,8 +542,8 @@ export interface VirtualRelation {
     | boolean
     | null;
   postLocalized?: string | null;
-  post?: (string | null) | Post;
-  posts?: (string | Post)[] | null;
+  post?: (number | null) | Post;
+  posts?: (number | Post)[] | null;
   customID?: (string | null) | CustomId;
   customIDValue?: string | null;
   updatedAt: string;
@@ -566,7 +566,7 @@ export interface CustomId {
  * via the `definition` "fields-persistance".
  */
 export interface FieldsPersistance {
-  id: string;
+  id: number;
   text?: string | null;
   textHooked?: string | null;
   array?:
@@ -585,7 +585,7 @@ export interface FieldsPersistance {
  * via the `definition` "fake-custom-ids".
  */
 export interface FakeCustomId {
-  id: string;
+  id: number;
   title?: string | null;
   group?: {
     id?: string | null;
@@ -601,11 +601,11 @@ export interface FakeCustomId {
  * via the `definition` "relationships-migration".
  */
 export interface RelationshipsMigration {
-  id: string;
-  relationship?: (string | null) | DefaultValue;
+  id: number;
+  relationship?: (number | null) | DefaultValue;
   relationship_2?: {
     relationTo: 'default-values';
-    value: string | DefaultValue;
+    value: number | DefaultValue;
   } | null;
   updatedAt: string;
   createdAt: string;
@@ -615,7 +615,7 @@ export interface RelationshipsMigration {
  * via the `definition` "compound-indexes".
  */
 export interface CompoundIndex {
-  id: string;
+  id: number;
   one?: string | null;
   two?: string | null;
   three?: string | null;
@@ -630,7 +630,7 @@ export interface CompoundIndex {
  * via the `definition` "aliases".
  */
 export interface Alias {
-  id: string;
+  id: number;
   thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName?:
     | {
         nestedArray?:
@@ -650,7 +650,7 @@ export interface Alias {
  * via the `definition` "blocks-docs".
  */
 export interface BlocksDoc {
-  id: string;
+  id: number;
   testBlocksLocalized?:
     | {
         text?: string | null;
@@ -675,7 +675,7 @@ export interface BlocksDoc {
  * via the `definition` "unique-fields".
  */
 export interface UniqueField {
-  id: string;
+  id: number;
   slugField?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -685,7 +685,7 @@ export interface UniqueField {
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
-  id: string;
+  id: number;
   key: string;
   data:
     | {
@@ -702,7 +702,7 @@ export interface PayloadKv {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -726,19 +726,19 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'noTimeStamps';
-        value: string | NoTimeStamp;
+        value: number | NoTimeStamp;
       } | null)
     | ({
         relationTo: 'categories';
-        value: string | Category;
+        value: number | Category;
       } | null)
     | ({
         relationTo: 'simple';
-        value: string | Simple;
+        value: number | Simple;
       } | null)
     | ({
         relationTo: 'categories-custom-id';
@@ -746,43 +746,43 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'error-on-unnamed-fields';
-        value: string | ErrorOnUnnamedField;
+        value: number | ErrorOnUnnamedField;
       } | null)
     | ({
         relationTo: 'default-values';
-        value: string | DefaultValue;
+        value: number | DefaultValue;
       } | null)
     | ({
         relationTo: 'relation-a';
-        value: string | RelationA;
+        value: number | RelationA;
       } | null)
     | ({
         relationTo: 'relation-b';
-        value: string | RelationB;
+        value: number | RelationB;
       } | null)
     | ({
         relationTo: 'pg-migrations';
-        value: string | PgMigration;
+        value: number | PgMigration;
       } | null)
     | ({
         relationTo: 'custom-schema';
-        value: string | CustomSchema;
+        value: number | CustomSchema;
       } | null)
     | ({
         relationTo: 'places';
-        value: string | Place;
+        value: number | Place;
       } | null)
     | ({
         relationTo: 'virtual-relations';
-        value: string | VirtualRelation;
+        value: number | VirtualRelation;
       } | null)
     | ({
         relationTo: 'fields-persistance';
-        value: string | FieldsPersistance;
+        value: number | FieldsPersistance;
       } | null)
     | ({
         relationTo: 'custom-ids';
@@ -790,36 +790,36 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'fake-custom-ids';
-        value: string | FakeCustomId;
+        value: number | FakeCustomId;
       } | null)
     | ({
         relationTo: 'relationships-migration';
-        value: string | RelationshipsMigration;
+        value: number | RelationshipsMigration;
       } | null)
     | ({
         relationTo: 'compound-indexes';
-        value: string | CompoundIndex;
+        value: number | CompoundIndex;
       } | null)
     | ({
         relationTo: 'aliases';
-        value: string | Alias;
+        value: number | Alias;
       } | null)
     | ({
         relationTo: 'blocks-docs';
-        value: string | BlocksDoc;
+        value: number | BlocksDoc;
       } | null)
     | ({
         relationTo: 'unique-fields';
-        value: string | UniqueField;
+        value: number | UniqueField;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -829,10 +829,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -852,7 +852,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -1367,7 +1367,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "header".
  */
 export interface Header {
-  id: string;
+  id: number;
   itemsLvl1?:
     | {
         label?: string | null;
@@ -1400,7 +1400,7 @@ export interface Header {
  * via the `definition` "global".
  */
 export interface Global {
-  id: string;
+  id: number;
   text?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -1410,7 +1410,7 @@ export interface Global {
  * via the `definition` "global-2".
  */
 export interface Global2 {
-  id: string;
+  id: number;
   text?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -1420,7 +1420,7 @@ export interface Global2 {
  * via the `definition` "global-3".
  */
 export interface Global3 {
-  id: string;
+  id: number;
   text?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -1430,9 +1430,9 @@ export interface Global3 {
  * via the `definition` "virtual-relation-global".
  */
 export interface VirtualRelationGlobal {
-  id: string;
+  id: number;
   postTitle?: string | null;
-  post?: (string | null) | Post;
+  post?: (number | null) | Post;
   updatedAt?: string | null;
   createdAt?: string | null;
 }

--- a/test/database/up-down-migration/migrations/20260109_044207.json
+++ b/test/database/up-down-migration/migrations/20260109_044207.json
@@ -1,6 +1,4 @@
 {
-  "id": "ca9e6f22-341d-40bc-82b0-11e39ae3c549",
-  "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -76,8 +74,12 @@
           "name": "users_sessions_parent_id_fk",
           "tableFrom": "users_sessions",
           "tableTo": "users",
-          "columnsFrom": ["_parent_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -192,6 +194,53 @@
           "columns": [
             {
               "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -393,12 +442,16 @@
         }
       },
       "foreignKeys": {
-        "payload_locked_documents_rels_parent_1_idx": {
-          "name": "payload_locked_documents_rels_parent_1_idx",
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "payload_locked_documents",
-          "columnsFrom": ["parent_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -406,8 +459,12 @@
           "name": "payload_locked_documents_rels_users_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "users",
-          "columnsFrom": ["users_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -607,12 +664,16 @@
         }
       },
       "foreignKeys": {
-        "payload_preferences_rels_parent_1_idx": {
-          "name": "payload_preferences_rels_parent_1_idx",
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
           "tableFrom": "payload_preferences_rels",
           "tableTo": "payload_preferences",
-          "columnsFrom": ["parent_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -620,8 +681,12 @@
           "name": "payload_preferences_rels_users_fk",
           "tableFrom": "payload_preferences_rels",
           "tableTo": "users",
-          "columnsFrom": ["users_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -719,5 +784,7 @@
     "schemas": {},
     "tables": {},
     "columns": {}
-  }
+  },
+  "id": "326a0a7c-de8e-4c6d-985f-551dd7d6f840",
+  "prevId": "00000000-0000-0000-0000-000000000000"
 }

--- a/test/database/up-down-migration/migrations/20260109_044207.ts
+++ b/test/database/up-down-migration/migrations/20260109_044207.ts
@@ -1,6 +1,4 @@
-import type { MigrateDownArgs, MigrateUpArgs} from '@payloadcms/db-postgres';
-
-import { sql } from '@payloadcms/db-postgres'
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`
@@ -23,6 +21,12 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	"hash" varchar,
   	"login_attempts" numeric DEFAULT 0,
   	"lock_until" timestamp(3) with time zone
+  );
+  
+  CREATE TABLE "payload_kv" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"key" varchar NOT NULL,
+  	"data" jsonb NOT NULL
   );
   
   CREATE TABLE "payload_locked_documents" (
@@ -65,15 +69,16 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   );
   
   ALTER TABLE "users_sessions" ADD CONSTRAINT "users_sessions_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
-  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_parent_1_idx" FOREIGN KEY ("parent_id") REFERENCES "public"."payload_locked_documents"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."payload_locked_documents"("id") ON DELETE cascade ON UPDATE no action;
   ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_users_fk" FOREIGN KEY ("users_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
-  ALTER TABLE "payload_preferences_rels" ADD CONSTRAINT "payload_preferences_rels_parent_1_idx" FOREIGN KEY ("parent_id") REFERENCES "public"."payload_preferences"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "payload_preferences_rels" ADD CONSTRAINT "payload_preferences_rels_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."payload_preferences"("id") ON DELETE cascade ON UPDATE no action;
   ALTER TABLE "payload_preferences_rels" ADD CONSTRAINT "payload_preferences_rels_users_fk" FOREIGN KEY ("users_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
   CREATE INDEX "users_sessions_order_idx" ON "users_sessions" USING btree ("_order");
   CREATE INDEX "users_sessions_parent_id_idx" ON "users_sessions" USING btree ("_parent_id");
   CREATE INDEX "users_updated_at_idx" ON "users" USING btree ("updated_at");
   CREATE INDEX "users_created_at_idx" ON "users" USING btree ("created_at");
   CREATE UNIQUE INDEX "users_email_idx" ON "users" USING btree ("email");
+  CREATE UNIQUE INDEX "payload_kv_key_idx" ON "payload_kv" USING btree ("key");
   CREATE INDEX "payload_locked_documents_global_slug_idx" ON "payload_locked_documents" USING btree ("global_slug");
   CREATE INDEX "payload_locked_documents_updated_at_idx" ON "payload_locked_documents" USING btree ("updated_at");
   CREATE INDEX "payload_locked_documents_created_at_idx" ON "payload_locked_documents" USING btree ("created_at");
@@ -96,6 +101,7 @@ export async function down({ db, payload, req }: MigrateDownArgs): Promise<void>
   await db.execute(sql`
    DROP TABLE "users_sessions" CASCADE;
   DROP TABLE "users" CASCADE;
+  DROP TABLE "payload_kv" CASCADE;
   DROP TABLE "payload_locked_documents" CASCADE;
   DROP TABLE "payload_locked_documents_rels" CASCADE;
   DROP TABLE "payload_preferences" CASCADE;

--- a/test/database/up-down-migration/migrations/index.ts
+++ b/test/database/up-down-migration/migrations/index.ts
@@ -1,9 +1,9 @@
-import * as migration_20251030_115916 from './20251030_115916.js'
+import * as migration_20260109_044207 from './20260109_044207.js';
 
 export const migrations = [
   {
-    up: migration_20251030_115916.up,
-    down: migration_20251030_115916.down,
-    name: '20251030_115916',
+    up: migration_20260109_044207.up,
+    down: migration_20260109_044207.down,
+    name: '20260109_044207'
   },
-]
+];


### PR DESCRIPTION
The optimized upsert path in `upsertRow` was not wrapped in the error handling try/catch block, causing unique constraint violations to throw raw database errors instead of Payload `ValidationError`s.

**Changes:**

- Created `handleUpsertError.ts` utility to centralize unique constraint error handling, similar to how db-mongodb as `handleError`
- Wrapped optimized upsert path in error handling
- Added test for unique constraint errors in optimized update path