### PR TITLE
fix(richtext-slate): localized indicator not displaying in label

### DIFF
--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -56,6 +56,7 @@ const RichTextField: React.FC<LoadedSlateFieldProps> = (props) => {
       name,
       admin: { className, description, placeholder, readOnly: readOnlyFromAdmin } = {},
       label,
+      localized,
       required,
     },
     leaves,
@@ -254,13 +255,13 @@ const RichTextField: React.FC<LoadedSlateFieldProps> = (props) => {
         toolbarRef.current?.querySelectorAll(selectors)
 
       ;(toolbarButtons || []).forEach((child) => {
-        const isButton = child.tagName === 'BUTTON'
-        const isDisabling = clickState === 'disabled'
-        child.setAttribute('tabIndex', isDisabling ? '-1' : '0')
-        if (isButton) {
-          child.setAttribute('disabled', isDisabling ? 'disabled' : null)
-        }
-      })
+          const isButton = child.tagName === 'BUTTON'
+          const isDisabling = clickState === 'disabled'
+          child.setAttribute('tabIndex', isDisabling ? '-1' : '0')
+          if (isButton) {
+            child.setAttribute('disabled', isDisabling ? 'disabled' : null)
+          }
+        })
     }
 
     if (disabled) {
@@ -313,7 +314,7 @@ const RichTextField: React.FC<LoadedSlateFieldProps> = (props) => {
 
   return (
     <div className={classes} style={styles}>
-      {Label || <FieldLabel label={label} path={path} required={required} />}
+      {Label || <FieldLabel label={label} localized={localized} path={path} required={required} />}
       <div className={`${baseClass}__wrap`}>
         <RenderCustomComponent
           CustomComponent={Error}

--- a/test/localization/collections/AllFields/index.ts
+++ b/test/localization/collections/AllFields/index.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { slateEditor } from '@payloadcms/richtext-slate'
+
 import { allFieldsLocalizedSlug } from '../../shared.js'
 
 export const AllFieldsLocalized: CollectionConfig = {
@@ -60,6 +62,12 @@ export const AllFieldsLocalized: CollectionConfig = {
       name: 'date',
       type: 'date',
       localized: true,
+    },
+    {
+      name: 'richTextSlate',
+      type: 'richText',
+      localized: true,
+      editor: slateEditor({}),
     },
 
     // Localized group with localized children

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -763,6 +763,16 @@ describe('Localization', () => {
 
       expect(isActuallyVisible).toBe(true)
     })
+
+    test('should show locale in slate rich text field label', async () => {
+      await page.goto(urlAllFieldsLocalized.create)
+
+      const richTextLabel = page.locator('label[for="field-richTextSlate"]')
+      await expect(richTextLabel).toContainText('en')
+
+      await changeLocale(page, spanishLocale)
+      await expect(richTextLabel).toContainText('es')
+    })
   })
 
   test('should not show publish specific locale button when no localized fields exist', async () => {


### PR DESCRIPTION
### What
Fixes the localized indicator (e.g. `- en`) not appearing in field labels for **Slate** rich text fields.

### Why
The `localized` param was not being passed to `FieldLabel`, so the label could not determine whether it should render a locale suffix. As a result, localized Slate fields appeared identical to non-localized fields.

### Where
Destructured `localized` from the field config and pass it through to `FieldLabel` in  `richtext-slate/src/field/RichText.tsx`.

### Testing
Added to `test/localization/e2e.spec.ts`.

Fixes https://github.com/payloadcms/payload/issues/12364
