### PR TITLE
fix: proof-of-concept to support virtual fields added by hooks in `buildFormState`

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1627,6 +1627,7 @@ export type {
 export { getDefaultValue } from './fields/getDefaultValue.js'
 export { traverseFields as afterChangeTraverseFields } from './fields/hooks/afterChange/traverseFields.js'
 
+export { afterRead } from './fields/hooks/afterRead/index.js'
 export { promise as afterReadPromise } from './fields/hooks/afterRead/promise.js'
 export { traverseFields as afterReadTraverseFields } from './fields/hooks/afterRead/traverseFields.js'
 export { traverseFields as beforeChangeTraverseFields } from './fields/hooks/beforeChange/traverseFields.js'

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -845,6 +845,7 @@ export const Form: React.FC<FormProps> = (props) => {
 
         dispatchFields({
           type: 'MERGE_SERVER_STATE',
+          acceptValues: { overrideLocalChanges: false },
           prevStateRef: prevFormState,
           serverState,
         })

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -7,7 +7,7 @@ import type {
   ServerFunction,
 } from 'payload'
 
-import { canAccessAdmin, formatErrors, UnauthorizedError } from 'payload'
+import { afterRead, canAccessAdmin, formatErrors, UnauthorizedError } from 'payload'
 import { getSelectMode, reduceFieldsToValues } from 'payload/shared'
 
 import { fieldSchemasToFormState } from '../forms/fieldSchemasToFormState/index.js'
@@ -160,6 +160,62 @@ export const buildFormState = async (
   // If there is form state but no data, deduce data from that form state, e.g. on initial load
   // Otherwise, use the incoming data as the source of truth, e.g. on subsequent saves
   const data = incomingData || reduceFieldsToValues(formState, true)
+
+  const isTopLevelSchema = schemaPath === collectionSlug || schemaPath === globalSlug
+
+  if (isTopLevelSchema) {
+    const collectionConfig = collectionSlug ? payload.collections[collectionSlug]?.config : null
+    const globalConfig = globalSlug
+      ? (payload.config.globals?.find((g) => g.slug === globalSlug) ?? null)
+      : null
+
+    // Run field-level afterRead hooks
+    const hookedData = await afterRead({
+      collection: collectionConfig ?? null,
+      context: req.context,
+      depth: 0,
+      doc: data,
+      draft: false,
+      fallbackLocale: req.fallbackLocale,
+      flattenLocales: false,
+      global: globalConfig ?? null,
+      locale: req.locale,
+      overrideAccess: true,
+      req,
+      showHiddenFields: false,
+    })
+
+    // Run collection-level afterRead hooks
+    if (collectionConfig?.hooks?.afterRead?.length) {
+      let result = hookedData
+      for (const hook of collectionConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            overrideAccess: true,
+            req,
+          })) || result
+      }
+      Object.assign(data, result)
+    } else if (globalConfig?.hooks?.afterRead?.length) {
+      let result = hookedData
+      for (const hook of globalConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            context: req.context,
+            doc: result,
+            global: globalConfig,
+            overrideAccess: true,
+            req,
+          })) || result
+      }
+      Object.assign(data, result)
+    } else {
+      Object.assign(data, hookedData)
+    }
+  }
 
   let documentData = undefined
 

--- a/test/form-state/collections/VirtualFields/index.ts
+++ b/test/form-state/collections/VirtualFields/index.ts
@@ -1,0 +1,64 @@
+import type { CollectionConfig, Field } from 'payload'
+
+export const relatedSlug = 'related-docs'
+export const virtualFieldsSlug = 'virtual-fields'
+
+const relatedFields: Field[] = [
+  { name: 'title', type: 'text' },
+  { name: 'description', type: 'text' },
+]
+
+const relatedFieldNames = relatedFields
+  .filter((f): f is { name: string } & Field => 'name' in f)
+  .map((f) => f.name)
+
+const populateVirtualFromRelation = async ({ doc, req }) => {
+  if (!doc.relation) {
+    const embedded: Record<string, unknown> = {}
+    for (const name of relatedFieldNames) {
+      embedded[name] = null
+    }
+    return { ...doc, embedded }
+  }
+
+  const relationId = typeof doc.relation === 'string' ? doc.relation : doc.relation.id
+  const related = await req.payload.findByID({ collection: relatedSlug, id: relationId })
+
+  const embedded: Record<string, unknown> = {}
+  for (const name of relatedFieldNames) {
+    embedded[name] = related[name]
+  }
+
+  return { ...doc, embedded }
+}
+
+export const RelatedCollection: CollectionConfig = {
+  slug: relatedSlug,
+  access: {
+    read: () => true,
+    create: () => true,
+    update: () => true,
+  },
+  fields: relatedFields,
+}
+
+export const VirtualFieldsCollection: CollectionConfig = {
+  slug: virtualFieldsSlug,
+  access: {
+    read: () => true,
+    create: () => true,
+    update: () => true,
+  },
+  hooks: {
+    afterRead: [populateVirtualFromRelation],
+  },
+  fields: [
+    { name: 'relation', type: 'relationship', relationTo: relatedSlug },
+    {
+      name: 'embedded',
+      type: 'group',
+      virtual: true,
+      fields: relatedFields,
+    },
+  ],
+}

--- a/test/form-state/config.ts
+++ b/test/form-state/config.ts
@@ -5,12 +5,22 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { AutosavePostsCollection } from './collections/Autosave/index.js'
 import { PostsCollection, postsSlug } from './collections/Posts/index.js'
+import {
+  RelatedCollection,
+  relatedSlug,
+  VirtualFieldsCollection,
+} from './collections/VirtualFields/index.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  collections: [PostsCollection, AutosavePostsCollection],
+  collections: [
+    PostsCollection,
+    AutosavePostsCollection,
+    RelatedCollection,
+    VirtualFieldsCollection,
+  ],
   admin: {
     importMap: {
       baseDir: path.resolve(dirname),
@@ -29,6 +39,14 @@ export default buildConfigWithDefaults({
       collection: postsSlug,
       data: {
         title: 'example post',
+      },
+    })
+
+    await payload.create({
+      collection: relatedSlug,
+      data: {
+        title: 'Related Title',
+        description: 'Related Description',
       },
     })
   },

--- a/test/form-state/payload-types.ts
+++ b/test/form-state/payload-types.ts
@@ -69,6 +69,8 @@ export interface Config {
   collections: {
     posts: Post;
     'autosave-posts': AutosavePost;
+    'related-docs': RelatedDoc;
+    'virtual-fields': VirtualField;
     'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
@@ -79,6 +81,8 @@ export interface Config {
   collectionsSelect: {
     posts: PostsSelect<false> | PostsSelect<true>;
     'autosave-posts': AutosavePostsSelect<false> | AutosavePostsSelect<true>;
+    'related-docs': RelatedDocsSelect<false> | RelatedDocsSelect<true>;
+    'virtual-fields': VirtualFieldsSelect<false> | VirtualFieldsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -186,6 +190,33 @@ export interface AutosavePost {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "related-docs".
+ */
+export interface RelatedDoc {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-fields".
+ */
+export interface VirtualField {
+  id: string;
+  relation?: (string | null) | RelatedDoc;
+  embedded?: {
+    title?: string | null;
+    description?: string | null;
+    updatedAt?: string | null;
+    createdAt?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -240,6 +271,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'autosave-posts';
         value: string | AutosavePost;
+      } | null)
+    | ({
+        relationTo: 'related-docs';
+        value: string | RelatedDoc;
+      } | null)
+    | ({
+        relationTo: 'virtual-fields';
+        value: string | VirtualField;
       } | null)
     | ({
         relationTo: 'users';
@@ -350,6 +389,33 @@ export interface AutosavePostsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "related-docs_select".
+ */
+export interface RelatedDocsSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-fields_select".
+ */
+export interface VirtualFieldsSelect<T extends boolean = true> {
+  relation?: T;
+  embedded?:
+    | T
+    | {
+        title?: T;
+        description?: T;
+        updatedAt?: T;
+        createdAt?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### How come?

I am building a  setup where a base collection `Persons` is referenced by other collections like `Employees` and `Users`. To make editing that base data seamless, I include fields from `Persons` in a virtual group on other collections, in this example `Employees` like so:

<details open>
  <summary>Config</summary>

  ```
  const embeddedPersonField: Field = {
    name: 'personalData',
    type: 'group',
    virtual: true,
    fields: Persons.fields,
  }

  export const Employees: CollectionConfig = {
    slug: 'employees',
    hooks: {
      afterRead: [populateEmbeddedPersonData],
      beforeChange: [saveEmbeddedPersonData],
    },
    fields: [
      {
        name: 'persons',
        type: 'relationship',
        relationTo: 'persons',
      },
      embeddedPersonField,
    ],
  }
  ```

</details>

The data is populated and saved by hooks.

The bug: selecting a Person from the relationship dropdown re-renders the form after a request to `form-state`, but does not include field values from the selected Person.

<details>
  <summary>See a gif</summary>

  ![CleanShot 2026-02-16 at 11 25 20](https://github.com/user-attachments/assets/2bb585f5-b79e-489f-b56f-73cd27914e45)

</details>

### What?

Run `afterRead` hooks in `buildFormState` and accept server-computed values in the onChange form state merge.

### Why?

Virtual fields populated by `afterRead` hooks return empty when a relationship field changes in the admin panel. Two things prevent this:

- `buildFormState` never runs `afterRead` hooks. On initial load, `Document/index.tsx` fetches via `payload.findByID()` (which runs hooks) and passes the result to `buildFormState`. On subsequent rebuilds triggered by field changes, hooks are skipped entirely.

- `mergeServerFormState` discards the server-computed values. The onChange codepath dispatches `MERGE_SERVER_STATE` without `acceptValues`, so `shouldAcceptValue` is false and `value`/`initialValue` are stripped.

### How?

- Export `afterRead` from `payload` core
- Call field-level and collection/global-level `afterRead` hooks in `buildFormState` (guarded by `isTopLevelSchema`)
- Pass `acceptValues: { overrideLocalChanges: false }` in the onChange merge so server-computed values are accepted for unmodified fields

#### Note on architecture

- We just run that one hook here as a proof-of-concept.
- This imports `afterRead` directly from `payload` core into `@payloadcms/ui`. As far as I can tell, no other UI code currently does this. An alternative could be to expose something like `payload.runAfterReadHooks(collection, doc)` on the Payload instance.