### PR TITLE
fix: select hasMany prevent duplicate values

### DIFF
--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -983,6 +983,31 @@ export const select: SelectFieldValidation = (
     return t('validation:invalidSelection')
   }
 
+  // Check for duplicate values when hasMany is true
+  if (hasMany && Array.isArray(value) && value.length > 0) {
+    const counts = new Map<unknown, number>()
+
+    for (const item of value) {
+      counts.set(item, (counts.get(item) || 0) + 1)
+    }
+
+    const duplicates: unknown[] = []
+    for (const [item, count] of counts.entries()) {
+      if (count > 1) {
+        // Add the item 'count' times to show all occurrences
+        for (let i = 0; i < count; i++) {
+          duplicates.push(item)
+        }
+      }
+    }
+
+    if (duplicates.length > 0) {
+      return duplicates.reduce((err, duplicate, i) => {
+        return `${err} ${JSON.stringify(duplicate)}${i < duplicates.length - 1 ? ',' : ''}`
+      }, t('validation:invalidSelections')) as string
+    }
+  }
+
   if (
     typeof value === 'string' &&
     !filteredOptions.some(

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -984,7 +984,7 @@ export const select: SelectFieldValidation = (
   }
 
   // Check for duplicate values when hasMany is true
-  if (hasMany && Array.isArray(value) && value.length > 0) {
+  if (hasMany && Array.isArray(value) && value.length > 1) {
     const counts = new Map<unknown, number>()
 
     for (const item of value) {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1,8 +1,9 @@
 import type { MongooseAdapter } from '@payloadcms/db-mongodb'
 import type { IndexDirection, IndexOptions } from 'mongoose'
-import type { Payload, reload, ValidationError } from 'payload'
+import type { Payload, ValidationError } from 'payload'
 
 import path from 'path'
+import { reload } from 'payload'
 import { fileURLToPath } from 'url'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect } from 'vitest'
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1,8 +1,8 @@
 import type { MongooseAdapter } from '@payloadcms/db-mongodb'
 import type { IndexDirection, IndexOptions } from 'mongoose'
+import type { Payload, reload, ValidationError } from 'payload'
 
 import path from 'path'
-import { type Payload, reload } from 'payload'
 import { fileURLToPath } from 'url'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect } from 'vitest'
 
@@ -1013,6 +1013,25 @@ describe('Fields', () => {
       })
 
       expect(result).toBeTruthy()
+    })
+
+    it('should throw field error when duplicate values in hasMany select field', async () => {
+      let error: undefined | ValidationError
+
+      try {
+        await payload.create({
+          collection: 'select-fields',
+          data: {
+            selectHasMany: ['one', 'two', 'one', 'two', 'one'],
+          },
+        })
+      } catch (e) {
+        error = e as ValidationError
+      }
+
+      expect(error.data.errors[0].message).toBe(
+        'This field has the following invalid selections: "one", "one", "one", "two", "two"',
+      )
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15208

Adds duplicate value validation to select `hasMany: true` fields.
