### PR TITLE
fix(richtext-lexical): use headingLevel in danish heading label

### DIFF
--- a/packages/richtext-lexical/src/features/heading/server/i18n.ts
+++ b/packages/richtext-lexical/src/features/heading/server/i18n.ts
@@ -14,7 +14,7 @@ export const i18n: Partial<GenericLanguages> = {
     label: 'Nadpis {{headingLevel}}',
   },
   da: {
-    label: 'Overskrift {{overskriftNiveau}}',
+    label: 'Overskrift {{headingLevel}}',
   },
   de: {
     label: 'Überschrift {{headingLevel}}',


### PR DESCRIPTION
### What?

Danish rich text heading labels now show "Overskrift 1", "Overskrift 2", etc. instead of the raw placeholder "Overskrift {{overskriftNi...".

### Why?

With the UI in Danish, the heading dropdown (H1–H4) showed an unresolved placeholder because the Danish string used `{{overskriftNiveau}}` while the code only passes `headingLevel`. The interpolation key must be `{{headingLevel}}` for the value to be substituted.

### How?

In `packages/richtext-lexical/src/features/heading/server/i18n.ts`, the Danish (`da`) label was changed from `'Overskrift {{overskriftNiveau}}'` to `'Overskrift {{headingLevel}}'` so it matches the variable passed by the client. No other locales used a different placeholder.
