### PR TITLE
fix(plugin-cloud-storage): prevent infinite loop when cropping media

### DIFF
--- a/test/plugin-cloud-storage/collections/Media.ts
+++ b/test/plugin-cloud-storage/collections/Media.ts
@@ -4,6 +4,7 @@ export const Media: CollectionConfig = {
   slug: 'media',
   upload: {
     disableLocalStorage: true,
+    focalPoint: true,
     resizeOptions: {
       position: 'center',
       width: 200,

--- a/test/plugin-cloud-storage/payload-types.ts
+++ b/test/plugin-cloud-storage/payload-types.ts
@@ -203,9 +203,10 @@ export interface RestrictedMedia {
  */
 export interface TestMetadatum {
   id: string;
-  testUrl?: string | null;
-  testEtag?: string | null;
-  customField?: string | null;
+  /**
+   * Test note to identify this upload
+   */
+  testNote?: string | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -421,9 +422,7 @@ export interface RestrictedMediaSelect<T extends boolean = true> {
  * via the `definition` "test-metadata_select".
  */
 export interface TestMetadataSelect<T extends boolean = true> {
-  testUrl?: T;
-  testEtag?: T;
-  customField?: T;
+  testNote?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;


### PR DESCRIPTION
### What

When using `plugin-cloud-storage` and updating an existing image with cropping or focal point adjustments, the save operation enters an infinite loop.

### Why

The `afterChange` hook in plugins does the following:

1. User saves with crop/focal changes
2. `afterChange` hook uploads files to cloud storage
3. Hook calls `req.payload.update()` to persist metadata (URLs, sizes)
4. Internal update triggers `afterChange` hook **again**
5. Hook detects files in `req.file` and `req.payloadUploadSizes`
6. Attempts upload again → infinite loop

### How

Added a `skipCloudStorage` flag in the req.context to prevent hitting an infinite loop:

1. Set flag after calling the first `req.payload.update()`
2. Check flag at hook entry →  if set, return before attempting to re-upload

### Testing

Test added to `plugin-cloud-storage > e2e`

### Fixes

Fixes #15350 and #15393