### PR TITLE
fix(next): suppress webpack "Critical dependency" warning in dynamicImport

### DIFF
--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -35,14 +35,18 @@ export const withPayload = (nextConfig = {}, options = {}) => {
   }
 
   const consoleWarn = console.warn
-  const sassWarningText =
-    'Future import deprecation is not yet active, so silencing it is unnecessary'
+
+  const sassWarningTexts = [
+    // This warning is a lie - without silencing import deprecation warnings, sass will spam the console with deprecation warnings
+    'Future import deprecation is not yet active, so silencing it is unnecessary',
+    // Sometimes happens despite silenceDeprecations
+    'The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0',
+  ]
   console.warn = (...args) => {
     if (
-      (typeof args[1] === 'string' && args[1].includes(sassWarningText)) ||
-      (typeof args[0] === 'string' && args[0].includes(sassWarningText))
+      (typeof args[1] === 'string' && sassWarningTexts.some((text) => args[1].includes(text))) ||
+      (typeof args[0] === 'string' && sassWarningTexts.some((text) => args[0].includes(text)))
     ) {
-      // This warning is a lie - without silencing import deprecation warnings, sass will spam the console with deprecation warnings
       return
     }
 

--- a/packages/payload/src/utilities/dynamicImport.ts
+++ b/packages/payload/src/utilities/dynamicImport.ts
@@ -18,7 +18,7 @@ export async function dynamicImport<T = unknown>(modulePathOrSpecifier: string):
   // Vitest runs tests in a VM context where eval'd dynamic imports fail with
   // ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING. Use direct import in test environment.
   if (process.env.VITEST) {
-    return await import(importPath)
+    return await import(/* webpackIgnore: true */ importPath)
   }
 
   // Without the eval, the Next.js bundler will throw this error when encountering the import statement:


### PR DESCRIPTION
The Vitest-only branch in `dynamicImport` uses a bare `import(importPath)` which webpack still statically analyzes, even though it's behind a `process.env.VITEST` condition. This could cause a `"Critical dependency: the request of a dependency is an expression"` warning in Next.js projects. Adding `/* webpackIgnore: true */` should fix this.

Additionally, this hides another sass deprecation warning