### PR TITLE
feat(sdk): automatically fallback to generated types

### DIFF
--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -820,13 +820,26 @@ Example:
 
 ```ts
 import { PayloadSDK } from '@payloadcms/sdk'
+
+const sdk = new PayloadSDK({
+  baseURL: 'https://example.com/api',
+})
+```
+
+For projects without a `payload-types.ts` file, or when working with multiple Payload configs, you can manually pass the types as a generic:
+
+```ts
+import { PayloadSDK } from '@payloadcms/sdk'
 import type { Config } from './payload-types'
 
-// Pass your config from generated types as generic
 const sdk = new PayloadSDK<Config>({
   baseURL: 'https://example.com/api',
 })
+```
 
+### Operations
+
+```ts
 // Find operation
 const posts = await sdk.find({
   collection: 'posts',
@@ -1024,8 +1037,6 @@ const sdk = new PayloadSDK<Config>({
 Example of a custom `fetch` implementation for testing the REST API without needing to spin up a next development server:
 
 ```ts
-import type { GeneratedTypes, SanitizedConfig } from 'payload'
-
 import config from '@payload-config'
 import {
   REST_DELETE,
@@ -1035,8 +1046,6 @@ import {
   REST_PUT,
 } from '@payloadcms/next/routes'
 import { PayloadSDK } from '@payloadcms/sdk'
-
-export type TypedPayloadSDK = PayloadSDK<GeneratedTypes>
 
 const api = {
   GET: REST_GET(config),
@@ -1048,7 +1057,7 @@ const api = {
 
 const awaitedConfig = await config
 
-export const sdk = new PayloadSDK<GeneratedTypes>({
+export const sdk = new PayloadSDK({
   baseURL: ``,
   fetch: (path: string, init: RequestInit) => {
     const [slugs, search] = path.slice(1).split('?')

--- a/packages/payload/src/exports/internal.ts
+++ b/packages/payload/src/exports/internal.ts
@@ -4,3 +4,14 @@
 
 export { getEntityPermissions } from '../utilities/getEntityPermissions/getEntityPermissions.js'
 export { sanitizePermissions } from '../utilities/sanitizePermissions.js'
+
+/**
+ * Returns `TType[TDesiredKey]` if it exists, otherwise `TType[TFallbackKey]`.
+ *
+ * @see test "ResolveFallback pattern allows generic indexing" in test/types/types.spec.ts.
+ * Read the comment in this test before modifying this type. We *have* to use `infer` here, not `extends keyof`.
+ *
+ * @internal - for internal use only
+ */
+export type ResolveFallback<TType, TDesiredKey extends string, TFallbackKey extends keyof TType> =
+  TType extends Record<TDesiredKey, infer TValue> ? TValue : TType[TFallbackKey]

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -125,6 +125,8 @@ import type { SupportedLanguages } from '@payloadcms/translations'
 import { Cron } from 'croner'
 
 import type { ClientConfig } from './config/client.js'
+// eslint-disable-next-line payload/no-imports-from-exports-dir
+import type { ResolveFallback } from './exports/internal.js'
 import type { KVAdapter } from './kv/index.js'
 import type { BaseJob } from './queues/config/types/workflowTypes.js'
 import type { TypeWithVersion } from './versions/types.js'
@@ -235,46 +237,33 @@ export interface BaseGeneratedTypes {
  */
 export interface GeneratedTypes extends BaseGeneratedTypes {}
 
-/**
- * Returns `TType[TDesiredKey]` if it exists, otherwise `TType[TFallbackKey]`.
- *
- * @see test "ResolveFallback pattern allows generic indexing" in test/types/types.spec.ts.
- * Read the comment in this test before modifying this type. We *have* to use `infer` here, not `extends keyof`.
- */
-type ResolveFallback<TType, TDesiredKey extends string, TFallbackKey extends keyof TType> =
-  TType extends Record<TDesiredKey, infer TValue> ? TValue : TType[TFallbackKey]
-
 export type TypedCollection<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
   ResolveFallback<TGeneratedTypes, 'collections', 'collectionsUntyped'>
 
 export type TypedBlock = ResolveFallback<GeneratedTypes, 'blocks', 'blocksUntyped'>
 
-export type TypedUploadCollection = NonNever<{
-  [K in keyof TypedCollection]:
-    | 'filename'
-    | 'filesize'
-    | 'mimeType'
-    | 'url' extends keyof TypedCollection[K]
-    ? TypedCollection[K]
-    : never
-}>
+export type TypedUploadCollection<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
+  NonNever<{
+    [TCollectionSlug in keyof TypedCollection<TGeneratedTypes>]:
+      | 'filename'
+      | 'filesize'
+      | 'mimeType'
+      | 'url' extends keyof TypedCollection<TGeneratedTypes>[TCollectionSlug]
+      ? TypedCollection<TGeneratedTypes>[TCollectionSlug]
+      : never
+  }>
 
 export type TypedCollectionSelect<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
   ResolveFallback<TGeneratedTypes, 'collectionsSelect', 'collectionsSelectUntyped'>
 
-export type TypedCollectionJoins = ResolveFallback<
-  GeneratedTypes,
-  'collectionsJoins',
-  'collectionsJoinsUntyped'
->
+export type TypedCollectionJoins<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
+  ResolveFallback<TGeneratedTypes, 'collectionsJoins', 'collectionsJoinsUntyped'>
 
-export type TypedGlobal = ResolveFallback<GeneratedTypes, 'globals', 'globalsUntyped'>
+export type TypedGlobal<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
+  ResolveFallback<TGeneratedTypes, 'globals', 'globalsUntyped'>
 
-export type TypedGlobalSelect = ResolveFallback<
-  GeneratedTypes,
-  'globalsSelect',
-  'globalsSelectUntyped'
->
+export type TypedGlobalSelect<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
+  ResolveFallback<TGeneratedTypes, 'globalsSelect', 'globalsSelectUntyped'>
 
 // Extract string keys from the type
 export type StringKeyOf<T> = Extract<keyof T, string>
@@ -285,16 +274,20 @@ export type CollectionSlug<TGeneratedTypes extends BaseGeneratedTypes = Generate
 
 export type BlockSlug = StringKeyOf<TypedBlock>
 
-export type UploadCollectionSlug = StringKeyOf<TypedUploadCollection>
+export type UploadCollectionSlug<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
+  StringKeyOf<TypedUploadCollection<TGeneratedTypes>>
 
 export type DefaultDocumentIDType = ResolveFallback<
   GeneratedTypes,
   'db',
   'dbUntyped'
 >['defaultIDType']
-export type GlobalSlug = StringKeyOf<TypedGlobal>
+export type GlobalSlug<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> = StringKeyOf<
+  TypedGlobal<TGeneratedTypes>
+>
 
-export type TypedLocale = ResolveFallback<GeneratedTypes, 'locale', 'localeUntyped'>
+export type TypedLocale<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
+  ResolveFallback<TGeneratedTypes, 'locale', 'localeUntyped'>
 
 export type TypedFallbackLocale = ResolveFallback<
   GeneratedTypes,
@@ -307,7 +300,12 @@ export type TypedFallbackLocale = ResolveFallback<
  */
 export type TypedUser = ResolveFallback<GeneratedTypes, 'user', 'userUntyped'>
 
-export type TypedAuthOperations = ResolveFallback<GeneratedTypes, 'auth', 'authUntyped'>
+export type TypedAuthOperations<TGeneratedTypes extends BaseGeneratedTypes = GeneratedTypes> =
+  ResolveFallback<TGeneratedTypes, 'auth', 'authUntyped'>
+
+export type AuthCollectionSlug<TGeneratedTypes extends BaseGeneratedTypes> = StringKeyOf<
+  TypedAuthOperations<TGeneratedTypes>
+>
 
 export type TypedJobs = ResolveFallback<GeneratedTypes, 'jobs', 'jobsUntyped'>
 

--- a/packages/sdk/src/auth/forgotPassword.ts
+++ b/packages/sdk/src/auth/forgotPassword.ts
@@ -1,19 +1,20 @@
+import type { AuthCollectionSlug, BaseGeneratedTypes, TypedAuthOperations } from 'payload'
+
 import type { PayloadSDK } from '../index.js'
-import type { AuthCollectionSlug, PayloadGeneratedTypes, TypedAuth } from '../types.js'
 
 export type ForgotPasswordOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 > = {
   collection: TSlug
   data: {
     disableEmail?: boolean
     expiration?: number
-  } & Omit<TypedAuth<T>[TSlug]['forgotPassword'], 'password'>
+  } & Omit<TypedAuthOperations<T>[TSlug]['forgotPassword'], 'password'>
 }
 
 export async function forgotPassword<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 >(
   sdk: PayloadSDK<T>,

--- a/packages/sdk/src/auth/login.ts
+++ b/packages/sdk/src/auth/login.ts
@@ -1,17 +1,14 @@
-import type { PayloadSDK } from '../index.js'
-import type {
-  AuthCollectionSlug,
-  DataFromCollectionSlug,
-  PayloadGeneratedTypes,
-  TypedAuth,
-} from '../types.js'
+import type { AuthCollectionSlug, BaseGeneratedTypes, TypedAuthOperations } from 'payload'
 
-export type LoginOptions<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
+import type { PayloadSDK } from '../index.js'
+import type { DataFromCollectionSlug } from '../types.js'
+
+export type LoginOptions<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
   collection: TSlug
-  data: TypedAuth<T>[TSlug]['login']
+  data: TypedAuthOperations<T>[TSlug]['login']
 }
 
-export type LoginResult<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
+export type LoginResult<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
   exp?: number
   message: string
   token?: string
@@ -19,7 +16,7 @@ export type LoginResult<T extends PayloadGeneratedTypes, TSlug extends AuthColle
   user: DataFromCollectionSlug<T, TSlug>
 }
 
-export async function login<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>>(
+export async function login<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>>(
   sdk: PayloadSDK<T>,
   options: LoginOptions<T, TSlug>,
   init?: RequestInit,

--- a/packages/sdk/src/auth/me.ts
+++ b/packages/sdk/src/auth/me.ts
@@ -1,11 +1,13 @@
-import type { PayloadSDK } from '../index.js'
-import type { AuthCollectionSlug, DataFromCollectionSlug, PayloadGeneratedTypes } from '../types.js'
+import type { AuthCollectionSlug, BaseGeneratedTypes } from 'payload'
 
-export type MeOptions<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
+import type { PayloadSDK } from '../index.js'
+import type { DataFromCollectionSlug } from '../types.js'
+
+export type MeOptions<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
   collection: TSlug
 }
 
-export type MeResult<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
+export type MeResult<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
   collection?: TSlug
   exp?: number
   message: string
@@ -15,7 +17,7 @@ export type MeResult<T extends PayloadGeneratedTypes, TSlug extends AuthCollecti
   user: DataFromCollectionSlug<T, TSlug>
 }
 
-export async function me<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>>(
+export async function me<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>>(
   sdk: PayloadSDK<T>,
   options: MeOptions<T, TSlug>,
   init?: RequestInit,

--- a/packages/sdk/src/auth/refreshToken.ts
+++ b/packages/sdk/src/auth/refreshToken.ts
@@ -1,11 +1,13 @@
-import type { PayloadSDK } from '../index.js'
-import type { AuthCollectionSlug, DataFromCollectionSlug, PayloadGeneratedTypes } from '../types.js'
+import type { AuthCollectionSlug, BaseGeneratedTypes } from 'payload'
 
-export type RefreshOptions<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
+import type { PayloadSDK } from '../index.js'
+import type { DataFromCollectionSlug } from '../types.js'
+
+export type RefreshOptions<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
   collection: TSlug
 }
 
-export type RefreshResult<T extends PayloadGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
+export type RefreshResult<T extends BaseGeneratedTypes, TSlug extends AuthCollectionSlug<T>> = {
   exp: number
   refreshedToken: string
   setCookie?: boolean
@@ -15,7 +17,7 @@ export type RefreshResult<T extends PayloadGeneratedTypes, TSlug extends AuthCol
 }
 
 export async function refreshToken<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 >(
   sdk: PayloadSDK<T>,

--- a/packages/sdk/src/auth/resetPassword.ts
+++ b/packages/sdk/src/auth/resetPassword.ts
@@ -1,8 +1,10 @@
+import type { AuthCollectionSlug, BaseGeneratedTypes } from 'payload'
+
 import type { PayloadSDK } from '../index.js'
-import type { AuthCollectionSlug, DataFromCollectionSlug, PayloadGeneratedTypes } from '../types.js'
+import type { DataFromCollectionSlug } from '../types.js'
 
 export type ResetPasswordOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 > = {
   collection: TSlug
@@ -13,7 +15,7 @@ export type ResetPasswordOptions<
 }
 
 export type ResetPasswordResult<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 > = {
   token?: string
@@ -22,7 +24,7 @@ export type ResetPasswordResult<
 }
 
 export async function resetPassword<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 >(
   sdk: PayloadSDK<T>,

--- a/packages/sdk/src/auth/verifyEmail.ts
+++ b/packages/sdk/src/auth/verifyEmail.ts
@@ -1,8 +1,9 @@
+import type { AuthCollectionSlug, BaseGeneratedTypes } from 'payload'
+
 import type { PayloadSDK } from '../index.js'
-import type { AuthCollectionSlug, PayloadGeneratedTypes } from '../types.js'
 
 export type VerifyEmailOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 > = {
   collection: TSlug
@@ -10,7 +11,7 @@ export type VerifyEmailOptions<
 }
 
 export async function verifyEmail<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends AuthCollectionSlug<T>,
 >(
   sdk: PayloadSDK<T>,

--- a/packages/sdk/src/collections/count.ts
+++ b/packages/sdk/src/collections/count.ts
@@ -1,9 +1,8 @@
-import type { Where } from 'payload'
+import type { BaseGeneratedTypes, CollectionSlug, TypedLocale, Where } from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type { CollectionSlug, PayloadGeneratedTypes, TypedLocale } from '../types.js'
 
-export type CountOptions<T extends PayloadGeneratedTypes, TSlug extends CollectionSlug<T>> = {
+export type CountOptions<T extends BaseGeneratedTypes, TSlug extends CollectionSlug<T>> = {
   /**
    * the Collection slug to operate against.
    */
@@ -18,7 +17,7 @@ export type CountOptions<T extends PayloadGeneratedTypes, TSlug extends Collecti
   where?: Where
 }
 
-export async function count<T extends PayloadGeneratedTypes, TSlug extends CollectionSlug<T>>(
+export async function count<T extends BaseGeneratedTypes, TSlug extends CollectionSlug<T>>(
   sdk: PayloadSDK<T>,
   options: CountOptions<T, TSlug>,
   init?: RequestInit,

--- a/packages/sdk/src/collections/create.ts
+++ b/packages/sdk/src/collections/create.ts
@@ -1,20 +1,22 @@
-import type { SelectType } from 'payload'
+import type {
+  BaseGeneratedTypes,
+  CollectionSlug,
+  SelectType,
+  TypedLocale,
+  UploadCollectionSlug,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
 import type {
-  CollectionSlug,
-  PayloadGeneratedTypes,
   PopulateType,
   RequiredDataFromCollectionSlug,
   TransformCollectionWithSelect,
-  TypedLocale,
-  UploadCollectionSlug,
 } from '../types.js'
 
 import { resolveFileFromOptions } from '../utilities/resolveFileFromOptions.js'
 
 export type CreateOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectType,
 > = {
@@ -55,7 +57,7 @@ export type CreateOptions<
 }
 
 export async function create<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectType,
 >(

--- a/packages/sdk/src/collections/delete.ts
+++ b/packages/sdk/src/collections/delete.ts
@@ -1,18 +1,15 @@
-import type { SelectType, Where } from 'payload'
+import type { BaseGeneratedTypes, CollectionSlug, SelectType, TypedLocale, Where } from 'payload'
 
 import type { PayloadSDK } from '../index.js'
 import type {
   BulkOperationResult,
-  CollectionSlug,
-  PayloadGeneratedTypes,
   PopulateType,
   SelectFromCollectionSlug,
   TransformCollectionWithSelect,
-  TypedLocale,
 } from '../types.js'
 
 export type DeleteBaseOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectType,
 > = {
@@ -44,7 +41,7 @@ export type DeleteBaseOptions<
 }
 
 export type DeleteByIDOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 > = {
@@ -57,7 +54,7 @@ export type DeleteByIDOptions<
 } & DeleteBaseOptions<T, TSlug, TSelect>
 
 export type DeleteManyOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 > = {
@@ -69,13 +66,13 @@ export type DeleteManyOptions<
 } & DeleteBaseOptions<T, TSlug, TSelect>
 
 export type DeleteOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 > = DeleteByIDOptions<T, TSlug, TSelect> | DeleteManyOptions<T, TSlug, TSelect>
 
 export async function deleteOperation<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 >(

--- a/packages/sdk/src/collections/find.ts
+++ b/packages/sdk/src/collections/find.ts
@@ -1,17 +1,18 @@
-import type { PaginatedDocs, SelectType, Sort, Where } from 'payload'
+import type {
+  BaseGeneratedTypes,
+  CollectionSlug,
+  PaginatedDocs,
+  SelectType,
+  Sort,
+  TypedLocale,
+  Where,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  CollectionSlug,
-  JoinQuery,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TransformCollectionWithSelect,
-  TypedLocale,
-} from '../types.js'
+import type { JoinQuery, PopulateType, TransformCollectionWithSelect } from '../types.js'
 
 export type FindOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectType,
 > = {
@@ -86,7 +87,7 @@ export type FindOptions<
 }
 
 export async function find<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectType,
 >(

--- a/packages/sdk/src/collections/findByID.ts
+++ b/packages/sdk/src/collections/findByID.ts
@@ -1,17 +1,16 @@
-import type { ApplyDisableErrors, SelectType } from 'payload'
+import type {
+  ApplyDisableErrors,
+  BaseGeneratedTypes,
+  CollectionSlug,
+  SelectType,
+  TypedLocale,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  CollectionSlug,
-  JoinQuery,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TransformCollectionWithSelect,
-  TypedLocale,
-} from '../types.js'
+import type { JoinQuery, PopulateType, TransformCollectionWithSelect } from '../types.js'
 
 export type FindByIDOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TDisableErrors extends boolean,
   TSelect extends SelectType,
@@ -61,7 +60,7 @@ export type FindByIDOptions<
 }
 
 export async function findByID<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TDisableErrors extends boolean,
   TSelect extends SelectType,

--- a/packages/sdk/src/collections/findVersionByID.ts
+++ b/packages/sdk/src/collections/findVersionByID.ts
@@ -1,16 +1,17 @@
-import type { ApplyDisableErrors, SelectType, TypeWithVersion } from 'payload'
+import type {
+  ApplyDisableErrors,
+  BaseGeneratedTypes,
+  CollectionSlug,
+  SelectType,
+  TypedLocale,
+  TypeWithVersion,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  CollectionSlug,
-  DataFromCollectionSlug,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TypedLocale,
-} from '../types.js'
+import type { DataFromCollectionSlug, PopulateType } from '../types.js'
 
 export type FindVersionByIDOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TDisableErrors extends boolean,
 > = {
@@ -63,7 +64,7 @@ export type FindVersionByIDOptions<
 }
 
 export async function findVersionByID<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TDisableErrors extends boolean,
 >(

--- a/packages/sdk/src/collections/findVersions.ts
+++ b/packages/sdk/src/collections/findVersions.ts
@@ -1,18 +1,18 @@
-import type { PaginatedDocs, SelectType, Sort, TypeWithVersion, Where } from 'payload'
+import type {
+  BaseGeneratedTypes,
+  CollectionSlug,
+  PaginatedDocs,
+  SelectType,
+  Sort,
+  TypedLocale,
+  TypeWithVersion,
+  Where,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  CollectionSlug,
-  DataFromCollectionSlug,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TypedLocale,
-} from '../types.js'
+import type { DataFromCollectionSlug, PopulateType } from '../types.js'
 
-export type FindVersionsOptions<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
-> = {
+export type FindVersionsOptions<T extends BaseGeneratedTypes, TSlug extends CollectionSlug<T>> = {
   /**
    * the Collection slug to operate against.
    */
@@ -78,10 +78,7 @@ export type FindVersionsOptions<
   where?: Where
 }
 
-export async function findVersions<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
->(
+export async function findVersions<T extends BaseGeneratedTypes, TSlug extends CollectionSlug<T>>(
   sdk: PayloadSDK<T>,
   options: FindVersionsOptions<T, TSlug>,
   init?: RequestInit,

--- a/packages/sdk/src/collections/restoreVersion.ts
+++ b/packages/sdk/src/collections/restoreVersion.ts
@@ -1,14 +1,10 @@
+import type { BaseGeneratedTypes, CollectionSlug, TypedLocale } from 'payload'
+
 import type { PayloadSDK } from '../index.js'
-import type {
-  CollectionSlug,
-  DataFromCollectionSlug,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TypedLocale,
-} from '../types.js'
+import type { DataFromCollectionSlug, PopulateType } from '../types.js'
 
 export type RestoreVersionByIDOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
 > = {
   /**
@@ -41,10 +37,7 @@ export type RestoreVersionByIDOptions<
   populate?: PopulateType<T>
 }
 
-export async function restoreVersion<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
->(
+export async function restoreVersion<T extends BaseGeneratedTypes, TSlug extends CollectionSlug<T>>(
   sdk: PayloadSDK<T>,
   options: RestoreVersionByIDOptions<T, TSlug>,
   init?: RequestInit,

--- a/packages/sdk/src/collections/update.ts
+++ b/packages/sdk/src/collections/update.ts
@@ -1,23 +1,26 @@
-import type { SelectType, Where } from 'payload'
+import type {
+  BaseGeneratedTypes,
+  CollectionSlug,
+  SelectType,
+  TypedLocale,
+  UploadCollectionSlug,
+  Where,
+} from 'payload'
 import type { DeepPartial } from 'ts-essentials'
 
 import type { PayloadSDK } from '../index.js'
 import type {
   BulkOperationResult,
-  CollectionSlug,
-  PayloadGeneratedTypes,
   PopulateType,
   RequiredDataFromCollectionSlug,
   SelectFromCollectionSlug,
   TransformCollectionWithSelect,
-  TypedLocale,
-  UploadCollectionSlug,
 } from '../types.js'
 
 import { resolveFileFromOptions } from '../utilities/resolveFileFromOptions.js'
 
 export type UpdateBaseOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectType,
 > = {
@@ -67,7 +70,7 @@ export type UpdateBaseOptions<
 }
 
 export type UpdateByIDOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 > = {
@@ -77,7 +80,7 @@ export type UpdateByIDOptions<
 } & UpdateBaseOptions<T, TSlug, TSelect>
 
 export type UpdateManyOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 > = {
@@ -87,13 +90,13 @@ export type UpdateManyOptions<
 } & UpdateBaseOptions<T, TSlug, TSelect>
 
 export type UpdateOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 > = UpdateByIDOptions<T, TSlug, TSelect> | UpdateManyOptions<T, TSlug, TSelect>
 
 export async function update<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<T>,
   TSelect extends SelectFromCollectionSlug<T, TSlug>,
 >(

--- a/packages/sdk/src/globals/findOne.ts
+++ b/packages/sdk/src/globals/findOne.ts
@@ -1,17 +1,10 @@
-import type { SelectType } from 'payload'
+import type { BaseGeneratedTypes, GlobalSlug, SelectType, TypedLocale } from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  GlobalSlug,
-  PayloadGeneratedTypes,
-  PopulateType,
-  SelectFromGlobalSlug,
-  TransformGlobalWithSelect,
-  TypedLocale,
-} from '../types.js'
+import type { PopulateType, SelectFromGlobalSlug, TransformGlobalWithSelect } from '../types.js'
 
 export type FindGlobalOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
   TSelect extends SelectType,
 > = {
@@ -46,7 +39,7 @@ export type FindGlobalOptions<
 }
 
 export async function findGlobal<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
   TSelect extends SelectFromGlobalSlug<T, TSlug>,
 >(

--- a/packages/sdk/src/globals/findVersionByID.ts
+++ b/packages/sdk/src/globals/findVersionByID.ts
@@ -1,16 +1,17 @@
-import type { ApplyDisableErrors, SelectType, TypeWithVersion } from 'payload'
+import type {
+  ApplyDisableErrors,
+  BaseGeneratedTypes,
+  GlobalSlug,
+  SelectType,
+  TypedLocale,
+  TypeWithVersion,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  DataFromGlobalSlug,
-  GlobalSlug,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TypedLocale,
-} from '../types.js'
+import type { DataFromGlobalSlug, PopulateType } from '../types.js'
 
 export type FindGlobalVersionByIDOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
   TDisableErrors extends boolean,
 > = {
@@ -51,7 +52,7 @@ export type FindGlobalVersionByIDOptions<
 }
 
 export async function findGlobalVersionByID<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
   TDisableErrors extends boolean,
 >(

--- a/packages/sdk/src/globals/findVersions.ts
+++ b/packages/sdk/src/globals/findVersions.ts
@@ -1,18 +1,18 @@
-import type { PaginatedDocs, SelectType, Sort, TypeWithVersion, Where } from 'payload'
+import type {
+  BaseGeneratedTypes,
+  GlobalSlug,
+  PaginatedDocs,
+  SelectType,
+  Sort,
+  TypedLocale,
+  TypeWithVersion,
+  Where,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  DataFromGlobalSlug,
-  GlobalSlug,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TypedLocale,
-} from '../types.js'
+import type { DataFromGlobalSlug, PopulateType } from '../types.js'
 
-export type FindGlobalVersionsOptions<
-  T extends PayloadGeneratedTypes,
-  TSlug extends GlobalSlug<T>,
-> = {
+export type FindGlobalVersionsOptions<T extends BaseGeneratedTypes, TSlug extends GlobalSlug<T>> = {
   /**
    * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
    */
@@ -66,10 +66,7 @@ export type FindGlobalVersionsOptions<
   where?: Where
 }
 
-export async function findGlobalVersions<
-  T extends PayloadGeneratedTypes,
-  TSlug extends GlobalSlug<T>,
->(
+export async function findGlobalVersions<T extends BaseGeneratedTypes, TSlug extends GlobalSlug<T>>(
   sdk: PayloadSDK<T>,
   options: FindGlobalVersionsOptions<T, TSlug>,
   init?: RequestInit,

--- a/packages/sdk/src/globals/restoreVersion.ts
+++ b/packages/sdk/src/globals/restoreVersion.ts
@@ -1,16 +1,10 @@
-import type { TypeWithVersion } from 'payload'
+import type { BaseGeneratedTypes, GlobalSlug, TypedLocale, TypeWithVersion } from 'payload'
 
 import type { PayloadSDK } from '../index.js'
-import type {
-  DataFromGlobalSlug,
-  GlobalSlug,
-  PayloadGeneratedTypes,
-  PopulateType,
-  TypedLocale,
-} from '../types.js'
+import type { DataFromGlobalSlug, PopulateType } from '../types.js'
 
 export type RestoreGlobalVersionByIDOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
 > = {
   /**
@@ -41,7 +35,7 @@ export type RestoreGlobalVersionByIDOptions<
 }
 
 export async function restoreGlobalVersion<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
 >(
   sdk: PayloadSDK<T>,

--- a/packages/sdk/src/globals/update.ts
+++ b/packages/sdk/src/globals/update.ts
@@ -1,19 +1,16 @@
-import type { SelectType } from 'payload'
+import type { BaseGeneratedTypes, GlobalSlug, SelectType, TypedLocale } from 'payload'
 import type { DeepPartial } from 'ts-essentials'
 
 import type { PayloadSDK } from '../index.js'
 import type {
   DataFromGlobalSlug,
-  GlobalSlug,
-  PayloadGeneratedTypes,
   PopulateType,
   SelectFromGlobalSlug,
   TransformGlobalWithSelect,
-  TypedLocale,
 } from '../types.js'
 
 export type UpdateGlobalOptions<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
   TSelect extends SelectType,
 > = {
@@ -56,7 +53,7 @@ export type UpdateGlobalOptions<
 }
 
 export async function updateGlobal<
-  T extends PayloadGeneratedTypes,
+  T extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<T>,
   TSelect extends SelectFromGlobalSlug<T, TSlug>,
 >(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,11 @@
 import type {
   ApplyDisableErrors,
+  AuthCollectionSlug,
+  BaseGeneratedTypes,
+  CollectionSlug,
   ErrorResult,
+  GeneratedTypes,
+  GlobalSlug,
   PaginatedDocs,
   SelectType,
   TypeWithVersion,
@@ -25,13 +30,9 @@ import type { FindGlobalVersionsOptions } from './globals/findVersions.js'
 import type { RestoreGlobalVersionByIDOptions } from './globals/restoreVersion.js'
 import type { UpdateGlobalOptions } from './globals/update.js'
 import type {
-  AuthCollectionSlug,
   BulkOperationResult,
-  CollectionSlug,
   DataFromCollectionSlug,
   DataFromGlobalSlug,
-  GlobalSlug,
-  PayloadGeneratedTypes,
   SelectFromCollectionSlug,
   SelectFromGlobalSlug,
   TransformCollectionWithSelect,
@@ -131,7 +132,7 @@ type Args = {
 /**
  * @experimental
  */
-export class PayloadSDK<T extends PayloadGeneratedTypes = PayloadGeneratedTypes> {
+export class PayloadSDK<T extends BaseGeneratedTypes = GeneratedTypes> {
   baseInit: RequestInit
 
   baseURL: string

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -11,56 +11,9 @@ import type {
   TypedCollectionSelect,
   TypedGlobal,
   TypedGlobalSelect,
-  TypeWithID,
   Where,
 } from 'payload'
 import type { MarkOptional } from 'ts-essentials'
-
-export interface DefaultGeneratedTypes extends BaseGeneratedTypes {
-  auth: {
-    [slug: string]: {
-      forgotPassword: {
-        email: string
-      }
-      login: {
-        email: string
-        password: string
-      }
-      registerFirstUser: {
-        email: string
-        password: string
-      }
-      unlock: {
-        email: string
-      }
-    }
-  }
-
-  collections: {
-    [slug: string]: JsonObject & TypeWithID
-  }
-  collectionsJoins: {
-    [slug: string]: {
-      [schemaPath: string]: string
-    }
-  }
-
-  collectionsSelect: {
-    [slug: string]: any
-  }
-  db: {
-    defaultIDType: number | string
-  }
-  globals: {
-    [slug: string]: JsonObject
-  }
-
-  globalsSelect: {
-    [slug: string]: any
-  }
-
-  locale: null | string
-}
 
 // TODO: Investigate reusing the types from payload
 export type DataFromCollectionSlug<

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,15 +1,22 @@
 import type {
+  BaseGeneratedTypes,
+  CollectionSlug,
+  GlobalSlug,
   JsonObject,
   SelectType,
   Sort,
-  StringKeyOf,
   TransformDataWithSelect,
+  TypedCollection,
+  TypedCollectionJoins,
+  TypedCollectionSelect,
+  TypedGlobal,
+  TypedGlobalSelect,
   TypeWithID,
   Where,
 } from 'payload'
-import type { MarkOptional, NonNever } from 'ts-essentials'
+import type { MarkOptional } from 'ts-essentials'
 
-export interface PayloadGeneratedTypes {
+export interface DefaultGeneratedTypes extends BaseGeneratedTypes {
   auth: {
     [slug: string]: {
       forgotPassword: {
@@ -55,73 +62,41 @@ export interface PayloadGeneratedTypes {
   locale: null | string
 }
 
-export type TypedCollection<T extends PayloadGeneratedTypes> = T['collections']
-
-export type TypedGlobal<T extends PayloadGeneratedTypes> = T['globals']
-
-export type TypedCollectionSelect<T extends PayloadGeneratedTypes> = T['collectionsSelect']
-
-export type TypedCollectionJoins<T extends PayloadGeneratedTypes> = T['collectionsJoins']
-
-export type TypedGlobalSelect<T extends PayloadGeneratedTypes> = T['globalsSelect']
-
-export type TypedAuth<T extends PayloadGeneratedTypes> = T['auth']
-
-export type CollectionSlug<T extends PayloadGeneratedTypes> = StringKeyOf<TypedCollection<T>>
-
-export type GlobalSlug<T extends PayloadGeneratedTypes> = StringKeyOf<TypedGlobal<T>>
-
-export type AuthCollectionSlug<T extends PayloadGeneratedTypes> = StringKeyOf<TypedAuth<T>>
-
-export type TypedUploadCollection<T extends PayloadGeneratedTypes> = NonNever<{
-  [K in keyof TypedCollection<T>]:
-    | 'filename'
-    | 'filesize'
-    | 'mimeType'
-    | 'url' extends keyof TypedCollection<T>[K]
-    ? TypedCollection<T>[K]
-    : never
-}>
-
-export type UploadCollectionSlug<T extends PayloadGeneratedTypes> = StringKeyOf<
-  TypedUploadCollection<T>
->
-
 export type DataFromCollectionSlug<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
-> = TypedCollection<T>[TSlug]
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends CollectionSlug<TGeneratedTypes>,
+> = TypedCollection<TGeneratedTypes>[TSlug]
 
 export type DataFromGlobalSlug<
-  T extends PayloadGeneratedTypes,
-  TSlug extends GlobalSlug<T>,
-> = TypedGlobal<T>[TSlug]
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends GlobalSlug<TGeneratedTypes>,
+> = TypedGlobal<TGeneratedTypes>[TSlug]
 
 export type SelectFromCollectionSlug<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
-> = TypedCollectionSelect<T>[TSlug]
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends CollectionSlug<TGeneratedTypes>,
+> = TypedCollectionSelect<TGeneratedTypes>[TSlug]
 
 export type SelectFromGlobalSlug<
-  T extends PayloadGeneratedTypes,
-  TSlug extends GlobalSlug<T>,
-> = TypedGlobalSelect<T>[TSlug]
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends GlobalSlug<TGeneratedTypes>,
+> = TypedGlobalSelect<TGeneratedTypes>[TSlug]
 
 export type TransformCollectionWithSelect<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends CollectionSlug<TGeneratedTypes>,
   TSelect extends SelectType,
 > = TSelect extends SelectType
-  ? TransformDataWithSelect<DataFromCollectionSlug<T, TSlug>, TSelect>
-  : DataFromCollectionSlug<T, TSlug>
+  ? TransformDataWithSelect<DataFromCollectionSlug<TGeneratedTypes, TSlug>, TSelect>
+  : DataFromCollectionSlug<TGeneratedTypes, TSlug>
 
 export type TransformGlobalWithSelect<
-  T extends PayloadGeneratedTypes,
-  TSlug extends GlobalSlug<T>,
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends GlobalSlug<TGeneratedTypes>,
   TSelect extends SelectType,
 > = TSelect extends SelectType
-  ? TransformDataWithSelect<DataFromGlobalSlug<T, TSlug>, TSelect>
-  : DataFromGlobalSlug<T, TSlug>
+  ? TransformDataWithSelect<DataFromGlobalSlug<TGeneratedTypes, TSlug>, TSelect>
+  : DataFromGlobalSlug<TGeneratedTypes, TSlug>
 
 export type RequiredDataFromCollection<TData extends JsonObject> = MarkOptional<
   TData,
@@ -129,18 +104,19 @@ export type RequiredDataFromCollection<TData extends JsonObject> = MarkOptional<
 >
 
 export type RequiredDataFromCollectionSlug<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
-> = RequiredDataFromCollection<DataFromCollectionSlug<T, TSlug>>
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends CollectionSlug<TGeneratedTypes>,
+> = RequiredDataFromCollection<DataFromCollectionSlug<TGeneratedTypes, TSlug>>
 
-export type TypedLocale<T extends PayloadGeneratedTypes> = NonNullable<T['locale']>
-
-export type JoinQuery<T extends PayloadGeneratedTypes, TSlug extends CollectionSlug<T>> =
-  TypedCollectionJoins<T>[TSlug] extends Record<string, string>
+export type JoinQuery<
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends CollectionSlug<TGeneratedTypes>,
+> =
+  TypedCollectionJoins<TGeneratedTypes>[TSlug] extends Record<string, string>
     ?
         | false
         | Partial<{
-            [K in keyof TypedCollectionJoins<T>[TSlug]]:
+            [K in keyof TypedCollectionJoins<TGeneratedTypes>[TSlug]]:
               | {
                   count?: boolean
                   limit?: number
@@ -152,21 +128,23 @@ export type JoinQuery<T extends PayloadGeneratedTypes, TSlug extends CollectionS
           }>
     : never
 
-export type PopulateType<T extends PayloadGeneratedTypes> = Partial<TypedCollectionSelect<T>>
+export type PopulateType<TGeneratedTypes extends BaseGeneratedTypes> = Partial<
+  TypedCollectionSelect<TGeneratedTypes>
+>
 
 export type IDType<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
-> = DataFromCollectionSlug<T, TSlug>['id']
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends CollectionSlug<TGeneratedTypes>,
+> = DataFromCollectionSlug<TGeneratedTypes, TSlug>['id']
 
 export type BulkOperationResult<
-  T extends PayloadGeneratedTypes,
-  TSlug extends CollectionSlug<T>,
+  TGeneratedTypes extends BaseGeneratedTypes,
+  TSlug extends CollectionSlug<TGeneratedTypes>,
   TSelect extends SelectType,
 > = {
-  docs: TransformCollectionWithSelect<T, TSlug, TSelect>[]
+  docs: TransformCollectionWithSelect<TGeneratedTypes, TSlug, TSelect>[]
   errors: {
-    id: DataFromCollectionSlug<T, TSlug>['id']
+    id: DataFromCollectionSlug<TGeneratedTypes, TSlug>['id']
     message: string
   }[]
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -62,11 +62,13 @@ export interface DefaultGeneratedTypes extends BaseGeneratedTypes {
   locale: null | string
 }
 
+// TODO: Investigate reusing the types from payload
 export type DataFromCollectionSlug<
   TGeneratedTypes extends BaseGeneratedTypes,
   TSlug extends CollectionSlug<TGeneratedTypes>,
 > = TypedCollection<TGeneratedTypes>[TSlug]
 
+// TODO: Investigate reusing the types from payload
 export type DataFromGlobalSlug<
   TGeneratedTypes extends BaseGeneratedTypes,
   TSlug extends GlobalSlug<TGeneratedTypes>,

--- a/packages/sdk/src/utilities/buildSearchParams.ts
+++ b/packages/sdk/src/utilities/buildSearchParams.ts
@@ -5,10 +5,10 @@ import { stringify } from 'qs-esm'
 export type OperationArgs = {
   depth?: number
   draft?: boolean
-  fallbackLocale?: false | string
+  fallbackLocale?: false | null | string
   joins?: false | Record<string, unknown>
   limit?: number
-  locale?: string
+  locale?: null | string
   page?: number
   pagination?: boolean
   populate?: Record<string, unknown>

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -2,6 +2,7 @@ import type {
   BaseGeneratedTypes,
   BulkOperationResult,
   CollectionSlug,
+  Config,
   CustomDocumentViewConfig,
   DefaultDocumentViewConfig,
   GeneratedTypes,
@@ -23,10 +24,12 @@ import {
   type SerializedTextNode,
   type TypedEditorState,
 } from '@payloadcms/richtext-lexical'
+import { PayloadSDK } from '@payloadcms/sdk'
 import payload from 'payload'
 import { describe, expect, test } from 'tstyche'
 
 import type {
+  Config as LocalConfig,
   Menu,
   MyRadioOptions,
   MySelectOptions,
@@ -931,6 +934,44 @@ describe('Types testing', () => {
         })
         expect(result).type.toBe<TypedEditorState<DefaultNodeTypes>>()
       })
+    })
+  })
+
+  describe('sdk', () => {
+    test('ensure generated types can be manually assigned to PayloadSDK generic', () => {
+      expect(new PayloadSDK<LocalConfig>({ baseURL: '' })).type.not.toRaiseError()
+    })
+
+    test('ensure SDK without generic automatically uses GeneratedTypes', () => {
+      const _sdk = new PayloadSDK({ baseURL: '' })
+      // ensure collection property of sdk.create has posts in the union type
+      expect<Parameters<typeof _sdk.create>[0]['collection']>().type.toBe<
+        | 'draft-posts'
+        | 'pages'
+        | 'pages-categories'
+        | 'payload-kv'
+        | 'payload-locked-documents'
+        | 'payload-migrations'
+        | 'payload-preferences'
+        | 'posts'
+        | 'users'
+      >()
+    })
+
+    test('ensure SDK with explicit generic uses has correct collection types', () => {
+      const _sdk = new PayloadSDK<LocalConfig>({ baseURL: '' })
+      // ensure collection property of sdk.create has posts in the union type
+      expect<Parameters<typeof _sdk.create>[0]['collection']>().type.toBe<
+        | 'draft-posts'
+        | 'pages'
+        | 'pages-categories'
+        | 'payload-kv'
+        | 'payload-locked-documents'
+        | 'payload-migrations'
+        | 'payload-preferences'
+        | 'posts'
+        | 'users'
+      >()
     })
   })
 


### PR DESCRIPTION
**Prerequisite:** Merge #15163 first

### Before

You had to manually pass `GeneratedTypes` to the SDK:

```ts
import { PayloadSDK } from '@payloadcms/sdk'
import type { Config } from './payload-types'

const sdk = new PayloadSDK<Config>({})
```

### After

The SDK automatically uses your generated types via module augmentation - just like the Payload Local API. If your project has a `payload-types.ts`, the types are picked up automatically:

```ts
import { PayloadSDK } from '@payloadcms/sdk'

const sdk = new PayloadSDK({}) // Types inferred automatically
```

You can still pass a custom type if needed.

This PR also removes a lot of duplicated types between sdk and payload, by allowing the payload types to accept an optional `TGeneratedTypes` generic.