### PR TITLE
feat(kv-redis): add mget + getdel method for key retrieval

### DIFF
--- a/packages/kv-redis/src/index.ts
+++ b/packages/kv-redis/src/index.ts
@@ -49,6 +49,23 @@ export class RedisKVAdapter implements KVAdapter {
     return prefixedKeys
   }
 
+  async mget<T extends KVStoreValue>(keys: readonly string[]): Promise<Array<null | T>> {
+    if (keys.length === 0) {
+      return []
+    }
+
+    const prefixedKeys = keys.map((key) => `${this.keyPrefix}${key}`)
+    const values = await this.redisClient.mget(prefixedKeys)
+
+    return values.map((data) => {
+      if (data === null) {
+        return null
+      }
+
+      return JSON.parse(data)
+    })
+  }
+
   async set(key: string, data: KVStoreValue): Promise<void> {
     await this.redisClient.set(`${this.keyPrefix}${key}`, JSON.stringify(data))
   }

--- a/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
+++ b/packages/payload/src/kv/adapters/DatabaseKVAdapter.ts
@@ -49,6 +49,34 @@ export class DatabaseKVAdapter implements KVAdapter {
     return doc.data
   }
 
+  async getdel<T extends KVStoreValue>(key: string): Promise<null | T> {
+    const doc = await this.payload.db.findOne<{
+      data: T
+      id: number | string
+    }>({
+      collection: this.collectionSlug,
+      joins: false,
+      req,
+      select: {
+        data: true,
+        key: true,
+      },
+      where: { key: { equals: key } },
+    })
+
+    if (doc === null) {
+      return null
+    }
+
+    await this.payload.db.deleteOne({
+      collection: this.collectionSlug,
+      req,
+      where: { key: { equals: key } },
+    })
+
+    return doc.data
+  }
+
   async has(key: string): Promise<boolean> {
     const { totalDocs } = await this.payload.db.count({
       collection: this.collectionSlug,


### PR DESCRIPTION
Implement native Redis mget and getdel support in the KV adapter.

mget allows a single call to retrieve a batch set of keys.
getdel deletes a keys on retrieval.