### PR TITLE
docs: update custom components docs

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -216,6 +216,8 @@ The following options are available:
 
 #### Edit View Options
 
+Custom components within the Edit View are configured under `admin.components.edit`:
+
 ```ts
 import type { CollectionConfig } from 'payload'
 
@@ -224,15 +226,18 @@ export const MyCollection: CollectionConfig = {
   admin: {
     components: {
       edit: {
-        // highlight-line
-        // ...
+        // highlight-start
+        Status: '/path/to/CustomStatus',
+        SaveButton: '/path/to/CustomSaveButton',
+        PublishButton: '/path/to/CustomPublishButton',
+        // highlight-end
       },
     },
   },
 }
 ```
 
-The following options are available:
+The following components can be customized within `admin.components.edit`:
 
 | Option                   | Description                                                                                                                                                                                             |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -245,6 +250,14 @@ The following options are available:
 | `UnpublishButton`        | Replace the default Unpublish Button within the Edit View. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#unpublishbutton).                                |
 | `PreviewButton`          | Replace the default Preview Button within the Edit View. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
 | `Upload`                 | Replace the default Upload component within the Edit View. [Upload](../upload/overview) must be enabled. [More details](../custom-components/edit-view#upload).                                         |
+
+<Banner type="warning">
+  **Important:** All edit view components must be configured under
+  `admin.components.edit`, not directly under `admin.components`.
+
+For example, use `admin.components.edit.Status`, not `admin.components.Status`.
+
+</Banner>
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -195,20 +195,6 @@ The following elements can be customized within `admin.components.elements`:
 | `PreviewButton`          | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
 | `Status`                 | Replace the default Status component with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#status).                                         |
 
-<Banner type="warning">
-  **Important:** For globals, all edit view components must be configured under
-  `admin.components.elements`, not directly under `admin.components`.
-
-For example, use `admin.components.elements.Status`, not `admin.components.Status`.
-
-</Banner>
-
-<Banner type="info">
-  **Note:** Globals use `admin.components.elements` for edit view components,
-  while Collections use `admin.components.edit`. This is an important
-  distinction to remember when configuring custom components.
-</Banner>
-
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom
   Components](../custom-components/overview#building-custom-components).

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -161,23 +161,28 @@ The following options are available:
 
 #### Edit View Options
 
-```ts
-import type { SanitizedGlobalConfig } from 'payload'
+Custom components within the Edit View are configured under `admin.components.elements`:
 
-export const MyGlobal: SanitizedGlobalConfig = {
+```ts
+import type { GlobalConfig } from 'payload'
+
+export const MyGlobal: GlobalConfig = {
   // ...
   admin: {
     components: {
       elements: {
-        // highlight-line
-        // ...
+        // highlight-start
+        Status: '/path/to/CustomStatus',
+        SaveButton: '/path/to/CustomSaveButton',
+        PublishButton: '/path/to/CustomPublishButton',
+        // highlight-end
       },
     },
   },
 }
 ```
 
-The following options are available:
+The following elements can be customized within `admin.components.elements`:
 
 | Option                   | Description                                                                                                                                                                                                |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -189,6 +194,20 @@ The following options are available:
 | `UnpublishButton`        | Replace the default Unpublish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#unpublishbutton).                                |
 | `PreviewButton`          | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
 | `Status`                 | Replace the default Status component with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#status).                                         |
+
+<Banner type="warning">
+  **Important:** For globals, all edit view components must be configured under
+  `admin.components.elements`, not directly under `admin.components`.
+
+For example, use `admin.components.elements.Status`, not `admin.components.Status`.
+
+</Banner>
+
+<Banner type="info">
+  **Note:** Globals use `admin.components.elements` for edit view components,
+  while Collections use `admin.components.edit`. This is an important
+  distinction to remember when configuring custom components.
+</Banner>
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/docs/custom-components/edit-view.mdx
+++ b/docs/custom-components/edit-view.mdx
@@ -151,20 +151,44 @@ The following options are available:
 
 ### SaveButton
 
-The `SaveButton` property allows you to render a custom Save Button in the Edit View.
+The `SaveButton` component allows you to render a custom Save Button in the Edit View.
 
-To add a `SaveButton` component, use the `components.edit.SaveButton` property in your [Collection Config](../configuration/collections) or `components.elements.SaveButton` in your [Global Config](../configuration/globals):
+#### Configuration Path
+
+- **Collections:** `admin.components.edit.SaveButton`
+- **Globals:** `admin.components.elements.SaveButton`
+
+#### Example for Collections
 
 ```ts
 import type { CollectionConfig } from 'payload'
 
-export const MyCollection: CollectionConfig = {
-  // ...
+export const Posts: CollectionConfig = {
+  slug: 'posts',
   admin: {
     components: {
       edit: {
         // highlight-start
-        SaveButton: '/path/to/MySaveButton',
+        SaveButton: '/path/to/CustomSaveButton',
+        // highlight-end
+      },
+    },
+  },
+}
+```
+
+#### Example for Globals
+
+```ts
+import type { GlobalConfig } from 'payload'
+
+export const Header: GlobalConfig = {
+  slug: 'header',
+  admin: {
+    components: {
+      elements: {
+        // highlight-start
+        SaveButton: '/path/to/CustomSaveButton',
         // highlight-end
       },
     },
@@ -353,20 +377,50 @@ export const EditMenuItems = (props: EditViewMenuItemClientProps) => {
 
 ### SaveDraftButton
 
-The `SaveDraftButton` property allows you to render a custom Save Draft Button in the Edit View.
+The `SaveDraftButton` component allows you to render a custom Save Draft Button in the Edit View.
 
-To add a `SaveDraftButton` component, use the `components.edit.SaveDraftButton` property in your [Collection Config](../configuration/collections) or `components.elements.SaveDraftButton` in your [Global Config](../configuration/globals):
+#### Configuration Path
+
+- **Collections:** `admin.components.edit.SaveDraftButton`
+- **Globals:** `admin.components.elements.SaveDraftButton`
+
+#### Example for Collections
 
 ```ts
 import type { CollectionConfig } from 'payload'
 
-export const MyCollection: CollectionConfig = {
-  // ...
+export const Posts: CollectionConfig = {
+  slug: 'posts',
+  versions: {
+    drafts: true,
+  },
   admin: {
     components: {
       edit: {
         // highlight-start
-        SaveDraftButton: '/path/to/MySaveDraftButton',
+        SaveDraftButton: '/path/to/CustomSaveDraftButton',
+        // highlight-end
+      },
+    },
+  },
+}
+```
+
+#### Example for Globals
+
+```ts
+import type { GlobalConfig } from 'payload'
+
+export const Header: GlobalConfig = {
+  slug: 'header',
+  versions: {
+    drafts: true,
+  },
+  admin: {
+    components: {
+      elements: {
+        // highlight-start
+        SaveDraftButton: '/path/to/CustomSaveDraftButton',
         // highlight-end
       },
     },
@@ -403,20 +457,50 @@ export function MySaveDraftButton(props: SaveDraftButtonClientProps) {
 
 ### PublishButton
 
-The `PublishButton` property allows you to render a custom Publish Button in the Edit View.
+The `PublishButton` component allows you to render a custom Publish Button in the Edit View.
 
-To add a `PublishButton` component, use the `components.edit.PublishButton` property in your [Collection Config](../configuration/collections) or `components.elements.PublishButton` in your [Global Config](../configuration/globals):
+#### Configuration Path
+
+- **Collections:** `admin.components.edit.PublishButton`
+- **Globals:** `admin.components.elements.PublishButton`
+
+#### Example for Collections
 
 ```ts
 import type { CollectionConfig } from 'payload'
 
-export const MyCollection: CollectionConfig = {
-  // ...
+export const Posts: CollectionConfig = {
+  slug: 'posts',
+  versions: {
+    drafts: true,
+  },
   admin: {
     components: {
       edit: {
         // highlight-start
-        PublishButton: '/path/to/MyPublishButton',
+        PublishButton: '/path/to/CustomPublishButton',
+        // highlight-end
+      },
+    },
+  },
+}
+```
+
+#### Example for Globals
+
+```ts
+import type { GlobalConfig } from 'payload'
+
+export const Header: GlobalConfig = {
+  slug: 'header',
+  versions: {
+    drafts: true,
+  },
+  admin: {
+    components: {
+      elements: {
+        // highlight-start
+        PublishButton: '/path/to/CustomPublishButton',
         // highlight-end
       },
     },
@@ -501,20 +585,46 @@ export function MyUnpublishButton() {
 
 ### PreviewButton
 
-The `PreviewButton` property allows you to render a custom Preview Button in the Edit View.
+The `PreviewButton` component allows you to render a custom Preview Button in the Edit View.
 
-To add a `PreviewButton` component, use the `components.edit.PreviewButton` property in your [Collection Config](../configuration/collections) or `components.elements.PreviewButton` in your [Global Config](../configuration/globals):
+#### Configuration Path
+
+- **Collections:** `admin.components.edit.PreviewButton`
+- **Globals:** `admin.components.elements.PreviewButton`
+
+#### Example for Collections
 
 ```ts
 import type { CollectionConfig } from 'payload'
 
-export const MyCollection: CollectionConfig = {
-  // ...
+export const Posts: CollectionConfig = {
+  slug: 'posts',
   admin: {
+    preview: () => 'https://example.com/preview',
     components: {
       edit: {
         // highlight-start
-        PreviewButton: '/path/to/MyPreviewButton',
+        PreviewButton: '/path/to/CustomPreviewButton',
+        // highlight-end
+      },
+    },
+  },
+}
+```
+
+#### Example for Globals
+
+```ts
+import type { GlobalConfig } from 'payload'
+
+export const Header: GlobalConfig = {
+  slug: 'header',
+  admin: {
+    preview: () => 'https://example.com/preview',
+    components: {
+      elements: {
+        // highlight-start
+        PreviewButton: '/path/to/CustomPreviewButton',
         // highlight-end
       },
     },
@@ -602,20 +712,50 @@ export function MyDescriptionComponent(props: ViewDescriptionClientProps) {
 
 ### Status
 
-The `Status` property allows you to render a component that represents the collection or global status in the Edit View.
+The `Status` component displays the document's draft/published state when versioning with drafts is enabled.
 
-To add an `Status` component, use the `components.edit.Status` property in your [Collection Config](../configuration/collections):
+#### Configuration Path
+
+- **Collections:** `admin.components.edit.Status`
+- **Globals:** `admin.components.elements.Status`
+
+#### Example for Collections
 
 ```ts
 import type { CollectionConfig } from 'payload'
 
-export const MyCollection: CollectionConfig = {
-  // ...
+export const Posts: CollectionConfig = {
+  slug: 'posts',
+  versions: {
+    drafts: true,
+  },
   admin: {
     components: {
       edit: {
         // highlight-start
-        Status: '/path/to/MyStatusComponent',
+        Status: '/path/to/CustomStatus',
+        // highlight-end
+      },
+    },
+  },
+}
+```
+
+#### Example for Globals
+
+```ts
+import type { GlobalConfig } from 'payload'
+
+export const Header: GlobalConfig = {
+  slug: 'header',
+  versions: {
+    drafts: true,
+  },
+  admin: {
+    components: {
+      elements: {
+        // highlight-start
+        Status: '/path/to/CustomStatus',
         // highlight-end
       },
     },


### PR DESCRIPTION
Fixes #15413

**Collections**

- added clarifying text that edit components are configured under admin.components.edit
- updated code example to show actual component usage (Status, SaveButton, PublishButton)
- added warning banner about using correct path structure

**Globals**

- added clarifying text that edit elements are configured under admin.components.elements
- updated code example to show actual component usage
- added warning banner about correct path structure
- added info banner explaining the difference between collections and globals

**Edit View**

Updated component sections to include:

- "Configuration Path" section showing both collections and globals paths
- example for Collections
- example for Globals