### PR TITLE
docs: update examples for context

### DIFF
--- a/docs/hooks/context.mdx
+++ b/docs/hooks/context.mdx
@@ -80,6 +80,7 @@ const Customer: CollectionConfig = {
           data: {
             ...(await fetchCustomerData(data.customerID)),
           },
+          req,
         })
       },
     ],
@@ -112,6 +113,7 @@ const MyCollection: CollectionConfig = {
           data: {
             ...(await fetchCustomerData(data.customerID)),
           },
+          req,
           context: {
             // set a flag to prevent from running again
             triggerAfterChange: false,


### PR DESCRIPTION
Added missing `req` parameter to `req.payload.update` in hook context docs. Leaving out this parameter can lead to hanging requests.