### PR TITLE
chore(claude): post-write hook causes error when IDE checks output and doesn't apply formatting correctly

### DIFF
--- a/.claude/hooks/post-write-format.sh
+++ b/.claude/hooks/post-write-format.sh
@@ -21,20 +21,20 @@ fi
 # Format based on file type
 case "$FILE" in
   */package.json)
-    npx sort-package-json "$FILE" 2>/dev/null
+    pnpm sort-package-json "$FILE" >/dev/null 2>&1
     ;;
   *.yml|*.json)
-    npx prettier --write "$FILE" 2>/dev/null
+    pnpm prettier --write "$FILE" >/dev/null 2>&1
     ;;
   *.md|*.mdx)
-    npx prettier --write "$FILE" 2>/dev/null
+    pnpm prettier --write "$FILE" >/dev/null 2>&1
     if command -v markdownlint >/dev/null 2>&1; then
-      markdownlint -i node_modules "$FILE" 2>/dev/null
+      markdownlint -i node_modules "$FILE" >/dev/null 2>&1
     fi
     ;;
   *.js|*.jsx|*.ts|*.tsx)
-    npx prettier --write "$FILE" 2>/dev/null
-    npx eslint --cache --fix "$FILE" 2>/dev/null
+    pnpm eslint --cache --fix "$FILE" >/dev/null 2>&1
+    pnpm prettier --write "$FILE" >/dev/null 2>&1
     ;;
 esac
 


### PR DESCRIPTION
- Swap eslint/prettier order for JS/TS files so prettier formats the braces eslint adds
- Suppress stdout from formatting commands ([hook runners expect JSON or no output](https://cursor.com/docs/agent/hooks#command-based-hooks). (claude docs [here](https://code.claude.com/docs/en/hooks#advanced:-json-output))). Previously, the script filled the cursor hook execution log with errors
- Use pnpm instead of npx to ensure it uses the prettier/eslint version installed in our monorepo

## Why

The original hook ran prettier before eslint, so when eslint added missing braces (e.g., `if (x) return y` → `if (x) {return y}`), prettier never re-ran to format them onto separate lines.

Usually it's safer to run eslint before prettier, because eslint does all lint auto-fixes without formatting in mind, and the formatting prettier applies usually does not create a need to re-lint. This is not the case the other way around.

Stdout suppression is needed because prettier outputs filenames (e.g., `file.ts 50ms`) which hook runners interpret as malformed JSON responses.

## Cursor Hook Execution Log

### Previous

![Screenshot 2026-01-30 at 18 09 34](https://github.com/user-attachments/assets/0b775ccf-e048-46dc-b0a5-30d818a01edd)

### After

![Screenshot 2026-01-30 at 18 10 03](https://github.com/user-attachments/assets/5d073c40-41d1-4dc5-8983-1bec2d6912d3)
