### PR TITLE
fix(plugin-mcp): auto-detect basePath from Payload config routes

### DIFF
--- a/packages/plugin-mcp/src/mcp/getMcpHandler.ts
+++ b/packages/plugin-mcp/src/mcp/getMcpHandler.ts
@@ -506,7 +506,7 @@ export const getMCPHandler = (
         serverInfo: serverOptions.serverInfo,
       },
       {
-        basePath: MCPHandlerOptions.basePath || '/api',
+        basePath: MCPHandlerOptions.basePath || payload.config.routes?.api || '/api',
         maxDuration: MCPHandlerOptions.maxDuration || 60,
         // INFO: Disabled until developer clarity is reached for server side streaming and we have an auth pattern for all SSE patterns
         // redisUrl: MCPHandlerOptions.redisUrl || process.env.REDIS_URL,


### PR DESCRIPTION
When Payload CMS has custom routes configured (e.g., routes: { api: '/cms/api' }), the MCP handler was using hardcoded '/api'  instead of the actual configured path.

This caused 404 errors when comparing url.pathname against the wrong base path.

The fix uses `payload.config.routes?.api` as the default fallback before '/api', so the handler automatically respects custom route configurations.