### PR TITLE
fix(plugin-mcp): use inline block schemas in JSON output

### DIFF
--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -143,7 +143,7 @@ describe('configToJSONSchema', () => {
             oneOf: [
               {
                 type: 'object',
-                additionalProperties: false,
+                additionalProperties: true,
                 properties: {
                   id: {
                     type: ['string', 'null'],
@@ -169,7 +169,7 @@ describe('configToJSONSchema', () => {
             oneOf: [
               {
                 type: 'object',
-                additionalProperties: false,
+                additionalProperties: true,
                 properties: {
                   id: {
                     type: ['string', 'null'],
@@ -388,6 +388,18 @@ describe('configToJSONSchema', () => {
 
     const schema = configToJSONSchema(sanitizedConfig, 'text')
 
+    const expectedBlockSchema = {
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        id: { type: ['string', 'null'] },
+        blockName: { type: ['string', 'null'] },
+        blockType: { const: 'sharedBlock' },
+        richText: { type: ['array', 'null'], items: { type: 'object' } },
+      },
+      required: ['blockType'],
+    }
+
     expect(schema?.definitions?.test).toStrictEqual({
       type: 'object',
       additionalProperties: false,
@@ -399,18 +411,15 @@ describe('configToJSONSchema', () => {
         someBlockField: {
           type: ['array', 'null'],
           items: {
-            oneOf: [
-              {
-                $ref: '#/definitions/SharedBlock',
-              },
-            ],
+            oneOf: [expectedBlockSchema],
           },
         },
       },
       required: ['id'],
     })
 
-    expect(schema?.definitions?.SharedBlock).toBeDefined()
+    // The definition should still be registered for TypeScript type generation
+    expect(schema?.definitions?.SharedBlock).toStrictEqual(expectedBlockSchema)
   })
 
   it('should allow overriding required to false', async () => {

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -143,7 +143,7 @@ describe('configToJSONSchema', () => {
             oneOf: [
               {
                 type: 'object',
-                additionalProperties: true,
+                additionalProperties: false,
                 properties: {
                   id: {
                     type: ['string', 'null'],
@@ -169,7 +169,7 @@ describe('configToJSONSchema', () => {
             oneOf: [
               {
                 type: 'object',
-                additionalProperties: true,
+                additionalProperties: false,
                 properties: {
                   id: {
                     type: ['string', 'null'],
@@ -390,7 +390,7 @@ describe('configToJSONSchema', () => {
 
     const expectedBlockSchema = {
       type: 'object',
-      additionalProperties: true,
+      additionalProperties: false,
       properties: {
         id: { type: ['string', 'null'] },
         blockName: { type: ['string', 'null'] },

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -338,7 +338,7 @@ export function fieldsToJSONSchema(
 
                         const resolvedBlockSchema: JSONSchema4 = {
                           type: 'object',
-                          additionalProperties: true,
+                          additionalProperties: false,
                           properties: {
                             ...resolvedBlockFieldSchemas.properties,
                             blockType: {
@@ -367,7 +367,7 @@ export function fieldsToJSONSchema(
                       )
                       const blockSchema: JSONSchema4 = {
                         type: 'object',
-                        additionalProperties: true,
+                        additionalProperties: false,
                         properties: {
                           ...blockFieldSchemas.properties,
                           blockType: {

--- a/test/plugin-mcp/collections/Pages.ts
+++ b/test/plugin-mcp/collections/Pages.ts
@@ -1,0 +1,45 @@
+import type { CollectionConfig } from 'payload'
+
+export const heroBlockSlug = 'hero'
+export const textBlockSlug = 'textContent'
+
+export const Pages: CollectionConfig = {
+  slug: 'pages',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'layout',
+      type: 'blocks',
+      blocks: [
+        {
+          slug: heroBlockSlug,
+          interfaceName: 'HeroBlock',
+          fields: [
+            {
+              name: 'heading',
+              type: 'text',
+              required: true,
+            },
+            {
+              name: 'subheading',
+              type: 'text',
+            },
+          ],
+        },
+        {
+          slug: textBlockSlug,
+          fields: [
+            {
+              name: 'body',
+              type: 'textarea',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Media } from './collections/Media.js'
 import { ModifiedPrompts } from './collections/ModifiedPrompts.js'
+import { Pages } from './collections/Pages.js'
 import { Posts } from './collections/Posts.js'
 import { Products } from './collections/Products.js'
 import { ReturnedResources } from './collections/ReturnedResources.js'
@@ -26,7 +27,7 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media, Posts, Products, Rolls, ModifiedPrompts, ReturnedResources],
+  collections: [Users, Media, Posts, Products, Rolls, ModifiedPrompts, ReturnedResources, Pages],
   localization: {
     defaultLocale: 'en',
     fallback: true,
@@ -94,6 +95,15 @@ export default buildConfigWithDefaults({
       collections: {
         [Products.slug]: {
           enabled: true,
+        },
+        pages: {
+          enabled: {
+            find: true,
+            create: true,
+            update: true,
+            delete: true,
+          },
+          description: 'Pages with block-based layouts.',
         },
         posts: {
           enabled: {

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -3,7 +3,7 @@ import type { Payload } from 'payload'
 import { randomUUID } from 'crypto'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
@@ -1300,13 +1300,6 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('Blocks fields', () => {
     const createdPageIds: (number | string)[] = []
 
-    afterEach(async () => {
-      for (const id of createdPageIds) {
-        await payload.delete({ collection: 'pages', id })
-      }
-      createdPageIds.length = 0
-    })
-
     const getPagesApiKey = async (enableUpdate = false) => {
       const doc = await payload.create({
         collection: 'payload-mcp-api-keys',
@@ -1361,10 +1354,9 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[0].text).toContain('"blockType": "hero"')
       expect(json.result.content[0].text).toContain('"heading": "Welcome to our site"')
 
-      const responseText = json.result.content[0].text
-      const match = responseText.match(/"id":\s*"?([^",}\s]+)"?/)
-      if (match) {
-        createdPageIds.push(match[1])
+      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
+      if (jsonMatch) {
+        createdPageIds.push(JSON.parse(jsonMatch[1]).id)
       }
     })
 
@@ -1410,10 +1402,9 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[0].text).toContain('"heading": "Page Hero"')
       expect(json.result.content[0].text).toContain('"body": "This is the body text."')
 
-      const responseText = json.result.content[0].text
-      const match = responseText.match(/"id":\s*"?([^",}\s]+)"?/)
-      if (match) {
-        createdPageIds.push(match[1])
+      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
+      if (jsonMatch) {
+        createdPageIds.push(JSON.parse(jsonMatch[1]).id)
       }
     })
 

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -3,7 +3,7 @@ import type { Payload } from 'payload'
 import { randomUUID } from 'crypto'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
@@ -1294,6 +1294,188 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[1].text).toContain('Override MCP response for Posts!')
 
       await payload.delete({ id: createdPost.id, collection: 'posts' })
+    })
+  })
+
+  describe('Blocks fields', () => {
+    const createdPageIds: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of createdPageIds) {
+        await payload.delete({ collection: 'pages', id })
+      }
+      createdPageIds.length = 0
+    })
+
+    const getPagesApiKey = async (enableUpdate = false) => {
+      const doc = await payload.create({
+        collection: 'payload-mcp-api-keys',
+        data: {
+          enableAPIKey: true,
+          label: 'Pages API Key',
+          pages: { create: true, find: true, update: enableUpdate, delete: true },
+          posts: { create: false, find: false },
+          products: { find: false },
+          apiKey: randomUUID(),
+          user: userId,
+        },
+      })
+      return doc.apiKey as string
+    }
+
+    it('should create a page with a block', async () => {
+      const apiKey = await getPagesApiKey()
+
+      const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'createPages',
+            arguments: {
+              title: 'Hero Page',
+              layout: [
+                {
+                  blockType: 'hero',
+                  heading: 'Welcome to our site',
+                  subheading: 'Discover amazing things',
+                },
+              ],
+            },
+          },
+        }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await parseStreamResponse(response)
+
+      expect(json.result).toBeDefined()
+      expect(json.result.isError).toBeFalsy()
+      expect(json.result.content[0].type).toBe('text')
+      expect(json.result.content[0].text).toContain('"title": "Hero Page"')
+      expect(json.result.content[0].text).toContain('"blockType": "hero"')
+      expect(json.result.content[0].text).toContain('"heading": "Welcome to our site"')
+
+      const responseText = json.result.content[0].text
+      const match = responseText.match(/"id":\s*"?([^",}\s]+)"?/)
+      if (match) {
+        createdPageIds.push(match[1])
+      }
+    })
+
+    it('should create a page with multiple block types', async () => {
+      const apiKey = await getPagesApiKey()
+
+      const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'createPages',
+            arguments: {
+              title: 'Multi-block Page',
+              layout: [
+                {
+                  blockType: 'hero',
+                  heading: 'Page Hero',
+                  subheading: 'Hero subtitle',
+                },
+                {
+                  blockType: 'textContent',
+                  body: 'This is the body text.',
+                },
+              ],
+            },
+          },
+        }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await parseStreamResponse(response)
+
+      expect(json.result).toBeDefined()
+      expect(json.result.isError).toBeFalsy()
+      expect(json.result.content[0].text).toContain('"blockType": "hero"')
+      expect(json.result.content[0].text).toContain('"blockType": "textContent"')
+      expect(json.result.content[0].text).toContain('"heading": "Page Hero"')
+      expect(json.result.content[0].text).toContain('"body": "This is the body text."')
+
+      const responseText = json.result.content[0].text
+      const match = responseText.match(/"id":\s*"?([^",}\s]+)"?/)
+      if (match) {
+        createdPageIds.push(match[1])
+      }
+    })
+
+    it('should update a page layout that contains blocks', async () => {
+      const page = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Page to Update',
+          layout: [],
+        },
+      })
+
+      createdPageIds.push(page.id)
+
+      const apiKey = await getPagesApiKey(true)
+
+      const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'updatePages',
+            arguments: {
+              id: page.id,
+              layout: [
+                {
+                  blockType: 'hero',
+                  heading: 'Updated Hero Heading',
+                },
+                {
+                  blockType: 'textContent',
+                  body: 'Updated body text.',
+                },
+              ],
+            },
+          },
+        }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await parseStreamResponse(response)
+
+      expect(json.result).toBeDefined()
+      expect(json.result.isError).toBeFalsy()
+      expect(json.result.content[0].text).toContain('"blockType": "hero"')
+      expect(json.result.content[0].text).toContain('"heading": "Updated Hero Heading"')
+      expect(json.result.content[0].text).toContain('"blockType": "textContent"')
+      expect(json.result.content[0].text).toContain('"body": "Updated body text."')
+
+      const updatedPage = await payload.findByID({
+        collection: 'pages',
+        id: page.id,
+      })
+
+      expect((updatedPage as any).layout).toHaveLength(2)
+      expect((updatedPage as any).layout[0].blockType).toBe('hero')
+      expect((updatedPage as any).layout[0].heading).toBe('Updated Hero Heading')
     })
   })
 

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -317,7 +317,6 @@ export interface Page {
             id?: string | null;
             blockName?: string | null;
             blockType: 'textContent';
-            [k: string]: unknown;
           }
       )[]
     | null;
@@ -334,7 +333,6 @@ export interface HeroBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'hero';
-  [k: string]: unknown;
 }
 /**
  * API keys control which collections, resources, tools, and prompts MCP clients can access

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -75,6 +75,7 @@ export interface Config {
     rolls: Roll;
     'modified-prompts': ModifiedPrompt;
     'returned-resources': ReturnedResource;
+    pages: Page;
     'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -90,6 +91,7 @@ export interface Config {
     rolls: RollsSelect<false> | RollsSelect<true>;
     'modified-prompts': ModifiedPromptsSelect<false> | ModifiedPromptsSelect<true>;
     'returned-resources': ReturnedResourcesSelect<false> | ReturnedResourcesSelect<true>;
+    pages: PagesSelect<false> | PagesSelect<true>;
     'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -301,6 +303,40 @@ export interface ReturnedResource {
   createdAt: string;
 }
 /**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages".
+ */
+export interface Page {
+  id: string;
+  title: string;
+  layout?:
+    | (
+        | HeroBlock
+        | {
+            body?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'textContent';
+            [k: string]: unknown;
+          }
+      )[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "HeroBlock".
+ */
+export interface HeroBlock {
+  heading: string;
+  subheading?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'hero';
+  [k: string]: unknown;
+}
+/**
  * API keys control which collections, resources, tools, and prompts MCP clients can access
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -335,6 +371,24 @@ export interface PayloadMcpApiKey {
     update?: boolean | null;
     /**
      * Allow clients to delete products.
+     */
+    delete?: boolean | null;
+  };
+  pages?: {
+    /**
+     * Allow clients to find pages.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create pages.
+     */
+    create?: boolean | null;
+    /**
+     * Allow clients to update pages.
+     */
+    update?: boolean | null;
+    /**
+     * Allow clients to delete pages.
      */
     delete?: boolean | null;
   };
@@ -460,6 +514,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'returned-resources';
         value: string | ReturnedResource;
+      } | null)
+    | ({
+        relationTo: 'pages';
+        value: string | Page;
       } | null)
     | ({
         relationTo: 'payload-mcp-api-keys';
@@ -619,6 +677,37 @@ export interface ReturnedResourcesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages_select".
+ */
+export interface PagesSelect<T extends boolean = true> {
+  title?: T;
+  layout?:
+    | T
+    | {
+        hero?: T | HeroBlockSelect<T>;
+        textContent?:
+          | T
+          | {
+              body?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "HeroBlock_select".
+ */
+export interface HeroBlockSelect<T extends boolean = true> {
+  heading?: T;
+  subheading?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-mcp-api-keys_select".
  */
 export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
@@ -626,6 +715,14 @@ export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
   label?: T;
   description?: T;
   products?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+        update?: T;
+        delete?: T;
+      };
+  pages?:
     | T
     | {
         find?: T;


### PR DESCRIPTION
Blocks were previously emitted as `$ref` references in the JSON Schema. This caused MCP tools to reject block field values during schema validation.

Fixes #15399