### PR TITLE
fix(ui): upsertPreferences did not return preferences when creating new preferences

### DIFF
--- a/packages/ui/src/utilities/upsertPreferences.ts
+++ b/packages/ui/src/utilities/upsertPreferences.ts
@@ -83,7 +83,7 @@ export const upsertPreferences = async <T extends Record<string, unknown> | stri
   let newPrefs = existingPrefs?.value
 
   if (!existingPrefs?.id) {
-    await req.payload.create({
+    const createdPrefs = await req.payload.create({
       collection: 'payload-preferences',
       data: {
         key,
@@ -97,6 +97,7 @@ export const upsertPreferences = async <T extends Record<string, unknown> | stri
       disableTransaction: true,
       user: req.user,
     })
+    return createdPrefs.value
   } else {
     let mergedPrefs: T
 


### PR DESCRIPTION
This fixes a bug where `upsertPreferences` returned undefined if the preferences did not exist before. In the list view, this causes url params to be ignored on the first page load, as the following happened:

1. take query params from url
2. store them in preferences using `upsertPreferences`
3. work with the result of `upsertPreferences`
4. original query params are lost, even though they should have been returned from `upsertPreferences`

An e2e test for this is added in https://github.com/payloadcms/payload/pull/15320, which depends on this PR.