### PR TITLE
fix(plugin-cloud-storage): infinite loop in upload edits

### DIFF
--- a/packages/plugin-cloud-storage/src/hooks/afterChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.ts
@@ -12,6 +12,9 @@ interface Args {
 export const getAfterChangeHook =
   ({ adapter, collection }: Args): CollectionAfterChangeHook<FileData & TypeWithID> =>
   async ({ doc, operation, previousDoc, req }) => {
+    if (req.context?.triggerAfterChange === false) {
+      return doc
+    }
     try {
       const files = getIncomingFiles({ data: doc, req })
 
@@ -71,7 +74,15 @@ export const getAfterChangeHook =
               collection: collection.slug,
               data: uploadMetadata,
               depth: 0,
-              req,
+              req: {
+                ...req,
+                context: {
+                  ...req.context,
+                  triggerAfterChange: false,
+                },
+                file: undefined,
+                query: {},
+              },
             })
             return { ...doc, ...uploadMetadata }
           } catch (updateError: unknown) {


### PR DESCRIPTION
### What?
Prevent afterChange hook from triggering itself again and again

### Why?
The current implementation loops forever

### How?
Make sure we only do the processing once

I am not sure this is "the correct fix" according to Payload devs but at least it is _**a**_ fix.
