### PR TITLE
chore(templates): fix postgres volume

### DIFF
--- a/templates/with-postgres/docker-compose.yml
+++ b/templates/with-postgres/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     restart: always
     image: postgres:latest
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     ports:
       - '5432:5432'
     environment:


### PR DESCRIPTION
* from the docker hub readme:

Important Note: (for PostgreSQL 17 and below) Mount the data volume at /var/lib/postgresql/data and not at /var/lib/postgresql because mounts at the latter path WILL NOT PERSIST database data when the container is re-created. The Dockerfile that builds the image declares a volume at /var/lib/postgresql/data and if no data volume is mounted at that path then the container runtime will automatically create an anonymous volume that is not reused across container re-creations. Data will be written to the anonymous volume rather than your intended data volume and won't persist when the container is deleted and re-created.

### What?

Fixes database volume in docker compose for the postgres template.

### Why?

The latest major version of docker postgres is now v18.

