### PR TITLE
fix(plugin-cloud-storage): should persist external data returned by storage providers

### DIFF
--- a/packages/plugin-cloud-storage/src/types.ts
+++ b/packages/plugin-cloud-storage/src/types.ts
@@ -34,7 +34,11 @@ export type HandleUpload = (args: {
   data: any
   file: File
   req: PayloadRequest
-}) => Promise<void> | void
+}) =>
+  | Partial<FileData & TypeWithID>
+  | Promise<Partial<FileData & TypeWithID>>
+  | Promise<void>
+  | void
 
 export interface TypeWithPrefix {
   prefix?: string

--- a/test/plugin-cloud-storage/collections/TestMetadata.ts
+++ b/test/plugin-cloud-storage/collections/TestMetadata.ts
@@ -18,63 +18,6 @@ export const TestMetadata: CollectionConfig = {
         description: 'Test note to identify this upload',
       },
     },
-    // Metadata fields that will be automatically populated by the custom adapter
-    {
-      name: 'customStorageId',
-      type: 'text',
-      admin: {
-        description: 'Custom storage identifier from adapter',
-        readOnly: true,
-      },
-    },
-    {
-      name: 'uploadTimestamp',
-      type: 'text',
-      admin: {
-        description: 'Upload timestamp from adapter',
-        readOnly: true,
-      },
-    },
-    {
-      name: 'storageProvider',
-      type: 'text',
-      admin: {
-        description: 'Storage provider name from adapter',
-        readOnly: true,
-      },
-    },
-    {
-      name: 'bucketName',
-      type: 'text',
-      admin: {
-        description: 'Storage bucket name from adapter',
-        readOnly: true,
-      },
-    },
-    {
-      name: 'objectKey',
-      type: 'text',
-      admin: {
-        description: 'Storage object key from adapter',
-        readOnly: true,
-      },
-    },
-    {
-      name: 'processingStatus',
-      type: 'text',
-      admin: {
-        description: 'Processing status from adapter',
-        readOnly: true,
-      },
-    },
-    {
-      name: 'uploadVersion',
-      type: 'text',
-      admin: {
-        description: 'Upload version from adapter',
-        readOnly: true,
-      },
-    },
   ],
   upload: {
     adminThumbnail: 'thumbnail',

--- a/test/plugin-cloud-storage/collections/TestMetadata.ts
+++ b/test/plugin-cloud-storage/collections/TestMetadata.ts
@@ -1,0 +1,88 @@
+import type { CollectionConfig } from 'payload'
+
+import { testMetadataSlug } from '../shared.js'
+
+export const TestMetadata: CollectionConfig = {
+  slug: testMetadataSlug,
+  access: {
+    create: () => true,
+    read: () => true,
+    update: () => true,
+    delete: () => true,
+  },
+  fields: [
+    {
+      name: 'testNote',
+      type: 'text',
+      admin: {
+        description: 'Test note to identify this upload',
+      },
+    },
+    // Metadata fields that will be automatically populated by the custom adapter
+    {
+      name: 'customStorageId',
+      type: 'text',
+      admin: {
+        description: 'Custom storage identifier from adapter',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'uploadTimestamp',
+      type: 'text',
+      admin: {
+        description: 'Upload timestamp from adapter',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'storageProvider',
+      type: 'text',
+      admin: {
+        description: 'Storage provider name from adapter',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'bucketName',
+      type: 'text',
+      admin: {
+        description: 'Storage bucket name from adapter',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'objectKey',
+      type: 'text',
+      admin: {
+        description: 'Storage object key from adapter',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'processingStatus',
+      type: 'text',
+      admin: {
+        description: 'Processing status from adapter',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'uploadVersion',
+      type: 'text',
+      admin: {
+        description: 'Upload version from adapter',
+        readOnly: true,
+      },
+    },
+  ],
+  upload: {
+    adminThumbnail: 'thumbnail',
+    imageSizes: [
+      {
+        name: 'thumbnail',
+        width: 300,
+      },
+    ],
+  },
+}

--- a/test/plugin-cloud-storage/config.ts
+++ b/test/plugin-cloud-storage/config.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'payload'
 
+import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 import { azureStorage } from '@payloadcms/storage-azure'
 import { gcsStorage } from '@payloadcms/storage-gcs'
 import { s3Storage } from '@payloadcms/storage-s3'
@@ -12,14 +13,21 @@ import { devUser } from '../credentials.js'
 import { Media } from './collections/Media.js'
 import { MediaWithPrefix } from './collections/MediaWithPrefix.js'
 import { RestrictedMedia } from './collections/RestrictedMedia.js'
+import { TestMetadata } from './collections/TestMetadata.js'
 import { Users } from './collections/Users.js'
-import { mediaSlug, mediaWithPrefixSlug, restrictedMediaSlug, prefix } from './shared.js'
+import {
+  mediaSlug,
+  mediaWithPrefixSlug,
+  prefix,
+  restrictedMediaSlug,
+  testMetadataSlug,
+} from './shared.js'
 import { createTestBucket } from './utils.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-let storagePlugin: Plugin
+let storagePlugin: Plugin = {} as Plugin
 let uploadOptions
 
 // Load config to work with emulated services
@@ -37,9 +45,9 @@ if (process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER === 'azure') {
       [restrictedMediaSlug]: true,
     },
     allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
-    baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL,
-    connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
-    containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
+    baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL!,
+    connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING!,
+    containerName: process.env.AZURE_STORAGE_CONTAINER_NAME!,
   })
 }
 
@@ -52,7 +60,7 @@ if (process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER === 'gcs') {
       },
       [restrictedMediaSlug]: true,
     },
-    bucket: process.env.GCS_BUCKET,
+    bucket: process.env.GCS_BUCKET!,
     options: {
       apiEndpoint: process.env.GCS_ENDPOINT,
       projectId: process.env.GCS_PROJECT_ID,
@@ -77,11 +85,11 @@ if (
       },
       [restrictedMediaSlug]: true,
     },
-    bucket: process.env.S3_BUCKET,
+    bucket: process.env.S3_BUCKET ?? '',
     config: {
       credentials: {
-        accessKeyId: process.env.S3_ACCESS_KEY_ID,
-        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+        accessKeyId: process.env.S3_ACCESS_KEY_ID ?? '',
+        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY ?? '',
       },
       endpoint: process.env.S3_ENDPOINT,
       forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
@@ -98,11 +106,11 @@ if (process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER === 'r2') {
         prefix,
       },
     },
-    bucket: process.env.R2_BUCKET,
+    bucket: process.env.R2_BUCKET ?? '',
     config: {
       credentials: {
-        accessKeyId: process.env.S3_ACCESS_KEY_ID,
-        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+        accessKeyId: process.env.S3_ACCESS_KEY_ID ?? '',
+        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY ?? '',
       },
       endpoint: process.env.S3_ENDPOINT,
       forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
@@ -111,13 +119,38 @@ if (process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER === 'r2') {
   })
 }
 
+const testMetadataPlugin = cloudStoragePlugin({
+  collections: {
+    [testMetadataSlug]: {
+      adapter: () => ({
+        name: 'test-metadata-adapter',
+        handleUpload: ({ file, data }) => {
+          const metadata = {
+            ...data,
+            customStorageId: `storage-${Date.now()}`,
+            uploadTimestamp: new Date().toISOString(),
+            storageProvider: 'test-adapter',
+            bucketName: 'test-bucket',
+            objectKey: data.filename || file.filename, // Use the processed filename from data
+            processingStatus: 'completed',
+            uploadVersion: '1.0.0',
+          }
+          return metadata
+        },
+        handleDelete: () => Promise.resolve(),
+        staticHandler: () => new Response('Not found', { status: 404 }),
+      }),
+    },
+  },
+})
+
 export default buildConfigWithDefaults({
   admin: {
     importMap: {
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Media, MediaWithPrefix, RestrictedMedia, Users],
+  collections: [Media, MediaWithPrefix, RestrictedMedia, TestMetadata, Users],
   onInit: async (payload) => {
     /*const client = new AWS.S3({
       endpoint: process.env.S3_ENDPOINT,
@@ -151,7 +184,7 @@ export default buildConfigWithDefaults({
       `Using plugin-cloud-storage adapter: ${process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER}`,
     )
   },
-  plugins: [storagePlugin],
+  plugins: [storagePlugin, testMetadataPlugin],
   upload: uploadOptions,
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),

--- a/test/plugin-cloud-storage/payload-types.ts
+++ b/test/plugin-cloud-storage/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     media: Media;
     'media-with-prefix': MediaWithPrefix;
     'restricted-media': RestrictedMedia;
+    'test-metadata': TestMetadatum;
     users: User;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -81,6 +82,7 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     'media-with-prefix': MediaWithPrefixSelect<false> | MediaWithPrefixSelect<true>;
     'restricted-media': RestrictedMediaSelect<false> | RestrictedMediaSelect<true>;
+    'test-metadata': TestMetadataSelect<false> | TestMetadataSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -197,6 +199,37 @@ export interface RestrictedMedia {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "test-metadata".
+ */
+export interface TestMetadatum {
+  id: string;
+  testUrl?: string | null;
+  testEtag?: string | null;
+  customField?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+  sizes?: {
+    thumbnail?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+  };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -254,6 +287,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'restricted-media';
         value: string | RestrictedMedia;
+      } | null)
+    | ({
+        relationTo: 'test-metadata';
+        value: string | TestMetadatum;
       } | null)
     | ({
         relationTo: 'users';
@@ -381,6 +418,40 @@ export interface RestrictedMediaSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "test-metadata_select".
+ */
+export interface TestMetadataSelect<T extends boolean = true> {
+  testUrl?: T;
+  testEtag?: T;
+  customField?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+  sizes?:
+    | T
+    | {
+        thumbnail?:
+          | T
+          | {
+              url?: T;
+              width?: T;
+              height?: T;
+              mimeType?: T;
+              filesize?: T;
+              filename?: T;
+            };
+      };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
@@ -451,6 +522,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }

--- a/test/plugin-cloud-storage/shared.ts
+++ b/test/plugin-cloud-storage/shared.ts
@@ -1,4 +1,5 @@
 export const mediaSlug = 'media'
 export const mediaWithPrefixSlug = 'media-with-prefix'
 export const restrictedMediaSlug = 'restricted-media'
+export const testMetadataSlug = 'test-metadata'
 export const prefix = 'test-prefix'


### PR DESCRIPTION
### What
Fixes issue where storage metadata (object keys, timestamps, custom IDs, etc.) from external providers (s3, azure, etc) is no longer persisted back to the main doc. This issue was introduced in PR #14988 when the external upload process was moved from the `beforeChange` to `afterChange` hook.

### Why
Without automatically persisting metadata from external storage, users have to manually update the doc themselves. This restores backward compatibility for existing custom storage adapters.

### Where
Added automatic data capture/persistence in `packages/plugin-cloud-storage/src/hooks/afterChange`

#### Testing
Added to test suite `test/plugin-cloud-storage`