### PR TITLE
fix(db-mongodb): avoid unnecessary `$lookup` when a join field is not selected

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -133,6 +133,7 @@ export const find: Find = async function find(
     draftsEnabled,
     joins,
     locale,
+    projection: paginationOptions.projection,
     query,
   })
 

--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -264,7 +264,8 @@ export const buildJoinAggregation = async ({
     }
 
     for (const join of joinsList) {
-      if (projection && !projection[join.joinPath]) {
+      const projectionPath = versions ? `version.${join.joinPath}` : join.joinPath
+      if (projection && !projection[projectionPath]) {
         continue
       }
 

--- a/test/generateDatabaseAdapter.ts
+++ b/test/generateDatabaseAdapter.ts
@@ -160,3 +160,13 @@ export function generateDatabaseAdapter(dbAdapter: keyof typeof allDatabaseAdapt
   console.log('Wrote', dbAdapter, 'db adapter')
   return databaseAdapter
 }
+
+export type DatabaseAdapterType = keyof typeof allDatabaseAdapters
+
+export const getCurrentDatabaseAdapter = (): DatabaseAdapterType => {
+  const dbAdapter = process.env.DB_ADAPTER as DatabaseAdapterType | undefined
+  if (dbAdapter && Object.keys(allDatabaseAdapters).includes(dbAdapter)) {
+    return dbAdapter
+  }
+  return 'mongodb'
+}

--- a/test/generateDatabaseAdapter.ts
+++ b/test/generateDatabaseAdapter.ts
@@ -164,7 +164,7 @@ export function generateDatabaseAdapter(dbAdapter: keyof typeof allDatabaseAdapt
 export type DatabaseAdapterType = keyof typeof allDatabaseAdapters
 
 export const getCurrentDatabaseAdapter = (): DatabaseAdapterType => {
-  const dbAdapter = process.env.DB_ADAPTER as DatabaseAdapterType | undefined
+  const dbAdapter = process.env.PAYLOAD_DATABASE as DatabaseAdapterType | undefined
   if (dbAdapter && Object.keys(allDatabaseAdapters).includes(dbAdapter)) {
     return dbAdapter
   }

--- a/test/joins/buildJoinAggregation.int.spec.ts
+++ b/test/joins/buildJoinAggregation.int.spec.ts
@@ -1,0 +1,337 @@
+import type mongoose from 'mongoose'
+// @ts-ignore
+import type { SanitizedCollectionConfig } from 'payload'
+
+// @ts-ignore
+import { type MongooseAdapter } from '@payloadcms/db-mongodb'
+import { buildConfig, buildVersionCollectionFields, getPayload } from 'payload'
+import { expect, it } from 'vitest'
+
+import { buildJoinAggregation } from '../../packages/db-mongodb/src/utilities/buildJoinAggregation.js'
+import { buildProjectionFromSelect } from '../../packages/db-mongodb/src/utilities/buildProjectionFromSelect.js'
+import { describe } from '../helpers/vitest.js'
+
+describe('buildJoinAggregation', { db: 'mongo' }, () => {
+  const getAdapter = async (): Promise<MongooseAdapter> => {
+    const payload = await getPayload({
+      key: '_buildJoinAggregation',
+      config: await buildConfig({
+        secret: '______',
+        db: await import('../databaseAdapter.js').then((mod) => mod.databaseAdapter),
+        collections: [
+          {
+            slug: 'categories',
+            fields: [
+              {
+                name: 'posts',
+                type: 'join',
+                collection: 'posts',
+                on: 'category',
+              },
+              {
+                name: 'postsMany',
+                type: 'join',
+                collection: 'posts',
+                on: 'categories',
+              },
+            ],
+          },
+          {
+            slug: 'versioned-categories',
+            versions: { drafts: true },
+            fields: [
+              {
+                name: 'posts',
+                type: 'join',
+                // @ts-expect-error not generated
+                collection: 'versioned-posts',
+                on: 'category',
+              },
+              {
+                name: 'postsMany',
+                type: 'join',
+                // @ts-expect-error not generated
+                collection: 'versioned-posts',
+                on: 'categories',
+              },
+            ],
+          },
+          {
+            slug: 'posts',
+            fields: [
+              {
+                name: 'category',
+                type: 'relationship',
+                relationTo: 'categories',
+              },
+              {
+                name: 'categories',
+                type: 'relationship',
+                relationTo: 'categories',
+                hasMany: true,
+              },
+            ],
+          },
+          {
+            slug: 'versioned-posts',
+            versions: { drafts: true },
+            fields: [
+              {
+                name: 'category',
+                type: 'relationship',
+                // @ts-expect-error not generated
+                relationTo: 'versioned-categories',
+              },
+              {
+                name: 'categories',
+                type: 'relationship',
+                // @ts-expect-error not generated
+                relationTo: 'versioned-categories',
+                hasMany: true,
+              },
+            ],
+          },
+        ],
+      }),
+    })
+
+    return payload.db as unknown as MongooseAdapter
+  }
+
+  const getCollection = (adapter: MongooseAdapter): SanitizedCollectionConfig =>
+    adapter.payload.collections.categories.config
+
+  const getVersionedCollection = (adapter: MongooseAdapter): SanitizedCollectionConfig =>
+    // @ts-expect-error not generated
+    adapter.payload.collections['versioned-categories'].config
+
+  const getLookups = (aggregation: mongoose.PipelineStage[]) =>
+    aggregation.filter((each) => '$lookup' in each).map((each) => each.$lookup)
+
+  it('should add all the joins to the aggregation', async () => {
+    const adapter = await getAdapter()
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getCollection(adapter).slug,
+      collectionConfig: getCollection(adapter),
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+
+    const lookups = getLookups(aggregation!)
+
+    expect(lookups).toHaveLength(2)
+
+    expect(lookups[0]!.as).toBe('posts.docs')
+    expect(lookups[0]!.foreignField).toBe('category')
+    expect(lookups[0]!.from).toBe('posts')
+    expect(lookups[0]!.localField).toBe('_id')
+
+    expect(lookups[1]!.as).toBe('postsMany.docs')
+    expect(lookups[1]!.foreignField).toBe('categories')
+    expect(lookups[1]!.from).toBe('posts')
+    expect(lookups[1]!.localField).toBe('_id')
+  })
+
+  it('should add only 1 join because of the projection (include)', async () => {
+    const adapter = await getAdapter()
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getCollection(adapter).slug,
+      collectionConfig: getCollection(adapter),
+      projection: buildProjectionFromSelect({
+        adapter,
+        fields: getCollection(adapter).flattenedFields,
+        select: {
+          posts: true,
+        },
+      }),
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+
+    const lookups = getLookups(aggregation!)
+    expect(lookups).toHaveLength(1)
+
+    expect(lookups[0]!.as).toBe('posts.docs')
+    expect(lookups[0]!.foreignField).toBe('category')
+    expect(lookups[0]!.from).toBe('posts')
+    expect(lookups[0]!.localField).toBe('_id')
+  })
+
+  it('should add only 1 join because of the projection (exclude)', async () => {
+    const adapter = await getAdapter()
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getCollection(adapter).slug,
+      collectionConfig: getCollection(adapter),
+      projection: buildProjectionFromSelect({
+        adapter,
+        fields: getCollection(adapter).flattenedFields,
+        select: {
+          posts: false,
+        },
+      }),
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+
+    const lookups = getLookups(aggregation!)
+    expect(lookups).toHaveLength(1)
+
+    expect(lookups[0]!.as).toBe('postsMany.docs')
+    expect(lookups[0]!.foreignField).toBe('categories')
+    expect(lookups[0]!.from).toBe('posts')
+    expect(lookups[0]!.localField).toBe('_id')
+  })
+
+  it('should not add any joins because of the projection', async () => {
+    const adapter = await getAdapter()
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getCollection(adapter).slug,
+      collectionConfig: getCollection(adapter),
+      projection: buildProjectionFromSelect({
+        adapter,
+        fields: getCollection(adapter).flattenedFields,
+        select: {
+          id: true,
+        },
+      }),
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+    expect(aggregation).toHaveLength(0)
+  })
+
+  it('should add all the joins to the aggregation with versions', async () => {
+    const adapter = await getAdapter()
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getVersionedCollection(adapter).slug,
+      collectionConfig: getVersionedCollection(adapter),
+      versions: true,
+      draftsEnabled: true,
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+
+    const lookups = getLookups(aggregation!)
+
+    expect(lookups).toHaveLength(2)
+
+    expect(lookups[0]!.as).toBe('version.posts.docs')
+    expect(lookups[0]!.foreignField).toBe('version.category')
+    expect(lookups[0]!.from).toBe('_versioned-posts_versions')
+    expect(lookups[0]!.localField).toBe('parent')
+
+    expect(lookups[1]!.as).toBe('version.postsMany.docs')
+    expect(lookups[1]!.foreignField).toBe('version.categories')
+    expect(lookups[1]!.from).toBe('_versioned-posts_versions')
+    expect(lookups[1]!.localField).toBe('parent')
+  })
+
+  it('should add only 1 join because of the projection (include) with versions', async () => {
+    const adapter = await getAdapter()
+    const fields = buildVersionCollectionFields(
+      adapter.payload.config,
+      getVersionedCollection(adapter),
+      true,
+    )
+
+    const projection = buildProjectionFromSelect({
+      adapter,
+      fields,
+      select: {
+        version: { posts: true },
+      },
+    })
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getVersionedCollection(adapter).slug,
+      collectionConfig: getVersionedCollection(adapter),
+      projection,
+      versions: true,
+      draftsEnabled: true,
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+
+    const lookups = getLookups(aggregation!)
+    expect(lookups).toHaveLength(1)
+
+    expect(lookups[0]!.as).toBe('version.posts.docs')
+    expect(lookups[0]!.foreignField).toBe('version.category')
+    expect(lookups[0]!.from).toBe('_versioned-posts_versions')
+    expect(lookups[0]!.localField).toBe('parent')
+  })
+
+  it('should add only 1 join because of the projection (exclude) with versions', async () => {
+    const adapter = await getAdapter()
+    const fields = buildVersionCollectionFields(
+      adapter.payload.config,
+      getVersionedCollection(adapter),
+      true,
+    )
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getVersionedCollection(adapter).slug,
+      collectionConfig: getVersionedCollection(adapter),
+      projection: buildProjectionFromSelect({
+        adapter,
+        fields,
+        select: {
+          version: {
+            posts: false,
+          },
+        },
+      }),
+      versions: true,
+      draftsEnabled: true,
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+
+    const lookups = getLookups(aggregation!)
+    expect(lookups).toHaveLength(1)
+
+    expect(lookups[0]!.as).toBe('version.postsMany.docs')
+    expect(lookups[0]!.foreignField).toBe('version.categories')
+    expect(lookups[0]!.from).toBe('_versioned-posts_versions')
+    expect(lookups[0]!.localField).toBe('parent')
+  })
+
+  it('should not add any joins because of the projection with versions', async () => {
+    const adapter = await getAdapter()
+    const fields = buildVersionCollectionFields(
+      adapter.payload.config,
+      getVersionedCollection(adapter),
+      true,
+    )
+
+    const aggregation = await buildJoinAggregation({
+      adapter,
+      collection: getVersionedCollection(adapter).slug,
+      collectionConfig: getVersionedCollection(adapter),
+      projection: buildProjectionFromSelect({
+        adapter,
+        fields,
+        select: {
+          id: true,
+        },
+      }),
+      versions: true,
+      draftsEnabled: true,
+    })
+
+    expect(aggregation).toBeInstanceOf(Array)
+    expect(aggregation).toHaveLength(0)
+  })
+})

--- a/test/joins/buildJoinAggregation.int.spec.ts
+++ b/test/joins/buildJoinAggregation.int.spec.ts
@@ -11,327 +11,331 @@ import { buildJoinAggregation } from '../../packages/db-mongodb/src/utilities/bu
 import { buildProjectionFromSelect } from '../../packages/db-mongodb/src/utilities/buildProjectionFromSelect.js'
 import { describe } from '../helpers/vitest.js'
 
-describe('buildJoinAggregation', { db: 'mongo' }, () => {
-  const getAdapter = async (): Promise<MongooseAdapter> => {
-    const payload = await getPayload({
-      key: '_buildJoinAggregation',
-      config: await buildConfig({
-        secret: '______',
-        db: await import('../databaseAdapter.js').then((mod) => mod.databaseAdapter),
-        collections: [
-          {
-            slug: 'categories',
-            fields: [
-              {
-                name: 'posts',
-                type: 'join',
-                collection: 'posts',
-                on: 'category',
-              },
-              {
-                name: 'postsMany',
-                type: 'join',
-                collection: 'posts',
-                on: 'categories',
-              },
-            ],
-          },
-          {
-            slug: 'versioned-categories',
-            versions: { drafts: true },
-            fields: [
-              {
-                name: 'posts',
-                type: 'join',
-                // @ts-expect-error not generated
-                collection: 'versioned-posts',
-                on: 'category',
-              },
-              {
-                name: 'postsMany',
-                type: 'join',
-                // @ts-expect-error not generated
-                collection: 'versioned-posts',
-                on: 'categories',
-              },
-            ],
-          },
-          {
-            slug: 'posts',
-            fields: [
-              {
-                name: 'category',
-                type: 'relationship',
-                relationTo: 'categories',
-              },
-              {
-                name: 'categories',
-                type: 'relationship',
-                relationTo: 'categories',
-                hasMany: true,
-              },
-            ],
-          },
-          {
-            slug: 'versioned-posts',
-            versions: { drafts: true },
-            fields: [
-              {
-                name: 'category',
-                type: 'relationship',
-                // @ts-expect-error not generated
-                relationTo: 'versioned-categories',
-              },
-              {
-                name: 'categories',
-                type: 'relationship',
-                // @ts-expect-error not generated
-                relationTo: 'versioned-categories',
-                hasMany: true,
-              },
-            ],
-          },
-        ],
-      }),
-    })
+describe(
+  'buildJoinAggregation',
+  { db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' },
+  () => {
+    const getAdapter = async (): Promise<MongooseAdapter> => {
+      const payload = await getPayload({
+        key: '_buildJoinAggregation',
+        config: await buildConfig({
+          secret: '______',
+          db: await import('../databaseAdapter.js').then((mod) => mod.databaseAdapter),
+          collections: [
+            {
+              slug: 'categories',
+              fields: [
+                {
+                  name: 'posts',
+                  type: 'join',
+                  collection: 'posts',
+                  on: 'category',
+                },
+                {
+                  name: 'postsMany',
+                  type: 'join',
+                  collection: 'posts',
+                  on: 'categories',
+                },
+              ],
+            },
+            {
+              slug: 'versioned-categories',
+              versions: { drafts: true },
+              fields: [
+                {
+                  name: 'posts',
+                  type: 'join',
+                  // @ts-expect-error not generated
+                  collection: 'versioned-posts',
+                  on: 'category',
+                },
+                {
+                  name: 'postsMany',
+                  type: 'join',
+                  // @ts-expect-error not generated
+                  collection: 'versioned-posts',
+                  on: 'categories',
+                },
+              ],
+            },
+            {
+              slug: 'posts',
+              fields: [
+                {
+                  name: 'category',
+                  type: 'relationship',
+                  relationTo: 'categories',
+                },
+                {
+                  name: 'categories',
+                  type: 'relationship',
+                  relationTo: 'categories',
+                  hasMany: true,
+                },
+              ],
+            },
+            {
+              slug: 'versioned-posts',
+              versions: { drafts: true },
+              fields: [
+                {
+                  name: 'category',
+                  type: 'relationship',
+                  // @ts-expect-error not generated
+                  relationTo: 'versioned-categories',
+                },
+                {
+                  name: 'categories',
+                  type: 'relationship',
+                  // @ts-expect-error not generated
+                  relationTo: 'versioned-categories',
+                  hasMany: true,
+                },
+              ],
+            },
+          ],
+        }),
+      })
 
-    return payload.db as unknown as MongooseAdapter
-  }
+      return payload.db as unknown as MongooseAdapter
+    }
 
-  const getCollection = (adapter: MongooseAdapter): SanitizedCollectionConfig =>
-    adapter.payload.collections.categories.config
+    const getCollection = (adapter: MongooseAdapter): SanitizedCollectionConfig =>
+      adapter.payload.collections.categories.config
 
-  const getVersionedCollection = (adapter: MongooseAdapter): SanitizedCollectionConfig =>
-    // @ts-expect-error not generated
-    adapter.payload.collections['versioned-categories'].config
+    const getVersionedCollection = (adapter: MongooseAdapter): SanitizedCollectionConfig =>
+      // @ts-expect-error not generated
+      adapter.payload.collections['versioned-categories'].config
 
-  const getLookups = (aggregation: mongoose.PipelineStage[]) =>
-    aggregation.filter((each) => '$lookup' in each).map((each) => each.$lookup)
+    const getLookups = (aggregation: mongoose.PipelineStage[]) =>
+      aggregation.filter((each) => '$lookup' in each).map((each) => each.$lookup)
 
-  it('should add all the joins to the aggregation', async () => {
-    const adapter = await getAdapter()
+    it('should add all the joins to the aggregation', async () => {
+      const adapter = await getAdapter()
 
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getCollection(adapter).slug,
-      collectionConfig: getCollection(adapter),
-    })
-
-    expect(aggregation).toBeInstanceOf(Array)
-
-    const lookups = getLookups(aggregation!)
-
-    expect(lookups).toHaveLength(2)
-
-    expect(lookups[0]!.as).toBe('posts.docs')
-    expect(lookups[0]!.foreignField).toBe('category')
-    expect(lookups[0]!.from).toBe('posts')
-    expect(lookups[0]!.localField).toBe('_id')
-
-    expect(lookups[1]!.as).toBe('postsMany.docs')
-    expect(lookups[1]!.foreignField).toBe('categories')
-    expect(lookups[1]!.from).toBe('posts')
-    expect(lookups[1]!.localField).toBe('_id')
-  })
-
-  it('should add only 1 join because of the projection (include)', async () => {
-    const adapter = await getAdapter()
-
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getCollection(adapter).slug,
-      collectionConfig: getCollection(adapter),
-      projection: buildProjectionFromSelect({
+      const aggregation = await buildJoinAggregation({
         adapter,
-        fields: getCollection(adapter).flattenedFields,
-        select: {
-          posts: true,
-        },
-      }),
+        collection: getCollection(adapter).slug,
+        collectionConfig: getCollection(adapter),
+      })
+
+      expect(aggregation).toBeInstanceOf(Array)
+
+      const lookups = getLookups(aggregation!)
+
+      expect(lookups).toHaveLength(2)
+
+      expect(lookups[0]!.as).toBe('posts.docs')
+      expect(lookups[0]!.foreignField).toBe('category')
+      expect(lookups[0]!.from).toBe('posts')
+      expect(lookups[0]!.localField).toBe('_id')
+
+      expect(lookups[1]!.as).toBe('postsMany.docs')
+      expect(lookups[1]!.foreignField).toBe('categories')
+      expect(lookups[1]!.from).toBe('posts')
+      expect(lookups[1]!.localField).toBe('_id')
     })
 
-    expect(aggregation).toBeInstanceOf(Array)
+    it('should add only 1 join because of the projection (include)', async () => {
+      const adapter = await getAdapter()
 
-    const lookups = getLookups(aggregation!)
-    expect(lookups).toHaveLength(1)
-
-    expect(lookups[0]!.as).toBe('posts.docs')
-    expect(lookups[0]!.foreignField).toBe('category')
-    expect(lookups[0]!.from).toBe('posts')
-    expect(lookups[0]!.localField).toBe('_id')
-  })
-
-  it('should add only 1 join because of the projection (exclude)', async () => {
-    const adapter = await getAdapter()
-
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getCollection(adapter).slug,
-      collectionConfig: getCollection(adapter),
-      projection: buildProjectionFromSelect({
+      const aggregation = await buildJoinAggregation({
         adapter,
-        fields: getCollection(adapter).flattenedFields,
-        select: {
-          posts: false,
-        },
-      }),
+        collection: getCollection(adapter).slug,
+        collectionConfig: getCollection(adapter),
+        projection: buildProjectionFromSelect({
+          adapter,
+          fields: getCollection(adapter).flattenedFields,
+          select: {
+            posts: true,
+          },
+        }),
+      })
+
+      expect(aggregation).toBeInstanceOf(Array)
+
+      const lookups = getLookups(aggregation!)
+      expect(lookups).toHaveLength(1)
+
+      expect(lookups[0]!.as).toBe('posts.docs')
+      expect(lookups[0]!.foreignField).toBe('category')
+      expect(lookups[0]!.from).toBe('posts')
+      expect(lookups[0]!.localField).toBe('_id')
     })
 
-    expect(aggregation).toBeInstanceOf(Array)
+    it('should add only 1 join because of the projection (exclude)', async () => {
+      const adapter = await getAdapter()
 
-    const lookups = getLookups(aggregation!)
-    expect(lookups).toHaveLength(1)
-
-    expect(lookups[0]!.as).toBe('postsMany.docs')
-    expect(lookups[0]!.foreignField).toBe('categories')
-    expect(lookups[0]!.from).toBe('posts')
-    expect(lookups[0]!.localField).toBe('_id')
-  })
-
-  it('should not add any joins because of the projection', async () => {
-    const adapter = await getAdapter()
-
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getCollection(adapter).slug,
-      collectionConfig: getCollection(adapter),
-      projection: buildProjectionFromSelect({
+      const aggregation = await buildJoinAggregation({
         adapter,
-        fields: getCollection(adapter).flattenedFields,
-        select: {
-          id: true,
-        },
-      }),
-    })
-
-    expect(aggregation).toBeInstanceOf(Array)
-    expect(aggregation).toHaveLength(0)
-  })
-
-  it('should add all the joins to the aggregation with versions', async () => {
-    const adapter = await getAdapter()
-
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getVersionedCollection(adapter).slug,
-      collectionConfig: getVersionedCollection(adapter),
-      versions: true,
-      draftsEnabled: true,
-    })
-
-    expect(aggregation).toBeInstanceOf(Array)
-
-    const lookups = getLookups(aggregation!)
-
-    expect(lookups).toHaveLength(2)
-
-    expect(lookups[0]!.as).toBe('version.posts.docs')
-    expect(lookups[0]!.foreignField).toBe('version.category')
-    expect(lookups[0]!.from).toBe('_versioned-posts_versions')
-    expect(lookups[0]!.localField).toBe('parent')
-
-    expect(lookups[1]!.as).toBe('version.postsMany.docs')
-    expect(lookups[1]!.foreignField).toBe('version.categories')
-    expect(lookups[1]!.from).toBe('_versioned-posts_versions')
-    expect(lookups[1]!.localField).toBe('parent')
-  })
-
-  it('should add only 1 join because of the projection (include) with versions', async () => {
-    const adapter = await getAdapter()
-    const fields = buildVersionCollectionFields(
-      adapter.payload.config,
-      getVersionedCollection(adapter),
-      true,
-    )
-
-    const projection = buildProjectionFromSelect({
-      adapter,
-      fields,
-      select: {
-        version: { posts: true },
-      },
-    })
-
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getVersionedCollection(adapter).slug,
-      collectionConfig: getVersionedCollection(adapter),
-      projection,
-      versions: true,
-      draftsEnabled: true,
-    })
-
-    expect(aggregation).toBeInstanceOf(Array)
-
-    const lookups = getLookups(aggregation!)
-    expect(lookups).toHaveLength(1)
-
-    expect(lookups[0]!.as).toBe('version.posts.docs')
-    expect(lookups[0]!.foreignField).toBe('version.category')
-    expect(lookups[0]!.from).toBe('_versioned-posts_versions')
-    expect(lookups[0]!.localField).toBe('parent')
-  })
-
-  it('should add only 1 join because of the projection (exclude) with versions', async () => {
-    const adapter = await getAdapter()
-    const fields = buildVersionCollectionFields(
-      adapter.payload.config,
-      getVersionedCollection(adapter),
-      true,
-    )
-
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getVersionedCollection(adapter).slug,
-      collectionConfig: getVersionedCollection(adapter),
-      projection: buildProjectionFromSelect({
-        adapter,
-        fields,
-        select: {
-          version: {
+        collection: getCollection(adapter).slug,
+        collectionConfig: getCollection(adapter),
+        projection: buildProjectionFromSelect({
+          adapter,
+          fields: getCollection(adapter).flattenedFields,
+          select: {
             posts: false,
           },
-        },
-      }),
-      versions: true,
-      draftsEnabled: true,
+        }),
+      })
+
+      expect(aggregation).toBeInstanceOf(Array)
+
+      const lookups = getLookups(aggregation!)
+      expect(lookups).toHaveLength(1)
+
+      expect(lookups[0]!.as).toBe('postsMany.docs')
+      expect(lookups[0]!.foreignField).toBe('categories')
+      expect(lookups[0]!.from).toBe('posts')
+      expect(lookups[0]!.localField).toBe('_id')
     })
 
-    expect(aggregation).toBeInstanceOf(Array)
+    it('should not add any joins because of the projection', async () => {
+      const adapter = await getAdapter()
 
-    const lookups = getLookups(aggregation!)
-    expect(lookups).toHaveLength(1)
+      const aggregation = await buildJoinAggregation({
+        adapter,
+        collection: getCollection(adapter).slug,
+        collectionConfig: getCollection(adapter),
+        projection: buildProjectionFromSelect({
+          adapter,
+          fields: getCollection(adapter).flattenedFields,
+          select: {
+            id: true,
+          },
+        }),
+      })
 
-    expect(lookups[0]!.as).toBe('version.postsMany.docs')
-    expect(lookups[0]!.foreignField).toBe('version.categories')
-    expect(lookups[0]!.from).toBe('_versioned-posts_versions')
-    expect(lookups[0]!.localField).toBe('parent')
-  })
+      expect(aggregation).toBeInstanceOf(Array)
+      expect(aggregation).toHaveLength(0)
+    })
 
-  it('should not add any joins because of the projection with versions', async () => {
-    const adapter = await getAdapter()
-    const fields = buildVersionCollectionFields(
-      adapter.payload.config,
-      getVersionedCollection(adapter),
-      true,
-    )
+    it('should add all the joins to the aggregation with versions', async () => {
+      const adapter = await getAdapter()
 
-    const aggregation = await buildJoinAggregation({
-      adapter,
-      collection: getVersionedCollection(adapter).slug,
-      collectionConfig: getVersionedCollection(adapter),
-      projection: buildProjectionFromSelect({
+      const aggregation = await buildJoinAggregation({
+        adapter,
+        collection: getVersionedCollection(adapter).slug,
+        collectionConfig: getVersionedCollection(adapter),
+        versions: true,
+        draftsEnabled: true,
+      })
+
+      expect(aggregation).toBeInstanceOf(Array)
+
+      const lookups = getLookups(aggregation!)
+
+      expect(lookups).toHaveLength(2)
+
+      expect(lookups[0]!.as).toBe('version.posts.docs')
+      expect(lookups[0]!.foreignField).toBe('version.category')
+      expect(lookups[0]!.from).toBe('_versioned-posts_versions')
+      expect(lookups[0]!.localField).toBe('parent')
+
+      expect(lookups[1]!.as).toBe('version.postsMany.docs')
+      expect(lookups[1]!.foreignField).toBe('version.categories')
+      expect(lookups[1]!.from).toBe('_versioned-posts_versions')
+      expect(lookups[1]!.localField).toBe('parent')
+    })
+
+    it('should add only 1 join because of the projection (include) with versions', async () => {
+      const adapter = await getAdapter()
+      const fields = buildVersionCollectionFields(
+        adapter.payload.config,
+        getVersionedCollection(adapter),
+        true,
+      )
+
+      const projection = buildProjectionFromSelect({
         adapter,
         fields,
         select: {
-          id: true,
+          version: { posts: true },
         },
-      }),
-      versions: true,
-      draftsEnabled: true,
+      })
+
+      const aggregation = await buildJoinAggregation({
+        adapter,
+        collection: getVersionedCollection(adapter).slug,
+        collectionConfig: getVersionedCollection(adapter),
+        projection,
+        versions: true,
+        draftsEnabled: true,
+      })
+
+      expect(aggregation).toBeInstanceOf(Array)
+
+      const lookups = getLookups(aggregation!)
+      expect(lookups).toHaveLength(1)
+
+      expect(lookups[0]!.as).toBe('version.posts.docs')
+      expect(lookups[0]!.foreignField).toBe('version.category')
+      expect(lookups[0]!.from).toBe('_versioned-posts_versions')
+      expect(lookups[0]!.localField).toBe('parent')
     })
 
-    expect(aggregation).toBeInstanceOf(Array)
-    expect(aggregation).toHaveLength(0)
-  })
-})
+    it('should add only 1 join because of the projection (exclude) with versions', async () => {
+      const adapter = await getAdapter()
+      const fields = buildVersionCollectionFields(
+        adapter.payload.config,
+        getVersionedCollection(adapter),
+        true,
+      )
+
+      const aggregation = await buildJoinAggregation({
+        adapter,
+        collection: getVersionedCollection(adapter).slug,
+        collectionConfig: getVersionedCollection(adapter),
+        projection: buildProjectionFromSelect({
+          adapter,
+          fields,
+          select: {
+            version: {
+              posts: false,
+            },
+          },
+        }),
+        versions: true,
+        draftsEnabled: true,
+      })
+
+      expect(aggregation).toBeInstanceOf(Array)
+
+      const lookups = getLookups(aggregation!)
+      expect(lookups).toHaveLength(1)
+
+      expect(lookups[0]!.as).toBe('version.postsMany.docs')
+      expect(lookups[0]!.foreignField).toBe('version.categories')
+      expect(lookups[0]!.from).toBe('_versioned-posts_versions')
+      expect(lookups[0]!.localField).toBe('parent')
+    })
+
+    it('should not add any joins because of the projection with versions', async () => {
+      const adapter = await getAdapter()
+      const fields = buildVersionCollectionFields(
+        adapter.payload.config,
+        getVersionedCollection(adapter),
+        true,
+      )
+
+      const aggregation = await buildJoinAggregation({
+        adapter,
+        collection: getVersionedCollection(adapter).slug,
+        collectionConfig: getVersionedCollection(adapter),
+        projection: buildProjectionFromSelect({
+          adapter,
+          fields,
+          select: {
+            id: true,
+          },
+        }),
+        versions: true,
+        draftsEnabled: true,
+      })
+
+      expect(aggregation).toBeInstanceOf(Array)
+      expect(aggregation).toHaveLength(0)
+    })
+  },
+)


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15064

Added a new integration test suite `buildJoinAggregation.int.spec.ts` that verifies join inclusion/exclusion based on projection fields for both regular and versioned collections, covering include, exclude, and no-join scenarios.