### PR TITLE
fix(storage-s3): respect upload limits with client uploads

### DIFF
--- a/packages/storage-s3/src/client/S3ClientUploadHandler.ts
+++ b/packages/storage-s3/src/client/S3ClientUploadHandler.ts
@@ -1,5 +1,6 @@
 'use client'
 import { createClientUploadHandler } from '@payloadcms/plugin-cloud-storage/client'
+import { toast } from '@payloadcms/ui'
 import { formatAdminURL } from 'payload/shared'
 
 export const S3ClientUploadHandler = createClientUploadHandler({
@@ -9,15 +10,25 @@ export const S3ClientUploadHandler = createClientUploadHandler({
       path: serverHandlerPath,
       serverURL,
     })
+
     const response = await fetch(endpointRoute, {
       body: JSON.stringify({
         collectionSlug,
         filename: file.name,
+        filesize: file.size,
         mimeType: file.type,
       }),
       credentials: 'include',
       method: 'POST',
     })
+
+    if (!response.ok) {
+      const { errors } = (await response.json()) as {
+        errors: { message: string }[]
+      }
+
+      throw new Error(errors.reduce((acc, err) => `${acc ? `${acc}, ` : ''}${err.message}`, ''))
+    }
 
     const { url } = (await response.json()) as {
       url: string

--- a/packages/storage-s3/src/generateSignedURL.ts
+++ b/packages/storage-s3/src/generateSignedURL.ts
@@ -4,9 +4,13 @@ import type { PayloadHandler } from 'payload'
 import * as AWS from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import path from 'path'
-import { APIError, Forbidden } from 'payload'
+import { APIError, Forbidden, ValidationError } from 'payload'
 
 import type { S3StorageOptions } from './index.js'
+
+const bytesToMB = (bytes: number) => {
+  return bytes / 1024 / 1024
+}
 
 interface Args {
   access?: ClientUploadsAccess
@@ -30,9 +34,16 @@ export const getGenerateSignedURLHandler = ({
       throw new APIError('Content-Type expected to be application/json', 400)
     }
 
-    const { collectionSlug, filename, mimeType } = (await req.json()) as {
+    let filesizeLimit = req.payload.config.upload.limits?.fileSize
+
+    if (filesizeLimit === Infinity) {
+      filesizeLimit = undefined
+    }
+
+    const { collectionSlug, filename, filesize, mimeType } = (await req.json()) as {
       collectionSlug: string
       filename: string
+      filesize: number
       mimeType: string
     }
 
@@ -49,12 +60,33 @@ export const getGenerateSignedURLHandler = ({
 
     const fileKey = path.posix.join(prefix, filename)
 
+    const signableHeaders = new Set()
+
+    if (filesizeLimit) {
+      if (filesize > filesizeLimit) {
+        throw new APIError(
+          `Exceeded file size limit. Limit: ${bytesToMB(filesizeLimit).toFixed(2)}MB, got: ${bytesToMB(filesize).toFixed(2)}MB`,
+          400,
+        )
+      }
+
+      // Still force S3 to validate
+      signableHeaders.add('content-length')
+    }
+
     const url = await getSignedUrl(
       // @ts-expect-error mismatch versions or something
       getStorageClient(),
-      new AWS.PutObjectCommand({ ACL: acl, Bucket: bucket, ContentType: mimeType, Key: fileKey }),
+      new AWS.PutObjectCommand({
+        ACL: acl,
+        Bucket: bucket,
+        ContentLength: filesizeLimit ? Math.min(filesize, filesizeLimit) : undefined,
+        ContentType: mimeType,
+        Key: fileKey,
+      }),
       {
         expiresIn: 600,
+        signableHeaders,
       },
     )
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -386,12 +386,12 @@ export const Form: React.FC<FormProps> = (props) => {
         return
       }
 
-      const formData = await contextRef.current.createFormData(overrides, {
-        data,
-        mergeOverrideData: Boolean(typeof overridesFromArgs !== 'function'),
-      })
-
       try {
+        const formData = await contextRef.current.createFormData(overrides, {
+          data,
+          mergeOverrideData: Boolean(typeof overridesFromArgs !== 'function'),
+        })
+
         let res
 
         if (typeof actionArg === 'string') {

--- a/test/storage-s3/collections/MediaWithClientUploads.ts
+++ b/test/storage-s3/collections/MediaWithClientUploads.ts
@@ -1,0 +1,15 @@
+import type { CollectionConfig } from 'payload'
+
+export const MediaWithClientUploads: CollectionConfig = {
+  slug: 'media-with-client-uploads',
+  fields: [
+    {
+      name: 'alt',
+      type: 'text',
+      label: 'Alt Text',
+    },
+  ],
+  upload: {
+    disableLocalStorage: true,
+  },
+}

--- a/test/storage-s3/config.ts
+++ b/test/storage-s3/config.ts
@@ -7,6 +7,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { Media } from './collections/Media.js'
 import { MediaWithAlwaysInsertFields } from './collections/MediaWithAlwaysInsertFields.js'
+import { MediaWithClientUploads } from './collections/MediaWithClientUploads.js'
 import { MediaWithDirectAccess } from './collections/MediaWithDirectAccess.js'
 import { MediaWithDynamicPrefix } from './collections/MediaWithDynamicPrefix.js'
 import { MediaWithPrefix } from './collections/MediaWithPrefix.js'
@@ -15,6 +16,7 @@ import { Users } from './collections/Users.js'
 import {
   mediaSlug,
   mediaWithAlwaysInsertFieldsSlug,
+  mediaWithClientUploadsSlug,
   mediaWithDirectAccessSlug,
   mediaWithDynamicPrefixSlug,
   mediaWithPrefixSlug,
@@ -23,8 +25,6 @@ import {
 } from './shared.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-let uploadOptions
 
 // Load config to work with emulated services
 dotenv.config({
@@ -40,6 +40,7 @@ export default buildConfigWithDefaults({
   collections: [
     Media,
     MediaWithAlwaysInsertFields,
+    MediaWithClientUploads,
     MediaWithDirectAccess,
     MediaWithDynamicPrefix,
     MediaWithPrefix,
@@ -57,8 +58,10 @@ export default buildConfigWithDefaults({
   },
   plugins: [
     s3Storage({
+      clientUploads: true,
       collections: {
         [mediaSlug]: true,
+        [mediaWithClientUploadsSlug]: true,
         [mediaWithDirectAccessSlug]: {
           disablePayloadAccessControl: true,
         },
@@ -106,7 +109,11 @@ export default buildConfigWithDefaults({
       enabled: false,
     }),
   ],
-  upload: uploadOptions,
+  upload: {
+    limits: {
+      fileSize: 1_000_000, // 1MB
+    },
+  },
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },

--- a/test/storage-s3/payload-types.ts
+++ b/test/storage-s3/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     media: Media;
     'media-with-always-insert-fields': MediaWithAlwaysInsertField;
+    'media-with-client-uploads': MediaWithClientUpload;
     'media-with-direct-access': MediaWithDirectAccess;
     'media-with-dynamic-prefix': MediaWithDynamicPrefix;
     'media-with-prefix': MediaWithPrefix;
@@ -83,6 +84,7 @@ export interface Config {
   collectionsSelect: {
     media: MediaSelect<false> | MediaSelect<true>;
     'media-with-always-insert-fields': MediaWithAlwaysInsertFieldsSelect<false> | MediaWithAlwaysInsertFieldsSelect<true>;
+    'media-with-client-uploads': MediaWithClientUploadsSelect<false> | MediaWithClientUploadsSelect<true>;
     'media-with-direct-access': MediaWithDirectAccessSelect<false> | MediaWithDirectAccessSelect<true>;
     'media-with-dynamic-prefix': MediaWithDynamicPrefixSelect<false> | MediaWithDynamicPrefixSelect<true>;
     'media-with-prefix': MediaWithPrefixSelect<false> | MediaWithPrefixSelect<true>;
@@ -171,6 +173,25 @@ export interface MediaWithAlwaysInsertField {
   id: string;
   alt?: string | null;
   prefix?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media-with-client-uploads".
+ */
+export interface MediaWithClientUpload {
+  id: string;
+  alt?: string | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -316,6 +337,10 @@ export interface PayloadLockedDocument {
         value: string | MediaWithAlwaysInsertField;
       } | null)
     | ({
+        relationTo: 'media-with-client-uploads';
+        value: string | MediaWithClientUpload;
+      } | null)
+    | ({
         relationTo: 'media-with-direct-access';
         value: string | MediaWithDirectAccess;
       } | null)
@@ -426,6 +451,24 @@ export interface MediaSelect<T extends boolean = true> {
 export interface MediaWithAlwaysInsertFieldsSelect<T extends boolean = true> {
   alt?: T;
   prefix?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media-with-client-uploads_select".
+ */
+export interface MediaWithClientUploadsSelect<T extends boolean = true> {
+  alt?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;

--- a/test/storage-s3/shared.ts
+++ b/test/storage-s3/shared.ts
@@ -6,3 +6,4 @@ export const prefix = 'test-prefix'
 
 export const mediaWithSignedDownloadsSlug = 'media-with-signed-downloads'
 export const mediaWithDirectAccessSlug = 'media-with-direct-access'
+export const mediaWithClientUploadsSlug = 'media-with-client-uploads'


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12671
Relies on https://github.com/payloadcms/payload/pull/15174 (merge this one first)

In addition to checking the passed `filesize` from `S3ClientUploadHandler`, this PR also uses S3 signed headers to ensure that `ContentLength` does not exceed `upload.limits.fileSize`.