### PR TITLE
fix(plugin-ecommerce): variant creation blocked by variants in trash

### DIFF
--- a/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
+++ b/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
@@ -29,6 +29,7 @@ export const validateOptions: (props?: Props) => Validate =
       joins: {
         variants: {
           where: {
+            deletedAt: { exists: false },
             ...(data.id && {
               id: {
                 not_equals: data.id, // exclude the current variant from the search


### PR DESCRIPTION
### What?

This PR fixes a type error that prevents variant creation in the admin panel when there is any variant currently in the trash

### Why?

When a variant is added, variants that are in the trash are included in the query, but these are not populated, which causes a type error when the variant.options array is accessed with a `.length` call.

Once there is a variant in the trash, adding new variants will always throw an error. 

### How?

By editing the query to filter deleted variants:
```ts
where {
  deletedAt: { exists: false },
```

Fixes #15448 

https://discord.com/channels/967097582721572934/1465838361561403516

### Comments

Perhaps the type for `variant` could also be narrowed in this function, as it is currently `any`. Something like 
`variant: { options: DefaultDocumentIDType[] }`