### PR TITLE
fix(richtext-lexical): fix import for single line code blocks with no language

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/converter.ts
+++ b/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/converter.ts
@@ -35,8 +35,8 @@ export const codeConverter: BlockJSX = {
 
     if (isSingleLineAndComplete) {
       return {
-        code: language + (children?.length ? children : ''), // No need to add space to children as they are not trimmed
-        language: '',
+        code: (language || '') + (children?.length ? children : ''), // No need to add space to children as they are not trimmed
+        language,
       }
     }
 


### PR DESCRIPTION
Single line code blocks with no language error out during import. Example:

```
Single line but no language
```

This change fixes the issue.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
