### PR TITLE
fix: exclude files from being sent to the form-state action

### DIFF
--- a/packages/payload/src/utilities/deepCopyObject.ts
+++ b/packages/payload/src/utilities/deepCopyObject.ts
@@ -135,7 +135,12 @@ export function deepCopyObjectSimple<T extends JsonValue>(value: T, filterUndefi
   }
 }
 
-export function deepCopyObjectSimpleWithoutReactComponents<T extends JsonValue>(value: T): T {
+export function deepCopyObjectSimpleWithoutReactComponents<T extends JsonValue>(
+  value: T,
+  opts: {
+    excludeFiles?: boolean
+  } = {},
+): T {
   if (
     typeof value === 'object' &&
     value !== null &&
@@ -150,8 +155,12 @@ export function deepCopyObjectSimpleWithoutReactComponents<T extends JsonValue>(
       typeof e !== 'object' || e === null ? e : deepCopyObjectSimpleWithoutReactComponents(e),
     ) as T
   } else {
-    // Handle File objects by returning them as-is (don't serialize to plain object)
+    // Handle File objects by returning them as-is (don't serialize to plain object) or exclude if excludeFiles is provided
     if (value instanceof File) {
+      if (opts.excludeFiles) {
+        return undefined!
+      }
+
       return value as unknown as T
     }
     if (value instanceof Date) {
@@ -163,7 +172,7 @@ export function deepCopyObjectSimpleWithoutReactComponents<T extends JsonValue>(
       ret[k] =
         typeof v !== 'object' || v === null
           ? v
-          : (deepCopyObjectSimpleWithoutReactComponents(v as T) as any)
+          : (deepCopyObjectSimpleWithoutReactComponents(v as T, opts) as any)
     }
     return ret as unknown as T
   }

--- a/packages/payload/src/utilities/deepCopyObject.ts
+++ b/packages/payload/src/utilities/deepCopyObject.ts
@@ -152,7 +152,7 @@ export function deepCopyObjectSimpleWithoutReactComponents<T extends JsonValue>(
     return value
   } else if (Array.isArray(value)) {
     return value.map((e) =>
-      typeof e !== 'object' || e === null ? e : deepCopyObjectSimpleWithoutReactComponents(e),
+      typeof e !== 'object' || e === null ? e : deepCopyObjectSimpleWithoutReactComponents(e, opts),
     ) as T
   } else {
     // Handle File objects by returning them as-is (don't serialize to plain object) or exclude if excludeFiles is provided

--- a/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
@@ -167,7 +167,9 @@ export const BlockComponent: React.FC<Props> = (props) => {
         data: formData,
         docPermissions: { fields: true },
         docPreferences: await getDocPreferences(),
-        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields),
+        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields, {
+          excludeFiles: true,
+        }),
         globalSlug,
         initialBlockData: formData,
         operation: 'update',
@@ -186,7 +188,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
         }
 
         const newFormStateData: BlockFields = reduceFieldsToValues(
-          deepCopyObjectSimpleWithoutReactComponents(state),
+          deepCopyObjectSimpleWithoutReactComponents(state, { excludeFiles: true }),
           true,
         ) as BlockFields
 
@@ -264,7 +266,9 @@ export const BlockComponent: React.FC<Props> = (props) => {
           fields: true,
         },
         docPreferences: await getDocPreferences(),
-        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields),
+        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields, {
+          excludeFiles: true,
+        }),
         formState: prevFormState,
         globalSlug,
         initialBlockFormState: prevFormState,
@@ -285,7 +289,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
 
       const newFormStateData: BlockFields = reduceFieldsToValues(
         removeEmptyArrayValues({
-          fields: deepCopyObjectSimpleWithoutReactComponents(newFormState),
+          fields: deepCopyObjectSimpleWithoutReactComponents(newFormState, { excludeFiles: true }),
         }),
         true,
       ) as BlockFields

--- a/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
@@ -194,7 +194,9 @@ export const InlineBlockComponent: React.FC<Props> = (props) => {
         data: formData,
         docPermissions: { fields: true },
         docPreferences: await getDocPreferences(),
-        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields),
+        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields, {
+          excludeFiles: true,
+        }),
         globalSlug,
         initialBlockData: formData,
         initialBlockFormState: formData,
@@ -207,7 +209,7 @@ export const InlineBlockComponent: React.FC<Props> = (props) => {
 
       if (state) {
         const newFormStateData: InlineBlockFields = reduceFieldsToValues(
-          deepCopyObjectSimpleWithoutReactComponents(state),
+          deepCopyObjectSimpleWithoutReactComponents(state, { excludeFiles: true }),
           true,
         ) as InlineBlockFields
 
@@ -267,7 +269,9 @@ export const InlineBlockComponent: React.FC<Props> = (props) => {
           fields: true,
         },
         docPreferences: await getDocPreferences(),
-        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields),
+        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields, {
+          excludeFiles: true,
+        }),
         formState: prevFormState,
         globalSlug,
         initialBlockFormState: prevFormState,

--- a/packages/richtext-lexical/src/utilities/fieldsDrawer/DrawerContent.tsx
+++ b/packages/richtext-lexical/src/utilities/fieldsDrawer/DrawerContent.tsx
@@ -62,7 +62,9 @@ export const DrawerContent: React.FC<Omit<FieldsDrawerProps, 'drawerSlug' | 'dra
           fields: true,
         },
         docPreferences: await getDocPreferences(),
-        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields),
+        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields, {
+          excludeFiles: true,
+        }),
         globalSlug,
         initialBlockData: data,
         operation: 'update',
@@ -106,7 +108,9 @@ export const DrawerContent: React.FC<Omit<FieldsDrawerProps, 'drawerSlug' | 'dra
           fields: true,
         },
         docPreferences: await getDocPreferences(),
-        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields),
+        documentFormState: deepCopyObjectSimpleWithoutReactComponents(parentDocumentFields, {
+          excludeFiles: true,
+        }),
         formState: prevFormState,
         globalSlug,
         initialBlockFormState: prevFormState,

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -578,7 +578,6 @@ export const Form: React.FC<FormProps> = (props) => {
 
       if (docConfig && 'upload' in docConfig && docConfig.upload && file) {
         delete data.file
-        console.log('DELETED', data)
 
         const handler = getUploadHandler({ collectionSlug })
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -313,6 +313,9 @@ export const Form: React.FC<FormProps> = (props) => {
 
       const serializableFormState = deepCopyObjectSimpleWithoutReactComponents(
         contextRef.current.fields,
+        {
+          excludeFiles: true,
+        },
       )
 
       // Execute server side validations
@@ -389,6 +392,7 @@ export const Form: React.FC<FormProps> = (props) => {
       })
 
       try {
+        console.log({ formData })
         let res
 
         if (typeof actionArg === 'string') {
@@ -575,6 +579,7 @@ export const Form: React.FC<FormProps> = (props) => {
 
       if (docConfig && 'upload' in docConfig && docConfig.upload && file) {
         delete data.file
+        console.log('DELETED', data)
 
         const handler = getUploadHandler({ collectionSlug })
 
@@ -619,6 +624,8 @@ export const Form: React.FC<FormProps> = (props) => {
         indices: true,
         nullsAsUndefineds: false,
       })
+
+      console.log(formData, dataToSerialize)
 
       return formData
     },
@@ -833,7 +840,9 @@ export const Form: React.FC<FormProps> = (props) => {
         for (const onChangeFn of onChange) {
           // Edit view default onChange is in packages/ui/src/views/Edit/index.tsx. This onChange usually sends a form state request
           serverState = await onChangeFn({
-            formState: deepCopyObjectSimpleWithoutReactComponents(formState),
+            formState: deepCopyObjectSimpleWithoutReactComponents(formState, {
+              excludeFiles: true,
+            }),
             submitted,
           })
         }

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -392,7 +392,6 @@ export const Form: React.FC<FormProps> = (props) => {
       })
 
       try {
-        console.log({ formData })
         let res
 
         if (typeof actionArg === 'string') {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15073
Surprasses https://github.com/payloadcms/payload/pull/15078

We use the `deepCopyObjectSimpleWithoutReactComponents` function to serialize data for the form state action. This PR adds a new option to `deepCopyObjectSimpleWithoutReactComponents` - `excludeFiles: boolean` and adds usage of it in places where we call the form state action to:

* Avoid overhead of sending the file on every form state calculation when the collection has uploads enabled, since we don't actually use the file inside the form state action.
* Fix the issue with client uploads when the file exceeds the platform limit.
