### PR TITLE
docs: clarify supported Next.js versions and optional dependencies in installation guide

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -29,7 +29,7 @@ Payload requires the following software:
 
 To quickly scaffold a new Payload app in the fastest way possible, you can use [create-payload-app](https://npmjs.com/package/create-payload-app). To do so, run the following command:
 
-```
+```bash
 npx create-payload-app
 ```
 
@@ -43,10 +43,20 @@ If you don't have a Next.js app already, but you still want to start a project f
 
 #### 1. Install the relevant packages
 
-First, you'll want to add the required Payload packages to your project and can do so by running the command below:
+First, you'll want to add the required Payload packages to your project:
 
 ```bash
-pnpm i payload @payloadcms/next @payloadcms/richtext-lexical sharp graphql
+pnpm i payload @payloadcms/next
+```
+
+You'll also likely want to install the following optional packages:
+
+- `@payloadcms/richtext-lexical` - Rich text editor (not needed if you don't use Rich Text)
+- `sharp` - Image resizing, cropping, and focal point support (only needed if you use [Upload](/docs/upload/overview) collections with image manipulation)
+- `graphql` - Only needed if you want to use the [GraphQL API](/docs/graphql/overview)
+
+```bash
+pnpm i @payloadcms/richtext-lexical sharp graphql
 ```
 
 <Banner type="warning">
@@ -118,9 +128,6 @@ import { withPayload } from '@payloadcms/next/withPayload'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Your Next.js config here
-  experimental: {
-    reactCompiler: false,
-  },
 }
 
 // Make sure you wrap your `nextConfig`

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -10,13 +10,19 @@ keywords: documentation, getting started, guide, Content Management System, cms,
 
 Payload requires the following software:
 
-- Any JavaScript package manager (pnpm, npm, or yarn - pnpm is preferred)
+- Any JavaScript package manager (pnpm, npm, or yarn 2+ - pnpm is preferred, yarn 1.x is not supported)
 - Node.js version 20.9.0+
+- Next.js (one of the following version ranges):
+  - `15.2.9` - `15.2.x`
+  - `15.3.9` - `15.3.x`
+  - `15.4.11` - `15.4.x`
+  - `16.2.0-canary.10`+
 - Any [compatible database](/docs/database/overview) (MongoDB, Postgres or SQLite)
 
 <Banner type="warning">
   **Important:** Before proceeding any further, please ensure that you have the
-  above requirements met.
+  above requirements met. Not all Next.js 15/16 releases are compatible — make
+  sure you're using one of the supported version ranges listed above.
 </Banner>
 
 ## Quickstart with create-payload-app
@@ -34,10 +40,6 @@ Then just follow the prompts! You'll get set up with a new folder and a function
 Adding Payload to an existing Next.js app is super straightforward. You can either run the `npx create-payload-app` command inside your Next.js project's folder, or manually install Payload by following the steps below.
 
 If you don't have a Next.js app already, but you still want to start a project from a blank Next.js app, you can create a new Next.js app using `npx create-next-app` - and then just follow the steps below to install Payload.
-
-<Banner type="info">
-  **Note:** Next.js version 15 or higher is required for Payload.
-</Banner>
 
 #### 1. Install the relevant packages
 


### PR DESCRIPTION
Updates the installation docs to explicitly list supported Next.js version ranges instead of the generic "version 15 or higher", consolidates all software requirements into one section, notes that yarn 1.x is not supported, and separates required packages from optional ones (`richtext-lexical`, `sharp`, `graphql`).