### PR TITLE
fix(ui): prevent Tabs field crash when stored tabIndex exceeds tab count

### DIFF
--- a/packages/ui/src/fields/Tabs/index.tsx
+++ b/packages/ui/src/fields/Tabs/index.tsx
@@ -69,7 +69,7 @@ const TabsFieldComponent: TabsFieldClientComponent = (props) => {
 
   const activeTabInfo = tabStates[activeTabIndex]
   const activeTabConfig = activeTabInfo?.tab
-  const activeTabDescription = activeTabConfig.admin?.description ?? activeTabConfig.description
+  const activeTabDescription = activeTabConfig?.admin?.description ?? activeTabConfig?.description
 
   const activeTabStaticDescription =
     typeof activeTabDescription === 'function'
@@ -120,7 +120,7 @@ const TabsFieldComponent: TabsFieldClientComponent = (props) => {
           ? existingPreferences?.fields?.[path]?.tabIndex
           : existingPreferences?.fields?.[tabsPrefKey]?.tabIndex
 
-        const newIndex = initialIndex || 0
+        const newIndex = typeof initialIndex === 'number' && initialIndex < tabStates.length ? initialIndex : 0
         setActiveTabIndex(newIndex)
       }
       void getInitialPref()


### PR DESCRIPTION
## Summary

Fixes #15587

The `TabsFieldComponent` crashes with `Cannot read properties of undefined (reading 'admin')` when a stored tab preference (`tabIndex`) references a tab that no longer exists.

## Root Cause

When a developer reduces the number of tabs in a collection config, documents previously viewed with a higher tab selected retain a stale `tabIndex` in `payload_preferences`. On next load, `tabStates[activeTabIndex]` returns `undefined`, and `activeTabConfig.admin?.description` throws because `activeTabConfig` is `undefined`.

## Changes

Two defensive fixes in `packages/ui/src/fields/Tabs/index.tsx`:

1. **Optional chaining on `activeTabConfig`** — prevents the crash when `activeTabConfig` is `undefined`:
   ```diff
   - const activeTabDescription = activeTabConfig.admin?.description ?? activeTabConfig.description
   + const activeTabDescription = activeTabConfig?.admin?.description ?? activeTabConfig?.description
   ```

2. **Clamp restored tabIndex to valid range** — prevents the stale preference from being used in the first place:
   ```diff
   - const newIndex = initialIndex || 0
   + const newIndex = typeof initialIndex === 'number' && initialIndex < tabStates.length ? initialIndex : 0
   ```

## Test Plan

- Remove a tab from a collection that has documents with stored tab preferences for higher indices
- Verify the document loads without crashing, defaulting to the first tab

Made with [Cursor](https://cursor.com)