### PR TITLE
fix(ui): folder view toggle button styles overridden due to equal specificity

### DIFF
--- a/packages/ui/src/elements/FolderView/ToggleViewButtons/index.scss
+++ b/packages/ui/src/elements/FolderView/ToggleViewButtons/index.scss
@@ -1,7 +1,7 @@
 @import '../../../scss/styles.scss';
 
 @layer payload-default {
-  .folder-view-toggle-button {
+  .btn.folder-view-toggle-button {
     padding: 0;
     background-color: transparent;
 


### PR DESCRIPTION
### What

Folder view toggle buttons render with inconsistent padding across different environments due to CSS cascade order differences.

### Why

The `.folder-view-toggle-button` selector has equal specificity to `.btn`, so whichever CSS loads last wins. Different build tools and environments load CSS in different orders, causing the padding to apply inconsistently.

### How

Increased selector specificity from `.folder-view-toggle-button` to `.btn.folder-view-toggle-button`.

Fixes #15523 