### PR TITLE
test: fix data pollution between e2e test runs in trash suite

### DIFF
--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -371,6 +371,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }


### PR DESCRIPTION
### What

Fixes flaky trash e2e tests that were failing in CI with incorrect document counts.

### Why

Tests were creating documents but not resetting the database between runs. When tests failed and retried, data accumulated (2→4→6→8→10 docs), causing count mismatches and test failures.

### How

- Added `reInitializeDB` in `beforeEach` to reset database to clean snapshot before each test
- Changed `beforeAll/afterAll` to `beforeEach/afterEach` for proper test isolation
- Added missing cleanup for `postsDocTwo` that was created but never deleted
