### PR TITLE
chore(plugin-redirects): add Swedish translation

### DIFF
--- a/packages/plugin-redirects/src/translations/index.ts
+++ b/packages/plugin-redirects/src/translations/index.ts
@@ -4,12 +4,14 @@ import { en } from './languages/en.js'
 import { es } from './languages/es.js'
 import { fr } from './languages/fr.js'
 import { ja } from './languages/ja.js'
+import { sv } from './languages/sv.js'
 
 export const translations = {
   en,
   es,
   fr,
   ja,
+  sv
 }
 
 export type RedirectsTranslations = GenericTranslationsObject

--- a/packages/plugin-redirects/src/translations/languages/sv.ts
+++ b/packages/plugin-redirects/src/translations/languages/sv.ts
@@ -1,0 +1,13 @@
+import type { GenericTranslationsObject } from '@payloadcms/translations'
+
+export const sv: GenericTranslationsObject = {
+  $schema: '../translation-schema.json',
+  'plugin-redirects': {
+    customUrl: 'URL',
+    documentToRedirect: 'Dokument',
+    fromUrl: 'Från',
+    internalLink: 'Intern länk',
+    redirectType: 'Typ',
+    toUrlType: 'Till',
+  },
+}


### PR DESCRIPTION
### What?

Adds Swedish translation to the redirects plugin.

### Why?

While all other plugins had automatically generated Swedish translations, the redirects plugin did not.