### PR TITLE
fix(live-preview): remove payload import

### DIFF
--- a/packages/live-preview/src/mergeData.ts
+++ b/packages/live-preview/src/mergeData.ts
@@ -1,12 +1,12 @@
-import { formatAdminURL } from 'payload/shared'
-
 import type { CollectionPopulationRequestHandler } from './types.js'
 
-const defaultRequestHandler: CollectionPopulationRequestHandler = ({ apiPath, data, endpoint }) => {
-  const url = formatAdminURL({
-    apiRoute: apiPath,
-    path: `/${endpoint}`,
-  })
+const defaultRequestHandler: CollectionPopulationRequestHandler = ({
+  apiPath,
+  data,
+  endpoint,
+  serverURL,
+}) => {
+  const url = `${serverURL}${apiPath}/${endpoint}`
 
   return fetch(url, {
     body: JSON.stringify(data),


### PR DESCRIPTION
Fixes #15024.

The `@payloadcms/live-preview` package was importing from `payload/shared`, which is not a dependency of this module. This causes installations that are not running a payload as a peer dependency to crash, e.g. Svelte frontends, etc.

The use of `formatAdminURL` doesn't really make sense here anyway as it relies on Next.js' base path. The SDK is designed to be front-end agnostic. If needed, the user should just include it in the `serverURL` they provide.