### PR TITLE
fix: hasMany text fields cannot be filtered with contains operator

### DIFF
--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -390,6 +390,21 @@ export function parseParams({
                   resolvedQueryValue = queryValue.filter((v) => v !== null)
                 }
 
+                if (operator === 'contains' && Array.isArray(queryValue)) {
+                  // Create OR conditions for each value in the array
+                  orConditions.push(
+                    ...queryValue.map((val) =>
+                      adapter.operators[queryOperator](resolvedColumn, val),
+                    ),
+                  )
+                  // Set constraint to combine all OR conditions
+                  const constraint = orConditions.length > 0 ? or(...orConditions) : undefined
+                  if (constraint) {
+                    constraints.push(constraint)
+                  }
+                  break
+                }
+
                 let constraint = adapter.operators[queryOperator](
                   resolvedColumn,
                   resolvedQueryValue,

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -390,7 +390,6 @@ export function parseParams({
                   resolvedQueryValue = queryValue.filter((v) => v !== null)
                 }
 
-                // Handle hasMany text/number/select fields with contains operator and array values
                 if (
                   operator === 'contains' &&
                   Array.isArray(queryValue) &&

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -390,7 +390,14 @@ export function parseParams({
                   resolvedQueryValue = queryValue.filter((v) => v !== null)
                 }
 
-                if (operator === 'contains' && Array.isArray(queryValue)) {
+                // Handle hasMany text/number/select fields with contains operator and array values
+                if (
+                  operator === 'contains' &&
+                  Array.isArray(queryValue) &&
+                  'hasMany' in field &&
+                  field.hasMany &&
+                  ['number', 'select', 'text'].includes(field.type)
+                ) {
                   // Create OR conditions for each value in the array
                   orConditions.push(
                     ...queryValue.map((val) =>

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -238,10 +238,6 @@ export const sanitizeQueryValue = ({
     }
   }
 
-  if ('hasMany' in field && field.hasMany && operator === 'contains') {
-    operator = 'equals'
-  }
-
   if (operator === 'near' && field.type === 'point' && typeof formattedValue === 'string') {
     const [lng, lat, maxDistance, minDistance] = formattedValue.split(',')
 
@@ -249,7 +245,12 @@ export const sanitizeQueryValue = ({
   }
 
   if (operator === 'contains') {
-    formattedValue = `%${formattedValue}%`
+    if (Array.isArray(formattedValue)) {
+      // For array values, wrap each element with % for LIKE matching
+      formattedValue = formattedValue.map((val) => `%${val}%`)
+    } else {
+      formattedValue = `%${formattedValue}%`
+    }
   }
 
   if (operator === 'exists') {

--- a/test/fields/collections/Text/e2e.spec.ts
+++ b/test/fields/collections/Text/e2e.spec.ts
@@ -21,8 +21,8 @@ import {
   selectTableRow,
 } from '../../../__helpers/e2e/helpers.js'
 import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
-import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../../../__helpers/shared/rest.js'
 import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 import { textFieldsSlug } from '../../slugs.js'
@@ -342,6 +342,43 @@ describe('Text', () => {
 
     await wait(300)
     await expect(page.locator('table >> tbody >> tr')).toHaveCount(1)
+  })
+
+  test('should filter Text field hasMany: true in the collection list view - contains single value', async () => {
+    await page.goto(url.list)
+    await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
+
+    await addListFilter({
+      page,
+      fieldLabel: 'Has Many',
+      operatorLabel: 'contains',
+      value: 'two',
+    })
+
+    await wait(300)
+    await expect(page.locator('table >> tbody >> tr')).toHaveCount(1)
+  })
+
+  test('should filter Text field hasMany: true in the collection list view - contains multiple values', async () => {
+    await page.goto(url.list)
+    await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
+
+    // Add filter with first value
+    const { condition } = await addListFilter({
+      page,
+      fieldLabel: 'Has Many',
+      operatorLabel: 'contains',
+      value: 'one',
+    })
+
+    // Add second value to the same filter
+    const valueInput = condition.locator('.condition__value input')
+    await valueInput.click()
+    await page.keyboard.type('three')
+    await page.keyboard.press('Enter')
+
+    await wait(300)
+    await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
   })
 
   describe('A11y', () => {

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -280,6 +280,21 @@ export interface ArrayField {
     text: string;
     anotherText?: string | null;
     localizedText?: string | null;
+    richTextField?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
     subArray?:
       | {
           text?: string | null;
@@ -2121,6 +2136,7 @@ export interface ArrayFieldsSelect<T extends boolean = true> {
         text?: T;
         anotherText?: T;
         localizedText?: T;
+        richTextField?: T;
         subArray?:
           | T
           | {


### PR DESCRIPTION
### What

Fixed `contains` operator for hasMany text fields in MongoDB and Drizzle adapters.

### Why

Filtering hasMany text fields with `contains` failed with `TypeError: formattedValue.replace is not a function` because the code didn't handle array values.

### How

- MongoDB: Use `$elemMatch` with regex to search within array elements
- Drizzle: Handle array values by creating OR conditions with LIKE matching

Fixes #15662

