### PR TITLE
docs: fix typo in ecommerce template link in seo plugin docs

### DIFF
--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -312,7 +312,7 @@ const generateTitle: GenerateTitle<Page> = async ({ doc, locale }) => {
 
 ## Examples
 
-The [Templates Directory](https://github.com/payloadcms/payload/tree/main/templates) contains an official [Website Template](https://github.com/payloadcms/payload/tree/main/templates/website) and [E-commerce Template](https://github.com/payloadcms/payload/tree/main/templates/ecommere) which demonstrates exactly how to configure this plugin in Payload and implement it on your front-end.
+The [Templates Directory](https://github.com/payloadcms/payload/tree/main/templates) contains an official [Website Template](https://github.com/payloadcms/payload/tree/main/templates/website) and [E-commerce Template](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) which demonstrates exactly how to configure this plugin in Payload and implement it on your front-end.
 
 ## Screenshots
 


### PR DESCRIPTION
Fixes typo in E-commerce Template URL (ecommere → ecommerce) in docs/plugins/seo.mdx.