### PR TITLE
fix(storage-gcs): use sanitized filename for client uploads

### DIFF
--- a/packages/storage-gcs/package.json
+++ b/packages/storage-gcs/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "@google-cloud/storage": "7.17.2",
-    "@payloadcms/plugin-cloud-storage": "workspace:*"
+    "@payloadcms/plugin-cloud-storage": "workspace:*",
+    "sanitize-filename": "1.6.3"
   },
   "devDependencies": {
     "payload": "workspace:*"

--- a/packages/storage-gcs/src/client/GcsClientUploadHandler.ts
+++ b/packages/storage-gcs/src/client/GcsClientUploadHandler.ts
@@ -1,9 +1,27 @@
 'use client'
 import { createClientUploadHandler } from '@payloadcms/plugin-cloud-storage/client'
 import { formatAdminURL } from 'payload/shared'
+import sanitize from 'sanitize-filename'
+
+function getSafeFilename(name: string): string {
+  const base = sanitize(name.substring(0, name.lastIndexOf('.')) || name)
+  const ext = name.includes('.') ? name.split('.').pop()?.split('?')[0] : ''
+  return ext ? `${base}.${ext}` : base
+}
 
 export const GcsClientUploadHandler = createClientUploadHandler({
-  handler: async ({ apiRoute, collectionSlug, file, prefix, serverHandlerPath, serverURL }) => {
+  handler: async ({
+    apiRoute,
+    collectionSlug,
+    file,
+    prefix,
+    serverHandlerPath,
+    serverURL,
+    updateFilename,
+  }) => {
+    const safeFilename = getSafeFilename(file.name)
+    updateFilename(safeFilename)
+
     const endpointRoute = formatAdminURL({
       apiRoute,
       path: serverHandlerPath,
@@ -12,7 +30,7 @@ export const GcsClientUploadHandler = createClientUploadHandler({
     const response = await fetch(endpointRoute, {
       body: JSON.stringify({
         collectionSlug,
-        filename: file.name,
+        filename: safeFilename,
         mimeType: file.type,
       }),
       credentials: 'include',


### PR DESCRIPTION
### What?
- Client uploads to GCS now use a sanitized filename (same as Payload) so the GCS object key matches the stored filename.

### Why?

- The client sent the raw filename (e.g. with trailing space) to GCS while Payload stored a sanitized name, so links returned 404.

### How?

- Sanitize the filename in the GCS client handler and in the signed-URL handler so both use the same name for the object key and the doc.

fixes #15352