### PR TITLE
chore: only add publishAllLocales to publish when localizeStatus is enabled

### DIFF
--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -4,7 +4,12 @@ import type { PublishButtonClientProps } from 'payload'
 
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
-import { formatAdminURL, hasAutosaveEnabled, hasScheduledPublishEnabled } from 'payload/shared'
+import {
+  formatAdminURL,
+  hasAutosaveEnabled,
+  hasLocalizeStatusEnabled,
+  hasScheduledPublishEnabled,
+} from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { useCallback, useEffect, useState } from 'react'
 
@@ -150,6 +155,8 @@ export function PublishButton({
     }
   })
 
+  const localizeStatusEnabled = hasLocalizeStatusEnabled(entityConfig)
+
   const publish = useCallback(async () => {
     if (uploadStatus === 'uploading') {
       return
@@ -159,7 +166,7 @@ export function PublishButton({
       {
         depth: 0,
         locale: localeCode,
-        publishAllLocales: true,
+        ...(localizeStatusEnabled && { publishAllLocales: true }),
       },
       { addQueryPrefix: true },
     )
@@ -185,6 +192,7 @@ export function PublishButton({
     }
   }, [
     localeCode,
+    localizeStatusEnabled,
     api,
     collectionSlug,
     globalSlug,


### PR DESCRIPTION
### What
The Publish button was sending `publishAllLocales=true` as a query parameter on the default publish action, regardless of whether the `localizeStatus` feature was enabled for the collection/global. 

This was being ignored in the request itself and had no real effect, but we still shouldn't be passing it.

### Why
The `publishAllLocales` parameter is part of the experimental `localizeStatus` feature (which allows per-locale draft/publish status). When this feature is not enabled, the parameter should not appear in the request URL as it's confusing and adds unnecessary noice.

### How
Updates the publish button component to only add `publishAllLocales=true` when `localizeStatus` is enabled.