### PR TITLE
fix(drizzle): use cascade delete for required relationships

### DIFF
--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -957,12 +957,14 @@ export const traverseFields = ({
           }
 
           // make the foreign key column for relationship using the correct id column type
+          // Use 'cascade' for required relationships since 'set null' is incompatible with NOT NULL
+          const onDelete = field.required && !field.admin?.condition ? 'cascade' : 'set null'
           targetTable[fieldName] = {
             name: `${columnName}_id`,
             type: colType,
             reference: {
               name: 'id',
-              onDelete: 'set null',
+              onDelete,
               table: tableName,
             },
           }

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -1016,6 +1016,33 @@ export const getConfig: () => Partial<Config> = () => ({
         },
       ],
     },
+    // Collections for testing required relationship onDelete behavior
+    {
+      slug: 'required-rel-parent',
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+    {
+      slug: 'required-rel-child',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'parent',
+          type: 'relationship',
+          relationTo: 'required-rel-parent',
+          required: true, // This causes the bug: onDelete: 'set null' + NOT NULL constraint
+        },
+      ],
+    },
   ],
   globals: [
     {

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -89,6 +89,8 @@ export interface Config {
     aliases: Alias;
     'blocks-docs': BlocksDoc;
     'unique-fields': UniqueField;
+    'required-rel-parent': RequiredRelParent;
+    'required-rel-child': RequiredRelChild;
     'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
@@ -119,6 +121,8 @@ export interface Config {
     aliases: AliasesSelect<false> | AliasesSelect<true>;
     'blocks-docs': BlocksDocsSelect<false> | BlocksDocsSelect<true>;
     'unique-fields': UniqueFieldsSelect<false> | UniqueFieldsSelect<true>;
+    'required-rel-parent': RequiredRelParentSelect<false> | RequiredRelParentSelect<true>;
+    'required-rel-child': RequiredRelChildSelect<false> | RequiredRelChildSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -695,6 +699,27 @@ export interface UniqueField {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "required-rel-parent".
+ */
+export interface RequiredRelParent {
+  id: string;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "required-rel-child".
+ */
+export interface RequiredRelChild {
+  id: string;
+  title: string;
+  parent: string | RequiredRelParent;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -829,6 +854,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'unique-fields';
         value: string | UniqueField;
+      } | null)
+    | ({
+        relationTo: 'required-rel-parent';
+        value: string | RequiredRelParent;
+      } | null)
+    | ({
+        relationTo: 'required-rel-child';
+        value: string | RequiredRelChild;
       } | null)
     | ({
         relationTo: 'users';
@@ -1327,6 +1360,25 @@ export interface BlocksDocsSelect<T extends boolean = true> {
  */
 export interface UniqueFieldsSelect<T extends boolean = true> {
   slugField?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "required-rel-parent_select".
+ */
+export interface RequiredRelParentSelect<T extends boolean = true> {
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "required-rel-child_select".
+ */
+export interface RequiredRelChildSelect<T extends boolean = true> {
+  title?: T;
+  parent?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
Required relationship fields were generating incompatible schema: `NOT NULL` constraint with `onDelete: 'set null'`. When deleting a parent document, PostgreSQL would error because it can't set a required field to null.

Now uses `onDelete: 'cascade'` for required relationships, so child documents are deleted with their parent.

Fixes https://github.com/payloadcms/payload/issues/14576

TODO: this is not the proper solution. Do more research