### PR TITLE
feat(richtext-lexical): add custom component support to LinkJSXConverter and UploadJSXConverter

### DIFF
--- a/docs/rich-text/converting-jsx.mdx
+++ b/docs/rich-text/converting-jsx.mdx
@@ -81,97 +81,31 @@ export const MyComponent: React.FC<{
 }
 ```
 
-### Custom Link Component
+### Custom Components
 
-By default, the link converter renders standard `<a>` elements. If you want to use a framework-specific link component (e.g. Next.js `Link`), you can pass a `LinkComponent` to `LinkJSXConverter`:
+Both `LinkJSXConverter` and `UploadJSXConverter` accept optional component props, so you can use framework-specific components (e.g. `next/link`, `next/image`) without overriding the full converter logic:
 
 ```tsx
-import type {
-  DefaultNodeTypes,
-  SerializedLinkNode,
-} from '@payloadcms/richtext-lexical'
-import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
-
 import {
   type JSXConvertersFunction,
   LinkJSXConverter,
-  RichText,
+  UploadJSXConverter,
 } from '@payloadcms/richtext-lexical/react'
+import Image from 'next/image'
 import Link from 'next/link'
-import React from 'react'
 
-const internalDocToHref = ({ linkNode }: { linkNode: SerializedLinkNode }) => {
-  const { relationTo, value } = linkNode.fields.doc!
-  if (typeof value !== 'object') {
-    throw new Error('Expected value to be an object')
-  }
-  const slug = value.slug
-
-  switch (relationTo) {
-    case 'posts':
-      return `/posts/${slug}`
-    case 'pages':
-      return `/${slug}`
-    default:
-      return `/${relationTo}/${slug}`
-  }
-}
-
-const jsxConverters: JSXConvertersFunction<DefaultNodeTypes> = ({
-  defaultConverters,
-}) => ({
+const jsxConverters: JSXConvertersFunction = ({ defaultConverters }) => ({
   ...defaultConverters,
   ...LinkJSXConverter({
-    internalDocToHref,
+    internalDocToHref: ({ linkNode }) => `/${linkNode.fields.doc?.value?.slug}`,
     LinkComponent: ({ href, children, ...rest }) => (
       <Link href={href} {...rest}>
         {children}
       </Link>
     ),
   }),
-})
-
-export const MyComponent: React.FC<{
-  lexicalData: SerializedEditorState
-}> = ({ lexicalData }) => {
-  return <RichText converters={jsxConverters} data={lexicalData} />
-}
-```
-
-The `LinkComponent` receives `href`, `rel`, `target`, and `children` as props and is used for both autolink and link nodes.
-
-### Custom Upload Components
-
-The `UploadJSXConverter` accepts optional parameters for customizing how uploads are rendered:
-
-- **`ImageComponent`** – Custom component for rendering `<img>` elements. Used for images without sizes, and as the fallback inside `<picture>` for images with sizes.
-- **`LinkComponent`** – Custom component for rendering non-image file links.
-- **`buildFullUrl`** – Function that transforms upload paths into absolute URLs (e.g. for cloud storage / CDN).
-
-```tsx
-import type { DefaultNodeTypes } from '@payloadcms/richtext-lexical'
-import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
-
-import {
-  type JSXConvertersFunction,
-  RichText,
-  UploadJSXConverter,
-} from '@payloadcms/richtext-lexical/react'
-import Image from 'next/image'
-import Link from 'next/link'
-import React from 'react'
-
-const jsxConverters: JSXConvertersFunction<DefaultNodeTypes> = ({
-  defaultConverters,
-}) => ({
-  ...defaultConverters,
   ...UploadJSXConverter({
     buildFullUrl: (path) => `https://cdn.example.com${path}`,
-    LinkComponent: ({ href, children, ...rest }) => (
-      <Link href={href} {...rest}>
-        {children}
-      </Link>
-    ),
     ImageComponent: ({ alt, height, src, width }) => (
       <Image
         alt={alt ?? ''}
@@ -180,24 +114,26 @@ const jsxConverters: JSXConvertersFunction<DefaultNodeTypes> = ({
         width={width ?? 0}
       />
     ),
+    LinkComponent: ({ href, children, ...rest }) => (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    ),
   }),
 })
-
-export const MyComponent: React.FC<{
-  lexicalData: SerializedEditorState
-}> = ({ lexicalData }) => {
-  return <RichText converters={jsxConverters} data={lexicalData} />
-}
 ```
 
-<Banner type="info">
-  For images **with sizes**, the converter uses `{'<picture>'}` with `
-  {'<source>'}` tags. `ImageComponent` replaces the fallback `{'<img>'}` inside
-  `{'<picture>'}` and is also used for images without sizes. `next/image` does
-  not support `{'<picture>'}` natively, so this is the standard approach.
-</Banner>
+**`LinkJSXConverter` options:**
 
-All parameters are optional — calling `UploadJSXConverter()` with no arguments produces the same default behavior as before.
+- **`LinkComponent`** – Replaces `<a>` for both autolink and link nodes. Receives `href`, `rel`, `target`, and `children`.
+
+**`UploadJSXConverter` options:**
+
+- **`ImageComponent`** – Replaces `<img>` for images. For images with sizes, it replaces the fallback `<img>` inside `<picture>`.
+- **`LinkComponent`** – Replaces `<a>` for non-image file uploads.
+- **`buildFullUrl`** – Transforms upload paths into absolute URLs (e.g. for CDN). Applied to the main URL and all size URLs.
+
+All parameters are optional — calling `UploadJSXConverter()` with no arguments or `LinkJSXConverter({})` produces the same defaults as before.
 
 ### Lexical Blocks
 
@@ -255,7 +191,7 @@ export const MyComponent: React.FC<{
 
 You can override any of the default JSX converters by passing your custom converter, keyed to the node type, to the `converters` prop / the converters function.
 
-For common customizations like using `next/image` or `next/link`, use the built-in component props on `UploadJSXConverter` and `LinkJSXConverter` as shown in the [Custom Upload Components](#custom-upload-components) and [Custom Link Component](#custom-link-component) sections above.
+For common customizations like using `next/image` or `next/link`, use the built-in component props on `UploadJSXConverter` and `LinkJSXConverter` as shown in the [Custom Components](#custom-components) section above.
 
 For fully custom rendering logic, you can override a converter entirely by providing your own function keyed to the node type:
 

--- a/docs/rich-text/converting-jsx.mdx
+++ b/docs/rich-text/converting-jsx.mdx
@@ -81,6 +81,124 @@ export const MyComponent: React.FC<{
 }
 ```
 
+### Custom Link Component
+
+By default, the link converter renders standard `<a>` elements. If you want to use a framework-specific link component (e.g. Next.js `Link`), you can pass a `LinkComponent` to `LinkJSXConverter`:
+
+```tsx
+import type {
+  DefaultNodeTypes,
+  SerializedLinkNode,
+} from '@payloadcms/richtext-lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
+import {
+  type JSXConvertersFunction,
+  LinkJSXConverter,
+  RichText,
+} from '@payloadcms/richtext-lexical/react'
+import Link from 'next/link'
+import React from 'react'
+
+const internalDocToHref = ({ linkNode }: { linkNode: SerializedLinkNode }) => {
+  const { relationTo, value } = linkNode.fields.doc!
+  if (typeof value !== 'object') {
+    throw new Error('Expected value to be an object')
+  }
+  const slug = value.slug
+
+  switch (relationTo) {
+    case 'posts':
+      return `/posts/${slug}`
+    case 'pages':
+      return `/${slug}`
+    default:
+      return `/${relationTo}/${slug}`
+  }
+}
+
+const jsxConverters: JSXConvertersFunction<DefaultNodeTypes> = ({
+  defaultConverters,
+}) => ({
+  ...defaultConverters,
+  ...LinkJSXConverter({
+    internalDocToHref,
+    LinkComponent: ({ href, children, ...rest }) => (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    ),
+  }),
+})
+
+export const MyComponent: React.FC<{
+  lexicalData: SerializedEditorState
+}> = ({ lexicalData }) => {
+  return <RichText converters={jsxConverters} data={lexicalData} />
+}
+```
+
+The `LinkComponent` receives `href`, `rel`, `target`, and `children` as props and is used for both autolink and link nodes.
+
+### Custom Upload Components
+
+The `UploadJSXConverter` accepts optional parameters for customizing how uploads are rendered:
+
+- **`ImageComponent`** – Custom component for rendering `<img>` elements. Used for images without sizes, and as the fallback inside `<picture>` for images with sizes.
+- **`LinkComponent`** – Custom component for rendering non-image file links.
+- **`buildFullUrl`** – Function that transforms upload paths into absolute URLs (e.g. for cloud storage / CDN).
+
+```tsx
+import type { DefaultNodeTypes } from '@payloadcms/richtext-lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
+import {
+  type JSXConvertersFunction,
+  RichText,
+  UploadJSXConverter,
+} from '@payloadcms/richtext-lexical/react'
+import Image from 'next/image'
+import Link from 'next/link'
+import React from 'react'
+
+const jsxConverters: JSXConvertersFunction<DefaultNodeTypes> = ({
+  defaultConverters,
+}) => ({
+  ...defaultConverters,
+  ...UploadJSXConverter({
+    buildFullUrl: (path) => `https://cdn.example.com${path}`,
+    LinkComponent: ({ href, children, ...rest }) => (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    ),
+    ImageComponent: ({ alt, height, src, width }) => (
+      <Image
+        alt={alt ?? ''}
+        height={height ?? 0}
+        src={src}
+        width={width ?? 0}
+      />
+    ),
+  }),
+})
+
+export const MyComponent: React.FC<{
+  lexicalData: SerializedEditorState
+}> = ({ lexicalData }) => {
+  return <RichText converters={jsxConverters} data={lexicalData} />
+}
+```
+
+<Banner type="info">
+  For images **with sizes**, the converter uses `{'<picture>'}` with `
+  {'<source>'}` tags. `ImageComponent` replaces the fallback `{'<img>'}` inside
+  `{'<picture>'}` and is also used for images without sizes. `next/image` does
+  not support `{'<picture>'}` natively, so this is the standard approach.
+</Banner>
+
+All parameters are optional — calling `UploadJSXConverter()` with no arguments produces the same default behavior as before.
+
 ### Lexical Blocks
 
 If your rich text includes custom Blocks or Inline Blocks, you must supply custom converters that match each block's slug. This converter is not included by default, as Payload doesn't know how to render your custom blocks.
@@ -137,7 +255,9 @@ export const MyComponent: React.FC<{
 
 You can override any of the default JSX converters by passing your custom converter, keyed to the node type, to the `converters` prop / the converters function.
 
-Example - overriding the upload node converter to use next/image:
+For common customizations like using `next/image` or `next/link`, use the built-in component props on `UploadJSXConverter` and `LinkJSXConverter` as shown in the [Custom Upload Components](#custom-upload-components) and [Custom Link Component](#custom-link-component) sections above.
+
+For fully custom rendering logic, you can override a converter entirely by providing your own function keyed to the node type:
 
 ```tsx
 'use client'

--- a/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/converters/link.tsx
+++ b/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/converters/link.tsx
@@ -3,7 +3,16 @@ import type { JSXConverters } from '../types.js'
 
 export const LinkJSXConverter: (args: {
   internalDocToHref?: (args: { linkNode: SerializedLinkNode }) => string
-}) => JSXConverters<SerializedAutoLinkNode | SerializedLinkNode> = ({ internalDocToHref }) => ({
+  LinkComponent?: React.ComponentType<{
+    children: React.ReactNode
+    href: string
+    rel?: string
+    target?: string
+  }>
+}) => JSXConverters<SerializedAutoLinkNode | SerializedLinkNode> = ({
+  internalDocToHref,
+  LinkComponent,
+}) => ({
   autolink: ({ node, nodesToJSX }) => {
     const children = nodesToJSX({
       nodes: node.children,
@@ -11,6 +20,14 @@ export const LinkJSXConverter: (args: {
 
     const rel: string | undefined = node.fields.newTab ? 'noopener noreferrer' : undefined
     const target: string | undefined = node.fields.newTab ? '_blank' : undefined
+
+    if (LinkComponent) {
+      return (
+        <LinkComponent href={node.fields.url ?? ''} rel={rel} target={target}>
+          {children}
+        </LinkComponent>
+      )
+    }
 
     return (
       <a href={node.fields.url} {...{ rel, target }}>
@@ -36,6 +53,14 @@ export const LinkJSXConverter: (args: {
         )
         href = '#' // fallback
       }
+    }
+
+    if (LinkComponent) {
+      return (
+        <LinkComponent href={href} rel={rel} target={target}>
+          {children}
+        </LinkComponent>
+      )
     }
 
     return (

--- a/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/defaultConverters.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/defaultConverters.ts
@@ -23,6 +23,6 @@ export const defaultJSXConverters: JSXConverters<DefaultNodeTypes> = {
   ...HorizontalRuleJSXConverter,
   ...ListJSXConverter,
   ...LinkJSXConverter({}),
-  ...UploadJSXConverter,
+  ...UploadJSXConverter(),
   ...TabJSXConverter,
 }


### PR DESCRIPTION
## Summary

Adds support for passing custom `LinkComponent` and `ImageComponent` into `LinkJSXConverter` and `UploadJSXConverter`, so Next.js apps (and other frameworks) can use their own `Link` and `Image` without copying the full converter logic into their project.

### Problem

- `LinkJSXConverter` hardcodes `<a>` with no option for a custom link component (e.g. `next/link`).
- `UploadJSXConverter` hardcodes `<a>` and `<img>` with no option for `next/image` or other framework components.
- Using framework-specific components currently requires copying and maintaining ~70–90 lines of converter logic per converter.

### Changes

**`LinkJSXConverter`** — Added optional `LinkComponent` prop:
- When provided, renders the custom component instead of `<a>` for both `autolink` and `link` nodes
- Passes `href`, `rel`, `target`, and `children`
- When omitted, behavior is identical to before — no breaking change
- `internalDocToHref` continues working as before

**`UploadJSXConverter`** — Converted from static object to function with optional parameters:
- `ImageComponent` — Custom component for `<img>` elements (images without sizes + fallback inside `<picture>`)
- `LinkComponent` — Custom component for non-image file links
- `buildFullUrl` — Transforms upload paths into absolute URLs (e.g. for CDN/cloud storage)
- `UploadJSXConverter()` with no arguments produces identical behavior to before
- **Breaking change**: Direct consumers who spread `UploadJSXConverter` as an object (`...UploadJSXConverter`) must update to `...UploadJSXConverter()`

**`defaultConverters.ts`** — Updated to call `...UploadJSXConverter()`.

**Documentation** — Added a "Custom Components" section to `docs/rich-text/converting-jsx.mdx` with Next.js examples for `LinkComponent`, `ImageComponent`, and `buildFullUrl`.

### Example usage

```tsx
import Link from 'next/link'
import Image from 'next/image'
import {
  RichText,
  LinkJSXConverter,
  UploadJSXConverter,
} from '@payloadcms/richtext-lexical/react'

const jsxConverters = ({ defaultConverters }) => ({
  ...defaultConverters,
  ...LinkJSXConverter({
    internalDocToHref: ({ linkNode }) => `/${linkNode.fields.doc.value.slug}`,
    LinkComponent: ({ href, children, ...rest }) => (
      <Link href={href} {...rest}>{children}</Link>
    ),
  }),
  ...UploadJSXConverter({
    buildFullUrl: (path) => `https://cdn.example.com${path}`,
    ImageComponent: ({ alt, height, src, width }) => (
      <Image src={src} alt={alt ?? ''} width={width ?? 0} height={height ?? 0} />
    ),
  }),
})
```

## Test plan

- [x] Verify `LinkJSXConverter({})` still works (no `LinkComponent`) — renders `<a>`
- [x] Verify `LinkJSXConverter({ LinkComponent: ... })` renders the custom component for both autolink and link nodes
- [x] Verify `UploadJSXConverter()` with no args produces same output as before
- [x] Verify `UploadJSXConverter({ ImageComponent, LinkComponent, buildFullUrl })` uses custom components and URL transformation
- [x] Verify `defaultJSXConverters` still works unchanged for consumers
- [x] Verify `buildFullUrl` is applied to both the main image URL and all size URLs inside `<picture>`