### PR TITLE
fix(plugin-import-export): respect defaultVersionStatus for versioned imports

### DIFF
--- a/packages/plugin-import-export/src/import/batchProcessor.ts
+++ b/packages/plugin-import-export/src/import/batchProcessor.ts
@@ -178,6 +178,7 @@ async function processImportBatch({
           const statusValue = createData._status || options.defaultVersionStatus
           const isPublished = statusValue !== 'draft'
           draftOption = !isPublished
+          createData._status = statusValue
 
           if (req.payload.config.debug) {
             req.payload.logger.info({
@@ -187,8 +188,7 @@ async function processImportBatch({
               willSetDraft: draftOption,
             })
           }
-
-          // Remove _status from data - it's controlled via draft option
+        } else {
           delete createData._status
         }
 
@@ -446,14 +446,13 @@ async function processImportBatch({
           const createData = { ...document }
           delete createData.id
 
-          // Only handle _status for versioned collections
           let draftOption: boolean | undefined
           if (collectionHasVersions) {
-            // Use defaultVersionStatus from config if _status not provided
             const statusValue = createData._status || options.defaultVersionStatus
             const isPublished = statusValue !== 'draft'
             draftOption = !isPublished
-            // Remove _status from data - it's controlled via draft option
+            createData._status = statusValue
+          } else {
             delete createData._status
           }
 


### PR DESCRIPTION
### What?

- Imports into versioned collections were always created as drafts even when defaultVersionStatus: 'published' was set.

### Why?

- We removed _status from the payload, so Payload’s default 'draft' was applied.

### How?

- We set and pass createData._status from the row or defaultVersionStatus instead of deleting it for versioned collections.

Fixes  : #15627