### PR TITLE
ci: prevent rate limiting in release-commenter action

### DIFF
--- a/.github/actions/release-commenter/src/__snapshots__/index.test.ts.snap
+++ b/.github/actions/release-commenter/src/__snapshots__/index.test.ts.snap
@@ -1,30 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tests feature tests can apply labels 1`] = `
-[
-  [
-    {
-      "issue_number": 123,
-      "labels": [
-        ":dart: landed",
-        "release-current_tag_name",
-        "Release Name",
-      ],
-    },
-  ],
-  [
-    {
-      "issue_number": 7,
-      "labels": [
-        ":dart: landed",
-        "release-current_tag_name",
-        "Release Name",
-      ],
-    },
-  ],
-]
-`;
-
 exports[`tests main test 1`] = `
 {
   "graphql": [MockFunction] {

--- a/.github/actions/release-commenter/src/index.test.ts
+++ b/.github/actions/release-commenter/src/index.test.ts
@@ -19,6 +19,23 @@ describe('tests', () => {
   ;(core.warning as any) = jest.fn(console.warn.bind(console))
   ;(core.error as any) = jest.fn(console.error.bind(console))
 
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  // Helper to flush all pending promises and timers for sequential processing
+  const flushPromisesAndTimers = async () => {
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve()
+      jest.runAllTimers()
+    }
+    await Promise.resolve()
+  }
+
   let commentTempate: string = ''
   let labelTemplate: string | null = null
   const skipLabelTemplate: string | null = 'skip,test'
@@ -228,7 +245,7 @@ describe('tests', () => {
       require('./index')
     })
 
-    await new Promise<void>(setImmediate)
+    await flushPromisesAndTimers()
 
     expect(mockOctokit).toMatchSnapshot()
     expect(mockOctokit.rest.issues.createComment).toHaveBeenCalledTimes(3)
@@ -314,7 +331,7 @@ describe('tests', () => {
         require('./index')
       })
 
-      await new Promise<void>((resolve) => setImmediate(() => resolve()))
+      await flushPromisesAndTimers()
 
       expect(github.getOctokit).toHaveBeenCalled()
       expect(mockOctokit.rest.repos.compareCommits.mock.calls).toEqual([
@@ -335,7 +352,7 @@ describe('tests', () => {
         require('./index')
       })
 
-      await new Promise<void>((resolve) => setImmediate(() => resolve()))
+      await flushPromisesAndTimers()
 
       expect(github.getOctokit).toHaveBeenCalled()
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled()
@@ -373,7 +390,7 @@ describe('tests', () => {
         require('./index')
       })
 
-      await new Promise<void>((resolve) => setImmediate(() => resolve()))
+      await flushPromisesAndTimers()
 
       expect(github.getOctokit).toHaveBeenCalled()
 
@@ -390,7 +407,7 @@ describe('tests', () => {
         require('./index')
       })
 
-      await new Promise<void>((resolve) => setImmediate(() => resolve()))
+      await flushPromisesAndTimers()
 
       expect(github.getOctokit).toHaveBeenCalled()
       expect(mockOctokit.rest.issues.addLabels.mock.calls).toMatchSnapshot()


### PR DESCRIPTION
# Overview

Fixes GitHub secondary rate limit errors in the `release-commenter` action when processing releases with many PRs.

## Key Changes

- **Sequential processing for comment creation**
  - Replaced parallel `Promise.all` with sequential processing and 1s delay between each PR
  - Added progress logging: `Processing issue/PR 1/20: #123`

- **Updated tests for async timing**
  - Added Jest fake timers to handle sequential delays in tests

## Design Decisions

GitHub's secondary rate limits restrict content creation to 80 requests/minute and penalize burst patterns regardless of total volume. The previous implementation fired all comment/label requests in parallel, triggering the "content creation" throttle even when under primary rate limits.

Sequential processing with a 1s delay trades speed for reliability. For a release with 20 PRs, processing takes ~20s instead of ~2s—an acceptable tradeoff given releases are infrequent and reliability matters more than speed.

GraphQL queries (read operations) remain parallel since they're less likely to trigger secondary limits.

## Overall Flow

```mermaid
sequenceDiagram
    participant Action
    participant GitHub API

    Action->>GitHub API: Get releases (parallel)
    Action->>GitHub API: Compare commits (parallel)
    Action->>GitHub API: GraphQL queries for PRs (parallel)
    
    loop For each linked issue/PR
        Action->>GitHub API: Get issue state
        Action->>GitHub API: Create comment (+ unlock/lock if needed)
        Action->>GitHub API: Add labels (if configured)
        Note over Action: Wait 1s before next
    end
```

## References / Links

- [GitHub REST API Rate Limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
- [Failed run example](https://github.com/payloadcms/payload/actions/runs/20973008294)