### PR TITLE
fix(ui): getEntityConfig did not respect globalSlug if collectionSlug is undefined

### DIFF
--- a/packages/ui/src/providers/Config/index.tsx
+++ b/packages/ui/src/providers/Config/index.tsx
@@ -68,11 +68,11 @@ export const ConfigProvider: React.FC<{
 
   const getEntityConfig = useCallback<GetEntityConfigFn>(
     (args) => {
-      if ('collectionSlug' in args) {
+      if ('collectionSlug' in args && args.collectionSlug) {
         return collectionsBySlug[args.collectionSlug] ?? null
       }
 
-      if ('globalSlug' in args) {
+      if ('globalSlug' in args && args.globalSlug) {
         return globalsBySlug[args.globalSlug] ?? null
       }
 


### PR DESCRIPTION
Previously, if you used `getEntityConfig({ globalSlug: 'test', collectionSlug: undefined )}` it would return `null` instead of the actual global config. This PR fixes this behavior by checking if the properties actually exist.