### PR TITLE
feat: thread override access in doc level hooks

### DIFF
--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -27,6 +27,7 @@ export type Arguments<TSlug extends CollectionSlug> = {
   } & AuthOperationsFromCollectionSlug<TSlug>['forgotPassword']
   disableEmail?: boolean
   expiration?: number
+  overrideAccess?: boolean
   req: PayloadRequest
 }
 
@@ -36,7 +37,7 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
   incomingArgs: Arguments<TSlug>,
 ): Promise<null | string> => {
   const loginWithUsername = incomingArgs.collection.config.auth.loginWithUsername
-  const { data } = incomingArgs
+  const { data, overrideAccess } = incomingArgs
 
   const { canLoginWithEmail, canLoginWithUsername } = getLoginOptions(loginWithUsername)
 
@@ -69,6 +70,7 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection.config,
       operation: 'forgotPassword',
+      overrideAccess,
     })
 
     const {
@@ -211,6 +213,7 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection?.config,
       operation: 'forgotPassword',
+      overrideAccess,
       result: token,
     })
 

--- a/packages/payload/src/auth/operations/local/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/local/forgotPassword.ts
@@ -14,6 +14,7 @@ export type Options<T extends CollectionSlug> = {
   }
   disableEmail?: boolean
   expiration?: number
+  overrideAccess?: boolean
   req?: Partial<PayloadRequest>
 }
 
@@ -21,7 +22,13 @@ export async function forgotPasswordLocal<T extends CollectionSlug>(
   payload: Payload,
   options: Options<T>,
 ): Promise<Result> {
-  const { collection: collectionSlug, data, disableEmail, expiration } = options
+  const {
+    collection: collectionSlug,
+    data,
+    disableEmail,
+    expiration,
+    overrideAccess = true,
+  } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -38,6 +45,7 @@ export async function forgotPasswordLocal<T extends CollectionSlug>(
     data,
     disableEmail,
     expiration,
+    overrideAccess,
     req: await createLocalReq(options, payload),
   }) as Promise<Result>
 }

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -85,6 +85,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     args,
     collection: args.collection.config,
     operation: 'login',
+    overrideAccess: args.overrideAccess!,
   })
 
   const {
@@ -394,6 +395,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection?.config,
       operation: 'login',
+      overrideAccess: args.overrideAccess!,
       result,
     })
 

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -91,7 +91,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     collection: { config: collectionConfig },
     data,
     depth,
-    overrideAccess,
+    overrideAccess = false,
     req,
     req: {
       fallbackLocale,
@@ -358,7 +358,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
       fallbackLocale: fallbackLocale!,
       global: null,
       locale: locale!,
-      overrideAccess: overrideAccess!,
+      overrideAccess,
       req,
       showHiddenFields: showHiddenFields!,
     })
@@ -374,6 +374,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
             collection: args.collection?.config,
             context: req.context,
             doc: user,
+            overrideAccess,
             req,
           })) || user
       }

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -44,6 +44,7 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
       args,
       collection: args.collection.config,
       operation: 'refresh',
+      overrideAccess: false,
     })
 
     // /////////////////////////////////////
@@ -181,6 +182,7 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
       args,
       collection: args.collection?.config,
       operation: 'refresh',
+      overrideAccess: false,
       result,
     })
 

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -69,6 +69,7 @@ export const resetPasswordOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection.config,
       operation: 'resetPassword',
+      overrideAccess,
     })
 
     // /////////////////////////////////////
@@ -236,6 +237,7 @@ export const resetPasswordOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection?.config,
       operation: 'resetPassword',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/auth/operations/unlock.ts
+++ b/packages/payload/src/auth/operations/unlock.ts
@@ -63,6 +63,7 @@ export const unlockOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection.config,
       operation: 'unlock',
+      overrideAccess,
     })
 
     const shouldCommit = await initTransaction(req)
@@ -135,6 +136,7 @@ export const unlockOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection.config,
       operation: 'unlock',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -200,6 +200,10 @@ export type AfterReadHook<T extends TypeWithID = any> = (args: {
   context: RequestContext
   doc: T
   findMany?: boolean
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess: boolean
   query?: { [key: string]: any }
   req: PayloadRequest
 }) => any

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -186,6 +186,10 @@ export type BeforeReadHook<T extends TypeWithID = any> = (args: {
   collection: SanitizedCollectionConfig
   context: RequestContext
   doc: T
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess: boolean
   query: { [key: string]: any }
   req: PayloadRequest
 }) => any

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -177,6 +177,10 @@ export type AfterChangeHook<T extends TypeWithID = any> = (args: {
    * Hook operation being performed
    */
   operation: CreateOrUpdateOperation
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   previousDoc: T
   req: PayloadRequest
 }) => any
@@ -189,7 +193,7 @@ export type BeforeReadHook<T extends TypeWithID = any> = (args: {
   /**
    * Whether access control is being overridden for this operation
    */
-  overrideAccess: boolean
+  overrideAccess?: boolean
   query: { [key: string]: any }
   req: PayloadRequest
 }) => any
@@ -203,7 +207,7 @@ export type AfterReadHook<T extends TypeWithID = any> = (args: {
   /**
    * Whether access control is being overridden for this operation
    */
-  overrideAccess: boolean
+  overrideAccess?: boolean
   query?: { [key: string]: any }
   req: PayloadRequest
 }) => any

--- a/packages/payload/src/collections/operations/count.ts
+++ b/packages/payload/src/collections/operations/count.ts
@@ -36,6 +36,7 @@ export const countOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection.config,
       operation: 'count',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -99,6 +100,7 @@ export const countOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: collectionConfig,
       operation: 'count',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/countVersions.ts
+++ b/packages/payload/src/collections/operations/countVersions.ts
@@ -34,6 +34,7 @@ export const countVersionsOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: args.collection.config,
       operation: 'countVersions',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -97,6 +98,7 @@ export const countVersionsOperation = async <TSlug extends CollectionSlug>(
       args,
       collection: collectionConfig,
       operation: 'countVersions',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -378,6 +378,7 @@ export const createOperation = async <
             collection: collectionConfig,
             context: req.context,
             doc: result,
+            overrideAccess: overrideAccess!,
             req,
           })) || result
       }

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -87,6 +87,7 @@ export const createOperation = async <
       args,
       collection: args.collection.config,
       operation: 'create',
+      overrideAccess: args.overrideAccess!,
     })
 
     if (args.publishSpecificLocale) {
@@ -378,7 +379,7 @@ export const createOperation = async <
             collection: collectionConfig,
             context: req.context,
             doc: result,
-            overrideAccess: overrideAccess!,
+            overrideAccess,
             req,
           })) || result
       }
@@ -412,6 +413,7 @@ export const createOperation = async <
             data,
             doc: result,
             operation: 'create',
+            overrideAccess,
             previousDoc: {},
             req: args.req,
           })) || result
@@ -426,6 +428,7 @@ export const createOperation = async <
       args,
       collection: collectionConfig,
       operation: 'create',
+      overrideAccess: args.overrideAccess!,
       result,
     })
 

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -62,6 +62,7 @@ export const deleteOperation = async <
       args,
       collection: args.collection.config,
       operation: 'delete',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -254,7 +255,7 @@ export const deleteOperation = async <
                 collection: collectionConfig,
                 context: req.context,
                 doc: result || doc,
-                overrideAccess: overrideAccess!,
+                overrideAccess,
                 req,
               })) || result
           }
@@ -336,6 +337,7 @@ export const deleteOperation = async <
       args,
       collection: collectionConfig,
       operation: 'delete',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -254,6 +254,7 @@ export const deleteOperation = async <
                 collection: collectionConfig,
                 context: req.context,
                 doc: result || doc,
+                overrideAccess: overrideAccess!,
                 req,
               })) || result
           }

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -55,6 +55,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
       args,
       collection: args.collection.config,
       operation: 'delete',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -231,7 +232,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
             collection: collectionConfig,
             context: req.context,
             doc: result,
-            overrideAccess: overrideAccess!,
+            overrideAccess,
             req,
           })) || result
       }
@@ -262,6 +263,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
       args,
       collection: collectionConfig,
       operation: 'deleteByID',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -231,6 +231,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
             collection: collectionConfig,
             context: req.context,
             doc: result,
+            overrideAccess: overrideAccess!,
             req,
           })) || result
       }

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -291,7 +291,7 @@ export const findOperation = async <
                 collection: collectionConfig,
                 context: req.context,
                 doc: docRef,
-                overrideAccess,
+                overrideAccess: overrideAccess!,
                 query: fullWhere,
                 req,
               })) || docRef
@@ -344,7 +344,7 @@ export const findOperation = async <
                 context: req.context,
                 doc: docRef,
                 findMany: true,
-                overrideAccess,
+                overrideAccess: overrideAccess!,
                 query: fullWhere,
                 req,
               })) || docRef

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -73,6 +73,7 @@ export const findOperation = async <
       args,
       collection: args.collection.config,
       operation: 'read',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -363,6 +364,7 @@ export const findOperation = async <
       args,
       collection: collectionConfig,
       operation: 'find',
+      overrideAccess: overrideAccess!,
       result,
     })
 

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -291,6 +291,7 @@ export const findOperation = async <
                 collection: collectionConfig,
                 context: req.context,
                 doc: docRef,
+                overrideAccess,
                 query: fullWhere,
                 req,
               })) || docRef
@@ -343,6 +344,7 @@ export const findOperation = async <
                 context: req.context,
                 doc: docRef,
                 findMany: true,
+                overrideAccess,
                 query: fullWhere,
                 req,
               })) || docRef

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -274,6 +274,7 @@ export const findByIDOperation = async <
             collection: collectionConfig,
             context: req.context,
             doc: result,
+            overrideAccess,
             query: findOneArgs.where,
             req,
           })) || result

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -314,6 +314,7 @@ export const findByIDOperation = async <
             collection: collectionConfig,
             context: req.context,
             doc: result,
+            overrideAccess,
             query: findOneArgs.where,
             req,
           })) || result

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -72,6 +72,7 @@ export const findByIDOperation = async <
       args,
       collection: args.collection.config,
       operation: 'read',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -329,6 +330,7 @@ export const findByIDOperation = async <
       args,
       collection: collectionConfig,
       operation: 'findByID',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/findDistinct.ts
+++ b/packages/payload/src/collections/operations/findDistinct.ts
@@ -49,6 +49,7 @@ export const findDistinctOperation = async (
       args,
       collection: args.collection.config,
       operation: 'readDistinct',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -237,6 +238,7 @@ export const findDistinctOperation = async (
       args,
       collection: collectionConfig,
       operation: 'findDistinct',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -61,6 +61,7 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
       args,
       collection: collectionConfig,
       operation: 'findVersionByID',
+      overrideAccess,
     })
 
     // /////////////////////////////////////
@@ -141,7 +142,7 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
             collection: collectionConfig,
             context: req.context,
             doc: result.version,
-            overrideAccess: overrideAccess!,
+            overrideAccess,
             query: fullWhere,
             req,
           })) || result.version
@@ -181,7 +182,7 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
             collection: collectionConfig,
             context: req.context,
             doc: result.version,
-            overrideAccess: overrideAccess!,
+            overrideAccess,
             query: fullWhere,
             req,
           })) || result.version
@@ -196,6 +197,7 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
       args,
       collection: collectionConfig,
       operation: 'findVersionByID',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -141,6 +141,7 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
             collection: collectionConfig,
             context: req.context,
             doc: result.version,
+            overrideAccess: overrideAccess!,
             query: fullWhere,
             req,
           })) || result.version
@@ -180,6 +181,7 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
             collection: collectionConfig,
             context: req.context,
             doc: result.version,
+            overrideAccess: overrideAccess!,
             query: fullWhere,
             req,
           })) || result.version

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -144,6 +144,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
                 collection: collectionConfig,
                 context: req.context,
                 doc: docRef.version,
+                overrideAccess: overrideAccess!,
                 query: fullWhere,
                 req,
               })) || docRef.version
@@ -196,6 +197,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
                 context: req.context,
                 doc: doc.version,
                 findMany: true,
+                overrideAccess: overrideAccess!,
                 query: fullWhere,
                 req,
               })) || doc.version

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -46,6 +46,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
       args,
       collection: args.collection.config,
       operation: 'findVersions',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -144,7 +145,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
                 collection: collectionConfig,
                 context: req.context,
                 doc: docRef.version,
-                overrideAccess: overrideAccess!,
+                overrideAccess,
                 query: fullWhere,
                 req,
               })) || docRef.version
@@ -197,7 +198,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
                 context: req.context,
                 doc: doc.version,
                 findMany: true,
-                overrideAccess: overrideAccess!,
+                overrideAccess,
                 query: fullWhere,
                 req,
               })) || doc.version
@@ -221,6 +222,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
       args,
       collection: collectionConfig,
       operation: 'findVersions',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -66,6 +66,7 @@ export const restoreVersionOperation = async <
       args,
       collection: args.collection.config,
       operation: 'restoreVersion',
+      overrideAccess,
     })
 
     if (!id) {
@@ -347,6 +348,7 @@ export const restoreVersionOperation = async <
             data: result,
             doc: result,
             operation: 'update',
+            overrideAccess,
             previousDoc: prevDocWithLocales,
             req,
           })) || result
@@ -361,6 +363,7 @@ export const restoreVersionOperation = async <
       args,
       collection: collectionConfig,
       operation: 'restoreVersion',
+      overrideAccess,
       result,
     })
 

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -313,6 +313,7 @@ export const restoreVersionOperation = async <
             collection: collectionConfig,
             context: req.context,
             doc: result,
+            overrideAccess,
             req,
           })) || result
       }

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -86,6 +86,7 @@ export const updateOperation = async <
       args,
       collection: args.collection.config,
       operation: 'update',
+      overrideAccess: args.overrideAccess!,
     })
 
     const {
@@ -320,6 +321,7 @@ export const updateOperation = async <
       args,
       collection: collectionConfig,
       operation: 'update',
+      overrideAccess,
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       result,
     })

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -73,6 +73,7 @@ export const updateByIDOperation = async <
       args,
       collection: args.collection.config,
       operation: 'update',
+      overrideAccess: args.overrideAccess!,
     })
 
     if (args.publishSpecificLocale) {
@@ -236,6 +237,7 @@ export const updateByIDOperation = async <
       args,
       collection: collectionConfig,
       operation: 'updateByID',
+      overrideAccess,
       result,
     })) as TransformCollectionWithSelect<TSlug, TSelect>
 

--- a/packages/payload/src/collections/operations/utilities/buildAfterOperation.ts
+++ b/packages/payload/src/collections/operations/utilities/buildAfterOperation.ts
@@ -7,7 +7,7 @@ export const buildAfterOperation = async <
 >(
   operationArgs: { operation: O } & Omit<AfterOperationArg<TOperationGeneric>, 'req'>,
 ): Promise<any | OperationResult<TOperationGeneric, O>> => {
-  const { args, collection, operation, result } = operationArgs
+  const { args, collection, operation, overrideAccess, result } = operationArgs
 
   let newResult = result as OperationResult<TOperationGeneric, O>
 
@@ -17,6 +17,7 @@ export const buildAfterOperation = async <
         args,
         collection,
         operation,
+        overrideAccess,
         req: args.req,
         result: newResult,
       } as AfterOperationArg<TOperationGeneric>)

--- a/packages/payload/src/collections/operations/utilities/buildBeforeOperation.ts
+++ b/packages/payload/src/collections/operations/utilities/buildBeforeOperation.ts
@@ -80,7 +80,7 @@ export async function buildBeforeOperation<
 export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug>(
   operationArgs: Omit<BeforeOperationArg<TOperationGeneric>, 'context' | 'req'>,
 ): Promise<unknown> {
-  const { args, collection, operation } = operationArgs
+  const { args, collection, operation, overrideAccess } = operationArgs
 
   let newArgs = args
 
@@ -95,6 +95,7 @@ export async function buildBeforeOperation<TOperationGeneric extends CollectionS
         collection,
         context: args.req!.context,
         operation: hookOperation,
+        overrideAccess,
         req: args.req!,
       } as BeforeOperationArg<TOperationGeneric>)
 

--- a/packages/payload/src/collections/operations/utilities/types.ts
+++ b/packages/payload/src/collections/operations/utilities/types.ts
@@ -53,6 +53,10 @@ export type OperationMap<TOperationGeneric extends CollectionSlug> = {
 export type AfterOperationArg<TOperationGeneric extends CollectionSlug> = {
   /** The collection which this hook is being run on */
   collection: SanitizedCollectionConfig
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   req: PayloadRequest
 } & (
   | {
@@ -195,6 +199,10 @@ export type BeforeOperationArg<TOperationGeneric extends CollectionSlug> = {
   /** The collection which this hook is being run on */
   collection: SanitizedCollectionConfig
   context: RequestContext
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   req: PayloadRequest
 } & (
   | {

--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -419,6 +419,7 @@ export const updateDocument = async <
           collection: collectionConfig,
           context: req.context,
           doc: result,
+          overrideAccess,
           req,
         })) || result
     }

--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -453,6 +453,7 @@ export const updateDocument = async <
           data,
           doc: result,
           operation: 'update',
+          overrideAccess,
           previousDoc: originalDoc,
           req,
         })) || result

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -45,6 +45,10 @@ export type BeforeValidateHook = (args: {
   /** The global which this hook is being run on */
   global: SanitizedGlobalConfig
   originalDoc?: any
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   req: PayloadRequest
 }) => any
 
@@ -54,6 +58,10 @@ export type BeforeChangeHook = (args: {
   /** The global which this hook is being run on */
   global: SanitizedGlobalConfig
   originalDoc?: any
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   req: PayloadRequest
 }) => any
 
@@ -63,6 +71,10 @@ export type AfterChangeHook = (args: {
   doc: any
   /** The global which this hook is being run on */
   global: SanitizedGlobalConfig
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   previousDoc: any
   req: PayloadRequest
 }) => any
@@ -72,6 +84,10 @@ export type BeforeReadHook = (args: {
   doc: any
   /** The global which this hook is being run on */
   global: SanitizedGlobalConfig
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   req: PayloadRequest
 }) => any
 
@@ -81,6 +97,10 @@ export type AfterReadHook = (args: {
   findMany?: boolean
   /** The global which this hook is being run on */
   global: SanitizedGlobalConfig
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   query?: Where
   req: PayloadRequest
 }) => any
@@ -98,6 +118,10 @@ export type BeforeOperationHook = (args: {
    * Hook operation being performed
    */
   operation: HookOperationType
+  /**
+   * Whether access control is being overridden for this operation
+   */
+  overrideAccess?: boolean
   req: PayloadRequest
 }) => any
 

--- a/packages/payload/src/globals/operations/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/countGlobalVersions.ts
@@ -40,6 +40,7 @@ export const countGlobalVersionsOperation = async <TSlug extends GlobalSlug>(
             context: req.context,
             global,
             operation: 'countVersions',
+            overrideAccess,
             req,
           })) || args
       }

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -73,6 +73,7 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
             context: args.req.context,
             global: globalConfig,
             operation: 'read',
+            overrideAccess,
             req: args.req,
           })) || args
       }
@@ -204,6 +205,7 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
             context: req.context,
             doc,
             global: globalConfig,
+            overrideAccess,
             req,
           })) || doc
       }
@@ -254,6 +256,7 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
             context: req.context,
             doc,
             global: globalConfig,
+            overrideAccess,
             req,
           })) || doc
       }

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -118,6 +118,7 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
             context: req.context,
             doc: result.version,
             global: globalConfig,
+            overrideAccess,
             req,
           })) || result.version
       }
@@ -155,6 +156,7 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
             context: req.context,
             doc: result.version,
             global: globalConfig,
+            overrideAccess,
             query: findGlobalVersionsArgs.where,
             req,
           })) || result.version

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -150,6 +150,7 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
                 doc: doc.version,
                 findMany: true,
                 global: globalConfig,
+                overrideAccess,
                 query: fullWhere,
                 req,
               })) || doc.version

--- a/packages/payload/src/globals/operations/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/restoreVersion.ts
@@ -43,6 +43,7 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
             context: req.context,
             global: globalConfig,
             operation: 'restoreVersion',
+            overrideAccess,
             req,
           })) || args
       }
@@ -159,6 +160,7 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
             context: req.context,
             doc: result,
             global: globalConfig,
+            overrideAccess,
             req,
           })) || result
       }
@@ -191,6 +193,7 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
             data: result,
             doc: result,
             global: globalConfig,
+            overrideAccess,
             previousDoc,
             req,
           })) || result

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -98,6 +98,7 @@ export const updateOperation = async <
             context: args.req.context,
             global: globalConfig,
             operation: 'update',
+            overrideAccess,
             req: args.req,
           })) || args
       }
@@ -215,6 +216,7 @@ export const updateOperation = async <
             data,
             global: globalConfig,
             originalDoc,
+            overrideAccess,
             req,
           })) || data
       }
@@ -232,6 +234,7 @@ export const updateOperation = async <
             data,
             global: globalConfig,
             originalDoc,
+            overrideAccess,
             req,
           })) || data
       }
@@ -428,6 +431,7 @@ export const updateOperation = async <
             context: req.context,
             doc: result,
             global: globalConfig,
+            overrideAccess,
             req,
           })) || result
       }
@@ -460,6 +464,7 @@ export const updateOperation = async <
             data,
             doc: result,
             global: globalConfig,
+            overrideAccess,
             previousDoc: originalDoc,
             req,
           })) || result

--- a/test/hooks/collections/OverrideAccess/index.ts
+++ b/test/hooks/collections/OverrideAccess/index.ts
@@ -1,0 +1,54 @@
+import type { CollectionConfig } from 'payload'
+
+export const overrideAccessSlug = 'override-access-hooks'
+
+export const OverrideAccessCollection: CollectionConfig = {
+  slug: overrideAccessSlug,
+  access: {
+    create: () => true,
+    delete: () => true,
+    read: () => true,
+    update: () => true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    {
+      name: 'beforeReadCalled',
+      type: 'checkbox',
+    },
+    {
+      name: 'beforeReadOverrideAccess',
+      type: 'checkbox',
+    },
+    {
+      name: 'afterReadCalled',
+      type: 'checkbox',
+    },
+    {
+      name: 'afterReadOverrideAccess',
+      type: 'checkbox',
+    },
+  ],
+  hooks: {
+    afterRead: [
+      ({ context, doc, overrideAccess }) => {
+        return {
+          ...doc,
+          afterReadCalled: true,
+          afterReadOverrideAccess: overrideAccess,
+          beforeReadCalled: context['beforeReadCalled'] as boolean,
+          beforeReadOverrideAccess: context['beforeReadOverrideAccess'] as boolean,
+        }
+      },
+    ],
+    beforeRead: [
+      ({ context, overrideAccess }) => {
+        context['beforeReadCalled'] = true
+        context['beforeReadOverrideAccess'] = overrideAccess
+      },
+    ],
+  },
+}

--- a/test/hooks/config.ts
+++ b/test/hooks/config.ts
@@ -22,6 +22,7 @@ import { DataHooks } from './collections/Data/index.js'
 import Hooks, { hooksSlug } from './collections/Hook/index.js'
 import NestedAfterChangeHooks from './collections/NestedAfterChangeHook/index.js'
 import NestedAfterReadHooks from './collections/NestedAfterReadHooks/index.js'
+import { OverrideAccessCollection } from './collections/OverrideAccess/index.js'
 import Relations from './collections/Relations/index.js'
 import TransformHooks from './collections/Transform/index.js'
 import Users, { seedHooksUsers } from './collections/Users/index.js'
@@ -52,6 +53,7 @@ export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
     BeforeDelete2Collection,
     ValueCollection,
     AfterReadCollection,
+    OverrideAccessCollection,
   ],
   globals: [DataHooksGlobal],
   endpoints: [

--- a/test/hooks/shared.ts
+++ b/test/hooks/shared.ts
@@ -1,3 +1,4 @@
 export const beforeValidateSlug = 'before-validate'
 export const fieldPathsSlug = 'field-paths'
 export const afterReadSlug = 'after-read'
+export const overrideAccessSlug = 'override-access-hooks'


### PR DESCRIPTION
Threads `overrideAccess` into collection and global level hooks. This does not cover field level hooks. That can be done in a future PR if deemed useful.

This is needed in the [hierarchical document PR](https://github.com/payloadcms/payload/pull/14747) because it would be helpful to know what the overrideAccess is when querying up the tree for related documents.