### PR TITLE
chore: deprecate skip parameter from db-adapters

### DIFF
--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -57,9 +57,12 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
   })
 
   const session = await getSession(this, req)
+  // Calculate skip from page for cases where pagination is disabled but offset is still needed
+  const skip = typeof page === 'number' && page > 1 ? (page - 1) * (limit || 0) : undefined
   const options: QueryOptions = {
     limit,
     session,
+    skip,
   }
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -22,7 +22,6 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     pagination,
     req,
     select,
-    skip,
     sort: sortArg,
     where = {},
   },
@@ -61,7 +60,6 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
   const options: QueryOptions = {
     limit,
     session,
-    skip,
   }
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -61,9 +61,12 @@ export const findVersions: FindVersions = async function findVersions(
   })
 
   const session = await getSession(this, req)
+  // Calculate skip from page for cases where pagination is disabled but offset is still needed
+  const skip = typeof page === 'number' && page > 1 ? (page - 1) * (limit || 0) : undefined
   const options: QueryOptions = {
     limit,
     session,
+    skip,
   }
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -22,7 +22,6 @@ export const findVersions: FindVersions = async function findVersions(
     pagination,
     req = {},
     select,
-    skip,
     sort: sortArg,
     where = {},
   },
@@ -65,7 +64,6 @@ export const findVersions: FindVersions = async function findVersions(
   const options: QueryOptions = {
     limit,
     session,
-    skip,
   }
 
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.

--- a/packages/drizzle/src/find/findMany.ts
+++ b/packages/drizzle/src/find/findMany.ts
@@ -31,7 +31,6 @@ export const findMany = async function find({
   pagination,
   req,
   select,
-  skip,
   sort,
   tableName,
   versions,
@@ -43,7 +42,7 @@ export const findMany = async function find({
   let hasPrevPage: boolean
   let hasNextPage: boolean
   let pagingCounter: number
-  const offset = skip || (page - 1) * limit
+  const offset = (page - 1) * limit
 
   if (limit === 0) {
     pagination = false

--- a/packages/drizzle/src/findGlobalVersions.ts
+++ b/packages/drizzle/src/findGlobalVersions.ts
@@ -9,7 +9,7 @@ import { findMany } from './find/findMany.js'
 
 export const findGlobalVersions: FindGlobalVersions = async function findGlobalVersions(
   this: DrizzleAdapter,
-  { global, limit, locale, page, pagination, req, select, skip, sort: sortArg, where },
+  { global, limit, locale, page, pagination, req, select, sort: sortArg, where },
 ) {
   const globalConfig: SanitizedGlobalConfig = this.payload.globals.config.find(
     ({ slug }) => slug === global,
@@ -31,7 +31,6 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     pagination,
     req,
     select,
-    skip,
     sort,
     tableName,
     where,

--- a/packages/drizzle/src/findVersions.ts
+++ b/packages/drizzle/src/findVersions.ts
@@ -9,7 +9,7 @@ import { findMany } from './find/findMany.js'
 
 export const findVersions: FindVersions = async function findVersions(
   this: DrizzleAdapter,
-  { collection, limit, locale, page, pagination, req, select, skip, sort: sortArg, where },
+  { collection, limit, locale, page, pagination, req, select, sort: sortArg, where },
 ) {
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const sort = sortArg !== undefined && sortArg !== null ? sortArg : collectionConfig.defaultSort
@@ -30,7 +30,6 @@ export const findVersions: FindVersions = async function findVersions(
     pagination,
     req,
     select,
-    skip,
     sort,
     tableName,
     where,

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -234,6 +234,10 @@ export type FindArgs = {
   projection?: Record<string, unknown>
   req?: Partial<PayloadRequest>
   select?: SelectType
+  /**
+   * @deprecated This parameter is going to be removed in the next major version. Use page instead.
+   */
+  skip?: number
   sort?: Sort
   versions?: boolean
   where?: Where
@@ -268,6 +272,10 @@ type BaseVersionArgs = {
   pagination?: boolean
   req?: Partial<PayloadRequest>
   select?: SelectType
+  /**
+   * @deprecated This parameter is going to be removed in the next major version. Use page instead.
+   */
+  skip?: number
   sort?: Sort
   versions?: boolean
   where?: Where

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -234,7 +234,6 @@ export type FindArgs = {
   projection?: Record<string, unknown>
   req?: Partial<PayloadRequest>
   select?: SelectType
-  skip?: number
   sort?: Sort
   versions?: boolean
   where?: Where
@@ -269,7 +268,6 @@ type BaseVersionArgs = {
   pagination?: boolean
   req?: Partial<PayloadRequest>
   select?: SelectType
-  skip?: number
   sort?: Sort
   versions?: boolean
   where?: Where

--- a/packages/payload/src/versions/enforceMaxVersions.ts
+++ b/packages/payload/src/versions/enforceMaxVersions.ts
@@ -35,9 +35,9 @@ export const enforceMaxVersions = async ({
       const query = await payload.db.findVersions({
         collection: collection.slug,
         limit: 1,
+        page: max + 1,
         pagination: false,
         req,
-        skip: max,
         sort: '-updatedAt',
         where,
       })
@@ -47,9 +47,9 @@ export const enforceMaxVersions = async ({
       const query = await payload.db.findGlobalVersions({
         global: globalConfig.slug,
         limit: 1,
+        page: max + 1,
         pagination: false,
         req,
-        skip: max,
         sort: '-updatedAt',
         where,
       })


### PR DESCRIPTION
`skip` is an internal API. It is used only by the database adapters and is not publicly exposed through the local API, only when accessing the database directly. It does exactly the same thing as `page`, but with different semantics. In this PR I am deprecating it because it adds nothing but complexity. It is used only once in the entire repository and conflicts with the `page` parameter.