### PR TITLE
fix(drizzle): use dynamic import for ts in blocksToJsonMigrator.

### DIFF
--- a/packages/drizzle/src/utilities/blocksToJsonMigrator.ts
+++ b/packages/drizzle/src/utilities/blocksToJsonMigrator.ts
@@ -5,6 +5,7 @@ import type {
   PayloadRequest,
   SanitizedConfig,
 } from 'payload'
+import type { SourceFile, Visitor } from 'typescript'
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import path from 'path'
@@ -16,7 +17,6 @@ import {
 } from 'payload'
 import { findConfig } from 'payload/node'
 import { fieldShouldBeLocalized } from 'payload/shared'
-import * as ts from 'typescript'
 
 import type {
   BlocksToJsonBlockToMigrate,
@@ -627,6 +627,8 @@ class BlocksToJsonMigratorImpl implements BlocksToJsonMigrator {
   }
 
   async updatePayloadConfigFile(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    const ts = await dynamicImport<typeof import('typescript')>('typescript')
     let configPath: string
 
     try {
@@ -648,7 +650,7 @@ class BlocksToJsonMigratorImpl implements BlocksToJsonMigrator {
       (ctx) => (sourceFile) => {
         const factory = ctx.factory
 
-        const visit: ts.Visitor = (node) => {
+        const visit: Visitor = (node) => {
           if (
             ts.isPropertyAssignment(node) &&
             ts.isIdentifier(node.name) &&
@@ -691,7 +693,7 @@ class BlocksToJsonMigratorImpl implements BlocksToJsonMigrator {
           return ts.visitEachChild(node, visit, ctx)
         }
 
-        return ts.visitNode(sourceFile, visit) as ts.SourceFile
+        return ts.visitNode(sourceFile, visit) as SourceFile
       },
     ])
 


### PR DESCRIPTION
### What?
I've noticed that after upgrading to v3.73 my bundle size has grown even though I've not added any other external packages in my personal project. I've started investigation of the changes in that release. I've used esbuild analyzer to check what changed, and indeed, typescript was in the bundle.

### Why?
The static import of typescript at a module level causes the entire TS compiler (~15MB) to be bundled into production builds, even when the blocksAsJSON migration is never used. This was an issue in my project as I deploy the app to Cloudflare Workers. I've saved ~1.6MB in gzipped bundle size with this fix. The dynamic import pattern is the same as for prettier in the same file.

### How?
Added a dynamic import for typescript (following "prettier" import in the same file) + imported only used types from Typescript.  I've tested and pnpm build:drizzle runs correctly.

Fixes #
packages/drizzle/src/utilities/blocksToJsonMigrator.ts

I've attached screenshots of bundle size.
## After
<img width="1197" height="762" alt="after-ts-fix" src="https://github.com/user-attachments/assets/d14bedbb-4bcf-4f22-b71a-b8e8676dcdc3" />
## Before
<img width="1197" height="762" alt="before-ts-fix" src="https://github.com/user-attachments/assets/012bb302-fe6d-4e5a-ba30-64b6668f79f2" />

Please be gentle, my first contribution :) if something is not right let me know I'll fix it.
