### PR TITLE
fix(plugin-multi-tenant): return false instead of query when no tenants

### DIFF
--- a/packages/plugin-multi-tenant/src/utilities/getTenantAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getTenantAccess.ts
@@ -1,5 +1,3 @@
-import type { Where } from 'payload'
-
 import type { UserWithTenantsField } from '../types.js'
 
 import { defaults } from '../defaults.js'
@@ -16,7 +14,11 @@ export function getTenantAccess({
   tenantsArrayFieldName = defaults.tenantsArrayFieldName,
   tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
   user,
-}: Args): Where {
+}: Args): {
+  [fieldName: string]: {
+    in: (number | string)[]
+  }
+} {
   const userAssignedTenantIDs = getUserTenantIDs(user, {
     tenantsArrayFieldName,
     tenantsArrayTenantFieldName,

--- a/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
@@ -65,6 +65,20 @@ export const withTenantAccess =
         tenantsArrayTenantFieldName,
         user: args.req.user as UserWithTenantsField,
       })
+
+      // User with no tenants should have no access to tenant-scoped documents
+      // except for their own user document
+      if (tenantConstraint[fieldName]?.in.length === 0) {
+        const result: AccessResult =
+          collection.slug === args.req.user.collection
+            ? { id: { equals: args.req.user.id } }
+            : false
+
+        return accessResultCallback
+          ? accessResultCallback({ accessKey, accessResult: result, ...args })
+          : result
+      }
+
       if (collection.slug === args.req.user.collection) {
         constraints.push({
           or: [

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -7,8 +7,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Relationship } from './payload-types.js'
 
-import { devUser } from '../credentials.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { devUser } from '../credentials.js'
 import { relationshipsSlug, tenantsSlug, usersSlug } from './shared.js'
 
 let payload: Payload
@@ -133,6 +133,110 @@ describe('@payloadcms/plugin-multi-tenant', () => {
           }),
         ).rejects.toThrow('The following field is invalid: Relationship')
       })
+    })
+  })
+
+  describe('access control for users with no tenant memberships', () => {
+    it('should return Forbidden error (not 500) for user with no tenants', async () => {
+      // Create a user with no tenant memberships
+      const noTenantUser = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'no-tenants@test.com',
+          password: 'test',
+          tenants: [],
+        },
+      })
+
+      // Create a tenant and document for testing
+      const tenant = await payload.create({
+        collection: tenantsSlug,
+        data: { name: 'Test Tenant', domain: 'test-tenant.test' },
+      })
+      const doc = await payload.create({
+        collection: relationshipsSlug,
+        data: { tenant: tenant.id, title: 'Test Doc' },
+      })
+
+      // User with no tenants should get a Forbidden error (clean rejection)
+      // not a 500 server error (which happens with { $in: [] } on CosmosDB)
+      await expect(
+        payload.find({
+          collection: relationshipsSlug,
+          overrideAccess: false,
+          user: noTenantUser,
+          where: { id: { equals: doc.id } },
+        }),
+      ).rejects.toThrow('You are not allowed to perform this action.')
+
+      // Cleanup
+      await payload.delete({ id: doc.id, collection: relationshipsSlug })
+      await payload.delete({ id: tenant.id, collection: tenantsSlug })
+      await payload.delete({ id: noTenantUser.id, collection: usersSlug })
+    })
+
+    it('should allow user with no tenants to access their own user document', async () => {
+      // Create a user with no tenant memberships
+      const noTenantUser = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'no-tenants-self@test.com',
+          password: 'test',
+          tenants: [],
+        },
+      })
+
+      // User should be able to find themselves
+      const result = await payload.find({
+        collection: usersSlug,
+        overrideAccess: false,
+        user: noTenantUser,
+        where: { id: { equals: noTenantUser.id } },
+      })
+
+      expect(result.docs).toHaveLength(1)
+      expect(result.docs[0].id).toBe(noTenantUser.id)
+
+      // Cleanup
+      await payload.delete({ id: noTenantUser.id, collection: usersSlug })
+    })
+
+    it('should allow admin with empty tenants array to access all documents', async () => {
+      // Create an admin user with empty tenants array
+      const adminUser = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'admin-empty-tenants@test.com',
+          password: 'test',
+          tenants: [],
+          roles: ['admin'],
+        },
+      })
+
+      // Create a tenant and document
+      const tenant = await payload.create({
+        collection: tenantsSlug,
+        data: { name: 'Admin Test Tenant', domain: 'admin-test.test' },
+      })
+      const doc = await payload.create({
+        collection: relationshipsSlug,
+        data: { tenant: tenant.id, title: 'Admin Test Doc' },
+      })
+
+      // Admin should have access (userHasAccessToAllTenants returns true for super-admin)
+      const result = await payload.find({
+        collection: relationshipsSlug,
+        overrideAccess: false,
+        user: adminUser,
+        where: { id: { equals: doc.id } },
+      })
+
+      expect(result.docs).toHaveLength(1)
+
+      // Cleanup
+      await payload.delete({ id: doc.id, collection: relationshipsSlug })
+      await payload.delete({ id: tenant.id, collection: tenantsSlug })
+      await payload.delete({ id: adminUser.id, collection: usersSlug })
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15638

## Summary

Users with zero tenants generated `{ $in: [] }` queries that Azure CosmosDB cannot handle. This returns access denied instead of the empty query, while still allowing users to access their own user document.