### PR TITLE
fix(plugin-nested-docs): await populateBreadcrumbs in resaveChildren

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -16,6 +16,22 @@ export const resaveChildren =
 
     const parentSlug = pluginConfig?.parentFieldSlug || 'parent'
 
+    const initialDraftChildren = await req.payload.find({
+      collection: collection.slug,
+      depth: 0,
+      draft: true,
+      limit: 0,
+      locale: req.locale,
+      req,
+      where: {
+        [parentSlug]: {
+          equals: doc.id,
+        },
+      },
+    })
+
+    const draftChildren = initialDraftChildren.docs.filter((child) => child._status === 'draft')
+
     const publishedChildren = await req.payload.find({
       collection: collection.slug,
       depth: 0,
@@ -30,49 +46,32 @@ export const resaveChildren =
       },
     })
 
-    const publishedChildIds = new Set<string>(publishedChildren.docs.map((child) => child.id))
+    const childrenById = [...draftChildren, ...publishedChildren.docs].reduce<
+      Record<string, JsonObject[]>
+    >((acc, child) => {
+      acc[child.id] = acc[child.id] || []
+      acc[child.id]!.push(child)
+      return acc
+    }, {})
 
-    // For versioned collections, find draft-only children (those that have
-    // never been published). Children that have both a published and a draft
-    // version must only have their published version updated — updating both
-    // causes `createVersion` to set `latest = false` on the published version,
-    // making it inaccessible on the live site.
-    const draftOnlyChildren: JsonObject[] = []
-
-    if (collection?.versions?.drafts) {
-      const allDraftChildren = await req.payload.find({
-        collection: collection.slug,
-        depth: 0,
-        draft: true,
-        limit: 0,
-        locale: req.locale,
-        req,
-        where: {
-          [parentSlug]: {
-            equals: doc.id,
-          },
-        },
-      })
-
-      for (const child of allDraftChildren.docs) {
-        if (child._status === 'draft' && !publishedChildIds.has(child.id)) {
-          draftOnlyChildren.push(child)
+    const sortedChildren = Object.values(childrenById).flatMap((group: JsonObject[]) => {
+      return group.sort((a, b) => {
+        if (a.updatedAt !== b.updatedAt) {
+          return a.updatedAt > b.updatedAt ? 1 : -1
         }
-      }
-    }
+        return a._status === 'published' ? 1 : -1
+      })
+    })
 
-    const children: Array<{ doc: JsonObject; isDraft: boolean }> = [
-      ...publishedChildren.docs.map((doc) => ({ doc, isDraft: false })),
-      ...draftOnlyChildren.map((doc) => ({ doc, isDraft: true })),
-    ]
-
-    if (children.length) {
+    if (sortedChildren.length) {
       try {
-        for (const { doc: child, isDraft } of children) {
+        for (const child of sortedChildren) {
+          const isDraft = child._status !== 'published'
+
           await req.payload.update({
             id: child.id,
             collection: collection.slug,
-            data: populateBreadcrumbs({
+            data: await populateBreadcrumbs({
               collection,
               data: child,
               generateLabel: pluginConfig.generateLabel,

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -2,7 +2,7 @@ import type { ArrayField, Payload, RelationshipField } from 'payload'
 
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import type { Page } from './payload-types.js'
 
@@ -193,6 +193,16 @@ describe('@payloadcms/plugin-nested-docs', () => {
   })
 
   describe('versions', () => {
+    const createdPageIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      // Clean up in reverse order (children before parents)
+      for (const id of [...createdPageIDs].reverse()) {
+        await payload.delete({ collection: 'pages', id })
+      }
+      createdPageIDs.length = 0
+    })
+
     it('should preserve published version of child when parent is saved and child has unpublished draft', async () => {
       // Step 1: Create parent page and publish it
       const parentDoc = await payload.create({
@@ -203,6 +213,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
           _status: 'published',
         },
       })
+      createdPageIDs.push(parentDoc.id)
 
       // Step 2: Create child page and publish it
       const childDoc = await payload.create({
@@ -214,6 +225,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
           _status: 'published',
         },
       })
+      createdPageIDs.push(childDoc.id)
 
       // Verify initial published state
       const initialPublished = await payload.findByID({
@@ -277,6 +289,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
           _status: 'published',
         },
       })
+      createdPageIDs.push(parentDoc.id)
 
       // Create a child that is never published (draft-only)
       const draftChild = await payload.create({
@@ -288,6 +301,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
           _status: 'draft',
         },
       })
+      createdPageIDs.push(draftChild.id)
 
       expect(draftChild._status).toBe('draft')
 
@@ -311,6 +325,70 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       expect(updatedDraftChild.breadcrumbs).toHaveLength(2)
       expect(updatedDraftChild.breadcrumbs?.[0]?.url).toBe('/draft-parent-updated')
+    })
+
+    it('should update breadcrumbs for both published and draft versions when parent changes', async () => {
+      const parent = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Breadcrumb Parent',
+          slug: 'breadcrumb-parent',
+          _status: 'published',
+        },
+      })
+      createdPageIDs.push(parent.id)
+
+      const child = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Breadcrumb Child',
+          slug: 'breadcrumb-child',
+          parent: parent.id,
+          _status: 'published',
+        },
+      })
+      createdPageIDs.push(child.id)
+
+      // Create draft edit on child
+      await payload.update({
+        id: child.id,
+        collection: 'pages',
+        data: {
+          title: 'Breadcrumb Child Draft',
+        },
+        draft: true,
+      })
+
+      // Update parent slug
+      await payload.update({
+        id: parent.id,
+        collection: 'pages',
+        data: {
+          slug: 'breadcrumb-parent-updated',
+          _status: 'published',
+        },
+      })
+
+      // Published child has updated breadcrumbs and is accessible
+      const published = await payload.findByID({
+        id: child.id,
+        collection: 'pages',
+        draft: false,
+      })
+
+      expect(published._status).toBe('published')
+      expect(published.breadcrumbs?.[0]?.url).toBe('/breadcrumb-parent-updated')
+
+      // Draft child also has updated breadcrumbs
+      const draft = await payload.findByID({
+        id: child.id,
+        collection: 'pages',
+        draft: true,
+      })
+
+      expect(draft._status).toBe('draft')
+      expect(draft.title).toBe('Breadcrumb Child Draft')
+      expect(draft.breadcrumbs?.[0]?.url).toBe('/breadcrumb-parent-updated')
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14943

## Summary

The async `populateBreadcrumbs()` function was not being awaited in `resaveChildren`. This caused `payload.update()` to receive a Promise instead of the child document's data, so updates couldn't preserve the `_status` field and defaulted to the main document's draft status.

When a parent was saved, all child updates created draft versions instead of preserving the published/draft distinction. Querying with `draft: false` then returned draft data, making the published version "disappear."

The fix adds `await` to the `populateBreadcrumbs()` call.