### PR TITLE
chore(plugin-multi-tenant): use beforeNav instead of beforeNavLinks for tenant selector

### DIFF
--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -52,7 +52,7 @@ export const multiTenantPlugin =
     if (!incomingConfig.admin?.components) {
       incomingConfig.admin.components = {
         actions: [],
-        beforeNavLinks: [],
+        beforeNav: [],
         providers: [],
       }
     }
@@ -62,8 +62,8 @@ export const multiTenantPlugin =
     if (!incomingConfig.admin.components?.actions) {
       incomingConfig.admin.components.actions = []
     }
-    if (!incomingConfig.admin.components?.beforeNavLinks) {
-      incomingConfig.admin.components.beforeNavLinks = []
+    if (!incomingConfig.admin.components?.beforeNav) {
+      incomingConfig.admin.components.beforeNav = []
     }
     if (!incomingConfig.collections) {
       incomingConfig.collections = []
@@ -482,7 +482,7 @@ export const multiTenantPlugin =
     /**
      * Add tenant selector to admin UI
      */
-    incomingConfig.admin.components.beforeNavLinks.push({
+    incomingConfig.admin.components.beforeNav.push({
       clientProps: {
         enabledSlugs: [
           ...collectionSlugs,


### PR DESCRIPTION
Updates the tenant selector to use the new beforeNav component slot instead of beforeNavLinks, placing it before the entire navigation section for better UI placement in the future if a user enables sidebar tabs.