### PR TITLE
fix(templates): prevent jobs run if secret unset

### DIFF
--- a/docs/jobs-queue/queues.mdx
+++ b/docs/jobs-queue/queues.mdx
@@ -122,11 +122,14 @@ export default buildConfig({
         // Allow logged in users to execute this endpoint (default)
         if (req.user) return true
 
+        const secret = process.env.CRON_SECRET
+        if (!secret) return false
+
         // If there is no logged in user, then check
         // for the Vercel Cron secret to be present as an
         // Authorization header:
         const authHeader = req.headers.get('authorization')
-        return authHeader === `Bearer ${process.env.CRON_SECRET}`
+        return authHeader === `Bearer ${secret}`
       },
     },
     // Other job configurations...

--- a/templates/website/src/payload.config.ts
+++ b/templates/website/src/payload.config.ts
@@ -75,11 +75,14 @@ export default buildConfig({
         // Allow logged in users to execute this endpoint (default)
         if (req.user) return true
 
+        const secret = process.env.CRON_SECRET
+        if (!secret) return false
+
         // If there is no logged in user, then check
         // for the Vercel Cron secret to be present as an
         // Authorization header:
         const authHeader = req.headers.get('authorization')
-        return authHeader === `Bearer ${process.env.CRON_SECRET}`
+        return authHeader === `Bearer ${secret}`
       },
     },
     tasks: [],

--- a/templates/with-vercel-website/src/payload.config.ts
+++ b/templates/with-vercel-website/src/payload.config.ts
@@ -86,11 +86,14 @@ export default buildConfig({
         // Allow logged in users to execute this endpoint (default)
         if (req.user) return true
 
+        const secret = process.env.CRON_SECRET
+        if (!secret) return false
+
         // If there is no logged in user, then check
         // for the Vercel Cron secret to be present as an
         // Authorization header:
         const authHeader = req.headers.get('authorization')
-        return authHeader === `Bearer ${process.env.CRON_SECRET}`
+        return authHeader === `Bearer ${secret}`
       },
     },
     tasks: [],


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR prevents running jobs via `run` if a CRON_SECRET is unset. This change is only necessary for the website templates and docs.

### Why?
To harden the access controls around the `run` access check in the website templates.

### How?
Checking if the secret is truthy prior to comparing it against the auth header.