### PR TITLE
fix: add safety check to redirects from external file URL uploads

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -42,21 +42,18 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
     const maxRedirects = 3
 
     while (redirectCount <= maxRedirects) {
-      // Check if URL is allowed because of skipSafeFetch allowList
       const skipSafeFetch: boolean =
         uploadConfig.skipSafeFetch === true
           ? uploadConfig.skipSafeFetch
           : Array.isArray(uploadConfig.skipSafeFetch) &&
             isURLAllowed(fileURL, uploadConfig.skipSafeFetch)
 
-      // Check if URL is allowed because of pasteURL allowList
       const isAllowedPasteUrl: boolean | undefined =
         uploadConfig.pasteURL &&
         uploadConfig.pasteURL.allowList &&
         isURLAllowed(fileURL, uploadConfig.pasteURL.allowList)
 
       if (skipSafeFetch || isAllowedPasteUrl) {
-        // Allowed
         res = await fetch(fileURL, {
           credentials: 'include',
           headers,
@@ -72,7 +69,6 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
         })
       }
 
-      // Throw redirects errors
       if (res.status >= 300 && res.status < 400) {
         redirectCount++
         if (redirectCount > maxRedirects) {

--- a/packages/payload/src/uploads/safeFetch.ts
+++ b/packages/payload/src/uploads/safeFetch.ts
@@ -85,6 +85,7 @@ export const safeFetch = async (...args: Parameters<typeof undiciFetch>) => {
     return await undiciFetch(url, {
       ...options,
       dispatcher: safeDispatcher,
+      redirect: 'manual', // Prevent automatic redirects
     })
   } catch (error) {
     if (error instanceof Error) {

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -1598,13 +1598,123 @@ describe('Collections - Uploads', () => {
       expect(arrayBuffer.byteLength).toBe(1)
     })
   })
+
+  describe('External File Upload - Redirect Blocking', () => {
+    const validPNG = Buffer.from(
+      '89504e470d0a1a0a0000000d494844520000000100000001' +
+        '0806000000ifad8300000010494441541865000000018001' +
+        'ffa500051f37dbba0000000049454e44ae426082',
+      'hex',
+    )
+
+    const startServer = async (server: ReturnType<typeof createServer>): Promise<number> => {
+      return new Promise<number>((resolve) => {
+        server.listen(0, '0.0.0.0', () => {
+          resolve((server.address() as AddressInfo).port)
+        })
+      })
+    }
+
+    it('should block malicious redirect', async () => {
+      const internalServer = createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('SECRET_CREDENTIALS')
+      })
+
+      const internalServerPort = await startServer(internalServer)
+
+      const attackerServer = createServer((req, res) => {
+        res.writeHead(302, {
+          Location: `http://127.0.0.1:${internalServerPort}/secret`,
+        })
+        res.end()
+      })
+
+      const attackerServerPort = await startServer(attackerServer)
+
+      try {
+        await expect(
+          payload.create({
+            collection: mediaSlug,
+            data: {
+              filename: 'malicious.jpg',
+              url: `http://127.0.0.1:${attackerServerPort}/image.jpg`,
+            },
+          }),
+        ).rejects.toThrow()
+      } finally {
+        attackerServer.close()
+        internalServer.close()
+      }
+    })
+
+    it('should allow legitimate redirects within allowlist', async () => {
+      const edgeServer = createServer((req, res) => {
+        res.writeHead(200, {
+          'Content-Type': 'image/png',
+          'Content-Length': validPNG.length.toString(),
+        })
+        res.end(validPNG)
+      })
+
+      const edgeServerPort = await startServer(edgeServer)
+
+      const cdnServer = createServer((req, res) => {
+        res.writeHead(302, { Location: `http://127.0.0.1:${edgeServerPort}/image.png` })
+        res.end()
+      })
+
+      const cdnServerPort = await startServer(cdnServer)
+
+      try {
+        const doc = await payload.create({
+          collection: allowListMediaSlug,
+          data: {
+            filename: 'cdn-image.png',
+            url: `http://127.0.0.1:${cdnServerPort}/image.png`,
+          },
+        })
+
+        expect(doc.filename).toBe('cdn-image.png')
+        expect(doc.mimeType).toBe('image/png')
+      } finally {
+        cdnServer.close()
+        edgeServer.close()
+      }
+    })
+
+    it('should not allow infinite redirect loops', async () => {
+      let redirectServerPort: number
+
+      const redirectServer = createServer((req, res) => {
+        res.writeHead(302, { Location: `http://127.0.0.1:${redirectServerPort}/loop` })
+        res.end()
+      })
+
+      redirectServerPort = await startServer(redirectServer)
+
+      try {
+        await expect(
+          payload.create({
+            collection: allowListMediaSlug,
+            data: {
+              filename: 'loop.png',
+              url: `http://127.0.0.1:${redirectServerPort}/loop`,
+            },
+          }),
+        ).rejects.toThrow(/Too many redirects/)
+      } finally {
+        redirectServer.close()
+      }
+    })
+  })
 })
 
 async function fileExists(fileName: string): Promise<boolean> {
   try {
     await stat(fileName)
     return true
-  } catch (err) {
+  } catch (_err) {
     return false
   }
 }


### PR DESCRIPTION
### What
Fixes an `uploads` related security issue where redirects are able bypass URL validation in external file uploads. 

### Why
When uploading files via an external URL, HTTP redirects (3xx responses) were automatically followed. This meant an potential attacker could provide a public URL that redirected to internal services, bypassing the security checks that only ran on the initial URL.

### How
- Added `redirect: 'manual'` to `safeFetch()` to prevent automatic redirect following
- Modified `getExternalFile()` to manually handle redirects with re-validation at each step
- Limited redirects to maximum of 3x to prevent infinite loops
- Tests added to `uploads` test suite


#### Acknowledgement
Big thank you to `r3dbrothers1` for the responsible disclosure.

