### PR TITLE
fix(ui): relationship drawer selection with richText useAsTitle

### DIFF
--- a/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.tsx
+++ b/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.tsx
@@ -17,9 +17,10 @@ export const useCellProps = (): DefaultCellComponentProps | null => React.use(Ce
 export const RenderDefaultCell: React.FC<{
   clientProps: DefaultCellComponentProps
   columnIndex: number
+  customCell?: React.ReactNode
   enableRowSelections?: boolean
   isLinkedColumn?: boolean
-}> = ({ clientProps, columnIndex, isLinkedColumn }) => {
+}> = ({ clientProps, columnIndex, customCell, isLinkedColumn }) => {
   const { drawerSlug, onSelect } = useListDrawerContext()
   const { LinkedCellOverride } = useTableColumns()
 
@@ -28,7 +29,9 @@ export const RenderDefaultCell: React.FC<{
     columnIndex,
   }
 
-  if (isLinkedColumn && drawerSlug) {
+  const isInDrawer = isLinkedColumn && drawerSlug
+
+  if (isInDrawer) {
     propsToPass.className = `${baseClass}__first-cell`
     propsToPass.link = false
     propsToPass.onClick = ({ collectionSlug: rowColl, rowData }) => {
@@ -40,6 +43,50 @@ export const RenderDefaultCell: React.FC<{
         })
       }
     }
+  }
+
+  // When we have a custom cell and we're in a drawer, wrap it with a div that captures clicks
+  // This prevents any nested Link components from navigating and instead triggers selection
+  if (customCell && isInDrawer) {
+    return (
+      <CellPropsContext value={propsToPass}>
+        <button
+          className={`${baseClass}__first-cell`}
+          onClick={(e) => {
+            // Prevent any nested links from navigating
+            e.preventDefault()
+            e.stopPropagation()
+            if (typeof onSelect === 'function') {
+              onSelect({
+                collectionSlug: clientProps.collectionSlug,
+                doc: clientProps.rowData,
+                docID: clientProps.rowData?.id as string,
+              })
+            }
+          }}
+          onClickCapture={(e) => {
+            // Capture phase to intercept link clicks before they navigate
+            e.preventDefault()
+            e.stopPropagation()
+            if (typeof onSelect === 'function') {
+              onSelect({
+                collectionSlug: clientProps.collectionSlug,
+                doc: clientProps.rowData,
+                docID: clientProps.rowData?.id as string,
+              })
+            }
+          }}
+          type="button"
+        >
+          {customCell}
+        </button>
+      </CellPropsContext>
+    )
+  }
+
+  // When we have a custom cell but not in a drawer, render it as-is
+  if (customCell) {
+    return <CellPropsContext value={propsToPass}>{customCell}</CellPropsContext>
   }
 
   return (

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -13,7 +13,6 @@ import type {
 import { MissingEditorProp } from 'payload'
 import { formatAdminURL } from 'payload/shared'
 
-import { RenderCustomComponent } from '../../../elements/RenderCustomComponent/index.js'
 import { RenderServerComponent } from '../../../elements/RenderServerComponent/index.js'
 import {
   DefaultCell,
@@ -219,17 +218,15 @@ export function renderCell({
     }
   }
 
+  // Always use RenderDefaultCell to ensure drawer context is properly handled
+  // Pass CustomCell as a prop so it can be wrapped with drawer click handling when needed
   return (
-    <RenderCustomComponent
-      CustomComponent={CustomCell}
-      Fallback={
-        <RenderDefaultCell
-          clientProps={cellClientProps}
-          columnIndex={columnIndex}
-          enableRowSelections={enableRowSelections}
-          isLinkedColumn={isLinkedColumn}
-        />
-      }
+    <RenderDefaultCell
+      clientProps={cellClientProps}
+      columnIndex={columnIndex}
+      customCell={CustomCell}
+      enableRowSelections={enableRowSelections}
+      isLinkedColumn={isLinkedColumn}
       key={`${rowIndex}-${columnIndex}`}
     />
   )


### PR DESCRIPTION
## Summary
- Fixes relationship drawer selection when the related collection uses a richText field as `useAsTitle`
- When clicking an item in the drawer, it now properly selects the item instead of navigating away to the edit page
- Custom cell components (like Lexical richText cells) now go through `RenderDefaultCell` to ensure drawer context is properly handled

## Problem
When a relationship field uses `appearance: 'drawer'` and the related collection has a richText field as `useAsTitle`, clicking an item in the drawer would navigate to the edit page instead of selecting it.

This happened because custom cell components were rendered via `RenderCustomComponent`, bypassing `RenderDefaultCell` which handles drawer context and click selection.

## Solution
- Modified `RenderDefaultCell` to accept a `customCell` prop for custom cell components
- When a custom cell exists in drawer context, it's wrapped with a button that captures clicks using `onClickCapture` and prevents nested Link components from navigating
- Updated `renderCell.tsx` to always use `RenderDefaultCell`, passing custom cells as a prop

## Test plan
- [x] Navigate to a collection with a relationship field that has `appearance: 'drawer'`
- [x] The related collection should have a richText field as `useAsTitle`
- [x] Click on the relationship field to open the drawer
- [x] Click on an item in the list
- [x] Verify the item is selected and the drawer closes (instead of navigating to edit page)

Fixes #14050