### PR TITLE
refactor: extract regex escape pattern into shared utility

### DIFF
--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -2,7 +2,7 @@ import type { FilterQuery } from 'mongoose'
 import type { FlattenedField, Operator, PathToQuery, Payload } from 'payload'
 
 import { Types } from 'mongoose'
-import { APIError, getFieldByPath, getLocalizedPaths } from 'payload'
+import { APIError, escapeRegExp, getFieldByPath, getLocalizedPaths } from 'payload'
 import { validOperatorSet } from 'payload/shared'
 
 import type { MongooseAdapter } from '../index.js'
@@ -316,7 +316,7 @@ export async function buildSearchParam({
             $and: words.map((word) => ({
               [path]: {
                 $options: 'i',
-                $regex: word.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
+                $regex: escapeRegExp(word),
               },
             })),
           },
@@ -334,7 +334,7 @@ export async function buildSearchParam({
               [path]: {
                 $not: {
                   $options: 'i',
-                  $regex: word.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
+                  $regex: escapeRegExp(word),
                 },
               },
             })),

--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -8,7 +8,7 @@ import type {
 } from 'payload'
 
 import { Types } from 'mongoose'
-import { createArrayFromCommaDelineated } from 'payload'
+import { createArrayFromCommaDelineated, escapeRegExp } from 'payload'
 import { fieldShouldBeLocalized } from 'payload/shared'
 
 type SanitizeQueryValueArgs = {
@@ -458,7 +458,7 @@ export const sanitizeQueryValue = ({
         // For array fields, we need to use $elemMatch to search within array elements
         if (typeof formattedValue === 'string') {
           // Search for documents where any array element contains this string
-          const escapedValue = formattedValue.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
+          const escapedValue = escapeRegExp(formattedValue)
           return {
             rawQuery: {
               [path]: {
@@ -474,7 +474,7 @@ export const sanitizeQueryValue = ({
           return {
             rawQuery: {
               $or: formattedValue.map((val) => {
-                const escapedValue = String(val).replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
+                const escapedValue = escapeRegExp(String(val))
                 return {
                   [path]: {
                     $elemMatch: {
@@ -491,7 +491,7 @@ export const sanitizeQueryValue = ({
         // Regular (non-hasMany) text field
         formattedValue = {
           $options: 'i',
-          $regex: formattedValue.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
+          $regex: escapeRegExp(formattedValue),
         }
       }
     }

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1786,6 +1786,7 @@ export {
 } from './utilities/dependencies/dependencyChecker.js'
 export { getDependencies } from './utilities/dependencies/getDependencies.js'
 export { dynamicImport } from './utilities/dynamicImport.js'
+export { escapeRegExp } from './utilities/escapeRegExp.js'
 export {
   findUp,
   findUpSync,

--- a/packages/payload/src/utilities/escapeRegExp.ts
+++ b/packages/payload/src/utilities/escapeRegExp.ts
@@ -1,0 +1,7 @@
+/**
+ * Escapes special characters in a string for use in a regular expression
+ * @param string - The string to escape
+ * @returns The escaped string safe for use in RegExp
+ */
+export const escapeRegExp = (string: string): string =>
+  string.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')

--- a/packages/payload/src/utilities/wordBoundariesRegex.ts
+++ b/packages/payload/src/utilities/wordBoundariesRegex.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from './escapeRegExp.js'
+
 export const wordBoundariesRegex = (input: string): RegExp => {
   const words = input.split(' ')
 
@@ -5,7 +7,7 @@ export const wordBoundariesRegex = (input: string): RegExp => {
   const wordBoundaryBefore = '(?:(?:[^\\p{L}\\p{N}])|^)' // Converted to a non-matching group instead of positive lookbehind for Safari
   const wordBoundaryAfter = '(?=[^\\p{L}\\p{N}]|$)'
   const regex = words.reduce((pattern, word, i) => {
-    const escapedWord = word.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
+    const escapedWord = escapeRegExp(word)
     return `${pattern}(?=.*${wordBoundaryBefore}.*${escapedWord}.*${wordBoundaryAfter})${
       i + 1 === words.length ? '.+' : ''
     }`


### PR DESCRIPTION
### What

Extracted duplicate regex escape logic into a shared `escapeRegExp` utility.

### Why

The same regex escape pattern `.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')` was duplicated across multiple locations.

### How

- Created `packages/payload/src/utilities/escapeRegExp.ts`
- Exported from payload package
- Replaced 5 inline occurrences with utility calls
