### PR TITLE
fix: wrong construction of urlToUse leads to false alert with logger.error

### DIFF
--- a/packages/payload/src/utilities/createLocalReq.spec.ts
+++ b/packages/payload/src/utilities/createLocalReq.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Payload } from '../index.js'
+
+import { createLocalReq } from './createLocalReq.js'
+
+describe('createLocalReq - URL construction', () => {
+  const mockPayload = {
+    config: {
+      serverURL: undefined,
+      i18n: {
+        fallbackLanguage: 'en',
+        supportedLanguages: { en: {} },
+        translations: {},
+      },
+      localization: undefined,
+    },
+    logger: {
+      error: vi.fn(),
+    },
+  } as unknown as Payload
+
+  it('should use req.url when provided and serverURL is undefined', async () => {
+    const req = {
+      url: 'http://example.com/api/test',
+    }
+
+    const result = await createLocalReq({ req }, mockPayload)
+
+    expect(result.url).toBe('http://example.com/api/test')
+    expect(mockPayload.logger.error).not.toHaveBeenCalled()
+  })
+
+  it('should use serverURL when req.url is not provided', async () => {
+    const payloadWithServerURL = {
+      config: {
+        serverURL: 'http://configured-server.com',
+        i18n: {
+          fallbackLanguage: 'en',
+          supportedLanguages: { en: {} },
+          translations: {},
+        },
+        localization: undefined,
+      },
+      logger: {
+        error: vi.fn(),
+      },
+    } as unknown as Payload
+
+    const req = {}
+
+    const result = await createLocalReq({ req, urlSuffix: '/api' }, payloadWithServerURL)
+
+    expect(result.url).toContain('http://configured-server.com/api')
+    expect(payloadWithServerURL.logger.error).not.toHaveBeenCalled()
+  })
+
+  it('should prioritize req.url over serverURL', async () => {
+    const payloadWithServerURL = {
+      config: {
+        serverURL: 'http://configured-server.com',
+        i18n: {
+          fallbackLanguage: 'en',
+          supportedLanguages: { en: {} },
+          translations: {},
+        },
+        localization: undefined,
+      },
+      logger: {
+        error: vi.fn(),
+      },
+    } as unknown as Payload
+
+    const req = {
+      url: 'http://actual-request.com/api/test',
+    }
+
+    const result = await createLocalReq({ req }, payloadWithServerURL)
+
+    expect(result.url).toBe('http://actual-request.com/api/test')
+    expect(payloadWithServerURL.logger.error).not.toHaveBeenCalled()
+  })
+
+  it('should fall back to localhost when neither req.url nor serverURL provided', async () => {
+    const req = {}
+
+    const result = await createLocalReq({ req }, mockPayload)
+
+    expect(result.url).toBe('http://localhost/')
+    expect(mockPayload.logger.error).not.toHaveBeenCalled()
+  })
+
+  it('should append urlSuffix to serverURL when used', async () => {
+    const payloadWithServerURL = {
+      config: {
+        serverURL: 'http://configured-server.com',
+        i18n: {
+          fallbackLanguage: 'en',
+          supportedLanguages: { en: {} },
+          translations: {},
+        },
+        localization: undefined,
+      },
+      logger: {
+        error: vi.fn(),
+      },
+    } as unknown as Payload
+
+    const req = {}
+
+    const result = await createLocalReq({ req, urlSuffix: '/api/preview' }, payloadWithServerURL)
+
+    expect(result.url).toContain('/api/preview')
+    expect(payloadWithServerURL.logger.error).not.toHaveBeenCalled()
+  })
+
+  it('should append urlSuffix to fallback URL when neither req.url nor serverURL provided', async () => {
+    const req = {}
+
+    const result = await createLocalReq({ req, urlSuffix: '/api/test' }, mockPayload)
+
+    expect(result.url).toBe('http://localhost/api/test')
+    expect(mockPayload.logger.error).not.toHaveBeenCalled()
+  })
+})

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -39,9 +39,10 @@ const attachFakeURLProperties = (req: Partial<PayloadRequest>, urlSuffix?: strin
     const fallbackURL = `http://${req.host || 'localhost'}${urlSuffix || ''}`
 
     const urlToUse =
-      req?.url || req.payload?.config?.serverURL
+      req?.url ||
+      (req.payload?.config?.serverURL
         ? `${req.payload?.config.serverURL}${urlSuffix || ''}`
-        : fallbackURL
+        : fallbackURL)
 
     try {
       urlObject = new URL(urlToUse)


### PR DESCRIPTION
### What?

Fixes operator precedence bug in `createLocalReq.ts` that causes false error logs when using Preview feature without a configured `serverURL`.

### Why

The `||` operator has higher precedence than the ternary `?:`, causing incorrect URL construction logic. When `req.url` exists but `serverURL` is undefined, the code attempts to construct a URL from `undefined`, triggering an error log even though a valid URL is available.

### How

Wrapped the ternary operator in parentheses to establish correct precedence: `req.url` is checked first, then falls back to `serverURL` construction if available, and finally uses localhost fallback. 

Fixes #12880 
