### PR TITLE
test: fix flaky lexical e2e navigation timeouts and drawer clicks

### DIFF
--- a/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -18,17 +18,18 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../../../../../__helpers/shared/sdk/index.js'
 import type { Config, LexicalField, Upload } from '../../../../payload-types.js'
 
+import { assertNetworkRequests } from '../../../../../__helpers/e2e/assertNetworkRequests.js'
 import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
   saveDocAndAssert,
   waitForFormReady,
 } from '../../../../../__helpers/e2e/helpers.js'
+import { goToFirstCell } from '../../../../../__helpers/e2e/navigateToDoc.js'
 import { AdminUrlUtil } from '../../../../../__helpers/shared/adminUrlUtil.js'
 import { assertToastErrors } from '../../../../../__helpers/shared/assertToastErrors.js'
-import { assertNetworkRequests } from '../../../../../__helpers/e2e/assertNetworkRequests.js'
-import { initPayloadE2ENoConfig } from '../../../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../../../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../../../../../__helpers/shared/rest.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../../../playwright.config.js'
 import { lexicalFieldsSlug } from '../../../../slugs.js'
@@ -1274,8 +1275,12 @@ describe('lexicalBlocks', () => {
       // Previously, we had the issue that nested lexical fields did not display the field label and description, as
       // their client field configs were generated incorrectly on the server.
       await page.goto('http://localhost:3000/admin/collections/LexicalInBlock?limit=10')
-      await page.locator('.cell-id a').first().click()
-      await page.waitForURL(`**/collections/LexicalInBlock/**`)
+
+      // Wait for table to be fully loaded
+      await expect(page.locator('tbody tr')).not.toHaveCount(0)
+
+      await goToFirstCell(page, serverURL)
+      await waitForFormReady(page)
 
       await expect(
         page.locator('.LexicalEditorTheme__block-blockInLexical .render-fields label.field-label'),
@@ -1293,12 +1298,15 @@ describe('lexicalBlocks', () => {
     test('ensure individual inline blocks in lexical editor within a block have initial state on initial load', async () => {
       await page.goto('http://localhost:3000/admin/collections/LexicalInBlock?limit=10')
 
+      // Wait for table to be fully loaded
+      await expect(page.locator('tbody tr')).not.toHaveCount(0)
+
       await assertNetworkRequests(
         page,
         '/collections/LexicalInBlock/',
         async () => {
-          await page.locator('.cell-id a').first().click()
-          await page.waitForURL(`**/collections/LexicalInBlock/**`)
+          await goToFirstCell(page, serverURL)
+          await waitForFormReady(page)
 
           await expect(
             page.locator('.LexicalEditorTheme__inlineBlock:has-text("Inline Block In Lexical")'),
@@ -1452,8 +1460,11 @@ describe('lexicalBlocks', () => {
     test('ensure inline blocks restore their state after undoing a removal', async () => {
       await page.goto('http://localhost:3000/admin/collections/LexicalInBlock?limit=10')
 
-      await page.locator('.cell-id a').first().click()
-      await page.waitForURL(`**/collections/LexicalInBlock/**`)
+      // Wait for table to be fully loaded
+      await expect(page.locator('tbody tr')).not.toHaveCount(0)
+
+      await goToFirstCell(page, serverURL)
+      await waitForFormReady(page)
 
       // Wait for the page to be fully loaded and elements to be stable
       await page.waitForLoadState('domcontentloaded')

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -20,11 +20,12 @@ import {
   initPageConsoleErrorCatch,
   saveDocAndAssert,
   saveDocHotkeyAndAssert,
-  throttleTest,
+  waitForFormReady,
 } from '../../../../../__helpers/e2e/helpers.js'
+import { goToFirstCell } from '../../../../../__helpers/e2e/navigateToDoc.js'
 import { AdminUrlUtil } from '../../../../../__helpers/shared/adminUrlUtil.js'
-import { initPayloadE2ENoConfig } from '../../../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../../../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../../../../../__helpers/shared/rest.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../../../playwright.config.js'
 import { lexicalFieldsSlug } from '../../../../slugs.js'
@@ -54,13 +55,12 @@ async function navigateToLexicalFields(
     await page.goto(url.list)
   }
 
-  const linkToDoc = page.locator('tbody tr:first-child a').first()
-  await expect(() => expect(linkToDoc).toBeTruthy()).toPass({ timeout: POLL_TOPASS_TIMEOUT })
-  const linkDocHref = await linkToDoc.getAttribute('href')
+  // Wait for table to be fully loaded
+  await expect(page.locator('tbody tr')).not.toHaveCount(0)
 
-  await linkToDoc.click()
-
-  await page.waitForURL(`**${linkDocHref}`)
+  // Navigate to first document using helper
+  await goToFirstCell(page, serverURL)
+  await waitForFormReady(page)
 
   if (collectionSlug === 'lexical-fields') {
     const richTextField = page.locator('.rich-text-lexical').nth(2) // second
@@ -607,10 +607,12 @@ describe('lexicalMain', () => {
     )
 
     // Click on button with class lexical-upload__upload-drawer-toggler
-    await newUploadNode
+    const drawerToggler = newUploadNode
       .locator('.LexicalEditorTheme__upload__upload-drawer-toggler')
       .first()
-      .click()
+    await drawerToggler.waitFor({ state: 'visible' })
+    await drawerToggler.scrollIntoViewIfNeeded()
+    await drawerToggler.click()
 
     const uploadExtraFieldsDrawer = page
       .locator('dialog[id^=drawer_1_lexical-upload-drawer-]')
@@ -649,10 +651,12 @@ describe('lexicalMain', () => {
     await reloadedUploadNode.click() // Focus the upload node
     await reloadedUploadNode.hover()
 
-    await reloadedUploadNode
+    const reloadedDrawerToggler = reloadedUploadNode
       .locator('.LexicalEditorTheme__upload__upload-drawer-toggler')
       .first()
-      .click()
+    await reloadedDrawerToggler.waitFor({ state: 'visible' })
+    await reloadedDrawerToggler.scrollIntoViewIfNeeded()
+    await reloadedDrawerToggler.click()
     const reloadedUploadExtraFieldsDrawer = page
       .locator('dialog[id^=drawer_1_lexical-upload-drawer-]')
       .first()
@@ -1438,8 +1442,12 @@ describe('lexicalMain', () => {
     // Previously, we had the issue that the lexical field values did not update when moving blocks, as the MOVE_ROW form action did not request
     // re-rendering of server components
     await page.goto('http://localhost:3000/admin/collections/LexicalInBlock?limit=10')
-    await page.locator('.cell-id a').first().click()
-    await page.waitForURL(`**/collections/LexicalInBlock/**`)
+
+    // Wait for table to be fully loaded
+    await expect(page.locator('tbody tr')).not.toHaveCount(0)
+
+    await goToFirstCell(page, serverURL)
+    await waitForFormReady(page)
 
     await expect(page.locator('#blocks-row-0 .LexicalEditorTheme__paragraph')).toContainText('1')
     await expect(page.locator('#blocks-row-0 .section-title__input')).toHaveValue('1') // block name

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -1413,7 +1413,14 @@ describe('lexicalMain', () => {
   // https://github.com/payloadcms/payload/issues/5146
   test('Preserve indent and text-align when converting Lexical <-> HTML', async () => {
     await page.goto('http://localhost:3000/admin/collections/rich-text-fields?limit=10')
-    await page.getByLabel('Create new Rich Text Field').click()
+
+    await expect(page.locator('tbody tr').first()).toBeVisible()
+
+    const createButton = page.getByLabel('Create new Rich Text Field')
+    await expect(createButton).toBeEnabled()
+    const href = await createButton.getAttribute('href')
+    await page.goto(`${serverURL}${href}`)
+    await waitForFormReady(page)
     await page.getByLabel('Title*').click()
     await page.getByLabel('Title*').fill('Indent and Text-align')
     await page.getByRole('paragraph').nth(1).click()

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -58,7 +58,7 @@ async function navigateToLexicalFields(
   // Wait for table to be fully loaded
   await expect(page.locator('tbody tr')).not.toHaveCount(0)
 
-  // Navigate to first document using helper
+  // Navigate to first document
   await goToFirstCell(page, serverURL)
   await waitForFormReady(page)
 

--- a/test/lexical/collections/RichText/e2e.spec.ts
+++ b/test/lexical/collections/RichText/e2e.spec.ts
@@ -9,10 +9,12 @@ import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
   saveDocAndAssert,
+  waitForFormReady,
 } from '../../../__helpers/e2e/helpers.js'
+import { goToFirstCell } from '../../../__helpers/e2e/navigateToDoc.js'
 import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
-import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -53,13 +55,12 @@ describe('Rich Text', () => {
     const url: AdminUrlUtil = new AdminUrlUtil(serverURL, 'rich-text-fields')
     await page.goto(url.list)
 
-    const linkToDoc = page.locator('.row-1 .cell-title a').first()
-    await expect(() => expect(linkToDoc).toBeTruthy()).toPass({ timeout: POLL_TOPASS_TIMEOUT })
-    const linkDocHref = await linkToDoc.getAttribute('href')
+    // Wait for table to be fully loaded
+    await expect(page.locator('tbody tr')).not.toHaveCount(0)
 
-    await linkToDoc.click()
-
-    await page.waitForURL(`**${linkDocHref}`)
+    // Navigate to first document
+    await goToFirstCell(page, serverURL)
+    await waitForFormReady(page)
   }
 
   describe('cell', () => {

--- a/test/lexical/payload-types.ts
+++ b/test/lexical/payload-types.ts
@@ -84,6 +84,7 @@ export interface Config {
   blocks: {};
   collections: {
     'lexical-fully-featured': LexicalFullyFeatured;
+    'lexical-autosave': LexicalAutosave;
     'lexical-link-feature': LexicalLinkFeature;
     'lexical-lists-features': LexicalListsFeature;
     'lexical-heading-feature': LexicalHeadingFeature;
@@ -111,6 +112,7 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     'lexical-fully-featured': LexicalFullyFeaturedSelect<false> | LexicalFullyFeaturedSelect<true>;
+    'lexical-autosave': LexicalAutosaveSelect<false> | LexicalAutosaveSelect<true>;
     'lexical-link-feature': LexicalLinkFeatureSelect<false> | LexicalLinkFeatureSelect<true>;
     'lexical-lists-features': LexicalListsFeaturesSelect<false> | LexicalListsFeaturesSelect<true>;
     'lexical-heading-feature': LexicalHeadingFeatureSelect<false> | LexicalHeadingFeatureSelect<true>;
@@ -193,6 +195,37 @@ export interface LexicalFullyFeatured {
   } | null;
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "lexical-autosave".
+ */
+export interface LexicalAutosave {
+  id: string;
+  title?: string | null;
+  cta?:
+    | {
+        richText?: {
+          root: {
+            type: string;
+            children: {
+              type: any;
+              version: number;
+              [k: string]: unknown;
+            }[];
+            direction: ('ltr' | 'rtl') | null;
+            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+            indent: number;
+            version: number;
+          };
+          [k: string]: unknown;
+        } | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1050,6 +1083,10 @@ export interface PayloadLockedDocument {
         value: string | LexicalFullyFeatured;
       } | null)
     | ({
+        relationTo: 'lexical-autosave';
+        value: string | LexicalAutosave;
+      } | null)
+    | ({
         relationTo: 'lexical-link-feature';
         value: string | LexicalLinkFeature;
       } | null)
@@ -1175,6 +1212,22 @@ export interface LexicalFullyFeaturedSelect<T extends boolean = true> {
   richText?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "lexical-autosave_select".
+ */
+export interface LexicalAutosaveSelect<T extends boolean = true> {
+  title?: T;
+  cta?:
+    | T
+    | {
+        richText?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What

Fixed flaky lexical e2e tests that were timing out on navigation in CI:

**test/lexical/collections/Lexical/e2e/main/e2e.spec.ts:**
- `ensure lexical fields in blocks have correct value when moving blocks`
- `select decoratorNodes`
- `ensure newly created upload node has fields, saves them, and loads them correctly`
- `Preserve indent and text-align when converting Lexical <-> HTML`

**test/lexical/collections/RichText/e2e.spec.ts:**
- `should only list RTE enabled collections in link drawer`
- `should only list non-upload collections in relationship drawer`
- `should populate relationship link`
- `should open upload document drawer from read-only field`
- `should populate new links`

**test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts:**
- `ensure individual inline blocks in lexical editor within a block have initial state on initial load`
- `nested lexical fields display label and description`
- `ensure inline blocks restore their state after undoing a removal`

<img width="1444" height="582" alt="Screenshot 2026-02-19 at 2 02 07 PM" src="https://github.com/user-attachments/assets/0009c55a-1dd9-4e54-82ca-2f989ef78e70" />

<img width="1316" height="310" alt="Screenshot 2026-02-19 at 2 37 35 PM" src="https://github.com/user-attachments/assets/3828afce-3828-4894-bc6e-9899e7caaa3e" />

<img width="1807" height="586" alt="Screenshot 2026-02-19 at 3 42 29 PM" src="https://github.com/user-attachments/assets/fd30ee9d-d484-4190-ad6a-553e3cb103b8" />

### Why

List view link clicks were timing out in CI after 30 seconds. Clicks weren't reliably triggering navigation in slow environments. The upload node test also tried clicking drawer togglers before they were visible, causing page crashes.

### How

- Replaced link clicks with `goToFirstCell` helper in `navigateToLexicalFields` and affected tests
- Added `waitForFormReady` to ensure forms are hydrated before interaction
- Added explicit `waitFor({ state: 'visible' })` for drawer toggler buttons before clicking