### PR TITLE
fix(richtext-lexical): support nested fields in LinkFeature custom fields

### DIFF
--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -33,16 +33,16 @@ const filterFieldByName = (fields: Field[], name: string): Field[] => {
     .filter((field) => !('name' in field) || field.name !== name)
     .map((field) => {
       if (field.type === 'row' || field.type === 'collapsible') {
-        return { ...field, fields: filterFieldByName(field.fields, name) }
+        return { ...field, fields: filterFieldByName(field.fields, name) } as typeof field
       }
       if (field.type === 'tabs') {
         return {
           ...field,
-          tabs: field.tabs.map((tab: { fields: Field[] }) => ({
+          tabs: field.tabs.map((tab) => ({
             ...tab,
             fields: filterFieldByName(tab.fields, name),
           })),
-        }
+        } as typeof field
       }
       return field
     })
@@ -136,13 +136,10 @@ export const LinkFeature = createServerFeature<
 
     // Use flattenTopLevelFields to find linkType and url fields, which may be nested inside layout fields (row, collapsible, etc.)
     const flattenedFields = flattenTopLevelFields(sanitizedFields)
-    const linkTypeField =
-      flattenedFields.find(
-        (field): field is Field => 'name' in field && field.name === 'linkType',
-      ) ?? null
-    const linkURLField =
-      flattenedFields.find((field): field is Field => 'name' in field && field.name === 'url') ??
-      null
+    const linkTypeField = flattenedFields.find(
+      (field) => 'name' in field && field.name === 'linkType',
+    )
+    const linkURLField = flattenedFields.find((field) => 'name' in field && field.name === 'url')
 
     const defaultLinkType = linkTypeField
       ? 'defaultValue' in linkTypeField && typeof linkTypeField.defaultValue === 'string'

--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -8,7 +8,7 @@ import type {
 } from 'payload'
 
 import escapeHTML from 'escape-html'
-import { sanitizeFields } from 'payload'
+import { flattenTopLevelFields, sanitizeFields } from 'payload'
 
 import type { NodeWithHooks } from '../../typesServer.js'
 import type { ClientProps } from '../client/index.js'
@@ -23,6 +23,30 @@ import { linkPopulationPromiseHOC } from './graphQLPopulationPromise.js'
 import { i18n } from './i18n.js'
 import { transformExtraFields } from './transformExtraFields.js'
 import { linkValidation } from './validate.js'
+
+/**
+ * Recursively filters out a field by name while preserving the field structure.
+ * This is needed because fields like 'text' may be nested inside layout fields (row, collapsible, tabs).
+ */
+const filterFieldByName = (fields: Field[], name: string): Field[] => {
+  return fields
+    .filter((field) => !('name' in field) || field.name !== name)
+    .map((field) => {
+      if (field.type === 'row' || field.type === 'collapsible') {
+        return { ...field, fields: filterFieldByName(field.fields, name) }
+      }
+      if (field.type === 'tabs') {
+        return {
+          ...field,
+          tabs: field.tabs.map((tab: { fields: Field[] }) => ({
+            ...tab,
+            fields: filterFieldByName(tab.fields, name),
+          })),
+        }
+      }
+      return field
+    })
+}
 
 export type ExclusiveLinkCollectionsProps =
   | {
@@ -107,22 +131,18 @@ export const LinkFeature = createServerFeature<
     // the text field is not included in the node data.
     // Thus, for tasks like validation, we do not want to pass it a text field in the schema which will never have data.
     // Otherwise, it will cause a validation error (field is required).
-    const sanitizedFieldsWithoutText = sanitizedFields.filter(
-      (field) => !('name' in field) || field.name !== 'text',
-    )
+    // We use filterFieldByName to recursively filter out the text field, in case it's nested inside layout fields.
+    const sanitizedFieldsWithoutText = filterFieldByName(sanitizedFields, 'text')
 
-    let linkTypeField: Field | null = null
-    let linkURLField: Field | null = null
-
-    for (const field of sanitizedFields) {
-      if ('name' in field && field.name === 'linkType') {
-        linkTypeField = field
-      }
-
-      if ('name' in field && field.name === 'url') {
-        linkURLField = field
-      }
-    }
+    // Use flattenTopLevelFields to find linkType and url fields, which may be nested inside layout fields (row, collapsible, etc.)
+    const flattenedFields = flattenTopLevelFields(sanitizedFields)
+    const linkTypeField =
+      flattenedFields.find(
+        (field): field is Field => 'name' in field && field.name === 'linkType',
+      ) ?? null
+    const linkURLField =
+      flattenedFields.find((field): field is Field => 'name' in field && field.name === 'url') ??
+      null
 
     const defaultLinkType = linkTypeField
       ? 'defaultValue' in linkTypeField && typeof linkTypeField.defaultValue === 'string'

--- a/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
+++ b/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
@@ -70,4 +70,37 @@ describe('Lexical Link Feature', () => {
 
     await expect(checkboxField).toBeChecked()
   })
+
+  test('can add links with fields wrapped in row layout', async ({ page }) => {
+    const lexical = new LexicalHelpers(page)
+
+    // Use the second editor which has fields wrapped in a row
+    const secondEditor = lexical.editor.nth(1)
+    await secondEditor.focus()
+    await secondEditor.fill('nested link')
+    await page.keyboard.press('Control+a')
+
+    const linkButtonClass = `.rich-text-lexical__wrap .fixed-toolbar .toolbar-popup__button-link`
+    const linkButton = page.locator(linkButtonClass).nth(1)
+
+    await linkButton.click()
+
+    // Verify the url field is visible (it's inside a row layout)
+    const urlField = lexical.drawer.locator('#field-url')
+    await expect(urlField).toBeVisible()
+
+    // Verify the custom field is also visible
+    const customField = lexical.drawer.locator('#field-customField')
+    await expect(customField).toBeVisible()
+
+    // Fill in the URL and verify it works
+    await urlField.fill('https://example.com')
+
+    // Submit the link
+    const submitButton = lexical.drawer.locator('button[type="submit"]')
+    await submitButton.click()
+
+    // Verify the link was created
+    await expect(secondEditor.locator('a')).toBeVisible()
+  })
 })

--- a/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
+++ b/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
@@ -41,9 +41,10 @@ describe('Lexical Link Feature', () => {
 
   test('can add new custom fields in link feature modal', async ({ page }) => {
     const lexical = new LexicalHelpers(page)
+    const firstEditor = lexical.editor.first()
 
-    await lexical.editor.fill('link')
-    await lexical.editor.selectText()
+    await firstEditor.fill('link')
+    await firstEditor.selectText()
 
     const linkButtonClass = `.rich-text-lexical__wrap .fixed-toolbar .toolbar-popup__button-link`
     const linkButton = page.locator(linkButtonClass).first()
@@ -57,9 +58,10 @@ describe('Lexical Link Feature', () => {
 
   test('can set default value of newTab checkbox to checked', async ({ page }) => {
     const lexical = new LexicalHelpers(page)
+    const firstEditor = lexical.editor.first()
 
-    await lexical.editor.fill('link')
-    await lexical.editor.selectText()
+    await firstEditor.fill('link')
+    await firstEditor.selectText()
 
     const linkButtonClass = `.rich-text-lexical__wrap .fixed-toolbar .toolbar-popup__button-link`
     const linkButton = page.locator(linkButtonClass).first()

--- a/test/lexical/collections/LexicalLinkFeature/index.ts
+++ b/test/lexical/collections/LexicalLinkFeature/index.ts
@@ -40,5 +40,26 @@ export const LexicalLinkFeature: CollectionConfig = {
         ],
       }),
     },
+    {
+      name: 'richTextNestedFields',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [
+          ...defaultFeatures,
+          TreeViewFeature(),
+          LinkFeature({
+            // Test that LinkFeature works when fields are wrapped in a row layout
+            fields: ({ defaultFields }) => [
+              {
+                type: 'row',
+                fields: defaultFields,
+              },
+              { type: 'text', name: 'customField' },
+            ],
+          }),
+          FixedToolbarFeature(),
+        ],
+      }),
+    },
   ],
 }

--- a/test/lexical/payload-types.ts
+++ b/test/lexical/payload-types.ts
@@ -215,6 +215,21 @@ export interface LexicalLinkFeature {
     };
     [k: string]: unknown;
   } | null;
+  richTextNestedFields?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1182,6 +1197,7 @@ export interface LexicalFullyFeaturedSelect<T extends boolean = true> {
  */
 export interface LexicalLinkFeatureSelect<T extends boolean = true> {
   richText?: T;
+  richTextNestedFields?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?
Fixes `LinkFeature` to correctly handle moving default fields into wrapping layout fields (`row`, `collapsible`, `tabs`).
### Why?
When users provide a `fields` prop to the `LinkFeature` such that we move some of the default fields into wrapping layout fields, the feature fails because it only searches for its default fields (`text` being the main breaking point) at the root level:
```ts
// This configuration will return validation errors on save and not prefill defaults correctly client-side
LinkFeature({
  fields: ({ defaultFields }) => [
    { type: 'row', fields: defaultFields },
  ],
})
```
The `linkType` and `url` fields aren't found (breaking default values), and the `text` field isn't properly filtered out for validation (causing validation errors).

In our use case, we're trying to apply some specific layout adjustments alongside new fields, while reusing the `defaultFields` within a new multi-row layout. This is currently not achievable.
### How?
1. **Use `flattenTopLevelFields`** (existing Payload utility) to find `linkType` and `url` fields regardless of nesting depth
2. **Add `filterFieldByName` helper** to recursively filter out the `text` field while preserving the nested field structure for the drawer form
**Before:**
```ts
// Only filters/searches root-level fields
const sanitizedFieldsWithoutText = sanitizedFields.filter(
  (field) => !('name' in field) || field.name !== 'text',
)
let linkTypeField = null
for (const field of sanitizedFields) {
  if ('name' in field && field.name === 'linkType') {
    linkTypeField = field
  }
}
```
**After:**
```ts
// Recursively filters nested fields
const sanitizedFieldsWithoutText = filterFieldByName(sanitizedFields, 'text')
// Flattens to find fields at any depth
const flattenedFields = flattenTopLevelFields(sanitizedFields)
const linkTypeField = flattenedFields.find(
  (field) => 'name' in field && field.name === 'linkType',
) ?? null
```