### PR TITLE
fix(next): sync modular dashboard widgets when server component re-renders

### DIFF
--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
@@ -9,7 +9,7 @@ import {
   usePreferences,
   useServerFunctions,
 } from '@payloadcms/ui'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import type { WidgetInstanceClient, WidgetItem } from './index.client.js'
 import type { GetDefaultLayoutServerFnReturnType } from './renderWidget/getDefaultLayoutServerFn.js'
@@ -24,6 +24,13 @@ export function useDashboardLayout(initialLayout: WidgetInstanceClient[]) {
   const { openModal } = useModal()
   const cancelModalSlug = 'cancel-dashboard-changes'
   const { serverFunction } = useServerFunctions()
+
+  // Sync state when initialLayout prop changes (e.g., when query params change and server component re-renders)
+  useEffect(() => {
+    if (!isEditing) {
+      setCurrentLayout(initialLayout)
+    }
+  }, [initialLayout, isEditing])
 
   const saveLayout = useCallback(async () => {
     try {

--- a/test/dashboard/components/PageQuery.tsx
+++ b/test/dashboard/components/PageQuery.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable no-restricted-exports */
+
+import { type WidgetServerProps } from 'payload'
+import React from 'react'
+
+import { PageQueryButton } from './PageQueryButton.client.js'
+
+export default function PageQuery({ req }: WidgetServerProps) {
+  // Get page from query params
+  const queryPage = req.query?.page
+  const currentPage = typeof queryPage === 'string' ? parseInt(queryPage, 10) : 0
+
+  return (
+    <div
+      className="page-query-widget card"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        height: '100%',
+        padding: '16px',
+      }}
+    >
+      <div>
+        <h3 style={{ fontSize: '16px', fontWeight: 600, margin: 0 }}>Page Query Widget</h3>
+        <p style={{ color: '#6b7280', fontSize: '14px', margin: '8px 0 0 0' }}>
+          Current page from query: <strong>{currentPage}</strong>
+        </p>
+      </div>
+
+      <PageQueryButton currentPage={currentPage} />
+    </div>
+  )
+}

--- a/test/dashboard/components/PageQueryButton.client.tsx
+++ b/test/dashboard/components/PageQueryButton.client.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation.js'
+import { useCallback } from 'react'
+
+type PageQueryButtonProps = {
+  currentPage: number
+}
+
+export function PageQueryButton({ currentPage }: PageQueryButtonProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const handleIncrement = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    const newPage = currentPage + 1
+    params.set('page', String(newPage))
+    router.push(`${pathname}?${params.toString()}`)
+  }, [currentPage, pathname, router, searchParams])
+
+  return (
+    <button
+      onClick={handleIncrement}
+      style={{
+        backgroundColor: '#2563eb',
+        border: 'none',
+        borderRadius: '6px',
+        color: 'white',
+        cursor: 'pointer',
+        fontSize: '14px',
+        fontWeight: 500,
+        padding: '8px 16px',
+      }}
+      type="button"
+    >
+      Increment Page ({currentPage} → {currentPage + 1})
+    </button>
+  )
+}

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -42,10 +42,6 @@ export default buildConfigWithDefaults({
             widgetSlug: 'revenue',
             width: 'full',
           },
-          {
-            widgetSlug: 'page-query',
-            width: 'medium',
-          },
         ]
 
         if (user?.email === 'dev@payloadcms.com') {

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -13,9 +13,6 @@ const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
   admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
     components: {
       afterDashboard: ['./components/BeforeOrAfterDashboard.js'],
       beforeDashboard: ['./components/BeforeOrAfterDashboard.js'],
@@ -44,6 +41,10 @@ export default buildConfigWithDefaults({
           {
             widgetSlug: 'revenue',
             width: 'full',
+          },
+          {
+            widgetSlug: 'page-query',
+            width: 'medium',
           },
         ]
 
@@ -78,7 +79,15 @@ export default buildConfigWithDefaults({
           label: ({ i18n }) => (i18n.language === 'es' ? 'Gráfico de Ingresos' : 'Revenue Chart'),
           minWidth: 'medium',
         },
+        {
+          slug: 'page-query',
+          ComponentPath: './components/PageQuery.tsx#default',
+          label: 'Page Query Widget',
+        },
       ],
+    },
+    importMap: {
+      baseDir: path.resolve(dirname),
     },
   },
   collections: [

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -199,4 +199,27 @@ describe('Dashboard', () => {
       expect(labels).toContain('Collections')
     }).toPass({ timeout: 1000 })
   })
+
+  test('widget re-renders when query params change (= modular dashboard RSC rerenders)', async ({
+    page,
+  }) => {
+    // Find the page-query widget
+    const pageQueryWidget = page.locator('.page-query-widget')
+    await expect(pageQueryWidget).toBeVisible()
+
+    // Initially, page should be 0 (default)
+    await expect(pageQueryWidget.getByText(/Current page from query: 0/)).toBeVisible()
+
+    // Click the increment button
+    const incrementButton = pageQueryWidget.getByRole('button', { name: /Increment Page/ })
+    await incrementButton.click()
+
+    // The page number should update to 1 without a page refresh
+    // This test will fail until the server component re-renders when query params change
+    await expect(pageQueryWidget.getByText(/Current page from query: 1/)).toBeVisible()
+
+    // Click again to increment to 2
+    await incrementButton.click()
+    await expect(pageQueryWidget.getByText(/Current page from query: 2/)).toBeVisible()
+  })
 })

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -203,6 +203,12 @@ describe('Dashboard', () => {
   test('widget re-renders when query params change (= modular dashboard RSC rerenders)', async ({
     page,
   }) => {
+    const d = new DashboardHelper(page)
+    await d.setEditing()
+    await d.addWidget('page query')
+    await d.assertWidget(8, 'page-query', 'x-small')
+    await d.saveChangesAndValidate()
+
     // Find the page-query widget
     const pageQueryWidget = page.locator('.page-query-widget')
     await expect(pageQueryWidget).toBeVisible()


### PR DESCRIPTION
## Problem

When a widget updates query parameters via `router.push` (e.g., incrementing a page counter), the server component `ModularDashboard` correctly re-renders with updated `req.query` values and creates a new `serverLayout` array containing the fresh server-rendered widget components.

However, the client component `ModularDashboardClient` didn't reflect these changes because `useDashboardLayout` only used `initialLayout` on mount via `useState`, which ignores subsequent prop changes after the initial render. This meant that even though the server component was producing new data with updated query params, the client component's state remained stale and widgets continued displaying the old values until a full page refresh occurred.

## Use-Case Example

One example use case would be rendering a list view table within a widget. When you perform pagination or sort columns, it changes the query params, expecting the RSC to re-run, otherwise the list won't react to these actions.

## Solution

Added a `useEffect` hook in `useDashboardLayout` that syncs the `currentLayout` state whenever the `initialLayout` prop changes.