### PR TITLE
chore: removes never implemented readDrafts access arg on globals

### DIFF
--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -185,7 +185,6 @@ export type GlobalConfig<TSlug extends GlobalSlug = any> = {
   _sanitized?: boolean
   access?: {
     read?: Access
-    readDrafts?: Access
     readVersions?: Access
     update?: Access
   }


### PR DESCRIPTION
Removes `readDrafts` access property from globals as it has never been implemented or documented. It never actually did anything but was in the access type for globals.
