### PR TITLE
fix: thumbnailURL hook, virtually populate from thumbnail size

### DIFF
--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -33,7 +33,7 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
     },
     hooks: {
       afterRead: [
-        ({ originalDoc, req, value }) => {
+        ({ originalDoc, req }) => {
           const adminThumbnail =
             typeof collection.upload !== 'boolean' ? collection.upload?.adminThumbnail : undefined
 
@@ -50,20 +50,12 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
                 : undefined,
             relative: false,
             serverURL: req.payload.config.serverURL,
-            urlOrPath: value,
+            urlOrPath:
+              typeof adminThumbnail === 'string'
+                ? (originalDoc.sizes?.[adminThumbnail].url as string)
+                : undefined,
           })
         },
-      ],
-      beforeChange: [
-        ({ collection, data, originalDoc, req, value }) =>
-          generateFilePathOrURL({
-            collectionSlug: collection?.slug as string,
-            config,
-            filename: data?.filename || originalDoc?.filename,
-            relative: true,
-            serverURL: req.payload.config.serverURL,
-            urlOrPath: value,
-          }),
       ],
     },
     label: 'Thumbnail URL',


### PR DESCRIPTION
Removes beforeChange hook on thumbnailURL. Really should be a virtual field, but that would be a breaking change. Corrects the way the url is created by using the thumbnail url in the url generation.
