### PR TITLE
test: trash e2e tests check URL before navigation completes

### DIFF
--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -1091,6 +1091,8 @@ describe('Trash', () => {
       await expect(page.locator('.row-1 .cell-name')).toHaveText('Dev')
       await page.locator('.row-1 .cell-name').click()
 
+      await page.locator('input[name="email"]').waitFor({ state: 'visible' })
+
       await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}/)
     })
 
@@ -1100,6 +1102,8 @@ describe('Trash', () => {
       await page.goto(usersUrl.trash)
 
       await page.locator('.row-1 .cell-name').click()
+
+      await page.locator('input[name="email"]').waitFor({ state: 'visible' })
 
       await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}/)
 
@@ -1117,6 +1121,8 @@ describe('Trash', () => {
 
       await expect(page.locator('.row-1 .cell-name')).toHaveText('Dev')
       await page.locator('.row-1 .cell-name').click()
+
+      await page.locator('.doc-controls__controls #action-restore').waitFor({ state: 'visible' })
 
       await expect(page).toHaveURL(/\/users\/trash\/[a-f0-9]{24}/)
 

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -94,9 +94,7 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
-  user: User & {
-    collection: 'users';
-  };
+  user: User;
   jobs: {
     tasks: unknown;
     workflows: unknown;
@@ -181,6 +179,7 @@ export interface User {
       }[]
     | null;
   password?: string | null;
+  collection: 'users';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What

Fixes three trash e2e tests that were checking the URL immediately after clicking a row, before the navigation had completed.

### Why

The tests clicked `.row-1 .cell-name` and immediately asserted `toHaveURL(/\/users\/trash\/[a-f0-9]{24}/)` without waiting. In CI environments, the URL hadn't changed yet, causing the assertion to see the list view URL instead of the edit view URL and fail after timing out.

### How

Added `waitFor({ state: 'visible' })` calls for destination page elements (email input field and restore button) before asserting the URL, ensuring navigation is complete before checking.