### PR TITLE
fix(ui): resolve bulk upload lint issues and refactor saveAllDocs

### DIFF
--- a/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
@@ -39,7 +39,7 @@ export function AddFilesView({ acceptMimeTypes, onCancel, onDrop }: Props) {
           </Button>
           <input
             accept={acceptMimeTypes}
-            aria-hidden="true"
+            aria-label={t('upload:selectFile')}
             className={`${baseClass}__hidden-input`}
             hidden
             multiple


### PR DESCRIPTION
This PR addresses several linting issues and code smells in the BulkUpload component.

**Changes:**
- **Accessibility**: Removed invalid `aria-hidden` attribute and added `aria-label` to the hidden file input in `AddFilesView`.
- **Refactoring**: Extracted `uploadForm` helper function from `saveAllDocs` in `FormsManager` to reduce Cognitive Complexity.
- **Code Quality**: Fixed exception handling to use optional catch binding (`catch {}`) instead of unused variables.
- **Performance**: Memoized the `Context` value in `FormsManager` to prevent unnecessary re-renders.
- **Cleanup**: Removed redundant code and unnecessary dependencies in `useCallback` hooks.

These changes improve code maintainability, accessibility, and performance without altering the core functionality.