### PR TITLE
fix: return orphaned documents in root folder view

### DIFF
--- a/packages/payload/src/folders/utils/getFolderData.ts
+++ b/packages/payload/src/folders/utils/getFolderData.ts
@@ -85,11 +85,26 @@ export const getFolderData = async ({
       req,
       where: folderWhere,
     })
-    const [breadcrumbs, subfolders] = await Promise.all([breadcrumbsPromise, subfoldersPromise])
+
+    const documentsPromise =
+      collectionSlug && payload.collections[collectionSlug]
+        ? getOrphanedDocs({
+            collectionSlug,
+            folderFieldName: payload.config.folders.fieldName,
+            req,
+            where: documentWhere,
+          })
+        : Promise.resolve([])
+
+    const [breadcrumbs, subfolders, documents] = await Promise.all([
+      breadcrumbsPromise,
+      subfoldersPromise,
+      documentsPromise,
+    ])
 
     return {
       breadcrumbs,
-      documents: [],
+      documents: sortDocs({ docs: documents, sort }),
       folderAssignedCollections: collectionSlug ? [collectionSlug] : undefined,
       subfolders: sortDocs({ docs: subfolders, sort }),
     }


### PR DESCRIPTION
fix: #15622

### What?

- Media with no folder (orphaned items) do not appear in the "By Folder" view.

### Why?

- At root, getFolderData only returned subfolders and always set documents: [].

### How?

- At root, when collectionSlug is set, we also load orphaned documents from that collection with getOrphanedDocs and return them with the subfolders.