### PR TITLE
feat(kv): add mget and getdel method for key retrieval

### DIFF
--- a/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
@@ -83,6 +83,7 @@ export class DatabaseKVAdapter implements KVAdapter {
       key: string
     }>({
       collection: this.collectionSlug,
+      joins: false,
       limit: 0,
       pagination: false,
       req,
@@ -92,7 +93,7 @@ export class DatabaseKVAdapter implements KVAdapter {
       },
       where: {
         key: {
-          in: [...keys],
+          in: keys,
         },
       },
     })

--- a/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
@@ -49,6 +49,34 @@ export class DatabaseKVAdapter implements KVAdapter {
     return doc.data
   }
 
+  async getdel<T extends KVStoreValue>(key: string): Promise<null | T> {
+    const doc = await this.payload.db.findOne<{
+      data: T
+      id: number | string
+    }>({
+      collection: this.collectionSlug,
+      joins: false,
+      req,
+      select: {
+        data: true,
+        key: true,
+      },
+      where: { key: { equals: key } },
+    })
+
+    if (doc === null) {
+      return null
+    }
+
+    await this.payload.db.deleteOne({
+      collection: this.collectionSlug,
+      req,
+      where: { key: { equals: key } },
+    })
+
+    return doc.data
+  }
+
   async has(key: string): Promise<boolean> {
     const { totalDocs } = await this.payload.db.count({
       collection: this.collectionSlug,

--- a/packages/payload/src/kv/adapters/InMemoryKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/InMemoryKVAdapter.ts
@@ -30,6 +30,13 @@ export class InMemoryKVAdapter implements KVAdapter {
     return Array.from(this.store.keys())
   }
 
+  async mget<T extends KVStoreValue>(keys: readonly string[]): Promise<Array<null | T>> {
+    return keys.map((key) => {
+      const value = this.store.get(key) as T | undefined
+      return typeof value === 'undefined' ? null : value
+    })
+  }
+
   async set(key: string, value: KVStoreValue): Promise<void> {
     this.store.set(key, value)
   }

--- a/packages/payload/src/kv/adapters/InMemoryKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/InMemoryKVAdapter.ts
@@ -22,6 +22,17 @@ export class InMemoryKVAdapter implements KVAdapter {
     return value
   }
 
+  async getdel<T extends KVStoreValue>(key: string): Promise<null | T> {
+    const value = this.store.get(key) as T | undefined
+
+    if (typeof value === 'undefined') {
+      return null
+    }
+
+    this.store.delete(key)
+    return value
+  }
+
   async has(key: string): Promise<boolean> {
     return this.store.has(key)
   }

--- a/packages/payload/src/kv/index.ts
+++ b/packages/payload/src/kv/index.ts
@@ -25,6 +25,13 @@ export interface KVAdapter {
   get<T extends KVStoreValue>(key: string): Promise<null | T>
 
   /**
+   * Retrieves and deletes a value from the store by its key.
+   * @param key - The key to look up and delete.
+   * @returns A promise that resolves to the value, or `null` if not found.
+   */
+  getdel?<T extends KVStoreValue>(key: string): Promise<null | T>
+
+  /**
    * Checks if a key exists in the store.
    * @param key - The key to check.
    * @returns A promise that resolves to `true` if the key exists, otherwise `false`.
@@ -39,8 +46,9 @@ export interface KVAdapter {
 
   /**
    * Retrieves multiple values from the store by their keys.
-   * Order of results MUST match order of keys.
-   * Missing keys MUST resolve to null.
+   * Order of results match order of keys.
+   * @param keys - The keys to look up.
+   * @returns A promise that resolves to an array of values aligned to the input keys.
    */
   mget?<T extends KVStoreValue>(keys: readonly string[]): Promise<Array<null | T>>
 

--- a/packages/payload/src/kv/index.ts
+++ b/packages/payload/src/kv/index.ts
@@ -38,6 +38,13 @@ export interface KVAdapter {
   keys(): Promise<string[]>
 
   /**
+   * Retrieves multiple values from the store by their keys.
+   * Order of results MUST match order of keys.
+   * Missing keys MUST resolve to null.
+   */
+  mget?<T extends KVStoreValue>(keys: readonly string[]): Promise<Array<null | T>>
+
+  /**
    * Sets a value in the store with the given key.
    * @param key - The key to associate with the value.
    * @param value - The value to store.


### PR DESCRIPTION
Introduce optional mget support to the KV adapter interface and implement it across in-memory and database adapters.

- Extend KV Adapter with optional mget method for batch key retrieval
- Implement mget for InMemory KV Adapter with ordered, null-safe results
- Implement mget for Database KV Adapter using bulk find
- Implement getdel for InMemory and Database KV
- Allows deletion of keys on retrieval

This enables efficient batch reads and provides a foundation for layered or composite KV strategies.