### PR TITLE
fix(deps): move ts-essentials to devDependencies

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -55,14 +55,14 @@
   "dependencies": {
     "graphql-scalars": "1.22.2",
     "pluralize": "8.0.0",
-    "ts-essentials": "10.0.3",
     "tsx": "4.21.0"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",
     "@types/pluralize": "^0.0.33",
     "graphql-http": "^1.22.0",
-    "payload": "workspace:*"
+    "payload": "workspace:*",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "graphql": "^16.8.1",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -125,7 +125,6 @@
     "qs-esm": "7.0.2",
     "range-parser": "1.2.1",
     "sanitize-filename": "1.6.3",
-    "ts-essentials": "10.0.3",
     "tsx": "4.21.0",
     "undici": "7.18.2",
     "uuid": "10.0.0",
@@ -150,7 +149,8 @@
     "rimraf": "6.0.1",
     "rollup": "4.52.3",
     "rollup-plugin-dts": "6.2.3",
-    "sharp": "0.32.6"
+    "sharp": "0.32.6",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "graphql": "^16.8.1"

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -393,7 +393,6 @@
     "micromark-extension-mdx-jsx": "3.0.1",
     "qs-esm": "7.0.2",
     "react-error-boundary": "4.1.2",
-    "ts-essentials": "10.0.3",
     "uuid": "10.0.0"
   },
   "devDependencies": {
@@ -414,7 +413,8 @@
     "esbuild": "0.27.1",
     "esbuild-sass-plugin": "3.3.1",
     "payload": "workspace:*",
-    "swc-plugin-transform-remove-imports": "8.3.0"
+    "swc-plugin-transform-remove-imports": "8.3.0",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "@faceless-ui/modal": "3.0.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,11 +42,11 @@
   },
   "dependencies": {
     "payload": "workspace:*",
-    "qs-esm": "7.0.2",
-    "ts-essentials": "10.0.3"
+    "qs-esm": "7.0.2"
   },
   "devDependencies": {
-    "@payloadcms/eslint-config": "workspace:*"
+    "@payloadcms/eslint-config": "workspace:*",
+    "ts-essentials": "10.0.3"
   },
   "publishConfig": {
     "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -157,7 +157,6 @@
     "react-select": "5.9.0",
     "scheduler": "0.25.0",
     "sonner": "^1.7.2",
-    "ts-essentials": "10.0.3",
     "use-context-selector": "2.0.0",
     "uuid": "10.0.0"
   },
@@ -175,7 +174,8 @@
     "babel-plugin-react-compiler": "19.1.0-rc.3",
     "esbuild": "0.27.1",
     "esbuild-sass-plugin": "3.3.1",
-    "payload": "workspace:*"
+    "payload": "workspace:*",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || >=16.1.1-canary.35 <16.2.0 || ^16.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,9 +674,6 @@ importers:
       pluralize:
         specifier: 8.0.0
         version: 8.0.0
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -693,6 +690,9 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../payload
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   packages/kv-redis:
     dependencies:
@@ -943,9 +943,6 @@ importers:
       sanitize-filename:
         specifier: 1.6.3
         version: 1.6.3
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1016,6 +1013,9 @@ importers:
       sharp:
         specifier: 0.32.6
         version: 0.32.6
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   packages/payload-cloud:
     dependencies:
@@ -1468,9 +1468,6 @@ importers:
       react-error-boundary:
         specifier: 4.1.2
         version: 4.1.2(react@19.2.4)
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       uuid:
         specifier: 10.0.0
         version: 10.0.0
@@ -1529,6 +1526,9 @@ importers:
       swc-plugin-transform-remove-imports:
         specifier: 8.3.0
         version: 8.3.0
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   packages/richtext-slate:
     dependencies:
@@ -1587,13 +1587,13 @@ importers:
       qs-esm:
         specifier: 7.0.2
         version: 7.0.2
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   packages/storage-azure:
     dependencies:
@@ -1778,9 +1778,6 @@ importers:
       sonner:
         specifier: ^1.7.2
         version: 1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       use-context-selector:
         specifier: 2.0.0
         version: 2.0.0(react@19.2.4)(scheduler@0.25.0)
@@ -1830,6 +1827,9 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../payload
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   templates/blank:
     dependencies:
@@ -1998,7 +1998,7 @@ importers:
         version: 8.6.0(react@19.2.4)
       geist:
         specifier: ^1.3.0
-        version: 1.5.1(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
+        version: 1.5.1(next@15.4.11(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -23206,6 +23206,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  geist@1.5.1(next@15.4.11(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)):
+    dependencies:
+      next: 15.4.11(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
 
   geist@1.5.1(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)):
     dependencies:


### PR DESCRIPTION
# Overview

Move `ts-essentials` from `dependencies` to `devDependencies` in 5 packages to prevent TypeScript (~22MB) from being pulled into production bundles.

Resolves ECMS-407

## Key Changes

- Moved `ts-essentials` to `devDependencies` in:
  - `packages/payload`
  - `packages/ui`
  - `packages/graphql`
  - `packages/richtext-lexical`
  - `packages/sdk`

## Design Decisions

`ts-essentials` is only used for type utilities (`DeepPartial`, `MarkOptional`, `DeepRequired`, etc.) via `import type` statements—it provides zero runtime value. However, having it as a production dependency causes pnpm to auto-install its optional peer dependency (`typescript`) when users install Payload packages.

This happens because:
1. `ts-essentials` declares `typescript` as an optional peer dependency
2. pnpm defaults to `auto-install-peers=true` (since v8)
3. When a project has TypeScript in devDependencies, pnpm links it to satisfy the peer

Moving to devDependencies breaks this chain for end users while still making the types available at build time.