### PR TITLE
fix: folder creation errors when collection uses translation function labels

### DIFF
--- a/packages/payload/src/folders/createFolderCollection.ts
+++ b/packages/payload/src/folders/createFolderCollection.ts
@@ -25,8 +25,16 @@ export const createFolderCollection = ({
   const { collectionOptions, collectionSlugs } = folderEnabledCollections.reduce(
     (acc, collection: CollectionConfig) => {
       acc.collectionSlugs.push(collection.slug)
+
+      // Determine the label - if it's a function, use the slug instead to avoid serialization issues
+      const labelValue = collection.labels?.plural
+      const label =
+        typeof labelValue === 'function' || typeof labelValue === 'undefined'
+          ? collection.slug
+          : labelValue
+
       acc.collectionOptions.push({
-        label: collection.labels?.plural || collection.slug,
+        label,
         value: collection.slug,
       })
 

--- a/packages/payload/src/folders/createFolderCollection.ts
+++ b/packages/payload/src/folders/createFolderCollection.ts
@@ -26,7 +26,6 @@ export const createFolderCollection = ({
     (acc, collection: CollectionConfig) => {
       acc.collectionSlugs.push(collection.slug)
 
-      // Determine the label - if it's a function, use the slug instead to avoid serialization issues
       const labelValue = collection.labels?.plural
       const label =
         typeof labelValue === 'function' || typeof labelValue === 'undefined'

--- a/packages/payload/src/folders/createFolderCollection.ts
+++ b/packages/payload/src/folders/createFolderCollection.ts
@@ -25,15 +25,8 @@ export const createFolderCollection = ({
   const { collectionOptions, collectionSlugs } = folderEnabledCollections.reduce(
     (acc, collection: CollectionConfig) => {
       acc.collectionSlugs.push(collection.slug)
-
-      const labelValue = collection.labels?.plural
-      const label =
-        typeof labelValue === 'function' || typeof labelValue === 'undefined'
-          ? collection.slug
-          : labelValue
-
       acc.collectionOptions.push({
-        label,
+        label: collection.labels?.plural || collection.slug,
         value: collection.slug,
       })
 
@@ -93,9 +86,6 @@ export const createFolderCollection = ({
               admin: {
                 components: {
                   Field: {
-                    clientProps: {
-                      options: collectionOptions,
-                    },
                     path: '@payloadcms/ui#FolderTypeField',
                   },
                 },

--- a/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
+++ b/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
@@ -11,10 +11,7 @@ import { useField } from '../../../forms/useField/index.js'
 import { useFolder } from '../../../providers/Folders/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 
-export const FolderTypeField = ({
-  options: allSelectOptions,
-  ...props
-}: { options: Option[] } & SelectFieldClientProps) => {
+export const FolderTypeField = (props: SelectFieldClientProps) => {
   const {
     field,
     field: {
@@ -28,6 +25,7 @@ export const FolderTypeField = ({
       hasMany = false,
       label,
       localized,
+      options: allSelectOptions = [],
       required,
     },
     onChange: onChangeFromProps,

--- a/test/folders/collections/Posts/index.ts
+++ b/test/folders/collections/Posts/index.ts
@@ -7,6 +7,10 @@ export const Posts: CollectionConfig = {
   admin: {
     useAsTitle: 'title',
   },
+  labels: {
+    singular: ({ t }) => t('authentication:account'),
+    plural: ({ t }) => t('authentication:account'),
+  },
   folders: true,
   trash: true,
   fields: [

--- a/test/folders/collections/Posts/index.ts
+++ b/test/folders/collections/Posts/index.ts
@@ -7,10 +7,6 @@ export const Posts: CollectionConfig = {
   admin: {
     useAsTitle: 'title',
   },
-  labels: {
-    singular: ({ t }) => t('authentication:account'),
-    plural: ({ t }) => t('authentication:account'),
-  },
   folders: true,
   trash: true,
   fields: [

--- a/test/folders/collections/TranslatedLabels/index.ts
+++ b/test/folders/collections/TranslatedLabels/index.ts
@@ -1,0 +1,19 @@
+import type { CollectionConfig } from 'payload'
+
+export const TranslatedLabels: CollectionConfig = {
+  slug: 'translated-labels',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  folders: true,
+  labels: {
+    plural: ({ t }) => t('general:documents'),
+    singular: ({ t }) => t('general:document'),
+  },
+}

--- a/test/folders/config.ts
+++ b/test/folders/config.ts
@@ -9,6 +9,7 @@ import { Drafts } from './collections/Drafts/index.js'
 import { Media } from './collections/Media/index.js'
 import { OmittedFromBrowseBy } from './collections/OmittedFromBrowseBy/index.js'
 import { Posts } from './collections/Posts/index.js'
+import { TranslatedLabels } from './collections/TranslatedLabels/index.js'
 // import { seed } from './seed/index.js'
 
 export default buildConfigWithDefaults({
@@ -29,7 +30,7 @@ export default buildConfigWithDefaults({
       },
     ],
   },
-  collections: [Posts, Media, Drafts, Autosave, OmittedFromBrowseBy],
+  collections: [Posts, Media, Drafts, Autosave, OmittedFromBrowseBy, TranslatedLabels],
   globals: [
     {
       slug: 'global',

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -119,8 +119,11 @@ test.describe('Folders', () => {
       // Should be able to open the select menu without errors
       await openSelectMenu({ selectLocator })
 
-      const postsOption = page.locator('.rs__option', { hasText: 'posts' })
-      await expect(postsOption).toBeVisible()
+      // The TranslatedLabels collection has translation function labels, so it should appear with its slug
+      const translatedLabelsOption = page.locator('.rs__option', {
+        hasText: 'translated-labels',
+      })
+      await expect(translatedLabelsOption).toBeVisible()
     })
   })
 

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -99,6 +99,35 @@ test.describe('Folders', () => {
       await folderPill.click()
       await createFolderFromDoc({ folderName: 'New Folder From Doc', page })
     })
+
+    test('should create folder with collection that has translation function labels', async () => {
+      // This test verifies the fix for the bug where collections with translation function labels
+      // (like `singular: ({ t }) => t('authentication:account')`) would cause a React error:
+      // "Functions cannot be passed directly to Client Components"
+      await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))
+
+      // Click create folder button - this should not throw an error
+      const createButton = page
+        .locator('.list-header__title-and-actions .create-new-doc-in-folder__button')
+        .filter({ hasText: 'Create folder' })
+      await expect(createButton).toBeVisible()
+      await createButton.click()
+
+      // The folder drawer should open successfully without React serialization errors
+      const drawer = page.locator('dialog .collection-edit--payload-folders')
+      await expect(drawer).toBeVisible()
+
+      // Verify the folderType select field is present and functional
+      const selectLocator = drawer.locator('#field-folderType')
+      await expect(selectLocator).toBeVisible()
+
+      // Should be able to open the select menu without errors
+      await openSelectMenu({ selectLocator })
+
+      // The Posts collection has translation function labels, so it should appear in the options
+      const postsOption = page.locator('.rs__option', { hasText: 'posts' })
+      await expect(postsOption).toBeVisible()
+    })
   })
 
   test.describe('Folder view actions', () => {

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -101,12 +101,8 @@ test.describe('Folders', () => {
     })
 
     test('should create folder with collection that has translation function labels', async () => {
-      // This test verifies the fix for the bug where collections with translation function labels
-      // (like `singular: ({ t }) => t('authentication:account')`) would cause a React error:
-      // "Functions cannot be passed directly to Client Components"
       await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))
 
-      // Click create folder button - this should not throw an error
       const createButton = page
         .locator('.list-header__title-and-actions .create-new-doc-in-folder__button')
         .filter({ hasText: 'Create folder' })
@@ -117,14 +113,12 @@ test.describe('Folders', () => {
       const drawer = page.locator('dialog .collection-edit--payload-folders')
       await expect(drawer).toBeVisible()
 
-      // Verify the folderType select field is present and functional
       const selectLocator = drawer.locator('#field-folderType')
       await expect(selectLocator).toBeVisible()
 
       // Should be able to open the select menu without errors
       await openSelectMenu({ selectLocator })
 
-      // The Posts collection has translation function labels, so it should appear in the options
       const postsOption = page.locator('.rs__option', { hasText: 'posts' })
       await expect(postsOption).toBeVisible()
     })

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -119,9 +119,8 @@ test.describe('Folders', () => {
       // Should be able to open the select menu without errors
       await openSelectMenu({ selectLocator })
 
-      // The TranslatedLabels collection has translation function labels, so it should appear with its slug
       const translatedLabelsOption = page.locator('.rs__option', {
-        hasText: 'translated-labels',
+        hasText: 'Documents',
       })
       await expect(translatedLabelsOption).toBeVisible()
     })

--- a/test/folders/payload-types.ts
+++ b/test/folders/payload-types.ts
@@ -72,6 +72,7 @@ export interface Config {
     drafts: Draft;
     autosave: Autosave;
     'omitted-from-browse-by': OmittedFromBrowseBy;
+    'translated-labels': TranslatedLabel;
     'payload-kv': PayloadKv;
     users: User;
     'payload-folders': FolderInterface;
@@ -81,7 +82,14 @@ export interface Config {
   };
   collectionsJoins: {
     'payload-folders': {
-      documentsAndFolders: 'payload-folders' | 'posts' | 'media' | 'drafts' | 'autosave' | 'omitted-from-browse-by';
+      documentsAndFolders:
+        | 'payload-folders'
+        | 'posts'
+        | 'media'
+        | 'drafts'
+        | 'autosave'
+        | 'omitted-from-browse-by'
+        | 'translated-labels';
     };
   };
   collectionsSelect: {
@@ -90,6 +98,7 @@ export interface Config {
     drafts: DraftsSelect<false> | DraftsSelect<true>;
     autosave: AutosaveSelect<false> | AutosaveSelect<true>;
     'omitted-from-browse-by': OmittedFromBrowseBySelect<false> | OmittedFromBrowseBySelect<true>;
+    'translated-labels': TranslatedLabelsSelect<false> | TranslatedLabelsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-folders': PayloadFoldersSelect<false> | PayloadFoldersSelect<true>;
@@ -202,11 +211,15 @@ export interface FolderInterface {
           relationTo?: 'omitted-from-browse-by';
           value: string | OmittedFromBrowseBy;
         }
+      | {
+          relationTo?: 'translated-labels';
+          value: string | TranslatedLabel;
+        }
     )[];
     hasNextPage?: boolean;
     totalDocs?: number;
   };
-  folderType?: ('posts' | 'media' | 'drafts' | 'autosave' | 'omitted-from-browse-by')[] | null;
+  folderType?: ('posts' | 'media' | 'drafts' | 'autosave' | 'omitted-from-browse-by' | 'translated-labels')[] | null;
   folderSlug?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -240,6 +253,17 @@ export interface Autosave {
  * via the `definition` "omitted-from-browse-by".
  */
 export interface OmittedFromBrowseBy {
+  id: string;
+  title?: string | null;
+  folder?: (string | null) | FolderInterface;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "translated-labels".
+ */
+export interface TranslatedLabel {
   id: string;
   title?: string | null;
   folder?: (string | null) | FolderInterface;
@@ -313,6 +337,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'omitted-from-browse-by';
         value: string | OmittedFromBrowseBy;
+      } | null)
+    | ({
+        relationTo: 'translated-labels';
+        value: string | TranslatedLabel;
       } | null)
     | ({
         relationTo: 'users';
@@ -423,6 +451,16 @@ export interface AutosaveSelect<T extends boolean = true> {
  * via the `definition` "omitted-from-browse-by_select".
  */
 export interface OmittedFromBrowseBySelect<T extends boolean = true> {
+  title?: T;
+  folder?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "translated-labels_select".
+ */
+export interface TranslatedLabelsSelect<T extends boolean = true> {
   title?: T;
   folder?: T;
   updatedAt?: T;

--- a/test/folders/payload-types.ts
+++ b/test/folders/payload-types.ts
@@ -533,6 +533,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }


### PR DESCRIPTION
### What

Fixes the "Functions cannot be passed directly to Client Components" error that occurs when clicking the create folder button if any collection has translation function labels (e.g., `singular: ({ t }) => t('authentication:account')`).

### Why

The `folderType` select field was passing options through `clientProps`, which gets directly serialized when sent to the client component. 

When collection labels used translation functions, these functions were included in the serialized data, causing React to throw an error since functions can't be serialized across the server/client boundary.

### How

Moved the `folderType` field options from `clientProps` to the field definition itself (`field.options`), and updated `FolderTypeField` to read options from the field config. 

Fixes #15199 

