### PR TITLE
chore: replace rmdirSync to rmSync

### DIFF
--- a/examples/localization/src/endpoints/seed/index.ts
+++ b/examples/localization/src/endpoints/seed/index.ts
@@ -50,7 +50,7 @@ export const seed = async ({
 
   const mediaDir = path.resolve(dirname, '../../public/media')
   if (fs.existsSync(mediaDir)) {
-    fs.rmdirSync(mediaDir, { recursive: true })
+    fs.rmSync(mediaDir, { recursive: true })
   }
 
   payload.logger.info(`— Clearing collections and globals...`)

--- a/packages/ui/bundle.js
+++ b/packages/ui/bundle.js
@@ -83,7 +83,7 @@ async function build() {
 
   try {
     fs.renameSync('dist-styles/index.css', `${directoryArg}/styles.css`)
-    fs.rmdirSync('dist-styles', { recursive: true })
+    fs.rmSync('dist-styles', { recursive: true })
   } catch (err) {
     console.error(`Error while renaming index.css and dist-styles: ${err}`)
     throw err

--- a/test/database/up-down-migration/int.spec.ts
+++ b/test/database/up-down-migration/int.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmdirSync, rmSync } from 'fs'
+import { existsSync, rmSync } from 'fs'
 import path from 'path'
 import { buildConfig, getPayload } from 'payload'
 import { fileURLToPath } from 'url'


### PR DESCRIPTION
Replaces deprecated `fs.rmdirSync` with `fs.rmSync` in `examples/localization`, `packages/ui/bundle.js`, and `test/database/up-down-migration`. After upgrading to Node.js 25, running `pnpm build` failed in the `ui` package because `rmdirSync` with the recursive option was removed in v25 (DEP0147). The `rmSync` API with `{ recursive: true }` is the recommended replacement and has been available since Node.js v14.14.0.