### PR TITLE
feat(db-mongodb): allow custom id field types

### DIFF
--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -23,6 +23,7 @@ import type {
 import mongoose from 'mongoose'
 import { createDatabaseAdapter, defaultBeginTransaction, findMigrationDir } from 'payload'
 
+import type { MongooseIDType } from './models/buildSchema.js'
 import type {
   CollectionModel,
   GlobalModel,
@@ -146,6 +147,10 @@ export interface Args {
    * NOTE: not recommended for production. This can slow down the initialization of Payload.
    */
   ensureIndexes?: boolean
+  /**
+   * The type to use for IDs in MongoDB. Can be `String`, `Number`, `mongoose.Schema.Types.ObjectId`, or `mongoose.Schema.Types.BigInt`. Defaults to `String`.
+   */
+  idType?: MongooseIDType
   migrationDir?: string
   /**
    * typed as any to avoid dependency
@@ -262,6 +267,7 @@ export function mongooseAdapter({
   disableFallbackSort = false,
   disableIndexHints = false,
   ensureIndexes = false,
+  idType: mongooseIDType,
   migrationDir: migrationDirArg,
   mongoMemoryServer,
   prodMigrations,
@@ -328,6 +334,7 @@ export function mongooseAdapter({
       findGlobalVersions,
       findOne,
       findVersions,
+      idType: mongooseIDType,
       init,
       migrateFresh,
       migrationDir,

--- a/packages/db-mongodb/src/init.ts
+++ b/packages/db-mongodb/src/init.ts
@@ -30,7 +30,7 @@ export const init: Init = async function init(this: MongooseAdapter) {
   this.payload.config.collections.forEach((collection: SanitizedCollectionConfig) => {
     const schemaOptions = this.collectionsSchemaOptions?.[collection.slug]
 
-    const schema = buildCollectionSchema(collection, this.payload, schemaOptions)
+    const schema = buildCollectionSchema(collection, this.payload, schemaOptions, this.idType)
     if (collection.versions) {
       const versionModelName = getDBName({ config: collection, versions: true })
 
@@ -40,6 +40,7 @@ export const init: Init = async function init(this: MongooseAdapter) {
         buildSchemaOptions: {
           disableUnique: true,
           draftsEnabled: true,
+          idType: this.idType,
           indexSortableFields: this.payload.config.indexSortableFields,
           options: {
             minimize: false,
@@ -92,6 +93,7 @@ export const init: Init = async function init(this: MongooseAdapter) {
         buildSchemaOptions: {
           disableUnique: true,
           draftsEnabled: true,
+          idType: this.idType,
           indexSortableFields: this.payload.config.indexSortableFields,
           options: {
             minimize: false,

--- a/packages/db-mongodb/src/models/buildCollectionSchema.ts
+++ b/packages/db-mongodb/src/models/buildCollectionSchema.ts
@@ -3,6 +3,8 @@ import type { Payload, SanitizedCollectionConfig } from 'payload'
 
 import paginate from 'mongoose-paginate-v2'
 
+import type { MongooseIDType } from './buildSchema.js'
+
 import { getBuildQueryPlugin } from '../queries/getBuildQueryPlugin.js'
 import { buildSchema } from './buildSchema.js'
 
@@ -10,12 +12,14 @@ export const buildCollectionSchema = (
   collection: SanitizedCollectionConfig,
   payload: Payload,
   schemaOptions = {},
+  idType?: MongooseIDType,
 ): Schema => {
   const schema = buildSchema({
     buildSchemaOptions: {
       draftsEnabled: Boolean(
         typeof collection?.versions === 'object' && collection.versions.drafts,
       ),
+      idType,
       indexSortableFields: payload.config.indexSortableFields,
       options: {
         minimize: false,


### PR DESCRIPTION
# Summary

Allows setting the custom ID field type in the Mongoose adapter by adding a new argument `idType: mongooseIDType` and passing it to the function `buildSchema()`.

No test coverage yet, cuz I'm pretty new with the Node.js tests and Payload contributions.

### Why?

By default, Payload CMS creates docs using the MongoDB ObjectID as the ID value. But pretty often, the Payload's document IDs are reused in other database types, where the MongoDB's ObjectID value is not native and unclear. 

The pretty popular ID value type in most modern databases is UUID, so for some projects, it would be much more convenient to use UUID in all Payload Collections by default.

Yes, we already can customize the ID field, according to the docs https://payloadcms.com/docs/fields/overview#custom-id-fields, but it should be done manually in each collection, so much better to allow choosing the default ID field type for the whole project. 

And one more significant limitation of the current Payload Custom ID Field API is that even if we generate the UUID value in JS, it will be stored as a string, wasting 32-36 bytes per id and decreasing the database performance, instead of using the 16-byte binary storage. 

This resolves the missing UUID type for MongoDB issue discussed in #13054

### How?

- Adds a new argument `idType: mongooseIDType` to the function `mongooseAdapter()`.
- Passes the value to the function `buildSchema()`.
- Uses the custom type for the `_id` field schema in the collections.