### PR TITLE
fix(templates): display cart items when product.slug is missing

### DIFF
--- a/templates/ecommerce/src/components/Cart/CartModal.tsx
+++ b/templates/ecommerce/src/components/Cart/CartModal.tsx
@@ -64,7 +64,7 @@ export function CartModal() {
                   const product = item.product
                   const variant = item.variant
 
-                  if (typeof product !== 'object' || !item || !product || !product.slug)
+                  if (typeof product !== 'object' || !item || !product)
                     return <React.Fragment key={i} />
 
                   const metaImage =
@@ -113,7 +113,7 @@ export function CartModal() {
                         </div>
                         <Link
                           className="z-30 flex flex-row space-x-4"
-                          href={`/products/${(item.product as Product)?.slug}`}
+                          href={product?.slug ? `/products/${product.slug}` : '#'}
                         >
                           <div className="relative h-16 w-16 cursor-pointer overflow-hidden rounded-md border border-neutral-300 bg-neutral-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800">
                             {image?.url && (


### PR DESCRIPTION
## Summary

- Remove `!product.slug` from cart item guard condition
- Handle missing slug gracefully in Link href (fallback to `#`)

## Problem

Cart items were silently hidden when a product didn't have a `slug` set. Users could add products to cart but they would become invisible in the cart modal with no error message.

## Solution

The slug is only needed for the product detail link. Now:
1. Cart items display regardless of slug presence
2. Link href uses `#` when slug is missing instead of broken URL

## Test plan

- [ ] Create product without slug in admin
- [ ] Add to cart
- [ ] Verify item displays in cart modal
- [ ] Verify link is non-functional (`#`) but item is visible

Fixes #15455

🤖 Generated with [Claude Code](https://claude.ai/code)