### PR TITLE
feat(db-sqlite): add `busyTimeout` option

### DIFF
--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -51,6 +51,7 @@ export default buildConfig({
 | `autoIncrement`            | Pass `true` to enable SQLite [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for primary keys to ensure the same ID cannot be reused from deleted rows                      |
 | `allowIDOnCreate`          | Set to `true` to use the `id` passed in data on the create API operations without using a custom ID field.                                                                       |
 | `blocksAsJSON`             | Store blocks as a JSON column instead of using the relational structure which can improve performance with a large amount of blocks                                              |
+| `busyTimeout`              | Maximum time in milliseconds to wait when the database is locked. Default is `0`.                                                                                                |
 
 ## Access to Drizzle
 

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -18,6 +18,10 @@ export const connect: Connect = async function connect(
   try {
     if (!this.client) {
       this.client = createClient(this.clientConfig)
+
+      if (this.busyTimeout > 0) {
+        await this.client.execute(`PRAGMA busy_timeout = ${this.busyTimeout};`)
+      }
     }
 
     const logger = this.logger || false

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -93,6 +93,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       blocksAsJSON: args.blocksAsJSON ?? false,
+      busyTimeout: args.busyTimeout ?? 0,
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       client: undefined,
       clientConfig: args.client,

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -52,6 +52,11 @@ export type Args = {
    * To generate Drizzle schema from the database, see [Drizzle Kit introspection](https://orm.drizzle.team/kit-docs/commands#introspect--pull)
    */
   beforeSchemaInit?: SQLiteSchemaHook[]
+  /**
+   * Maximum time in milliseconds to wait when the database is locked.
+   * @default 0
+   */
+  busyTimeout?: number
   client: Config
 } & BaseSQLiteArgs
 
@@ -123,6 +128,7 @@ type ResolveSchemaType<T> = 'schema' extends keyof T
 type Drizzle = { $client: Client } & LibSQLDatabase<ResolveSchemaType<GeneratedDatabaseSchema>>
 
 export type SQLiteAdapter = {
+  busyTimeout: number
   client: Client
   clientConfig: Args['client']
   drizzle: Drizzle
@@ -199,6 +205,7 @@ declare module 'payload' {
     extends Omit<Args, 'idType' | 'logger' | 'migrationDir' | 'pool'>,
       DrizzleAdapter {
     beginTransaction: (options?: SQLiteTransactionConfig) => Promise<null | number | string>
+    busyTimeout: number
     drizzle: Drizzle
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name


### PR DESCRIPTION
Adds a new option for the SQLite adapter - `busyTimeout` which allows to set maximum time in milliseconds to wait when the database is locked. By default we keep the same behavior as before.