### PR TITLE
fix(plugin-cloud-storage): ensure file data persists across operations

### DIFF
--- a/packages/plugin-cloud-storage/src/hooks/afterChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.ts
@@ -76,6 +76,10 @@ export const getAfterChangeHook =
             }
             req.context.skipCloudStorage = true
 
+            // Clear to prevent re-processing
+            req.file = undefined
+            req.payloadUploadSizes = undefined
+
             await req.payload.update({
               id: doc.id,
               collection: collection.slug,

--- a/packages/plugin-cloud-storage/src/hooks/preserveFileData.ts
+++ b/packages/plugin-cloud-storage/src/hooks/preserveFileData.ts
@@ -1,0 +1,16 @@
+import type { CollectionBeforeChangeHook, FileData, TypeWithID } from 'payload'
+
+/**
+ * Preserves req.file in req.context and ensures nested calls don't overwrite the original file data.
+ */
+export const getPreserveFileDataHook =
+  (): CollectionBeforeChangeHook<FileData & TypeWithID> =>
+  ({ req }) => {
+    if (req.file && !req.context?._payloadCloudStorage) {
+      req.context = req.context || {}
+      req.context._payloadCloudStorage = {
+        file: req.file,
+        uploadSizes: req.payloadUploadSizes,
+      }
+    }
+  }

--- a/packages/plugin-cloud-storage/src/plugin.ts
+++ b/packages/plugin-cloud-storage/src/plugin.ts
@@ -5,6 +5,7 @@ import type { AllowList, PluginOptions } from './types.js'
 import { getFields } from './fields/getFields.js'
 import { getAfterChangeHook } from './hooks/afterChange.js'
 import { getAfterDeleteHook } from './hooks/afterDelete.js'
+import { getPreserveFileDataHook } from './hooks/preserveFileData.js'
 
 // This plugin extends all targeted collections by offloading uploaded files
 // to cloud storage instead of solely storing files locally.
@@ -158,6 +159,10 @@ export const cloudStoragePlugin =
               afterDelete: [
                 ...(existingCollection.hooks?.afterDelete || []),
                 getAfterDeleteHook({ adapter, collection: existingCollection }),
+              ],
+              beforeChange: [
+                ...(existingCollection.hooks?.beforeChange || []),
+                getPreserveFileDataHook(),
               ],
             },
             upload: {

--- a/packages/plugin-cloud-storage/src/utilities/getIncomingFiles.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getIncomingFiles.ts
@@ -2,6 +2,11 @@ import type { FileData, PayloadRequest } from 'payload'
 
 import type { File } from '../types.js'
 
+interface CloudStorageContext {
+  file: PayloadRequest['file']
+  uploadSizes: PayloadRequest['payloadUploadSizes']
+}
+
 export function getIncomingFiles({
   data,
   req,
@@ -9,7 +14,10 @@ export function getIncomingFiles({
   data: Partial<FileData>
   req: PayloadRequest
 }): File[] {
-  const file = req.file
+  // Fall back to context if req.file was cleared
+  const ctx = req.context?._payloadCloudStorage as CloudStorageContext | undefined
+  const file = req.file ?? ctx?.file
+  const payloadUploadSizes = req.payloadUploadSizes ?? ctx?.uploadSizes
 
   let files: File[] = []
 
@@ -27,12 +35,12 @@ export function getIncomingFiles({
 
     if (data?.sizes) {
       Object.entries(data.sizes).forEach(([key, resizedFileData]) => {
-        if (req.payloadUploadSizes?.[key] && resizedFileData.mimeType) {
+        if (payloadUploadSizes?.[key] && resizedFileData.mimeType) {
           files = files.concat([
             {
-              buffer: req.payloadUploadSizes[key],
+              buffer: payloadUploadSizes[key],
               filename: `${resizedFileData.filename}`,
-              filesize: req.payloadUploadSizes[key].length,
+              filesize: payloadUploadSizes[key].length,
               mimeType: resizedFileData.mimeType,
             },
           ])

--- a/test/storage-s3/searchBeforeS3.config.ts
+++ b/test/storage-s3/searchBeforeS3.config.ts
@@ -1,0 +1,65 @@
+import { searchPlugin } from '@payloadcms/plugin-search'
+import { s3Storage } from '@payloadcms/storage-s3'
+import dotenv from 'dotenv'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { devUser } from '../credentials.js'
+import { Media } from './collections/Media.js'
+import { Users } from './collections/Users.js'
+import { mediaSlug } from './shared.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+dotenv.config({
+  path: path.resolve(dirname, '../plugin-cloud-storage/.env.emulated'),
+})
+
+export default buildConfigWithDefaults({
+  admin: {
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+  },
+  collections: [Media, Users],
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
+  },
+  plugins: [
+    searchPlugin({
+      collections: [mediaSlug],
+      beforeSync: ({ originalDoc, searchDoc }) => {
+        return {
+          ...searchDoc,
+          title: originalDoc?.filename || 'Untitled',
+        }
+      },
+    }),
+    s3Storage({
+      collections: {
+        [mediaSlug]: true,
+      },
+      bucket: process.env.S3_BUCKET!,
+      config: {
+        credentials: {
+          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+        },
+        endpoint: process.env.S3_ENDPOINT,
+        forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+        region: process.env.S3_REGION,
+      },
+    }),
+  ],
+  typescript: {
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  },
+})

--- a/test/storage-s3/searchBeforeS3.int.spec.ts
+++ b/test/storage-s3/searchBeforeS3.int.spec.ts
@@ -1,0 +1,81 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { mediaSlug } from './shared.js'
+import { clearTestBucket, createTestBucket, verifyUploads } from './test-utils.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+let payload: Payload
+
+describe('Search plugin before S3 - Issue #15431', () => {
+  beforeAll(async () => {
+    ;({ payload } = await initPayloadInt(
+      dirname,
+      'storage-s3-search-before',
+      true,
+      'searchBeforeS3.config.ts',
+    ))
+    await createTestBucket()
+    await clearTestBucket()
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  afterEach(async () => {
+    await payload.delete({
+      collection: mediaSlug,
+      where: { id: { exists: true } },
+    })
+    // Only delete from search if the collection exists
+    if (payload.collections['search']) {
+      await payload.delete({
+        collection: 'search',
+        where: { id: { exists: true } },
+      })
+    }
+    await clearTestBucket()
+  })
+
+  it('should upload all image sizes to S3 when search plugin is listed before S3 plugin', async () => {
+    const upload = await payload.create({
+      collection: mediaSlug,
+      data: {},
+      filePath: path.resolve(dirname, '../uploads/image.png'),
+    })
+
+    expect(upload.id).toBeTruthy()
+    expect(upload.filename).toBeTruthy()
+
+    await verifyUploads({
+      collectionSlug: mediaSlug,
+      uploadId: upload.id,
+      payload,
+    })
+  })
+
+  it('should create search document when uploading media', async () => {
+    const upload = await payload.create({
+      collection: mediaSlug,
+      data: {},
+      filePath: path.resolve(dirname, '../uploads/image.png'),
+    })
+
+    const { docs: searchDocs } = await payload.find({
+      collection: 'search',
+      where: {
+        'doc.value': { equals: upload.id },
+        'doc.relationTo': { equals: mediaSlug },
+      },
+    })
+
+    expect(searchDocs.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## What

Fixes issue where S3 image sizes fail to be uploaded when the `@payloadcms/plugin-search` is listed before the cloud storage plugin.

## Why

These plugins share the same `req` object during operations, resulting in file data getting lost. Specifically:

1. User uploads an image
2. Search plugin's `afterChange` hook runs first (due to plugin order in config)
3. Search plugin calls `payload.create({ collection: 'search', req })` 
4. The local API's `createLocal` sets `req.file = undefined`
5. The storage plugin's `afterChange` hook runs, but `req.file` is now `undefined`

## Where

Preserve file data using context incase other plugins modify or clear it:

1. Adds a `beforeChange` hook that saves `req.file` and `req.payloadUploadSizes` to context
2. Modifies `getIncomingFiles` to fallback to context when `req.file` is undefined

### Testing

Added new test config and int file `searchBeforeS3.int.spec.ts` to `test/storage-s3`

Fixes #15431