### PR TITLE
fix: correct image size URLs in beforeChange

### DIFF
--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -239,7 +239,11 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
                     generateFilePathOrURL({
                       collectionSlug: collection?.slug as string,
                       config,
-                      filename: data?.filename || originalDoc?.filename,
+                      filename:
+                        data?.sizes?.[size.name]?.filename ||
+                        originalDoc?.sizes?.[size.name]?.filename ||
+                        data?.filename ||
+                        originalDoc?.filename,
                       relative: true,
                       serverURL: req.payload.config.serverURL,
                       urlOrPath: value,


### PR DESCRIPTION
### What
Fixes image size URLs in `beforeChange` pointing to original files instead of their correct sized files.

### Why
The `beforeChange` hook was returning incorrect URLs for image size variants. Plugins relying on the URLs were getting wrong file references, causing issues for `plugin-cloud-storage`.

### Where
Updated the `beforeChange` in `getBaseFields` to use the image size URL.

### Testing
Added tests to `test/plugin-cloud-storage/int.spec.ts`