### PR TITLE
fix(plugin-mcp): exclude virtual fields from create/update tool schemas

### DIFF
--- a/packages/plugin-mcp/src/mcp/getMcpHandler.ts
+++ b/packages/plugin-mcp/src/mcp/getMcpHandler.ts
@@ -117,6 +117,10 @@ export const getMCPHandler = (
             const allowFind: boolean | undefined = toolCapabilities?.find as boolean
             const allowDelete: boolean | undefined = toolCapabilities?.delete as boolean
 
+            const collectionConfig = payload.config.collections.find(
+              (c) => c.slug === enabledCollectionSlug,
+            )
+
             if (allowCreate) {
               registerTool(
                 allowCreate,
@@ -130,6 +134,7 @@ export const getMCPHandler = (
                     enabledCollectionSlug,
                     collectionsPluginConfig,
                     schema,
+                    collectionConfig?.fields,
                   ),
                 payload,
                 useVerboseLogs,
@@ -148,6 +153,7 @@ export const getMCPHandler = (
                     enabledCollectionSlug,
                     collectionsPluginConfig,
                     schema,
+                    collectionConfig?.fields,
                   ),
                 payload,
                 useVerboseLogs,
@@ -208,6 +214,8 @@ export const getMCPHandler = (
             const allowFind: boolean | undefined = toolCapabilities?.['find'] as boolean
             const allowUpdate: boolean | undefined = toolCapabilities?.['update'] as boolean
 
+            const globalConfig = payload.config.globals.find((g) => g.slug === enabledGlobalSlug)
+
             if (allowFind) {
               registerTool(
                 allowFind,
@@ -238,6 +246,7 @@ export const getMCPHandler = (
                     enabledGlobalSlug,
                     globalsPluginConfig,
                     schema,
+                    globalConfig?.fields,
                   ),
                 payload,
                 useVerboseLogs,

--- a/packages/plugin-mcp/src/mcp/tools/global/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/global/update.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { JSONSchema4 } from 'json-schema'
-import type { PayloadRequest, SelectType, TypedUser } from 'payload'
+import type { Field, PayloadRequest, SelectType, TypedUser } from 'payload'
 
 import { z } from 'zod'
 
@@ -18,6 +18,7 @@ export const updateGlobalTool = (
   globalSlug: string,
   globals: PluginMCPServerConfig['globals'],
   schema: JSONSchema4,
+  fields?: Field[],
 ) => {
   const tool = async (
     data: string,
@@ -147,7 +148,7 @@ ${JSON.stringify(result, null, 2)}
   }
 
   if (globals?.[globalSlug]?.enabled) {
-    const convertedFields = convertCollectionSchemaToZod(schema)
+    const convertedFields = convertCollectionSchemaToZod(schema, fields)
 
     // Make all fields optional for partial updates (PATCH-style)
     const optionalFields = Object.fromEntries(

--- a/packages/plugin-mcp/src/mcp/tools/resource/create.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/create.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { JSONSchema4 } from 'json-schema'
-import type { PayloadRequest, SelectType, TypedUser } from 'payload'
+import type { Field, PayloadRequest, SelectType, TypedUser } from 'payload'
 
 import { z } from 'zod'
 
@@ -17,6 +17,7 @@ export const createResourceTool = (
   collectionSlug: string,
   collections: PluginMCPServerConfig['collections'],
   schema: JSONSchema4,
+  fields?: Field[],
 ) => {
   const tool = async (
     data: string,
@@ -140,7 +141,7 @@ ${JSON.stringify(result, null, 2)}
   }
 
   if (collections?.[collectionSlug]?.enabled) {
-    const convertedFields = convertCollectionSchemaToZod(schema)
+    const convertedFields = convertCollectionSchemaToZod(schema, fields)
 
     // Create a new schema that combines the converted fields with create-specific parameters
     const createResourceSchema = z.object({

--- a/packages/plugin-mcp/src/mcp/tools/resource/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/update.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { JSONSchema4 } from 'json-schema'
-import type { PayloadRequest, SelectType, TypedUser } from 'payload'
+import type { Field, PayloadRequest, SelectType, TypedUser } from 'payload'
 
 import { z } from 'zod'
 
@@ -17,6 +17,7 @@ export const updateResourceTool = (
   collectionSlug: string,
   collections: PluginMCPServerConfig['collections'],
   schema: JSONSchema4,
+  fields?: Field[],
 ) => {
   const tool = async (
     data: string,
@@ -280,7 +281,7 @@ ${JSON.stringify(errors, null, 2)}
   }
 
   if (collections?.[collectionSlug]?.enabled) {
-    const convertedFields = convertCollectionSchemaToZod(schema)
+    const convertedFields = convertCollectionSchemaToZod(schema, fields)
 
     // Create a new schema that combines the converted fields with update-specific parameters
     // Use .partial() to make all fields optional for partial updates

--- a/test/plugin-mcp/collections/Posts.ts
+++ b/test/plugin-mcp/collections/Posts.ts
@@ -32,6 +32,17 @@ export const Posts: CollectionConfig = {
         description: 'The author of the post',
       },
     },
+    {
+      name: 'relatedProducts',
+      type: 'join',
+      collection: 'products',
+      on: 'relatedPost',
+    },
+    {
+      name: 'computedLabel',
+      type: 'text',
+      virtual: true,
+    },
   ],
   hooks: {
     beforeRead: [

--- a/test/plugin-mcp/collections/Products.ts
+++ b/test/plugin-mcp/collections/Products.ts
@@ -15,5 +15,10 @@ export const Products: CollectionConfig = {
       name: 'price',
       type: 'number',
     },
+    {
+      name: 'relatedPost',
+      type: 'relationship',
+      relationTo: 'posts',
+    },
   ],
 }

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -341,6 +341,10 @@ describe('@payloadcms/plugin-mcp', () => {
         'Optional: define exactly which fields you\'d like to create (JSON), e.g., \'{"title": "My Post"}\'',
       )
 
+      // Virtual fields should NOT appear in create schema
+      expect(json.result.tools[1].inputSchema.properties.relatedProducts).toBeUndefined()
+      expect(json.result.tools[1].inputSchema.properties.computedLabel).toBeUndefined()
+
       expect(json.result.tools[2].inputSchema).toBeDefined()
       expect(json.result.tools[2].inputSchema.required).not.toBeDefined()
       expect(json.result.tools[2].inputSchema.type).toBe('object')
@@ -547,6 +551,10 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(updateToolSchema.inputSchema.properties.select.description).toContain(
         'Optional: define exactly which fields you\'d like to return in the response (JSON), e.g., \'{"title": "My Post"}\'',
       )
+
+      // Virtual fields should NOT appear in update schema
+      expect(updateToolSchema.inputSchema.properties.relatedProducts).toBeUndefined()
+      expect(updateToolSchema.inputSchema.properties.computedLabel).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
### What?

Excludes virtual fields (join fields, `virtual: true`, and `virtual: 'path.to.source'`) from the MCP plugin's create and update tool schemas so AI agents don't attempt to set non-writable fields.

### Why?

Virtual fields exist in API responses but have no database columns — they're computed values (joins, derived paths, hook-populated). When these appear in MCP tool schemas, AI agents waste tokens trying to set them and get confused by validation errors.

### How?

- `convertCollectionSchemaToZod` now accepts an optional `fields` parameter (the Payload collection/global field config)
- Uses `flattenAllFields` + `fieldIsVirtual` from `payload/shared` to identify virtual field names, plus an explicit `type === 'join'` check (join fields don't have `virtual: true` set)
- Removes matching properties from the JSON schema before Zod conversion
- `getMcpHandler.ts` looks up the collection/global config and passes `.fields` through to create/update tool registrations
- Find/read operations are unaffected — virtual fields still appear in responses

**Test additions:**
- Added `relatedProducts` (join) and `computedLabel` (virtual) fields to the Posts test collection
- Added assertions verifying these fields are absent from `createPosts` and `updatePosts` tool schemas