### PR TITLE
test: field update access control test times out locally

### DIFF
--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -155,6 +155,8 @@ describe('Access Control', () => {
     })
 
     test('ensure field with update access control is readOnly during both initial load and after saving', async () => {
+      test.setTimeout(TEST_TIMEOUT_LONG)
+
       async function waitForFormState(action: 'reload' | 'save') {
         await assertNetworkRequests(
           page,


### PR DESCRIPTION
### What

The `ensure field with update access control is readOnly during both initial load and after saving` e2e test consistently times out when running locally but passes in CI.

### Why

The test performs 3 saves + 2 reloads, each with 5-second network polling, plus form validations. This exceeds the default 20-second local test timeout but fits within CI's 60-second timeout (3x multiplier).

### How

Added `test.setTimeout(TEST_TIMEOUT_LONG)` at the start of the test to use the extended timeout (same as the `beforeAll` hook)