### PR TITLE
fix(db-postgres): add filenameCompoundIndex baseIndexes for upload collections

### DIFF
--- a/packages/drizzle/src/schema/buildRawSchema.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.ts
@@ -59,9 +59,9 @@ export const buildRawSchema = ({
 
     buildTable({
       adapter,
+      baseIndexes,
       blocksTableNameMap: {},
       compoundIndexes: collection.sanitizedIndexes,
-      baseIndexes: baseIndexes,
       disableNotNull: !!collection?.versions?.drafts,
       disableUnique: false,
       fields: collection.flattenedFields,

--- a/packages/drizzle/src/schema/buildRawSchema.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.ts
@@ -48,7 +48,7 @@ export const buildRawSchema = ({
     const baseIndexes: Record<string, RawIndex> = {}
 
     if (collection.upload.filenameCompoundIndex) {
-      const indexName = buildIndexName({ name: `${tableName}_filename_compound_idx`, adapter })
+      const indexName = buildIndexName({ name: `${tableName}_filename_compound`, adapter })
 
       baseIndexes.filename_compound_index = {
         name: indexName,

--- a/packages/drizzle/src/schema/buildRawSchema.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.ts
@@ -61,6 +61,7 @@ export const buildRawSchema = ({
       adapter,
       blocksTableNameMap: {},
       compoundIndexes: collection.sanitizedIndexes,
+      baseIndexes: baseIndexes,
       disableNotNull: !!collection?.versions?.drafts,
       disableUnique: false,
       fields: collection.flattenedFields,


### PR DESCRIPTION
Description:
When using the filenameCompoundIndex property on an upload collection, this index was not being added to the database. By adding this rule, the compound index is now correctly applied.

What?

The filenameCompoundIndex property was ignored when defining upload collections, so compound indexes were not created in the database.

Why?

Without this index, queries that rely on the compound key (e.g., filename + some other field) are slower and may lead to unexpected duplicates.

How?

Updated the logic for creating upload collection indexes to include the filenameCompoundIndex rule. This ensures that the compound index is added to the database during collection setup.