### PR TITLE
test: trash e2e URL regex too strict and blocks query parameters

### DIFF
--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -1091,7 +1091,7 @@ describe('Trash', () => {
       await expect(page.locator('.row-1 .cell-name')).toHaveText('Dev')
       await page.locator('.row-1 .cell-name').click()
 
-      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}$/)
+      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}/)
     })
 
     test('Should properly disable auth fields in the trashed user edit view', async ({ page }) => {
@@ -1101,7 +1101,7 @@ describe('Trash', () => {
 
       await page.locator('.row-1 .cell-name').click()
 
-      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}$/)
+      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}/)
 
       await expect(page.locator('input[name="email"]')).toBeDisabled()
       await expect(page.locator('#change-password')).toBeDisabled()
@@ -1118,7 +1118,7 @@ describe('Trash', () => {
       await expect(page.locator('.row-1 .cell-name')).toHaveText('Dev')
       await page.locator('.row-1 .cell-name').click()
 
-      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}$/)
+      await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}/)
 
       await page.locator('.doc-controls__controls #action-restore').click()
 

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -94,7 +94,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
-  user: User;
+  user: User & {
+    collection: 'users';
+  };
   jobs: {
     tasks: unknown;
     workflows: unknown;
@@ -179,7 +181,6 @@ export interface User {
       }[]
     | null;
   password?: string | null;
-  collection: 'users';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What?

The URL assertion regex in trash auth e2e tests is too strict - can be flaky and fail when URLs have query parameters like `?limit=10`

<img width="769" height="425" alt="image" src="https://github.com/user-attachments/assets/5ff69515-03d4-4a5e-8a85-d5ae324b2268" />

### Why

The regex pattern `/\/users\/trash\/[a-f0-9]{24}$/` uses `$` anchor which requires an exact end-of-string match.

### How

Removed the `$` anchor from the URL regex pattern in all three auth collection tests.