### PR TITLE
docs: jobs queue improvements

### DIFF
--- a/docs/jobs-queue/overview.mdx
+++ b/docs/jobs-queue/overview.mdx
@@ -69,6 +69,74 @@ Here's a quick overview:
 - A Job is an instance of a single task or workflow which will be executed
 - A Queue is a way to segment your jobs into different "groups" - for example, some to run nightly, and others to run every 10 minutes
 
+### How Jobs Flow Through the System
+
+Here's a visual representation of how the pieces fit together:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  1. DEFINE WORK                                             │
+├─────────────────────────────────────────────────────────────┤
+│  Task/Workflow Definition                                   │
+│  - slug: 'sendEmail'                                        │
+│  - handler: async () => { /* your logic */ }                │
+└─────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│  2. QUEUE JOBS (Choose one or both)                         │
+├─────────────────────────────────────────────────────────────┤
+│  Option A: Manual Queuing                                   │
+│    → payload.jobs.queue({ task: 'sendEmail' })              │
+│    → Used for user-triggered actions                        │
+│                                                             │
+│  Option B: Automatic Queuing (Scheduled)                    │
+│    → schedule: [{ cron: '0 8 * * *', queue: 'emails' }]     │
+│    → Used for recurring tasks                               │
+└─────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│  3. STORAGE                                                 │
+├─────────────────────────────────────────────────────────────┤
+│  payload-jobs collection (database)                         │
+│  - Stores queued jobs waiting to run                        │
+│  - Tracks job status, retries, errors                       │
+│  - Jobs remain here until processed                         │
+└─────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│  4. RUN JOBS (Choose one)                                   │
+├─────────────────────────────────────────────────────────────┤
+│  Option A: autoRun (Dedicated Server)                       │
+│    → autoRun: [{ cron: '* * * * *', queue: 'emails' }]      │
+│    → Automatic execution on schedule                        │
+│                                                             │
+│  Option B: API Endpoint (Serverless)                        │
+│    → GET /api/payload-jobs/run?queue=emails                 │
+│    → Triggered by external cron (Vercel Cron, etc.)         │
+│                                                             │
+│  Option C: Manual                                           │
+│    → payload.jobs.run({ queue: 'emails' })                  │
+│    → Programmatic control                                   │
+└─────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│  5. EXECUTION                                               │
+├─────────────────────────────────────────────────────────────┤
+│  Task/Workflow handler runs                                 │
+│  - Success → Job marked complete (optionally deleted)       │
+│  - Failure → Retry (if configured) or mark as failed        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Key Insights:**
+
+- **Steps 2 (queuing) and 4 (running) are separate and independent**
+- You can queue without running, and run without auto-queuing
+- The `queue` name connects queuing and running (they must match)
+- Jobs persist in the database between queuing and execution
+
+**Common Mistake:** Configuring only step 2 (queuing via `schedule`) or only step 4 (`autoRun`) won't work. You need both for scheduled jobs to execute automatically.
+
 ### Visualizing Jobs in the Admin UI
 
 By default, the internal `payload-jobs` collection is hidden from the Payload Admin Panel. To make this collection visible for debugging or inspection purposes, you can override its configuration using `jobsCollectionOverrides`.

--- a/docs/jobs-queue/overview.mdx
+++ b/docs/jobs-queue/overview.mdx
@@ -88,13 +88,22 @@ handler: async () => {
 
 ```ts
 // Option A: Manual Queuing—Used for user-triggered actions
-  payload.jobs.queue({ task: 'sendEmail' })
+payload.jobs.queue({ task: 'sendEmail', input: { to: 'user@example.com' } })
 
-// Option B: Automatic Queuing (Scheduled)— Used for recurring tasks
-  schedule: [{ cron: '0 8 * * *', queue: 'emails' }]
+// Option B: Scheduled Queuing
+// Step 1 - Define schedules in task/workflow config:
+schedule: [{ cron: '0 8 * * *', queue: 'emails' }]
 
-// Option C: Bin Script (for handling schedules)—Triggers schedule queuing in separate process
-pnpm payload jobs:handle-schedules --cron "* * * * *"
+// Step 2 - Execute schedules to queue jobs - choose ONE:
+
+// Dedicated server: Bin script
+pnpm payload jobs:handle-schedules --cron "* * * * *" --queue emails
+
+// Serverless: API endpoint via external cron (Vercel Cron, etc.)
+GET /api/payload-jobs/handle-schedules?queue=emails
+
+// Dedicated server: autoRun (calls handleSchedules internally)
+autoRun: [{ cron: '* * * * *', queue: 'emails' }]
 ```
 
 <Arrow direction="down" />
@@ -113,20 +122,26 @@ pnpm payload jobs:handle-schedules --cron "* * * * *"
 
 <Pill text="Run Jobs" />
 
-```
-// Option A: Bin Scripts (Dedicated Server) [RECOMMENDED]—Separate process,
-easier to deploy/scale pnpm payload jobs:run --cron "* * * * *" --queue...
+```ts
+// Option A: Bin Script (Dedicated Server) [RECOMMENDED]
+// Separate process, easier to deploy/scale
+pnpm payload jobs:run --cron "* * * * *" --queue emails
 
-// Option B: autoRun (Dedicated Server)—Runs within Next.js process
-autoRun: [{ cron: '* * * * *', queue: 'emails' }]
+// Option B: autoRun (Dedicated Server)
+// Runs within Next.js process, handles BOTH scheduling + running
+autoRun: [{
+  cron: '* * * * *',
+  queue: 'emails',
+  // disableScheduling: false (default) - also calls handleSchedules
+  // disableScheduling: true - only runs jobs, doesn't handle schedules
+}]
 
-//Option C: API Endpoint (Serverless)—Triggered by external
-//cron (Vercel Cron, etc.)
+// Option C: API Endpoint (Serverless)
+// Triggered by external cron (Vercel Cron, GitHub Actions, etc.)
 GET /api/payload-jobs/run?queue=emails
 
 // Option D: Manual
 payload.jobs.run({ queue: 'emails' })
-
 ```
 
 <Arrow direction="down" />
@@ -145,12 +160,78 @@ payload.jobs.run({ queue: 'emails' })
 
 **Key Insights:**
 
+- **Scheduling is two-part:** Defining schedules (passive) + Executing schedules (active queuing)
 - **Steps 2 (queuing) and 4 (running) are separate and independent**
-- You can queue without running, and run without auto-queuing
+- You can queue without running, and run without queuing
 - The `queue` name connects queuing and running (they must match)
 - Jobs persist in the database between queuing and execution
+- **autoRun is dual-purpose:** It both executes schedules (queues jobs) AND runs queued jobs
 
-**Common Mistake:** Configuring only step 2 (queuing via `schedule`) or only step 4 (`autoRun`) won't work. You need both for scheduled jobs to execute automatically.
+### Common Pitfalls
+
+#### Defining schedules without executing them
+
+Adding a `schedule` property to your task/workflow config but not implementing a mechanism to execute those schedules.
+
+```ts
+// This alone won't queue any jobs
+export const EmailTask: TaskConfig = {
+  slug: 'sendEmail',
+  schedule: [{ cron: '0 8 * * *', queue: 'emails' }],
+  handler: async () => {
+    /* ... */
+  },
+}
+```
+
+You must also implement ONE of these to execute the schedules:
+
+- Bin script: `pnpm payload jobs:handle-schedules --cron "* * * * *" --queue emails`
+- API endpoint called by external cron (Vercel Cron, etc.)
+- `autoRun` config (for dedicated servers only)
+
+#### Duplicate job scheduling
+
+Using both the `handle-schedules` bin script AND `autoRun` for the same queue, causing duplicate jobs to be queued.
+
+```ts
+// This will cause duplicate jobs
+pnpm payload jobs:handle-schedules --cron "* * * * *"
+// Config:
+jobs: {
+  autoRun: [{ cron: '* * * * *', queue: 'emails' }] // Also calls handleSchedules by default
+}
+```
+
+Choose ONE approach:
+
+- **Dedicated server with bin scripts:** Use `handle-schedules` bin script + `run` bin script
+- **Dedicated server with autoRun:** Use `autoRun` config (it handles both scheduling and running)
+- **Serverless:** Use API endpoints for both `handle-schedules` and `run`, triggered by external cron
+
+If you need to use `autoRun` only for running jobs (not scheduling), set `disableScheduling: true`:
+
+```ts
+autoRun: [
+  {
+    cron: '* * * * *',
+    queue: 'emails',
+    disableScheduling: true, // Only run jobs, don't handle schedules
+  },
+]
+```
+
+#### Using autoRun on serverless platforms
+
+Configuring `autoRun` on platforms like Vercel, Lambda, or other serverless environments where long-running background processes aren't supported.
+
+On serverless platforms, use API endpoints called by external cron services:
+
+- Vercel Cron → `GET /api/payload-jobs/handle-schedules?queue=emails`
+- Vercel Cron → `GET /api/payload-jobs/run?queue=emails`
+- GitHub Actions / other CI cron → Same endpoints
+
+Never use `autoRun` on serverless platforms.
 
 ### Visualizing Jobs in the Admin UI
 

--- a/docs/jobs-queue/overview.mdx
+++ b/docs/jobs-queue/overview.mdx
@@ -73,68 +73,75 @@ Here's a quick overview:
 
 Here's a visual representation of how the pieces fit together:
 
-```plaintext
-┌─────────────────────────────────────────────────────────────┐
-│  1. DEFINE WORK                                             │
-├─────────────────────────────────────────────────────────────┤
-│  Task/Workflow Definition                                   │
-│  - slug: 'sendEmail'                                        │
-│  - handler: async () => { /* your logic */ }                │
-└─────────────────────────────────────────────────────────────┘
-                           ↓
-┌─────────────────────────────────────────────────────────────┐
-│  2. QUEUE JOBS (Choose one or both)                         │
-├─────────────────────────────────────────────────────────────┤
-│  Option A: Manual Queuing                                   │
-│    → payload.jobs.queue({ task: 'sendEmail' })              │
-│    → Used for user-triggered actions                        │
-│                                                             │
-│  Option B: Automatic Queuing (Scheduled)                    │
-│    → schedule: [{ cron: '0 8 * * *', queue: 'emails' }]     │
-│    → Used for recurring tasks                               │
-│                                                             │
-│  Option C: Bin Script (for handling schedules)              │
-│    → pnpm payload jobs:handle-schedules --cron "* * * * *"  │
-│    → Triggers schedule queuing in separate process          │
-└─────────────────────────────────────────────────────────────┘
-                           ↓
-┌─────────────────────────────────────────────────────────────┐
-│  3. STORAGE                                                 │
-├─────────────────────────────────────────────────────────────┤
-│  payload-jobs collection (database)                         │
-│  - Stores queued jobs waiting to run                        │
-│  - Tracks job status, retries, errors                       │
-│  - Jobs remain here until processed                         │
-└─────────────────────────────────────────────────────────────┘
-                           ↓
-┌─────────────────────────────────────────────────────────────┐
-│  4. RUN JOBS (Choose one)                                   │
-├─────────────────────────────────────────────────────────────┤
-│  Option A: Bin Scripts (Dedicated Server) [RECOMMENDED]    │
-│    → pnpm payload jobs:run --cron "* * * * *" --queue...   │
-│    → Separate process, easier to deploy/scale               │
-│                                                             │
-│  Option B: autoRun (Dedicated Server)                       │
-│    → autoRun: [{ cron: '* * * * *', queue: 'emails' }]      │
-│    → Runs within Next.js process                            │
-│                                                             │
-│  Option C: API Endpoint (Serverless)                        │
-│    → GET /api/payload-jobs/run?queue=emails                 │
-│    → Triggered by external cron (Vercel Cron, etc.)         │
-│                                                             │
-│  Option D: Manual                                           │
-│    → payload.jobs.run({ queue: 'emails' })                  │
-│    → Programmatic control                                   │
-└─────────────────────────────────────────────────────────────┘
-                           ↓
-┌─────────────────────────────────────────────────────────────┐
-│  5. EXECUTION                                               │
-├─────────────────────────────────────────────────────────────┤
-│  Task/Workflow handler runs                                 │
-│  - Success → Job marked complete (optionally deleted)       │
-│  - Failure → Retry (if configured) or mark as failed        │
-└─────────────────────────────────────────────────────────────┘
+<Pill text="Define Work" />
+
+```ts
+slug: 'sendEmail'
+handler: async () => {
+  /* your logic */
+}
 ```
+
+<Arrow direction="down" />
+
+<Pill text="Queue Jobs" />
+
+```ts
+// Option A: Manual Queuing—Used for user-triggered actions
+  payload.jobs.queue({ task: 'sendEmail' })
+
+// Option B: Automatic Queuing (Scheduled)— Used for recurring tasks
+  schedule: [{ cron: '0 8 * * *', queue: 'emails' }]
+
+// Option C: Bin Script (for handling schedules)—Triggers schedule queuing in separate process
+pnpm payload jobs:handle-schedules --cron "* * * * *"
+```
+
+<Arrow direction="down" />
+
+<Pill text="Storage (Jobs Collection)" />
+
+<BulletList
+  items={[
+    { text: 'Stores queued jobs waiting to run', icon: 'check' },
+    { text: 'Tracks job status, retries, errors', icon: 'check' },
+    { text: 'Jobs remain here until processed', icon: 'check' },
+  ]}
+/>
+
+<Arrow direction="down" />
+
+<Pill text="Run Jobs" />
+
+```
+// Option A: Bin Scripts (Dedicated Server) [RECOMMENDED]—Separate process,
+easier to deploy/scale pnpm payload jobs:run --cron "* * * * *" --queue...
+
+// Option B: autoRun (Dedicated Server)—Runs within Next.js process
+autoRun: [{ cron: '* * * * *', queue: 'emails' }]
+
+//Option C: API Endpoint (Serverless)—Triggered by external
+//cron (Vercel Cron, etc.)
+GET /api/payload-jobs/run?queue=emails
+
+// Option D: Manual
+payload.jobs.run({ queue: 'emails' })
+
+```
+
+<Arrow direction="down" />
+
+<Pill text="Execution(Task/Workflow handler runs)" />
+
+<BulletList
+  items={[
+    {
+      text: 'Success → Job marked complete',
+      icon: 'check',
+    },
+    { text: 'Failure → Retry or mark as failed', icon: 'x' },
+  ]}
+/>
 
 **Key Insights:**
 

--- a/docs/jobs-queue/overview.mdx
+++ b/docs/jobs-queue/overview.mdx
@@ -73,7 +73,7 @@ Here's a quick overview:
 
 Here's a visual representation of how the pieces fit together:
 
-```
+```plaintext
 ┌─────────────────────────────────────────────────────────────┐
 │  1. DEFINE WORK                                             │
 ├─────────────────────────────────────────────────────────────┤
@@ -92,6 +92,10 @@ Here's a visual representation of how the pieces fit together:
 │  Option B: Automatic Queuing (Scheduled)                    │
 │    → schedule: [{ cron: '0 8 * * *', queue: 'emails' }]     │
 │    → Used for recurring tasks                               │
+│                                                             │
+│  Option C: Bin Script (for handling schedules)              │
+│    → pnpm payload jobs:handle-schedules --cron "* * * * *"  │
+│    → Triggers schedule queuing in separate process          │
 └─────────────────────────────────────────────────────────────┘
                            ↓
 ┌─────────────────────────────────────────────────────────────┐
@@ -106,15 +110,19 @@ Here's a visual representation of how the pieces fit together:
 ┌─────────────────────────────────────────────────────────────┐
 │  4. RUN JOBS (Choose one)                                   │
 ├─────────────────────────────────────────────────────────────┤
-│  Option A: autoRun (Dedicated Server)                       │
-│    → autoRun: [{ cron: '* * * * *', queue: 'emails' }]      │
-│    → Automatic execution on schedule                        │
+│  Option A: Bin Scripts (Dedicated Server) [RECOMMENDED]    │
+│    → pnpm payload jobs:run --cron "* * * * *" --queue...   │
+│    → Separate process, easier to deploy/scale               │
 │                                                             │
-│  Option B: API Endpoint (Serverless)                        │
+│  Option B: autoRun (Dedicated Server)                       │
+│    → autoRun: [{ cron: '* * * * *', queue: 'emails' }]      │
+│    → Runs within Next.js process                            │
+│                                                             │
+│  Option C: API Endpoint (Serverless)                        │
 │    → GET /api/payload-jobs/run?queue=emails                 │
 │    → Triggered by external cron (Vercel Cron, etc.)         │
 │                                                             │
-│  Option C: Manual                                           │
+│  Option D: Manual                                           │
 │    → payload.jobs.run({ queue: 'emails' })                  │
 │    → Programmatic control                                   │
 └─────────────────────────────────────────────────────────────┘

--- a/docs/jobs-queue/queues.mdx
+++ b/docs/jobs-queue/queues.mdx
@@ -30,7 +30,25 @@ As mentioned above, you can queue jobs, but the jobs won't run unless a worker p
 
 ### Cron jobs
 
-The `jobs.autoRun` property allows you to configure cron jobs that automatically run queued jobs at specified intervals. Note that this does not _queue_ new jobs - only _runs_ jobs that are already in the specified queue.
+The `jobs.autoRun` property allows you to configure cron jobs that automatically **execute** jobs from your queue at specified intervals.
+
+<Banner type="warning">
+  **Important Distinction:** `autoRun` does NOT queue new jobs—it only **runs**
+  jobs that are already in the queue.
+
+- To manually queue jobs: Use `payload.jobs.queue()` in your code
+- To automatically queue recurring jobs: Use the `schedule` property on
+  tasks/workflows (see [Job Schedules](/docs/jobs-queue/schedules))
+- To execute queued jobs: Use `autoRun` (this section)
+
+</Banner>
+
+Think of it this way:
+
+- **Queuing** = Adding jobs to the database to be run later
+- **Running** = Actually executing the job handler functions
+
+`autoRun` only handles the **running** part.
 
 **Example**:
 
@@ -39,17 +57,44 @@ export default buildConfig({
   // Other configurations...
   jobs: {
     tasks: [
-      // your tasks here
+      {
+        slug: 'processPayment',
+        handler: async ({ input }) => {
+          // Payment processing logic
+          return { output: { success: true } }
+        },
+      },
+      {
+        slug: 'generateReport',
+        // This task auto-queues itself daily at midnight
+        schedule: [
+          {
+            cron: '0 0 * * *',
+            queue: 'nightly',
+          },
+        ],
+        handler: async () => {
+          // Report generation logic
+          return { output: { reportId: '123' } }
+        },
+      },
     ],
+
+    // autoRun processes queued jobs from specified queues
     // autoRun can optionally be a function that receives `payload` as an argument
     autoRun: [
       {
-        cron: '0 * * * *', // every hour at minute 0
-        limit: 100, // limit jobs to process each run
-        queue: 'hourly', // name of the queue
+        cron: '*/5 * * * *', // Check every 5 minutes
+        queue: 'default', // Process 'default' queue (for manually queued jobs)
+        limit: 50,
       },
-      // add as many cron jobs as you want
+      {
+        cron: '* * * * *', // Check every minute
+        queue: 'nightly', // Process 'nightly' queue (for scheduled jobs)
+        limit: 100,
+      },
     ],
+
     shouldAutoRun: async (payload) => {
       // Tell Payload if it should run jobs or not. This function is optional and will return true by default.
       // This function will be invoked each time Payload goes to pick up and run jobs.
@@ -59,6 +104,13 @@ export default buildConfig({
   },
 })
 ```
+
+In this example:
+
+- `processPayment` jobs are queued manually (e.g., from API endpoints using `payload.jobs.queue()`)
+- `generateReport` jobs are auto-queued at midnight via the `schedule` property
+- The first `autoRun` entry processes manually-queued jobs from the 'default' queue every 5 minutes
+- The second `autoRun` entry processes scheduled jobs from the 'nightly' queue every minute
 
 <Banner type="warning">
   autoRun is intended for use with a dedicated server that is always running,
@@ -405,7 +457,109 @@ Here's a quick guide to help you choose:
 
 ## Troubleshooting
 
-Jobs aren't running
+### Jobs aren't running (Most Common Issues)
+
+If you configured `autoRun` but jobs aren't executing, check these common causes in order:
+
+#### 1. You only configured `autoRun` without queuing any jobs
+
+**Symptom:** `autoRun` is configured but no jobs ever execute.
+
+**Diagnosis:** `autoRun` runs jobs that are already in the queue. If nothing is adding jobs to the queue, there's nothing to run.
+
+**Solution:** Queue jobs either:
+
+- **Manually** via `payload.jobs.queue()` in your code (e.g., in hooks, endpoints), OR
+- **Automatically** via the `schedule` property on tasks/workflows
+
+**Example of the problem:**
+
+```ts
+// This alone won't do anything - no jobs are being queued!
+jobs: {
+  tasks: [{ slug: 'myTask', handler: async () => {} }],
+  autoRun: [{ cron: '* * * * *', queue: 'default' }],
+}
+```
+
+**Solution:**
+
+```ts
+// Option A: Queue manually in your code
+await payload.jobs.queue({ task: 'myTask' })
+
+// Option B: Add schedule property to auto-queue
+jobs: {
+  tasks: [
+    {
+      slug: 'myTask',
+      schedule: [{ cron: '0 8 * * *', queue: 'default' }], // ✅ Now jobs will be queued
+      handler: async () => {},
+    },
+  ]
+}
+```
+
+#### 2. Queue name mismatch
+
+**Symptom:** Jobs appear in the `payload-jobs` collection but never execute.
+
+**Diagnosis:** The `queue` name in your task's `schedule` doesn't match the `queue` name in `autoRun`.
+
+**Example of the problem:**
+
+```ts
+// Task queues to 'reports'
+schedule: [{ cron: '0 8 * * *', queue: 'reports' }]
+
+// But autoRun processes 'default' ❌
+autoRun: [{ queue: 'default' }] // Won't pick up the job!
+```
+
+**Solution:** Make sure queue names match exactly:
+
+```ts
+// Task queues to 'reports'
+schedule: [{ cron: '0 8 * * *', queue: 'reports' }]
+
+// autoRun also processes 'reports' ✅
+autoRun: [{ cron: '* * * * *', queue: 'reports' }] // Now they match!
+```
+
+#### 3. You're on a serverless platform (Vercel, Netlify, etc.)
+
+**Symptom:** Jobs work locally but don't run in production on serverless platforms.
+
+**Diagnosis:** `autoRun` requires a long-running server and won't work on serverless platforms where instances shut down between requests.
+
+**Solution:** Use the [endpoint method with Vercel Cron](#vercel-cron-example) instead of `autoRun`.
+
+#### 4. Jobs are scheduled for the future
+
+**Symptom:** Jobs exist in the `payload-jobs` collection with `completedAt: null` but aren't running.
+
+**Diagnosis:** Jobs may have `waitUntil` set to a future date - they won't run until that time passes.
+
+**Solution:** Check the `payload-jobs` collection:
+
+```ts
+const jobs = await payload.find({
+  collection: 'payload-jobs',
+  where: {
+    completedAt: { exists: false },
+  },
+})
+
+console.log(jobs.docs[0].waitUntil) // Check if this is in the future
+```
+
+#### 5. Jobs stopped after hot module reload (development)
+
+**Symptom:** Jobs work initially but stop running after you make code changes in development.
+
+**Diagnosis:** Hot Module Reload (HMR) in Next.js disrupts cron schedules. This is expected behavior in development.
+
+**Solution:** Restart your dev server after making changes to job configurations. This is not an issue in production.
 
 **Is `shouldAutoRun` returning true?**
 

--- a/docs/jobs-queue/queues.mdx
+++ b/docs/jobs-queue/queues.mdx
@@ -28,9 +28,57 @@ Then, you could configure two different runner strategies:
 
 As mentioned above, you can queue jobs, but the jobs won't run unless a worker picks up your jobs and runs them. This can be done in four ways:
 
-### Cron jobs
+### Bin script (Recommended for Dedicated Servers)
 
-The `jobs.autoRun` property allows you to configure cron jobs that automatically **execute** jobs from your queue at specified intervals.
+For dedicated servers, the recommended approach is to use Payload's bin script to run jobs. This creates a completely separate process from your Next.js server, making it easier to deploy, scale, and manage workers independently.
+
+```sh
+# Basic usage - run jobs from default queue
+pnpm payload jobs:run
+
+# Run with custom queue and limit
+pnpm payload jobs:run --queue myQueue --limit 15
+
+# Run on a cron schedule (recommended for production)
+pnpm payload jobs:run --cron "*/5 * * * *" --queue myQueue
+
+# Run and also handle schedules (both queuing and running)
+pnpm payload jobs:run --cron "*/5 * * * *" --queue myQueue --handle-schedules
+
+# Run all jobs from all queues
+pnpm payload jobs:run --all-queues
+```
+
+**Benefits of using bin scripts:**
+
+- **Separate process**: Runs completely independently from your Next.js server, preventing any impact on API response times
+- **Easy deployment**: Can be deployed as a separate service/container, making it simple to scale workers independently
+- **Simple monitoring**: Each worker process can be monitored, restarted, and scaled independently
+- **No Next.js overhead**: Workers don't load the entire Next.js application, making them lighter and faster
+
+**Deployment example:**
+
+```yaml
+# docker-compose.yml or similar
+services:
+  nextjs:
+    # Your main Next.js app
+    command: pnpm start
+
+  worker-default:
+    # Worker for default queue
+    command: pnpm payload jobs:run --cron "*/5 * * * *" --queue default
+
+  worker-nightly:
+    # Worker for nightly queue
+    command: pnpm payload jobs:run --cron "* * * * *" --queue nightly --handle-schedules
+```
+
+This makes it easy to run multiple workers for different queues, scale them independently, and deploy them to different servers if needed.
+
+### autoRun (Alternative for Dedicated Servers)
+
+The `jobs.autoRun` property allows you to configure cron jobs that automatically **execute** jobs from your queue at specified intervals. This runs within your Next.js process.
 
 <Banner type="warning">
   **Important Distinction:** `autoRun` does NOT queue new jobs—it only **runs**
@@ -114,7 +162,9 @@ In this example:
 
 <Banner type="warning">
   autoRun is intended for use with a dedicated server that is always running,
-  and should not be used on serverless platforms like Vercel.
+  and should not be used on serverless platforms like Vercel. For dedicated
+  servers, consider using bin scripts instead, as they run in a separate process
+  and are easier to deploy and scale.
 </Banner>
 
 ### Endpoint
@@ -193,7 +243,7 @@ This works because Vercel automatically makes the `CRON_SECRET` environment vari
 
 After the project is deployed to Vercel, the Vercel Cron job will automatically trigger the `/api/payload-jobs/run` endpoint in the specified schedule, running the queued jobs in the background.
 
-### Local API
+### Local API (For Programmatic Control)
 
 If you want to process jobs programmatically from your server-side code, you can use the Local API:
 
@@ -221,38 +271,6 @@ await payload.jobs.run({
 const results = await payload.jobs.runByID({
   id: myJobID,
 })
-```
-
-### Bin script
-
-Finally, you can process jobs via the bin script that comes with Payload out of the box. By default, this script will run jobs from the `default` queue, with a limit of 10 jobs per invocation:
-
-```sh
-pnpm payload jobs:run
-```
-
-You can override the default queue and limit by passing the `--queue` and `--limit` flags:
-
-```sh
-pnpm payload jobs:run --queue myQueue --limit 15
-```
-
-If you want to run all jobs from all queues, you can pass the `--all-queues` flag:
-
-```sh
-pnpm payload jobs:run --all-queues
-```
-
-In addition, the bin script allows you to pass a `--cron` flag to the `jobs:run` command to run the jobs on a scheduled, cron basis:
-
-```sh
-pnpm payload jobs:run --cron "*/5 * * * *"
-```
-
-You can also pass `--handle-schedules` flag to the `jobs:run` command to make it schedule jobs according to configured schedules:
-
-```sh
-pnpm payload jobs:run --cron "*/5 * * * *" --queue myQueue --handle-schedules # This will both schedule jobs according to the configuration and run them
 ```
 
 ## Processing Order
@@ -441,17 +459,17 @@ This makes it easy to:
 
 Here's a quick guide to help you choose:
 
-| Method                    | Best For                               | Pros                                   | Cons                                               |
-| ------------------------- | -------------------------------------- | -------------------------------------- | -------------------------------------------------- |
-| **Cron jobs** (`autoRun`) | Dedicated servers, long-running apps   | Simple setup, automatic execution      | Not for serverless, requires always-running server |
-| **Endpoint**              | Serverless platforms (Vercel, Netlify) | Works with serverless, easy to trigger | Requires external cron (Vercel Cron, etc.)         |
-| **Local API**             | Custom scheduling, testing             | Full control, good for tests           | Must implement your own scheduling                 |
-| **Bin script**            | Development, manual execution          | Quick testing, manual control          | Manual invocation only                             |
+| Method         | Best For                               | Pros                                   | Cons                                       |
+| -------------- | -------------------------------------- | -------------------------------------- | ------------------------------------------ |
+| **Bin script** | Dedicated servers (Recommended)        | Separate process, easy to deploy/scale | Requires dedicated server                  |
+| **autoRun**    | Dedicated servers (Alternative)        | Simple setup, automatic execution      | Runs in Next.js process                    |
+| **Endpoint**   | Serverless platforms (Vercel, Netlify) | Works with serverless, easy to trigger | Requires external cron (Vercel Cron, etc.) |
+| **Local API**  | Custom scheduling, testing             | Full control, good for tests           | Must implement your own scheduling         |
 
 **Recommendations:**
 
+- **Production (Dedicated Server):** Use Bin script with `--cron` flag
 - **Production (Serverless):** Use Endpoint + Vercel Cron
-- **Production (Server):** Use Cron jobs (`autoRun`)
 - **Development:** Use Bin script or Local API
 - **Testing:** Use Local API with `payload.jobs.runByID()`
 
@@ -493,7 +511,7 @@ jobs: {
   tasks: [
     {
       slug: 'myTask',
-      schedule: [{ cron: '0 8 * * *', queue: 'default' }], // ✅ Now jobs will be queued
+      schedule: [{ cron: '0 8 * * *', queue: 'default' }], //  Now jobs will be queued
       handler: async () => {},
     },
   ]
@@ -512,7 +530,7 @@ jobs: {
 // Task queues to 'reports'
 schedule: [{ cron: '0 8 * * *', queue: 'reports' }]
 
-// But autoRun processes 'default' ❌
+// But autoRun processes 'default'
 autoRun: [{ queue: 'default' }] // Won't pick up the job!
 ```
 
@@ -522,7 +540,7 @@ autoRun: [{ queue: 'default' }] // Won't pick up the job!
 // Task queues to 'reports'
 schedule: [{ cron: '0 8 * * *', queue: 'reports' }]
 
-// autoRun also processes 'reports' ✅
+// autoRun also processes 'reports'
 autoRun: [{ cron: '* * * * *', queue: 'reports' }] // Now they match!
 ```
 

--- a/docs/jobs-queue/quick-start-example.mdx
+++ b/docs/jobs-queue/quick-start-example.mdx
@@ -110,6 +110,190 @@ export default buildConfig({
 })
 ```
 
-The [`autoRun`](/docs/jobs-queue/workflows#autorun) configuration automatically processes queued jobs on a schedule using cron syntax. In this example, Payload checks for pending jobs every 5 minutes and executes them. Alternatively, you can [manually trigger job processing](/docs/jobs-queue/workflows#manual-run) with `payload.jobs.run()` or run jobs in [separate worker processes](/docs/jobs-queue/workflows#inline-vs-workers) for better scalability.
+The [`autoRun`](/docs/jobs-queue/queues#cron-jobs) configuration automatically processes queued jobs on a schedule using cron syntax. In this example, Payload checks for pending jobs every 5 minutes and executes them. Alternatively, you can [manually trigger job processing](/docs/jobs-queue/queues#local-api) with `payload.jobs.run()` or use the [API endpoint](/docs/jobs-queue/queues#endpoint) for serverless platforms.
 
 That's it! Now when users sign up, a job is queued and will be processed within 5 minutes without blocking the API response.
+
+## Example 2: Recurring Scheduled Job
+
+The previous example showed **manual job queuing** (jobs triggered by user actions). Now let's look at a job that runs **automatically on a schedule** without any user action.
+
+We'll create a task that generates a daily analytics report every morning at 8 AM.
+
+### Why Use Scheduled Jobs?
+
+- **Automated recurring tasks**: No need to manually trigger them
+- **Predictable timing**: Reports, cleanups, syncs run at exact times
+- **No manual intervention**: Set it once and forget it
+
+### Step 1: Define a Task with Schedule
+
+```ts
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  // ... other config
+  jobs: {
+    tasks: [
+      {
+        slug: 'generateDailyReport',
+
+        // This automatically queues a job every day at 8 AM
+        schedule: [
+          {
+            cron: '0 8 * * *', // 8:00 AM daily
+            queue: 'reports', // Put it in the 'reports' queue
+          },
+        ],
+
+        inputSchema: [],
+
+        outputSchema: [
+          {
+            name: 'reportId',
+            type: 'text',
+          },
+        ],
+
+        handler: async ({ req }) => {
+          // Generate the report
+          const yesterday = new Date()
+          yesterday.setDate(yesterday.getDate() - 1)
+
+          const analytics = await req.payload.find({
+            collection: 'analytics',
+            where: {
+              createdAt: {
+                greater_than_equal: yesterday.toISOString(),
+              },
+            },
+          })
+
+          // Save the report
+          const report = await req.payload.create({
+            collection: 'reports',
+            data: {
+              date: new Date().toISOString(),
+              totalEvents: analytics.totalDocs,
+              summary: `Generated report for ${yesterday.toDateString()}`,
+            },
+          })
+
+          return {
+            output: {
+              reportId: report.id,
+            },
+          }
+        },
+      },
+    ],
+  },
+})
+```
+
+The `schedule` property tells Payload to automatically queue this job every day at 8 AM.
+
+### Step 2: Configure the Job Runner
+
+The `schedule` property only **queues** jobs—it doesn't run them. You also need to configure how queued jobs are executed:
+
+```ts
+export default buildConfig({
+  // ... other config
+  jobs: {
+    tasks: [
+      /* task from step 1 */
+    ],
+
+    // This processes jobs from the 'reports' queue
+    autoRun: [
+      {
+        cron: '* * * * *', // Check every minute
+        queue: 'reports', // Process 'reports' queue
+        limit: 10,
+      },
+    ],
+  },
+})
+```
+
+### How It Works
+
+Here's the complete flow:
+
+1. **At 8:00 AM:** The `schedule` configuration automatically queues a new job in the 'reports' queue
+2. **Within 1 minute:** The `autoRun` cron checks the 'reports' queue and finds the job
+3. **Execution:** The job runs and generates the report
+4. **The next day:** The process repeats automatically at 8:00 AM
+
+<Banner type="error">
+  **Critical:** Both `schedule.queue` and `autoRun.queue` must use the same
+  queue name ('reports' in this example). If they don't match, jobs will be
+  queued but never executed.
+</Banner>
+
+### Complete Configuration
+
+Here's the full config with both the task and runner:
+
+```ts
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  // ... other config
+  jobs: {
+    tasks: [
+      {
+        slug: 'generateDailyReport',
+        schedule: [
+          {
+            cron: '0 8 * * *',
+            queue: 'reports',
+          },
+        ],
+        handler: async ({ req }) => {
+          // Report generation logic
+          const report = await generateReport()
+          return { output: { reportId: report.id } }
+        },
+      },
+    ],
+    autoRun: [
+      {
+        cron: '* * * * *',
+        queue: 'reports',
+        limit: 10,
+      },
+    ],
+  },
+})
+```
+
+<Banner type="warning">
+  **For Serverless Platforms:** If deploying to Vercel or similar platforms,
+  `autoRun` won't work. Use the [Vercel Cron
+  approach](/docs/jobs-queue/queues#vercel-cron-example) instead.
+</Banner>
+
+### When to Use Each Approach
+
+| Approach                  | When to Use                                      | Example                                              |
+| ------------------------- | ------------------------------------------------ | ---------------------------------------------------- |
+| **Manual Queuing**        | Jobs triggered by user actions or data changes   | Welcome emails, payment processing, notifications    |
+| **Scheduled Jobs**        | Jobs that run automatically at regular intervals | Daily reports, weekly cleanups, nightly syncs        |
+| **Scheduled with Future** | One-time job in the future                       | Publish post at 3pm tomorrow, trial expiry reminders |
+
+**For scheduled jobs with `waitUntil`:**
+
+```ts
+// Queue a one-time job for the future
+await payload.jobs.queue({
+  task: 'publishPost',
+  input: { postId: '123' },
+  waitUntil: new Date('2024-12-25T15:00:00Z'), // Runs once at this time
+})
+```
+
+This is different from the `schedule` property, which repeats automatically.
+
+See [Job Schedules](/docs/jobs-queue/schedules) for more details on scheduling options and advanced patterns.

--- a/docs/jobs-queue/quick-start-example.mdx
+++ b/docs/jobs-queue/quick-start-example.mdx
@@ -191,11 +191,11 @@ export default buildConfig({
 })
 ```
 
-The `schedule` property tells Payload to automatically queue this job every day at 8 AM.
+The `schedule` property defines when this job should run (every day at 8 AM).
 
 ### Step 2: Configure the Job Runner
 
-The `schedule` property only **queues** jobs—it doesn't run them. You also need to configure how queued jobs are executed:
+To actually queue and execute scheduled jobs, you need to configure the `autoRun` property. This handles both queuing jobs based on their schedule and running them:
 
 ```ts
 export default buildConfig({

--- a/docs/jobs-queue/schedules.mdx
+++ b/docs/jobs-queue/schedules.mdx
@@ -26,6 +26,50 @@ Here's a quick guide to help you choose the right approach:
 | **Collection Hook** | Job triggered by document changes                    | Send email when post is published, generate PDF when order is created |
 | **Manual Queue**    | Job triggered by user action or API call             | User clicks "Generate Report" button                                  |
 
+## Complete Setup Requirements
+
+<Banner type="error">
+  **Critical:** To use scheduled jobs, you need TWO configurations working
+  together. Configuring only one will not work.
+</Banner>
+
+### 1. Schedule Configuration (This Page)
+
+Define the `schedule` property on your task or workflow to automatically queue jobs:
+
+```ts
+{
+  slug: 'myTask',
+  schedule: [{ cron: '0 9 * * *', queue: 'daily' }],
+  handler: async () => { /* ... */ }
+}
+```
+
+This handles the **QUEUING**—it adds jobs to the database on a schedule.
+
+### 2. Runner Configuration (See [Queues](/docs/jobs-queue/queues))
+
+Configure how queued jobs are executed:
+
+```ts
+jobs: {
+  autoRun: [{ cron: '* * * * *', queue: 'daily' }]
+}
+```
+
+This handles the **RUNNING**—it executes the job handler functions.
+
+### Quick Checklist
+
+Before wondering why your scheduled jobs aren't working, verify:
+
+- ✅ **Task has `schedule` property?** → Jobs will be queued automatically
+- ✅ **Config has `autoRun` or another runner?** → Queued jobs will be executed
+- ✅ **Both use the same `queue` name?** → Jobs will flow from schedule to execution
+- ✅ **Not on serverless platform?** → `autoRun` requires a long-running server
+
+If any checkbox is missing, your scheduled jobs won't work properly.
+
 **Example comparison:**
 
 ```ts

--- a/docs/jobs-queue/schedules.mdx
+++ b/docs/jobs-queue/schedules.mdx
@@ -49,7 +49,14 @@ This handles the **QUEUING**—it adds jobs to the database on a schedule.
 
 ### 2. Runner Configuration (See [Queues](/docs/jobs-queue/queues))
 
-Configure how queued jobs are executed:
+Configure how queued jobs are executed. For dedicated servers, use bin scripts (recommended):
+
+```sh
+# Recommended: Bin script runs in separate process
+pnpm payload jobs:run --cron "* * * * *" --queue daily --handle-schedules
+```
+
+Or use autoRun (alternative):
 
 ```ts
 jobs: {
@@ -63,10 +70,10 @@ This handles the **RUNNING**—it executes the job handler functions.
 
 Before wondering why your scheduled jobs aren't working, verify:
 
-- ✅ **Task has `schedule` property?** → Jobs will be queued automatically
-- ✅ **Config has `autoRun` or another runner?** → Queued jobs will be executed
-- ✅ **Both use the same `queue` name?** → Jobs will flow from schedule to execution
-- ✅ **Not on serverless platform?** → `autoRun` requires a long-running server
+- **Task has `schedule` property?** → Jobs will be queued automatically
+- **Config has `autoRun` or another runner?** → Queued jobs will be executed
+- **Both use the same `queue` name?** → Jobs will flow from schedule to execution
+- **Not on serverless platform?** → `autoRun` requires a long-running server
 
 If any checkbox is missing, your scheduled jobs won't work properly.
 
@@ -89,22 +96,74 @@ schedule: [{ cron: '0 0 * * *', queue: 'nightly' }] // Runs every day at midnigh
 
 ## Handling schedules
 
-Something needs to actually trigger the scheduling of jobs (execute the scheduling lifecycle seen below). By default, the `jobs.autorun` configuration, as well as the `/api/payload-jobs/run` will also handle scheduling for the queue specified in the `autorun` configuration.
+Something needs to actually trigger the scheduling of jobs (execute the scheduling lifecycle seen below). There are several ways to handle scheduling:
 
-You can disable this behavior by setting `disableScheduling: true` in your `autorun` configuration, or by passing `disableScheduling=true` to the `/api/payload-jobs/run` endpoint. This is useful if you want to handle scheduling manually, for example, by using a cron job or a serverless function that calls the `/api/payload-jobs/handle-schedules` endpoint or the `payload.jobs.handleSchedules()` local API method.
+### Bin Scripts (Recommended for Dedicated Servers)
 
-### Bin Scripts
+For dedicated servers, the recommended approach is to use Payload's bin scripts. This runs the scheduling logic in a separate process from your Next.js server.
 
-Payload provides a set of bin scripts that can be used to handle schedules. If you're already using the `jobs:run` bin script, you can set it to also handle schedules by passing the `--handle-schedules` flag:
+**Combined scheduling and running (recommended):**
 
 ```sh
-pnpm payload jobs:run --cron "*/5 * * * *" --queue myQueue --handle-schedules # This will both schedule jobs according to the configuration and run them
+# This will both schedule jobs according to the configuration AND run them
+pnpm payload jobs:run --cron "*/5 * * * *" --queue myQueue --handle-schedules
 ```
 
-If you only want to handle schedules, you can use the dedicated `jobs:handle-schedules` bin script:
+**Schedule-only (if you want separate processes for scheduling vs running):**
 
 ```sh
-pnpm payload jobs:handle-schedules --cron "*/5 * * * *" --queue myQueue # or --all-queues
+# This only handles scheduling - you'll need a separate process to run jobs
+pnpm payload jobs:handle-schedules --cron "*/5 * * * *" --queue myQueue
+# or for all queues:
+pnpm payload jobs:handle-schedules --cron "*/5 * * * *" --all-queues
+```
+
+**Benefits of bin scripts:**
+
+- Separate process from Next.js server
+- Easy to deploy as independent workers
+- Simple to scale by running multiple instances
+- No impact on Next.js server performance
+
+### autoRun (Alternative for Dedicated Servers)
+
+By default, the `jobs.autoRun` configuration handles scheduling for the queue specified in the `autoRun` configuration:
+
+```ts
+jobs: {
+  autoRun: [
+    {
+      cron: '*/5 * * * *',
+      queue: 'default',
+      // disableScheduling: false (default) - schedules are handled automatically
+    },
+  ],
+}
+```
+
+You can disable this behavior by setting `disableScheduling: true` in your `autoRun` configuration if you want to handle scheduling separately.
+
+### API Endpoint (For Serverless)
+
+For serverless environments, you can trigger scheduling via the `/api/payload-jobs/run` endpoint (which handles scheduling by default) or use the dedicated `/api/payload-jobs/handle-schedules` endpoint:
+
+```ts
+// This endpoint handles both scheduling and running
+await fetch('/api/payload-jobs/run?queue=myQueue')
+
+// Or disable scheduling if you want to handle it separately
+await fetch('/api/payload-jobs/run?queue=myQueue&disableScheduling=true')
+
+// Dedicated scheduling endpoint
+await fetch('/api/payload-jobs/handle-schedules?queue=myQueue')
+```
+
+### Local API (For Programmatic Control)
+
+You can also handle scheduling programmatically:
+
+```ts
+await payload.jobs.handleSchedules()
 ```
 
 ## Defining schedules on Tasks or Workflows
@@ -144,7 +203,16 @@ export const SendDigestEmail: TaskConfig<'SendDigestEmail'> = {
 }
 ```
 
-This configuration only queues the Job - it does not execute it immediately. To actually run the queued Job, you configure autorun in your Payload config (note that autorun should **not** be used on serverless platforms):
+This configuration only queues the Job - it does not execute it immediately. To actually run the queued Job, you have several options:
+
+**Option 1: Bin script (recommended for dedicated servers):**
+
+```sh
+# This will both schedule and run jobs from the nightly queue
+pnpm payload jobs:run --cron "* * * * *" --queue nightly --handle-schedules
+```
+
+**Option 2: autoRun (alternative for dedicated servers):**
 
 ```ts
 export default buildConfig({
@@ -160,7 +228,15 @@ export default buildConfig({
 })
 ```
 
-That way, Payload's scheduler will automatically enqueue the job into the `nightly` queue every day at midnight. The autorun configuration will check the `nightly` queue every minute and execute any Jobs that are due to run.
+**Option 3: API endpoint (for serverless platforms):**
+
+Configure Vercel Cron or similar to trigger:
+
+```
+GET /api/payload-jobs/run?queue=nightly
+```
+
+With any of these options, Payload's scheduler will automatically enqueue the job into the `nightly` queue every day at midnight, and the runner will check the `nightly` queue every minute to execute any Jobs that are due to run.
 
 ## Scheduling lifecycle
 

--- a/docs/jobs-queue/tasks.mdx
+++ b/docs/jobs-queue/tasks.mdx
@@ -193,6 +193,9 @@ schedule: [{ cron: '0 9 * * 1', queue: 'weekly' }]
 
 // Every 5 minutes
 schedule: [{ cron: '*/5 * * * *', queue: 'frequent' }]
+
+// Every 3 seconds (extended cron syntax with seconds field)
+schedule: [{ cron: '*/3 * * * * *', queue: 'realtime' }]
 ```
 
 See [Job Schedules](/docs/jobs-queue/schedules) for comprehensive scheduling documentation, including hooks, concurrency controls, and troubleshooting.

--- a/docs/jobs-queue/tasks.mdx
+++ b/docs/jobs-queue/tasks.mdx
@@ -33,6 +33,7 @@ Simply add a task to the `jobs.tasks` array in your Payload config. A task consi
 | `onSuccess`     | Function to be executed if the task succeeds.                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `retries`       | Specify the number of times that this step should be retried if it fails. If this is undefined, the task will either inherit the retries from the workflow or have no retries. If this is 0, the task will not be retried. By default, this is undefined.                                                                                                                                                                                        |
 | `concurrency`   | Control how jobs with the same concurrency key are handled. Jobs with the same key will run exclusively (one at a time). Requires `jobs.enableConcurrencyControl: true` to be set. See [Concurrency Controls](/docs/jobs-queue/workflows#concurrency-controls) for details.                                                                                                                                                                      |
+| `schedule`      | Define one or more schedules to automatically queue this task periodically. Each schedule requires a `cron` expression and a `queue` name. See [Job Schedules](/docs/jobs-queue/schedules) for complete documentation.                                                                                                                                                                                                                           |
 
 The logic for the Task is defined in the `handler` - which can be defined as a function, or a path to a function. The `handler` will run once a worker picks up a Job that includes this task.
 
@@ -92,6 +93,109 @@ export default buildConfig({
   },
 })
 ```
+
+### Scheduling Tasks to Run Automatically
+
+Tasks can be configured to run automatically on a schedule by adding the `schedule` property. This is useful for recurring operations like daily reports, periodic syncs, or scheduled cleanups.
+
+**How it works:**
+
+1. The `schedule` property automatically queues jobs at specified times (no need to call `payload.jobs.queue()` manually)
+2. You still need to configure a job runner (like `autoRun`) to execute the queued jobs
+3. Both the schedule and runner must use the same `queue` name
+
+**Example:**
+
+```ts
+export default buildConfig({
+  jobs: {
+    tasks: [
+      {
+        slug: 'dailyDigest',
+
+        // This automatically queues the task every day at 8 AM
+        schedule: [
+          {
+            cron: '0 8 * * *', // Every day at 8:00 AM
+            queue: 'daily', // Queue to add the job to
+          },
+        ],
+
+        inputSchema: [
+          {
+            name: 'date',
+            type: 'date',
+          },
+        ],
+
+        handler: async ({ req, input }) => {
+          // Send daily digest emails
+          const users = await req.payload.find({
+            collection: 'users',
+            where: { subscribed: { equals: true } },
+          })
+
+          for (const user of users.docs) {
+            await req.payload.sendEmail({
+              to: user.email,
+              subject: 'Your Daily Digest',
+              html: generateDigestHTML(user),
+            })
+          }
+
+          return {
+            output: {
+              emailsSent: users.docs.length,
+              date: input.date || new Date().toISOString(),
+            },
+          }
+        },
+      } as TaskConfig<'dailyDigest'>,
+    ],
+
+    // Important: You also need to configure a runner to execute scheduled jobs
+    autoRun: [
+      {
+        cron: '* * * * *', // Check for jobs every minute
+        queue: 'daily', // Process jobs from 'daily' queue
+        limit: 10,
+      },
+    ],
+  },
+})
+```
+
+<Banner type="warning">
+  **Important:** The `schedule` property only **queues** jobs—it doesn't execute
+  them. You must also configure a job runner (like `autoRun` above) to actually
+  run the queued jobs. Both must use the same `queue` name.
+</Banner>
+
+**Key Points:**
+
+- The `schedule` property automatically calls `payload.jobs.queue()` for you on the specified schedule
+- You can define multiple schedules per task by adding more objects to the `schedule` array
+- The `cron` field uses standard cron syntax (minute, hour, day, month, day-of-week)
+- Both `schedule.queue` and `autoRun.queue` must match for jobs to run
+- Scheduling is handled automatically by Payload's scheduler—no manual intervention needed
+
+**Common cron patterns:**
+
+```ts
+// Every hour at minute 0
+schedule: [{ cron: '0 * * * *', queue: 'hourly' }]
+
+// Every day at midnight
+schedule: [{ cron: '0 0 * * *', queue: 'nightly' }]
+
+// Every Monday at 9 AM
+schedule: [{ cron: '0 9 * * 1', queue: 'weekly' }]
+
+// Every 5 minutes
+schedule: [{ cron: '*/5 * * * *', queue: 'frequent' }]
+```
+
+See [Job Schedules](/docs/jobs-queue/schedules) for comprehensive scheduling documentation, including hooks, concurrency controls, and troubleshooting.
 
 ### Common Task Patterns
 


### PR DESCRIPTION
- Added `schedule` property to the task configuration options table
- Added new scheduling tasks to run automatically section
- Added to quick start example
- clarified distinction between queuing vs. running
- added workflow diagram in overview
- added setup requirements section

Fixes #10688