### PR TITLE
fix(ui): diff view columns have unequal widths for nested fields causing text misalignment

### DIFF
--- a/packages/ui/src/elements/FieldDiffContainer/index.tsx
+++ b/packages/ui/src/elements/FieldDiffContainer/index.tsx
@@ -51,7 +51,7 @@ export const FieldDiffContainer: React.FC<{
         style={
           nestingLevel
             ? {
-                gridTemplateColumns: `calc(var(--left-offset) - calc(var(--base)*0.5) )     calc(50% - calc(var(--base)*0.5) + calc(50% - var(--left-offset)))`,
+                gridTemplateColumns: `calc(var(--left-offset) - calc(var(--base)*0.5)) calc(var(--left-offset) - calc(var(--base)*0.5))`,
               }
             : undefined
         }


### PR DESCRIPTION
### What

Fixes unequal column widths in the `versions` comparison diff view for nested fields (fields inside `groups`, `arrays`, `tabs`, etc.)

### Why

When comparing nested `richtext` fields, the left column was narrower than the right column, causing text to wrap differently. Over long content, this made the columns progressively misaligned, making it difficult to visually compare changes side-by-side.

### How

Changed the grid column calculation to use equal widths for both columns when fields are nested. 

Both columns now use `calc(var(--left-offset) - calc(var(--base)*0.5))` instead of having the right column compensate with extra width. This maintains visual hierarchy through indentation while ensuring identical text wrapping.

**Before:**

Notice how "Some additional text." appears at different vertical positions - the left column shows it earlier while the right column has more text above it due to different wrapping.

<img width="1961" height="938" alt="Screenshot 2026-01-23 at 11 12 54 AM" src="https://github.com/user-attachments/assets/3e61e646-cabc-4cdf-8bd4-f4c79928c546" />

**After:**

Now "Some additional text." appears at the same vertical position in both columns, making it easy to compare changes side-by-side.

<img width="1956" height="923" alt="Screenshot 2026-01-23 at 11 13 34 AM" src="https://github.com/user-attachments/assets/cfaa5df9-9a29-472e-891c-dd508c769b6e" />

Fixes #15255 
