### PR TITLE
docs: improve select jsdocs and empty select docs

### DIFF
--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -17,7 +17,7 @@ To specify `select` in the [Local API](../local-api/overview), you can use the `
 ```ts
 import type { Payload } from 'payload'
 
-// Include mode
+// Include mode - result type will only contain: id, text, group.number, and array
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
@@ -37,7 +37,7 @@ const getPosts = async (payload: Payload) => {
   return posts
 }
 
-// Exclude mode
+// Exclude mode - result type will contain all fields except: array and group.number
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
@@ -54,6 +54,20 @@ const getPosts = async (payload: Payload) => {
 
   return posts
 }
+```
+
+### Empty select
+
+The `id` field is always included in the result, regardless of your `select` query. If you pass an empty `select` object, only the `id` will be returned:
+
+```ts
+const post = await payload.findByID({
+  collection: 'posts',
+  id: '1',
+  select: {},
+})
+
+console.log(post) // { id: '1' }
 ```
 
 <Banner type="warning">

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -6,7 +6,7 @@ import type { FindArgs } from '../database/types.js'
 import type { Payload, TypedFallbackLocale } from '../index.js'
 import type { PayloadRequest, PopulateType, SelectType } from '../types/index.js'
 import type { TypeWithID } from './config/types.js'
-import type { Options } from './operations/local/find.js'
+import type { FindOptions } from './operations/local/find.js'
 
 import { isValidID } from '../utilities/isValidID.js'
 
@@ -195,7 +195,7 @@ const createFindDataloaderCacheKey = ({
   showHiddenFields,
   sort,
   where,
-}: Options<string, SelectType>): string =>
+}: FindOptions<string, SelectType>): string =>
   JSON.stringify([
     collection,
     currentDepth,

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 
-import type { CollectionSlug, JsonObject } from '../../index.js'
+import type { CollectionSlug, FindOptions, JsonObject } from '../../index.js'
 import type {
   Document,
   PayloadRequest,
@@ -56,10 +56,9 @@ export type Arguments<TSlug extends CollectionSlug> = {
   publishAllLocales?: boolean
   publishSpecificLocale?: string
   req: PayloadRequest
-  select?: SelectType
   selectedLocales?: string[]
   showHiddenFields?: boolean
-}
+} & Pick<FindOptions<TSlug, SelectType>, 'select'>
 
 export const createOperation = async <
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -1,7 +1,7 @@
 import { status as httpStatus } from 'http-status'
 
 import type { AccessResult } from '../../config/types.js'
-import type { CollectionSlug } from '../../index.js'
+import type { CollectionSlug, FindOptions } from '../../index.js'
 import type { PayloadRequest, PopulateType, SelectType, Where } from '../../types/index.js'
 import type {
   BulkOperationResult,
@@ -39,11 +39,10 @@ export type Arguments = {
   overrideLock?: boolean
   populate?: PopulateType
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   trash?: boolean
   where: Where
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export const deleteOperation = async <
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -35,10 +35,9 @@ export type Arguments = {
   overrideLock?: boolean
   populate?: PopulateType
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   trash?: boolean
-}
+} & Pick<FindOptions<TSlug, SelectType>, 'select'>
 
 export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect extends SelectType>(
   incomingArgs: Arguments,

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -1,6 +1,5 @@
-import type { CollectionSlug } from '../../index.js'
+import type { CollectionSlug, FindOptions } from '../../index.js'
 import type {
-  FindOptions,
   PayloadRequest,
   PopulateType,
   SelectType,
@@ -38,7 +37,7 @@ export type Arguments = {
   req: PayloadRequest
   showHiddenFields?: boolean
   trash?: boolean
-} & Pick<FindOptions<TSlug, SelectType>, 'select'>
+} & Pick<FindOptions<CollectionSlug, SelectType>, 'select'>
 
 export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect extends SelectType>(
   incomingArgs: Arguments,

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -1,5 +1,6 @@
 import type { CollectionSlug } from '../../index.js'
 import type {
+  FindOptions,
   PayloadRequest,
   PopulateType,
   SelectType,

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -26,7 +26,7 @@ import { deleteScheduledPublishJobs } from '../../versions/deleteScheduledPublis
 import { buildAfterOperation } from './utilities/buildAfterOperation.js'
 import { buildBeforeOperation } from './utilities/buildBeforeOperation.js'
 
-export type Arguments = {
+export type Arguments<TSlug extends CollectionSlug, TSelect extends SelectType> = {
   collection: Collection
   depth?: number
   disableTransaction?: boolean
@@ -37,10 +37,10 @@ export type Arguments = {
   req: PayloadRequest
   showHiddenFields?: boolean
   trash?: boolean
-} & Pick<FindOptions<CollectionSlug, SelectType>, 'select'>
+} & Pick<FindOptions<TSlug, TSelect>, 'select'>
 
 export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect extends SelectType>(
-  incomingArgs: Arguments,
+  incomingArgs: Arguments<TSlug, TSelect>,
 ): Promise<TransformCollectionWithSelect<TSlug, TSelect>> => {
   let args = incomingArgs
 

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -1,6 +1,6 @@
 import type { AccessResult } from '../../config/types.js'
 import type { PaginatedDocs } from '../../database/types.js'
-import type { CollectionSlug, JoinQuery } from '../../index.js'
+import type { CollectionSlug, FindOptions, JoinQuery } from '../../index.js'
 import type {
   PayloadRequest,
   PopulateType,
@@ -48,12 +48,11 @@ export type Arguments = {
   pagination?: boolean
   populate?: PopulateType
   req?: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   sort?: Sort
   trash?: boolean
   where?: Where
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 const lockDurationDefault = 300 // Default 5 minutes in seconds
 

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -1,5 +1,5 @@
 import type { FindOneArgs } from '../../database/types.js'
-import type { CollectionSlug, JoinQuery } from '../../index.js'
+import type { CollectionSlug, FindOptions, JoinQuery } from '../../index.js'
 import type {
   ApplyDisableErrors,
   JsonObject,
@@ -49,10 +49,10 @@ export type FindByIDArgs = {
   overrideAccess?: boolean
   populate?: PopulateType
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   trash?: boolean
-} & Pick<AfterReadArgs<JsonObject>, 'flattenLocales'>
+} & Pick<AfterReadArgs<JsonObject>, 'flattenLocales'> &
+  Pick<FindOptions<string, SelectType>, 'select'>
 
 export const findByIDOperation = async <
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -1,5 +1,6 @@
 import { status as httpStatus } from 'http-status'
 
+import type { FindOptions } from '../../index.js'
 import type { PayloadRequest, PopulateType, SelectType } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'
 import type { Collection, TypeWithID } from '../config/types.js'
@@ -25,10 +26,9 @@ export type Arguments = {
   overrideAccess?: boolean
   populate?: PopulateType
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   trash?: boolean
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
   args: Arguments,

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -3,6 +3,7 @@ import type { PaginatedDocs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'
 import type { Collection } from '../config/types.js'
+import type { FindOptions } from './local/find.js'
 
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
@@ -27,12 +28,11 @@ export type Arguments = {
   pagination?: boolean
   populate?: PopulateType
   req?: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   sort?: Sort
   trash?: boolean
   where?: Where
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export const findVersionsOperation = async <TData extends TypeWithVersion<TData>>(
   args: Arguments,

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -18,6 +18,7 @@ import { APIError } from '../../../errors/index.js'
 import {
   type CollectionSlug,
   deepCopyObjectSimple,
+  type FindOptions,
   type Payload,
   type RequestContext,
   type TypedLocale,
@@ -98,10 +99,6 @@ type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -110,7 +107,7 @@ type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<TSlug, TSelect>, 'select'>
 
 export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> =
   | ({

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -65,10 +65,6 @@ export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -85,7 +81,7 @@ export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<TSlug, TSelect>, 'select'>
 
 export type ByIDOptions<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -1,4 +1,10 @@
-import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type {
+  CollectionSlug,
+  FindOptions,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type {
   Document,
   PayloadRequest,

--- a/packages/payload/src/collections/operations/local/duplicate.ts
+++ b/packages/payload/src/collections/operations/local/duplicate.ts
@@ -76,10 +76,6 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
-  /**
    * Specifies which locales to include when duplicating localized fields. Non-localized data is always duplicated.
    * By default, all locales are duplicated.
    */
@@ -93,7 +89,7 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<TSlug, TSelect>, 'select'>
 
 export async function duplicateLocal<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/local/duplicate.ts
+++ b/packages/payload/src/collections/operations/local/duplicate.ts
@@ -1,7 +1,7 @@
 import type { DeepPartial } from 'ts-essentials'
 
 import type { CollectionSlug, TypedLocale } from '../../..//index.js'
-import type { Payload, RequestContext } from '../../../index.js'
+import type { FindOptions, Payload, RequestContext } from '../../../index.js'
 import type {
   Document,
   PayloadRequest,

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -25,7 +25,7 @@ import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findOperation } from '../find.js'
 
-export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+export type FindOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
   /**
    * the Collection slug to operate against.
    */
@@ -103,7 +103,50 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   * By default, Payload's APIs will return all fields for a given collection or global.
+   * But you may not need all of that data for all of your queries.
+   * Sometimes, you might want just a few fields from the response.
+   *
+   * With the Select API, you can define exactly which fields you'd like to retrieve.
+   * This can impact performance by reducing database load and response size.
+   *
+   *
+   * **Example: Select specific fields**
+   * ```ts
+   * const post = await payload.findByID({
+   *   collection: 'posts',
+   *   id: '1',
+   *   select: { title: true, content: true },
+   * })
+   *
+   * console.log(post) // { id: '1', title: 'My Post', content: 'This is my post' }
+   * ```
+   *
+   * **Example: Select all fields except `content`**
+   *
+   * ```ts
+   * const post = await payload.findByID({
+   *   collection: 'posts',
+   *   id: '1',
+   *   select: { content: false },
+   * })
+   *
+   * console.log(post) // { id: '1', title: 'My Post', number: 3 }
+   * ```
+   *
+   * **Example: Empty select returns only `id`**
+   *
+   * ```ts
+   * const post = await payload.findByID({
+   *   collection: 'posts',
+   *   id: '1',
+   *   select: {},
+   * })
+   *
+   * console.log(post) // { id: '1' }
+   * ```
+   *
+   * @see https://payloadcms.com/docs/queries/select
    */
   select?: TSelect
   /**
@@ -142,7 +185,7 @@ export async function findLocal<
   TDraft extends boolean = false,
 >(
   payload: Payload,
-  options: { draft?: TDraft } & Options<TSlug, TSelect>,
+  options: { draft?: TDraft } & FindOptions<TSlug, TSelect>,
 ): Promise<
   PaginatedDocs<
     TDraft extends true

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -1,5 +1,6 @@
 import type {
   CollectionSlug,
+  FindOptions,
   JoinQuery,
   Payload,
   RequestContext,
@@ -97,10 +98,6 @@ export type Options<
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -118,7 +115,8 @@ export type Options<
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-} & Pick<FindByIDArgs, 'flattenLocales'>
+} & Pick<FindByIDArgs, 'flattenLocales'> &
+  Pick<FindOptions<TSlug, TSelect>, 'select'>
 
 export async function findByIDLocal<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -1,4 +1,10 @@
-import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type {
+  CollectionSlug,
+  FindOptions,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
 import type { TypeWithVersion } from '../../../versions/types.js'
@@ -61,10 +67,6 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: SelectType
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -82,7 +84,7 @@ export type Options<TSlug extends CollectionSlug> = {
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<TSlug, SelectType>, 'select'>
 
 export async function findVersionByIDLocal<TSlug extends CollectionSlug>(
   payload: Payload,

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -1,5 +1,11 @@
 import type { PaginatedDocs } from '../../../database/types.js'
-import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type {
+  CollectionSlug,
+  FindOptions,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
@@ -76,10 +82,6 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: SelectType
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -107,7 +109,7 @@ export type Options<TSlug extends CollectionSlug> = {
    * A filter [query](https://payloadcms.com/docs/queries/overview)
    */
   where?: Where
-}
+} & Pick<FindOptions<TSlug, SelectType>, 'select'>
 
 export async function findVersionsLocal<TSlug extends CollectionSlug>(
   payload: Payload,

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -1,4 +1,10 @@
-import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type {
+  CollectionSlug,
+  FindOptions,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
 import type { DataFromCollectionSlug } from '../../config/types.js'
@@ -55,10 +61,6 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: SelectType
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -67,7 +69,7 @@ export type Options<TSlug extends CollectionSlug> = {
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<TSlug, SelectType>, 'select'>
 
 export async function restoreVersionLocal<TSlug extends CollectionSlug>(
   payload: Payload,

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -1,6 +1,12 @@
 import type { DeepPartial } from 'ts-essentials'
 
-import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type {
+  CollectionSlug,
+  FindOptions,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
@@ -112,10 +118,7 @@ export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType
    * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
    */
   req?: Partial<PayloadRequest>
-  /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
+
   /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
@@ -136,7 +139,7 @@ export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<TSlug, TSelect>, 'select'>
 
 export type ByIDOptions<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -3,6 +3,7 @@ import { status as httpStatus } from 'http-status'
 import type { FindOneArgs } from '../../database/types.js'
 import type { JsonObject, PayloadRequest, PopulateType, SelectType } from '../../types/index.js'
 import type { Collection, TypeWithID } from '../config/types.js'
+import type { FindOptions } from './local/find.js'
 
 import { executeAccess } from '../../auth/executeAccess.js'
 import { hasWhereAccessResult } from '../../auth/types.js'
@@ -22,7 +23,6 @@ import { getLatestCollectionVersion } from '../../versions/getLatestCollectionVe
 import { saveVersion } from '../../versions/saveVersion.js'
 import { buildAfterOperation } from './utilities/buildAfterOperation.js'
 import { buildBeforeOperation } from './utilities/buildBeforeOperation.js'
-
 export type Arguments = {
   collection: Collection
   currentDepth?: number
@@ -34,9 +34,8 @@ export type Arguments = {
   overrideAccess?: boolean
   populate?: PopulateType
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export const restoreVersionOperation = async <
   TData extends JsonObject & TypeWithID = JsonObject & TypeWithID,

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -17,7 +17,7 @@ import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { sanitizeWhereQuery } from '../../database/sanitizeWhereQuery.js'
 import { APIError } from '../../errors/index.js'
-import { type CollectionSlug, deepCopyObjectSimple } from '../../index.js'
+import { type CollectionSlug, deepCopyObjectSimple, type FindOptions } from '../../index.js'
 import { generateFileData } from '../../uploads/generateFileData.js'
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.js'
@@ -51,7 +51,6 @@ export type Arguments<TSlug extends CollectionSlug> = {
   publishAllLocales?: boolean
   publishSpecificLocale?: string
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   /**
    * Sort the documents, can be a string or an array of strings
@@ -62,7 +61,7 @@ export type Arguments<TSlug extends CollectionSlug> = {
   trash?: boolean
   unpublishAllLocales?: boolean
   where: Where
-}
+} & Pick<FindOptions<TSlug, SelectType>, 'select'>
 
 export const updateOperation = async <
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -20,7 +20,7 @@ import { executeAccess } from '../../auth/executeAccess.js'
 import { hasWhereAccessResult } from '../../auth/types.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { APIError, Forbidden, NotFound } from '../../errors/index.js'
-import { type CollectionSlug, deepCopyObjectSimple } from '../../index.js'
+import { type CollectionSlug, deepCopyObjectSimple, type FindOptions } from '../../index.js'
 import { generateFileData } from '../../uploads/generateFileData.js'
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.js'
@@ -49,11 +49,10 @@ export type Arguments<TSlug extends CollectionSlug> = {
   publishAllLocales?: boolean
   publishSpecificLocale?: string
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   trash?: boolean
   unpublishAllLocales?: boolean
-}
+} & Pick<FindOptions<TSlug, SelectType>, 'select'>
 
 export const updateByIDOperation = async <
   TSlug extends CollectionSlug,

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -1,5 +1,6 @@
 import { ar } from '@payloadcms/translations/languages/ar'
 
+import type { FindOptions } from '../../collections/operations/local/find.js'
 import type { AccessResult } from '../../config/types.js'
 import type {
   JsonObject,
@@ -33,10 +34,10 @@ export type GlobalFindOneArgs = {
   overrideAccess?: boolean
   populate?: PopulateType
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   slug: string
-} & Pick<AfterReadArgs<JsonObject>, 'flattenLocales'>
+} & Pick<AfterReadArgs<JsonObject>, 'flattenLocales'> &
+  Pick<FindOptions<string, SelectType>, 'select'>
 
 export const findOneOperation = async <T extends Record<string, unknown>>(
   args: GlobalFindOneArgs,

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -1,3 +1,4 @@
+import type { FindOptions } from '../../collections/operations/local/find.js'
 import type { FindGlobalVersionsArgs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'
@@ -22,9 +23,8 @@ export type Arguments = {
   overrideAccess?: boolean
   populate?: PopulateType
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = any>(
   args: Arguments,

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -1,3 +1,4 @@
+import type { FindOptions } from '../../collections/operations/local/find.js'
 import type { PaginatedDocs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'
@@ -22,11 +23,10 @@ export type Arguments = {
   pagination?: boolean
   populate?: PopulateType
   req?: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   sort?: Sort
   where?: Where
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
   args: Arguments,

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -1,3 +1,4 @@
+import type { FindOptions } from '../../../collections/operations/local/find.js'
 import type {
   GlobalSlug,
   Payload,
@@ -68,10 +69,6 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -84,7 +81,8 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-} & Pick<GlobalFindOneArgs, 'flattenLocales'>
+} & Pick<FindOptions<string, SelectType>, 'select'> &
+  Pick<GlobalFindOneArgs, 'flattenLocales'>
 
 export async function findOneGlobalLocal<
   TSlug extends GlobalSlug,

--- a/packages/payload/src/globals/operations/local/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/local/findVersionByID.ts
@@ -1,4 +1,10 @@
-import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type {
+  FindOptions,
+  GlobalSlug,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { CreateLocalReqOptions } from '../../../utilities/createLocalReq.js'
 import type { TypeWithVersion } from '../../../versions/types.js'
@@ -52,10 +58,7 @@ export type Options<TSlug extends GlobalSlug> = {
    * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
    */
   req?: Partial<PayloadRequest>
-  /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: SelectType
+
   /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
@@ -69,7 +72,7 @@ export type Options<TSlug extends GlobalSlug> = {
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export async function findGlobalVersionByIDLocal<TSlug extends GlobalSlug>(
   payload: Payload,

--- a/packages/payload/src/globals/operations/local/findVersions.ts
+++ b/packages/payload/src/globals/operations/local/findVersions.ts
@@ -1,5 +1,11 @@
 import type { PaginatedDocs } from '../../../database/types.js'
-import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type {
+  FindOptions,
+  GlobalSlug,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
@@ -68,10 +74,6 @@ export type Options<TSlug extends GlobalSlug> = {
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: SelectType
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -94,7 +96,7 @@ export type Options<TSlug extends GlobalSlug> = {
    * A filter [query](https://payloadcms.com/docs/queries/overview)
    */
   where?: Where
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export async function findGlobalVersionsLocal<TSlug extends GlobalSlug>(
   payload: Payload,

--- a/packages/payload/src/globals/operations/local/update.ts
+++ b/packages/payload/src/globals/operations/local/update.ts
@@ -13,6 +13,7 @@ import type { DataFromGlobalSlug, SelectFromGlobalSlug } from '../../config/type
 import { APIError } from '../../../errors/index.js'
 import {
   deepCopyObjectSimple,
+  type FindOptions,
   type GlobalSlug,
   type Payload,
   type RequestContext,
@@ -81,10 +82,6 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    */
   req?: Partial<PayloadRequest>
   /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
-  /**
    * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
    * @default false
    */
@@ -101,7 +98,7 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
    * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
    */
   user?: Document
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export async function updateGlobalLocal<
   TSlug extends GlobalSlug,

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -1,5 +1,6 @@
 import type { DeepPartial } from 'ts-essentials'
 
+import type { FindOptions } from '../../collections/operations/local/find.js'
 import type { GlobalSlug, JsonObject } from '../../index.js'
 import type {
   Operation,
@@ -48,11 +49,10 @@ type Args<TSlug extends GlobalSlug> = {
   publishAllLocales?: boolean
   publishSpecificLocale?: string
   req: PayloadRequest
-  select?: SelectType
   showHiddenFields?: boolean
   slug: string
   unpublishAllLocales?: boolean
-}
+} & Pick<FindOptions<string, SelectType>, 'select'>
 
 export const updateOperation = async <
   TSlug extends GlobalSlug,

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -67,7 +67,8 @@ import {
   duplicateLocal,
   type Options as DuplicateOptions,
 } from './collections/operations/local/duplicate.js'
-import { findLocal, type Options as FindOptions } from './collections/operations/local/find.js'
+import { findLocal, type FindOptions } from './collections/operations/local/find.js'
+export type { FindOptions }
 import {
   findByIDLocal,
   type Options as FindByIDOptions,

--- a/packages/sdk/src/collections/findByID.ts
+++ b/packages/sdk/src/collections/findByID.ts
@@ -1,4 +1,11 @@
-import type { ApplyDisableErrors, CollectionSlug, PayloadTypesShape, TypedLocale } from 'payload'
+import type {
+  ApplyDisableErrors,
+  CollectionSlug,
+  FindOptions,
+  PayloadTypesShape,
+  SelectType,
+  TypedLocale,
+} from 'payload'
 
 import type { PayloadSDK } from '../index.js'
 import type {
@@ -52,11 +59,7 @@ export type FindByIDOptions<
    * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
    */
   populate?: PopulateType<T>
-  /**
-   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
-   */
-  select?: TSelect
-}
+} & Pick<FindOptions<TSlug, SelectType & TSelect>, 'select'>
 
 export async function findByID<
   T extends PayloadTypesShape,

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -994,6 +994,17 @@ describe('Types testing', () => {
       expect(result).type.toBe<Pick<Post, 'id' | 'namedGroup' | 'title'>>()
     })
 
+    test('SDK with empty select only returns id', async () => {
+      const _sdk = new PayloadSDK<LocalConfig>({ baseURL: '' })
+
+      const result = await _sdk.findByID({
+        collection: 'posts',
+        id: 'id',
+        select: {},
+      })
+      expect(result).type.toBe<{ id: string }>()
+    })
+
     test('SDK with select excluding field in findByID returns correct types', async () => {
       const _sdk = new PayloadSDK<LocalConfig>({ baseURL: '' })
       const result = await _sdk.findByID({


### PR DESCRIPTION
This PR ensures we have proper jsdocs in all public APIs that expose the `select` property. That way, people can easily grasp how to use select without having to open the docs page.

Also, we never documented how to select **just** the `id` field anywhere, or what happens if an empty select property is passed. Today, this actually confused me, as I wanted to select just the ID and, after reading the docs, didn't know how. Thus, this PR adds a section about empty select in the docs, as well as an example in the jsdocs.