### PR TITLE
fix: enhance theme determination logic for unauthorized users

### DIFF
--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -2,7 +2,7 @@ import type { AcceptedLanguages } from '@payloadcms/translations'
 import type { ImportMap, LanguageOptions, SanitizedConfig, ServerFunctionClient } from 'payload'
 
 import { rtlLanguages } from '@payloadcms/translations'
-import { defaultTheme, ProgressBar, RootProvider } from '@payloadcms/ui'
+import { ProgressBar, RootProvider } from '@payloadcms/ui'
 import { getClientConfig } from '@payloadcms/ui/utilities/getClientConfig'
 import { cookies as nextCookies } from 'next/headers.js'
 import { applyLocaleFiltering } from 'payload/shared'
@@ -93,7 +93,7 @@ export const RootLayout = async ({
 
   return (
     <html
-      data-theme={theme ?? defaultTheme}
+      data-theme={theme}
       dir={dir}
       lang={languageCode}
       suppressHydrationWarning={config?.admin?.suppressHydrationWarning ?? false}

--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -2,7 +2,7 @@ import type { AcceptedLanguages } from '@payloadcms/translations'
 import type { ImportMap, LanguageOptions, SanitizedConfig, ServerFunctionClient } from 'payload'
 
 import { rtlLanguages } from '@payloadcms/translations'
-import { ProgressBar, RootProvider } from '@payloadcms/ui'
+import { defaultTheme, ProgressBar, RootProvider } from '@payloadcms/ui'
 import { getClientConfig } from '@payloadcms/ui/utilities/getClientConfig'
 import { cookies as nextCookies } from 'next/headers.js'
 import { applyLocaleFiltering } from 'payload/shared'
@@ -93,7 +93,7 @@ export const RootLayout = async ({
 
   return (
     <html
-      data-theme={theme}
+      data-theme={theme ?? defaultTheme}
       dir={dir}
       lang={languageCode}
       suppressHydrationWarning={config?.admin?.suppressHydrationWarning ?? false}

--- a/packages/next/src/utilities/getRequestTheme.ts
+++ b/packages/next/src/utilities/getRequestTheme.ts
@@ -11,7 +11,19 @@ type GetRequestLanguageArgs = {
 
 const acceptedThemes: Theme[] = ['dark', 'light']
 
-export const getRequestTheme = ({ config, cookies, headers }: GetRequestLanguageArgs): Theme => {
+/**
+ * Determines the theme for a request based on admin settings, cookies, and headers.
+ * Priority:
+ * 1. Admin-configured theme (if not 'all')
+ * 2. Theme from cookies (user preference)
+ * 3. Theme from 'Sec-CH-Prefers-Color-Scheme' header (limited browser support)
+ * 4. Undefined (to allow client-side determination)
+ */
+export const getRequestTheme = ({
+  config,
+  cookies,
+  headers,
+}: GetRequestLanguageArgs): Theme | undefined => {
   if (config.admin.theme !== 'all' && acceptedThemes.includes(config.admin.theme)) {
     return config.admin.theme
   }
@@ -32,5 +44,5 @@ export const getRequestTheme = ({ config, cookies, headers }: GetRequestLanguage
     return themeFromHeader
   }
 
-  return defaultTheme
+  return undefined
 }

--- a/packages/next/src/utilities/getRequestTheme.ts
+++ b/packages/next/src/utilities/getRequestTheme.ts
@@ -17,13 +17,9 @@ const acceptedThemes: Theme[] = ['dark', 'light']
  * 1. Admin-configured theme (if not 'all')
  * 2. Theme from cookies (user preference)
  * 3. Theme from 'Sec-CH-Prefers-Color-Scheme' header (limited browser support)
- * 4. Undefined (to allow client-side determination)
+ * 4. Default theme
  */
-export const getRequestTheme = ({
-  config,
-  cookies,
-  headers,
-}: GetRequestLanguageArgs): Theme | undefined => {
+export const getRequestTheme = ({ config, cookies, headers }: GetRequestLanguageArgs): Theme => {
   if (config.admin.theme !== 'all' && acceptedThemes.includes(config.admin.theme)) {
     return config.admin.theme
   }
@@ -44,5 +40,5 @@ export const getRequestTheme = ({
     return themeFromHeader
   }
 
-  return undefined
+  return defaultTheme
 }

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -60,6 +60,7 @@ export type ClientConfig = {
 export type UnauthenticatedClientConfig = {
   admin: {
     routes: ClientConfig['admin']['routes']
+    theme: ClientConfig['admin']['theme']
     user: ClientConfig['admin']['user']
   }
   collections: [
@@ -134,6 +135,7 @@ export const createUnauthenticatedClientConfig = ({
   return {
     admin: {
       routes: clientConfig.admin.routes,
+      theme: clientConfig.admin.theme,
       user: clientConfig.admin.user,
     },
     collections: [

--- a/packages/ui/src/providers/Theme/index.tsx
+++ b/packages/ui/src/providers/Theme/index.tsx
@@ -69,18 +69,14 @@ export const ThemeProvider: React.FC<{
   const [autoMode, setAutoMode] = useState<boolean>()
 
   useEffect(() => {
-    /**
-     * when a theme is preselected or an initial theme is provided,
-     * we don't want to override it with the cookie or OS preference
-     */
-    if (['dark', 'light'].includes(preselectedTheme) || initialTheme !== undefined) {
+    if (preselectedTheme !== 'all') {
       return
     }
 
     const { theme, themeFromCookies } = getTheme(cookieKey)
     setThemeState(theme)
     setAutoMode(!themeFromCookies)
-  }, [preselectedTheme, cookieKey, initialTheme])
+  }, [preselectedTheme, cookieKey])
 
   const setTheme = useCallback(
     (themeToSet: 'auto' | Theme) => {

--- a/packages/ui/src/providers/Theme/index.tsx
+++ b/packages/ui/src/providers/Theme/index.tsx
@@ -7,7 +7,7 @@ export type Theme = 'dark' | 'light'
 
 export type ThemeContext = {
   autoMode: boolean
-  setTheme: (theme: Theme) => void
+  setTheme: (theme: 'auto' | Theme) => void
   theme: Theme
 }
 
@@ -69,14 +69,18 @@ export const ThemeProvider: React.FC<{
   const [autoMode, setAutoMode] = useState<boolean>()
 
   useEffect(() => {
-    if (preselectedTheme !== 'all') {
+    /**
+     * when a theme is preselected or an initial theme is provided,
+     * we don't want to override it with the cookie or OS preference
+     */
+    if (['dark', 'light'].includes(preselectedTheme) || initialTheme !== undefined) {
       return
     }
 
     const { theme, themeFromCookies } = getTheme(cookieKey)
     setThemeState(theme)
     setAutoMode(!themeFromCookies)
-  }, [preselectedTheme, cookieKey])
+  }, [preselectedTheme, cookieKey, initialTheme])
 
   const setTheme = useCallback(
     (themeToSet: 'auto' | Theme) => {


### PR DESCRIPTION
### What?
>When using theme: 'all' (the default) in the admin config, the login page always renders with the light theme even when the user's system is set to dark mode. After logging in, the dark theme works correctly on all other admin pages.

### Why?
Inconsistent theme switching on Safari/Chrome mainly due to limited support of [Sec-CH-Prefers-Color-Scheme](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-CH-Prefers-Color-Scheme)

### How?
Extending the `UnauthenticatedClientConfig` with the admin theme allowed triggering the auto mode switch for unauthorized users. And some minor comments and types changes added. 

Fixes: [#15326](https://github.com/payloadcms/payload/issues/15326)
