### PR TITLE
fix(ui): use optional chaining for potentiallyStalePath

### DIFF
--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -118,25 +118,20 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
   }, [isFormValid, showError, showField, openModal, value, docID, selectedTenantID, unique])
 
   if (showField) {
-    if (debug) {
-      return <TenantFieldInModal debug={debug} fieldArgs={fieldArgs} unique={unique} />
+    if (debug || isEditManyModalOpen) {
+      return <TenantRelationshipField debug={debug} fieldArgs={fieldArgs} unique={unique} />
     }
 
     if (!unique) {
       /** Editing a non-global tenant document */
       return (
-        <>
-          {isEditManyModalOpen ? (
-            <TenantRelationshipField fieldArgs={fieldArgs} unique={unique} />
-          ) : null}
-          <AssignTenantFieldModal
-            afterModalClose={afterModalClose}
-            afterModalOpen={afterModalOpen}
-            onConfirm={onConfirm}
-          >
-            <TenantFieldInModal debug={debug} fieldArgs={fieldArgs} unique={unique} />
-          </AssignTenantFieldModal>
-        </>
+        <AssignTenantFieldModal
+          afterModalClose={afterModalClose}
+          afterModalOpen={afterModalOpen}
+          onConfirm={onConfirm}
+        >
+          <TenantRelationshipField fieldArgs={fieldArgs} unique={unique} />
+        </AssignTenantFieldModal>
       )
     }
 
@@ -147,22 +142,6 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
 }
 
 const TenantRelationshipField: React.FC<{
-  fieldArgs: RelationshipFieldClientProps
-  unique?: boolean
-}> = ({ fieldArgs, unique }) => {
-  return (
-    <RelationshipField
-      {...fieldArgs}
-      field={{
-        ...fieldArgs.field,
-        required: true,
-      }}
-      readOnly={fieldArgs.readOnly || fieldArgs.field.admin?.readOnly || unique}
-    />
-  )
-}
-
-const TenantFieldInModal: React.FC<{
   debug?: boolean
   fieldArgs: RelationshipFieldClientProps
   unique?: boolean
@@ -175,7 +154,14 @@ const TenantFieldInModal: React.FC<{
             Multi-Tenant Debug Enabled
           </Pill>
         )}
-        <TenantRelationshipField fieldArgs={fieldArgs} unique={unique} />
+        <RelationshipField
+          {...fieldArgs}
+          field={{
+            ...fieldArgs.field,
+            required: true,
+          }}
+          readOnly={fieldArgs.readOnly || fieldArgs.field.admin?.readOnly || unique}
+        />
       </div>
     </div>
   )

--- a/packages/ui/src/forms/useField/index.tsx
+++ b/packages/ui/src/forms/useField/index.tsx
@@ -251,7 +251,7 @@ export const useField = <TValue,>(options?: Options): FieldType<TValue> => {
     // Use field context, if a field context exists **and** the path matches. If the path
     // does not match, this could be the field context of a parent field => there likely is
     // a nested <Form /> we should use instead => 'form'
-    const currentPath = options?.path || pathFromContext || options.potentiallyStalePath
+    const currentPath = options?.path || pathFromContext || options?.potentiallyStalePath
 
     hasFieldContext.current =
       fieldContext && currentPath && fieldContext.path === currentPath ? true : false


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15145

useField hook would throw an error attempting to read `potentiallyStalePath` but the args are optional.