### PR TITLE
feat(plugin-mcp): migrate from @vercel/mcp-adapter to mcp-handler

### DIFF
--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -48,10 +48,10 @@
     "pack:plugin": "pnpm build && pnpm pack"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "~1.24.0",
+    "@modelcontextprotocol/sdk": "1.25.2",
     "@types/json-schema": "7.0.15",
-    "@vercel/mcp-adapter": "^1.0.0",
     "json-schema-to-zod": "2.6.1",
+    "mcp-handler": "^1.0.7",
     "zod": "^3.25.50"
   },
   "devDependencies": {

--- a/packages/plugin-mcp/src/mcp/getMcpHandler.ts
+++ b/packages/plugin-mcp/src/mcp/getMcpHandler.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from 'json-schema'
 
-import { createMcpHandler } from '@vercel/mcp-adapter'
+import { createMcpHandler } from 'mcp-handler'
 import { join } from 'path'
 import { APIError, configToJSONSchema, type PayloadRequest, type TypedUser } from 'payload'
 
@@ -260,10 +260,12 @@ export const getMCPHandler = (
             isToolEnabled,
             tool.name,
             () =>
-              server.tool(
+              server.registerTool(
                 tool.name,
-                tool.description,
-                tool.parameters,
+                {
+                  description: tool.description,
+                  inputSchema: tool.parameters,
+                },
                 payloadToolHandler(tool.handler),
               ),
             payload,
@@ -507,9 +509,10 @@ export const getMCPHandler = (
       },
       {
         basePath: MCPHandlerOptions.basePath || payload.config.routes?.api || '/api',
+        disableSse: MCPHandlerOptions.disableSse ?? true,
         maxDuration: MCPHandlerOptions.maxDuration || 60,
-        // INFO: Disabled until developer clarity is reached for server side streaming and we have an auth pattern for all SSE patterns
-        // redisUrl: MCPHandlerOptions.redisUrl || process.env.REDIS_URL,
+        onEvent: MCPHandlerOptions.onEvent,
+        redisUrl: MCPHandlerOptions.redisUrl,
         verboseLogs: useVerboseLogs,
       },
     )

--- a/packages/plugin-mcp/src/mcp/tools/auth/auth.ts
+++ b/packages/plugin-mcp/src/mcp/tools/auth/auth.ts
@@ -58,10 +58,12 @@ export const authTool = (server: McpServer, req: PayloadRequest, verboseLogs: bo
     }
   }
 
-  server.tool(
+  server.registerTool(
     'auth',
-    toolSchemas.auth.description,
-    toolSchemas.auth.parameters.shape,
+    {
+      description: toolSchemas.auth.description,
+      inputSchema: toolSchemas.auth.parameters.shape,
+    },
     async ({ headers }) => {
       return await tool(headers)
     },

--- a/packages/plugin-mcp/src/mcp/tools/auth/forgotPassword.ts
+++ b/packages/plugin-mcp/src/mcp/tools/auth/forgotPassword.ts
@@ -57,10 +57,12 @@ export const forgotPasswordTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'forgotPassword',
-    toolSchemas.forgotPassword.description,
-    toolSchemas.forgotPassword.parameters.shape,
+    {
+      description: toolSchemas.forgotPassword.description,
+      inputSchema: toolSchemas.forgotPassword.parameters.shape,
+    },
     async ({ collection, disableEmail, email }) => {
       return await tool(collection, email, disableEmail)
     },

--- a/packages/plugin-mcp/src/mcp/tools/auth/login.ts
+++ b/packages/plugin-mcp/src/mcp/tools/auth/login.ts
@@ -59,10 +59,12 @@ export const loginTool = (server: McpServer, req: PayloadRequest, verboseLogs: b
     }
   }
 
-  server.tool(
+  server.registerTool(
     'login',
-    toolSchemas.login.description,
-    toolSchemas.login.parameters.shape,
+    {
+      description: toolSchemas.login.description,
+      inputSchema: toolSchemas.login.parameters.shape,
+    },
     async ({ collection, depth, email, overrideAccess, password, showHiddenFields }) => {
       return await tool(collection, email, password, depth, overrideAccess, showHiddenFields)
     },

--- a/packages/plugin-mcp/src/mcp/tools/auth/resetPassword.ts
+++ b/packages/plugin-mcp/src/mcp/tools/auth/resetPassword.ts
@@ -48,10 +48,12 @@ export const resetPasswordTool = (server: McpServer, req: PayloadRequest, verbos
     }
   }
 
-  server.tool(
+  server.registerTool(
     'resetPassword',
-    toolSchemas.resetPassword.description,
-    toolSchemas.resetPassword.parameters.shape,
+    {
+      description: toolSchemas.resetPassword.description,
+      inputSchema: toolSchemas.resetPassword.parameters.shape,
+    },
     async ({ collection, password, token }) => {
       return await tool(collection, token, password)
     },

--- a/packages/plugin-mcp/src/mcp/tools/auth/unlock.ts
+++ b/packages/plugin-mcp/src/mcp/tools/auth/unlock.ts
@@ -51,10 +51,12 @@ export const unlockTool = (server: McpServer, req: PayloadRequest, verboseLogs: 
     }
   }
 
-  server.tool(
+  server.registerTool(
     'unlock',
-    toolSchemas.unlock.description,
-    toolSchemas.unlock.parameters.shape,
+    {
+      description: toolSchemas.unlock.description,
+      inputSchema: toolSchemas.unlock.parameters.shape,
+    },
     async ({ collection, email }) => {
       return await tool(collection, email)
     },

--- a/packages/plugin-mcp/src/mcp/tools/auth/verify.ts
+++ b/packages/plugin-mcp/src/mcp/tools/auth/verify.ts
@@ -44,10 +44,12 @@ export const verifyTool = (server: McpServer, req: PayloadRequest, verboseLogs: 
     }
   }
 
-  server.tool(
+  server.registerTool(
     'verify',
-    toolSchemas.verify.description,
-    toolSchemas.verify.parameters.shape,
+    {
+      description: toolSchemas.verify.description,
+      inputSchema: toolSchemas.verify.parameters.shape,
+    },
     async ({ collection, token }) => {
       return await tool(collection, token)
     },

--- a/packages/plugin-mcp/src/mcp/tools/collection/create.ts
+++ b/packages/plugin-mcp/src/mcp/tools/collection/create.ts
@@ -225,10 +225,12 @@ export const createCollectionTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'createCollection',
-    toolSchemas.createCollection.description,
-    toolSchemas.createCollection.parameters.shape,
+    {
+      description: toolSchemas.createCollection.description,
+      inputSchema: toolSchemas.createCollection.parameters.shape,
+    },
     async ({ collectionDescription, collectionName, fields, hasUpload }) => {
       return await tool(collectionName, collectionDescription, fields, hasUpload)
     },

--- a/packages/plugin-mcp/src/mcp/tools/collection/delete.ts
+++ b/packages/plugin-mcp/src/mcp/tools/collection/delete.ts
@@ -216,10 +216,12 @@ export const deleteCollectionTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'deleteCollection',
-    toolSchemas.deleteCollection.description,
-    toolSchemas.deleteCollection.parameters.shape,
+    {
+      description: toolSchemas.deleteCollection.description,
+      inputSchema: toolSchemas.deleteCollection.parameters.shape,
+    },
     ({ collectionName, confirmDeletion, updateConfig }) => {
       return tool(collectionName, confirmDeletion, updateConfig)
     },

--- a/packages/plugin-mcp/src/mcp/tools/collection/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/collection/find.ts
@@ -211,10 +211,12 @@ export const findCollectionTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'findCollections',
-    toolSchemas.findCollections.description,
-    toolSchemas.findCollections.parameters.shape,
+    {
+      description: toolSchemas.findCollections.description,
+      inputSchema: toolSchemas.findCollections.parameters.shape,
+    },
     ({ collectionName, includeContent, includeCount }) => {
       return tool(collectionName, includeContent, includeCount)
     },

--- a/packages/plugin-mcp/src/mcp/tools/collection/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/collection/update.ts
@@ -277,10 +277,12 @@ export const updateCollectionTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'updateCollection',
-    toolSchemas.updateCollection.description,
-    toolSchemas.updateCollection.parameters.shape,
+    {
+      description: toolSchemas.updateCollection.description,
+      inputSchema: toolSchemas.updateCollection.parameters.shape,
+    },
     async (args) => {
       return await tool(args)
     },

--- a/packages/plugin-mcp/src/mcp/tools/config/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/config/find.ts
@@ -115,10 +115,12 @@ export const findConfigTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'findConfig',
-    toolSchemas.findConfig.description,
-    toolSchemas.findConfig.parameters.shape,
+    {
+      description: toolSchemas.findConfig.description,
+      inputSchema: toolSchemas.findConfig.parameters.shape,
+    },
     ({ includeMetadata }) => {
       return tool(includeMetadata)
     },

--- a/packages/plugin-mcp/src/mcp/tools/config/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/config/update.ts
@@ -271,10 +271,12 @@ export const updateConfigTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'updateConfig',
-    toolSchemas.updateConfig.description,
-    toolSchemas.updateConfig.parameters.shape,
+    {
+      description: toolSchemas.updateConfig.description,
+      inputSchema: toolSchemas.updateConfig.parameters.shape,
+    },
     (args) => {
       return tool(args)
     },

--- a/packages/plugin-mcp/src/mcp/tools/global/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/global/find.ts
@@ -114,10 +114,12 @@ ${JSON.stringify(result, null, 2)}
   }
 
   if (globals?.[globalSlug]?.enabled) {
-    server.tool(
+    server.registerTool(
       `find${globalSlug.charAt(0).toUpperCase() + toCamelCase(globalSlug).slice(1)}`,
-      `${toolSchemas.findGlobal.description.trim()}\n\n${globals?.[globalSlug]?.description || ''}`,
-      toolSchemas.findGlobal.parameters.shape,
+      {
+        description: `${toolSchemas.findGlobal.description.trim()}\n\n${globals?.[globalSlug]?.description || ''}`,
+        inputSchema: toolSchemas.findGlobal.parameters.shape,
+      },
       async ({ depth, fallbackLocale, locale, select }) => {
         return await tool(depth, locale, fallbackLocale, select)
       },

--- a/packages/plugin-mcp/src/mcp/tools/global/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/global/update.ts
@@ -176,10 +176,12 @@ ${JSON.stringify(result, null, 2)}
         ),
     })
 
-    server.tool(
+    server.registerTool(
       `update${globalSlug.charAt(0).toUpperCase() + toCamelCase(globalSlug).slice(1)}`,
-      `${toolSchemas.updateGlobal.description.trim()}\n\n${globals?.[globalSlug]?.description || ''}`,
-      updateGlobalSchema.shape,
+      {
+        description: `${toolSchemas.updateGlobal.description.trim()}\n\n${globals?.[globalSlug]?.description || ''}`,
+        inputSchema: updateGlobalSchema.shape,
+      },
       async (params: Record<string, unknown>) => {
         const { depth, draft, fallbackLocale, locale, select, ...rest } = params
         const data = JSON.stringify(rest)

--- a/packages/plugin-mcp/src/mcp/tools/job/create.ts
+++ b/packages/plugin-mcp/src/mcp/tools/job/create.ts
@@ -401,10 +401,12 @@ export const createJobTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'createJob',
-    'Creates a new Payload job (task or workflow) with specified configuration',
-    toolSchemas.createJob.parameters.shape,
+    {
+      description: 'Creates a new Payload job (task or workflow) with specified configuration',
+      inputSchema: toolSchemas.createJob.parameters.shape,
+    },
     async (args) => {
       return tool(
         args.jobName,

--- a/packages/plugin-mcp/src/mcp/tools/job/run.ts
+++ b/packages/plugin-mcp/src/mcp/tools/job/run.ts
@@ -177,10 +177,12 @@ export const runJobTool = (server: McpServer, req: PayloadRequest, verboseLogs: 
     }
   }
 
-  server.tool(
+  server.registerTool(
     'runJob',
-    'Runs a Payload job with specified input data and queue options',
-    toolSchemas.runJob.parameters.shape,
+    {
+      description: 'Runs a Payload job with specified input data and queue options',
+      inputSchema: toolSchemas.runJob.parameters.shape,
+    },
     async (args) => {
       const { delay, input, jobSlug, priority, queue } = args
       return await tool(jobSlug, input, queue, priority, delay)

--- a/packages/plugin-mcp/src/mcp/tools/job/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/job/update.ts
@@ -291,10 +291,13 @@ export const updateJobTool = (
     }
   }
 
-  server.tool(
+  server.registerTool(
     'updateJob',
-    'Updates an existing Payload job with new configuration, schema, or handler code',
-    toolSchemas.updateJob.parameters.shape,
+    {
+      description:
+        'Updates an existing Payload job with new configuration, schema, or handler code',
+      inputSchema: toolSchemas.updateJob.parameters.shape,
+    },
     async (args) => {
       const {
         configUpdate,

--- a/packages/plugin-mcp/src/mcp/tools/resource/create.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/create.ts
@@ -181,10 +181,12 @@ ${JSON.stringify(result, null, 2)}
         ),
     })
 
-    server.tool(
+    server.registerTool(
       `create${collectionSlug.charAt(0).toUpperCase() + toCamelCase(collectionSlug).slice(1)}`,
-      `${collections?.[collectionSlug]?.description || toolSchemas.createResource.description.trim()}`,
-      createResourceSchema.shape,
+      {
+        description: `${collections?.[collectionSlug]?.description || toolSchemas.createResource.description.trim()}`,
+        inputSchema: createResourceSchema.shape,
+      },
       async (params: Record<string, unknown>) => {
         const { depth, draft, fallbackLocale, locale, select, ...fieldData } = params
         const data = JSON.stringify(fieldData)

--- a/packages/plugin-mcp/src/mcp/tools/resource/delete.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/delete.ts
@@ -204,10 +204,12 @@ ${JSON.stringify(errors, null, 2)}
   }
 
   if (collections?.[collectionSlug]?.enabled) {
-    server.tool(
+    server.registerTool(
       `delete${collectionSlug.charAt(0).toUpperCase() + toCamelCase(collectionSlug).slice(1)}`,
-      `${collections?.[collectionSlug]?.description || toolSchemas.deleteResource.description.trim()}`,
-      toolSchemas.deleteResource.parameters.shape,
+      {
+        description: `${collections?.[collectionSlug]?.description || toolSchemas.deleteResource.description.trim()}`,
+        inputSchema: toolSchemas.deleteResource.parameters.shape,
+      },
       async ({ id, depth, fallbackLocale, locale, where }) => {
         return await tool(id, where, depth, locale, fallbackLocale)
       },

--- a/packages/plugin-mcp/src/mcp/tools/resource/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/find.ts
@@ -221,10 +221,12 @@ Page: ${result.page} of ${result.totalPages}
   }
 
   if (collections?.[collectionSlug]?.enabled) {
-    server.tool(
+    server.registerTool(
       `find${collectionSlug.charAt(0).toUpperCase() + toCamelCase(collectionSlug).slice(1)}`,
-      `${collections?.[collectionSlug]?.description || toolSchemas.findResources.description.trim()}`,
-      toolSchemas.findResources.parameters.shape,
+      {
+        description: `${collections?.[collectionSlug]?.description || toolSchemas.findResources.description.trim()}`,
+        inputSchema: toolSchemas.findResources.parameters.shape,
+      },
       async ({ id, depth, draft, fallbackLocale, limit, locale, page, select, sort, where }) => {
         return await tool(
           id,

--- a/packages/plugin-mcp/src/mcp/tools/resource/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/update.ts
@@ -335,10 +335,12 @@ ${JSON.stringify(errors, null, 2)}
         .describe('JSON string for where clause to update multiple documents'),
     })
 
-    server.tool(
+    server.registerTool(
       `update${collectionSlug.charAt(0).toUpperCase() + toCamelCase(collectionSlug).slice(1)}`,
-      `${collections?.[collectionSlug]?.description || toolSchemas.updateResource.description.trim()}`,
-      updateResourceSchema.shape,
+      {
+        description: `${collections?.[collectionSlug]?.description || toolSchemas.updateResource.description.trim()}`,
+        inputSchema: updateResourceSchema.shape,
+      },
       async (params: Record<string, unknown>) => {
         const {
           id,

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -343,16 +343,25 @@ export type MCPHandlerOptions = {
    */
   basePath?: string
   /**
+   * If true, disables the SSE endpoint. Only Streamable HTTP will be available.
+   * @default true
+   */
+  disableSse?: boolean
+  /**
    * Set the maximum duration of the MCP handler. This is the maximum duration that the MCP handler will run for.
    * @default 60
    */
   maxDuration?: number
   /**
+   * Callback function that receives MCP events.
+   * This can be used to track analytics, debug issues, or implement custom behaviors.
+   */
+  onEvent?: (event: unknown) => void
+  /**
    * Set the Redis URL for the MCP handler. This is the URL that will be used to access the Redis server.
    * @default process.env.REDIS_URL
-   * INFO: Disabled until developer clarity is reached for server side streaming and we have an auth pattern for all SSE patterns
    */
-  // redisUrl?: string
+  redisUrl?: string
   /**
    * Set verbose logging.
    * @default false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1181,17 +1181,17 @@ importers:
   packages/plugin-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ~1.24.0
-        version: 1.24.3(zod@3.25.76)
+        specifier: 1.25.2
+        version: 1.25.2(hono@4.11.9)(zod@3.25.76)
       '@types/json-schema':
         specifier: 7.0.15
         version: 7.0.15
-      '@vercel/mcp-adapter':
-        specifier: ^1.0.0
-        version: 1.0.0(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
       json-schema-to-zod:
         specifier: 2.6.1
         version: 2.6.1
+      mcp-handler:
+        specifier: ^1.0.7
+        version: 1.0.7(@modelcontextprotocol/sdk@1.25.2(hono@4.11.9)(zod@3.25.76))(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
       zod:
         specifier: ^3.25.50
         version: 3.25.76
@@ -2194,7 +2194,7 @@ importers:
         version: 15.4.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
+        version: 4.2.3(next@15.4.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
       payload:
         specifier: workspace:*
         version: link:../../packages/payload
@@ -2288,7 +2288,7 @@ importers:
     dependencies:
       recharts:
         specifier: 3.2.1
-        version: 3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1)
+        version: 3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.614.0
@@ -4857,6 +4857,12 @@ packages:
     resolution: {integrity: sha512-6xN0KNO8L/LIA5zu3CJwHkJiB6n65eykBLOb0E+RooiHYgX8CSao6lvQiKT9TBk2gL5g33LL3fmhDodZnt56rw==}
     engines: {node: '>=14'}
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -5348,6 +5354,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.24.3':
     resolution: {integrity: sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.25.2':
+    resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -7934,16 +7950,6 @@ packages:
   '@vercel/git-hooks@1.0.0':
     resolution: {integrity: sha512-OxDFAAdyiJ/H0b8zR9rFCu3BIb78LekBXOphOYG3snV4ULhKFX387pBPpqZ9HLiRTejBWBxYEahkw79tuIgdAA==}
 
-  '@vercel/mcp-adapter@1.0.0':
-    resolution: {integrity: sha512-o/QA4LhYCJvuL7/i8CfKPpOm29u25/L4m1LWH44EQZ8cfYJlc4B7Bu+YzDHl23m8A3hDxCJQmlgZEGmsPAQ0vQ==}
-    hasBin: true
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.12.0
-      next: '>=13.0.0'
-    peerDependenciesMeta:
-      next:
-        optional: true
-
   '@vercel/postgres@0.9.0':
     resolution: {integrity: sha512-WiI2g3+ce2g1u1gP41MoDj2DsMuQQ+us7vHobysRixKECGaLHpfTI7DuVZmHU087ozRAGr3GocSyqmWLLo+fig==}
     engines: {node: '>=14.6'}
@@ -10419,6 +10425,10 @@ packages:
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
+
+  hono@4.11.9:
+    resolution: {integrity: sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==}
+    engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
@@ -17365,6 +17375,10 @@ snapshots:
       - encoding
       - supports-color
 
+  '@hono/node-server@1.19.9(hono@4.11.9)':
+    dependencies:
+      hono: 4.11.9
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -17879,6 +17893,28 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.9)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.9)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - hono
       - supports-color
 
   '@monaco-editor/loader@1.7.0':
@@ -20757,13 +20793,6 @@ snapshots:
       undici: 5.29.0
 
   '@vercel/git-hooks@1.0.0': {}
-
-  '@vercel/mcp-adapter@1.0.0(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))':
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
-      mcp-handler: 1.0.7(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
-    optionalDependencies:
-      next: 15.4.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
 
   '@vercel/postgres@0.9.0':
     dependencies:
@@ -23740,6 +23769,8 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
+  hono@4.11.9: {}
+
   hookified@1.15.1: {}
 
   hosted-git-info@2.8.9: {}
@@ -24539,9 +24570,9 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
-  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)):
+  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.25.2(hono@4.11.9)(zod@3.25.76))(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.9)(zod@3.25.76)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1
@@ -25043,7 +25074,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next-sitemap@4.2.3(next@15.4.11(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)):
+  next-sitemap@4.2.3(next@15.4.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
@@ -26006,7 +26037,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts@3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1):
+  recharts@3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.9)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
       clsx: 2.1.1
@@ -26016,7 +26047,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@19.2.9)(react@19.2.4)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -18,6 +18,8 @@ import { seed } from './seed/index.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
+export const capturedMcpEvents: unknown[] = []
+
 export default buildConfigWithDefaults({
   admin: {
     importMap: {
@@ -133,6 +135,9 @@ export default buildConfigWithDefaults({
         handlerOptions: {
           verboseLogs: true,
           maxDuration: 60,
+          onEvent: (event: unknown) => {
+            capturedMcpEvents.push(event)
+          },
         },
         serverOptions: {
           serverInfo: {


### PR DESCRIPTION
- Replace deprecated @vercel/mcp-adapter with mcp-handler
- Bump @modelcontextprotocol/sdk from ~1.24.0 to 1.25.2 to address a security vulnerability. 
- Migrate all server.tool() calls to the new server.registerTool() API
- Expose disableSse, onEvent, and redisUrl handler options. 
- Add integration tests for the onEvent callback.

```ts
import { mcpPlugin } from '@payloadcms/plugin-mcp'

export default buildConfig({
  plugins: [
    mcpPlugin({
      // Optional: Enable SSE transport (disabled by default)
      disableSse: false,
      // Optional: Redis URL for SSE session management (defaults to REDIS_URL env)
      redisUrl: 'redis://localhost:6379',
      // Optional: Track MCP events for analytics/debugging
      onEvent: (event) => {
        console.log('MCP event:', event)
      },
    }),
  ],
})
```