### PR TITLE
fix: preserve blockType and id when filtering block data

### DIFF
--- a/packages/payload/src/utilities/filterDataToSelectedLocales.ts
+++ b/packages/payload/src/utilities/filterDataToSelectedLocales.ts
@@ -68,13 +68,18 @@ export function filterDataToSelectedLocales({
               }
 
               if (block) {
-                return filterDataToSelectedLocales({
+                const filtered = filterDataToSelectedLocales({
                   configBlockReferences,
                   docWithLocales: blockData,
                   fields: block?.fields || [],
                   parentIsLocalized: fieldIsLocalized,
                   selectedLocales,
                 })
+                return {
+                  ...filtered,
+                  blockType: blockData.blockType,
+                  ...(blockData.id !== undefined && { id: blockData.id }),
+                }
               }
 
               return blockData


### PR DESCRIPTION
fix: #15655

### What?
- Duplicate Selected Locales was dropping blockType on blocks, so duplicated docs showed “Block with type undefined” and couldn’t be opened.

### Why?
- filterDataToSelectedLocales only kept keys from the block’s field schema; blockType and id are structural and were omitted.

### How?
- After filtering each block’s fields, we reattach blockType and id from the original block item before returning.