### PR TITLE
fix: use optional chaining for adminThumbnail size lookup to prevent crash

### DIFF
--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -46,13 +46,13 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
             config,
             filename:
               typeof adminThumbnail === 'string'
-                ? (originalDoc.sizes?.[adminThumbnail].filename as string)
+                ? (originalDoc.sizes?.[adminThumbnail]?.filename as string)
                 : undefined,
             relative: false,
             serverURL: req.payload.config.serverURL,
             urlOrPath:
               typeof adminThumbnail === 'string'
-                ? (originalDoc.sizes?.[adminThumbnail].url as string)
+                ? (originalDoc.sizes?.[adminThumbnail]?.url as string)
                 : undefined,
           })
         },

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -20,6 +20,7 @@ import { tempFileHandler } from '../../packages/payload/src/uploads/fetchAPI-mul
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { createStreamableFile } from './createStreamableFile.js'
 import {
+  adminThumbnailSizeSlug,
   allowListMediaSlug,
   anyImagesSlug,
   enlargeSlug,
@@ -562,6 +563,33 @@ describe('Collections - Uploads', () => {
         })
         expect(await fileExists(path.join(expectedPath, doc.filename))).toBe(true)
         expect(doc.mimeType).toEqual('image/svg+xml')
+      })
+
+      it('should not crash when adminThumbnail size is not generated', async () => {
+        const svgFilePath = path.resolve(dirname, './svgWithXml.svg')
+        const fileBuffer = fs.readFileSync(svgFilePath)
+
+        // SVGs cannot be resized, so sizes.small should have null fields
+        const doc = await payload.create({
+          collection: adminThumbnailSizeSlug as CollectionSlug,
+          data: {},
+          file: {
+            data: fileBuffer,
+            mimetype: 'image/svg+xml',
+            name: 'test-thumbnail.svg',
+            size: fileBuffer.length,
+          },
+        })
+
+        expect(doc.id).toBeDefined()
+        expect(doc.filename).toBeDefined()
+        expect(doc.thumbnailURL).toBeNull()
+
+        // Clean up
+        await payload.delete({
+          collection: adminThumbnailSizeSlug as CollectionSlug,
+          id: doc.id,
+        })
       })
     })
 


### PR DESCRIPTION
Fixes issue with thumbnail lookups for documents without sizes.

Introduced: https://github.com/payloadcms/payload/pull/15232