### PR TITLE
fix: no modification allowed error in firefox bulk upload

### DIFF
--- a/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
@@ -13,7 +13,7 @@ const baseClass = 'bulk-upload--add-files'
 type Props = {
   readonly acceptMimeTypes?: string
   readonly onCancel: () => void
-  readonly onDrop: (acceptedFiles: FileList) => void
+  readonly onDrop: (acceptedFiles: File[] | FileList) => void
 }
 export function AddFilesView({ acceptMimeTypes, onCancel, onDrop }: Props) {
   const { t } = useTranslation()

--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -253,7 +253,7 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
   )
 
   const addFiles = React.useCallback(
-    async (files: FileList) => {
+    async (files: File[] | FileList) => {
       if (forms.length) {
         // save the state of the current form before adding new files
         dispatch({

--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -31,21 +31,22 @@ function DrawerContent() {
   const uploadMimeTypes = uploadConfig?.mimeTypes
 
   const onDrop = React.useCallback(
-    (acceptedFiles: FileList) => {
-      const fileTransfer = new DataTransfer()
-      for (const candidateFile of acceptedFiles) {
+    (acceptedFiles: File[] | FileList) => {
+      const filesToAdd: File[] = []
+      const acceptedFilesArray = Array.from(acceptedFiles)
+      for (const candidateFile of acceptedFilesArray) {
         if (
           uploadMimeTypes === undefined ||
           uploadMimeTypes.length === 0 ||
           validateMimeType(candidateFile.type, uploadMimeTypes)
         ) {
-          fileTransfer.items.add(candidateFile)
+          filesToAdd.push(candidateFile)
         }
       }
-      if (fileTransfer.files.length === 0) {
+      if (filesToAdd.length === 0) {
         toast.error(t('error:invalidFileType'))
       } else {
-        void addFiles(fileTransfer.files)
+        void addFiles(filesToAdd)
       }
     },
     [addFiles, t, uploadMimeTypes],

--- a/packages/ui/src/elements/Dropzone/index.tsx
+++ b/packages/ui/src/elements/Dropzone/index.tsx
@@ -16,7 +16,7 @@ export type Props = {
   readonly disabled?: boolean
   readonly dropzoneStyle?: 'default' | 'none'
   readonly multipleFiles?: boolean
-  readonly onChange: (e: FileList) => void
+  readonly onChange: (e: File[] | FileList) => void
 }
 
 export function Dropzone({
@@ -33,9 +33,7 @@ export function Dropzone({
   const addFiles = React.useCallback(
     (files: FileList) => {
       if (!multipleFiles && files.length > 1) {
-        const dataTransfer = new DataTransfer()
-        dataTransfer.items.add(files[0])
-        onChange(dataTransfer.files)
+        onChange([files[0]])
       } else {
         onChange(files)
       }


### PR DESCRIPTION
## Description
Fixes an issue where bulk uploading files in Firefox would throw a `NoModificationAllowedError`. This was caused by attempting to modify `DataTransfer` items during a drop event, which Firefox prevents for security reasons.

## Changes
- Replaced `DataTransfer` manipulation with standard `File[]` arrays in `BulkUpload` and `Dropzone` components.
- Updated `FormsManager` and `AddFilesView` to accept `FileList | File[]` types.
- Simplified the file filtering logic to use array operations instead of `DataTransfer`.

## Reproduction
1. Open Payload Admin in Firefox.
2. Go to a collection with uploads enabled.
3. Drag and drop multiple files to trigger the bulk upload drawer.
4. Before this fix: `NoModificationAllowedError` alert appears.
5. After this fix: Files are added correctly to the upload queue.
