### PR TITLE
fix(next): version view throws useLocale() server error

### DIFF
--- a/packages/next/src/views/Version/VersionPillLabel/VersionPillLabel.tsx
+++ b/packages/next/src/views/Version/VersionPillLabel/VersionPillLabel.tsx
@@ -2,7 +2,7 @@
 
 import type { TypeWithVersion } from 'payload'
 
-import { Pill, useConfig, useTranslation } from '@payloadcms/ui'
+import { Pill, useConfig, useLocale, useTranslation } from '@payloadcms/ui'
 import { formatDate } from '@payloadcms/ui/shared'
 import React from 'react'
 
@@ -63,8 +63,10 @@ export const VersionPillLabel: React.FC<{
     },
   } = useConfig()
   const { i18n, t } = useTranslation()
+  const { code: currentLocale } = useLocale()
 
   const { label, pillStyle } = getVersionLabel({
+    currentLocale,
     currentlyPublishedVersion,
     latestDraftVersion,
     t,

--- a/packages/next/src/views/Version/VersionPillLabel/getVersionLabel.ts
+++ b/packages/next/src/views/Version/VersionPillLabel/getVersionLabel.ts
@@ -1,8 +1,8 @@
 import type { TFunction } from '@payloadcms/translations'
-
-import { type Pill, useLocale } from '@payloadcms/ui'
+import type { Pill } from '@payloadcms/ui'
 
 type Args = {
+  currentLocale?: string
   currentlyPublishedVersion?: {
     id: number | string
     publishedLocale?: string
@@ -28,6 +28,7 @@ type Args = {
  * given existing versions and the current version status.
  */
 export function getVersionLabel({
+  currentLocale,
   currentlyPublishedVersion,
   latestDraftVersion,
   t,
@@ -37,7 +38,6 @@ export function getVersionLabel({
   name: 'currentDraft' | 'currentlyPublished' | 'draft' | 'previouslyPublished' | 'published'
   pillStyle: Parameters<typeof Pill>[0]['pillStyle']
 } {
-  const { code: currentLocale } = useLocale()
   const status = version.version._status
 
   if (status === 'draft') {

--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -41,6 +41,11 @@ export async function VersionView(props: DocumentViewServerProps) {
 
   const draftsEnabled = hasDraftsEnabled(collectionConfig || globalConfig)
 
+  // Resolve user's current locale for version label comparison (not 'all')
+  const userLocale =
+    (searchParams.locale as string) ||
+    (req.locale !== 'all' ? req.locale : localization && localization.defaultLocale)
+
   const localeCodesFromParams = searchParams.localeCodes
     ? JSON.parse(searchParams.localeCodes as string)
     : null
@@ -393,6 +398,7 @@ export async function VersionView(props: DocumentViewServerProps) {
           const label =
             optionWithSameID.labelOverride ||
             getVersionLabel({
+              currentLocale: userLocale,
               currentlyPublishedVersion,
               latestDraftVersion,
               t: i18n.t,


### PR DESCRIPTION
### What

Fixed `Attempted to call useLocale() from the server` error when navigating to version view.

### Why

`getVersionLabel` was calling the `useLocale()` hook directly, but it was being invoked from a server component context in the version comparison dropdown.

### How

- Changed `getVersionLabel` to accept `currentLocale` as an optional parameter
- Client component (`VersionPillLabel`) now calls `useLocale()` and passes the value down
- Server component (`VersionView`) passes the user's locale from the request

Fixes #15294 