### PR TITLE
fix: use window.location.origin as fallback for API URL copy

### DIFF
--- a/packages/next/src/views/API/index.client.tsx
+++ b/packages/next/src/views/API/index.client.tsx
@@ -38,6 +38,7 @@ export const APIViewClient: React.FC = () => {
       defaultDepth,
       localization,
       routes: { api: apiRoute },
+      serverURL,
     },
     getEntityConfig,
   } = useConfig()
@@ -83,6 +84,7 @@ export const APIViewClient: React.FC = () => {
   const fetchURL = formatAdminURL({
     apiRoute,
     path: `${docEndpoint}?${params}`,
+    serverURL: serverURL || window.location.origin,
   })
 
   React.useEffect(() => {


### PR DESCRIPTION
In the API tab, if a `serverURL` wasn't provided in the Payload config, the URL shown would be relative. This fix uses `window.location.origin` as a fallback if `serverURL` is not provided.

<img width="737" height="229" alt="image" src="https://github.com/user-attachments/assets/7d36843b-1edc-447b-83c4-677df5e0c784" />
