### PR TITLE
docs: add payload.logger.error usage guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ Payload is a monorepo structured around Next.js, containing the core CMS platfor
   - Execution flow: Skip comments when code is self-documenting. Keep for complex logic, non-obvious "why", multi-line context, or if following a documented, multi-step flow.
   - Top of file/module: Use sparingly; only for non-obvious purpose/context or an overview of complex logic.
   - Type definitions: Property/interface documentation is always acceptable.
+- Logger Usage (`payload.logger.error`)
+  - Valid: `payload.logger.error('message')` or `payload.logger.error({ msg: '...', err: error })`
+  - Invalid: `payload.logger.error('message', err)` - don't pass error as second argument
+  - Use `err` not `error`, use `msg` not `message` in object form
 
 ### Running Dev Server
 


### PR DESCRIPTION
# Overview

Documents proper `payload.logger.error()` usage patterns in CLAUDE.md, mirroring the existing `proper-payload-logger-usage` eslint rule.

## Key Changes

- Added Logger Usage section under "Coding Patterns and Best Practices"
  - Valid patterns: single string or object with `msg`/`err` keys
  - Invalid patterns: error as second argument, wrong key names (`error`/`message` instead of `err`/`msg`)

## References / Links

- [proper-payload-logger-usage.js](https://github.com/payloadcms/payload/blob/main/packages/eslint-plugin/customRules/proper-payload-logger-usage.js)