### PR TITLE
fix(plugin-cloud-storage): generateFileURL only ran when disablePayloadAccessControl was true

### DIFF
--- a/packages/plugin-cloud-storage/src/hooks/afterRead.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterRead.ts
@@ -17,7 +17,7 @@ export const getAfterReadHook =
     const prefix = data?.prefix
     let url = value
 
-    if (disablePayloadAccessControl && filename) {
+    if (filename) {
       if (generateFileURL) {
         url = await generateFileURL({
           collection,
@@ -25,7 +25,7 @@ export const getAfterReadHook =
           prefix,
           size,
         })
-      } else if (adapter.generateURL) {
+      } else if (disablePayloadAccessControl && adapter.generateURL) {
         url = await adapter.generateURL({
           collection,
           data,

--- a/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
@@ -13,35 +13,29 @@ interface Args {
 export const getBeforeChangeHook =
   ({ adapter, collection, disablePayloadAccessControl, generateFileURL, size }: Args): FieldHook =>
   async ({ data, originalDoc, value }) => {
-    if (!disablePayloadAccessControl) {
-      return value
-    } else {
-      const newFilename = size ? data?.sizes?.[size.name]?.filename : data?.filename
-      const originalFilename = size
-        ? originalDoc?.sizes?.[size.name]?.filename
-        : originalDoc?.filename
-      const filename = newFilename || originalFilename
-      const prefix = data?.prefix
-      let url = value
+    const newFilename = size ? data?.sizes?.[size.name]?.filename : data?.filename
+    const originalFilename = size
+      ? originalDoc?.sizes?.[size.name]?.filename
+      : originalDoc?.filename
+    const filename = newFilename || originalFilename
+    const prefix = data?.prefix
+    let url = value
 
-      // Store the full URL in the database so files can be accessed directly
-      // from the storage provider without going through Payload's API
-      if (generateFileURL) {
-        url = await generateFileURL({
-          collection,
-          filename,
-          prefix,
-          size,
-        })
-      } else if (adapter.generateURL) {
-        url = await adapter.generateURL({
-          collection,
-          data: data || originalDoc,
-          filename,
-          prefix,
-        })
-      }
-
-      return url
+    if (generateFileURL && filename) {
+      url = await generateFileURL({
+        collection,
+        filename,
+        prefix,
+        size,
+      })
+    } else if (disablePayloadAccessControl && filename && adapter.generateURL) {
+      url = await adapter.generateURL({
+        collection,
+        data: data || originalDoc,
+        filename,
+        prefix,
+      })
     }
+
+    return url
   }

--- a/test/plugin-cloud-storage/collections/MediaWithGenerateFileURL.ts
+++ b/test/plugin-cloud-storage/collections/MediaWithGenerateFileURL.ts
@@ -1,0 +1,9 @@
+import type { CollectionConfig } from 'payload'
+
+export const MediaWithGenerateFileURL: CollectionConfig = {
+  slug: 'media-with-generate-file-url',
+  upload: {
+    disableLocalStorage: true,
+  },
+  fields: [],
+}

--- a/test/plugin-cloud-storage/config.ts
+++ b/test/plugin-cloud-storage/config.ts
@@ -13,6 +13,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { Media } from './collections/Media.js'
 import { MediaWithCustomURL } from './collections/MediaWithCustomURL.js'
+import { MediaWithGenerateFileURL } from './collections/MediaWithGenerateFileURL.js'
 import { MediaWithPrefix } from './collections/MediaWithPrefix.js'
 import { RestrictedMedia } from './collections/RestrictedMedia.js'
 import { TestMetadata } from './collections/TestMetadata.js'
@@ -20,6 +21,7 @@ import { Users } from './collections/Users.js'
 import {
   mediaSlug,
   mediaWithCustomURLSlug,
+  mediaWithGenerateFileURLSlug,
   mediaWithPrefixSlug,
   prefix,
   restrictedMediaSlug,
@@ -94,6 +96,15 @@ if (
             ? `https://test-cdn.example.com/${prefix}/${encodeURIComponent(filename)}`
             : null,
       } as S3StorageOptions['collections'][keyof S3StorageOptions['collections']],
+      [mediaWithGenerateFileURLSlug]: {
+        prefix,
+        // disablePayloadAccessControl defaults to false - files proxied through Payload
+        // This tests that generateFileURL works even when Payload proxies files
+        generateFileURL: ({ filename, prefix }) =>
+          filename
+            ? `https://cdn-proxied.example.com/${prefix}/${encodeURIComponent(filename)}`
+            : null,
+      } as S3StorageOptions['collections'][keyof S3StorageOptions['collections']],
       [restrictedMediaSlug]: true,
     },
     bucket: process.env.S3_BUCKET ?? '',
@@ -161,7 +172,15 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Media, MediaWithCustomURL, MediaWithPrefix, RestrictedMedia, TestMetadata, Users],
+  collections: [
+    Media,
+    MediaWithCustomURL,
+    MediaWithGenerateFileURL,
+    MediaWithPrefix,
+    RestrictedMedia,
+    TestMetadata,
+    Users,
+  ],
   onInit: async (payload) => {
     /*const client = new AWS.S3({
       endpoint: process.env.S3_ENDPOINT,

--- a/test/plugin-cloud-storage/shared.ts
+++ b/test/plugin-cloud-storage/shared.ts
@@ -1,6 +1,7 @@
 export const mediaSlug = 'media'
 export const mediaWithPrefixSlug = 'media-with-prefix'
 export const mediaWithCustomURLSlug = 'media-with-custom-url'
+export const mediaWithGenerateFileURLSlug = 'media-with-generate-file-url'
 export const restrictedMediaSlug = 'restricted-media'
 export const testMetadataSlug = 'test-metadata'
 export const prefix = 'test-prefix'


### PR DESCRIPTION
Fixes regression from #15565 where `generateFileURL` only ran when `disablePayloadAccessControl: true`.

This change allows users to customize URLs via `generateFileURL` regardless of whether files are passed through Payload or served directly from storage.

### Changes

`plugin-cloud-storage`:
- `afterRead.ts`: Moves `disablePayloadAccessControl` check to only gate `adapter.generateURL`, not `generateFileURL`
- `beforeChange.ts`: Same as above

#### Testing
Added to `plugin-cloud-storage > int`