### PR TITLE
feat(db-sqlite): add WAL mode support

### DIFF
--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -51,7 +51,6 @@ export default buildConfig({
 | `autoIncrement`            | Pass `true` to enable SQLite [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for primary keys to ensure the same ID cannot be reused from deleted rows                      |
 | `allowIDOnCreate`          | Set to `true` to use the `id` passed in data on the create API operations without using a custom ID field.                                                                       |
 | `blocksAsJSON`             | Store blocks as a JSON column instead of using the relational structure which can improve performance with a large amount of blocks                                              |
-| `busyTimeout`              | Maximum time in milliseconds to wait when the database is locked. Default is `0`.                                                                                                |
 | `wal`                      | Enable Write-Ahead Logging (WAL) mode for improved performance and concurrency. [More Details](#wal-mode)                                                                        |
 
 ## Access to Drizzle

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -51,6 +51,7 @@ export default buildConfig({
 | `autoIncrement`            | Pass `true` to enable SQLite [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for primary keys to ensure the same ID cannot be reused from deleted rows                      |
 | `allowIDOnCreate`          | Set to `true` to use the `id` passed in data on the create API operations without using a custom ID field.                                                                       |
 | `blocksAsJSON`             | Store blocks as a JSON column instead of using the relational structure which can improve performance with a large amount of blocks                                              |
+| `busyTimeout`              | Maximum time in milliseconds to wait when the database is locked. Default is `0`.                                                                                                |
 | `wal`                      | Enable Write-Ahead Logging (WAL) mode for improved performance and concurrency. [More Details](#wal-mode)                                                                        |
 
 ## Access to Drizzle

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -51,6 +51,7 @@ export default buildConfig({
 | `autoIncrement`            | Pass `true` to enable SQLite [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for primary keys to ensure the same ID cannot be reused from deleted rows                      |
 | `allowIDOnCreate`          | Set to `true` to use the `id` passed in data on the create API operations without using a custom ID field.                                                                       |
 | `blocksAsJSON`             | Store blocks as a JSON column instead of using the relational structure which can improve performance with a large amount of blocks                                              |
+| `wal`                      | Enable Write-Ahead Logging (WAL) mode for improved performance and concurrency. [More Details](#wal-mode)                                                                        |
 
 ## Access to Drizzle
 
@@ -336,3 +337,30 @@ export default buildConfig({
 ```
 
 You can then verify that they're being used by checking the logs in your Cloudflare dashboard. You should see logs indicating whether a read or write operation was performed, and on which database instance.
+
+### WAL Mode
+
+You can enable Write-Ahead Logging (WAL) mode for improved performance and concurrency by passing the `wal` option to the SQLite adapter.
+
+```ts title="Example SQLite Adapter with WAL"
+import { sqliteAdapter } from '@payloadcms/db-sqlite'
+export default buildConfig({
+  // Your config goes here
+  collections: [
+    // Collections go here
+  ],
+  // Configure the SQLite adapter here
+  db: sqliteAdapter({
+    wal: true, // Enable WAL mode with default settings
+    client: {
+      url: process.env.DATABASE_URL,
+    },
+  }),
+})
+```
+
+Settings for the `wal` option:
+| Setting | Description | Default |
+| ------------------ | ------------------------------------------------------------------------------------------------- | ----------------- |
+| `journalSizeLimit` | Max size of the WAL file before checkpointing to the main DB. | `67108864` (64MB) |
+| `synchronous` | WAL sync mode: `EXTRA`, `FULL`, `NORMAL`, `OFF`. Controls balance of performance vs. data safety. | `'FULL'` |

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -19,10 +19,6 @@ export const connect: Connect = async function connect(
     if (!this.client) {
       this.client = createClient(this.clientConfig)
 
-      if (this.busyTimeout > 0) {
-        await this.client.execute(`PRAGMA busy_timeout = ${this.busyTimeout};`)
-      }
-
       if (this.wal) {
         const result = await this.client.execute('PRAGMA journal_mode;')
 

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -19,6 +19,10 @@ export const connect: Connect = async function connect(
     if (!this.client) {
       this.client = createClient(this.clientConfig)
 
+      if (this.busyTimeout > 0) {
+        await this.client.execute(`PRAGMA busy_timeout = ${this.busyTimeout};`)
+      }
+
       if (this.wal) {
         const result = await this.client.execute('PRAGMA journal_mode;')
 

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -115,7 +115,6 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       blocksAsJSON: args.blocksAsJSON ?? false,
-      busyTimeout: args.busyTimeout ?? 0,
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       client: undefined,
       clientConfig: args.client,

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -115,6 +115,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       blocksAsJSON: args.blocksAsJSON ?? false,
+      busyTimeout: args.busyTimeout ?? 0,
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       client: undefined,
       clientConfig: args.client,

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -57,7 +57,7 @@ import { like, notLike } from 'drizzle-orm'
 import { createDatabaseAdapter, defaultBeginTransaction, findMigrationDir } from 'payload'
 import { fileURLToPath } from 'url'
 
-import type { Args, SQLiteAdapter } from './types.js'
+import type { Args, SQLiteAdapter, WalConfig } from './types.js'
 
 import { connect } from './connect.js'
 
@@ -85,6 +85,28 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       like,
       not_like: notLike,
     } as unknown as Operators
+
+    let wal: false | WalConfig = false
+
+    const defaultJournalSizeLimit = 67108864 // 64MB
+
+    if (args.wal && !args.client.url.startsWith('file:')) {
+      payload.logger.warn(
+        '[db-sqlite] WAL mode is not supported for in-memory or TCP database connections. Disabling WAL.',
+      )
+      args.wal = false
+    }
+
+    if (!args.wal) {
+      wal = false
+    } else if (args.wal === true) {
+      wal = { journalSizeLimit: defaultJournalSizeLimit, synchronous: 'FULL' }
+    } else {
+      wal = {
+        journalSizeLimit: args.wal.journalSizeLimit ?? defaultJournalSizeLimit,
+        synchronous: args.wal.synchronous ?? 'FULL',
+      }
+    }
 
     return createDatabaseAdapter<SQLiteAdapter>({
       name: 'sqlite',
@@ -116,6 +138,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       logger: args.logger,
       operators,
       prodMigrations: args.prodMigrations,
+      wal,
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       push: args.push,
       rawRelations: {},

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -53,6 +53,7 @@ export type Args = {
    */
   beforeSchemaInit?: SQLiteSchemaHook[]
   client: Config
+  wal?: boolean | Partial<WalConfig>
 } & BaseSQLiteArgs
 
 export type GenericColumns = {
@@ -122,10 +123,33 @@ type ResolveSchemaType<T> = 'schema' extends keyof T
 
 type Drizzle = { $client: Client } & LibSQLDatabase<ResolveSchemaType<GeneratedDatabaseSchema>>
 
+export type WalConfig = {
+  /**
+   * Maximum size of the WAL file before it is written back to the main database.
+   * @default 67108864 (64MB)
+   */
+  journalSizeLimit: number
+
+  /**
+   * Controls how often data is synced to disk:
+   * - 'EXTRA': Highest data safety
+   * - 'FULL': Safe and balanced
+   * - 'NORMAL': Moderate safety, better performance
+   * - 'OFF': Fastest, but risk of data loss
+   *
+   * @default 'FULL'
+   */
+  synchronous: 'EXTRA' | 'FULL' | 'NORMAL' | 'OFF'
+}
+
 export type SQLiteAdapter = {
   client: Client
   clientConfig: Args['client']
   drizzle: Drizzle
+  /**
+   * Write-Ahead Logging (WAL) configuration. If false or not set, WAL mode is disabled.
+   */
+  wal: false | WalConfig
 } & BaseSQLiteAdapter &
   SQLiteDrizzleAdapter
 

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -52,11 +52,6 @@ export type Args = {
    * To generate Drizzle schema from the database, see [Drizzle Kit introspection](https://orm.drizzle.team/kit-docs/commands#introspect--pull)
    */
   beforeSchemaInit?: SQLiteSchemaHook[]
-  /**
-   * Maximum time in milliseconds to wait when the database is locked.
-   * @default 0
-   */
-  busyTimeout?: number
   client: Config
   wal?: boolean | Partial<WalConfig>
 } & BaseSQLiteArgs
@@ -148,7 +143,6 @@ export type WalConfig = {
 }
 
 export type SQLiteAdapter = {
-  busyTimeout: number
   client: Client
   clientConfig: Args['client']
   drizzle: Drizzle
@@ -229,7 +223,6 @@ declare module 'payload' {
     extends Omit<Args, 'idType' | 'logger' | 'migrationDir' | 'pool'>,
       DrizzleAdapter {
     beginTransaction: (options?: SQLiteTransactionConfig) => Promise<null | number | string>
-    busyTimeout: number
     drizzle: Drizzle
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -52,6 +52,11 @@ export type Args = {
    * To generate Drizzle schema from the database, see [Drizzle Kit introspection](https://orm.drizzle.team/kit-docs/commands#introspect--pull)
    */
   beforeSchemaInit?: SQLiteSchemaHook[]
+  /**
+   * Maximum time in milliseconds to wait when the database is locked.
+   * @default 0
+   */
+  busyTimeout?: number
   client: Config
   wal?: boolean | Partial<WalConfig>
 } & BaseSQLiteArgs
@@ -143,6 +148,7 @@ export type WalConfig = {
 }
 
 export type SQLiteAdapter = {
+  busyTimeout: number
   client: Client
   clientConfig: Args['client']
   drizzle: Drizzle
@@ -223,6 +229,7 @@ declare module 'payload' {
     extends Omit<Args, 'idType' | 'logger' | 'migrationDir' | 'pool'>,
       DrizzleAdapter {
     beginTransaction: (options?: SQLiteTransactionConfig) => Promise<null | number | string>
+    busyTimeout: number
     drizzle: Drizzle
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name


### PR DESCRIPTION
Adds support for [WAL](https://sqlite.org/wal.html) mode.
Fixes https://github.com/payloadcms/payload/issues/9290

```ts title="Example SQLite Adapter with WAL"
import { sqliteAdapter } from '@payloadcms/db-sqlite'
export default buildConfig({
  // Your config goes here
  collections: [
    // Collections go here
  ],
  // Configure the SQLite adapter here
  db: sqliteAdapter({
    wal: true, // Enable WAL mode with default settings,
    wal: { synchronous: 'NORMAL' }, // with configurable settings
    client: {
      url: process.env.DATABASE_URL,
    },
  }),
})
```

Settings for the `wal` option:
| Setting | Description | Default |
| ------------------ | ------------------------------------------------------------------------------------------------- | ----------------- |
| `journalSizeLimit` | Max size of the WAL file before checkpointing to the main DB. | `67108864` (64MB) |
| `synchronous` | WAL sync mode: `EXTRA`, `FULL`, `NORMAL`, `OFF`. Controls balance of performance vs. data safety. | `'FULL'` |
