### PR TITLE
style: run lint-staged commands in correct order

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,8 +147,8 @@
     "**/package.json": "sort-package-json",
     "*.{md,mdx,yml,json}": "prettier --write",
     "*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --cache --fix"
+      "eslint --cache --fix",
+      "prettier --write"
     ],
     "templates/**/pnpm-lock.yaml": "pnpm runts scripts/remove-template-lock-files.ts",
     "tsconfig.base.json": "node scripts/reset-tsconfig.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -103,8 +103,8 @@
     "**/package.json": "sort-package-json",
     "*.{md,mdx,yml,json}": "prettier --write",
     "*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --cache --fix"
+      "eslint --cache --fix",
+      "prettier --write"
     ]
   },
   "dependencies": {

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -362,8 +362,8 @@
     "**/package.json": "sort-package-json",
     "*.{md,mdx,yml,json}": "prettier --write",
     "*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --cache --fix"
+      "eslint --cache --fix",
+      "prettier --write"
     ]
   },
   "dependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -15,8 +15,8 @@
     "**/package.json": "sort-package-json",
     "*.{md,mdx,yml,json}": "prettier --write",
     "*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --cache --fix"
+      "eslint --cache --fix",
+      "prettier --write"
     ],
     "templates/website/**/*": "sh -c \"cd templates/website; pnpm install --ignore-workspace --frozen-lockfile; pnpm run lint --fix\"",
     "tsconfig.json": "node scripts/reset-tsconfig.js"


### PR DESCRIPTION
Ensures lint-stages runs eslint first, then prettier. See https://github.com/payloadcms/payload/pull/15445 for reasoning.

## Example

Input:

```ts
export function negate(n: number): number {
  if (n === 0) return 0
  return -n
}
```

Prettier > eslint output (Before this PR):

```ts
export function negate(n: number): number {
  if (n === 0) {return 0}
  return -n
}
```

Eslint > prettier output (After this PR):

```ts
export function negate(n: number): number {
  if (n === 0) {
    return 0
  }
  return -n
}
```