### PR TITLE
refactor: clean up generated type resolution

### DIFF
--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -1,9 +1,9 @@
 import type { PaginatedDocs } from '../../../database/types.js'
 import type {
   CollectionSlug,
-  GeneratedTypes,
   JoinQuery,
   Payload,
+  PayloadTypes,
   RequestContext,
   TypedFallbackLocale,
   TypedLocale,
@@ -146,7 +146,7 @@ export async function findLocal<
 ): Promise<
   PaginatedDocs<
     TDraft extends true
-      ? GeneratedTypes extends { strictDraftTypes: true }
+      ? PayloadTypes extends { strictDraftTypes: true }
         ? DraftTransformCollectionWithSelect<TSlug, TSelect>
         : TransformCollectionWithSelect<TSlug, TSelect>
       : TransformCollectionWithSelect<TSlug, TSelect>

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -237,15 +237,17 @@ export interface GeneratedTypes extends BaseGeneratedTypes {}
 
 /**
  * Generic type resolver for generated types with untyped fallbacks.
- * Uses `infer` to safely extract the typed property when present,
- * falling back to the untyped variant otherwise.
  */
-type Resolve<T, K extends string, F extends keyof T> = T extends Record<K, infer V> ? V : T[F]
+type ResolveFallback<
+  TType,
+  TDesiredKey extends string,
+  TFallbackKey extends keyof TType,
+> = TDesiredKey extends keyof TType ? TType[TDesiredKey] : TType[TFallbackKey]
 
 // Applying helper types to GeneratedTypes
-export type TypedCollection = Resolve<GeneratedTypes, 'collections', 'collectionsUntyped'>
+export type TypedCollection = ResolveFallback<GeneratedTypes, 'collections', 'collectionsUntyped'>
 
-export type TypedBlock = Resolve<GeneratedTypes, 'blocks', 'blocksUntyped'>
+export type TypedBlock = ResolveFallback<GeneratedTypes, 'blocks', 'blocksUntyped'>
 
 export type TypedUploadCollection = NonNever<{
   [K in keyof TypedCollection]:
@@ -257,21 +259,25 @@ export type TypedUploadCollection = NonNever<{
     : never
 }>
 
-export type TypedCollectionSelect = Resolve<
+export type TypedCollectionSelect = ResolveFallback<
   GeneratedTypes,
   'collectionsSelect',
   'collectionsSelectUntyped'
 >
 
-export type TypedCollectionJoins = Resolve<
+export type TypedCollectionJoins = ResolveFallback<
   GeneratedTypes,
   'collectionsJoins',
   'collectionsJoinsUntyped'
 >
 
-export type TypedGlobal = Resolve<GeneratedTypes, 'globals', 'globalsUntyped'>
+export type TypedGlobal = ResolveFallback<GeneratedTypes, 'globals', 'globalsUntyped'>
 
-export type TypedGlobalSelect = Resolve<GeneratedTypes, 'globalsSelect', 'globalsSelectUntyped'>
+export type TypedGlobalSelect = ResolveFallback<
+  GeneratedTypes,
+  'globalsSelect',
+  'globalsSelectUntyped'
+>
 
 // Extract string keys from the type
 export type StringKeyOf<T> = Extract<keyof T, string>
@@ -283,21 +289,29 @@ export type BlockSlug = StringKeyOf<TypedBlock>
 
 export type UploadCollectionSlug = StringKeyOf<TypedUploadCollection>
 
-export type DefaultDocumentIDType = Resolve<GeneratedTypes, 'db', 'dbUntyped'>['defaultIDType']
+export type DefaultDocumentIDType = ResolveFallback<
+  GeneratedTypes,
+  'db',
+  'dbUntyped'
+>['defaultIDType']
 export type GlobalSlug = StringKeyOf<TypedGlobal>
 
-export type TypedLocale = Resolve<GeneratedTypes, 'locale', 'localeUntyped'>
+export type TypedLocale = ResolveFallback<GeneratedTypes, 'locale', 'localeUntyped'>
 
-export type TypedFallbackLocale = Resolve<GeneratedTypes, 'fallbackLocale', 'fallbackLocaleUntyped'>
+export type TypedFallbackLocale = ResolveFallback<
+  GeneratedTypes,
+  'fallbackLocale',
+  'fallbackLocaleUntyped'
+>
 
 /**
  * @todo rename to `User` in 4.0
  */
-export type TypedUser = Resolve<GeneratedTypes, 'user', 'userUntyped'>
+export type TypedUser = ResolveFallback<GeneratedTypes, 'user', 'userUntyped'>
 
-export type TypedAuthOperations = Resolve<GeneratedTypes, 'auth', 'authUntyped'>
+export type TypedAuthOperations = ResolveFallback<GeneratedTypes, 'auth', 'authUntyped'>
 
-export type TypedJobs = Resolve<GeneratedTypes, 'jobs', 'jobsUntyped'>
+export type TypedJobs = ResolveFallback<GeneratedTypes, 'jobs', 'jobsUntyped'>
 
 type HasPayloadJobsType = 'collections' extends keyof GeneratedTypes
   ? 'payload-jobs' extends keyof TypedCollection

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -238,36 +238,8 @@ export interface GeneratedTypes extends BaseGeneratedTypes {}
 /**
  * Returns `TType[TDesiredKey]` if it exists, otherwise `TType[TFallbackKey]`.
  *
- * WHY WE USE `infer`:
- *
- * We want TypedCollection<T> to return T['collections'] if the user defined it,
- * or fall back to T['collectionsUntyped'] for the base case.
- *
- * Attempt 1 - checking if key exists (BROKEN):
- * ```ts
- * type TypedCollection<T> = 'collections' extends keyof T ? T['collections'] : T['collectionsUntyped']
- * ```
- * This works fine when T is a specific type:
- *   TypedCollection<GeneratedTypes>  // Works: TS knows GeneratedTypes has 'collections'
- *
- * But breaks when T is a type parameter that hasn't been filled in yet:
- * ```ts
- * function getCollection<T extends BaseGeneratedTypes, S extends keyof TypedCollection<T>>() {
- *   type Result = TypedCollection<T>[S]  // Error: S cannot index TypedCollection<T>
- * }
- * ```
- * Even though T extends BaseGeneratedTypes, T could be passed as GeneratedTypes (has 'collections')
- * or BaseGeneratedTypes (if no payload-types.ts that module augments GeneratedTypes. BaseGeneratedTypes doesn't have 'collections'). TypeScript can't pick a branch because
- * it depends on what T will be when the function is called. So the type is unresolved and unusable.
- *
- * Attempt 2 - using `infer` to extract the value (WORKS):
- * ```ts
- * type TypedCollection<T> = T extends { collections: infer V } ? V : T['collectionsUntyped']
- * ```
- * Both patterns correctly pick the right branch when T is a concrete type.
- * But when T is a type parameter, only the `infer` pattern produces a type you can index into.
- *
- * @see test "ResolveFallback pattern allows generic indexing" in test/types/types.spec.ts
+ * @see test "ResolveFallback pattern allows generic indexing" in test/types/types.spec.ts.
+ * Read the comment in this test before modifying this type. We *have* to use `infer` here, not `extends keyof`.
  */
 type ResolveFallback<TType, TDesiredKey extends string, TFallbackKey extends keyof TType> =
   TType extends Record<TDesiredKey, infer TValue> ? TValue : TType[TFallbackKey]

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -468,7 +468,7 @@ export class BasePayload {
   ): Promise<
     PaginatedDocs<
       TDraft extends true
-        ? GeneratedTypes extends { strictDraftTypes: true }
+        ? PayloadTypes extends { strictDraftTypes: true }
           ? DraftTransformCollectionWithSelect<TSlug, TSelect>
           : TransformCollectionWithSelect<TSlug, TSelect>
         : TransformCollectionWithSelect<TSlug, TSelect>

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -272,7 +272,6 @@ export interface GeneratedTypes extends BaseGeneratedTypes {}
 type ResolveFallback<TType, TDesiredKey extends string, TFallbackKey extends keyof TType> =
   TType extends Record<TDesiredKey, infer TValue> ? TValue : TType[TFallbackKey]
 
-// Applying helper types to GeneratedTypes
 export type TypedCollection<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
   ResolveFallback<TGeneratedTypes, 'collections', 'collectionsUntyped'>
 

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -265,9 +265,7 @@ type IsAugmented = keyof GeneratedTypes extends never ? false : true
 /**
  * PayloadTypes merges GeneratedTypes with UntypedPayloadTypes.
  * - When augmented: uses augmented properties, fills gaps with untyped fallbacks
- * - When not augmented: uses UntypedPayloadTypes entirely
- *
- * This pattern is similar to the Job type - it automatically resolves to the right type.
+ * - When not augmented: uses only UntypedPayloadTypes
  */
 export type PayloadTypes = IsAugmented extends true
   ? GeneratedTypes & Omit<UntypedPayloadTypes, keyof GeneratedTypes>

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -264,11 +264,8 @@ export interface GeneratedTypes extends BaseGeneratedTypes {}
  * ```ts
  * type TypedCollection<T> = T extends { collections: infer V } ? V : T['collectionsUntyped']
  * ```
- * The difference: `'collections' extends keyof T` asks "list all keys of T and check if 'collections' is one".
- * But `T extends { collections: infer V }` asks "does T have a collections property?".
- * TypeScript can answer the second question even when T is unknown - it just checks if the constraint
- * (BaseGeneratedTypes) is compatible with having a 'collections' property, which it is (subtypes can add keys).
- * This produces a usable type even when T hasn't been filled in yet.
+ * Both patterns correctly pick the right branch when T is a concrete type.
+ * But when T is a type parameter, only the `infer` pattern produces a type you can index into.
  *
  * @see test "ResolveFallback pattern allows generic indexing" in test/types/types.spec.ts
  */

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { ExecutionResult, GraphQLSchema, ValidationRule } from 'graphql'
 import type { Request as graphQLRequest, OperationArgs } from 'graphql-http'
 import type { Logger } from 'pino'
@@ -165,7 +164,11 @@ export { extractAccessFromPermission } from './auth/extractAccessFromPermission.
 export { getAccessResults } from './auth/getAccessResults.js'
 export { getFieldsToSign } from './auth/getFieldsToSign.js'
 export { getLoginOptions } from './auth/getLoginOptions.js'
-export interface GeneratedTypes {
+
+/**
+ * Untyped, base GeneratedTypes interface.
+ */
+export interface BaseGeneratedTypes {
   authUntyped: {
     [slug: string]: {
       forgotPassword: {
@@ -227,41 +230,22 @@ export interface GeneratedTypes {
   userUntyped: UntypedUser
 }
 
-// Helper type to resolve the correct type using conditional types
-type ResolveCollectionType<T> = 'collections' extends keyof T
-  ? T['collections']
-  : // @ts-expect-error
-    T['collectionsUntyped']
+/**
+ * Typed GeneratedTypes interface. This interface will be module-augmented by the `payload-types.ts` file.
+ */
+export interface GeneratedTypes extends BaseGeneratedTypes {}
 
-type ResolveBlockType<T> = 'blocks' extends keyof T
-  ? T['blocks']
-  : // @ts-expect-error
-    T['blocksUntyped']
-
-type ResolveCollectionSelectType<T> = 'collectionsSelect' extends keyof T
-  ? T['collectionsSelect']
-  : // @ts-expect-error
-    T['collectionsSelectUntyped']
-
-type ResolveCollectionJoinsType<T> = 'collectionsJoins' extends keyof T
-  ? T['collectionsJoins']
-  : // @ts-expect-error
-    T['collectionsJoinsUntyped']
-
-type ResolveGlobalType<T> = 'globals' extends keyof T
-  ? T['globals']
-  : // @ts-expect-error
-    T['globalsUntyped']
-
-type ResolveGlobalSelectType<T> = 'globalsSelect' extends keyof T
-  ? T['globalsSelect']
-  : // @ts-expect-error
-    T['globalsSelectUntyped']
+/**
+ * Generic type resolver for generated types with untyped fallbacks.
+ * Uses `infer` to safely extract the typed property when present,
+ * falling back to the untyped variant otherwise.
+ */
+type Resolve<T, K extends string, F extends keyof T> = T extends Record<K, infer V> ? V : T[F]
 
 // Applying helper types to GeneratedTypes
-export type TypedCollection = ResolveCollectionType<GeneratedTypes>
+export type TypedCollection = Resolve<GeneratedTypes, 'collections', 'collectionsUntyped'>
 
-export type TypedBlock = ResolveBlockType<GeneratedTypes>
+export type TypedBlock = Resolve<GeneratedTypes, 'blocks', 'blocksUntyped'>
 
 export type TypedUploadCollection = NonNever<{
   [K in keyof TypedCollection]:
@@ -273,13 +257,21 @@ export type TypedUploadCollection = NonNever<{
     : never
 }>
 
-export type TypedCollectionSelect = ResolveCollectionSelectType<GeneratedTypes>
+export type TypedCollectionSelect = Resolve<
+  GeneratedTypes,
+  'collectionsSelect',
+  'collectionsSelectUntyped'
+>
 
-export type TypedCollectionJoins = ResolveCollectionJoinsType<GeneratedTypes>
+export type TypedCollectionJoins = Resolve<
+  GeneratedTypes,
+  'collectionsJoins',
+  'collectionsJoinsUntyped'
+>
 
-export type TypedGlobal = ResolveGlobalType<GeneratedTypes>
+export type TypedGlobal = Resolve<GeneratedTypes, 'globals', 'globalsUntyped'>
 
-export type TypedGlobalSelect = ResolveGlobalSelectType<GeneratedTypes>
+export type TypedGlobalSelect = Resolve<GeneratedTypes, 'globalsSelect', 'globalsSelectUntyped'>
 
 // Extract string keys from the type
 export type StringKeyOf<T> = Extract<keyof T, string>
@@ -291,41 +283,21 @@ export type BlockSlug = StringKeyOf<TypedBlock>
 
 export type UploadCollectionSlug = StringKeyOf<TypedUploadCollection>
 
-type ResolveDbType<T> = 'db' extends keyof T
-  ? T['db']
-  : // @ts-expect-error
-    T['dbUntyped']
-
-export type DefaultDocumentIDType = ResolveDbType<GeneratedTypes>['defaultIDType']
+export type DefaultDocumentIDType = Resolve<GeneratedTypes, 'db', 'dbUntyped'>['defaultIDType']
 export type GlobalSlug = StringKeyOf<TypedGlobal>
 
-// now for locale and user
+export type TypedLocale = Resolve<GeneratedTypes, 'locale', 'localeUntyped'>
 
-// @ts-expect-error
-type ResolveLocaleType<T> = 'locale' extends keyof T ? T['locale'] : T['localeUntyped']
-type ResolveFallbackLocaleType<T> = 'fallbackLocale' extends keyof T
-  ? T['fallbackLocale']
-  : // @ts-expect-error
-    T['fallbackLocaleUntyped']
-// @ts-expect-error
-type ResolveUserType<T> = 'user' extends keyof T ? T['user'] : T['userUntyped']
-
-export type TypedLocale = ResolveLocaleType<GeneratedTypes>
-
-export type TypedFallbackLocale = ResolveFallbackLocaleType<GeneratedTypes>
+export type TypedFallbackLocale = Resolve<GeneratedTypes, 'fallbackLocale', 'fallbackLocaleUntyped'>
 
 /**
  * @todo rename to `User` in 4.0
  */
-export type TypedUser = ResolveUserType<GeneratedTypes>
+export type TypedUser = Resolve<GeneratedTypes, 'user', 'userUntyped'>
 
-// @ts-expect-error
-type ResolveAuthOperationsType<T> = 'auth' extends keyof T ? T['auth'] : T['authUntyped']
-export type TypedAuthOperations = ResolveAuthOperationsType<GeneratedTypes>
+export type TypedAuthOperations = Resolve<GeneratedTypes, 'auth', 'authUntyped'>
 
-// @ts-expect-error
-type ResolveJobOperationsType<T> = 'jobs' extends keyof T ? T['jobs'] : T['jobsUntyped']
-export type TypedJobs = ResolveJobOperationsType<GeneratedTypes>
+export type TypedJobs = Resolve<GeneratedTypes, 'jobs', 'jobsUntyped'>
 
 type HasPayloadJobsType = 'collections' extends keyof GeneratedTypes
   ? 'payload-jobs' extends keyof TypedCollection

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -349,8 +349,7 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
     } catch (error) {
       if (error instanceof JobCancelledError) {
         if (
-          // @ts-expect-error error is not typed
-          !job.error?.cancelled ||
+          !(job.error as Record<string, unknown> | undefined)?.cancelled ||
           !job.hasError ||
           job.processing ||
           job.completedAt ||

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -171,6 +171,38 @@ describe('Types testing', () => {
 
   test('ResolveFallback allows generic indexing', () => {
     // This type fails to compile if ResolveFallback uses `K extends keyof T` instead of `T extends Record<K, infer V>`
+
+    /**
+     * WHY WE USE `infer`:
+     *
+     * We want TypedCollection<T> to return T['collections'] if the user defined it,
+     * or fall back to T['collectionsUntyped'] for the base case.
+     *
+     * Attempt 1 - checking if key exists (BROKEN):
+     * ```ts
+     * type TypedCollection<T> = 'collections' extends keyof T ? T['collections'] : T['collectionsUntyped']
+     * ```
+     * This works fine when T is a specific type:
+     *   TypedCollection<GeneratedTypes>  // Works: TS knows GeneratedTypes has 'collections'
+     *
+     * But breaks when T is a type parameter that hasn't been filled in yet:
+     * ```ts
+     * function getCollection<T extends BaseGeneratedTypes, S extends keyof TypedCollection<T>>() {
+     *   type Result = TypedCollection<T>[S]  // Error: S cannot index TypedCollection<T>
+     * }
+     * ```
+     * Even though T extends BaseGeneratedTypes, T could be passed as GeneratedTypes (has 'collections')
+     * or BaseGeneratedTypes (if no payload-types.ts that module augments GeneratedTypes. BaseGeneratedTypes doesn't have 'collections'). TypeScript can't pick a branch because
+     * it depends on what T will be when the function is called. So the type is unresolved and unusable.
+     *
+     * Attempt 2 - using `infer` to extract the value (WORKS):
+     * ```ts
+     * type TypedCollection<T> = T extends { collections: infer V } ? V : T['collectionsUntyped']
+     * ```
+     * Both patterns correctly pick the right branch when T is a concrete type.
+     * But when T is a type parameter, only the `infer` pattern produces a type you can index into.
+     *
+     */
     type Select<
       T extends BaseGeneratedTypes,
       S extends CollectionSlug<T>,

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -1,10 +1,14 @@
 import type {
+  BaseGeneratedTypes,
   BulkOperationResult,
+  CollectionSlug,
   CustomDocumentViewConfig,
   DefaultDocumentViewConfig,
+  GeneratedTypes,
   JoinQuery,
   PaginatedDocs,
   SelectType,
+  TypedCollectionSelect,
   TypeWithVersion,
   Where,
 } from 'payload'
@@ -163,6 +167,15 @@ describe('Types testing', () => {
       expect<NonNullable<Post['externalType']>>().type.toHaveProperty('externalField')
       expect<NonNullable<Post['externalType']>>().type.toHaveProperty('externalNumber')
     })
+  })
+
+  test('ResolveFallback allows generic indexing', () => {
+    // This type fails to compile if ResolveFallback uses `K extends keyof T` instead of `T extends Record<K, infer V>`
+    type Select<
+      T extends BaseGeneratedTypes,
+      S extends CollectionSlug<T>,
+    > = TypedCollectionSelect<T>[S]
+    expect<Select<GeneratedTypes, 'users'>>().type.not.toBeNever()
   })
 
   describe('fields', () => {

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -23,10 +23,12 @@ import {
   type SerializedTextNode,
   type TypedEditorState,
 } from '@payloadcms/richtext-lexical'
+import { PayloadSDK } from '@payloadcms/sdk'
 import payload from 'payload'
 import { describe, expect, test } from 'tstyche'
 
 import type {
+  Config,
   Menu,
   MyRadioOptions,
   MySelectOptions,
@@ -931,6 +933,28 @@ describe('Types testing', () => {
         })
         expect(result).type.toBe<TypedEditorState<DefaultNodeTypes>>()
       })
+    })
+  })
+
+  describe('sdk', () => {
+    test('ensure generated types can be manually assigned to PayloadSDK generic', () => {
+      expect(new PayloadSDK<Config>({ baseURL: '' })).type.not.toRaiseError()
+    })
+
+    test('ensure SDK with explicit generic uses has correct collection types', () => {
+      const _sdk = new PayloadSDK<Config>({ baseURL: '' })
+      // ensure collection property of sdk.create has posts in the union type
+      expect<Parameters<typeof _sdk.create>[0]['collection']>().type.toBe<
+        | 'draft-posts'
+        | 'pages'
+        | 'pages-categories'
+        | 'payload-kv'
+        | 'payload-locked-documents'
+        | 'payload-migrations'
+        | 'payload-preferences'
+        | 'posts'
+        | 'users'
+      >()
     })
   })
 


### PR DESCRIPTION
Previously, `GeneratedTypes` contained both augmented properties and `*Untyped` fallbacks in the same interface. This required complex `Resolve*` conditional types with numerous `@ts-expect-error` suppressions to handle both cases.

This PR restructures the type system into three parts: `GeneratedTypes` (empty, module-augmented by payload-types.ts), `UntypedPayloadTypes` (fallbacks), and `PayloadTypes` (merges both automatically).

A new `PayloadTypesShape` interface defines the expected structure, enabling simple property access like `T['collections']` instead of complex conditional types. All `Typed*` types are now one-liners.

This not only eliminates 10+ `@ts-expect-error` suppressions, but also makes more sense semantically. GENERATEDTypes now exclusively contain types that were GENERATED. Previously, they also contained fallbacks.

`CollectionSlug`, `GlobalSlug`, and `AuthCollectionSlug` now accept an optional generic parameter, enabling the SDK to use custom Config types without type duplication.