### PR TITLE
fix: sass warning not hidden during webpack build

### DIFF
--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -36,7 +36,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
 
   const consoleWarn = console.warn
   const sassWarningText =
-    'SassWarning: Future import deprecation is not yet active, so silencing it is unnecessary'
+    'Future import deprecation is not yet active, so silencing it is unnecessary'
   console.warn = (...args) => {
     if (
       (typeof args[1] === 'string' && args[1].includes(sassWarningText)) ||


### PR DESCRIPTION
In webpack, the "Future import deprecation is not yet active, so silencing it is unnecessary" warning wasn’t prefixed with `SassWarning:`, so our silencer didn’t catch it when running `next build --turbo`. This fixes that.