### PR TITLE
test: trash auth e2e tests have race condition on navigation

### DIFF
--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -1101,6 +1101,8 @@ describe('Trash', () => {
 
       await page.locator('.row-1 .cell-name').click()
 
+      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}$/)
+
       await expect(page.locator('input[name="email"]')).toBeDisabled()
       await expect(page.locator('#change-password')).toBeDisabled()
 
@@ -1115,6 +1117,8 @@ describe('Trash', () => {
 
       await expect(page.locator('.row-1 .cell-name')).toHaveText('Dev')
       await page.locator('.row-1 .cell-name').click()
+
+      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}$/)
 
       await page.locator('.doc-controls__controls #action-restore').click()
 


### PR DESCRIPTION
### What

Two trash e2e tests for auth-enabled collections are flaky in CI: "`Should properly disable auth fields in the trashed user edit view`" and "`Should properly restore trashed user as draft`"

### Why

Race condition: both tests click a table row to navigate but don't wait for navigation to complete before asserting on page elements. CI environments can be slower, causing elements to not exist yet when the assertions run.

### How

Added `await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}$/)` after row clicks to wait for navigation to complete before checking for elements.
