### PR TITLE
fix(ui): duplicate document has unused serverURL dependency

### DIFF
--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -51,7 +51,6 @@ export const DuplicateDocument: React.FC<Props> = ({
     config: {
       localization,
       routes: { admin: adminRoute, api: apiRoute },
-      serverURL,
     },
     getEntityConfig,
   } = useConfig()
@@ -148,7 +147,6 @@ export const DuplicateDocument: React.FC<Props> = ({
       onDuplicate,
       redirectAfterDuplicate,
       router,
-      serverURL,
       setModified,
       singularLabel,
       slug,


### PR DESCRIPTION
`serverURL` was included in the `handleDuplicate` dependency array but never used in the callback function.

Removed serverURL from the useCallback dependency array since it's not referenced in the function body.
