### PR TITLE
feat(ui): add addSuffix option to formatTimeToNow

### DIFF
--- a/packages/ui/src/utilities/formatDocTitle/formatDateTitle.ts
+++ b/packages/ui/src/utilities/formatDocTitle/formatDateTitle.ts
@@ -35,11 +35,12 @@ export const formatDate = ({ date, i18n, pattern, timezone }: FormatDateArgs): s
 type FormatTimeToNowArgs = {
   date: Date | number | string | undefined
   i18n: I18n<unknown, unknown> | I18nClient<unknown>
+  addSuffix?: boolean
 }
 
-export const formatTimeToNow = ({ date, i18n }: FormatTimeToNowArgs): string => {
+export const formatTimeToNow = ({ date, i18n, addSuffix }: FormatTimeToNowArgs): string => {
   const theDate = typeof date === 'string' ? new Date(date) : date
   return i18n?.dateFNS
-    ? formatDistanceToNow(theDate, { locale: i18n.dateFNS })
+    ? formatDistanceToNow(theDate, { locale: i18n.dateFNS, addSuffix })
     : `${i18n.t('general:loading')}...`
 }


### PR DESCRIPTION
## Summary
- Adds optional `addSuffix` parameter to the `formatTimeToNow` utility function
- Passes it through to date-fns `formatDistanceToNow`, enabling output like "3 minutes ago" instead of just "3 minutes"
- This allows plugin developers to reuse this utility with the suffix behavior when displaying relative timestamps

## Test plan
- [ ] Verify existing callers of `formatTimeToNow` are unaffected (parameter is optional with no default change)
- [ ] Verify passing `addSuffix: true` appends the suffix correctly (e.g. "3 minutes ago")