### PR TITLE
fix: isolate payload-preferences by auth collection

### DIFF
--- a/packages/payload/src/preferences/config.ts
+++ b/packages/payload/src/preferences/config.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from '../collections/config/types.js'
 import type { Access, Config } from '../config/types.js'
+import type { Where } from '../types/index.js'
 
 import { deleteHandler } from './requestHandlers/delete.js'
 import { findByIDHandler } from './requestHandlers/findOne.js'
@@ -10,10 +11,20 @@ const preferenceAccess: Access = ({ req }) => {
     return false
   }
 
-  return {
+  const userValueCondition: Where = {
     'user.value': {
-      equals: req?.user?.id,
+      equals: req.user.id,
     },
+  }
+
+  const userRelationCondition: Where = {
+    'user.relationTo': {
+      equals: req.user.collection,
+    },
+  }
+
+  return {
+    and: [userValueCondition, userRelationCondition],
   }
 }
 


### PR DESCRIPTION
### What
Fixes preferences being accessible across different auth collections in multi-auth setups.

### Why
The `preferenceAccess` function only checked user ID without verifying which auth collection the user belonged to. In setups with multiple auth collections using sequential IDs, this could allow unintended access to preferences.

### How
Updated `preferenceAccess` to check both user ID and auth collection, consistent with the existing operation handlers. Added tests to verify proper isolation.

