### PR TITLE
fix: correct previousValue and value in afterChange when using seo-plugin

### DIFF
--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -314,7 +314,7 @@ export const promise = async ({
       if (isNamedTab) {
         tabSiblingData = (siblingData?.[field.name] ?? {}) as JsonObject
         tabSiblingDoc = (siblingDoc?.[field.name] ?? {}) as JsonObject
-        tabPreviousSiblingDoc = (previousSiblingDoc?.[field.name] ?? {}) as JsonObject
+        tabPreviousSiblingDoc = (previousDoc?.[field.name] ?? {}) as JsonObject
       }
 
       await traverseFields({

--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -307,14 +307,14 @@ export const promise = async ({
     case 'tab': {
       let tabSiblingData = siblingData
       let tabSiblingDoc = siblingDoc
-      let tabPreviousSiblingDoc = previousSiblingDoc
+      let tabPreviousSiblingDoc = { ...previousDoc }
 
       const isNamedTab = tabHasName(field)
 
       if (isNamedTab) {
         tabSiblingData = (siblingData?.[field.name] ?? {}) as JsonObject
         tabSiblingDoc = (siblingDoc?.[field.name] ?? {}) as JsonObject
-        tabPreviousSiblingDoc = (previousDoc?.[field.name] ?? {}) as JsonObject
+        tabPreviousSiblingDoc = (previousSiblingDoc?.[field.name] ?? {}) as JsonObject
       }
 
       await traverseFields({

--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -307,14 +307,14 @@ export const promise = async ({
     case 'tab': {
       let tabSiblingData = siblingData
       let tabSiblingDoc = siblingDoc
-      let tabPreviousSiblingDoc = siblingDoc
+      let tabPreviousSiblingDoc = previousSiblingDoc
 
       const isNamedTab = tabHasName(field)
 
       if (isNamedTab) {
         tabSiblingData = (siblingData?.[field.name] ?? {}) as JsonObject
         tabSiblingDoc = (siblingDoc?.[field.name] ?? {}) as JsonObject
-        tabPreviousSiblingDoc = (previousDoc?.[field.name] ?? {}) as JsonObject
+        tabPreviousSiblingDoc = (previousSiblingDoc?.[field.name] ?? {}) as JsonObject
       }
 
       await traverseFields({

--- a/test/plugin-seo/collections/Pages.ts
+++ b/test/plugin-seo/collections/Pages.ts
@@ -44,6 +44,26 @@ export const Pages: CollectionConfig = {
                 position: 'sidebar',
               },
             },
+            {
+              name: 'featuredMedia',
+              type: 'relationship',
+              relationTo: 'media',
+              hooks: {
+                afterChange: [
+                  ({ previousValue, value }) => {
+                    if (
+                      previousValue === value &&
+                      previousValue !== null &&
+                      previousValue !== undefined
+                    ) {
+                      console.log('IDENTICAL VALUES')
+                    }
+
+                    return value
+                  },
+                ],
+              },
+            },
           ],
         },
       ],

--- a/test/plugin-seo/collections/Pages.ts
+++ b/test/plugin-seo/collections/Pages.ts
@@ -50,13 +50,13 @@ export const Pages: CollectionConfig = {
               relationTo: 'media',
               hooks: {
                 afterChange: [
-                  ({ previousValue, value }) => {
+                  ({ previousValue, value, req }) => {
                     if (
                       previousValue === value &&
                       previousValue !== null &&
                       previousValue !== undefined
                     ) {
-                      console.log('IDENTICAL VALUES')
+                      req.context.identicalCount = ((req.context.identicalCount as number) || 0) + 1
                     }
 
                     return value

--- a/test/plugin-seo/int.spec.ts
+++ b/test/plugin-seo/int.spec.ts
@@ -59,30 +59,24 @@ describe('@payloadcms/plugin-seo', () => {
   })
 
   it('should return different previousValue and value in afterChange hooks when relationship changes', async () => {
-    const consoleSpy = vi.spyOn(console, 'log')
-
     // The existing page has mediaDoc as featuredMedia
     // Update it to mediaDoc2 and we expect to see different previousValue and value in the hook
+    const context: { identicalCount?: number } = {}
     await payload.update({
       collection: 'pages',
       id: page.id,
       data: {
-        // this field has an afterChange hook that will log 'IDENTICAL VALUES'
+        // this field has an afterChange hook that will increment req.context.identicalCount
         // when previousValue === value
         featuredMedia: mediaDoc2.id,
       },
       depth: 0,
+      context,
     })
 
-    const identicalValuesLogs = consoleSpy.mock.calls.filter((call) =>
-      call.some((arg) => typeof arg === 'string' && arg.includes('IDENTICAL VALUES')),
-    )
-
-    // If 'IDENTICAL VALUES' was logged, it means previousValue and value
-    // because we updated the field, they should be different
-    expect(identicalValuesLogs.length).toBe(0)
-
-    consoleSpy.mockRestore()
+    // If identicalCount was incremented, it means previousValue === value incorrectly
+    // Since we updated the field, they should be different, so count should be undefined
+    expect(context.identicalCount).toBeUndefined()
   })
 
   it('should add meta title', async () => {

--- a/test/plugin-seo/int.spec.ts
+++ b/test/plugin-seo/int.spec.ts
@@ -58,23 +58,29 @@ describe('@payloadcms/plugin-seo', () => {
     await payload.destroy()
   })
 
-  it('should return correct value and previousValue data in hooks', async () => {
+  it('should return different previousValue and value in afterChange hooks when relationship changes', async () => {
     const consoleSpy = vi.spyOn(console, 'log')
 
+    // The existing page has mediaDoc as featuredMedia
+    // Update it to mediaDoc2 and we expect to see different previousValue and value in the hook
     await payload.update({
       collection: 'pages',
       id: page.id,
       data: {
+        // this field has an afterChange hook that will log 'IDENTICAL VALUES'
+        // when previousValue === value
         featuredMedia: mediaDoc2.id,
       },
       depth: 0,
     })
 
-    const hookCalls = consoleSpy.mock.calls.filter((call) =>
+    const identicalValuesLogs = consoleSpy.mock.calls.filter((call) =>
       call.some((arg) => typeof arg === 'string' && arg.includes('IDENTICAL VALUES')),
     )
 
-    expect(hookCalls.length).toBe(0)
+    // If 'IDENTICAL VALUES' was logged, it means previousValue and value
+    // because we updated the field, they should be different
+    expect(identicalValuesLogs.length).toBe(0)
 
     consoleSpy.mockRestore()
   })

--- a/test/plugin-seo/int.spec.ts
+++ b/test/plugin-seo/int.spec.ts
@@ -3,7 +3,7 @@ import type { Payload } from 'payload'
 import path from 'path'
 import { getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
 import removeFiles from '../helpers/removeFiles.js'
@@ -17,6 +17,7 @@ let payload: Payload
 describe('@payloadcms/plugin-seo', () => {
   let page = null
   let mediaDoc = null
+  let mediaDoc2 = null
 
   beforeAll(async () => {
     const uploadsDir = path.resolve(dirname, './media')
@@ -38,16 +39,44 @@ describe('@payloadcms/plugin-seo', () => {
       data: {
         title: 'Test page',
         slug: 'test-page',
+        featuredMedia: mediaDoc.id,
         meta: {
           title: 'Test page',
         },
       },
       depth: 0,
     })
+
+    mediaDoc2 = await payload.create({
+      collection: mediaSlug,
+      data: {},
+      file,
+    })
   })
 
   afterAll(async () => {
     await payload.destroy()
+  })
+
+  it('should return correct value and previousValue data in hooks', async () => {
+    const consoleSpy = vi.spyOn(console, 'log')
+
+    await payload.update({
+      collection: 'pages',
+      id: page.id,
+      data: {
+        featuredMedia: mediaDoc2.id,
+      },
+      depth: 0,
+    })
+
+    const hookCalls = consoleSpy.mock.calls.filter((call) =>
+      call.some((arg) => typeof arg === 'string' && arg.includes('IDENTICAL VALUES')),
+    )
+
+    expect(hookCalls.length).toBe(0)
+
+    consoleSpy.mockRestore()
   })
 
   it('should add meta title', async () => {

--- a/test/plugin-seo/payload-types.ts
+++ b/test/plugin-seo/payload-types.ts
@@ -153,6 +153,7 @@ export interface Page {
   title: string;
   excerpt?: string | null;
   slug: string;
+  featuredMedia?: (string | null) | Media;
   meta: {
     title: string;
     description?: string | null;
@@ -337,6 +338,7 @@ export interface PagesSelect<T extends boolean = true> {
   title?: T;
   excerpt?: T;
   slug?: T;
+  featuredMedia?: T;
   meta?:
     | T
     | {
@@ -445,6 +447,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }


### PR DESCRIPTION
### What
Fixes issue where `previousValue` and `value` return identical data in `afterChange` hook when using `tabs` fields. 
This bug was surfaced by the `plugin-seo`, which wraps all fields in a `tabs` field when `tabbedUI` is enabled.

### Why
In `afterChange/promise.ts`, for the `tab` case, we incorrectly assign:

```ts
tabPreviousSiblingDoc = siblingDoc
```

instead of:

```ts
tabPreviousSiblingDoc = {...previousSiblingDoc}
```

This caused hooks to receive the **current document state** for both `previousValue` and `value`.

### Where
Updates the code in `promise.ts`.

#### Testing
Int test added to `plugin-seo`.