### PR TITLE
fix: find afterRead hooks should behave like findByID

### DIFF
--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -346,7 +346,7 @@ export const findOperation = async <
                 findMany: true,
                 query: fullWhere,
                 req,
-              })) || doc
+              })) || docRef
           }
 
           return docRef

--- a/test/hooks/collections/AfterRead/index.ts
+++ b/test/hooks/collections/AfterRead/index.ts
@@ -1,0 +1,26 @@
+import type { CollectionConfig } from 'payload'
+
+import { afterReadSlug } from '../../shared.js'
+
+export const AfterReadCollection: CollectionConfig = {
+  slug: afterReadSlug,
+  hooks: {
+    afterRead: [
+      ({ doc }) => {
+        return {
+          ...doc,
+          title: 'afterRead',
+        }
+      },
+      () => {
+        return undefined
+      },
+    ],
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}

--- a/test/hooks/config.ts
+++ b/test/hooks/config.ts
@@ -8,6 +8,7 @@ import { APIError } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { AfterOperationCollection } from './collections/AfterOperation/index.js'
+import { AfterReadCollection } from './collections/AfterRead/index.js'
 import { BeforeChangeHooks } from './collections/BeforeChange/index.js'
 import {
   BeforeDelete2Collection,
@@ -50,6 +51,7 @@ export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
     BeforeDeleteCollection,
     BeforeDelete2Collection,
     ValueCollection,
+    AfterReadCollection,
   ],
   globals: [DataHooksGlobal],
   endpoints: [

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -28,10 +28,9 @@ import {
 import { relationsSlug } from './collections/Relations/index.js'
 import { transformSlug } from './collections/Transform/index.js'
 import { hooksUsersSlug } from './collections/Users/index.js'
-import { valueHooksSlug } from './collections/Value/index.js'
 import { HooksConfig } from './config.js'
 import { dataHooksGlobalSlug } from './globals/Data/index.js'
-import { beforeValidateSlug, fieldPathsSlug } from './shared.js'
+import { afterReadSlug, beforeValidateSlug } from './shared.js'
 
 let restClient: NextRESTClient
 let payload: Payload
@@ -976,6 +975,37 @@ describe('Hooks', () => {
       })
 
       expect(getLastOperation()).toEqual('restoreVersion')
+    })
+  })
+
+  describe('afterRead', () => {
+    it('should return same for find and findByID', async () => {
+      const createdDoc = await payload.create({
+        collection: afterReadSlug,
+        data: {
+          title: 'test',
+        },
+      })
+
+      const docFromFind = await payload.findByID({
+        collection: afterReadSlug,
+        id: createdDoc.id,
+      })
+
+      const { docs } = await payload.find({
+        collection: afterReadSlug,
+        where: {
+          id: {
+            equals: createdDoc.id,
+          },
+        },
+      })
+
+      const docFromFindMany = docs[0]
+
+      expect(docFromFind.title).toEqual('afterRead')
+      expect(docFromFindMany.title).toEqual('afterRead')
+      expect(docFromFind.title).toEqual(docFromFindMany.title)
     })
   })
 })

--- a/test/hooks/payload-types.ts
+++ b/test/hooks/payload-types.ts
@@ -83,6 +83,7 @@ export interface Config {
     'before-delete-hooks': BeforeDeleteHook;
     'before-delete-2-hooks': BeforeDelete2Hook;
     'value-hooks': ValueHook;
+    'after-read': AfterRead;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -106,6 +107,7 @@ export interface Config {
     'before-delete-hooks': BeforeDeleteHooksSelect<false> | BeforeDeleteHooksSelect<true>;
     'before-delete-2-hooks': BeforeDelete2HooksSelect<false> | BeforeDelete2HooksSelect<true>;
     'value-hooks': ValueHooksSelect<false> | ValueHooksSelect<true>;
+    'after-read': AfterReadSelect<false> | AfterReadSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -390,6 +392,16 @@ export interface ValueHook {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "after-read".
+ */
+export interface AfterRead {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -475,6 +487,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'value-hooks';
         value: string | ValueHook;
+      } | null)
+    | ({
+        relationTo: 'after-read';
+        value: string | AfterRead;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -727,6 +743,15 @@ export interface ValueHooksSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "after-read_select".
+ */
+export interface AfterReadSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -803,6 +828,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }

--- a/test/hooks/shared.ts
+++ b/test/hooks/shared.ts
@@ -1,2 +1,3 @@
 export const beforeValidateSlug = 'before-validate'
 export const fieldPathsSlug = 'field-paths'
+export const afterReadSlug = 'after-read'


### PR DESCRIPTION
## Issue
Fixes `find` afterRead hooks that should behave like `findByID` afterRead hooks. 

## Before
The find afterRead hooks were falling back to the `doc` if the hook returned undefined/null.

## After
The find afterRead hooks now fallback to the `docRef` if the afterRead hook returns undefined/null.

## Alignment
You can see [here](https://github.com/payloadcms/payload/blob/main/packages/payload/src/collections/operations/findByID.ts#L310-L319) that the findByID already behaves this way.
