### PR TITLE
fix(next): ensure query presets are applied from URL

### DIFF
--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -201,6 +201,13 @@ export const renderListView = async (
         })) as QueryPreset
 
         if (queryPreset) {
+          // apply columns, groupBy and where from preset
+          query.columns = queryPreset.columns
+            ? transformColumnsToSearchParams(queryPreset.columns)
+            : undefined
+          query.groupBy = queryPreset.groupBy || ''
+          query.where = queryPreset.where || {}
+
           queryPresetPermissions = await getDocumentPermissions({
             id: queryPreset.id,
             collectionConfig: config.collections.find((c) => c.slug === 'payload-query-presets'),

--- a/test/query-presets/config.ts
+++ b/test/query-presets/config.ts
@@ -11,7 +11,6 @@ import { seed } from './seed.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-// eslint-disable-next-line no-restricted-exports
 export default buildConfigWithDefaults({
   admin: {
     importMap: {

--- a/test/query-presets/e2e.spec.ts
+++ b/test/query-presets/e2e.spec.ts
@@ -304,6 +304,32 @@ describe('Query Presets', () => {
     })
   })
 
+  test('should apply preset from URL query param', async () => {
+    // Navigate directly to the list view with a preset query param
+    await page.goto(`${pagesUrl.list}?preset=${everyoneID}`)
+
+    // Verify the preset is selected in the preset selector
+    await expect(
+      page.locator('button#select-preset', {
+        hasText: exactText(seededData.everyone.title),
+      }),
+    ).toBeVisible()
+
+    // Verify the where query is in the URL
+    await assertURLParams({
+      page,
+      columns: seededData.everyone.columns,
+      where: seededData.everyone.where,
+      preset: everyoneID,
+    })
+
+    // Verify the actual results are filtered correctly
+    // The seeded preset filters for text: { equals: 'example page' }
+    const tableRows = page.locator('.collection-list .table tbody tr')
+    await expect(tableRows).toHaveCount(1)
+    await expect(tableRows.first()).toContainText('example page')
+  })
+
   test('should only show "edit" and "delete" controls when there is an active preset', async () => {
     await page.goto(pagesUrl.list)
     await expect(page.locator('#edit-preset')).toBeHidden()


### PR DESCRIPTION
Fixes query presets not being applied when loading a list view directly with a `?preset=` URL param. Adds e2e test to verify the preset selector, URL filters, and table results all reflect the applied preset.