### PR TITLE
fix(email-resend): add Custom headers for Resend

### DIFF
--- a/packages/email-resend/src/index.ts
+++ b/packages/email-resend/src/index.ts
@@ -84,6 +84,7 @@ function mapPayloadEmailToResendEmail(
     attachments: mapAttachments(message.attachments),
     html: message.html?.toString() || '',
     text: message.text?.toString() || '',
+    headers: message.headers,
   } as ResendSendEmailOptions
 }
 


### PR DESCRIPTION
I found that the Resend adapter does not pass custom headers from the Payload `sendEmail` options to the Resend API.

When I attempt to send an email with custom headers (below), they are ignored because the `mapPayloadEmailToResendEmail` function creates a new object that excludes the headers property.

    await payload.sendEmail({
      from: "The Gremlins <welcome@thegremlins.com.au>",
      to: (email as string).toLowerCase().trim(),
      subject: "WELCOME TO GREMNATION",
      html: html,
      headers: {
        "List-Unsubscribe": "<https://example.com/unsubscribe>",
        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
      },
    });

This has been fixed by adding `headers: message.headers,` to the function.