### PR TITLE
feat: extend strictDraftTypes to all draft operations

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -136,7 +136,7 @@ The following options are available:
 | **`autoGenerate`**     | By default, Payload will auto-generate TypeScript interfaces for all collections and globals that your config defines. Opt out by setting `typescript.autoGenerate: false`. [More details](../typescript/overview).                                         |
 | **`declare`**          | By default, Payload adds a `declare` block to your generated types, which makes sure that Payload uses your generated types for all Local API methods. Opt out by setting `typescript.declare: false`.                                                      |
 | **`outputFile`**       | Control the output path and filename of Payload's auto-generated types by defining the `typescript.outputFile` property to a full, absolute path.                                                                                                           |
-| **`strictDraftTypes`** | Enable strict type safety for draft mode queries. When enabled, `find` operations with `draft: true` will type required fields as optional, since validation is skipped for drafts. Defaults to `false`. **This will become the default behavior in v4.0.** |
+| **`strictDraftTypes`** | Enable strict type safety for draft mode. When enabled: (1) Query operations (`find`, `findByID`) with `draft: true` will type required fields as optional, since validation is skipped for drafts. (2) The `draft` property is forbidden for collections without drafts in create operations. (3) Create operations enforce proper data requirements via discriminated unions. Defaults to `false`. **This will become the default behavior in v4.0.** |
 
 ## Config Location
 

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -38,6 +38,7 @@ import type {
   CollectionAdminCustom,
   CollectionCustom,
   CollectionSlug,
+  GeneratedTypes,
   JsonObject,
   RequestContext,
   TypedAuthOperations,
@@ -67,6 +68,46 @@ import type {
 export type DataFromCollectionSlug<TSlug extends CollectionSlug> = TypedCollection[TSlug]
 
 export type SelectFromCollectionSlug<TSlug extends CollectionSlug> = TypedCollectionSelect[TSlug]
+
+/**
+ * Collection slugs that do NOT have drafts enabled.
+ * Used to disallow draft option only for collections that definitely don't have drafts.
+ * In generated types, only collections with versions + drafts include the internal `_status` field.
+ */
+export type CollectionsWithoutDrafts = {
+  [TSlug in CollectionSlug]: DataFromCollectionSlug<TSlug> extends { _status?: any }
+    ? never
+    : TSlug
+}[CollectionSlug]
+
+/**
+ * Reusable type for draft flag in read/query operations.
+ * When strictDraftTypes is enabled:
+ * - For collections without drafts: draft property is forbidden
+ * - For collections with drafts or generic slugs: draft property is allowed
+ */
+export type DraftFlagFromCollectionSlug<TSlug extends CollectionSlug> = GeneratedTypes extends {
+  strictDraftTypes: true
+}
+  ? TSlug extends CollectionsWithoutDrafts
+    ? {
+        /**
+         * This collection does not have drafts enabled.
+         */
+        draft?: never
+      }
+    : {
+        /**
+         * Whether the document(s) should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+         */
+        draft?: boolean
+      }
+  : {
+      /**
+       * Whether the document(s) should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+       */
+      draft?: boolean
+    }
 
 export type AuthOperationsFromCollectionSlug<TSlug extends CollectionSlug> =
   TypedAuthOperations[TSlug]

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -70,21 +70,16 @@ export type DataFromCollectionSlug<TSlug extends CollectionSlug> = TypedCollecti
 export type SelectFromCollectionSlug<TSlug extends CollectionSlug> = TypedCollectionSelect[TSlug]
 
 /**
- * Collection slugs that do NOT have drafts enabled.
- * Used to disallow draft option only for collections that definitely don't have drafts.
- * In generated types, only collections with versions + drafts include the internal `_status` field.
+ * Collection slugs that do not have drafts enabled.
+ * Detects collections without drafts by checking for the absence of the `_status` field.
  */
 export type CollectionsWithoutDrafts = {
-  [TSlug in CollectionSlug]: DataFromCollectionSlug<TSlug> extends { _status?: any }
-    ? never
-    : TSlug
+  [TSlug in CollectionSlug]: DataFromCollectionSlug<TSlug> extends { _status?: any } ? never : TSlug
 }[CollectionSlug]
 
 /**
- * Reusable type for draft flag in read/query operations.
- * When strictDraftTypes is enabled:
- * - For collections without drafts: draft property is forbidden
- * - For collections with drafts or generic slugs: draft property is allowed
+ * Conditionally allows or forbids the `draft` property based on collection configuration.
+ * When `strictDraftTypes` is enabled, the `draft` property is forbidden on collections without drafts.
  */
 export type DraftFlagFromCollectionSlug<TSlug extends CollectionSlug> = GeneratedTypes extends {
   strictDraftTypes: true
@@ -92,7 +87,7 @@ export type DraftFlagFromCollectionSlug<TSlug extends CollectionSlug> = Generate
   ? TSlug extends CollectionsWithoutDrafts
     ? {
         /**
-         * This collection does not have drafts enabled.
+         * The `draft` property is not allowed because this collection does not have `versions.drafts` enabled.
          */
         draft?: never
       }

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -111,55 +111,55 @@ type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
   user?: Document
 } & Pick<FindOptions<TSlug, TSelect>, 'select'>
 
-export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> =
-  GeneratedTypes extends { strictDraftTypes: true }
-    ? // Strict mode: enforce draft constraints
-      CollectionsWithoutDrafts extends TSlug
+export type Options<
+  TSlug extends CollectionSlug,
+  TSelect extends SelectType,
+> = GeneratedTypes extends { strictDraftTypes: true }
+  ? CollectionsWithoutDrafts extends TSlug
+    ? {
+        /**
+         * The data for the document to create.
+         */
+        data: DataFromCollectionSlug<TSlug>
+        /**
+         * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+         */
+        draft?: boolean
+      } & BaseOptions<TSlug, TSelect>
+    : TSlug extends CollectionsWithoutDrafts
       ? {
-          // Generic case: relaxed for backward compatibility
+          data: RequiredDataFromCollectionSlug<TSlug>
           /**
-           * The data for the document to create.
+           * The `draft` property is not allowed because this collection does not have `versions.drafts` enabled.
            */
-          data: DataFromCollectionSlug<TSlug>
-          /**
-           * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-           */
-          draft?: boolean
+          draft?: never
         } & BaseOptions<TSlug, TSelect>
-      : TSlug extends CollectionsWithoutDrafts
-        ? {
-            // Concrete non-draft collection: require full data, forbid draft
-            data: RequiredDataFromCollectionSlug<TSlug>
-            draft?: never
-          } & BaseOptions<TSlug, TSelect>
-        : {
-            // Concrete draft-enabled collection: discriminated union for strictness
-          } & (
-              | {
-                  /**
-                   * The data for the document to create.
-                   */
-                  data: RequiredDataFromCollectionSlug<TSlug>
-                  /**
-                   * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-                   * Omit this property or set to `false` to create a published document.
-                   */
-                  draft?: false
-                }
-              | {
-                  /**
-                   * The data for the document to create.
-                   * When creating a draft, required fields are optional as validation is skipped by default.
-                   */
-                  data: DraftDataFromCollectionSlug<TSlug>
-                  /**
-                   * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-                   */
-                  draft: true
-                }
-            ) &
-            BaseOptions<TSlug, TSelect>
-    : // Non-strict mode: backward compatible (original behavior)
+      : (
+          | {
+              /**
+               * The data for the document to create.
+               */
+              data: RequiredDataFromCollectionSlug<TSlug>
+              /**
+               * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+               * Omit this property or set to `false` to create a published document.
+               */
+              draft?: false
+            }
+          | {
+              /**
+               * The data for the document to create.
+               * When creating a draft, required fields are optional as validation is skipped by default.
+               */
+              data: DraftDataFromCollectionSlug<TSlug>
+              /**
+               * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+               */
+              draft: true
+            }
+        ) &
+          BaseOptions<TSlug, TSelect>
+  :
       | ({
           /**
            * The data for the document to create.

--- a/packages/payload/src/collections/operations/local/duplicate.ts
+++ b/packages/payload/src/collections/operations/local/duplicate.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
 import type {
+  DraftFlagFromCollectionSlug,
   RequiredDataFromCollectionSlug,
   SelectFromCollectionSlug,
 } from '../../config/types.js'
@@ -19,7 +20,7 @@ import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { duplicateOperation } from '../duplicate.js'
 
-export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
   /**
    * the Collection slug to operate against.
    */
@@ -44,10 +45,6 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
    * @default false
    */
   disableTransaction?: boolean
-  /**
-   * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -90,6 +87,9 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
    */
   user?: Document
 } & Pick<FindOptions<TSlug, TSelect>, 'select'>
+
+export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> =
+  BaseOptions<TSlug, TSelect> & DraftFlagFromCollectionSlug<TSlug>
 
 export async function duplicateLocal<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -1,6 +1,7 @@
 import type { PaginatedDocs } from '../../../database/types.js'
 import type {
   CollectionSlug,
+  GeneratedTypes,
   JoinQuery,
   Payload,
   PayloadTypes,
@@ -19,13 +20,16 @@ import type {
   Where,
 } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
-import type { SelectFromCollectionSlug } from '../../config/types.js'
+import type {
+  DraftFlagFromCollectionSlug,
+  SelectFromCollectionSlug,
+} from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findOperation } from '../find.js'
 
-export type FindOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+type BaseFindOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
   /**
    * the Collection slug to operate against.
    */
@@ -50,10 +54,6 @@ export type FindOptions<TSlug extends CollectionSlug, TSelect extends SelectType
    * When set to `true`, errors will not be thrown.
    */
   disableErrors?: boolean
-  /**
-   * Whether the documents should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -178,6 +178,13 @@ export type FindOptions<TSlug extends CollectionSlug, TSelect extends SelectType
    */
   where?: Where
 }
+
+export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> =
+  BaseFindOptions<TSlug, TSelect> & DraftFlagFromCollectionSlug<TSlug>
+
+// Backward compatibility export
+export type FindOptions<TSlug extends CollectionSlug, TSelect extends SelectType> =
+  Options<TSlug, TSelect>
 
 export async function findLocal<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -16,13 +16,16 @@ import type {
   TransformCollectionWithSelect,
 } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
-import type { SelectFromCollectionSlug } from '../../config/types.js'
+import type {
+  DraftFlagFromCollectionSlug,
+  SelectFromCollectionSlug,
+} from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { type FindByIDArgs, findByIDOperation } from '../findByID.js'
 
-export type Options<
+type BaseFindByIDOptions<
   TSlug extends CollectionSlug,
   TDisableErrors extends boolean,
   TSelect extends SelectType,
@@ -57,10 +60,6 @@ export type Options<
    * `null` will be returned instead, if the document on this ID was not found.
    */
   disableErrors?: TDisableErrors
-  /**
-   * Whether the document should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -117,6 +116,12 @@ export type Options<
   user?: Document
 } & Pick<FindByIDArgs, 'flattenLocales'> &
   Pick<FindOptions<TSlug, TSelect>, 'select'>
+
+export type Options<
+  TSlug extends CollectionSlug,
+  TDisableErrors extends boolean,
+  TSelect extends SelectType,
+> = BaseFindByIDOptions<TSlug, TDisableErrors, TSelect> & DraftFlagFromCollectionSlug<TSlug>
 
 export async function findByIDLocal<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -8,13 +8,16 @@ import type {
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
 import type { TypeWithVersion } from '../../../versions/types.js'
-import type { DataFromCollectionSlug } from '../../config/types.js'
+import type {
+  DataFromCollectionSlug,
+  DraftFlagFromCollectionSlug,
+} from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findVersionByIDOperation } from '../findVersionByID.js'
 
-export type Options<TSlug extends CollectionSlug> = {
+type BaseOptions<TSlug extends CollectionSlug> = {
   /**
    * the Collection slug to operate against.
    */
@@ -35,10 +38,6 @@ export type Options<TSlug extends CollectionSlug> = {
    * `null` will be returned instead, if the document on this ID was not found.
    */
   disableErrors?: boolean
-  /**
-   * Whether the document should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -85,6 +84,9 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   user?: Document
 } & Pick<FindOptions<TSlug, SelectType>, 'select'>
+
+export type Options<TSlug extends CollectionSlug> =
+  BaseOptions<TSlug> & DraftFlagFromCollectionSlug<TSlug>
 
 export async function findVersionByIDLocal<TSlug extends CollectionSlug>(
   payload: Payload,

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -16,13 +16,16 @@ import type {
 } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
 import type { TypeWithVersion } from '../../../versions/types.js'
-import type { DataFromCollectionSlug } from '../../config/types.js'
+import type {
+  DataFromCollectionSlug,
+  DraftFlagFromCollectionSlug,
+} from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findVersionsOperation } from '../findVersions.js'
 
-export type Options<TSlug extends CollectionSlug> = {
+type BaseOptions<TSlug extends CollectionSlug> = {
   /**
    * the Collection slug to operate against.
    */
@@ -38,10 +41,6 @@ export type Options<TSlug extends CollectionSlug> = {
    * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
    */
   depth?: number
-  /**
-   * Whether the documents should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -110,6 +109,9 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   where?: Where
 } & Pick<FindOptions<TSlug, SelectType>, 'select'>
+
+export type Options<TSlug extends CollectionSlug> =
+  BaseOptions<TSlug> & DraftFlagFromCollectionSlug<TSlug>
 
 export async function findVersionsLocal<TSlug extends CollectionSlug>(
   payload: Payload,

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -7,13 +7,16 @@ import type {
 } from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
-import type { DataFromCollectionSlug } from '../../config/types.js'
+import type {
+  DataFromCollectionSlug,
+  DraftFlagFromCollectionSlug,
+} from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { restoreVersionOperation } from '../restoreVersion.js'
 
-export type Options<TSlug extends CollectionSlug> = {
+type BaseOptions<TSlug extends CollectionSlug> = {
   /**
    * the Collection slug to operate against.
    */
@@ -29,10 +32,6 @@ export type Options<TSlug extends CollectionSlug> = {
    * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
    */
   depth?: number
-  /**
-   * Whether the document should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -70,6 +69,9 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   user?: Document
 } & Pick<FindOptions<TSlug, SelectType>, 'select'>
+
+export type Options<TSlug extends CollectionSlug> =
+  BaseOptions<TSlug> & DraftFlagFromCollectionSlug<TSlug>
 
 export async function restoreVersionLocal<TSlug extends CollectionSlug>(
   payload: Payload,

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -20,6 +20,7 @@ import type { File } from '../../../uploads/types.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
 import type {
   BulkOperationResult,
+  DraftFlagFromCollectionSlug,
   RequiredDataFromCollectionSlug,
   SelectFromCollectionSlug,
 } from '../../config/types.js'
@@ -60,10 +61,6 @@ export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType
    * @default false
    */
   disableTransaction?: boolean
-  /**
-   * Update documents to a draft.
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -163,7 +160,8 @@ export type ByIDOptions<
    * A filter [query](https://payloadcms.com/docs/queries/overview)
    */
   where?: never
-} & BaseOptions<TSlug, TSelect>
+} & BaseOptions<TSlug, TSelect> &
+  DraftFlagFromCollectionSlug<TSlug>
 
 export type ManyOptions<
   TSlug extends CollectionSlug,
@@ -187,7 +185,8 @@ export type ManyOptions<
    * A filter [query](https://payloadcms.com/docs/queries/overview)
    */
   where: Where
-} & BaseOptions<TSlug, TSelect>
+} & BaseOptions<TSlug, TSelect> &
+  DraftFlagFromCollectionSlug<TSlug>
 
 export type Options<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1476,11 +1476,10 @@ export type Config = {
     >
 
     /**
-     * Enable strict type safety for draft mode queries and create operations.
-     * When enabled:
-     * - Find operations with draft: true will type required fields as optional
-     * - The `draft` property is forbidden for collections without drafts in create operations
-     * - Discriminated unions enforce proper data requirements for draft-enabled collections
+     * Enable strict type safety for draft operations. When enabled, the `draft` parameter is forbidden
+     * on collections without drafts, and query results with `draft: true` type required fields as optional.
+     * This prevents invalid draft usage at compile time and ensures type correctness across all Local API operations.
+     *
      * @default false
      * @todo Remove in v4. Strict draft types will become the default behavior.
      */

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1476,8 +1476,11 @@ export type Config = {
     >
 
     /**
-     * Enable strict type safety for draft mode queries.
-     * When enabled, find operations with draft: true will type required fields as optional.
+     * Enable strict type safety for draft mode queries and create operations.
+     * When enabled:
+     * - Find operations with draft: true will type required fields as optional
+     * - The `draft` property is forbidden for collections without drafts in create operations
+     * - Discriminated unions enforce proper data requirements for draft-enabled collections
      * @default false
      * @todo Remove in v4. Strict draft types will become the default behavior.
      */

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -41,19 +41,16 @@ export type DataFromGlobalSlug<TSlug extends GlobalSlug> = TypedGlobal[TSlug]
 export type SelectFromGlobalSlug<TSlug extends GlobalSlug> = TypedGlobalSelect[TSlug]
 
 /**
- * Global slugs that do NOT have drafts enabled.
- * Used to disallow draft option only for globals that definitely don't have drafts.
- * In generated types, only globals with versions + drafts include the internal `_status` field.
+ * Global slugs that do not have drafts enabled.
+ * Detects globals without drafts by checking for the absence of the `_status` field.
  */
 export type GlobalsWithoutDrafts = {
   [TSlug in GlobalSlug]: DataFromGlobalSlug<TSlug> extends { _status?: any } ? never : TSlug
 }[GlobalSlug]
 
 /**
- * Reusable type for draft flag in global operations.
- * When strictDraftTypes is enabled:
- * - For globals without drafts: draft property is forbidden
- * - For globals with drafts or generic slugs: draft property is allowed
+ * Conditionally allows or forbids the `draft` property based on global configuration.
+ * When `strictDraftTypes` is enabled, the `draft` property is forbidden on globals without drafts.
  */
 export type DraftFlagFromGlobalSlug<TSlug extends GlobalSlug> = GeneratedTypes extends {
   strictDraftTypes: true
@@ -61,7 +58,7 @@ export type DraftFlagFromGlobalSlug<TSlug extends GlobalSlug> = GeneratedTypes e
   ? TSlug extends GlobalsWithoutDrafts
     ? {
         /**
-         * This global does not have drafts enabled.
+         * The `draft` property is not allowed because this global does not have `versions.drafts` enabled.
          */
         draft?: never
       }

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -14,13 +14,16 @@ import type {
   TransformGlobalWithSelect,
 } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
-import type { SelectFromGlobalSlug } from '../../config/types.js'
+import type {
+  DraftFlagFromGlobalSlug,
+  SelectFromGlobalSlug,
+} from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findOneOperation, type GlobalFindOneArgs } from '../findOne.js'
 
-export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
+type BaseFindOneOptions<TSlug extends GlobalSlug, TSelect extends SelectType> = {
   /**
    * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
    * which can be read by hooks. Useful if you want to pass additional information to the hooks which
@@ -37,10 +40,6 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
    */
   depth?: number
-  /**
-   * Whether the document should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -83,6 +82,9 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
   user?: Document
 } & Pick<FindOptions<string, SelectType>, 'select'> &
   Pick<GlobalFindOneArgs, 'flattenLocales'>
+
+export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> =
+  BaseFindOneOptions<TSlug, TSelect> & DraftFlagFromGlobalSlug<TSlug>
 
 export async function findOneGlobalLocal<
   TSlug extends GlobalSlug,

--- a/packages/payload/src/globals/operations/local/update.ts
+++ b/packages/payload/src/globals/operations/local/update.ts
@@ -8,7 +8,11 @@ import type {
   TransformGlobalWithSelect,
 } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
-import type { DataFromGlobalSlug, SelectFromGlobalSlug } from '../../config/types.js'
+import type {
+  DataFromGlobalSlug,
+  DraftFlagFromGlobalSlug,
+  SelectFromGlobalSlug,
+} from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import {
@@ -22,7 +26,7 @@ import {
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { updateOperation } from '../update.js'
 
-export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
+type BaseOptions<TSlug extends GlobalSlug, TSelect extends SelectType> = {
   /**
    * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
    * which can be read by hooks. Useful if you want to pass additional information to the hooks which
@@ -38,10 +42,6 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
    */
   depth?: number
-  /**
-   * Update documents to a draft.
-   */
-  draft?: boolean
   /**
    * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
    */
@@ -99,6 +99,9 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    */
   user?: Document
 } & Pick<FindOptions<string, SelectType>, 'select'>
+
+export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> =
+  BaseOptions<TSlug, TSelect> & DraftFlagFromGlobalSlug<TSlug>
 
 export async function updateGlobalLocal<
   TSlug extends GlobalSlug,

--- a/test/types/config.ts
+++ b/test/types/config.ts
@@ -155,6 +155,18 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      slug: 'settings',
+      versions: {
+        drafts: true,
+      },
+      fields: [
+        {
+          type: 'text',
+          name: 'siteName',
+        },
+      ],
+    },
   ],
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),

--- a/test/types/payload-types.ts
+++ b/test/types/payload-types.ts
@@ -109,9 +109,11 @@ export interface Config {
   fallbackLocale: null;
   globals: {
     menu: Menu;
+    settings: Setting;
   };
   globalsSelect: {
     menu: MenuSelect<false> | MenuSelect<true>;
+    settings: SettingsSelect<false> | SettingsSelect<true>;
   };
   locale: null;
   strictDraftTypes: true;
@@ -451,10 +453,32 @@ export interface Menu {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "settings".
+ */
+export interface Setting {
+  id: string;
+  siteName?: string | null;
+  _status?: ('draft' | 'published') | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "menu_select".
  */
 export interface MenuSelect<T extends boolean = true> {
   text?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "settings_select".
+ */
+export interface SettingsSelect<T extends boolean = true> {
+  siteName?: T;
+  _status?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
@@ -469,6 +493,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -1196,63 +1196,100 @@ describe('Types testing', () => {
       })
 
       // Additional operations tests
-      test('find with draft:true on non-draft collection should error', async () => {
-        // @ts-expect-error - draft property should be forbidden on collections without drafts
-        await payload.find({ collection: 'pages', draft: true })
+      test('find with draft:true on non-draft collection should error', () => {
+        expect(payload.find({ collection: 'pages', draft: true })).type.toRaiseError()
       })
 
-      test('find with draft:false on non-draft collection should error', async () => {
-        // @ts-expect-error - draft property should be forbidden on collections without drafts
-        await payload.find({ collection: 'pages', draft: false })
+      test('find with draft:false on non-draft collection should error', () => {
+        expect(payload.find({ collection: 'pages', draft: false })).type.toRaiseError()
       })
 
-      test('find with draft:true on draft-enabled collection should work', async () => {
-        await payload.find({ collection: 'draft-posts', draft: true })
+      test('find with draft:true on draft-enabled collection should work', () => {
+        expect(payload.find({ collection: 'draft-posts', draft: true })).type.not.toRaiseError()
       })
 
-      test('findByID with draft:true on non-draft collection should error', async () => {
-        // @ts-expect-error - draft property should be forbidden on collections without drafts
-        await payload.findByID({ collection: 'pages', id: 1, draft: true })
+      test('find with draft:false on draft-enabled collection should work', () => {
+        expect(payload.find({ collection: 'draft-posts', draft: false })).type.not.toRaiseError()
       })
 
-      test('findByID with draft:true on draft-enabled collection should work', async () => {
-        await payload.findByID({ collection: 'draft-posts', id: 1, draft: true })
+      test('findByID with draft:true on non-draft collection should error', () => {
+        expect(payload.findByID({ collection: 'pages', id: 1, draft: true })).type.toRaiseError()
       })
 
-      test('update with draft:true on non-draft collection should error', async () => {
-        // @ts-expect-error - draft property should be forbidden on collections without drafts
-        await payload.update({ collection: 'pages', id: 1, data: { title: 'Test' }, draft: true })
+      test('findByID with draft:false on non-draft collection should error', () => {
+        expect(payload.findByID({ collection: 'pages', id: 1, draft: false })).type.toRaiseError()
       })
 
-      test('update with draft:true on draft-enabled collection should work', async () => {
-        await payload.update({ collection: 'draft-posts', id: 1, data: { title: 'Test' }, draft: true })
+      test('findByID with draft:true on draft-enabled collection should work', () => {
+        expect(
+          payload.findByID({ collection: 'draft-posts', id: 1, draft: true }),
+        ).type.not.toRaiseError()
       })
 
-      test('duplicate with draft:true on non-draft collection should error', async () => {
-        // @ts-expect-error - draft property should be forbidden on collections without drafts
-        await payload.duplicate({ collection: 'pages', id: 1, draft: true })
+      test('update with draft:true on non-draft collection should error', () => {
+        expect(
+          payload.update({ collection: 'pages', id: 1, data: { title: 'Test' }, draft: true }),
+        ).type.toRaiseError()
       })
 
-      test('duplicate with draft:true on draft-enabled collection should work', async () => {
-        await payload.duplicate({ collection: 'draft-posts', id: 1, draft: true })
+      test('update with draft:false on non-draft collection should error', () => {
+        expect(
+          payload.update({ collection: 'pages', id: 1, data: { title: 'Test' }, draft: false }),
+        ).type.toRaiseError()
       })
 
-      test('global findOne with draft:true on non-draft global should error', async () => {
-        // @ts-expect-error - draft property should be forbidden on globals without drafts
-        await payload.findGlobal({ slug: 'menu', draft: true })
+      test('update with draft:true on draft-enabled collection should work', () => {
+        expect(
+          payload.update({ collection: 'draft-posts', id: 1, data: { title: 'Test' }, draft: true }),
+        ).type.not.toRaiseError()
       })
 
-      test('global findOne with draft:true on draft-enabled global should work', async () => {
-        await payload.findGlobal({ slug: 'settings', draft: true })
+      test('duplicate with draft:true on non-draft collection should error', () => {
+        expect(
+          payload.duplicate({ collection: 'pages', id: 1, draft: true }),
+        ).type.toRaiseError()
       })
 
-      test('global update with draft:true on non-draft global should error', async () => {
-        // @ts-expect-error - draft property should be forbidden on globals without drafts
-        await payload.updateGlobal({ slug: 'menu', data: {}, draft: true })
+      test('duplicate with draft:false on non-draft collection should error', () => {
+        expect(
+          payload.duplicate({ collection: 'pages', id: 1, draft: false }),
+        ).type.toRaiseError()
       })
 
-      test('global update with draft:true on draft-enabled global should work', async () => {
-        await payload.updateGlobal({ slug: 'settings', data: {}, draft: true })
+      test('duplicate with draft:true on draft-enabled collection should work', () => {
+        expect(
+          payload.duplicate({ collection: 'draft-posts', id: 1, draft: true }),
+        ).type.not.toRaiseError()
+      })
+
+      test('global findOne with draft:true on non-draft global should error', () => {
+        expect(payload.findGlobal({ slug: 'menu', draft: true })).type.toRaiseError()
+      })
+
+      test('global findOne with draft:false on non-draft global should error', () => {
+        expect(payload.findGlobal({ slug: 'menu', draft: false })).type.toRaiseError()
+      })
+
+      test('global findOne with draft:true on draft-enabled global should work', () => {
+        expect(payload.findGlobal({ slug: 'settings', draft: true })).type.not.toRaiseError()
+      })
+
+      test('global update with draft:true on non-draft global should error', () => {
+        expect(
+          payload.updateGlobal({ slug: 'menu', data: {}, draft: true }),
+        ).type.toRaiseError()
+      })
+
+      test('global update with draft:false on non-draft global should error', () => {
+        expect(
+          payload.updateGlobal({ slug: 'menu', data: {}, draft: false }),
+        ).type.toRaiseError()
+      })
+
+      test('global update with draft:true on draft-enabled global should work', () => {
+        expect(
+          payload.updateGlobal({ slug: 'settings', data: {}, draft: true }),
+        ).type.not.toRaiseError()
       })
     })
 


### PR DESCRIPTION
## What

This PR extends the `typescript.strictDraftTypes` configuration flag to enforce **draft type safety across all Local API operations** that accept a `draft` parameter, for both collections and globals.

When `strictDraftTypes: true` is enabled, the `draft` option is now:

- ❌ **Forbidden** for collections/globals without drafts enabled
- ✅ **Allowed** for collections/globals with drafts enabled
- ⚠️ **Conditionally allowed** when the slug is generic and cannot be statically narrowed

Additionally, in **create operations**:
- `DraftDataFromCollectionSlug` can only be used with **draft-enabled** collections
- This prevents sending partial draft data to non-draft collections

---

## ⚠️ Important Note on Generic Usage

This change may surface backward-compatibility issues when **generic collection or global slugs** are used.

When a Local API helper accepts a generic `TSlug`, TypeScript may be unable to determine whether drafts are enabled. In these cases, an explicit type assertion may be required:

```ts
function createDocument<TSlug extends CollectionSlug>(slug: TSlug) {
  return payload.create({
    collection: slug,
    data: someData,
    draft: true,
  } as Options<TSlug, SelectType>)
}
```
This is a limitation of TypeScript’s type narrowing and does not affect runtime behavior.

## Why

PR #14388 introduced the `strictDraftTypes` flag to improve **query return types** when `draft: true` is used (for example, making required fields optional).

However, draft usage itself was not enforced, which led to several issues:

1. **Silent runtime behavior**  
   Passing `draft: true` to a collection or global without drafts enabled is silently ignored

2. **Type safety gaps**  
   TypeScript allows partial draft data to be sent to entities that do not support drafts

3. **Inconsistent API behavior**  
   Some operations enforced draft rules, while others did not

This PR addresses these gaps by enforcing draft constraints at **compile time**, ensuring invalid draft usage is caught during development.

## How

### 1. Introduced reusable helper types
- `CollectionsWithoutDrafts` / `GlobalsWithoutDrafts`  
  Identify collections and globals that do not support drafts

- `DraftFlagFromCollectionSlug<TSlug>` / `DraftFlagFromGlobalSlug<TSlug>`  
  Conditional types that:
  - Respect the `strictDraftTypes` flag
  - Forbid the `draft` property for non-draft entities
  - Allow the `draft` property for draft-enabled or generic slugs

### 2. Applied helpers across all operations
- Split operation `Options` types into `BaseOptions` plus draft-flag intersections
- Removed duplicated draft-related type logic across files

### 3. Documentation updates
- Expanded the `strictDraftTypes` documentation to cover draft enforcement across **all Local API operations**

---

## Backward Compatibility

- The feature is **opt-in**
- `strictDraftTypes` defaults to `false`
- Existing code is unaffected unless the flag is enabled

---

## Related

Builds upon **#14388**, which introduced `strictDraftTypes` for query return types.
