### PR TITLE
fix(richtext-lexical): fix Safari 15 regex compatibility issue

### DIFF
--- a/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
@@ -43,11 +43,16 @@ export function createLinkMatcherWithRegExp(
     if (match === null) {
       return null
     }
+    let matchedText = match[0]
+    // Remove trailing characters that shouldn't be part of URL
+    // This replaces the negative lookbehind (?<![-.+():%]) for Safari 15 compatibility
+    const trailingChars = /[-.+():%]+$/
+    matchedText = matchedText.replace(trailingChars, '')
     return {
       index: match.index,
-      length: match[0].length,
-      text: match[0],
-      url: urlTransformer(match[0]),
+      length: matchedText.length,
+      text: matchedText,
+      url: urlTransformer(matchedText),
     }
   }
 }
@@ -444,7 +449,7 @@ function useAutoLink(
 }
 
 const URL_REGEX =
-  /((https?:\/\/(www\.)?)|(www\.))[-\w@:%.+~#=]{1,256}\.[a-zA-Z\d()]{1,6}\b([-\w()@:%+.~#?&/=]*)(?<![-.+():%])/
+  /((https?:\/\/(www\.)?)|(www\.))[-\w@:%.+~#=]{1,256}\.[a-zA-Z\d()]{1,6}\b([-\w()@:%+.~#?&/=]*)/
 
 const EMAIL_REGEX =
   /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\])|(([a-z\-\d]+\.)+[a-z]{2,}))/i


### PR DESCRIPTION
## Description

Fixes Safari 15 compatibility issue where the negative lookbehind assertion `(?<![-.+():%])` in URL_REGEX causes "invalid group specifier name" error.

Related issue #7241

## Reason

I'm submitting this PR because my client uses older devices running macOS Catalina 10.15.7, which cannot be updated and therefore cannot upgrade Safari to version 16.2+. I hope the maintainers can support this compatibility requirement.

## Changes

- Removed negative lookbehind from URL_REGEX (not supported in Safari 15)
- Added post-processing logic in `createLinkMatcherWithRegExp` to remove trailing characters that shouldn't be part of URL
- Maintains the same functionality while being compatible with Safari 15
