### PR TITLE
fix(db-mongodb): hasMany relationship filtering with equals operator returns no results

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -307,7 +307,51 @@ export const sanitizeQueryValue = ({
       }, [])
     }
 
+    // Handle hasMany relationships with equals operator and array values
+    // For array equality checking
     if (
+      ['equals', 'not_equals'].includes(operator) &&
+      Array.isArray(formattedValue) &&
+      'hasMany' in field &&
+      field.hasMany
+    ) {
+      if (typeof relationTo === 'string') {
+        const customIDType = payload.collections[relationTo]?.customIDType
+
+        // Convert array values to proper types (ObjectId or custom ID type)
+        formattedValue = formattedValue.map((v) => {
+          if (customIDType === 'number') {
+            const parsed = parseFloat(v)
+            return Number.isNaN(parsed) ? v : parsed
+          }
+          if (!Types.ObjectId.isValid(v)) {
+            return v
+          }
+          return new Types.ObjectId(v)
+        })
+      } else {
+        // Polymorphic hasMany - convert array of {relationTo, value} objects
+        formattedValue = formattedValue.map((item) => {
+          if (typeof item === 'object' && 'value' in item) {
+            const relTo = item.relationTo
+            const customIDType = payload.collections[relTo]?.customIDType
+            if (customIDType === 'number') {
+              const parsed = parseFloat(item.value)
+              return { relationTo: relTo, value: Number.isNaN(parsed) ? item.value : parsed }
+            }
+            if (Types.ObjectId.isValid(item.value)) {
+              return { relationTo: relTo, value: new Types.ObjectId(item.value) }
+            }
+            return item
+          }
+          // Non-polymorphic format - just IDs
+          if (Types.ObjectId.isValid(item)) {
+            return new Types.ObjectId(item)
+          }
+          return item
+        })
+      }
+    } else if (
       ['contains', 'equals', 'like', 'not_equals'].includes(operator) &&
       (!Array.isArray(relationTo) || !path.endsWith('.relationTo'))
     ) {

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -726,6 +726,74 @@ describe('relationship', () => {
     await expect(page.locator(tableRowLocator)).toHaveCount(1)
   })
 
+  test('should allow filtering by non-polymorphic hasMany relationship field / equals', async () => {
+    const textDoc1 = await createTextFieldDoc({ text: 'Text 1' })
+    const textDoc2 = await createTextFieldDoc({ text: 'Text 2' })
+    const textDoc3 = await createTextFieldDoc({ text: 'Text 3' })
+
+    await createRelationshipFieldDoc(
+      { value: textDoc1.id, relationTo: 'text-fields' },
+      {
+        relationshipHasMany: [textDoc1.id],
+      },
+    )
+
+    await createRelationshipFieldDoc(
+      { value: textDoc2.id, relationTo: 'text-fields' },
+      {
+        relationshipHasMany: [textDoc2.id, textDoc3.id],
+      },
+    )
+
+    await page.goto(url.list)
+    await wait(1000)
+
+    await addListFilter({
+      page,
+      fieldLabel: 'Relationship Has Many',
+      operatorLabel: 'equals',
+      value: 'Text 1',
+      multiSelect: true,
+    })
+
+    await expect(page.locator(tableRowLocator)).toHaveCount(1)
+  })
+
+  test('should allow filtering by polymorphic hasMany relationship field / equals', async () => {
+    const textDoc1 = await createTextFieldDoc({ text: 'Poly Text 1' })
+    const textDoc2 = await createTextFieldDoc({ text: 'Poly Text 2' })
+
+    await createRelationshipFieldDoc(
+      { value: textDoc1.id, relationTo: 'text-fields' },
+      {
+        relationHasManyPolymorphic: [{ relationTo: 'text-fields', value: textDoc1.id }],
+      },
+    )
+
+    await createRelationshipFieldDoc(
+      { value: textDoc2.id, relationTo: 'text-fields' },
+      {
+        relationHasManyPolymorphic: [
+          { relationTo: 'text-fields', value: textDoc1.id },
+          { relationTo: 'text-fields', value: textDoc2.id },
+        ],
+      },
+    )
+
+    await page.goto(url.list)
+    await wait(1000)
+
+    await addListFilter({
+      page,
+      fieldLabel: 'Relation Has Many Polymorphic',
+      operatorLabel: 'equals',
+      value: 'Poly Text 1',
+      multiSelect: true,
+    })
+
+    await expect(page.locator(tableRowLocator)).toHaveCount(1)
+  })
+
   test('should be able to select relationship with drawer appearance', async () => {
     await loadCreatePage()
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -3578,10 +3578,6 @@ describe('Fields', () => {
     })
 
     describe('querying', () => {
-      if (payload.db.name !== 'mongoose') {
-        return
-      }
-
       const createdIDs: (number | string)[] = []
 
       afterEach(async () => {
@@ -3592,6 +3588,10 @@ describe('Fields', () => {
       })
 
       it('should query non-polymorphic hasMany - equals', async () => {
+        if (payload.db.name !== 'mongoose') {
+          return
+        }
+
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
@@ -3625,6 +3625,10 @@ describe('Fields', () => {
       })
 
       it('should query polymorphic hasMany - equals', async () => {
+        if (payload.db.name !== 'mongoose') {
+          return
+        }
+
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
@@ -3665,6 +3669,10 @@ describe('Fields', () => {
       })
 
       it('should query non-polymorphic hasMany - not_equals', async () => {
+        if (payload.db.name !== 'mongoose') {
+          return
+        }
+
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
@@ -3714,6 +3722,10 @@ describe('Fields', () => {
       })
 
       it('should query polymorphic hasMany - not_equals', async () => {
+        if (payload.db.name !== 'mongoose') {
+          return
+        }
+
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },


### PR DESCRIPTION
### What

Fixes filtering `hasMany` `relationship` fields (both polymorphic and non-polymorphic) with the `equals` and `not_equals` operators in the MongoDB adapter. 

When using the WhereBuilder UI to filter by these fields, queries would return zero results instead of matching documents.

### Why

The MongoDB adapter's `sanitizeQueryValue` function wasn't handling array values properly for `equals`/`not_equals` operators on hasMany relationship fields. 

The values coming from the UI are string IDs that need to be converted to MongoDB ObjectIds before comparison:

```
// Before fix - strings don't match ObjectIds
{ relationshipHasMany: { $eq: ['507f1f77bcf86cd799439011', '507f191e810c19729de860ea'] } } 
```

```
// After fix - converted to ObjectIds
{ relationshipHasMany: { $eq: [ObjectId('507f1f77bcf86cd799439011'), ObjectId('507f191e810c19729de860ea')] } } 
```

### How

Added handling in `sanitizeQueryValue.ts` to detect when:
- The operator is `equals` or `not_equals`
- The value is an array
- The field has `hasMany: true`

For these cases, the array values are converted to the proper ID types (ObjectId for MongoDB IDs, or custom ID types like numbers) before the query is built. 

**Note:** This fix is MongoDB-specific. Exact array equality filtering for hasMany relationships is not currently supported in SQL adapters (Drizzle/Postgres).


