### PR TITLE
chore: fix deprecation warning when running reinstall or clean:all monorepo script

### DIFF
--- a/scripts/delete-recursively.js
+++ b/scripts/delete-recursively.js
@@ -35,7 +35,7 @@ async function deleteRecursively(targetPath, fullDelete = false) {
   try {
     if (fullDelete && existsSync(targetPath)) {
       const size = await calculateSize(targetPath)
-      await fs.rmdir(targetPath, { recursive: true }) // Use async version of rmdir
+      await fs.rm(targetPath, { recursive: true, force: true }) // Use async version of rmdir
       return size
     }
 

--- a/scripts/delete-recursively.js
+++ b/scripts/delete-recursively.js
@@ -35,7 +35,7 @@ async function deleteRecursively(targetPath, fullDelete = false) {
   try {
     if (fullDelete && existsSync(targetPath)) {
       const size = await calculateSize(targetPath)
-      await fs.rm(targetPath, { recursive: true, force: true }) // Use async version of rmdir
+      await fs.rm(targetPath, { recursive: true, force: true })
       return size
     }
 


### PR DESCRIPTION
Previously, the following warning would be thrown:

`(node:82543) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead`