### PR TITLE
feat(graphql): add schema sort flag

### DIFF
--- a/docs/graphql/graphql-schema.mdx
+++ b/docs/graphql/graphql-schema.mdx
@@ -22,6 +22,14 @@ Run the following command to generate the schema:
 pnpm payload-graphql generate:schema
 ```
 
+To generate a lexicographically sorted schema (useful for stable diffs), add the `--sort-schema` flag:
+
+```bash
+pnpm payload-graphql generate:schema --sort-schema
+```
+
+You can also use the short alias `--sort`.
+
 ## Custom Field Schemas
 
 For `array`, `block`, `group` and named `tab` fields, you can generate top level reusable interfaces. The following group field config:

--- a/packages/graphql/src/bin/generateSchema.ts
+++ b/packages/graphql/src/bin/generateSchema.ts
@@ -1,13 +1,21 @@
 import type { SanitizedConfig } from 'payload'
 
 import fs from 'fs'
-import { printSchema } from 'graphql'
+import { lexicographicSortSchema, printSchema } from 'graphql'
 
 import { configToSchema } from '../index.js'
-export function generateSchema(config: SanitizedConfig): void {
+
+type GenerateSchemaOptions = {
+  sortSchema?: boolean
+}
+
+export function generateSchema(config: SanitizedConfig, options: GenerateSchemaOptions = {}): void {
   const outputFile = process.env.PAYLOAD_GRAPHQL_SCHEMA_PATH || config.graphQL.schemaOutputFile
 
   const { schema } = configToSchema(config)
 
-  fs.writeFileSync(outputFile, printSchema(schema))
+  const shouldSortSchema = options.sortSchema ?? false
+  const schemaToPrint = shouldSortSchema ? lexicographicSortSchema(schema) : schema
+
+  fs.writeFileSync(outputFile, printSchema(schemaToPrint))
 }

--- a/packages/graphql/src/bin/index.ts
+++ b/packages/graphql/src/bin/index.ts
@@ -14,7 +14,10 @@ export const bin = async () => {
   const script = (typeof args._[0] === 'string' ? args._[0] : '').toLowerCase()
 
   if (script === 'generate:schema') {
-    return generateSchema(config)
+    const sortSchemaArg = args['sort-schema'] ?? args.sort
+    const shouldSortSchema = sortSchemaArg === true || sortSchemaArg === 'true'
+
+    return generateSchema(config, { sortSchema: shouldSortSchema })
   }
 
   console.log(`Unknown script: "${script}".`)


### PR DESCRIPTION
### What?

A flag on the GraphQL CLI to generate the schema.graphql. This will use the built-in `lexicographicSortSchema` to sort the schema lexicographically.

### Why?

We check-in our schema.graphql for two reasons. Firstly, we can review the changes for our frontend and secondly we use it for type checking in combination with [gql.tada](https://gql-tada.0no.co).

I was refactoring some collections in Payload and had changes to the schema.graphql that don't actually change anything for consumers of the API. So I tried finding a way to sort them so refactoring wouldn't change the schema. Turns out there is a built-in function that already does this to a schema. So I added a flag to the CLI that sorts the schema.

### How?

Add a flag, sort with the built-in `lexicographicSortSchema`, output schema like normal.
