### PR TITLE
feat(ui): document info parent contexts

### DIFF
--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from '../Translation/index.js'
 import { UploadEditsProvider, useUploadEdits } from '../UploadEdits/index.js'
 import { useGetDocPermissions } from './useGetDocPermissions.js'
 
-const Context = createContext({} as DocumentInfoContext)
+const Context = createContext(undefined)
 
 export type * from './types.js'
 
@@ -28,6 +28,10 @@ export const useDocumentInfo = (): DocumentInfoContext => use(Context)
 const DocumentInfo: React.FC<
   {
     readonly children: React.ReactNode
+    /**
+     * Note: This is intentionally left out of `DocumentInfoProps` as it is automatically provided.
+     */
+    readonly parents?: DocumentInfoContext['parents']
   } & DocumentInfoProps
 > = ({ children, ...props }) => {
   const {
@@ -44,6 +48,7 @@ const DocumentInfo: React.FC<
     isLocked: isLockedFromProps,
     lastUpdateTime: lastUpdateTimeFromProps,
     mostRecentVersionIsAutosaved: mostRecentVersionIsAutosavedFromProps,
+    parents,
     unpublishedVersionCount: unpublishedVersionCountFromProps,
     versionCount: versionCountFromProps,
   } = props
@@ -394,6 +399,7 @@ const DocumentInfo: React.FC<
     isInitializing,
     lastUpdateTime,
     mostRecentVersionIsAutosaved,
+    parents,
     preferencesKey,
     savedDocumentData: data,
     setCurrentEditor,
@@ -427,9 +433,19 @@ export const DocumentInfoProvider: React.FC<
     readonly children: React.ReactNode
   } & DocumentInfoProps
 > = (props) => {
+  const parentDocInfo = useDocumentInfo()
+
+  const parents = useMemo(() => {
+    if (parentDocInfo) {
+      return [...(parentDocInfo?.parents || []), parentDocInfo]
+    }
+
+    return undefined
+  }, [parentDocInfo])
+
   return (
     <UploadEditsProvider>
-      <DocumentInfo {...props} />
+      <DocumentInfo {...props} parents={parents} />
     </UploadEditsProvider>
   )
 }

--- a/packages/ui/src/providers/DocumentInfo/types.ts
+++ b/packages/ui/src/providers/DocumentInfo/types.ts
@@ -63,6 +63,12 @@ export type DocumentInfoContext = {
   getDocPreferences: () => Promise<DocumentPreferences>
   incrementVersionCount: () => void
   isInitializing: boolean
+  /**
+   * The tree of parent `DocumentInfo` contexts leading to this one, if any.
+   * E.g. relationship drawers override the main document context with their own,
+   * removing access to the main document's context without this property.
+   */
+  parents?: DocumentInfoContext[]
   preferencesKey?: string
   /**
    * @deprecated This property is deprecated and will be removed in v4.

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1017,7 +1017,7 @@ export interface DateField {
   dayAndTimeWithTimezone: string;
   dayAndTimeWithTimezone_tz: SupportedTimezones;
   dayAndTimeWithTimezoneFixed?: string | null;
-  dayAndTimeWithTimezoneFixed_tz?: 'Europe/London' | null;
+  dayAndTimeWithTimezoneFixed_tz?: SupportedTimezones;
   dayAndTimeWithTimezoneRequired?: string | null;
   dayAndTimeWithTimezoneRequired_tz: SupportedTimezones;
   dayAndTimeWithTimezoneReadOnly?: string | null;
@@ -1049,9 +1049,9 @@ export interface DateField {
       }[]
     | null;
   dateWithOffsetTimezone?: string | null;
-  dateWithOffsetTimezone_tz?: ('+05:30' | '-08:00' | '+00:00') | null;
+  dateWithOffsetTimezone_tz?: SupportedTimezones;
   dateWithMixedTimezones?: string | null;
-  dateWithMixedTimezones_tz?: ('America/New_York' | '+05:30' | 'UTC') | null;
+  dateWithMixedTimezones_tz?: SupportedTimezones;
   dateWithTimezoneWithDisabledColumns?: string | null;
   dateWithTimezoneWithDisabledColumns_tz?: SupportedTimezones;
   updatedAt: string;
@@ -3647,6 +3647,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,7 +32,7 @@
     ],
     "paths": {
       "@payloadcms/figma": ["../enterprise-plugins/packages/figma/src/index.ts"],
-      "@payload-config": ["./test/plugin-import-export/config.ts"],
+      "@payload-config": ["./test/_community/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],


### PR DESCRIPTION
Adds the ability to read parent document info contexts from child components.

For example, when opening a document in a relationship drawer, the result of `useDocumentInfo()` points drawer's document, not the root document where the field was originally rendered. It is impossible to get the root document's context, or any other document within the current document tree.

This is because to support recursively nested documents, we override the document info context on each traversal.

For example:

```tsx
export const DocumentInfoProvider: React.FC<
  {
    readonly children: React.ReactNode
  } & DocumentInfoProps
> = (props) => {
  return (
    <DocumentInfo {...props} />
  )
}
```

To solve this, there is now a `parents` array on the document info context that stores an array of all parent contexts leading up to this one.