### PR TITLE
fix: widgets and other features failing with transitive dependency imports

### DIFF
--- a/packages/next/src/exports/client.ts
+++ b/packages/next/src/exports/client.ts
@@ -3,3 +3,13 @@
 export { DefaultNavClient } from '../elements/Nav/index.client.js'
 export { NavHamburger } from '../elements/Nav/NavHamburger/index.js'
 export { NavWrapper } from '../elements/Nav/NavWrapper/index.js'
+export {
+  FolderTypeField,
+  QueryPresetsAccessCell,
+  QueryPresetsColumnField,
+  QueryPresetsColumnsCell,
+  QueryPresetsGroupByCell,
+  QueryPresetsGroupByField,
+  QueryPresetsWhereCell,
+  QueryPresetsWhereField,
+} from '@payloadcms/ui'

--- a/packages/next/src/exports/rsc.ts
+++ b/packages/next/src/exports/rsc.ts
@@ -1,3 +1,4 @@
 export { DocumentHeader } from '../elements/DocumentHeader/index.js'
 export { Logo } from '../elements/Logo/index.js'
 export { DefaultNav } from '../elements/Nav/index.js'
+export { CollectionCards, FolderField, FolderTableCell, SlugField } from '@payloadcms/ui/rsc'

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -57,7 +57,7 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
   }
   ;(sanitizedConfig.admin!.dashboard ??= { widgets: [] }).widgets.push({
     slug: 'collections',
-    ComponentPath: '@payloadcms/ui/rsc#CollectionCards',
+    ComponentPath: '@payloadcms/next/rsc#CollectionCards',
     minWidth: 'full',
   })
   sanitizedConfig.admin!.dashboard.defaultLayout ??= [

--- a/packages/payload/src/fields/baseFields/slug/index.ts
+++ b/packages/payload/src/fields/baseFields/slug/index.ts
@@ -131,7 +131,7 @@ export const slugField: SlugField = ({
               clientProps: {
                 useAsSlug,
               } satisfies SlugFieldClientPropsOnly,
-              path: '@payloadcms/ui#SlugField',
+              path: '@payloadcms/next/rsc#SlugField',
             },
           },
           width: '100%',

--- a/packages/payload/src/folders/addFolderFieldToCollection.ts
+++ b/packages/payload/src/folders/addFolderFieldToCollection.ts
@@ -23,8 +23,8 @@ export const addFolderFieldToCollection = ({
           allowCreate: false,
           allowEdit: false,
           components: {
-            Cell: '@payloadcms/ui/rsc#FolderTableCell',
-            Field: '@payloadcms/ui/rsc#FolderField',
+            Cell: '@payloadcms/next/rsc#FolderTableCell',
+            Field: '@payloadcms/next/rsc#FolderField',
           },
         },
       },

--- a/packages/payload/src/folders/createFolderCollection.ts
+++ b/packages/payload/src/folders/createFolderCollection.ts
@@ -86,7 +86,7 @@ export const createFolderCollection = ({
               admin: {
                 components: {
                   Field: {
-                    path: '@payloadcms/ui#FolderTypeField',
+                    path: '@payloadcms/next/client#FolderTypeField',
                   },
                 },
                 position: 'sidebar',

--- a/packages/payload/src/query-presets/config.ts
+++ b/packages/payload/src/query-presets/config.ts
@@ -51,8 +51,8 @@ export const getQueryPresetsConfig = (config: Config): CollectionConfig => ({
       type: 'json',
       admin: {
         components: {
-          Cell: '@payloadcms/ui#QueryPresetsWhereCell',
-          Field: '@payloadcms/ui#QueryPresetsWhereField',
+          Cell: '@payloadcms/next/client#QueryPresetsWhereCell',
+          Field: '@payloadcms/next/client#QueryPresetsWhereField',
         },
       },
       hooks: {
@@ -78,8 +78,8 @@ export const getQueryPresetsConfig = (config: Config): CollectionConfig => ({
       type: 'json',
       admin: {
         components: {
-          Cell: '@payloadcms/ui#QueryPresetsColumnsCell',
-          Field: '@payloadcms/ui#QueryPresetsColumnField',
+          Cell: '@payloadcms/next/client#QueryPresetsColumnsCell',
+          Field: '@payloadcms/next/client#QueryPresetsColumnField',
         },
       },
       validate: (value) => {
@@ -99,8 +99,8 @@ export const getQueryPresetsConfig = (config: Config): CollectionConfig => ({
       type: 'text',
       admin: {
         components: {
-          Cell: '@payloadcms/ui#QueryPresetsGroupByCell',
-          Field: '@payloadcms/ui#QueryPresetsGroupByField',
+          Cell: '@payloadcms/next/client#QueryPresetsGroupByCell',
+          Field: '@payloadcms/next/client#QueryPresetsGroupByField',
         },
       },
       label: 'Group By',

--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -29,7 +29,7 @@ export const getConstraints = (config: Config): Field => ({
   type: 'group',
   admin: {
     components: {
-      Cell: '@payloadcms/ui#QueryPresetsAccessCell',
+      Cell: '@payloadcms/next/client#QueryPresetsAccessCell',
     },
     condition: (data) => Boolean(data?.isShared),
   },

--- a/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
+++ b/packages/ui/src/elements/FolderView/FolderTypeField/index.tsx
@@ -1,4 +1,4 @@
-import type { Option, OptionObject, SelectFieldClientProps } from 'payload'
+import type { OptionObject, SelectFieldClientProps } from 'payload'
 
 import React from 'react'
 


### PR DESCRIPTION
### What

Re-exports UI components from `@payloadcms/next/rsc` and `@payloadcms/next/client` instead of requiring direct imports from `@payloadcms/ui` in the generated importMap.

### Why

The generated `importMap.js` was importing from `@payloadcms/ui`, which isn't in users' `package.json` (it's a transitive dependency through `@payloadcms/next`). This breaks import resolution with pnpm and can fail in production builds with any package manager without `@payloadcms/ui` installed.

### How

- Added re-exports in `@payloadcms/next/rsc` for: `CollectionCards`, `FolderField`, `FolderTableCell`, `SlugField`
- Added re-exports in `@payloadcms/next/client` for: `FolderTypeField` and all `QueryPresets*` components
- Updated all component paths in `@payloadcms/payload` to use `@payloadcms/next/rsc` or `@payloadcms/next/client` instead of `@payloadcms/ui`

Fixes #15010
