### PR TITLE
revert: diff view highlights don't span full width for nested fields

### DIFF
--- a/packages/ui/src/elements/FieldDiffContainer/index.tsx
+++ b/packages/ui/src/elements/FieldDiffContainer/index.tsx
@@ -51,7 +51,7 @@ export const FieldDiffContainer: React.FC<{
         style={
           nestingLevel
             ? {
-                gridTemplateColumns: `calc(var(--left-offset) - calc(var(--base)*0.5)) calc(var(--left-offset) - calc(var(--base)*0.5))`,
+                gridTemplateColumns: `calc(var(--left-offset) - calc(var(--base)*0.5) )     calc(50% - calc(var(--base)*0.5) + calc(50% - var(--left-offset)))`,
               }
             : undefined
         }

--- a/packages/ui/src/elements/FieldDiffContainer/index.tsx
+++ b/packages/ui/src/elements/FieldDiffContainer/index.tsx
@@ -51,7 +51,7 @@ export const FieldDiffContainer: React.FC<{
         style={
           nestingLevel
             ? {
-                gridTemplateColumns: `calc(var(--left-offset) - calc(var(--base)*0.5) )     calc(50% - calc(var(--base)*0.5) + calc(50% - var(--left-offset)))`,
+                gridTemplateColumns: `calc(var(--left-offset) - calc(var(--base)*0.5)) calc(var(--left-offset) - calc(var(--base)*0.5))`,
               }
             : undefined
         }


### PR DESCRIPTION
Revert of PR #15330

While the above PR fixes unequal column widths in the versions comparison diff view for nested fields (fields inside groups, arrays, tabs, etc.) 

The column diff highlighting is tied directly to the content width which caused inconsistent highlighting widths. Need to come up with a better solution