### PR TITLE
fix(ui): copy to locale function swallowing errors

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -80,6 +80,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'error:logoutFailed',
   'error:noMatchedField',
   'error:notAllowedToAccessPage',
+  'error:notAllowedToPerformAction',
   'error:previewing',
   'error:unableToCopy',
   'error:unableToDeleteCount',

--- a/packages/ui/src/elements/CopyLocaleData/index.tsx
+++ b/packages/ui/src/elements/CopyLocaleData/index.tsx
@@ -91,7 +91,12 @@ export const CopyLocaleData: React.FC = () => {
 
         toggleModal(drawerSlug)
       } catch (error) {
-        toast.error(error.message)
+        setCopying(false)
+        const errorMessage = (error as Error).message || 'error:unknown'
+        const translatedMessage = errorMessage.startsWith('error:')
+          ? t(errorMessage as any)
+          : errorMessage
+        toast.error(translatedMessage)
       }
     },
     [
@@ -104,6 +109,7 @@ export const CopyLocaleData: React.FC = () => {
       router,
       admin,
       startRouteTransition,
+      t,
     ],
   )
 

--- a/packages/ui/src/providers/ServerFunctions/index.tsx
+++ b/packages/ui/src/providers/ServerFunctions/index.tsx
@@ -256,17 +256,18 @@ export const ServerFunctionsProvider: React.FC<{
     async (args) => {
       const { signal: remoteSignal, ...rest } = args || {}
 
-      try {
-        const result = (await serverFunction({
-          name: 'copy-data-from-locale',
-          args: rest,
-        })) as { data: Data }
+      const result = (await serverFunction({
+        name: 'copy-data-from-locale',
+        args: rest,
+      })) as { data?: Data; error?: string }
 
-        if (!remoteSignal?.aborted) {
-          return result
+      if (!remoteSignal?.aborted) {
+        // Check if server returned an error
+        if (result?.error) {
+          throw new Error(result.error)
         }
-      } catch (_err) {
-        console.error(_err) // eslint-disable-line no-console
+
+        return { data: result?.data }
       }
     },
     [serverFunction],

--- a/packages/ui/src/providers/ServerFunctions/index.tsx
+++ b/packages/ui/src/providers/ServerFunctions/index.tsx
@@ -259,15 +259,10 @@ export const ServerFunctionsProvider: React.FC<{
       const result = (await serverFunction({
         name: 'copy-data-from-locale',
         args: rest,
-      })) as { data?: Data; error?: string }
+      })) as Data
 
       if (!remoteSignal?.aborted) {
-        // Check if server returned an error
-        if (result?.error) {
-          throw new Error(result.error)
-        }
-
-        return { data: result?.data }
+        return { data: result }
       }
     },
     [serverFunction],

--- a/packages/ui/src/utilities/copyDataFromLocale.ts
+++ b/packages/ui/src/utilities/copyDataFromLocale.ts
@@ -214,17 +214,15 @@ export const copyDataFromLocaleHandler: ServerFunction<CopyDataFromLocaleArgs> =
   const { req } = args
 
   try {
-    const result = await copyDataFromLocale(args)
-    return { data: result }
+    return await copyDataFromLocale(args)
   } catch (err) {
     req.payload.logger.error({
       err,
       msg: `There was an error copying data from "${args.fromLocale}" to "${args.toLocale}"`,
     })
 
-    return {
-      error: err instanceof Error ? err.message : String(err),
-    }
+    // Re-throw the error so it can be caught by the client
+    throw err
   }
 }
 

--- a/packages/ui/src/utilities/copyDataFromLocale.ts
+++ b/packages/ui/src/utilities/copyDataFromLocale.ts
@@ -5,7 +5,6 @@ import {
   type Data,
   type Field,
   type FlattenedBlock,
-  formatErrors,
   type PayloadRequest,
   type ServerFunction,
   traverseFields,
@@ -215,18 +214,17 @@ export const copyDataFromLocaleHandler: ServerFunction<CopyDataFromLocaleArgs> =
   const { req } = args
 
   try {
-    return await copyDataFromLocale(args)
+    const result = await copyDataFromLocale(args)
+    return { data: result }
   } catch (err) {
     req.payload.logger.error({
       err,
       msg: `There was an error copying data from "${args.fromLocale}" to "${args.toLocale}"`,
     })
 
-    if (err.message === 'Unauthorized') {
-      return null
+    return {
+      error: err instanceof Error ? err.message : String(err),
     }
-
-    return formatErrors(err)
   }
 }
 

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -29,6 +29,7 @@ import {
   englishTitle,
   globalWithDraftsSlug,
   hungarianLocale,
+  localeRestrictedSlug,
   localizedDateFieldsSlug,
   localizedPostsSlug,
   localizedSortSlug,
@@ -351,6 +352,20 @@ export default buildConfigWithDefaults({
         },
       ],
       slug: cannotCreateDefaultLocale,
+    },
+    {
+      access: {
+        ...openAccess,
+        update: ({ req }) => req.locale === spanishLocale,
+      },
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          localized: true,
+        },
+      ],
+      slug: localeRestrictedSlug,
     },
     NestedToArrayAndBlock,
     Group,

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -10,7 +10,6 @@ import { upsertPreferences } from '__helpers/e2e/preferences.js'
 import { runAxeScan } from '__helpers/e2e/runAxeScan.js'
 import { openDocDrawer } from '__helpers/e2e/toggleDocDrawer.js'
 import { waitForAutoSaveToRunAndComplete } from '__helpers/e2e/waitForAutoSaveToRunAndComplete.js'
-import { RESTClient } from '../__helpers/shared/rest.js'
 import path from 'path'
 import { formatAdminURL } from 'payload/shared'
 import { fileURLToPath } from 'url'
@@ -32,6 +31,7 @@ import {
 } from '../__helpers/e2e/helpers.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
+import { RESTClient } from '../__helpers/shared/rest.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { arrayCollectionSlug } from './collections/Array/index.js'
 import { blocksCollectionSlug } from './collections/Blocks/index.js'
@@ -44,6 +44,7 @@ import {
   defaultLocale,
   englishTitle,
   hungarianLocale,
+  localeRestrictedSlug,
   localizedDraftsSlug,
   localizedPostsSlug,
   relationshipLocalizedSlug,
@@ -85,6 +86,7 @@ let payload: PayloadTestSDK<Config>
 let client: RESTClient
 let serverURL: string
 let richTextURL: AdminUrlUtil
+let urlLocaleRestricted: AdminUrlUtil
 let context: BrowserContext
 
 describe('Localization', () => {
@@ -103,6 +105,7 @@ describe('Localization', () => {
     noLocalizedFieldsURL = new AdminUrlUtil(serverURL, noLocalizedFieldsCollectionSlug)
     urlBlocks = new AdminUrlUtil(serverURL, blocksCollectionSlug)
     urlAllFieldsLocalized = new AdminUrlUtil(serverURL, allFieldsLocalizedSlug)
+    urlLocaleRestricted = new AdminUrlUtil(serverURL, localeRestrictedSlug)
 
     context = await browser.newContext()
     page = await context.newPage()
@@ -541,6 +544,27 @@ describe('Localization', () => {
       await copyButton.click()
 
       await expect(page.locator('.payload-toast-container')).toContainText('unsaved')
+    })
+
+    test('should show error when copying to locale without update access', async () => {
+      await changeLocale(page, spanishLocale)
+      await page.goto(urlLocaleRestricted.create)
+      await page.locator('#field-title').fill('Spanish title')
+      await saveDocAndAssert(page)
+
+      // Try to copy to English (no access)
+      await openCopyToLocaleDrawer(page)
+
+      const toLocaleDropdown = page.locator('#field-toLocale')
+      await toLocaleDropdown.click()
+      await page.locator('.rs__option').filter({ hasText: 'English' }).click()
+      const copyButton = page
+        .locator('.copy-locale-data__sub-header button')
+        .filter({ hasText: 'Copy' })
+      await copyButton.click()
+
+      // Should show error
+      await expect(page.locator('.payload-toast-container .toast-error')).toBeVisible()
     })
   })
 

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -82,6 +82,7 @@ export interface Config {
     'with-localized-relationship': WithLocalizedRelationship;
     'relationship-localized': RelationshipLocalized;
     'cannot-create-default-locale': CannotCreateDefaultLocale;
+    'locale-restricted': LocaleRestricted;
     nested: Nested;
     groups: Group;
     tabs: Tab;
@@ -111,6 +112,7 @@ export interface Config {
     'with-localized-relationship': WithLocalizedRelationshipSelect<false> | WithLocalizedRelationshipSelect<true>;
     'relationship-localized': RelationshipLocalizedSelect<false> | RelationshipLocalizedSelect<true>;
     'cannot-create-default-locale': CannotCreateDefaultLocaleSelect<false> | CannotCreateDefaultLocaleSelect<true>;
+    'locale-restricted': LocaleRestrictedSelect<false> | LocaleRestrictedSelect<true>;
     nested: NestedSelect<false> | NestedSelect<true>;
     groups: GroupsSelect<false> | GroupsSelect<true>;
     tabs: TabsSelect<false> | TabsSelect<true>;
@@ -391,6 +393,11 @@ export interface AllFieldsLocalized {
   radio?: ('radio1' | 'radio2') | null;
   checkbox?: boolean | null;
   date?: string | null;
+  richTextSlate?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
   localizedGroup?: {
     title?: string | null;
     description?: string | null;
@@ -654,6 +661,16 @@ export interface RelationshipLocalized {
         id?: string | null;
       }[]
     | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "locale-restricted".
+ */
+export interface LocaleRestricted {
+  id: string;
+  title?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -934,6 +951,10 @@ export interface PayloadLockedDocument {
         value: string | CannotCreateDefaultLocale;
       } | null)
     | ({
+        relationTo: 'locale-restricted';
+        value: string | LocaleRestricted;
+      } | null)
+    | ({
         relationTo: 'nested';
         value: string | Nested;
       } | null)
@@ -1184,6 +1205,7 @@ export interface AllFieldsLocalizedSelect<T extends boolean = true> {
   radio?: T;
   checkbox?: T;
   date?: T;
+  richTextSlate?: T;
   localizedGroup?:
     | T
     | {
@@ -1451,6 +1473,15 @@ export interface RelationshipLocalizedSelect<T extends boolean = true> {
  */
 export interface CannotCreateDefaultLocaleSelect<T extends boolean = true> {
   name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "locale-restricted_select".
+ */
+export interface LocaleRestrictedSelect<T extends boolean = true> {
+  title?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -24,5 +24,6 @@ export const blocksWithLocalizedSameName = 'blocks-same-name'
 export const cannotCreateDefaultLocale = 'cannot-create-default-locale'
 export const allFieldsLocalizedSlug = 'all-fields-localized'
 export const arrayWithFallbackCollectionSlug = 'array-with-fallback-fields'
+export const localeRestrictedSlug = 'locale-restricted'
 
 export const globalWithDraftsSlug = 'global-drafts'


### PR DESCRIPTION
## What

Updates the **Copy to Locale** functionality to properly surface access control errors when a user attempts to copy to/from locales they do not have permission to update.

## Why

Previously, copying to a restricted locale would fail silently, giving the impression that the operation succeeded when it did not. 

Ideally, the available locales, or the entire `copyToLocale` buttonm would be conditionally rendered based on access. However, doing this reliably today would require multiple additional access checks from the UI. A more robust solution would involve exposing this information from the backend, which we will addressed as an enhancement.

This change focuses on ensuring incorrect permissions are **clearly communicated** when the action is attempted.

## Where

- Updated `copyToLocale` to return serializable error objects instead of failing silently
- Updated the client wrapper to detect and throw these errors for proper handling
- Updated the UI to catch these errors and display translated error messages in a toast notification

## Testing

Test added to `localization > e2e`

Fixes #12361
