### PR TITLE
test(plugin-cloud-storage): add test for focal point adjustments

### DIFF
--- a/test/plugin-cloud-storage/e2e.spec.ts
+++ b/test/plugin-cloud-storage/e2e.spec.ts
@@ -4,9 +4,12 @@ import { expect, test } from '@playwright/test'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 
+import type { Config, Media } from './payload-types.js'
+
 import { ensureCompilationIsDone, saveDocAndAssert } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
+import { RESTClient } from '../helpers/rest.js'
 import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { mediaSlug } from './shared.js'
 
@@ -15,16 +18,26 @@ const dirname = path.dirname(filename)
 
 test.describe('Cloud Storage Plugin', () => {
   let page: Page
+  let client: RESTClient
+  let serverURL: string
   let mediaURL: AdminUrlUtil
 
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    const { serverURL } = await initPayloadE2ENoConfig({ dirname })
+    ;({ serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
     mediaURL = new AdminUrlUtil(serverURL, mediaSlug)
 
     const context = await browser.newContext()
     page = await context.newPage()
     await ensureCompilationIsDone({ page, serverURL })
+  })
+
+  test.beforeEach(async () => {
+    if (client) {
+      await client.logout()
+    }
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
+    await client.login()
   })
 
   test('should create file upload', async () => {
@@ -88,5 +101,79 @@ test.describe('Cloud Storage Plugin', () => {
       timeout: 30000,
     })
     await expect.poll(() => updateRequestCount).toBeLessThanOrEqual(2)
+  })
+
+  test('should preserve image sizes when changing focal point', async () => {
+    await page.goto(mediaURL.create)
+    await page.setInputFiles('input[type="file"]', path.resolve(dirname, './image.png'))
+    await expect(page.locator('.file-field__filename')).toHaveValue('image.png')
+    await saveDocAndAssert(page)
+
+    const mediaId = page.url().split('/').pop() as string
+
+    const uploadedMedia = await client.findByID<Media & Record<string, unknown>>({
+      id: mediaId,
+      slug: mediaSlug,
+      auth: true,
+    })
+
+    // eslint-disable-next-line payload/no-flaky-assertions
+    const stringExpectation = expect.any(String)
+    // eslint-disable-next-line payload/no-flaky-assertions
+    const numberExpectation = expect.any(Number)
+
+    // eslint-disable-next-line payload/no-flaky-assertions
+    const sizeExpectation = expect.objectContaining({
+      url: stringExpectation,
+      mimeType: stringExpectation,
+      filename: stringExpectation,
+      width: numberExpectation,
+      height: numberExpectation,
+      filesize: numberExpectation,
+    })
+
+    // eslint-disable-next-line payload/no-flaky-assertions
+    const sizesExpectation = expect.objectContaining({
+      square: sizeExpectation,
+      sixteenByNineMedium: sizeExpectation,
+    })
+
+    await expect
+      .poll(() => uploadedMedia.doc)
+      .toEqual(
+        expect.objectContaining({
+          focalX: 50,
+          focalY: 50,
+          sizes: sizesExpectation,
+        }),
+      )
+
+    await page.locator('.file-field__edit').click()
+
+    // set focal point
+    const newFocalX = 12
+    const newFocalY = 20
+    await page.locator('.edit-upload__input input[name="X %"]').fill(newFocalX.toString()) // left focal point
+    await page.locator('.edit-upload__input input[name="Y %"]').fill(newFocalY.toString()) // top focal point
+
+    // apply focal point
+    await page.locator('button:has-text("Apply Changes")').click()
+    await saveDocAndAssert(page)
+
+    const updatedMedia = await client.findByID<Media & Record<string, unknown>>({
+      id: mediaId,
+      slug: mediaSlug,
+      auth: true,
+    })
+
+    await expect
+      .poll(() => updatedMedia.doc)
+      .toEqual(
+        expect.objectContaining({
+          focalX: newFocalX,
+          focalY: newFocalY,
+          sizes: sizesExpectation,
+        }),
+      )
   })
 })


### PR DESCRIPTION
### What?
When using plugin-cloud-storage and updating an existing image with cropping or focal point adjustments, the images in the `sizes` property are deleted and not recreated.

### Why?
TBD - I think the underlying issue is actually upstream of this

### How?
TBD

Fixes #
TBD

Additional information in [this comment](https://github.com/payloadcms/payload/pull/15188#issuecomment-3802891301)
Thought to be fixed in PR #15393 
Related to issue #12234 