### PR TITLE
feat: adds beforeNav and afterNav component slots

### DIFF
--- a/packages/next/src/elements/Nav/index.client.tsx
+++ b/packages/next/src/elements/Nav/index.client.tsx
@@ -16,11 +16,9 @@ const baseClass = 'nav'
  * @internal
  */
 export const DefaultNavClient: React.FC<{
-  afterNavLinks?: React.ReactNode
-  beforeNavLinks?: React.ReactNode
   groups: ReturnType<typeof groupNavItems>
   navPreferences: NavPreferences
-}> = ({ afterNavLinks, beforeNavLinks, groups, navPreferences }) => {
+}> = ({ groups, navPreferences }) => {
   const pathname = usePathname()
 
   const {
@@ -44,7 +42,6 @@ export const DefaultNavClient: React.FC<{
 
   return (
     <Fragment>
-      {beforeNavLinks}
       {folders && folders.browseByFolder && <BrowseByFolderButton active={viewingRootFolderView} />}
       {groups.map(({ entities, label }, key) => {
         return (
@@ -91,7 +88,6 @@ export const DefaultNavClient: React.FC<{
           </NavGroup>
         )
       })}
-      {afterNavLinks}
     </Fragment>
   )
 }

--- a/packages/next/src/elements/Nav/index.client.tsx
+++ b/packages/next/src/elements/Nav/index.client.tsx
@@ -16,9 +16,11 @@ const baseClass = 'nav'
  * @internal
  */
 export const DefaultNavClient: React.FC<{
+  afterNavLinks?: React.ReactNode
+  beforeNavLinks?: React.ReactNode
   groups: ReturnType<typeof groupNavItems>
   navPreferences: NavPreferences
-}> = ({ groups, navPreferences }) => {
+}> = ({ afterNavLinks, beforeNavLinks, groups, navPreferences }) => {
   const pathname = usePathname()
 
   const {
@@ -42,6 +44,7 @@ export const DefaultNavClient: React.FC<{
 
   return (
     <Fragment>
+      {beforeNavLinks}
       {folders && folders.browseByFolder && <BrowseByFolderButton active={viewingRootFolderView} />}
       {groups.map(({ entities, label }, key) => {
         return (
@@ -88,6 +91,7 @@ export const DefaultNavClient: React.FC<{
           </NavGroup>
         )
       })}
+      {afterNavLinks}
     </Fragment>
   )
 }

--- a/packages/next/src/elements/Nav/index.tsx
+++ b/packages/next/src/elements/Nav/index.tsx
@@ -93,7 +93,7 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
     },
   })
 
-  const renderedSettingsMenu =
+  const RenderedSettingsMenu =
     settingsMenu && Array.isArray(settingsMenu)
       ? settingsMenu.map((item, index) =>
           RenderServerComponent({
@@ -117,7 +117,25 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
         )
       : []
 
-  const renderedBeforeNavLinks = RenderServerComponent({
+  const RenderedBeforeNav = RenderServerComponent({
+    clientProps: {
+      documentSubViewType,
+      viewType,
+    },
+    Component: beforeNav,
+    importMap: payload.importMap,
+    serverProps: {
+      i18n,
+      locale,
+      params,
+      payload,
+      permissions,
+      searchParams,
+      user,
+    },
+  })
+
+  const RenderedBeforeNavLinks = RenderServerComponent({
     clientProps: {
       documentSubViewType,
       viewType,
@@ -135,7 +153,7 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
     },
   })
 
-  const renderedAfterNavLinks = RenderServerComponent({
+  const RenderedAfterNavLinks = RenderServerComponent({
     clientProps: {
       documentSubViewType,
       viewType,
@@ -153,54 +171,37 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
     },
   })
 
+  const RenderedAfterNav = RenderServerComponent({
+    clientProps: {
+      documentSubViewType,
+      viewType,
+    },
+    Component: afterNav,
+    importMap: payload.importMap,
+    serverProps: {
+      i18n,
+      locale,
+      params,
+      payload,
+      permissions,
+      searchParams,
+      user,
+    },
+  })
+
   return (
     <NavWrapper baseClass={baseClass}>
-      {RenderServerComponent({
-        clientProps: {
-          documentSubViewType,
-          viewType,
-        },
-        Component: beforeNav,
-        importMap: payload.importMap,
-        serverProps: {
-          i18n,
-          locale,
-          params,
-          payload,
-          permissions,
-          searchParams,
-          user,
-        },
-      })}
+      {RenderedBeforeNav}
       <nav className={`${baseClass}__wrap`}>
-        <DefaultNavClient
-          afterNavLinks={renderedAfterNavLinks}
-          beforeNavLinks={renderedBeforeNavLinks}
-          groups={groups}
-          navPreferences={navPreferences}
-        />
+        {RenderedBeforeNavLinks}
+        <DefaultNavClient groups={groups} navPreferences={navPreferences} />
+        {RenderedAfterNavLinks}
         <div className={`${baseClass}__controls`}>
-          <SettingsMenuButton settingsMenu={renderedSettingsMenu} />
+          <SettingsMenuButton settingsMenu={RenderedSettingsMenu} />
           {LogoutComponent}
         </div>
       </nav>
-      {RenderServerComponent({
-        clientProps: {
-          documentSubViewType,
-          viewType,
-        },
-        Component: afterNav,
-        importMap: payload.importMap,
-        serverProps: {
-          i18n,
-          locale,
-          params,
-          payload,
-          permissions,
-          searchParams,
-          user,
-        },
-      })}
+      {RenderedAfterNav}
       <div className={`${baseClass}__header`}>
         <div className={`${baseClass}__header-content`}>
           <NavHamburger baseClass={baseClass} />

--- a/packages/next/src/elements/Nav/index.tsx
+++ b/packages/next/src/elements/Nav/index.tsx
@@ -41,7 +41,7 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
 
   const {
     admin: {
-      components: { afterNavLinks, beforeNavLinks, logout, settingsMenu },
+      components: { afterNav, afterNavLinks, beforeNav, beforeNavLinks, logout, settingsMenu },
     },
     collections,
     globals,
@@ -117,49 +117,90 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
         )
       : []
 
+  const renderedBeforeNavLinks = RenderServerComponent({
+    clientProps: {
+      documentSubViewType,
+      viewType,
+    },
+    Component: beforeNavLinks,
+    importMap: payload.importMap,
+    serverProps: {
+      i18n,
+      locale,
+      params,
+      payload,
+      permissions,
+      searchParams,
+      user,
+    },
+  })
+
+  const renderedAfterNavLinks = RenderServerComponent({
+    clientProps: {
+      documentSubViewType,
+      viewType,
+    },
+    Component: afterNavLinks,
+    importMap: payload.importMap,
+    serverProps: {
+      i18n,
+      locale,
+      params,
+      payload,
+      permissions,
+      searchParams,
+      user,
+    },
+  })
+
   return (
     <NavWrapper baseClass={baseClass}>
+      {RenderServerComponent({
+        clientProps: {
+          documentSubViewType,
+          viewType,
+        },
+        Component: beforeNav,
+        importMap: payload.importMap,
+        serverProps: {
+          i18n,
+          locale,
+          params,
+          payload,
+          permissions,
+          searchParams,
+          user,
+        },
+      })}
       <nav className={`${baseClass}__wrap`}>
-        {RenderServerComponent({
-          clientProps: {
-            documentSubViewType,
-            viewType,
-          },
-          Component: beforeNavLinks,
-          importMap: payload.importMap,
-          serverProps: {
-            i18n,
-            locale,
-            params,
-            payload,
-            permissions,
-            searchParams,
-            user,
-          },
-        })}
-        <DefaultNavClient groups={groups} navPreferences={navPreferences} />
-        {RenderServerComponent({
-          clientProps: {
-            documentSubViewType,
-            viewType,
-          },
-          Component: afterNavLinks,
-          importMap: payload.importMap,
-          serverProps: {
-            i18n,
-            locale,
-            params,
-            payload,
-            permissions,
-            searchParams,
-            user,
-          },
-        })}
+        <DefaultNavClient
+          afterNavLinks={renderedAfterNavLinks}
+          beforeNavLinks={renderedBeforeNavLinks}
+          groups={groups}
+          navPreferences={navPreferences}
+        />
         <div className={`${baseClass}__controls`}>
           <SettingsMenuButton settingsMenu={renderedSettingsMenu} />
           {LogoutComponent}
         </div>
       </nav>
+      {RenderServerComponent({
+        clientProps: {
+          documentSubViewType,
+          viewType,
+        },
+        Component: afterNav,
+        importMap: payload.importMap,
+        serverProps: {
+          i18n,
+          locale,
+          params,
+          payload,
+          permissions,
+          searchParams,
+          user,
+        },
+      })}
       <div className={`${baseClass}__header`}>
         <div className={`${baseClass}__header-content`}>
           <NavHamburger baseClass={baseClass} />

--- a/packages/payload/src/bin/generateImportMap/iterateConfig.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateConfig.ts
@@ -64,9 +64,11 @@ export function iterateConfig({
   addToImportMap(config.admin?.components?.actions)
   addToImportMap(config.admin?.components?.afterDashboard)
   addToImportMap(config.admin?.components?.afterLogin)
+  addToImportMap(config.admin?.components?.afterNav)
   addToImportMap(config.admin?.components?.afterNavLinks)
   addToImportMap(config.admin?.components?.beforeDashboard)
   addToImportMap(config.admin?.components?.beforeLogin)
+  addToImportMap(config.admin?.components?.beforeNav)
   addToImportMap(config.admin?.components?.beforeNavLinks)
 
   addToImportMap(config.admin?.components?.providers)

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -852,6 +852,10 @@ export type Config = {
        */
       afterLogin?: CustomComponent[]
       /**
+       * Add custom components after the navigation section
+       */
+      afterNav?: CustomComponent[]
+      /**
        * Add custom components after the navigation links
        */
       afterNavLinks?: CustomComponent[]
@@ -863,6 +867,10 @@ export type Config = {
        * Add custom components before the email/password field
        */
       beforeLogin?: CustomComponent[]
+      /**
+       * Add custom components before the navigation section
+       */
+      beforeNav?: CustomComponent[]
       /**
        * Add custom components before the navigation links
        */

--- a/test/admin/components/AfterNav/index.tsx
+++ b/test/admin/components/AfterNav/index.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import type { PayloadClientReactComponent, SanitizedConfig } from 'payload'
+
+import React from 'react'
+
+const baseClass = 'after-nav'
+
+export const AfterNav: PayloadClientReactComponent<
+  SanitizedConfig['admin']['components']['afterNav'][0]
+> = () => {
+  return (
+    <div
+      className={baseClass}
+      id="after-nav-component"
+      style={{
+        backgroundColor: 'var(--theme-success-100)',
+        borderRadius: 'var(--style-radius-m)',
+        color: 'var(--theme-success-750)',
+        marginTop: 'var(--base)',
+        padding: 'calc(var(--base) * 0.5)',
+      }}
+    >
+      <p style={{ margin: 0 }}>After Nav Content</p>
+    </div>
+  )
+}

--- a/test/admin/components/AfterNavLinks/index.tsx
+++ b/test/admin/components/AfterNavLinks/index.tsx
@@ -2,11 +2,11 @@
 
 import type { PayloadClientReactComponent, SanitizedConfig } from 'payload'
 
-import LinkImport from 'next/link.js'
-const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
-
 import { useConfig } from '@payloadcms/ui'
+import LinkImport from 'next/link.js'
 import React from 'react'
+
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 const baseClass = 'after-nav-links'
 
@@ -22,26 +22,47 @@ export const AfterNavLinks: PayloadClientReactComponent<
   return (
     <div
       className={baseClass}
+      id="after-nav-links-component"
       style={{
+        backgroundColor: 'var(--theme-success-100)',
+        borderRadius: 'var(--style-radius-m)',
+        color: 'var(--theme-success-750)',
         display: 'flex',
         flexDirection: 'column',
-        gap: 'calc(var(--base) / 4)',
+        marginTop: 'var(--base)',
+        padding: 'var(--base)',
+        width: '100%',
       }}
     >
-      <h4 className="nav__label" style={{ color: 'var(--theme-elevation-400)', margin: 0 }}>
-        Custom Routes
-      </h4>
-      <h4 className="nav__link" style={{ margin: 0 }}>
-        <Link href={`${adminRoute}/custom-default-view`} style={{ textDecoration: 'none' }}>
-          Default Template
-        </Link>
-      </h4>
-      <h4 className="nav__link" style={{ margin: 0 }}>
-        <Link href={`${adminRoute}/custom-minimal-view`} style={{ textDecoration: 'none' }}>
-          Minimal Template
-        </Link>
-      </h4>
-      <div id="custom-css" />
+      <p style={{ marginBottom: '16px', marginTop: 0 }}>afterNavLinks</p>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '5px',
+        }}
+      >
+        <p className="nav__label" style={{ color: '#1565c0', margin: 0 }}>
+          Custom Routes
+        </p>
+        <p className="nav__link" style={{ margin: 0 }}>
+          <Link
+            href={`${adminRoute}/custom-default-view`}
+            style={{ color: '#1976d2', textDecoration: 'none' }}
+          >
+            Default Template
+          </Link>
+        </p>
+        <p className="nav__link" style={{ margin: 0 }}>
+          <Link
+            href={`${adminRoute}/custom-minimal-view`}
+            style={{ color: '#1976d2', textDecoration: 'none' }}
+          >
+            Minimal Template
+          </Link>
+        </p>
+        <div id="custom-css" />
+      </div>
     </div>
   )
 }

--- a/test/admin/components/BeforeNav/index.tsx
+++ b/test/admin/components/BeforeNav/index.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import type { PayloadClientReactComponent, SanitizedConfig } from 'payload'
+
+import React from 'react'
+
+const baseClass = 'before-nav'
+
+export const BeforeNav: PayloadClientReactComponent<
+  SanitizedConfig['admin']['components']['beforeNav'][0]
+> = () => {
+  return (
+    <div
+      className={baseClass}
+      id="before-nav-component"
+      style={{
+        backgroundColor: 'var(--theme-success-100)',
+        borderRadius: 'var(--style-radius-m)',
+        color: 'var(--theme-success-750)',
+        marginBottom: 'var(--base)',
+        padding: 'calc(var(--base) * 0.5)',
+      }}
+    >
+      <p style={{ margin: 0 }}>Before Nav Content</p>
+    </div>
+  )
+}

--- a/test/admin/components/BeforeNav/index.tsx
+++ b/test/admin/components/BeforeNav/index.tsx
@@ -21,7 +21,7 @@ export const BeforeNav: PayloadClientReactComponent<
         padding: 'calc(var(--base) * 0.5)',
       }}
     >
-      <p style={{ margin: 0 }}>Before Nav Content</p>
+      <p style={{ margin: 0 }}>beforeNav</p>
     </div>
   )
 }

--- a/test/admin/components/BeforeNavLinks/index.tsx
+++ b/test/admin/components/BeforeNavLinks/index.tsx
@@ -4,24 +4,25 @@ import type { PayloadClientReactComponent, SanitizedConfig } from 'payload'
 
 import React from 'react'
 
-const baseClass = 'after-nav'
+const baseClass = 'before-nav-links'
 
-export const AfterNav: PayloadClientReactComponent<
-  SanitizedConfig['admin']['components']['afterNav'][0]
+export const BeforeNavLinks: PayloadClientReactComponent<
+  SanitizedConfig['admin']['components']['beforeNavLinks'][0]
 > = () => {
   return (
     <div
       className={baseClass}
-      id="after-nav-component"
+      id="before-nav-links-component"
       style={{
         backgroundColor: 'var(--theme-success-100)',
         borderRadius: 'var(--style-radius-m)',
         color: 'var(--theme-success-750)',
-        marginTop: 'var(--base)',
+        marginBottom: 'var(--base)',
         padding: 'calc(var(--base) * 0.5)',
+        width: '100%',
       }}
     >
-      <p style={{ margin: 0 }}>afterNav</p>
+      beforeNavLinks
     </div>
   )
 }

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -73,6 +73,7 @@ export default buildConfigWithDefaults({
       afterNavLinks: ['/components/AfterNavLinks/index.js#AfterNavLinks'],
       beforeLogin: ['/components/BeforeLogin/index.js#BeforeLogin'],
       beforeNav: ['/components/BeforeNav/index.js#BeforeNav'],
+      beforeNavLinks: ['/components/BeforeNavLinks/index.js#BeforeNavLinks'],
       graphics: {
         Icon: '/components/graphics/Icon.js#Icon',
         Logo: '/components/graphics/Logo.js#Logo',

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -63,36 +63,31 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 export default buildConfigWithDefaults({
   admin: {
-    livePreview: {
-      collections: [reorderTabsSlug, editMenuItemsSlug],
-      url: 'http://localhost:3000',
-    },
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
     components: {
       actions: ['/components/actions/AdminButton/index.js#AdminButton'],
       afterDashboard: [
         '/components/AfterDashboard/index.js#AfterDashboard',
         '/components/AfterDashboardClient/index.js#AfterDashboardClient',
       ],
+      afterNav: ['/components/AfterNav/index.js#AfterNav'],
       afterNavLinks: ['/components/AfterNavLinks/index.js#AfterNavLinks'],
       beforeLogin: ['/components/BeforeLogin/index.js#BeforeLogin'],
+      beforeNav: ['/components/BeforeNav/index.js#BeforeNav'],
       graphics: {
-        Logo: '/components/graphics/Logo.js#Logo',
         Icon: '/components/graphics/Icon.js#Icon',
+        Logo: '/components/graphics/Logo.js#Logo',
       },
       header: ['/components/CustomHeader/index.js#CustomHeader'],
       logout: {
         Button: '/components/Logout/index.js#Logout',
       },
-      settingsMenu: [
-        '/components/SettingsMenuItems/Item1.tsx#SettingsMenuItem1',
-        '/components/SettingsMenuItems/Item2.tsx#SettingsMenuItem2',
-      ],
       providers: [
         '/components/CustomProviderServer/index.js#CustomProviderServer',
         '/components/CustomProvider/index.js#CustomProvider',
+      ],
+      settingsMenu: [
+        '/components/SettingsMenuItems/Item1.tsx#SettingsMenuItem1',
+        '/components/SettingsMenuItems/Item2.tsx#SettingsMenuItem2',
       ],
       views: {
         // Dashboard: CustomDashboardView,
@@ -107,10 +102,10 @@ export default buildConfigWithDefaults({
         },
         CustomMinimalView: {
           Component: '/components/views/CustomMinimal/index.js#CustomMinimalView',
-          path: '/custom-minimal-view',
           meta: {
             title: customRootViewMetaTitle,
           },
+          path: '/custom-minimal-view',
         },
         CustomNestedView: {
           Component: '/components/views/CustomViewNested/index.js#CustomNestedView',
@@ -123,6 +118,10 @@ export default buildConfigWithDefaults({
           path: customViewPath,
           strict: true,
         },
+        CustomViewWithParam: {
+          Component: '/components/views/CustomViewWithParam/index.js#CustomViewWithParam',
+          path: customParamViewPath,
+        },
         ProtectedCustomNestedView: {
           Component: '/components/views/CustomProtectedView/index.js#CustomProtectedView',
           exact: true,
@@ -134,11 +133,23 @@ export default buildConfigWithDefaults({
           path: publicCustomViewPath,
           strict: true,
         },
-        CustomViewWithParam: {
-          Component: '/components/views/CustomViewWithParam/index.js#CustomViewWithParam',
-          path: customParamViewPath,
-        },
       },
+    },
+    dependencies: {
+      myTestComponent: {
+        type: 'component',
+        clientProps: {
+          test: 'hello',
+        },
+        path: '/components/TestComponent.js#TestComponent',
+      },
+    },
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+    livePreview: {
+      collections: [reorderTabsSlug, editMenuItemsSlug],
+      url: 'http://localhost:3000',
     },
     meta: {
       description: 'This is a custom meta description',
@@ -162,15 +173,6 @@ export default buildConfigWithDefaults({
       titleSuffix: '- Custom Title Suffix',
     },
     routes: customAdminRoutes,
-    dependencies: {
-      myTestComponent: {
-        path: '/components/TestComponent.js#TestComponent',
-        type: 'component',
-        clientProps: {
-          test: 'hello',
-        },
-      },
-    },
   },
   collections: [
     UploadCollection,
@@ -229,8 +231,8 @@ export default buildConfigWithDefaults({
     },
   },
   localization: {
-    defaultLocalePublishOption: 'active',
     defaultLocale: 'en',
+    defaultLocalePublishOption: 'active',
     locales: [
       {
         code: 'es',

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -838,7 +838,7 @@ describe('General', () => {
       await openNav(page)
       const beforeNav = page.locator('#before-nav-component')
       await expect(beforeNav).toBeVisible()
-      await expect(beforeNav).toContainText('Before Nav Content')
+      await expect(beforeNav).toContainText('beforeNav')
     })
 
     test('should render afterNav component', async () => {
@@ -846,7 +846,7 @@ describe('General', () => {
       await openNav(page)
       const afterNav = page.locator('#after-nav-component')
       await expect(afterNav).toBeVisible()
-      await expect(afterNav).toContainText('After Nav Content')
+      await expect(afterNav).toContainText('afterNav')
     })
 
     test('should render beforeNav and afterNav outside nav element', async () => {
@@ -866,13 +866,24 @@ describe('General', () => {
       await expect(afterNavInNav).toHaveCount(0)
     })
 
+    test('should render beforeNavLinks inside nav element', async () => {
+      await page.goto(formatAdminURL({ adminRoute, path: '', serverURL }))
+      await openNav(page)
+
+      // Verify beforeNavLinks is inside the nav element
+      const beforeNavLinksInNav = page.locator('nav.nav__wrap #before-nav-links-component')
+      await expect(beforeNavLinksInNav).toBeVisible()
+      await expect(beforeNavLinksInNav).toContainText('beforeNavLinks')
+    })
+
     test('should render afterNavLinks inside nav element', async () => {
       await page.goto(formatAdminURL({ adminRoute, path: '', serverURL }))
       await openNav(page)
 
       // Verify afterNavLinks is inside the nav element
-      const afterNavLinksInNav = page.locator('nav.nav__wrap .after-nav-links')
+      const afterNavLinksInNav = page.locator('nav.nav__wrap #after-nav-links-component')
       await expect(afterNavLinksInNav).toBeVisible()
+      await expect(afterNavLinksInNav).toContainText('afterNavLinks')
     })
   })
 

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -832,6 +832,48 @@ describe('General', () => {
       const header = page.locator('.custom-header')
       await expect(header).toContainText('Here is a custom header')
     })
+
+    test('should render beforeNav component', async () => {
+      await page.goto(formatAdminURL({ adminRoute, path: '', serverURL }))
+      await openNav(page)
+      const beforeNav = page.locator('#before-nav-component')
+      await expect(beforeNav).toBeVisible()
+      await expect(beforeNav).toContainText('Before Nav Content')
+    })
+
+    test('should render afterNav component', async () => {
+      await page.goto(formatAdminURL({ adminRoute, path: '', serverURL }))
+      await openNav(page)
+      const afterNav = page.locator('#after-nav-component')
+      await expect(afterNav).toBeVisible()
+      await expect(afterNav).toContainText('After Nav Content')
+    })
+
+    test('should render beforeNav and afterNav outside nav element', async () => {
+      await page.goto(formatAdminURL({ adminRoute, path: '', serverURL }))
+      await openNav(page)
+
+      // Verify beforeNav is outside the nav element
+      const beforeNav = page.locator('#before-nav-component')
+      await expect(beforeNav).toBeVisible()
+      const beforeNavInNav = page.locator('nav.nav__wrap #before-nav-component')
+      await expect(beforeNavInNav).toHaveCount(0)
+
+      // Verify afterNav is outside the nav element
+      const afterNav = page.locator('#after-nav-component')
+      await expect(afterNav).toBeVisible()
+      const afterNavInNav = page.locator('nav.nav__wrap #after-nav-component')
+      await expect(afterNavInNav).toHaveCount(0)
+    })
+
+    test('should render afterNavLinks inside nav element', async () => {
+      await page.goto(formatAdminURL({ adminRoute, path: '', serverURL }))
+      await openNav(page)
+
+      // Verify afterNavLinks is inside the nav element
+      const afterNavLinksInNav = page.locator('nav.nav__wrap .after-nav-links')
+      await expect(afterNavLinksInNav).toBeVisible()
+    })
   })
 
   describe('i18n', () => {


### PR DESCRIPTION
Allows custom components to be slotted in before the nav, and not specifically beforeNavLinks. `beforeNavLinks` semantically means before the links themselves, but for a PR like https://github.com/payloadcms/payload/pull/15470, we will want to be able to place things outside of the nav links section. Think about the multi-tenant selector, you would not want that visible in just the first tab, but outside of the tabs - i.e. before the nav.
