### PR TITLE
feat(ui): allows opting out of popup closing logic

### DIFF
--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -308,8 +308,8 @@ export const Popup: React.FC<PopupProps> = (props) => {
   const handleActionableClick = useEffectEvent((e: MouseEvent) => {
     const target = e.target as HTMLElement
 
-    // Allow opting out with data-popup-keep-open attribute on element or ancestor
-    if (target.closest('[data-popup-keep-open]')) {
+    // Allow opting out with data-popup-prevent-close attribute on element or ancestor
+    if (target.closest('[data-popup-prevent-close]')) {
       return
     }
 

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -307,6 +307,12 @@ export const Popup: React.FC<PopupProps> = (props) => {
 
   const handleActionableClick = useEffectEvent((e: MouseEvent) => {
     const target = e.target as HTMLElement
+
+    // Allow opting out with data-popup-keep-open attribute on element or ancestor
+    if (target.closest('[data-popup-keep-open]')) {
+      return
+    }
+
     // Check if the clicked element or any ancestor is an actionable element
     const actionable = target.closest('button, a[href], [role="button"], [role="menuitem"]')
     if (actionable && popupRef.current?.contains(actionable)) {


### PR DESCRIPTION
This PR allows you to add interactive elements into a popup and not have them close the popup when clicking them, by adding the `data-popup-prevent-close` data attribute.