### PR TITLE
fix(next): handle undefined fieldTab in version diff tabs

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Tabs/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Tabs/index.tsx
@@ -29,10 +29,13 @@ export const Tabs: TabsFieldDiffClientComponent = (props) => {
           return null
         }
         const fieldTab = field.tabs?.[i]
+        if (!fieldTab) {
+          return null
+        }
         return (
           <div className={`${baseClass}__tab`} key={i}>
             {(() => {
-              if ('name' in fieldTab && selectedLocales && fieldTab.localized) {
+              if (fieldTab && 'name' in fieldTab && selectedLocales && fieldTab.localized) {
                 // Named localized tab
                 return selectedLocales.map((locale, index) => {
                   const localizedTabProps: TabProps = {

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Tabs/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Tabs/index.tsx
@@ -35,7 +35,7 @@ export const Tabs: TabsFieldDiffClientComponent = (props) => {
         return (
           <div className={`${baseClass}__tab`} key={i}>
             {(() => {
-              if (fieldTab && 'name' in fieldTab && selectedLocales && fieldTab.localized) {
+              if ('name' in fieldTab && selectedLocales && fieldTab.localized) {
                 // Named localized tab
                 return selectedLocales.map((locale, index) => {
                   const localizedTabProps: TabProps = {


### PR DESCRIPTION
Fixes application error when viewing versions with tabs fields.

**Issue:** `field.tabs?.[i]` can return undefined when schema changes 
between versions, causing error when using `in` operator.

**Fix:** Added null checks before accessing fieldTab properties.


### What?

Fixes application error when viewing versions of documents with tabs fields.

### Why?

When viewing version diffs, `field.tabs?.[i]` can return `undefined` if the schema 
changed between versions (e.g., tabs were added/removed/reordered). The code was 
using the `in` operator on this potentially undefined value, which throws a runtime 
error and blocks users from viewing/restoring versions.

### How?

Added two safety checks in `RenderFieldsToDiff/fields/Tabs/index.tsx`:

1. Early return guard (line 32-34): Skip rendering if `fieldTab` is undefined
2. Defensive null check (line 38): Added `fieldTab &&` before `'name' in fieldTab`

This gracefully handles schema mismatches by skipping tabs that don't exist in 
the comparison version, allowing other valid tabs to render correctly.

**Code diff:**
  const fieldTab = field.tabs?.[i]
+ if (!fieldTab) {
+   return null
+ }
  return (
    <div className={`${baseClass}__tab`} key={i}>
      {(() => {
-       if ('name' in fieldTab && selectedLocales && fieldTab.localized) {
+       if (fieldTab && 'name' in fieldTab && selectedLocales && fieldTab.localized) {

Fixes #15589 
