### PR TITLE
fix(plugin-cloud-storage): adds beforeChange hook to generate url on create

### DIFF
--- a/packages/plugin-cloud-storage/src/fields/getFields.ts
+++ b/packages/plugin-cloud-storage/src/fields/getFields.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import type { GeneratedAdapter, GenerateFileURL } from '../types.js'
 
 import { getAfterReadHook } from '../hooks/afterRead.js'
+import { getBeforeChangeHook } from '../hooks/beforeChange.js'
 
 interface Args {
   adapter?: GeneratedAdapter
@@ -73,6 +74,10 @@ export const getFields = ({
           getAfterReadHook({ adapter, collection, disablePayloadAccessControl, generateFileURL }),
           ...(existingURLField?.hooks?.afterRead || []),
         ],
+        beforeChange: [
+          getBeforeChangeHook({ adapter, collection, disablePayloadAccessControl }),
+          ...(existingURLField?.hooks?.beforeChange || []),
+        ],
       },
     } as TextField)
   } else {
@@ -131,6 +136,18 @@ export const getFields = ({
                   ...((typeof existingSizeURLField === 'object' &&
                     'hooks' in existingSizeURLField &&
                     existingSizeURLField?.hooks?.afterRead) ||
+                    []),
+                ],
+                beforeChange: [
+                  getBeforeChangeHook({
+                    adapter,
+                    collection,
+                    disablePayloadAccessControl,
+                    size,
+                  }),
+                  ...((typeof existingSizeURLField === 'object' &&
+                    'hooks' in existingSizeURLField &&
+                    existingSizeURLField?.hooks?.beforeChange) ||
                     []),
                 ],
               },

--- a/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
@@ -1,0 +1,41 @@
+import type { CollectionConfig, FieldHook, ImageSize } from 'payload'
+
+import type { GeneratedAdapter } from '../types.js'
+
+interface Args {
+  adapter: GeneratedAdapter
+  collection: CollectionConfig
+  disablePayloadAccessControl?: boolean
+  size?: ImageSize
+}
+
+export const getBeforeChangeHook =
+  ({ adapter, collection, disablePayloadAccessControl, size }: Args): FieldHook =>
+  async ({ data, originalDoc, value }) => {
+    // Only handle the disablePayloadAccessControl: true case here
+    // When false, let the core beforeChange hook from getBaseFields handle it
+    if (!disablePayloadAccessControl) {
+      return value
+    }
+
+    const filename = size ? data?.sizes?.[size.name]?.filename : data?.filename
+
+    if (!filename) {
+      return value
+    }
+
+    const prefix = data?.prefix
+
+    // Store the full URL in the database so files can be accessed directly
+    // from the storage provider without going through Payload's API
+    if (adapter.generateURL) {
+      return await adapter.generateURL({
+        collection,
+        data: data || originalDoc,
+        filename,
+        prefix,
+      })
+    }
+
+    return value
+  }

--- a/test/storage-s3/collections/MediaWithDirectAccess.ts
+++ b/test/storage-s3/collections/MediaWithDirectAccess.ts
@@ -4,6 +4,15 @@ export const MediaWithDirectAccess: CollectionConfig = {
   slug: 'media-with-direct-access',
   upload: {
     disableLocalStorage: true,
+    adminThumbnail: 'thumbnail',
+    imageSizes: [
+      {
+        name: 'thumbnail',
+        width: 400,
+        height: 300,
+        crop: 'center',
+      },
+    ],
   },
   fields: [
     {

--- a/test/storage-s3/int.spec.ts
+++ b/test/storage-s3/int.spec.ts
@@ -154,6 +154,55 @@ describe('@payloadcms/storage-s3', () => {
       const response = await fetch(upload.url)
       expect(response.status).toBe(200)
       expect(response.headers.get('Content-Type')).toBe('image/png')
+
+      // CRITICAL: Verify that the database stores the full S3 URL, not a relative path
+      // This is important because disablePayloadAccessControl means files should be accessed directly from S3
+      const dbDoc = await payload.db.findOne({
+        collection: mediaWithDirectAccessSlug,
+        where: {
+          id: {
+            equals: upload.id,
+          },
+        },
+      })
+
+      expect(dbDoc).toBeDefined()
+      expect(dbDoc.url).toBeDefined()
+      // URL in database should be the full S3 URL, not a relative path
+      expect(dbDoc.url).toContain(process.env.S3_ENDPOINT)
+      expect(dbDoc.url).toContain(getTestBucketName())
+      expect(dbDoc.url).not.toMatch(/^\/api\//)
+    })
+
+    it('should store full S3 URLs in database for image sizes when disablePayloadAccessControl is true', async () => {
+      const upload = await payload.create({
+        collection: mediaWithDirectAccessSlug,
+        data: {},
+        filePath: path.resolve(dirname, '../uploads/image.png'),
+      })
+
+      expect(upload.id).toBeTruthy()
+
+      // Verify image sizes URLs are returned correctly
+      expect(upload.sizes?.thumbnail?.url).toContain(process.env.S3_ENDPOINT)
+      expect(upload.sizes?.thumbnail?.url).toContain(getTestBucketName())
+
+      // CRITICAL: Verify that image size URLs are also stored as full S3 URLs in the database
+      const dbDoc = await payload.db.findOne({
+        collection: mediaWithDirectAccessSlug,
+        where: {
+          id: {
+            equals: upload.id,
+          },
+        },
+      })
+
+      expect(dbDoc).toBeDefined()
+      expect(dbDoc.sizes.thumbnail.url).toContain(process.env.S3_ENDPOINT)
+      expect(dbDoc.sizes.thumbnail.url).toContain(getTestBucketName())
+      expect(dbDoc.sizes.thumbnail.url).not.toMatch(/^\/api\//)
+
+      await payload.delete({ collection: mediaWithDirectAccessSlug, id: upload.id })
     })
 
     it('should return direct S3 URL without encoding issues for normal filenames', async () => {


### PR DESCRIPTION
Fixes #15382

## Summary
Adds beforeChange hook to url fields in the cloud-storage-plugin this way urls are stored on create. Which in turn fixes #15382 because the url will not fallback to generating a relative url. The default url field's [beforeChange hook](https://github.com/payloadcms/payload/blob/main/packages/payload/src/uploads/getBaseFields.ts#L139-L149) runs after we create the full url so it will skip creating the relative path.

## Issue
If you set `disablePayloadAccessControl: true` you want the full url in the DB

- #15089 fixed an issue where `create` was not saving the file url
- so this plugin would have a relative url generated for the url fields (payload internal behavior from #15089) no matter what

## Fix
Adds beforeChange hook to the `@payloadcms/plugin-cloud-storage` that generates the full url if `disablePayloadAccessControl: true` before the internal url generation runs. This skips the internal url generation because the url will not meet the [requirements](https://github.com/payloadcms/payload/blob/main/packages/payload/src/uploads/generateFilePathOrURL.ts#L30-L33) to create a relative url.