### PR TITLE
fix(ui): use the formatAdminUrl function to generate unpublish url

### DIFF
--- a/packages/ui/src/elements/UnpublishButton/index.tsx
+++ b/packages/ui/src/elements/UnpublishButton/index.tsx
@@ -2,6 +2,7 @@
 
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
+import { formatAdminURL } from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -73,12 +74,20 @@ export function UnpublishButton() {
         )
 
         if (collectionSlug) {
-          url = `${serverURL}${api}/${collectionSlug}/${id}${queryString}`
+          url = formatAdminURL({
+            apiRoute: api,
+            path: `/${collectionSlug}${id ? `/${id}` : ''}${queryString}`,
+            serverURL,
+          })
           method = 'patch'
         }
 
         if (globalSlug) {
-          url = `${serverURL}${api}/globals/${globalSlug}${queryString}`
+          url = formatAdminURL({
+            apiRoute: api,
+            path: `/globals/${globalSlug}${queryString}`,
+            serverURL,
+          })
           method = 'post'
         }
 

--- a/packages/ui/src/elements/UnpublishButton/index.tsx
+++ b/packages/ui/src/elements/UnpublishButton/index.tsx
@@ -76,7 +76,7 @@ export function UnpublishButton() {
         if (collectionSlug) {
           url = formatAdminURL({
             apiRoute: api,
-            path: `/${collectionSlug}${id ? `/${id}` : ''}${queryString}`,
+            path: `/${collectionSlug}/${id}${queryString}`,
             serverURL,
           })
           method = 'patch'


### PR DESCRIPTION
### What?
The unpublish button on the admin panel sends a request to the wrong url if the application has a base path configured in the next config. This PR uses the formatAdminURL function to conditionally add the base path if needed.

### Why?
Unpublish button does not work if base path is set.

### How?
Using the formatAdminURL correctly includes the basePath in the url

Fixes https://github.com/payloadcms/payload/issues/15369

