### PR TITLE
fix(next): export SlugField from the client dir not rsc

### DIFF
--- a/packages/next/src/exports/client.ts
+++ b/packages/next/src/exports/client.ts
@@ -12,4 +12,5 @@ export {
   QueryPresetsGroupByField,
   QueryPresetsWhereCell,
   QueryPresetsWhereField,
+  SlugField,
 } from '@payloadcms/ui'

--- a/packages/next/src/exports/rsc.ts
+++ b/packages/next/src/exports/rsc.ts
@@ -1,4 +1,4 @@
 export { DocumentHeader } from '../elements/DocumentHeader/index.js'
 export { Logo } from '../elements/Logo/index.js'
 export { DefaultNav } from '../elements/Nav/index.js'
-export { CollectionCards, FolderField, FolderTableCell, SlugField } from '@payloadcms/ui/rsc'
+export { CollectionCards, FolderField, FolderTableCell } from '@payloadcms/ui/rsc'

--- a/packages/payload/src/fields/baseFields/slug/index.ts
+++ b/packages/payload/src/fields/baseFields/slug/index.ts
@@ -131,7 +131,7 @@ export const slugField: SlugField = ({
               clientProps: {
                 useAsSlug,
               } satisfies SlugFieldClientPropsOnly,
-              path: '@payloadcms/next/rsc#SlugField',
+              path: '@payloadcms/next/client#SlugField',
             },
           },
           width: '100%',


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15451.

Changes introduced in https://github.com/payloadcms/payload/pull/15392 moved the `SlugField` from client to server exports, throwing the following runtime error when navigating to the edit view:

```
useServerFunctions must be used within a ServerFunctionsProvider
```