### PR TITLE
test: richText fields serialization

### DIFF
--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -48,6 +48,10 @@ const ArrayFields: CollectionConfig = {
           localized: true,
         },
         {
+          name: 'richTextField',
+          type: 'richText',
+        },
+        {
           name: 'subArray',
           fields: [
             {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -2375,6 +2375,48 @@ describe('Fields', () => {
       expect(res.totalDocs).toBe(1)
       expect(res.docs[0].id).toBe(withoutCollapsed.id)
     })
+
+    it('should properly handle richText inside array', async () => {
+      const richTextValue = {
+        root: {
+          type: 'root',
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'Hello from array', format: 1 }],
+            },
+          ],
+        },
+      }
+
+      const doc = await payload.create({
+        collection,
+        data: {
+          items: [
+            {
+              text: 'required',
+              richTextField: richTextValue,
+            },
+          ],
+          localized: [{ text: 'req' }],
+        },
+      })
+
+      // Verify richText is returned as an object, not a string
+      expect(doc.items[0].richTextField).toBeDefined()
+      expect(typeof doc.items[0].richTextField).toBe('object')
+      expect(doc.items[0].richTextField).toEqual(richTextValue)
+
+      // Also verify on read
+      const found = await payload.findByID({
+        collection,
+        id: doc.id,
+      })
+
+      expect(found.items[0].richTextField).toBeDefined()
+      expect(typeof found.items[0].richTextField).toBe('object')
+      expect(found.items[0].richTextField).toEqual(richTextValue)
+    })
   })
 
   describe('group', () => {


### PR DESCRIPTION
Add a test about a bug that was detected while developing a database adapter that stores richtext fields as strings instead of as JSON objects (something all database adapters should do).