### PR TITLE
fix(drizzle): use scalar for equals/not_equals on relationship filters

### DIFF
--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -262,6 +262,16 @@ export const sanitizeQueryValue = ({
     }
   }
 
+  if (
+    (operator === 'equals' || operator === 'not_equals') &&
+    (field.type === 'relationship' || field.type === 'upload') &&
+    !relationOrPath.endsWith('relationTo') &&
+    Array.isArray(formattedValue) &&
+    formattedValue.length > 0
+  ) {
+    formattedValue = formattedValue[0]
+  }
+
   return {
     columns: formattedColumns,
     operator,

--- a/packages/ui/src/elements/WhereBuilder/field-types.tsx
+++ b/packages/ui/src/elements/WhereBuilder/field-types.tsx
@@ -166,12 +166,14 @@ export const getValidFieldOperators = ({
     value: string
   }[] = []
 
-  if (field.type === 'relationship' && Array.isArray(field.relationTo)) {
-    if ('hasMany' in field && field.hasMany) {
-      validOperators = [...equalsOperators, exists]
-    } else {
-      validOperators = [...base]
-    }
+  if (
+    (field.type === 'relationship' || field.type === 'upload') &&
+    'hasMany' in field &&
+    field.hasMany
+  ) {
+    validOperators = [...arrayOperators, exists]
+  } else if (field.type === 'relationship' && Array.isArray(field.relationTo)) {
+    validOperators = [...base]
   } else {
     validOperators = [...fieldTypeConditions[field.type].operators]
   }

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -727,7 +727,7 @@ describe('relationship', () => {
     await expect(page.locator(tableRowLocator)).toHaveCount(1)
   })
 
-  test('should allow filtering by non-polymorphic hasMany relationship field / equals', async () => {
+  test('should allow filtering by non-polymorphic hasMany relationship field / is in', async () => {
     const textDoc1 = await createTextFieldDoc({ text: 'Text 1' })
     const textDoc2 = await createTextFieldDoc({ text: 'Text 2' })
     const textDoc3 = await createTextFieldDoc({ text: 'Text 3' })
@@ -752,7 +752,7 @@ describe('relationship', () => {
     await addListFilter({
       page,
       fieldLabel: 'Relationship Has Many',
-      operatorLabel: 'equals',
+      operatorLabel: 'is in',
       value: 'Text 1',
       multiSelect: true,
     })
@@ -760,7 +760,7 @@ describe('relationship', () => {
     await expect(page.locator(tableRowLocator)).toHaveCount(1)
   })
 
-  test('should allow filtering by polymorphic hasMany relationship field / equals', async () => {
+  test('should allow filtering by polymorphic hasMany relationship field / is in', async () => {
     const textDoc1 = await createTextFieldDoc({ text: 'Poly Text 1' })
     const textDoc2 = await createTextFieldDoc({ text: 'Poly Text 2' })
 
@@ -787,7 +787,7 @@ describe('relationship', () => {
     await addListFilter({
       page,
       fieldLabel: 'Relation Has Many Polymorphic',
-      operatorLabel: 'equals',
+      operatorLabel: 'is in',
       value: 'Poly Text 1',
       multiSelect: true,
     })


### PR DESCRIPTION
### What?

- Use a single value for “equals” / “not equals” on relationship filters so the list no longer errors.

### Why?

- The UI sends an array (e.g. [2]). Passing that to column = $1 made Postgres treat it as an array and throw invalid input syntax for type integer.

### How?

- In sanitizeQueryValue, when operator is equals or not_equals and the value is an array, use value[0] before passing it to the DB.

Fixes #15387