### PR TITLE
fix(plugin-import-export): remove deprecated import

### DIFF
--- a/packages/plugin-import-export/src/components/ExportPreview/index.tsx
+++ b/packages/plugin-import-export/src/components/ExportPreview/index.tsx
@@ -1,6 +1,5 @@
 'use client'
-import type { Column } from '@payloadcms/ui'
-import type { ClientField, PaginatedDocs, Where } from 'payload'
+import type { ClientField, Column, PaginatedDocs, Where } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import {

--- a/packages/plugin-import-export/src/components/ImportPreview/index.tsx
+++ b/packages/plugin-import-export/src/components/ImportPreview/index.tsx
@@ -1,6 +1,5 @@
 'use client'
-import type { Column } from '@payloadcms/ui'
-import type { ClientField, PaginatedDocs } from 'payload'
+import type { ClientField, Column, PaginatedDocs } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import {


### PR DESCRIPTION
The `column` from `ui` is deprecated; it must be imported from `payload`. 