### PR TITLE
fix(next): conditionally query snapshot field based on localization

### DIFF
--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -101,11 +101,13 @@ export async function VersionsView(props: DocumentViewServerProps) {
           },
           status: 'published',
           user,
-          where: {
-            snapshot: {
-              not_equals: true,
-            },
-          },
+          where: localization
+            ? {
+                snapshot: {
+                  not_equals: true,
+                },
+              }
+            : undefined,
         })
       : Promise.resolve(null),
     draftsEnabled
@@ -127,11 +129,13 @@ export async function VersionsView(props: DocumentViewServerProps) {
           },
           status: 'draft',
           user,
-          where: {
-            snapshot: {
-              not_equals: true,
-            },
-          },
+          where: localization
+            ? {
+                snapshot: {
+                  not_equals: true,
+                },
+              }
+            : undefined,
         })
       : Promise.resolve(null),
   ])


### PR DESCRIPTION
# Overview

Fixes a query validation error in the Versions view that occurs when viewing versions for collections without localization enabled.

## Key Changes

- Made the `snapshot` query conditional on localization in `fetchLatestVersion` calls
  - The `snapshot` field only exists in version schemas when `config.localization` is enabled
  - Collections without localization (e.g., trash tests) would fail with "The following path cannot be queried: snapshot"

- Aligns with the existing pattern already used earlier in the same file

## Design Decisions

The fix follows the existing pattern in the same file where the `snapshot` filter is conditionally applied:

```typescript
if (localization && draftsEnabled) {
  whereQuery.and.push({ snapshot: { not_equals: true } })
}
```

The two `fetchLatestVersion` calls for `currentlyPublishedVersion` and `latestDraftVersion` were missing this guard, causing failures when localization is disabled.

When localization is disabled, no snapshot versions exist anyway, so the filter is unnecessary.