### PR TITLE
chore: fix typos in comments

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
@@ -63,7 +63,7 @@ export const BlocksPlugin: PluginComponent = () => {
               // Insert blocks node BEFORE potentially removing focusNode, as $insertNodeToNearestRoot errors if the focusNode doesn't exist
               $insertNodeToNearestRoot(blockNode)
 
-              // Delete the node it it's an empty paragraph
+              // Delete the node if it's an empty paragraph
               if ($isParagraphNode(focusNode) && !focusNode.__first) {
                 focusNode.remove()
               }

--- a/packages/richtext-lexical/src/features/relationship/client/plugins/index.tsx
+++ b/packages/richtext-lexical/src/features/relationship/client/plugins/index.tsx
@@ -51,7 +51,7 @@ export const RelationshipPlugin: PluginComponent<RelationshipFeatureProps> = ({ 
           // Insert relationship node BEFORE potentially removing focusNode, as $insertNodeToNearestRoot errors if the focusNode doesn't exist
           $insertNodeToNearestRoot(relationshipNode)
 
-          // Delete the node it it's an empty paragraph
+          // Delete the node if it's an empty paragraph
           if ($isParagraphNode(focusNode) && !focusNode.__first) {
             focusNode.remove()
           }

--- a/packages/richtext-lexical/src/features/upload/client/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/plugin/index.tsx
@@ -245,7 +245,7 @@ export const UploadPlugin: PluginComponent<UploadFeaturePropsClient> = ({ client
               // Insert upload node BEFORE potentially removing focusNode, as $insertNodeToNearestRoot errors if the focusNode doesn't exist
               $insertNodeToNearestRoot(uploadNode)
 
-              // Delete the node it it's an empty paragraph
+              // Delete the node if it's an empty paragraph
               if ($isParagraphNode(focusNode) && !focusNode.__first) {
                 focusNode.remove()
               }
@@ -304,7 +304,7 @@ export const UploadPlugin: PluginComponent<UploadFeaturePropsClient> = ({ client
                   // Insert upload node BEFORE potentially removing focusNode, as $insertNodeToNearestRoot errors if the focusNode doesn't exist
                   $insertNodeToNearestRoot(pendingUploadNode)
 
-                  // Delete the node it it's an empty paragraph
+                  // Delete the node if it's an empty paragraph
                   if ($isParagraphNode(focusNode) && !focusNode.__first) {
                     focusNode.remove()
                   }
@@ -377,7 +377,7 @@ export const UploadPlugin: PluginComponent<UploadFeaturePropsClient> = ({ client
                   // Insert upload node BEFORE potentially removing focusNode, as $insertNodeToNearestRoot errors if the focusNode doesn't exist
                   $insertNodeToNearestRoot(pendingUploadNode)
 
-                  // Delete the node it it's an empty paragraph
+                  // Delete the node if it's an empty paragraph
                   if ($isParagraphNode(focusNode) && !focusNode.__first) {
                     focusNode.remove()
                   }

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -134,7 +134,7 @@ export type CreateFormData = (
    */
   options?: {
     /**
-     * If provided, will use this instead of of derived data from the current form state.
+     * If provided, will use this instead of derived data from the current form state.
      */
     data?: Data
     mergeOverrideData?: boolean

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -364,7 +364,7 @@ export function initPageConsoleErrorCatch(page: Page, options?: { ignoreCORS?: b
       !msg.text().includes('Failed to load resource: net::ERR_FAILED')
     ) {
       // "Failed to fetch RSC payload for" happens seemingly randomly. There are lots of issues in the next.js repository for this. Causes e2e tests to fail and flake. Will ignore for now
-      // the the server responded with a status of error happens frequently. Will ignore it for now.
+      // the server responded with a status of error happens frequently. Will ignore it for now.
       // Most importantly, this should catch react errors.
       const { url, lineNumber, columnNumber } = msg.location() || {}
       const locationSuffix = url ? `\n at ${url}:${lineNumber ?? 0}:${columnNumber ?? 0}` : ''


### PR DESCRIPTION
Fix typos in comments:
- `the the server` → `the server`
- `of of derived` → `of derived`
- `it it's` → `if it's` (x5)