### PR TITLE
refactor: replace directional properties with logical properties

### DIFF
--- a/packages/next/src/elements/Nav/NavWrapper/index.scss
+++ b/packages/next/src/elements/Nav/NavWrapper/index.scss
@@ -12,8 +12,8 @@
     opacity: 0;
 
     [dir='rtl'] & {
-      border-right: none;
-      border-left: 1px solid var(--theme-elevation-100);
+      border-inline-start: none;
+      border-inline-end: 1px solid var(--theme-elevation-100);
     }
 
     &--nav-animate {

--- a/packages/next/src/elements/Nav/index.scss
+++ b/packages/next/src/elements/Nav/index.scss
@@ -17,8 +17,8 @@
     --nav-padding-block-end: calc(var(--base) * 2);
 
     [dir='rtl'] & {
-      border-right: none;
-      border-left: 1px solid var(--theme-elevation-100);
+      border-inline-start: none;
+      border-inline-end: 1px solid var(--theme-elevation-100);
     }
 
     &--nav-animate {

--- a/packages/next/src/templates/Default/index.scss
+++ b/packages/next/src/templates/Default/index.scss
@@ -6,8 +6,8 @@
     color: var(--theme-text);
 
     [dir='rtl'] &__nav-toggler-wrapper {
-      left: unset;
-      right: 0;
+      inset-inline-end: unset;
+      inset-inline-start: 0;
     }
 
     &__nav-toggler-wrapper {

--- a/packages/next/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.scss
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.scss
@@ -63,11 +63,11 @@
       }
       [dir='rtl'] & {
         // Vertical gutter
-        border-right: 2px solid var(--theme-elevation-100);
+        border-inline-start: 2px solid var(--theme-elevation-100);
         // Center-align the gutter with the chevron
-        margin-right: 3px;
+        margin-inline-start: 3px;
         // Content indentation
-        padding-right: calc(var(--base) * 0.5);
+        padding-inline-start: calc(var(--base) * 0.5);
       }
     }
 

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Iterable/index.scss
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Iterable/index.scss
@@ -43,7 +43,7 @@
         margin-right: calc(var(--base) * 0.25);
       }
       [dir='rtl'] & {
-        margin-left: calc(var(--base) * 0.25);
+        margin-inline-end: calc(var(--base) * 0.25);
       }
     }
 

--- a/packages/next/src/views/Versions/index.scss
+++ b/packages/next/src/views/Versions/index.scss
@@ -31,7 +31,7 @@
       }
 
       [dir='rtl'] & {
-        margin-right: auto;
+        margin-inline-start: auto;
       }
     }
 
@@ -59,8 +59,8 @@
       }
 
       [dir='rtl'] & {
-        margin-left: var(--base);
-        margin-right: auto;
+        margin-inline-end: var(--base);
+        margin-inline-start: auto;
       }
     }
 
@@ -97,7 +97,7 @@
         }
 
         [dir='rtl'] & {
-          margin-right: 0;
+          margin-inline-start: 0;
         }
       }
 

--- a/packages/plugin-multi-tenant/src/components/TenantField/index.scss
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.scss
@@ -22,7 +22,7 @@
       }
 
       [dir='rtl'] & {
-        margin-right: calc(-1 * var(--tenant-gutter-h-right));
+        margin-inline-start: calc(-1 * var(--tenant-gutter-h-right));
         background-image: repeating-linear-gradient(
           -120deg,
           var(--theme-elevation-50) 0px,

--- a/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
+++ b/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
@@ -274,10 +274,10 @@
     // See comment above for why we need this
     &__listItemUnchecked[dir='rtl'],
     &__listItemChecked[dir='rtl'] {
-      margin-left: 0;
-      padding-left: 0;
-      padding-right: 25px;
-      margin-right: 15px;
+      margin-inline-end: 0;
+      padding-inline-end: 0;
+      padding-inline-start: 25px;
+      margin-inline-start: 15px;
     }
 
     &__listItemChecked {
@@ -299,8 +299,8 @@
 
     &__listItemUnchecked[dir='rtl']:before,
     &__listItemChecked[dir='rtl']:before {
-      left: auto;
-      right: 0;
+      inset-inline-end: auto;
+      inset-inline-start: 0;
     }
 
     &__listItemUnchecked:focus:before,

--- a/packages/ui/src/elements/AppHeader/index.scss
+++ b/packages/ui/src/elements/AppHeader/index.scss
@@ -21,8 +21,8 @@
     // place the localizer outside the `overflow: hidden` container so that the popup is visible
     // this means we need to use a placeholder div so that the space is retained in the DOM
     [dir='rtl'] &__localizer {
-      right: unset;
-      left: base(4.5);
+      inset-inline-start: unset;
+      inset-inline-end: base(4.5);
     }
 
     &__localizer-spacing {

--- a/packages/ui/src/elements/BulkUpload/EditMany/index.scss
+++ b/packages/ui/src/elements/BulkUpload/EditMany/index.scss
@@ -84,9 +84,9 @@
       flex-grow: 1;
     }
     [dir='rtl'] &__sidebar-wrap {
-      left: 0;
-      border-right: 1px solid var(--theme-elevation-100);
-      right: auto;
+      inset-inline-end: 0;
+      border-inline-start: 1px solid var(--theme-elevation-100);
+      inset-inline-start: auto;
     }
 
     &__sidebar-wrap {

--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -126,15 +126,15 @@
       align-items: center;
 
       html:not([dir='RTL']) & {
-        border-left: 1px solid var(--theme-bg);
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        border-inline-start: 1px solid var(--theme-bg);
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
       }
 
       html[dir='RTL'] & {
-        border-right: 1px solid var(--theme-bg);
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-inline-start: 1px solid var(--theme-bg);
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
       }
 
       &:hover,
@@ -349,13 +349,13 @@
 
     &--withPopup .btn {
       html:not([dir='RTL']) & {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
       }
 
       html[dir='RTL'] & {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
       }
     }
 

--- a/packages/ui/src/elements/DatePicker/index.scss
+++ b/packages/ui/src/elements/DatePicker/index.scss
@@ -6,7 +6,7 @@ $cal-icon-width: 18px;
   [dir='rtl'] {
     .date-time-picker {
       .react-datepicker__input-container input {
-        padding-right: base(3.4);
+        padding-inline-start: base(3.4);
       }
     }
   }

--- a/packages/ui/src/elements/DocumentControls/index.scss
+++ b/packages/ui/src/elements/DocumentControls/index.scss
@@ -189,7 +189,7 @@
 
       &__popup {
         [dir='rtl'] & {
-          padding-left: var(--gutter-h);
+          padding-inline-end: var(--gutter-h);
         }
       }
 

--- a/packages/ui/src/elements/DocumentFields/index.scss
+++ b/packages/ui/src/elements/DocumentFields/index.scss
@@ -54,8 +54,8 @@
 
           [dir='rtl'] & {
             top: 0;
-            left: 0;
-            border-left: var(--main-border);
+            inset-inline-end: 0;
+            border-inline-end: var(--main-border);
           }
         }
 
@@ -177,7 +177,7 @@
             }
 
             [dir='rtl'] & {
-              border-left: 0;
+              border-inline-end: 0;
             }
           }
 

--- a/packages/ui/src/elements/EditMany/index.scss
+++ b/packages/ui/src/elements/EditMany/index.scss
@@ -54,9 +54,9 @@
       flex-grow: 1;
     }
     [dir='rtl'] &__sidebar-wrap {
-      left: 0;
-      border-right: 1px solid var(--theme-elevation-100);
-      right: auto;
+      inset-inline-end: 0;
+      border-inline-start: 1px solid var(--theme-elevation-100);
+      inset-inline-start: auto;
     }
 
     &__sidebar-wrap {
@@ -88,7 +88,7 @@
         padding-left: base(1.5);
       }
       [dir='rtl'] & {
-        padding-right: base(1.5);
+        padding-inline-start: base(1.5);
       }
     }
 

--- a/packages/ui/src/elements/EditUpload/index.scss
+++ b/packages/ui/src/elements/EditUpload/index.scss
@@ -27,8 +27,8 @@ $header-height: base(5);
     }
 
     [dir='rtl'] &__actions {
-      margin-right: auto;
-      margin-left: unset;
+      margin-inline-start: auto;
+      margin-inline-end: unset;
     }
 
     &__actions {

--- a/packages/ui/src/elements/FieldDiffContainer/index.scss
+++ b/packages/ui/src/elements/FieldDiffContainer/index.scss
@@ -11,7 +11,7 @@
         margin-right: calc(var(--base) * 0.25);
       }
       [dir='rtl'] & {
-        margin-left: calc(var(--base) * 0.25);
+        margin-inline-end: calc(var(--base) * 0.25);
       }
     }
 

--- a/packages/ui/src/elements/PageControls/index.scss
+++ b/packages/ui/src/elements/PageControls/index.scss
@@ -13,8 +13,8 @@
       }
 
       [dir='rtl'] & {
-        margin-left: base(1);
-        margin-right: auto;
+        margin-inline-end: base(1);
+        margin-inline-start: auto;
       }
     }
 

--- a/packages/ui/src/elements/SearchFilter/index.scss
+++ b/packages/ui/src/elements/SearchFilter/index.scss
@@ -3,8 +3,8 @@
 @layer payload-default {
   [dir='rtl'] .search-filter {
     svg {
-      right: base(0.5);
-      left: 0;
+      inset-inline-start: base(0.5);
+      inset-inline-end: auto;
     }
     &__input {
       padding-right: base(2);

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Checkbox/index.scss
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Checkbox/index.scss
@@ -15,7 +15,7 @@
       padding-left: base(0.0875 + 0.25);
     }
     [dir='rtl'] & {
-      padding-right: base(0.0875 + 0.25);
+      padding-inline-start: base(0.0875 + 0.25);
     }
 
     background: var(--theme-elevation-100);

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Code/index.scss
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Code/index.scss
@@ -19,7 +19,7 @@
     }
 
     [dir='rtl'] & {
-      padding-right: base(0.0875 + 0.25);
+      padding-inline-start: base(0.0875 + 0.25);
     }
 
     &:hover {

--- a/packages/ui/src/elements/Table/DefaultCell/fields/File/index.scss
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/File/index.scss
@@ -18,7 +18,7 @@
         margin-left: var(--base);
       }
       [dir='rtl'] & {
-        margin-right: var(--base);
+        margin-inline-start: var(--base);
       }
     }
   }

--- a/packages/ui/src/elements/Table/DefaultCell/fields/JSON/index.scss
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/JSON/index.scss
@@ -16,7 +16,7 @@
       padding-left: base(0.0875 + 0.25);
     }
     [dir='rtl'] & {
-      padding-right: base(0.0875 + 0.25);
+      padding-inline-start: base(0.0875 + 0.25);
     }
 
     background: var(--theme-elevation-100);

--- a/packages/ui/src/fields/Checkbox/index.scss
+++ b/packages/ui/src/fields/Checkbox/index.scss
@@ -29,8 +29,8 @@
     }
 
     [dir='rtl'] &__input {
-      margin-right: 0;
-      margin-left: base(0.5);
+      margin-inline-start: 0;
+      margin-inline-end: base(0.5);
     }
 
     &__input {

--- a/packages/ui/src/fields/FieldLabel/index.scss
+++ b/packages/ui/src/fields/FieldLabel/index.scss
@@ -16,7 +16,7 @@
       margin-right: auto;
     }
     [dir='rtl'] & {
-      margin-left: auto;
+      margin-inline-end: auto;
     }
 
     .required {
@@ -28,7 +28,7 @@
         margin-left: base(0.25);
       }
       [dir='rtl'] & {
-        margin-right: base(0.25);
+        margin-inline-start: base(0.25);
       }
     }
   }
@@ -39,7 +39,7 @@
       margin-left: base(0.25);
     }
     [dir='rtl'] & {
-      margin-right: base(0.25);
+      margin-inline-start: base(0.25);
     }
   }
 }

--- a/packages/ui/src/fields/RadioGroup/Radio/index.scss
+++ b/packages/ui/src/fields/RadioGroup/Radio/index.scss
@@ -49,8 +49,8 @@
     }
 
     [dir='rtl'] &__label {
-      margin-left: 0;
-      margin-right: base(0.5);
+      margin-inline-end: 0;
+      margin-inline-start: base(0.5);
     }
 
     &__label {

--- a/packages/ui/src/fields/RadioGroup/index.scss
+++ b/packages/ui/src/fields/RadioGroup/index.scss
@@ -21,7 +21,7 @@
           padding-right: $baseline;
         }
         [dir='rtl'] & {
-          padding-left: $baseline;
+          padding-inline-end: $baseline;
         }
       }
     }

--- a/packages/ui/src/scss/toasts.scss
+++ b/packages/ui/src/scss/toasts.scss
@@ -28,9 +28,9 @@
         background: none;
       }
 
-      [dir='RTL'] & {
-        right: unset;
-        left: 0.5rem;
+      [dir='rtl'] & {
+        inset-inline-start: unset;
+        inset-inline-end: 0.5rem;
       }
     }
 

--- a/packages/ui/src/views/BrowseByFolder/index.scss
+++ b/packages/ui/src/views/BrowseByFolder/index.scss
@@ -103,8 +103,8 @@
         margin-left: auto;
       }
       [dir='rtl'] & {
-        margin-left: base(1);
-        margin-right: auto;
+        margin-inline-end: base(1);
+        margin-inline-start: auto;
       }
     }
 

--- a/packages/ui/src/views/CollectionFolder/index.scss
+++ b/packages/ui/src/views/CollectionFolder/index.scss
@@ -91,8 +91,8 @@
         margin-left: auto;
       }
       [dir='rtl'] & {
-        margin-left: base(1);
-        margin-right: auto;
+        margin-inline-end: base(1);
+        margin-inline-start: auto;
       }
     }
 


### PR DESCRIPTION
### ### What?

In this pull request, I have replaced directional CSS properties with logical properties and explicitly mapped them for both `dir="ltr"` and `dir="rtl"` contexts.

This PR demonstrates how directional styles (e.g., `left`, `margin-right`, etc.) can be systematically converted into logical equivalents while preserving correct layout behavior in both directions.

---

### ### Why?

Payload supports multilingual content, including right-to-left (RTL) languages. Using directional properties (such as `left` and `right`) can require additional overrides when switching between LTR and RTL layouts.

By introducing logical equivalents with clear direction-based mappings, spacing and alignment remain consistent and predictable in both layout directions.

Before expanding this refactor across the codebase, I would like to confirm whether this approach aligns with the project's styling strategy.

---

### ### How?

The following mappings were applied:

#### When `dir="ltr"`:

* `left` → `inset-inline-start`
* `right` → `inset-inline-end`
* `padding-left` → `padding-inline-start`
* `padding-right` → `padding-inline-end`
* `margin-left` → `margin-inline-start`
* `margin-right` → `margin-inline-end`
* `border-left` → `border-inline-start`
* `border-right` → `border-inline-end`
* `border-bottom-left-radius` → `border-end-start-radius`
* `border-bottom-right-radius` → `border-end-end-radius`
* `border-top-left-radius` → `border-start-start-radius`
* `border-top-right-radius` → `border-start-end-radius`

---

#### When `dir="rtl"`:

* `left` → `inset-inline-end`
* `right` → `inset-inline-start`
* `padding-left` → `padding-inline-end`
* `padding-right` → `padding-inline-start`
* `margin-left` → `margin-inline-end`
* `margin-right` → `margin-inline-start`
* `border-left` → `border-inline-end`
* `border-right` → `border-inline-start`
* `border-bottom-left-radius` → `border-end-end-radius`
* `border-bottom-right-radius` → `border-end-start-radius`
* `border-top-left-radius` → `border-start-end-radius`
* `border-top-right-radius` → `border-start-start-radius`
---

This PR is intentionally limited in scope and serves as a proof of concept.
If this direction is approved, I can continue refactoring other directional styles in a follow-up PR.

Thank you for your feedback.