### PR TITLE
feat(plugin-mcp): adds select API with CRUD tools

### DIFF
--- a/packages/plugin-mcp/src/mcp/tools/resource/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/find.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import type { PayloadRequest, TypedUser } from 'payload'
+import type { PayloadRequest, SelectType, TypedUser } from 'payload'
 
 import type { PluginMCPServerConfig } from '../../../types.js'
 
@@ -20,6 +20,7 @@ export const findResourceTool = (
     page: number = 1,
     sort?: string,
     where?: string,
+    select?: string,
     depth: number = 0,
     locale?: string,
     fallbackLocale?: string,
@@ -62,6 +63,26 @@ export const findResourceTool = (
         }
       }
 
+      // Parse select clause if provided
+      let selectClause: SelectType | undefined
+      if (select) {
+        try {
+          selectClause = JSON.parse(select) as SelectType
+        } catch (_parseError) {
+          payload.logger.warn(`[payload-mcp] Invalid select clause JSON: ${select}`)
+          const response = {
+            content: [{ type: 'text' as const, text: 'Error: Invalid JSON in select clause' }],
+          }
+          return (collections?.[collectionSlug]?.overrideResponse?.(response, {}, req) ||
+            response) as {
+            content: Array<{
+              text: string
+              type: 'text'
+            }>
+          }
+        }
+      }
+
       // If ID is provided, use findByID
       if (id) {
         try {
@@ -69,6 +90,7 @@ export const findResourceTool = (
             id,
             collection: collectionSlug,
             depth,
+            ...(selectClause && { select: selectClause }),
             overrideAccess: false,
             req,
             user,
@@ -129,6 +151,7 @@ ${JSON.stringify(doc, null, 2)}`,
         page,
         req,
         user,
+        ...(selectClause && { select: selectClause }),
         ...(locale && { locale }),
         ...(fallbackLocale && { fallbackLocale }),
         ...(draft !== undefined && { draft }),
@@ -202,8 +225,19 @@ Page: ${result.page} of ${result.totalPages}
       `find${collectionSlug.charAt(0).toUpperCase() + toCamelCase(collectionSlug).slice(1)}`,
       `${collections?.[collectionSlug]?.description || toolSchemas.findResources.description.trim()}`,
       toolSchemas.findResources.parameters.shape,
-      async ({ id, depth, draft, fallbackLocale, limit, locale, page, sort, where }) => {
-        return await tool(id, limit, page, sort, where, depth, locale, fallbackLocale, draft)
+      async ({ id, depth, draft, fallbackLocale, limit, locale, page, select, sort, where }) => {
+        return await tool(
+          id,
+          limit,
+          page,
+          sort,
+          where,
+          select,
+          depth,
+          locale,
+          fallbackLocale,
+          draft,
+        )
       },
     )
   }

--- a/packages/plugin-mcp/src/mcp/tools/schemas.ts
+++ b/packages/plugin-mcp/src/mcp/tools/schemas.ts
@@ -26,7 +26,7 @@ export const toolSchemas = {
         .string()
         .optional()
         .describe(
-          'Optional JSON string for selecting specific fields (e.g., \'{"siteName": true}\')',
+          "Optional: define exactly which fields you'd like to return in the response (JSON), e.g., '{\"title\": true}'",
         ),
     }),
   },
@@ -83,7 +83,7 @@ export const toolSchemas = {
         .string()
         .optional()
         .describe(
-          'Optional JSON string for selecting specific fields (e.g., \'{"title": true, "slug": true}\')',
+          "Optional: define exactly which fields you'd like to return in the response (JSON), e.g., '{\"title\": true}'",
         ),
       sort: z
         .string()
@@ -124,6 +124,12 @@ export const toolSchemas = {
         .optional()
         .describe(
           'Optional: locale code to create the document in (e.g., "en", "es"). Defaults to the default locale',
+        ),
+      select: z
+        .string()
+        .optional()
+        .describe(
+          "Optional: define exactly which fields you'd like to return in the response (JSON), e.g., '{\"title\": true}'",
         ),
     }),
   },
@@ -166,6 +172,12 @@ export const toolSchemas = {
         .optional()
         .default(false)
         .describe('Whether to overwrite existing files'),
+      select: z
+        .string()
+        .optional()
+        .describe(
+          "Optional: define exactly which fields you'd like to return in the response (JSON), e.g., '{\"title\": true}'",
+        ),
       where: z
         .string()
         .optional()
@@ -227,6 +239,12 @@ export const toolSchemas = {
         .optional()
         .describe(
           'Optional: locale code to update data in (e.g., "en", "es"). Use "all" to update all locales for localized fields',
+        ),
+      select: z
+        .string()
+        .optional()
+        .describe(
+          "Optional: define exactly which fields you'd like to return in the response (JSON), e.g., '{\"siteName\": true}'",
         ),
     }),
   },

--- a/packages/plugin-mcp/src/mcp/tools/schemas.ts
+++ b/packages/plugin-mcp/src/mcp/tools/schemas.ts
@@ -22,6 +22,12 @@ export const toolSchemas = {
         .describe(
           'Optional: locale code to retrieve data in (e.g., "en", "es"). Use "all" to retrieve all locales for localized fields',
         ),
+      select: z
+        .string()
+        .optional()
+        .describe(
+          'Optional JSON string for selecting specific fields (e.g., \'{"siteName": true}\')',
+        ),
     }),
   },
 
@@ -73,6 +79,12 @@ export const toolSchemas = {
         .optional()
         .default(1)
         .describe('Page number for pagination (default: 1)'),
+      select: z
+        .string()
+        .optional()
+        .describe(
+          'Optional JSON string for selecting specific fields (e.g., \'{"title": true, "slug": true}\')',
+        ),
       sort: z
         .string()
         .optional()


### PR DESCRIPTION
## Goals
- Helps reduce token usage.
- Better sync with the existing Payload API.

MCP Tools effected:
- Find, Create, and Update tools for Globals and Collections.

### Discussion: https://github.com/payloadcms/payload/discussions/14921
