### PR TITLE
chore: move unpublish actions into dropdown

### DIFF
--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -275,12 +275,11 @@ export const DocumentControls: React.FC<{
                     {(unsavedDraftWithValidations ||
                       !autosaveEnabled ||
                       (autosaveEnabled && showSaveDraftButton)) && (
-                      <RenderCustomComponent
-                        CustomComponent={CustomSaveDraftButton}
-                        Fallback={<SaveDraftButton />}
-                      />
-                    )}
-                    <UnpublishButton />
+                        <RenderCustomComponent
+                          CustomComponent={CustomSaveDraftButton}
+                          Fallback={<SaveDraftButton />}
+                        />
+                      )}
                     <RenderCustomComponent
                       CustomComponent={CustomPublishButton}
                       Fallback={<PublishButton />}
@@ -398,6 +397,7 @@ export const DocumentControls: React.FC<{
                     useAsTitle={collectionConfig?.admin?.useAsTitle}
                   />
                 )}
+                <UnpublishButton />
                 {EditMenuItems}
               </PopupList.ButtonGroup>
             </Popup>

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -765,6 +765,28 @@ describe('Localization', () => {
     })
   })
 
+  describe('unpublish button', () => {
+    test('should show unpublish in specific locale when localizeStatus is enabled', async () => {
+      await page.goto(urlAllFieldsLocalized.create)
+      await page.locator('#field-text').fill('EN Published')
+      await saveDocAndAssert(page, '#publish-locale')
+      await openDocControls(page)
+
+      await expect(page.locator('#action-unpublish')).toBeVisible()
+      await expect(page.locator('#action-unpublish-locale')).toBeVisible()
+    })
+
+    test('should not show unpublish in specific locale when localizeStatus is not enabled', async () => {
+      await page.goto(urlPostsWithDrafts.create)
+      await page.locator('#field-title').fill('EN Published')
+      await saveDocAndAssert(page, '#publish-locale')
+      await openDocControls(page)
+
+      await expect(page.locator('#action-unpublish')).toBeVisible()
+      await expect(page.locator('#action-unpublish-locale')).toHaveCount(0)
+    })
+  })
+
   test('should not show publish specific locale button when no localized fields exist', async () => {
     await page.goto(urlPostsWithDrafts.create)
     await expect(page.locator('#publish-locale')).toHaveCount(1)

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -50,6 +50,7 @@ import {
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { assertNetworkRequests } from '../helpers/e2e/assertNetworkRequests.js'
 import { navigateToDiffVersionView as _navigateToDiffVersionView } from '../helpers/e2e/navigateToDiffVersionView.js'
+import { openDocControls } from '../helpers/e2e/openDocControls.js'
 import { waitForAutoSaveToRunAndComplete } from '../helpers/e2e/waitForAutoSaveToRunAndComplete.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../helpers/reInitializeDB.js'
@@ -781,6 +782,8 @@ describe('Versions', () => {
 
       await page.goto(disablePublishURL.edit(String(publishedDoc.id)))
 
+      await openDocControls(page)
+
       // Verify unpublish button is hidden when user doesn't have publish permission
       await expect(page.locator('#action-unpublish')).not.toBeAttached()
     })
@@ -794,6 +797,9 @@ describe('Versions', () => {
         },
       })
       await page.goto(errorOnUnpublishURL.edit(String(publishedDoc.id)))
+
+      await openDocControls(page)
+
       await page.locator('#action-unpublish').click()
       await page.locator('[id^="confirm-un-publish-"] #confirm-action').click()
       await expect(
@@ -998,6 +1004,7 @@ describe('Versions', () => {
 
         await expect(page.locator('.doc-controls__status .status__value')).toContainText('Draft')
 
+        await openDocControls(page)
         await expect(page.locator('#action-unpublish')).toBeHidden()
       })
 
@@ -1016,6 +1023,7 @@ describe('Versions', () => {
           'Published',
         )
 
+        await openDocControls(page)
         await expect(page.locator('#action-unpublish')).toBeVisible()
       })
 
@@ -1031,6 +1039,7 @@ describe('Versions', () => {
         await page.locator('#field-description').fill('Updated Description')
         await saveDocAndAssert(page, '#action-save-draft')
 
+        await openDocControls(page)
         await expect(page.locator('.doc-controls__status .status__value')).toContainText('Draft')
         await expect(page.locator('#action-unpublish')).toBeHidden()
       })
@@ -1168,6 +1177,8 @@ describe('Versions', () => {
 
       const url = new AdminUrlUtil(serverURL, disablePublishGlobalSlug)
       await page.goto(url.global(disablePublishGlobalSlug))
+
+      await openDocControls(page)
 
       // Verify unpublish button is hidden when user doesn't have publish permission
       await expect(page.locator('#action-unpublish')).not.toBeAttached()


### PR DESCRIPTION
### What / Why

This PR updates and fixes aspects of the `unpublish` UI:

1. **Button location**: The **unpublish** button update in [v3.72.0](https://github.com/payloadcms/payload/releases/tag/v3.72.0) was reported as too prominent by the community. We have moved it into the additional document actions dropdown.
2. **Bug**:  The `Unpublish in [locale]` option should only be displayed when `localizeStatus` is enabled.
3. **Performance**: In the `unpublish` component, several variables were recalculating on every render, causing unnecessary load and causing ESLint warnings.

### Where

1. In `DocumentControls`, the `unpublish` button has been moved from the top level into the additional document actions dropdown.
2. Within the `unpublish` button component, the conditional logic for `canUnpublishCurrentLocale` has been corrected so it will only show when `localizeStatus` is enabled.
3. Lastly, the variables `canUnpublish` and `canUnpublishCurrentLocale` have been wrapped in `useMemo` to prevent excessive recalculating


#### Fixes https://github.com/payloadcms/payload/issues/15291

<img width="1013" height="409" alt="Screenshot 2026-01-29 at 11 51 47 AM" src="https://github.com/user-attachments/assets/a630406d-e444-4ecd-ab69-ba84f85d4b3e" />
