### PR TITLE
fix: clear req.file when duplicating to prevent file data leak

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -84,7 +84,10 @@ export const generateFileData = async <T>({
 
   const { serverURL, sharp } = req.payload.config
 
-  let file = req.file
+  // When duplicating, clear req.file so we always fetch the correct source file
+  // for the document being duplicated. Without this, req.file from a previous
+  // duplicate() call on the same request would leak and be reused.
+  let file = isDuplicating ? undefined : req.file
 
   const uploadEdits = parseUploadEditsFromReqOrIncomingData({
     data,


### PR DESCRIPTION
## Problem

When calling `payload.duplicate()` multiple times on the same `req` object (e.g. in batch operations within a transaction), `req.file` from the first call leaks into subsequent calls. This causes all duplicated documents to use the first document's file instead of their own.

Root cause: `generateFileData` reads `req.file` at the top (line 87) and only fetches the correct source file when `req.file` is falsy (line 114). After the first `duplicate()` call writes the processed file back to `req.file` (lines 348/373), the next call sees it already set and skips fetching entirely.

## Fix

When `isDuplicating` is true, initialize `file` as `undefined` instead of reading from `req.file`. This ensures each duplicate operation always fetches its own source file from storage, regardless of what previous calls may have left on the request.

```ts
// Before
let file = req.file

// After
let file = isDuplicating ? undefined : req.file
```

## Test plan

- Added integration test that creates two media documents with different files, then duplicates both using a shared `req` object
- Verifies each duplicated document's filename derives from its own source, not from the first document's file

Fixes #15619