### PR TITLE
fix(richtext-lexical): export textcolorfeature and textstatefeatureprops

### DIFF
--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -967,7 +967,8 @@ export {
   RelationshipServerNode,
 } from './features/relationship/server/nodes/RelationshipNode.js'
 export { defaultColors } from './features/textState/defaultColors.js'
-export { TextStateFeature } from './features/textState/feature.server.js'
+export { TextStateFeature, TextStateFeature as TextColorFeature } from './features/textState/feature.server.js'
+export type { TextStateFeatureProps } from './features/textState/feature.server.js'
 
 export { FixedToolbarFeature } from './features/toolbars/fixed/server/index.js'
 


### PR DESCRIPTION
### What?

- Export TextColorFeature and the TextStateFeatureProps type from @payloadcms/richtext-lexical.

### Why?

- Users expect a TextColorFeature export for text color in the Lexical editor and hit “Module has no exported member 'TextColorFeature'”. 
- Typing the feature config requires TextStateFeatureProps, which wasn’t exported.

### How?

- In the package’s main index.ts, TextColorFeature is exported as an alias of TextStateFeature, and TextStateFeatureProps is exported as a type from the textState feature module.

fix : #15432