### PR TITLE
fix(plugin-mcp): create and update resource tools now support point fields

### DIFF
--- a/packages/plugin-mcp/src/mcp/tools/resource/create.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/create.ts
@@ -8,6 +8,7 @@ import type { PluginMCPServerConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import { convertCollectionSchemaToZod } from '../../../utils/convertCollectionSchemaToZod.js'
+import { transformPointDataToPayload } from '../../../utils/transformPointDataToPayload.js'
 import { toolSchemas } from '../schemas.js'
 export const createResourceTool = (
   server: McpServer,
@@ -44,6 +45,10 @@ export const createResourceTool = (
       let parsedData: Record<string, unknown>
       try {
         parsedData = JSON.parse(data)
+
+        // Transform point fields from object format to tuple array
+        parsedData = transformPointDataToPayload(parsedData)
+
         if (verboseLogs) {
           payload.logger.info(
             `[payload-mcp] Parsed data for ${collectionSlug}: ${JSON.stringify(parsedData)}`,

--- a/packages/plugin-mcp/src/mcp/tools/resource/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/update.ts
@@ -8,6 +8,7 @@ import type { PluginMCPServerConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import { convertCollectionSchemaToZod } from '../../../utils/convertCollectionSchemaToZod.js'
+import { transformPointDataToPayload } from '../../../utils/transformPointDataToPayload.js'
 import { toolSchemas } from '../schemas.js'
 export const updateResourceTool = (
   server: McpServer,
@@ -49,6 +50,10 @@ export const updateResourceTool = (
       let parsedData: Record<string, unknown>
       try {
         parsedData = JSON.parse(data)
+
+        // Transform point fields from object format to tuple array
+        parsedData = transformPointDataToPayload(parsedData)
+
         if (verboseLogs) {
           payload.logger.info(
             `[payload-mcp] Parsed data for ${collectionSlug}: ${JSON.stringify(parsedData)}`,

--- a/packages/plugin-mcp/src/utils/convertCollectionSchemaToZod.ts
+++ b/packages/plugin-mcp/src/utils/convertCollectionSchemaToZod.ts
@@ -4,6 +4,8 @@ import { jsonSchemaToZod } from 'json-schema-to-zod'
 import * as ts from 'typescript'
 import { z } from 'zod'
 
+import { transformPointFieldsForMCP } from './transformPointFields.js'
+
 /**
  * Recursively processes JSON schema properties to simplify relationship fields.
  * For create/update validation we only need to accept IDs (string/number),
@@ -65,7 +67,8 @@ export const convertCollectionSchemaToZod = (schema: JSONSchema4) => {
     }
   }
 
-  const simplifiedSchema = simplifyRelationshipFields(schemaClone)
+  const pointTransformed = transformPointFieldsForMCP(schemaClone)
+  const simplifiedSchema = simplifyRelationshipFields(pointTransformed)
 
   const zodSchemaAsString = jsonSchemaToZod(simplifiedSchema)
 

--- a/packages/plugin-mcp/src/utils/transformPointDataToPayload.ts
+++ b/packages/plugin-mcp/src/utils/transformPointDataToPayload.ts
@@ -1,0 +1,40 @@
+/**
+ * Transforms incoming MCP tool data from object format to tuple array format.
+ * Converts { longitude: number, latitude: number } back to [longitude, latitude]
+ * for Payload's internal point field representation.
+ */
+export function transformPointDataToPayload(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!data || typeof data !== 'object') {
+    return data
+  }
+
+  const transformed: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(data)) {
+    if (
+      value &&
+      typeof value === 'object' &&
+      'longitude' in value &&
+      'latitude' in value &&
+      typeof value.longitude === 'number' &&
+      typeof value.latitude === 'number'
+    ) {
+      // Transform to tuple array [longitude, latitude]
+      transformed[key] = [value.longitude, value.latitude]
+    } else if (Array.isArray(value)) {
+      transformed[key] = value.map((item) =>
+        typeof item === 'object'
+          ? transformPointDataToPayload(item as Record<string, unknown>)
+          : item,
+      )
+    } else if (value && typeof value === 'object') {
+      transformed[key] = transformPointDataToPayload(value as Record<string, unknown>)
+    } else {
+      transformed[key] = value
+    }
+  }
+
+  return transformed
+}

--- a/packages/plugin-mcp/src/utils/transformPointFields.ts
+++ b/packages/plugin-mcp/src/utils/transformPointFields.ts
@@ -1,0 +1,55 @@
+import type { JSONSchema4 } from 'json-schema'
+
+export function transformPointFieldsForMCP(schema: JSONSchema4): JSONSchema4 {
+  if (!schema || typeof schema !== 'object') {
+    return schema
+  }
+
+  const transformed = { ...schema }
+
+  if (transformed.properties && typeof transformed.properties === 'object') {
+    transformed.properties = Object.fromEntries(
+      Object.entries(transformed.properties).map(([key, value]) => {
+        const isArrayType =
+          value.type === 'array' || (Array.isArray(value.type) && value.type.includes('array'))
+
+        if (
+          value &&
+          typeof value === 'object' &&
+          isArrayType &&
+          Array.isArray(value.items) &&
+          value.items.length === 2 &&
+          value.items.every((item: JSONSchema4) => item?.type === 'number')
+        ) {
+          // Transform to object format
+          const isNullable = Array.isArray(value.type) && value.type.includes('null')
+
+          return [
+            key,
+            {
+              type: isNullable ? ['object', 'null'] : 'object',
+              description: value.description || 'Geographic coordinates (longitude, latitude)',
+              properties: {
+                latitude: { type: 'number', description: 'Latitude coordinate' },
+                longitude: { type: 'number', description: 'Longitude coordinate' },
+              },
+              required: ['longitude', 'latitude'],
+            },
+          ]
+        }
+
+        return [key, transformPointFieldsForMCP(value)]
+      }),
+    )
+  }
+
+  if (
+    transformed.items &&
+    typeof transformed.items === 'object' &&
+    !Array.isArray(transformed.items)
+  ) {
+    transformed.items = transformPointFieldsForMCP(transformed.items)
+  }
+
+  return transformed
+}

--- a/test/plugin-mcp/collections/Posts.ts
+++ b/test/plugin-mcp/collections/Posts.ts
@@ -2,34 +2,38 @@ import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
-  versions: {
-    drafts: true,
-  },
   fields: [
     {
       name: 'title',
       type: 'text',
-      localized: true,
       admin: {
         description: 'The title of the post',
       },
+      localized: true,
       required: true,
     },
     {
       name: 'content',
       type: 'text',
-      localized: true,
       admin: {
         description: 'The content of the post',
       },
       defaultValue: 'Hello World.',
+      localized: true,
     },
     {
       name: 'author',
       type: 'relationship',
-      relationTo: 'users',
       admin: {
         description: 'The author of the post',
+      },
+      relationTo: 'users',
+    },
+    {
+      name: 'location',
+      type: 'point',
+      admin: {
+        description: 'Geographic location coordinates',
       },
     },
   ],
@@ -51,5 +55,8 @@ export const Posts: CollectionConfig = {
         return doc
       },
     ],
+  },
+  versions: {
+    drafts: true,
   },
 }

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -61,7 +61,7 @@ const getApiKey = async (
     data: {
       enableAPIKey: true,
       label: 'Test API Key',
-      posts: { find: true, create: true, update: enableUpdate, delete: enableDelete },
+      posts: { create: true, delete: enableDelete, find: true, update: enableUpdate },
       products: { find: true },
       ...(globalFind || globalUpdate
         ? { siteSettings: { find: globalFind, update: globalUpdate } }
@@ -101,17 +101,17 @@ describe('@payloadcms/plugin-mcp', () => {
   it('should ping', async () => {
     const apiKey = await getApiKey()
     const response = await restClient.POST('/mcp', {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        Accept: 'application/json, text/event-stream',
-        'Content-Type': 'application/json',
-      },
       body: JSON.stringify({
         id: 1,
         jsonrpc: '2.0',
         method: 'ping',
         params: {},
       }),
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
     })
 
     const json = await parseStreamResponse(response)
@@ -123,11 +123,11 @@ describe('@payloadcms/plugin-mcp', () => {
       const doc = await payload.create({
         collection: 'payload-mcp-api-keys',
         data: {
+          apiKey: randomUUID(),
           enableAPIKey: true,
           label: 'Test API Key',
-          posts: { find: true, create: true },
+          posts: { create: true, find: true },
           products: { find: true },
-          apiKey: randomUUID(),
           user: userId,
         },
       })
@@ -178,12 +178,12 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should not allow POST /api/mcp with unauthorized API key', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({}),
         headers: {
-          Authorization: `Bearer fake${apiKey}key`,
           Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer fake${apiKey}key`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({}),
       })
 
       const json: any = await response.json()
@@ -200,17 +200,17 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should list tools', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
           method: 'tools/list',
           params: {},
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -418,17 +418,17 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should list resources', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
           method: 'resources/list',
           params: {},
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -451,17 +451,17 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should list prompts', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
           method: 'prompts/list',
           params: {},
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -484,17 +484,17 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should list globals', async () => {
       const apiKey = await getApiKey(false, false, true, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
           method: 'tools/list',
           params: {},
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -525,17 +525,17 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should list updatePosts when API key permits update and include select schema', async () => {
       const apiKey = await getApiKey(true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
           method: 'tools/list',
           params: {},
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -554,11 +554,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should get echo prompt', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -570,6 +565,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -605,11 +605,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should read the data resource', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -618,6 +613,11 @@ describe('@payloadcms/plugin-mcp', () => {
             uri: 'data://app',
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -648,11 +648,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should read the dataByID resource', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -661,6 +656,11 @@ describe('@payloadcms/plugin-mcp', () => {
             uri: 'data://app/1',
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -693,11 +693,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should call diceRoll', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -709,6 +704,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -743,11 +743,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should call createPosts', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -755,11 +750,16 @@ describe('@payloadcms/plugin-mcp', () => {
           params: {
             name: 'createPosts',
             arguments: {
-              title: 'Test Post',
               content: 'Content for test post.',
+              title: 'Test Post',
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -782,11 +782,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should call createPosts with select to limit returned fields', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -794,12 +789,17 @@ describe('@payloadcms/plugin-mcp', () => {
           params: {
             name: 'createPosts',
             arguments: {
-              title: 'Select Create Post',
               content: 'Content should be omitted',
               select: '{"title": true}',
+              title: 'Select Create Post',
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -814,18 +814,13 @@ describe('@payloadcms/plugin-mcp', () => {
       await payload.create({
         collection: 'posts',
         data: {
-          title: 'Test Post for Finding',
           content: 'Content for test post.',
+          title: 'Test Post for Finding',
         },
       })
 
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -839,6 +834,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -860,18 +860,13 @@ describe('@payloadcms/plugin-mcp', () => {
       await payload.create({
         collection: 'posts',
         data: {
-          title: 'Select Test Post',
           content: 'Content that should be omitted',
+          title: 'Select Test Post',
         },
       })
 
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -886,6 +881,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -903,18 +903,13 @@ describe('@payloadcms/plugin-mcp', () => {
       const post = await payload.create({
         collection: 'posts',
         data: {
-          title: 'Test Post for Updating',
           content: 'Content for test post to update.',
+          title: 'Test Post for Updating',
         },
       })
 
       const apiKey = await getApiKey(true, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -927,6 +922,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -949,18 +949,13 @@ describe('@payloadcms/plugin-mcp', () => {
       const post = await payload.create({
         collection: 'posts',
         data: {
-          title: 'Select Update Post',
           content: 'Original content',
+          title: 'Select Update Post',
         },
       })
 
       const apiKey = await getApiKey(true, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -969,12 +964,17 @@ describe('@payloadcms/plugin-mcp', () => {
             name: 'updatePosts',
             arguments: {
               id: post.id,
-              title: 'Select Update Post Edited',
               content: 'Updated but should be omitted',
               select: '{"title": true}',
+              title: 'Select Update Post Edited',
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -991,18 +991,13 @@ describe('@payloadcms/plugin-mcp', () => {
       const post = await payload.create({
         collection: 'posts',
         data: {
-          title: 'Test Post for Deleting',
           content: 'Content for test post to delete.',
+          title: 'Test Post for Deleting',
         },
       })
 
       const apiKey = await getApiKey(false, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1014,6 +1009,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1029,6 +1029,106 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[0].text).toContain('```json')
       expect(json.result.content[0].text).toContain('"content": "Content for test post to delete."')
     })
+
+    it('should handle point fields with object format in createPosts', async () => {
+      const apiKey = await getApiKey()
+      const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'createPosts',
+            arguments: {
+              content: 'Testing point field transformation',
+              location: {
+                latitude: 40.7128,
+                longitude: -74.006,
+              },
+              title: 'Post with Location',
+            },
+          },
+        }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await parseStreamResponse(response)
+
+      expect(json).toBeDefined()
+      expect(json.result).toBeDefined()
+      expect(json.result.content).toHaveLength(2)
+      expect(json.result.content[0].type).toBe('text')
+      expect(json.result.content[0].text).toContain('Resource created successfully')
+
+      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
+      expect(jsonMatch).toBeDefined()
+      const createdDoc = JSON.parse(jsonMatch[1])
+
+      expect(createdDoc.location).toEqual([-74.006, 40.7128])
+
+      expect(json.result.content[1].type).toBe('text')
+      expect(json.result.content[1].text).toContain('Override MCP response for Posts!')
+
+      await payload.delete({ id: createdDoc.id, collection: 'posts' })
+    })
+
+    it('should handle point fields with object format in updatePosts', async () => {
+      const apiKey = await getApiKey(true)
+
+      const createdPost = await payload.create({
+        collection: 'posts',
+        data: {
+          location: [-118.2437, 34.0522],
+          title: 'Post to Update Location',
+        },
+      })
+
+      const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'updatePosts',
+            arguments: {
+              id: createdPost.id,
+              location: {
+                latitude: 51.5074,
+                longitude: -0.1278,
+              },
+            },
+          },
+        }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await parseStreamResponse(response)
+
+      expect(json).toBeDefined()
+      expect(json.result).toBeDefined()
+      expect(json.result.content).toHaveLength(2)
+      expect(json.result.content[0].type).toBe('text')
+      expect(json.result.content[0].text).toContain('Document updated successfully')
+
+      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
+      expect(jsonMatch).toBeDefined()
+      const updatedDoc = JSON.parse(jsonMatch[1])
+
+      expect(updatedDoc.location).toEqual([-0.1278, 51.5074])
+
+      expect(json.result.content[1].type).toBe('text')
+      expect(json.result.content[1].text).toContain('Override MCP response for Posts!')
+
+      await payload.delete({ id: createdPost.id, collection: 'posts' })
+    })
   })
 
   describe('payloadAPI context', () => {
@@ -1036,18 +1136,13 @@ describe('@payloadcms/plugin-mcp', () => {
       await payload.create({
         collection: 'posts',
         data: {
-          title: 'Test Post for Finding',
           content: 'Content for test post.',
+          title: 'Test Post for Finding',
         },
       })
 
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1061,6 +1156,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1077,11 +1177,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should find site-settings global', async () => {
       const apiKey = await getApiKey(false, false, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1091,6 +1186,11 @@ describe('@payloadcms/plugin-mcp', () => {
             arguments: {},
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1107,20 +1207,15 @@ describe('@payloadcms/plugin-mcp', () => {
       await payload.updateGlobal({
         slug: 'site-settings',
         data: {
-          siteName: 'MCP Site',
-          siteDescription: 'Should be excluded by select',
-          maintenanceMode: false,
           contactEmail: 'test@example.com',
+          maintenanceMode: false,
+          siteDescription: 'Should be excluded by select',
+          siteName: 'MCP Site',
         },
       })
 
       const apiKey = await getApiKey(false, false, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1132,6 +1227,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1150,11 +1250,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should update site-settings global', async () => {
       const apiKey = await getApiKey(false, false, true, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1162,12 +1257,17 @@ describe('@payloadcms/plugin-mcp', () => {
           params: {
             name: 'updateSiteSettings',
             arguments: {
-              siteName: 'MCP Test Site',
-              siteDescription: 'A test site for MCP global operations',
               maintenanceMode: false,
+              siteDescription: 'A test site for MCP global operations',
+              siteName: 'MCP Test Site',
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1182,11 +1282,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should update site-settings global with select', async () => {
       const apiKey = await getApiKey(false, false, true, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1194,13 +1289,18 @@ describe('@payloadcms/plugin-mcp', () => {
           params: {
             name: 'updateSiteSettings',
             arguments: {
-              siteName: 'MCP Test Site Select',
-              siteDescription: 'Should not appear',
               maintenanceMode: false,
               select: '{"siteName": true}',
+              siteDescription: 'Should not appear',
+              siteName: 'MCP Test Site Select',
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1221,17 +1321,17 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should include locale parameters in tool schemas', async () => {
       const apiKey = await getApiKey(true, true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
           method: 'tools/list',
           params: {},
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1268,11 +1368,6 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should create post with specific locale', async () => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1280,12 +1375,17 @@ describe('@payloadcms/plugin-mcp', () => {
           params: {
             name: 'createPosts',
             arguments: {
-              title: 'Hello World',
               content: 'This is my first post in English',
               locale: 'en',
+              title: 'Hello World',
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1301,19 +1401,14 @@ describe('@payloadcms/plugin-mcp', () => {
       const englishPost = await payload.create({
         collection: 'posts',
         data: {
-          title: 'English Title',
           content: 'English Content',
+          title: 'English Title',
         },
       })
 
       // Update with Spanish translation via MCP
       const apiKey = await getApiKey(true)
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1322,12 +1417,17 @@ describe('@payloadcms/plugin-mcp', () => {
             name: 'updatePosts',
             arguments: {
               id: englishPost.id,
-              title: 'Título Español',
               content: 'Contenido Español',
               locale: 'es',
+              title: 'Título Español',
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1343,8 +1443,8 @@ describe('@payloadcms/plugin-mcp', () => {
       const post = await payload.create({
         collection: 'posts',
         data: {
-          title: 'English Post',
           content: 'English Content',
+          title: 'English Post',
         },
       })
 
@@ -1352,8 +1452,8 @@ describe('@payloadcms/plugin-mcp', () => {
         id: post.id,
         collection: 'posts',
         data: {
-          title: 'Publicación Española',
           content: 'Contenido Español',
+          title: 'Publicación Española',
         },
         locale: 'es',
       })
@@ -1361,11 +1461,6 @@ describe('@payloadcms/plugin-mcp', () => {
       // Find in Spanish via MCP
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1378,6 +1473,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1394,8 +1494,8 @@ describe('@payloadcms/plugin-mcp', () => {
       const post = await payload.create({
         collection: 'posts',
         data: {
-          title: 'English Title',
           content: 'English Content',
+          title: 'English Title',
         },
       })
 
@@ -1403,8 +1503,8 @@ describe('@payloadcms/plugin-mcp', () => {
         id: post.id,
         collection: 'posts',
         data: {
-          title: 'Título Español',
           content: 'Contenido Español',
+          title: 'Título Español',
         },
         locale: 'es',
       })
@@ -1413,8 +1513,8 @@ describe('@payloadcms/plugin-mcp', () => {
         id: post.id,
         collection: 'posts',
         data: {
-          title: 'Titre Français',
           content: 'Contenu Français',
+          title: 'Titre Français',
         },
         locale: 'fr',
       })
@@ -1422,11 +1522,6 @@ describe('@payloadcms/plugin-mcp', () => {
       // Find with locale: all via MCP
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1439,6 +1534,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)
@@ -1468,11 +1568,6 @@ describe('@payloadcms/plugin-mcp', () => {
       // Try to find in French (which doesn't exist)
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           id: 1,
           jsonrpc: '2.0',
@@ -1485,6 +1580,11 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
       })
 
       const json = await parseStreamResponse(response)

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -219,6 +219,13 @@ export interface Post {
    * The author of the post
    */
   author?: (string | null) | User;
+  /**
+   * Geographic location coordinates
+   *
+   * @minItems 2
+   * @maxItems 2
+   */
+  location?: [number, number] | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -565,6 +572,7 @@ export interface PostsSelect<T extends boolean = true> {
   title?: T;
   content?: T;
   author?: T;
+  location?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -760,6 +768,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }


### PR DESCRIPTION
Fixes: https://github.com/payloadcms/payload/issues/15287


The Create and Update Resource tools were expecting a tuple for point fields, however they needed to also accept nest lat/lng objects.

Tools affected:
- createResource
- updateResource