### PR TITLE
ci: enable retries for int and unit tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
   },
   test: {
     watch: false, // too troublesome especially with the in memory DB setup
+    // Retry failed tests up to 3 times in CI to handle flaky tests
+    retry: process.env.CI ? 3 : 0,
     server: {
       deps: {
         inline: [/@payloadcms\/figma/],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,8 +22,8 @@ export default defineConfig({
   },
   test: {
     watch: false, // too troublesome especially with the in memory DB setup
-    // Retry failed tests up to 3 times in CI to handle flaky tests
-    retry: process.env.CI ? 3 : 0,
+    // Retry failed tests up to 2 times in CI to handle flaky tests (e.g. due to timing-sensitive int tests like job queues, installation failures due to temporary network issues)
+    retry: process.env.CI ? 2 : 0,
     server: {
       deps: {
         inline: [/@payloadcms\/figma/],


### PR DESCRIPTION
This allows int and unit tests to retry 2 times, to combat the flakes and the need for manual retrying.