### PR TITLE
fix(richtext-lexical): link tooltip overflows outside viewport with long URLs

### DIFF
--- a/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/LinkEditor/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/LinkEditor/index.tsx
@@ -28,7 +28,7 @@ import {
   SELECTION_CHANGE_COMMAND,
 } from 'lexical'
 import { formatAdminURL } from 'payload/shared'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import type { LinkNode } from '../../../../nodes/LinkNode.js'
 import type { LinkFields } from '../../../../nodes/types.js'
@@ -56,6 +56,7 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
   const [linkNode, setLinkNode] = useState<LinkNode>()
 
   const editorRef = useRef<HTMLDivElement | null>(null)
+  const selectedNodeRectRef = useRef<DOMRect | null>(null)
   const [linkUrl, setLinkUrl] = useState<null | string>(null)
   const [linkLabel, setLinkLabel] = useState<null | string>(null)
 
@@ -244,7 +245,8 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
 
       if (selectedNodeDomRect != null) {
         selectedNodeDomRect.y += 40
-        setFloatingElemPositionForLinkEditor(selectedNodeDomRect, editorElem, anchorElem)
+        // Store the rect for positioning in useLayoutEffect after content renders
+        selectedNodeRectRef.current = selectedNodeDomRect
       }
     } else if (activeElement == null || activeElement.className !== 'link-input') {
       if (rootElement !== null) {
@@ -346,6 +348,17 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
       void $updateLinkEditor()
     })
   }, [editor, $updateLinkEditor])
+
+  // Position the tooltip after React renders the link content
+  useLayoutEffect(() => {
+    if (!isLink || !editorRef.current || !anchorElem || !selectedNodeRectRef.current) {
+      return
+    }
+
+    // Now the DOM has the actual link element, we can position the tooltip
+    setFloatingElemPositionForLinkEditor(selectedNodeRectRef.current, editorRef.current, anchorElem)
+    // linkNode dependency ensures re-positioning when clicking between different links with the same URL
+  }, [linkUrl, linkLabel, isLink, anchorElem, linkNode])
 
   return (
     <React.Fragment>

--- a/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/index.scss
+++ b/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/index.scss
@@ -26,6 +26,8 @@
       flex-direction: row;
       flex-wrap: nowrap;
       min-height: 28px;
+      width: 100%;
+      min-width: 0;
       box-sizing: border-box;
       @extend %body;
       border: 0;
@@ -53,6 +55,7 @@
         margin-right: base(0.4);
         text-overflow: ellipsis;
         color: var(--theme-success-750);
+        min-width: 0;
 
         &:hover {
           color: var(--theme-success-850);

--- a/packages/richtext-lexical/src/lexical/utils/setFloatingElemPositionForLinkEditor.ts
+++ b/packages/richtext-lexical/src/lexical/utils/setFloatingElemPositionForLinkEditor.ts
@@ -17,12 +17,33 @@ export function setFloatingElemPositionForLinkEditor(
     return
   }
 
-  const floatingElemRect = floatingElem.getBoundingClientRect()
   const anchorElementRect = anchorElem.getBoundingClientRect()
   const editorScrollerRect = scrollerElem.getBoundingClientRect()
 
   let top = targetRect.top - verticalGap
   let left = targetRect.left - horizontalOffset
+
+  // Calculate available space on both sides to determine tooltip width
+  const availableRight = editorScrollerRect.right - left
+  const availableLeft = left - editorScrollerRect.left
+
+  // Choose the side with more space to maximize visible URL length
+  let tooltipWidth: number
+  if (availableRight >= availableLeft) {
+    tooltipWidth = availableRight
+  } else {
+    tooltipWidth = availableLeft + targetRect.width
+    left = targetRect.right - tooltipWidth
+  }
+
+  // Set explicit width to force tooltip expansion
+  floatingElem.style.width = `${tooltipWidth}px`
+  floatingElem.style.maxWidth = `${tooltipWidth}px`
+
+  // Force layout recalculation so getBoundingClientRect returns accurate dimensions
+  void floatingElem.offsetHeight
+
+  const floatingElemRect = floatingElem.getBoundingClientRect()
 
   if (top < editorScrollerRect.top) {
     top += floatingElemRect.height + targetRect.height + verticalGap * 2

--- a/packages/richtext-lexical/src/lexical/utils/setFloatingElemPositionForLinkEditor.ts
+++ b/packages/richtext-lexical/src/lexical/utils/setFloatingElemPositionForLinkEditor.ts
@@ -23,27 +23,42 @@ export function setFloatingElemPositionForLinkEditor(
   let top = targetRect.top - verticalGap
   let left = targetRect.left - horizontalOffset
 
+  // Reset width constraints to measure natural content size
+  floatingElem.style.width = 'max-content'
+  floatingElem.style.maxWidth = 'none'
+  const naturalWidth = floatingElem.scrollWidth
+
   // Calculate available space on both sides to determine tooltip width
   const availableRight = editorScrollerRect.right - left
   const availableLeft = left - editorScrollerRect.left
 
-  // Choose the side with more space to maximize visible URL length
-  let tooltipWidth: number
-  if (availableRight >= availableLeft) {
-    tooltipWidth = availableRight
+  let floatingElemRect: DOMRect
+
+  // Only constrain width if content doesn't fit in available space
+  if (naturalWidth <= availableRight) {
+    // Content fits naturally on the right, don't constrain
+    floatingElemRect = floatingElem.getBoundingClientRect()
   } else {
-    tooltipWidth = availableLeft + targetRect.width
-    left = targetRect.right - tooltipWidth
+    // Content doesn't fit on right, choose side with more space
+    const availableLeftTotal = availableLeft + targetRect.width
+    const useLeftSide = availableLeft > availableRight
+    const availableSpace = useLeftSide ? availableLeftTotal : availableRight
+    const tooltipWidth = Math.min(naturalWidth, availableSpace)
+
+    // Apply width constraint if needed
+    if (tooltipWidth < naturalWidth) {
+      floatingElem.style.width = `${tooltipWidth}px`
+      floatingElem.style.maxWidth = `${tooltipWidth}px`
+      void floatingElem.offsetHeight
+    }
+
+    // Position on chosen side
+    if (useLeftSide) {
+      left = targetRect.right - tooltipWidth
+    }
+
+    floatingElemRect = floatingElem.getBoundingClientRect()
   }
-
-  // Set explicit width to force tooltip expansion
-  floatingElem.style.width = `${tooltipWidth}px`
-  floatingElem.style.maxWidth = `${tooltipWidth}px`
-
-  // Force layout recalculation so getBoundingClientRect returns accurate dimensions
-  void floatingElem.offsetHeight
-
-  const floatingElemRect = floatingElem.getBoundingClientRect()
 
   if (top < editorScrollerRect.top) {
     top += floatingElemRect.height + targetRect.height + verticalGap * 2

--- a/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
+++ b/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
@@ -70,4 +70,276 @@ describe('Lexical Link Feature', () => {
 
     await expect(checkboxField).toBeChecked()
   })
+
+  test('long link on right stays within editor bounds', async ({ page }) => {
+    const lexical = new LexicalHelpers(page)
+
+    // Create a long paragraph to push link to the right
+    const longText =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad '
+    await lexical.editor.fill(longText + 'link')
+
+    // Select the word 'link' at the end
+    await page.keyboard.press('End')
+    for (let i = 0; i < 4; i++) {
+      await page.keyboard.press('Shift+ArrowLeft')
+    }
+
+    const linkButton = page
+      .locator('.rich-text-lexical__wrap .fixed-toolbar .toolbar-popup__button-link')
+      .first()
+    await linkButton.click()
+
+    const longUrl =
+      'https://example.com/some/very/long/path/that/should/cause/the/tooltip/to/overflow/when/displayed/in/the/editor/with/many/more/segments/to/make/it/even/longer'
+    const urlField = lexical.drawer.locator('#field-url')
+    await urlField.click()
+    await urlField.clear()
+    await urlField.pressSequentially(longUrl)
+    await lexical.save('drawer')
+
+    const linkElement = lexical.editor.locator('a').first()
+    await expect(linkElement).toBeVisible()
+
+    // Trigger tooltip by dispatching mouseover event
+    await page.evaluate(() => {
+      const link = document.querySelector('a')
+      if (link) {
+        const rect = link.getBoundingClientRect()
+        link.dispatchEvent(
+          new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+          }),
+        )
+      }
+    })
+
+    const tooltip = page.locator('.link-editor')
+    await expect(tooltip).toBeVisible()
+
+    // Assert tooltip stays within editor bounds
+    await expect
+      .poll(async () => {
+        const editorRect = await lexical.editor.evaluate((el) => {
+          const parent = el.parentElement
+          if (!parent) {
+            throw new Error('Editor parent not found')
+          }
+          return parent.getBoundingClientRect()
+        })
+
+        const tooltipRect = await tooltip.evaluate((el) => el.getBoundingClientRect())
+
+        return {
+          leftInBounds: tooltipRect.left >= editorRect.left - 10,
+          rightInBounds: tooltipRect.right <= editorRect.right + 10,
+          topInBounds: tooltipRect.top >= editorRect.top - 100,
+        }
+      })
+      .toEqual({
+        leftInBounds: true,
+        rightInBounds: true,
+        topInBounds: true,
+      })
+  })
+
+  test('long link on left stays within editor bounds', async ({ page }) => {
+    const lexical = new LexicalHelpers(page)
+
+    await lexical.editor.fill('link')
+    await lexical.editor.selectText()
+
+    const linkButton = page
+      .locator('.rich-text-lexical__wrap .fixed-toolbar .toolbar-popup__button-link')
+      .first()
+    await linkButton.click()
+
+    const longUrl =
+      'https://example.com/some/very/long/path/that/should/cause/the/tooltip/to/overflow/when/displayed/in/the/editor/with/many/more/segments/to/make/it/even/longer'
+    const urlField = lexical.drawer.locator('#field-url')
+    await urlField.click()
+    await urlField.clear()
+    await urlField.pressSequentially(longUrl)
+    await lexical.save('drawer')
+
+    const linkElement = lexical.editor.locator('a').first()
+    await expect(linkElement).toBeVisible()
+
+    // Trigger tooltip by dispatching mouseover event
+    await page.evaluate(() => {
+      const link = document.querySelector('a')
+      if (link) {
+        const rect = link.getBoundingClientRect()
+        link.dispatchEvent(
+          new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+          }),
+        )
+      }
+    })
+
+    const tooltip = page.locator('.link-editor')
+    await expect(tooltip).toBeVisible()
+
+    // Assert tooltip stays within editor bounds
+    await expect
+      .poll(async () => {
+        const editorRect = await lexical.editor.evaluate((el) => {
+          const parent = el.parentElement
+          if (!parent) {
+            throw new Error('Editor parent not found')
+          }
+          return parent.getBoundingClientRect()
+        })
+
+        const tooltipRect = await tooltip.evaluate((el) => el.getBoundingClientRect())
+
+        return {
+          leftInBounds: tooltipRect.left >= editorRect.left - 10,
+          rightInBounds: tooltipRect.right <= editorRect.right + 10,
+        }
+      })
+      .toEqual({
+        leftInBounds: true,
+        rightInBounds: true,
+      })
+  })
+
+  test('short link on left uses natural width', async ({ page }) => {
+    const lexical = new LexicalHelpers(page)
+
+    await lexical.editor.fill('link')
+    await lexical.editor.selectText()
+
+    const linkButton = page
+      .locator('.rich-text-lexical__wrap .fixed-toolbar .toolbar-popup__button-link')
+      .first()
+    await linkButton.click()
+
+    const shortUrl = 'https://google.com'
+    const urlField = lexical.drawer.locator('#field-url')
+    await urlField.click()
+    await urlField.clear()
+    await urlField.pressSequentially(shortUrl)
+    await lexical.save('drawer')
+
+    const linkElement = lexical.editor.locator('a').first()
+    await expect(linkElement).toBeVisible()
+
+    // Trigger tooltip
+    await page.evaluate(() => {
+      const link = document.querySelector('a')
+      if (link) {
+        const rect = link.getBoundingClientRect()
+        link.dispatchEvent(
+          new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+          }),
+        )
+      }
+    })
+
+    const tooltip = page.locator('.link-editor')
+    await expect(tooltip).toBeVisible()
+
+    // Assert tooltip is not spanning full width
+    await expect
+      .poll(async () => {
+        const editorRect = await lexical.editor.evaluate((el) => {
+          const parent = el.parentElement
+          if (!parent) {
+            throw new Error('Editor parent not found')
+          }
+          return parent.getBoundingClientRect()
+        })
+
+        const tooltipRect = await tooltip.evaluate((el) => el.getBoundingClientRect())
+        const editorWidth = editorRect.right - editorRect.left
+
+        // Tooltip should be much smaller than full editor width
+        return tooltipRect.width < editorWidth * 0.5
+      })
+      .toBe(true)
+  })
+
+  test('short link on right uses natural width', async ({ page }) => {
+    const lexical = new LexicalHelpers(page)
+
+    // Push link to right side
+    const longText =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad '
+    await lexical.editor.fill(longText + 'link')
+
+    await page.keyboard.press('End')
+    for (let i = 0; i < 4; i++) {
+      await page.keyboard.press('Shift+ArrowLeft')
+    }
+
+    const linkButton = page
+      .locator('.rich-text-lexical__wrap .fixed-toolbar .toolbar-popup__button-link')
+      .first()
+    await linkButton.click()
+
+    const shortUrl = 'https://google.com'
+    const urlField = lexical.drawer.locator('#field-url')
+    await urlField.click()
+    await urlField.clear()
+    await urlField.pressSequentially(shortUrl)
+    await lexical.save('drawer')
+
+    const linkElement = lexical.editor.locator('a').last()
+    await expect(linkElement).toBeVisible()
+
+    // Trigger tooltip
+    await page.evaluate(() => {
+      const links = document.querySelectorAll('a')
+      const link = links[links.length - 1]
+      if (link) {
+        const rect = link.getBoundingClientRect()
+        link.dispatchEvent(
+          new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+          }),
+        )
+      }
+    })
+
+    const tooltip = page.locator('.link-editor')
+    await expect(tooltip).toBeVisible()
+
+    // Assert tooltip is not spanning full width
+    await expect
+      .poll(async () => {
+        const editorRect = await lexical.editor.evaluate((el) => {
+          const parent = el.parentElement
+          if (!parent) {
+            throw new Error('Editor parent not found')
+          }
+          return parent.getBoundingClientRect()
+        })
+
+        const tooltipRect = await tooltip.evaluate((el) => el.getBoundingClientRect())
+        const editorWidth = editorRect.right - editorRect.left
+
+        // Tooltip should be much smaller than full editor width
+        return tooltipRect.width < editorWidth * 0.5
+      })
+      .toBe(true)
+  })
 })


### PR DESCRIPTION
### What
Link tooltip overflows outside the editor viewport when hovering links with long URLs, making the edit button inaccessible.

### Why
The tooltip had no width constraints and always expanded from the link position rightward, regardless of available space. This caused overflow when links were positioned toward the right side of the editor.

### How
Fixed React timing by moving positioning logic to `useLayoutEffect` that runs after content renders. Added `selectedNodeRectRef` to store positioning data and `linkNode` dependency to handle repositioning between same-URL links.

Improved positioning to calculate available space on both sides and choose the side with more room. Use `Math.min(naturalWidth, availableSpace)` to only constrain width when necessary—short links use natural width, long links constrain to available space with ellipsis.

Added `min-width: 0` CSS to `.link-input` and anchor elements to enable flex shrinking behavior. Added 4 e2e tests covering long/short links on left/right sides.

### Before
<img width="1239" height="223" alt="Screenshot 2026-02-10 at 2 21 41 PM" src="https://github.com/user-attachments/assets/7b16a1e5-701e-479f-b257-61fa6997da02" />

<img width="1504" height="398" alt="Screenshot 2026-02-10 at 2 21 55 PM" src="https://github.com/user-attachments/assets/163dec9e-aa49-4021-ab91-60ce76f7d7a8" />


### After

#### Long urls
<img width="1223" height="222" alt="Screenshot 2026-02-10 at 12 18 33 PM" src="https://github.com/user-attachments/assets/cd93ff6a-c68d-4f1f-80b5-9ead70fcff9e" />

<img width="1227" height="226" alt="Screenshot 2026-02-10 at 12 18 42 PM" src="https://github.com/user-attachments/assets/61291806-acb9-48d9-8983-22baf577e0df" />

#### Short urls
<img width="1241" height="243" alt="Screenshot 2026-02-10 at 5 12 56 PM" src="https://github.com/user-attachments/assets/5b94b834-169a-4a99-8567-822c31e7b66b" />

<img width="1237" height="220" alt="Screenshot 2026-02-10 at 5 13 05 PM" src="https://github.com/user-attachments/assets/b8decbfd-2c6b-4751-9b3d-475cc486b0d4" />


Fixes #15569 
