### PR TITLE
fix(drizzle): correctly apply query limit on polymorphic joins

### DIFF
--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -599,26 +599,38 @@ export const traverseFields = ({
 
           currentQuery = currentQuery.orderBy(sortOrder(sql`"sortPath"`)) as SQLSelect
 
+          const sortedUnionAlias = `${columnName}_sorted`
+
+          let limitOffsetSQL = sql.empty()
+          if (limit) {
+            limitOffsetSQL = sql` LIMIT ${limit}`
+          }
           if (page && limit !== 0) {
             const offset = (page - 1) * limit
             if (offset > 0) {
-              currentQuery = currentQuery.offset(offset) as SQLSelect
+              limitOffsetSQL = sql`${limitOffsetSQL} OFFSET ${offset}`
             }
           }
 
-          if (limit) {
-            currentQuery = currentQuery.limit(limit) as SQLSelect
+          // Correlate to parent row + apply any join where filters
+          let innerWhere = sql.raw(`"${sortedUnionAlias}"."${onPath}" = "${currentTableName}"."id"`)
+          if (where && Object.keys(where).length > 0) {
+            const additionalWhere = buildSQLWhere(where, sortedUnionAlias)
+            innerWhere = sql`${innerWhere} AND ${additionalWhere}`
           }
 
-          currentArgs.extras[columnName] = sql`${db
-            .select({
-              id: jsonAggBuildObject(adapter, {
-                id: sql.raw(`"${subQueryAlias}"."id"`),
-                relationTo: sql.raw(`"${subQueryAlias}"."relationTo"`),
-              }),
-            })
-            .from(sql`${currentQuery.as(subQueryAlias)}`)
-            .where(sqlWhere)}`.as(columnName)
+          // IMPORTANT: For polymorphic joins, LIMIT must be applied AFTER correlating to the parent row.
+          // Otherwise, the limit applies globally across ALL parents, not per-parent.
+          currentArgs.extras[columnName] = sql`(
+            SELECT ${jsonAggBuildObject(adapter, {
+              id: sql.raw(`"${subQueryAlias}"."id"`),
+              relationTo: sql.raw(`"${subQueryAlias}"."relationTo"`),
+            })}
+            FROM (
+              SELECT * FROM ${sql`${currentQuery.as(sortedUnionAlias)}`}
+              WHERE ${innerWhere}${limitOffsetSQL}
+            ) AS ${sql.raw(`"${subQueryAlias}"`)}
+          )`.as(columnName)
         } else {
           const useDrafts =
             (versions || draftsEnabled) &&


### PR DESCRIPTION
### What?
Fixes an issue where querying folders with nested subfolders returned incorrect results when using SQL databases.

### Why?

When resolving nested folder relationships, the generated polymorphic `UNION` query applied `LIMIT` at the global level. This caused the limit to be enforced across the entire result set before rows were correlated back to their respective parent folders.

As a result, some parents received incomplete or incorrect child data.

### How?

The polymorphic join query has been restructured so that parent correlation occurs **before** applying the `LIMIT`. This ensures:

- The `LIMIT` is enforced **per parent**
- Nested subfolder queries return accurate data

#### Testing

- Added tests under `folders > int`
