### PR TITLE
fix(ui): extra padding rendering in list view when no description exists

### DIFF
--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -163,17 +163,19 @@ export function DefaultListView(props: ListViewClientProps) {
               <CollectionListHeader
                 collectionConfig={collectionConfig}
                 Description={
-                  <div className={`${baseClass}__sub-header`}>
-                    <RenderCustomComponent
-                      CustomComponent={Description}
-                      Fallback={
-                        <ViewDescription
-                          collectionSlug={collectionSlug}
-                          description={collectionConfig?.admin?.description}
-                        />
-                      }
-                    />
-                  </div>
+                  Description || collectionConfig?.admin?.description ? (
+                    <div className={`${baseClass}__sub-header`}>
+                      <RenderCustomComponent
+                        CustomComponent={Description}
+                        Fallback={
+                          <ViewDescription
+                            collectionSlug={collectionSlug}
+                            description={collectionConfig?.admin?.description}
+                          />
+                        }
+                      />
+                    </div>
+                  ) : undefined
                 }
                 disableBulkDelete={disableBulkDelete}
                 disableBulkEdit={disableBulkEdit}


### PR DESCRIPTION
### What

Fixes extra padding appearing above search bar in collection list view when no description is configured.

### Why

The `__sub-header` wrapper div was always rendered with `padding-top: calc(var(--base) * 0.75)`, even when both the custom Description component and `collectionConfig?.admin?.description` were undefined - creating unwanted spacing.

### How

Conditionally render the `__sub-header` wrapper only when there's actual content to display (custom Description component or admin description config exists).

#### Before
<img width="1215" height="290" alt="Screenshot 2026-02-04 at 10 01 01 AM" src="https://github.com/user-attachments/assets/47e68f86-0aae-4501-bbe6-ac61b00d5280" />

#### After
<img width="1215" height="280" alt="Screenshot 2026-02-04 at 10 15 55 AM" src="https://github.com/user-attachments/assets/6bd09daa-eb38-40d6-b64e-6654a183c55c" />

#### After w/ Description
<img width="1215" height="328" alt="Screenshot 2026-02-04 at 10 16 28 AM" src="https://github.com/user-attachments/assets/2bbf9f38-b09c-4650-a1d0-68d86d2b7947" />

Fixes #15484
