### PR TITLE
fix: remove depth from count operation types

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -447,7 +447,6 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         if (count && limit === 0) {
           return await req.payload.count({
             collection,
-            depth: 0,
             overrideAccess: false,
             req,
             where: fullWhere,

--- a/packages/next/src/views/Document/getVersions.ts
+++ b/packages/next/src/views/Document/getVersions.ts
@@ -217,7 +217,6 @@ export const getVersions = async ({
 
     ;({ totalDocs: versionCount } = await payload.countVersions({
       collection: collectionConfig.slug,
-      depth: 0,
       locale,
       user,
       where: combineQueries(
@@ -270,7 +269,6 @@ export const getVersions = async ({
 
       if (publishedDoc?.updatedAt) {
         ;({ totalDocs: unpublishedVersionCount } = await payload.countGlobalVersions({
-          depth: 0,
           global: globalConfig.slug,
           locale,
           user,
@@ -296,7 +294,6 @@ export const getVersions = async ({
     }
 
     ;({ totalDocs: versionCount } = await payload.countGlobalVersions({
-      depth: 0,
       global: globalConfig.slug,
       locale,
       user,

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -6,7 +6,7 @@ import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { countOperation } from '../count.js'
 
-export type Options<TSlug extends CollectionSlug> = {
+export type CountOptions<TSlug extends CollectionSlug> = {
   /**
    * the Collection slug to operate against.
    */
@@ -58,7 +58,7 @@ export type Options<TSlug extends CollectionSlug> = {
 
 export async function countLocal<TSlug extends CollectionSlug>(
   payload: Payload,
-  options: Options<TSlug>,
+  options: CountOptions<TSlug>,
 ): Promise<{ totalDocs: number }> {
   const {
     collection: collectionSlug,

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -19,10 +19,6 @@ export type Options<TSlug extends CollectionSlug> = {
    */
   context?: RequestContext
   /**
-   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
-   */
-  depth?: number
-  /**
    * When set to `true`, errors will not be thrown.
    */
   disableErrors?: boolean

--- a/packages/payload/src/collections/operations/local/countVersions.ts
+++ b/packages/payload/src/collections/operations/local/countVersions.ts
@@ -6,7 +6,7 @@ import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { countVersionsOperation } from '../countVersions.js'
 
-export type Options<TSlug extends CollectionSlug> = {
+export type CountVersionsOptions<TSlug extends CollectionSlug> = {
   /**
    * the Collection slug to operate against.
    */
@@ -18,10 +18,6 @@ export type Options<TSlug extends CollectionSlug> = {
    * to determine if it should run or not.
    */
   context?: RequestContext
-  /**
-   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
-   */
-  depth?: number
   /**
    * When set to `true`, errors will not be thrown.
    */
@@ -53,7 +49,7 @@ export type Options<TSlug extends CollectionSlug> = {
 
 export async function countVersionsLocal<TSlug extends CollectionSlug>(
   payload: Payload,
-  options: Options<TSlug>,
+  options: CountVersionsOptions<TSlug>,
 ): Promise<{ totalDocs: number }> {
   const { collection: collectionSlug, disableErrors, overrideAccess = true, where } = options
 

--- a/packages/payload/src/fields/baseFields/slug/countVersions.ts
+++ b/packages/payload/src/fields/baseFields/slug/countVersions.ts
@@ -31,7 +31,6 @@ export const countVersions = async (args: {
     countFn = () =>
       req.payload.countVersions({
         collection: collectionSlug,
-        depth: 0,
         where,
       })
   }
@@ -39,7 +38,6 @@ export const countVersions = async (args: {
   if (globalSlug) {
     countFn = () =>
       req.payload.countGlobalVersions({
-        depth: 0,
         global: globalSlug,
         where,
       })

--- a/packages/payload/src/globals/operations/local/countVersions.ts
+++ b/packages/payload/src/globals/operations/local/countVersions.ts
@@ -15,10 +15,6 @@ export type CountGlobalVersionsOptions<TSlug extends GlobalSlug> = {
    */
   context?: RequestContext
   /**
-   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
-   */
-  depth?: number
-  /**
    * When set to `true`, errors will not be thrown.
    */
   disableErrors?: boolean

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -52,7 +52,7 @@ import type {
 } from './types/index.js'
 import type { TraverseFieldsCallback } from './utilities/traverseFields.js'
 
-import { countLocal, type Options as CountOptions } from './collections/operations/local/count.js'
+import { countLocal, type CountOptions } from './collections/operations/local/count.js'
 import {
   createLocal,
   type Options as CreateOptions,
@@ -136,7 +136,10 @@ import { APIKeyAuthentication } from './auth/strategies/apiKey.js'
 import { JWTAuthentication } from './auth/strategies/jwt.js'
 import { generateImportMap, type ImportMap } from './bin/generateImportMap/index.js'
 import { checkPayloadDependencies } from './checkPayloadDependencies.js'
-import { countVersionsLocal } from './collections/operations/local/countVersions.js'
+import {
+  countVersionsLocal,
+  type CountVersionsOptions,
+} from './collections/operations/local/countVersions.js'
 import { consoleEmailAdapter } from './email/consoleEmailAdapter.js'
 import { fieldAffectsData, type FlattenedBlock } from './fields/config/types.js'
 import { getJobsLocalAPI } from './queues/localAPI.js'
@@ -403,7 +406,7 @@ export class BasePayload {
    * @returns count of document versions satisfying query
    */
   countVersions = async <T extends CollectionSlug>(
-    options: CountOptions<T>,
+    options: CountVersionsOptions<T>,
   ): Promise<{ totalDocs: number }> => {
     return countVersionsLocal(this, options)
   }

--- a/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
@@ -92,7 +92,6 @@ export const tenantField = ({
         if (tenantFromCookie) {
           const isValidTenant = await req.payload.count({
             collection: tenantsCollectionSlug,
-            depth: 0,
             overrideAccess: false,
             req,
             user: req.user,

--- a/packages/richtext-lexical/src/utilities/migrateSlateToLexical/index.ts
+++ b/packages/richtext-lexical/src/utilities/migrateSlateToLexical/index.ts
@@ -121,7 +121,6 @@ async function migrateCollection({
   const documentCount = (
     await payload.count({
       collection: collection.slug,
-      depth: 0,
       locale: locale || undefined,
     })
   ).totalDocs

--- a/packages/richtext-lexical/src/utilities/upgradeLexicalData/index.ts
+++ b/packages/richtext-lexical/src/utilities/upgradeLexicalData/index.ts
@@ -92,7 +92,6 @@ async function upgradeCollection({
   const documentCount = (
     await payload.count({
       collection: collection.slug,
-      depth: 0,
       locale: locale || undefined,
     })
   ).totalDocs


### PR DESCRIPTION
The `payload.count`, `payload.countVersions` and `payload.countGlobalVersions` operations accepted a `depth` argument, but this value is never used in the count logic. Having it show up in auto-suggestions can be confusing for users (as I just experienced), since it raises the question of why a count operation would need a depth at all.

This PR removes the unused depth property