### PR TITLE
fix(drizzle): d1 sqlite IN querying of `id` when any other join is present in the query

### DIFF
--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -1,7 +1,7 @@
 import type { SQL, Table } from 'drizzle-orm'
 import type { FlattenedField, Operator, Sort, Where } from 'payload'
 
-import { and, isNotNull, isNull, ne, notInArray, or, sql } from 'drizzle-orm'
+import { and, getTableName, isNotNull, isNull, ne, notInArray, or, sql } from 'drizzle-orm'
 import { PgUUID } from 'drizzle-orm/pg-core'
 import { APIError, QueryError } from 'payload'
 import { validOperatorSet } from 'payload/shared'
@@ -423,7 +423,7 @@ export function parseParams({
 
                   constraints.push(
                     sql.raw(
-                      `${resolvedColumn.name} ${operator === 'in' ? 'IN' : 'NOT IN'} (${queryValue
+                      `"${getTableName(resolvedColumn.table)}"."${resolvedColumn.name}" ${operator === 'in' ? 'IN' : 'NOT IN'} (${queryValue
                         .map((e) => {
                           if (e === null) {
                             return `NULL`

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -108,6 +108,20 @@ export const getConfig: () => Partial<Config> = () => ({
       ],
     },
     {
+      slug: 'simple-localized',
+      fields: [
+        {
+          type: 'text',
+          localized: true,
+          name: 'text',
+        },
+        {
+          type: 'number',
+          name: 'number',
+        },
+      ],
+    },
+    {
       slug: 'categories-custom-id',
       versions: { drafts: true },
       fields: [

--- a/test/database/sqlite-bound-parameters-limit.int.spec.ts
+++ b/test/database/sqlite-bound-parameters-limit.int.spec.ts
@@ -2,97 +2,130 @@ import type { Payload } from 'payload'
 
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, expect, it } from 'vitest'
 
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
+import { describe } from '../helpers/vitest.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-const describeSqlite = process.env.PAYLOAD_DATABASE?.startsWith('sqlite') ? describe : describe.skip
-
 let payload: Payload
 
-describeSqlite('database - sqlite bound parameters limit', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should not use bound parameters for where querying on ID with IN if limitedBoundParameters: true', async () => {
-    const defaultExecute = payload.db.drizzle.$client.execute.bind(payload.db.drizzle.$client)
-
-    // Limit bounds parameters length
-    payload.db.drizzle.$client.execute = async function execute(...args) {
-      const res = await defaultExecute(...args)
-      const [{ args: boundParameters }] = args as [{ args: any[] }]
-
-      if (boundParameters.length > 100) {
-        throw new Error('Exceeded limit of bound parameters!')
-      }
-      return res
-    }
-
-    payload.db.limitedBoundParameters = false
-
-    const IN = Array.from({ length: 300 }, (_, i) => i)
-
-    // Should fail here because too the length exceeds the limit
-    await expect(
-      payload.find({
-        collection: 'simple',
-        pagination: false,
-        where: { id: { in: IN } },
-      }),
-    ).rejects.toBeTruthy()
-
-    // Should fail here because too the length exceeds the limit
-    await expect(
-      payload.find({
-        collection: 'simple',
-        pagination: false,
-        where: { id: { not_in: IN } },
-      }),
-    ).rejects.toBeTruthy()
-
-    payload.db.limitedBoundParameters = true
-
-    // Should not fail because limitedBoundParameters: true
-    await expect(
-      payload.find({
-        collection: 'simple',
-        pagination: false,
-        where: { id: { in: IN } },
-      }),
-    ).resolves.toBeTruthy()
-
-    // Should not fail because limitedBoundParameters: true
-    await expect(
-      payload.find({
-        collection: 'simple',
-        pagination: false,
-        where: { id: { not_in: IN } },
-      }),
-    ).resolves.toBeTruthy()
-
-    // Verify that "in" still works properly
-
-    const docs = await Promise.all(
-      Array.from({ length: 300 }, () => payload.create({ collection: 'simple', data: {} })),
-    )
-
-    const res = await payload.find({
-      collection: 'simple',
-      pagination: false,
-      where: { id: { in: docs.map((e) => e.id) } },
+describe(
+  'database - sqlite bound parameters limit',
+  { db: (type) => type.startsWith('sqlite') },
+  () => {
+    beforeAll(async () => {
+      ;({ payload } = await initPayloadInt(dirname))
     })
 
-    expect(res.totalDocs).toBe(300)
-    for (const docInRes of res.docs) {
-      expect(docs.some((doc) => doc.id === docInRes.id)).toBeTruthy()
-    }
-  })
-})
+    afterAll(async () => {
+      await payload.destroy()
+    })
+
+    it('should not use bound parameters for where querying on ID with IN if limitedBoundParameters: true', async () => {
+      const defaultExecute = payload.db.drizzle.$client.execute.bind(payload.db.drizzle.$client)
+
+      // Limit bounds parameters length
+      payload.db.drizzle.$client.execute = async function execute(...args) {
+        const res = await defaultExecute(...args)
+        const [{ args: boundParameters }] = args as [{ args: any[] }]
+
+        if (boundParameters.length > 100) {
+          throw new Error('Exceeded limit of bound parameters!')
+        }
+        return res
+      }
+
+      payload.db.limitedBoundParameters = false
+
+      const IN = Array.from({ length: 300 }, (_, i) => i)
+
+      // Should fail here because too the length exceeds the limit
+      await expect(
+        payload.find({
+          collection: 'simple',
+          pagination: false,
+          where: { id: { in: IN } },
+        }),
+      ).rejects.toBeTruthy()
+
+      // Should fail here because too the length exceeds the limit
+      await expect(
+        payload.find({
+          collection: 'simple',
+          pagination: false,
+          where: { id: { not_in: IN } },
+        }),
+      ).rejects.toBeTruthy()
+
+      payload.db.limitedBoundParameters = true
+
+      // Should not fail because limitedBoundParameters: true
+      await expect(
+        payload.find({
+          collection: 'simple',
+          pagination: false,
+          where: { id: { in: IN } },
+        }),
+      ).resolves.toBeTruthy()
+
+      // Should not fail because limitedBoundParameters: true
+      await expect(
+        payload.find({
+          collection: 'simple',
+          pagination: false,
+          where: { id: { not_in: IN } },
+        }),
+      ).resolves.toBeTruthy()
+
+      // Verify that "in" still works properly
+
+      const docs = await Promise.all(
+        Array.from({ length: 300 }, () => payload.create({ collection: 'simple', data: {} })),
+      )
+
+      const res = await payload.find({
+        collection: 'simple',
+        pagination: false,
+        where: { id: { in: docs.map((e) => e.id) } },
+      })
+
+      expect(res.totalDocs).toBe(300)
+      for (const docInRes of res.docs) {
+        expect(docs.some((doc) => doc.id === docInRes.id)).toBeTruthy()
+      }
+    })
+
+    it('should avoid ambiguous column name errors when limitedBoundParameters: true and multiple joins are present', async () => {
+      payload.db.limitedBoundParameters = true
+
+      const simpleLocalizedDoc = await payload.create({
+        collection: 'simple-localized',
+        data: {
+          text: 'Test',
+        },
+        locale: 'en',
+      })
+
+      const res = await payload.find({
+        collection: 'simple-localized',
+        pagination: false,
+        where: {
+          text: {
+            equals: 'Test',
+          },
+          id: {
+            in: [simpleLocalizedDoc.id],
+          },
+        },
+        locale: 'en',
+      })
+
+      expect(res.totalDocs).toBe(1)
+      expect(res.docs[0].id).toBe(simpleLocalizedDoc.id)
+      expect(res.docs[0].text).toBe('Test')
+    })
+  },
+)


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15196