### PR TITLE
docs: outline html lexical content conversion

### DIFF
--- a/docs/rich-text/converting-html.mdx
+++ b/docs/rich-text/converting-html.mdx
@@ -227,6 +227,10 @@ export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
 
 If you need to convert raw HTML into a Lexical editor state, use `convertHTMLToLexical` from `@payloadcms/richtext-lexical`, along with the [editorConfigFactory to retrieve the editor config](/docs/rich-text/converters#retrieving-the-editor-config):
 
+<Banner type="warning">
+  **Important:** When converting HTML to Lexical, `<img>` tags are NOT automatically uploaded to prevent unintended database modifications. Images will be omitted from the conversion unless you provide the proper data attributes. See [Converting HTML with Images](#converting-html-with-images) for guidance on handling images.
+</Banner>
+
 ```ts
 import {
   convertHTMLToLexical,
@@ -235,7 +239,7 @@ import {
 // Make sure you have jsdom and @types/jsdom installed
 import { JSDOM } from 'jsdom'
 
-const html = convertHTMLToLexical({
+const lexicalJSON = convertHTMLToLexical({
   editorConfig: await editorConfigFactory.default({
     config, // Your Payload Config
   }),
@@ -243,3 +247,212 @@ const html = convertHTMLToLexical({
   JSDOM, // Pass in the JSDOM import; it's not bundled to keep package size small
 })
 ```
+
+## Converting HTML with Images
+
+When converting HTML to Lexical, `<img>` tags require special handling because Payload does not automatically upload images to prevent unintended database modifications. Here are three approaches to handle images during HTML-to-Lexical conversion:
+
+### Approach 1: Pre-upload Images and Use Data Attributes (Recommended)
+
+The most reliable approach is to upload images to Payload first, then reference them in your HTML using special data attributes before conversion.
+
+```ts
+import {
+  convertHTMLToLexical,
+  editorConfigFactory,
+} from '@payloadcms/richtext-lexical'
+import { getPayload } from 'payload'
+import { JSDOM } from 'jsdom'
+import config from '@payload-config'
+
+const payload = await getPayload({ config })
+
+// Step 1: Upload the image to Payload
+const uploadedMedia = await payload.create({
+  collection: 'media', // Your upload collection slug
+  data: {
+    alt: 'My image description',
+  },
+  filePath: '/path/to/local/image.jpg', // or file: fileData for file uploads
+})
+
+// Step 2: Construct HTML with the proper data attributes
+const htmlWithImage = `
+  <p>Some text content</p>
+  <img
+    src="${uploadedMedia.url}"
+    data-lexical-upload-id="${uploadedMedia.id}"
+    data-lexical-upload-relation-to="media"
+    alt="My image description"
+  />
+  <p>More content</p>
+`
+
+// Step 3: Convert to Lexical
+const lexicalJSON = convertHTMLToLexical({
+  editorConfig: await editorConfigFactory.default({ config }),
+  html: htmlWithImage,
+  JSDOM,
+})
+
+// The lexicalJSON will now contain a proper upload node
+```
+
+**Required data attributes:**
+
+- `data-lexical-upload-id`: The ID of the uploaded document
+- `data-lexical-upload-relation-to`: The collection slug (e.g., 'media')
+
+### Approach 2: Parse and Upload Images Before Conversion
+
+For bulk content migration or when dealing with external image URLs, parse the HTML first, upload images, then replace the image tags with proper attributes.
+
+```ts
+import {
+  convertHTMLToLexical,
+  editorConfigFactory,
+} from '@payloadcms/richtext-lexical'
+import { getPayload } from 'payload'
+import { JSDOM } from 'jsdom'
+import config from '@payload-config'
+
+async function convertHTMLWithImageUpload(htmlString: string) {
+  const payload = await getPayload({ config })
+
+  // Step 1: Parse HTML to find all images
+  const dom = new JSDOM(htmlString)
+  const images = dom.window.document.querySelectorAll('img')
+
+  // Step 2: Upload each image and update the DOM
+  for (const img of Array.from(images)) {
+    const imageUrl = img.getAttribute('src')
+
+    if (!imageUrl) continue
+
+    try {
+      // Download the image (if external URL)
+      const response = await fetch(imageUrl)
+      const arrayBuffer = await response.arrayBuffer()
+      const buffer = Buffer.from(arrayBuffer)
+
+      // Upload to Payload
+      const uploadedMedia = await payload.create({
+        collection: 'media',
+        data: {
+          alt: img.getAttribute('alt') || '',
+        },
+        file: {
+          data: buffer,
+          mimetype: response.headers.get('content-type') || 'image/jpeg',
+          name: imageUrl.split('/').pop() || 'image.jpg',
+          size: buffer.length,
+        },
+      })
+
+      // Update the img tag with data attributes
+      img.setAttribute('data-lexical-upload-id', String(uploadedMedia.id))
+      img.setAttribute('data-lexical-upload-relation-to', 'media')
+      img.setAttribute('src', uploadedMedia.url)
+    } catch (error) {
+      console.error(`Failed to upload image: ${imageUrl}`, error)
+      // Optionally remove the img tag if upload fails
+      img.remove()
+    }
+  }
+
+  // Step 3: Convert the updated HTML to Lexical
+  const updatedHTML = dom.window.document.body.innerHTML
+
+  return convertHTMLToLexical({
+    editorConfig: await editorConfigFactory.default({ config }),
+    html: updatedHTML,
+    JSDOM,
+  })
+}
+
+// Usage
+const lexicalJSON = await convertHTMLWithImageUpload(
+  '<p>Text</p><img src="https://example.com/image.jpg" />',
+)
+```
+
+### Approach 3: Manually Construct Upload Nodes
+
+If you already have upload IDs and want to build the Lexical JSON structure manually, you can construct upload nodes directly.
+
+```ts
+import { v4 as uuid } from 'uuid'
+
+// Manually construct Lexical JSON with upload nodes
+const lexicalJSON = {
+  root: {
+    type: 'root',
+    format: '',
+    indent: 0,
+    version: 1,
+    children: [
+      {
+        type: 'paragraph',
+        format: '',
+        indent: 0,
+        version: 1,
+        children: [
+          {
+            type: 'text',
+            format: 0,
+            text: 'Some text content',
+            mode: 'normal',
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+      },
+      {
+        type: 'upload',
+        format: '',
+        version: 3,
+        relationTo: 'media',
+        value: 'your-upload-id-here', // ID of the uploaded document
+        fields: {}, // Any additional fields configured for the upload feature
+        id: uuid(), // Unique ID for this node instance (not the upload document ID)
+      },
+    ],
+    direction: 'ltr',
+  },
+}
+
+// Save to your collection
+await payload.create({
+  collection: 'pages',
+  data: {
+    title: 'My Page',
+    content: lexicalJSON,
+  },
+})
+```
+
+### Troubleshooting
+
+**Images disappear during conversion:**
+
+- Ensure images have both `data-lexical-upload-id` and `data-lexical-upload-relation-to` attributes
+- Verify the upload ID exists in your upload collection
+- Check that the `relationTo` value matches your upload collection slug
+
+**"Cannot read property 'id' of undefined" errors:**
+
+- The upload document may not exist - verify the ID is correct
+- Ensure the upload collection is properly configured
+- Check that the referenced upload hasn't been deleted
+
+**Images work in the admin UI but not in conversion:**
+
+- The admin UI handles pending uploads differently than server-side conversion
+- Server-side conversion requires existing upload IDs, not pending uploads
+- Always upload images before converting HTML
+
+<Banner type="success">
+  **Tip:** For large-scale content migrations, consider creating a migration
+  script that processes HTML in batches, uploads images in parallel with rate
+  limiting, and handles errors gracefully.
+</Banner>

--- a/docs/rich-text/converting-html.mdx
+++ b/docs/rich-text/converting-html.mdx
@@ -228,7 +228,7 @@ export const MyComponent = ({ data }: { data: SerializedEditorState }) => {
 If you need to convert raw HTML into a Lexical editor state, use `convertHTMLToLexical` from `@payloadcms/richtext-lexical`, along with the [editorConfigFactory to retrieve the editor config](/docs/rich-text/converters#retrieving-the-editor-config):
 
 <Banner type="warning">
-  **Important:** When converting HTML to Lexical, `<img>` tags are NOT automatically uploaded to prevent unintended database modifications. Images will be omitted from the conversion unless you provide the proper data attributes. See [Converting HTML with Images](#converting-html-with-images) for guidance on handling images.
+  **Important:** When converting HTML to Lexical, `<img>` tags are NOT automatically uploaded. This is intentional because we don't know which uploads-enabled collection to add them to, and that collection may have required fields that cannot be auto-filled. Images will be omitted from the conversion unless you provide the proper data attributes. See [Converting HTML with Images](#converting-html-with-images) for guidance on handling images.
 </Banner>
 
 ```ts
@@ -376,50 +376,29 @@ const lexicalJSON = await convertHTMLWithImageUpload(
 )
 ```
 
-### Approach 3: Manually Construct Upload Nodes
+### Approach 3: Construct Upload Nodes with buildEditorState
 
-If you already have upload IDs and want to build the Lexical JSON structure manually, you can construct upload nodes directly.
+If you already have upload IDs and want to build the Lexical JSON structure, use the `buildEditorState` helper for a type-safe, simplified approach. This helper requires less boilerplate and eliminates the need to manually construct the root node.
 
 ```ts
+import { buildEditorState } from '@payloadcms/richtext-lexical'
 import { v4 as uuid } from 'uuid'
 
-// Manually construct Lexical JSON with upload nodes
-const lexicalJSON = {
-  root: {
-    type: 'root',
-    format: '',
-    indent: 0,
-    version: 1,
-    children: [
-      {
-        type: 'paragraph',
-        format: '',
-        indent: 0,
-        version: 1,
-        children: [
-          {
-            type: 'text',
-            format: 0,
-            text: 'Some text content',
-            mode: 'normal',
-            version: 1,
-          },
-        ],
-        direction: 'ltr',
-      },
-      {
-        type: 'upload',
-        format: '',
-        version: 3,
-        relationTo: 'media',
-        value: 'your-upload-id-here', // ID of the uploaded document
-        fields: {}, // Any additional fields configured for the upload feature
-        id: uuid(), // Unique ID for this node instance (not the upload document ID)
-      },
-    ],
-    direction: 'ltr',
-  },
-}
+// Build Lexical JSON with upload nodes using the helper
+const lexicalJSON = buildEditorState({
+  text: 'Some text content',
+  nodes: [
+    {
+      type: 'upload',
+      format: '',
+      version: 3,
+      relationTo: 'media',
+      value: 'your-upload-id-here', // ID of the uploaded document
+      fields: {}, // Any additional fields configured for the upload feature
+      id: uuid(), // Unique ID for this node instance (not the upload document ID)
+    },
+  ],
+})
 
 // Save to your collection
 await payload.create({


### PR DESCRIPTION
Fixes #7884

- added warning banner that <img> tags don't auto-upload and will be omitted without data attributes
- created "Converting HTML with Images" section with a few different approaches
- added troubleshooting section for common image issues