### PR TITLE
fix(plugin-ecommerce): issue with slug map ignoring variants and threading through cart data

### DIFF
--- a/packages/plugin-ecommerce/src/index.ts
+++ b/packages/plugin-ecommerce/src/index.ts
@@ -29,10 +29,6 @@ export const ecommercePlugin =
     }
 
     const sanitizedPluginConfig = sanitizePluginConfig({ pluginConfig })
-    /**
-     * Used to keep track of the slugs of collections in case they are overridden by the user.
-     */
-    const collectionSlugMap = getCollectionSlugMap({ sanitizedPluginConfig })
 
     const accessConfig = sanitizedPluginConfig.access
 
@@ -41,8 +37,21 @@ export const ecommercePlugin =
       incomingConfig.collections = []
     }
 
-    // Controls whether variants are enabled in the plugin. This is toggled to true under products config
-    let enableVariants = false
+    // Determine if variants are enabled based on products config
+    const productsConfig =
+      typeof sanitizedPluginConfig.products === 'boolean'
+        ? sanitizedPluginConfig.products
+          ? { variants: true }
+          : undefined
+        : sanitizedPluginConfig.products
+
+    const enableVariants = Boolean(productsConfig?.variants)
+
+    /**
+     * Used to keep track of the slugs of collections in case they are overridden by the user.
+     * Variant-related slugs are only included when variants are enabled.
+     */
+    const collectionSlugMap = getCollectionSlugMap({ enableVariants, sanitizedPluginConfig })
 
     const currenciesConfig: Required<SanitizedEcommercePluginConfig['currencies']> =
       sanitizedPluginConfig.currencies
@@ -74,16 +83,7 @@ export const ecommercePlugin =
       incomingConfig.collections.push(addressesCollection)
     }
 
-    if (sanitizedPluginConfig.products) {
-      const productsConfig =
-        typeof sanitizedPluginConfig.products === 'boolean'
-          ? {
-              variants: true,
-            }
-          : sanitizedPluginConfig.products
-
-      enableVariants = Boolean(productsConfig.variants)
-
+    if (productsConfig) {
       if (productsConfig.variants) {
         const variantsConfig =
           typeof productsConfig.variants === 'boolean' ? undefined : productsConfig.variants
@@ -93,8 +93,8 @@ export const ecommercePlugin =
           currenciesConfig,
           inventory: sanitizedPluginConfig.inventory,
           productsSlug: collectionSlugMap.products,
-          variantOptionsSlug: collectionSlugMap.variantOptions,
-          variantTypesSlug: collectionSlugMap.variantTypes,
+          variantOptionsSlug: collectionSlugMap.variantOptions ?? 'variantOptions',
+          variantTypesSlug: collectionSlugMap.variantTypes ?? 'variantTypes',
         })
 
         const variants =
@@ -109,7 +109,7 @@ export const ecommercePlugin =
 
         const defaultVariantTypesCollection = createVariantTypesCollection({
           access: accessConfig,
-          variantOptionsSlug: collectionSlugMap.variantOptions,
+          variantOptionsSlug: collectionSlugMap.variantOptions ?? 'variantOptions',
         })
 
         const variantTypes =
@@ -124,7 +124,7 @@ export const ecommercePlugin =
 
         const defaultVariantOptionsCollection = createVariantOptionsCollection({
           access: accessConfig,
-          variantTypesSlug: collectionSlugMap.variantTypes,
+          variantTypesSlug: collectionSlugMap.variantTypes ?? 'variantTypes',
         })
 
         const variantOptions =
@@ -145,8 +145,8 @@ export const ecommercePlugin =
         currenciesConfig,
         enableVariants,
         inventory: sanitizedPluginConfig.inventory,
-        variantsSlug: collectionSlugMap.variants,
-        variantTypesSlug: collectionSlugMap.variantTypes,
+        variantsSlug: collectionSlugMap.variants ?? 'variants',
+        variantTypesSlug: collectionSlugMap.variantTypes ?? 'variantTypes',
       })
 
       const productsCollection =
@@ -172,7 +172,7 @@ export const ecommercePlugin =
           customersSlug: collectionSlugMap.customers,
           enableVariants: Boolean(productsConfig.variants),
           productsSlug: collectionSlugMap.products,
-          variantsSlug: collectionSlugMap.variants,
+          variantsSlug: collectionSlugMap.variants ?? 'variants',
         })
 
         const cartsCollection =
@@ -197,7 +197,7 @@ export const ecommercePlugin =
         customersSlug: collectionSlugMap.customers,
         enableVariants,
         productsSlug: collectionSlugMap.products,
-        variantsSlug: collectionSlugMap.variants,
+        variantsSlug: collectionSlugMap.variants ?? 'variants',
       })
 
       const ordersCollection =
@@ -238,7 +238,7 @@ export const ecommercePlugin =
               productsSlug: collectionSlugMap.products,
               productsValidation,
               transactionsSlug: collectionSlugMap.transactions,
-              variantsSlug: collectionSlugMap.variants,
+              variantsSlug: collectionSlugMap.variants ?? 'variants',
             }),
             method: 'post',
             path: `${methodPath}/initiate`,
@@ -250,8 +250,10 @@ export const ecommercePlugin =
               currenciesConfig,
               ordersSlug: collectionSlugMap.orders,
               paymentMethod,
+              productsSlug: collectionSlugMap.products,
               productsValidation,
               transactionsSlug: collectionSlugMap.transactions,
+              variantsSlug: collectionSlugMap.variants ?? 'variants',
             }),
             method: 'post',
             path: `${methodPath}/confirm-order`,
@@ -289,7 +291,7 @@ export const ecommercePlugin =
         ordersSlug: collectionSlugMap.orders,
         paymentMethods,
         productsSlug: collectionSlugMap.products,
-        variantsSlug: collectionSlugMap.variants,
+        variantsSlug: collectionSlugMap.variants ?? 'variants',
       })
 
       const transactionsCollection =

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -74,10 +74,15 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
             : item.variant
           : undefined
 
+        // Preserve any additional custom properties (e.g., deliveryOption, customizations)
+        // that may have been added via cartItemMatcher
+        const { product: _product, variant: _variant, ...customProperties } = item
+
         return {
+          ...customProperties,
           product: productID,
           quantity: item.quantity,
-          variant: variantID,
+          ...(variantID ? { variant: variantID } : {}),
         }
       })
 

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -617,6 +617,7 @@ export type ProductsValidation = (args: {
 /**
  * A map of collection slugs used by the Ecommerce plugin.
  * Provides an easy way to track the slugs of collections even when they are overridden.
+ * Variant-related slugs are only present when variants are enabled.
  */
 export type CollectionSlugMap = {
   addresses: string
@@ -625,9 +626,9 @@ export type CollectionSlugMap = {
   orders: string
   products: string
   transactions: string
-  variantOptions: string
-  variants: string
-  variantTypes: string
+  variantOptions?: string
+  variants?: string
+  variantTypes?: string
 }
 
 /**

--- a/packages/plugin-ecommerce/src/utilities/getCollectionSlugMap.spec.ts
+++ b/packages/plugin-ecommerce/src/utilities/getCollectionSlugMap.spec.ts
@@ -36,8 +36,21 @@ describe('getCollectionSlugMap', () => {
     transactions: true,
   }
 
-  it('should return default slug map when no overrides are provided', () => {
+  it('should return default slug map without variant slugs when enableVariants is false', () => {
     const result = getCollectionSlugMap({ sanitizedPluginConfig: baseConfig })
+
+    expect(result).toEqual({
+      addresses: 'addresses',
+      carts: 'carts',
+      customers: 'users',
+      orders: 'orders',
+      products: 'products',
+      transactions: 'transactions',
+    })
+  })
+
+  it('should return default slug map with variant slugs when enableVariants is true', () => {
+    const result = getCollectionSlugMap({ enableVariants: true, sanitizedPluginConfig: baseConfig })
 
     expect(result).toEqual({
       addresses: 'addresses',
@@ -60,12 +73,12 @@ describe('getCollectionSlugMap', () => {
       },
     }
 
-    const result = getCollectionSlugMap({ sanitizedPluginConfig: config })
+    const result = getCollectionSlugMap({ enableVariants: true, sanitizedPluginConfig: config })
 
     expect(result.customers).toBe('custom-users')
   })
 
-  it('should apply slugMap overrides', () => {
+  it('should apply slugMap overrides when variants enabled', () => {
     const config: SanitizedEcommercePluginConfig = {
       ...baseConfig,
       slugMap: {
@@ -75,7 +88,7 @@ describe('getCollectionSlugMap', () => {
       },
     }
 
-    const result = getCollectionSlugMap({ sanitizedPluginConfig: config })
+    const result = getCollectionSlugMap({ enableVariants: true, sanitizedPluginConfig: config })
 
     expect(result.products).toBe('custom-products')
     expect(result.variants).toBe('custom-variants')
@@ -83,6 +96,23 @@ describe('getCollectionSlugMap', () => {
     // Other slugs should remain default
     expect(result.addresses).toBe('addresses')
     expect(result.carts).toBe('carts')
+  })
+
+  it('should not apply variant slugMap overrides when variants disabled', () => {
+    const config: SanitizedEcommercePluginConfig = {
+      ...baseConfig,
+      slugMap: {
+        products: 'custom-products',
+        variants: 'custom-variants',
+        orders: 'custom-orders',
+      },
+    }
+
+    const result = getCollectionSlugMap({ enableVariants: false, sanitizedPluginConfig: config })
+
+    expect(result.products).toBe('custom-products')
+    expect(result.variants).toBeUndefined()
+    expect(result.orders).toBe('custom-orders')
   })
 
   it('should prioritize slugMap overrides over customers slug', () => {
@@ -96,12 +126,12 @@ describe('getCollectionSlugMap', () => {
       },
     }
 
-    const result = getCollectionSlugMap({ sanitizedPluginConfig: config })
+    const result = getCollectionSlugMap({ enableVariants: true, sanitizedPluginConfig: config })
 
     expect(result.customers).toBe('overridden-users')
   })
 
-  it('should handle partial slugMap overrides', () => {
+  it('should handle partial slugMap overrides with variants enabled', () => {
     const config: SanitizedEcommercePluginConfig = {
       ...baseConfig,
       slugMap: {
@@ -109,7 +139,7 @@ describe('getCollectionSlugMap', () => {
       },
     }
 
-    const result = getCollectionSlugMap({ sanitizedPluginConfig: config })
+    const result = getCollectionSlugMap({ enableVariants: true, sanitizedPluginConfig: config })
 
     expect(result.products).toBe('items')
     expect(result.addresses).toBe('addresses')
@@ -122,13 +152,34 @@ describe('getCollectionSlugMap', () => {
     expect(result.variantTypes).toBe('variantTypes')
   })
 
-  it('should handle empty slugMap', () => {
+  it('should handle partial slugMap overrides with variants disabled', () => {
+    const config: SanitizedEcommercePluginConfig = {
+      ...baseConfig,
+      slugMap: {
+        products: 'items',
+      },
+    }
+
+    const result = getCollectionSlugMap({ enableVariants: false, sanitizedPluginConfig: config })
+
+    expect(result.products).toBe('items')
+    expect(result.addresses).toBe('addresses')
+    expect(result.carts).toBe('carts')
+    expect(result.customers).toBe('users')
+    expect(result.orders).toBe('orders')
+    expect(result.transactions).toBe('transactions')
+    expect(result.variants).toBeUndefined()
+    expect(result.variantOptions).toBeUndefined()
+    expect(result.variantTypes).toBeUndefined()
+  })
+
+  it('should handle empty slugMap with variants enabled', () => {
     const config: SanitizedEcommercePluginConfig = {
       ...baseConfig,
       slugMap: {},
     }
 
-    const result = getCollectionSlugMap({ sanitizedPluginConfig: config })
+    const result = getCollectionSlugMap({ enableVariants: true, sanitizedPluginConfig: config })
 
     expect(result).toEqual({
       addresses: 'addresses',
@@ -143,13 +194,31 @@ describe('getCollectionSlugMap', () => {
     })
   })
 
-  it('should handle undefined slugMap', () => {
+  it('should handle empty slugMap with variants disabled', () => {
+    const config: SanitizedEcommercePluginConfig = {
+      ...baseConfig,
+      slugMap: {},
+    }
+
+    const result = getCollectionSlugMap({ enableVariants: false, sanitizedPluginConfig: config })
+
+    expect(result).toEqual({
+      addresses: 'addresses',
+      carts: 'carts',
+      customers: 'users',
+      orders: 'orders',
+      products: 'products',
+      transactions: 'transactions',
+    })
+  })
+
+  it('should handle undefined slugMap with variants enabled', () => {
     const config: SanitizedEcommercePluginConfig = {
       ...baseConfig,
       slugMap: undefined,
     }
 
-    const result = getCollectionSlugMap({ sanitizedPluginConfig: config })
+    const result = getCollectionSlugMap({ enableVariants: true, sanitizedPluginConfig: config })
 
     expect(result).toEqual({
       addresses: 'addresses',
@@ -161,6 +230,24 @@ describe('getCollectionSlugMap', () => {
       variantOptions: 'variantOptions',
       variants: 'variants',
       variantTypes: 'variantTypes',
+    })
+  })
+
+  it('should handle undefined slugMap with variants disabled', () => {
+    const config: SanitizedEcommercePluginConfig = {
+      ...baseConfig,
+      slugMap: undefined,
+    }
+
+    const result = getCollectionSlugMap({ enableVariants: false, sanitizedPluginConfig: config })
+
+    expect(result).toEqual({
+      addresses: 'addresses',
+      carts: 'carts',
+      customers: 'users',
+      orders: 'orders',
+      products: 'products',
+      transactions: 'transactions',
     })
   })
 })

--- a/packages/plugin-ecommerce/src/utilities/getCollectionSlugMap.ts
+++ b/packages/plugin-ecommerce/src/utilities/getCollectionSlugMap.ts
@@ -1,14 +1,19 @@
 import type { CollectionSlugMap, SanitizedEcommercePluginConfig } from '../types/index.js'
 
 type Props = {
+  enableVariants?: boolean
   sanitizedPluginConfig: SanitizedEcommercePluginConfig
 }
 
 /**
  * Generates a map of collection slugs based on the sanitized plugin configuration.
  * Takes into consideration any collection overrides provided in the plugin.
+ * Variant-related slugs are only included when enableVariants is true.
  */
-export const getCollectionSlugMap = ({ sanitizedPluginConfig }: Props): CollectionSlugMap => {
+export const getCollectionSlugMap = ({
+  enableVariants = false,
+  sanitizedPluginConfig,
+}: Props): CollectionSlugMap => {
   const defaultSlugMap: CollectionSlugMap = {
     addresses: 'addresses',
     carts: 'carts',
@@ -16,9 +21,13 @@ export const getCollectionSlugMap = ({ sanitizedPluginConfig }: Props): Collecti
     orders: 'orders',
     products: 'products',
     transactions: 'transactions',
-    variantOptions: 'variantOptions',
-    variants: 'variants',
-    variantTypes: 'variantTypes',
+    ...(enableVariants
+      ? {
+          variantOptions: 'variantOptions',
+          variants: 'variants',
+          variantTypes: 'variantTypes',
+        }
+      : {}),
   }
 
   const collectionSlugsMap: CollectionSlugMap = defaultSlugMap
@@ -27,5 +36,14 @@ export const getCollectionSlugMap = ({ sanitizedPluginConfig }: Props): Collecti
     collectionSlugsMap.customers = sanitizedPluginConfig.customers.slug
   }
 
-  return { ...collectionSlugsMap, ...(sanitizedPluginConfig.slugMap || {}) }
+  // Only include variant slugs from slugMap if variants are enabled
+  const slugMapOverrides = sanitizedPluginConfig.slugMap || {}
+
+  if (!enableVariants) {
+    delete slugMapOverrides.variantOptions
+    delete slugMapOverrides.variants
+    delete slugMapOverrides.variantTypes
+  }
+
+  return { ...collectionSlugsMap, ...slugMapOverrides }
 }


### PR DESCRIPTION
Fixes an issue with slug map ignoring that variants can be disabled which leads to an error when generating types.

Fixes a bug where we're not threading through the remaining cart data to transactions so any custom fields are lost.