### PR TITLE
feat(next, ui): widget fields

### DIFF
--- a/docs/custom-components/dashboard.mdx
+++ b/docs/custom-components/dashboard.mdx
@@ -28,20 +28,23 @@ Define widgets in your Payload config using the `admin.dashboard.widgets` proper
 import { buildConfig } from 'payload'
 
 export default buildConfig({
-  // ...
   admin: {
     dashboard: {
       widgets: [
         {
-          slug: 'user-stats',
-          ComponentPath: './components/UserStats.tsx#default',
-          minWidth: 'medium',
-          maxWidth: 'full',
-        },
-        {
-          slug: 'revenue-chart',
-          ComponentPath: './components/RevenueChart.tsx#default',
+          slug: 'sales-summary',
+          ComponentPath: './components/SalesSummary.tsx#default',
+          fields: [
+            { name: 'title', type: 'text' },
+            {
+              name: 'timeframe',
+              type: 'select',
+              options: ['daily', 'weekly', 'monthly', 'yearly'],
+            },
+            { name: 'showTrend', type: 'checkbox' },
+          ],
           minWidth: 'small',
+          maxWidth: 'medium',
         },
       ],
     },
@@ -55,6 +58,7 @@ export default buildConfig({
 | ------------------ | ------------- | -------------------------------------------------------------------- |
 | `slug` \*          | `string`      | Unique identifier for the widget                                     |
 | `ComponentPath` \* | `string`      | Path to the widget component (supports `#` syntax for named exports) |
+| `fields`           | `Field[]`     | Optional widget-specific form fields shown in the edit drawer        |
 | `minWidth`         | `WidgetWidth` | Minimum width the widget can be resized to (default: `'x-small'`)    |
 | `maxWidth`         | `WidgetWidth` | Maximum width the widget can be resized to (default: `'full'`)       |
 
@@ -103,6 +107,14 @@ export default buildConfig({
 
         return [
           { widgetSlug: 'collections', width: 'full' },
+          {
+            widgetSlug: 'sales-summary',
+            data: {
+              timeframe: 'monthly',
+              title: 'Revenue Overview',
+            },
+            width: isAdmin ? 'medium' : 'small',
+          },
           { widgetSlug: 'user-stats', width: isAdmin ? 'medium' : 'full' },
           { widgetSlug: 'revenue-chart', width: 'full' },
         ]
@@ -117,12 +129,38 @@ export default buildConfig({
 
 The `defaultLayout` function receives the request object and should return an array of `WidgetInstance` objects.
 
+If your widget has `fields`, you can type `widgetData` with generated widget types:
+
+```tsx
+import type { WidgetServerProps } from 'payload'
+
+import type { SalesSummaryWidget } from '../payload-types'
+
+export default async function SalesSummaryWidgetComponent({
+  widgetData,
+}: WidgetServerProps<SalesSummaryWidget>) {
+  const title = widgetData?.title ?? 'Sales Summary'
+  const timeframe = widgetData?.timeframe ?? 'monthly'
+
+  return (
+    <div className="card">
+      <h3>
+        {title} ({timeframe})
+      </h3>
+    </div>
+  )
+}
+```
+
 #### WidgetInstance Type
 
-| Property        | Type          | Description                                     |
-| --------------- | ------------- | ----------------------------------------------- |
-| `widgetSlug` \* | `string`      | Slug of the widget to display                   |
-| `width`         | `WidgetWidth` | Initial width of the widget (default: minWidth) |
+| Property        | Type          | Description                                          |
+| --------------- | ------------- | ---------------------------------------------------- |
+| `widgetSlug` \* | `string`      | Slug of the widget to display                        |
+| `data`          | `object`      | Optional widget-specific data passed to `widgetData` |
+| `width`         | `WidgetWidth` | Initial width of the widget (default: minWidth)      |
+
+`width` is constrained by each widget's `minWidth` and `maxWidth` when types are generated.
 
 <Banner type="success">
   **Tip:** Users can customize their dashboard layout, which is saved to their
@@ -145,9 +183,10 @@ Users can customize their dashboard by:
 1. Clicking the dashboard dropdown in the breadcrumb
 2. Selecting "Edit Dashboard"
 3. Adding widgets via the "Add +" button
-4. Resizing widgets using the width dropdown on each widget
-5. Reordering widgets via drag-and-drop
-6. Deleting widgets using the delete button
-7. Saving changes or canceling to revert
+4. Editing widget data (for widgets with `fields`) via the edit button
+5. Resizing widgets using the width dropdown on each widget (if multiple widths are allowed)
+6. Reordering widgets via drag-and-drop
+7. Deleting widgets using the delete button
+8. Saving changes or canceling to revert
 
 Users can also reset their dashboard to the default layout using the "Reset Layout" option.

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetConfigDrawer.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetConfigDrawer.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import type { ClientWidget, FormState } from 'payload'
+
+import {
+  Drawer,
+  Form,
+  FormSubmit,
+  OperationProvider,
+  RenderFields,
+  ShimmerEffect,
+  useModal,
+  useServerFunctions,
+  useTranslation,
+} from '@payloadcms/ui'
+import { abortAndIgnore } from '@payloadcms/ui/shared'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { v4 as uuid } from 'uuid'
+
+type WidgetConfigDrawerProps = {
+  drawerSlug: string
+  onSave: (data: Record<string, unknown>) => void
+  widget: ClientWidget
+  widgetData?: Record<string, unknown>
+}
+
+const EMPTY_WIDGET_PREFERENCES = {
+  fields: {},
+}
+
+export function WidgetConfigDrawer({
+  drawerSlug,
+  onSave,
+  widget,
+  widgetData,
+}: WidgetConfigDrawerProps) {
+  const { closeModal, modalState } = useModal()
+  const { getFormState } = useServerFunctions()
+  const { t } = useTranslation()
+  const onChangeAbortControllerRef = useRef<AbortController>(null)
+
+  const [initialState, setInitialState] = useState<false | FormState | undefined>(false)
+
+  const isOpen = Boolean(modalState?.[drawerSlug]?.isOpen)
+  const formUUID = useMemo(() => uuid(), [])
+  const widgetLabel = useMemo(
+    () => (typeof widget.label === 'string' ? widget.label : widget.slug),
+    [widget.label, widget.slug],
+  )
+  const fields = useMemo(() => widget.fields ?? [], [widget.fields])
+
+  useEffect(() => {
+    if (!isOpen || fields.length === 0) {
+      setInitialState(false)
+      return
+    }
+
+    const controller = new AbortController()
+
+    const loadInitialState = async () => {
+      const { state } = await getFormState({
+        data: widgetData ?? {},
+        docPermissions: {
+          fields: true,
+        },
+        docPreferences: EMPTY_WIDGET_PREFERENCES,
+        operation: 'update',
+        renderAllFields: true,
+        schemaPath: widget.slug,
+        signal: controller.signal,
+        widgetSlug: widget.slug,
+      })
+
+      if (state) {
+        setInitialState(state)
+      }
+    }
+
+    void loadInitialState()
+
+    return () => {
+      abortAndIgnore(controller)
+    }
+  }, [fields, getFormState, isOpen, widget.slug, widgetData])
+
+  const onChange = useCallback(
+    async ({ formState: prevFormState }: { formState: FormState }) => {
+      abortAndIgnore(onChangeAbortControllerRef.current)
+
+      const controller = new AbortController()
+      onChangeAbortControllerRef.current = controller
+
+      const { state } = await getFormState({
+        data: widgetData ?? {},
+        docPermissions: {
+          fields: true,
+        },
+        docPreferences: EMPTY_WIDGET_PREFERENCES,
+        formState: prevFormState,
+        operation: 'update',
+        schemaPath: widget.slug,
+        signal: controller.signal,
+        widgetSlug: widget.slug,
+      })
+
+      if (!state) {
+        return prevFormState
+      }
+
+      return state
+    },
+    [getFormState, widget.slug, widgetData],
+  )
+
+  useEffect(() => {
+    return () => {
+      abortAndIgnore(onChangeAbortControllerRef.current)
+    }
+  }, [])
+
+  return (
+    <Drawer slug={drawerSlug} title={`${t('general:edit')} ${widgetLabel}`}>
+      {initialState === false ? (
+        <ShimmerEffect height="250px" />
+      ) : (
+        <OperationProvider operation="update">
+          <Form
+            disableValidationOnSubmit
+            fields={fields}
+            initialState={initialState}
+            onChange={[onChange]}
+            onSubmit={(_, data) => {
+              onSave(data)
+              closeModal(drawerSlug)
+            }}
+            uuid={formUUID}
+          >
+            <RenderFields
+              fields={fields}
+              forceRender
+              parentIndexPath=""
+              parentPath=""
+              parentSchemaPath={widget.slug}
+              permissions={true}
+              readOnly={false}
+            />
+            <FormSubmit>{t('fields:saveChanges')}</FormSubmit>
+          </Form>
+        </OperationProvider>
+      )}
+    </Drawer>
+  )
+}

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetConfigDrawer.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetConfigDrawer.tsx
@@ -124,7 +124,6 @@ export function WidgetConfigDrawer({
       ) : (
         <OperationProvider operation="update">
           <Form
-            disableValidationOnSubmit
             fields={fields}
             initialState={initialState}
             onChange={[onChange]}

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetConfigDrawer.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetConfigDrawer.tsx
@@ -91,7 +91,6 @@ export function WidgetConfigDrawer({
       onChangeAbortControllerRef.current = controller
 
       const { state } = await getFormState({
-        data: widgetData ?? {},
         docPermissions: {
           fields: true,
         },
@@ -109,7 +108,7 @@ export function WidgetConfigDrawer({
 
       return state
     },
-    [getFormState, widget.slug, widgetData],
+    [getFormState, widget.slug],
   )
 
   useEffect(() => {

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetEditControl.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetEditControl.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import type { Data } from 'payload'
+
+import { EditIcon, useConfig, useModal, useTranslation } from '@payloadcms/ui'
+import React, { useId } from 'react'
+
+import { WidgetConfigDrawer } from './WidgetConfigDrawer.js'
+
+const getWidgetSlugFromID = (widgetID: string): string =>
+  widgetID.slice(0, widgetID.lastIndexOf('-'))
+
+export function WidgetEditControl({
+  onSave,
+  widgetData,
+  widgetID,
+}: {
+  onSave: (data: Data) => void
+  widgetData?: Record<string, unknown>
+  widgetID: string
+}) {
+  const { t } = useTranslation()
+  const { openModal } = useModal()
+  const { widgets: configWidgets = [] } = useConfig().config.admin.dashboard ?? {}
+
+  const widgetSlug = getWidgetSlugFromID(widgetID)
+  const widgetConfig = configWidgets.find((widget) => widget.slug === widgetSlug)
+  const hasEditableFields = Boolean(widgetConfig?.fields?.length)
+
+  const drawerID = useId()
+  const drawerSlug = `widget-editor-${drawerID}`
+
+  return (
+    <>
+      <button
+        className="widget-wrapper__edit-btn"
+        disabled={!hasEditableFields}
+        onClick={() => {
+          openModal(drawerSlug)
+        }}
+        type="button"
+      >
+        <span className="sr-only">
+          {t('general:edit')} {widgetID}
+        </span>
+        <EditIcon />
+      </button>
+      {widgetConfig?.fields?.length ? (
+        <WidgetConfigDrawer
+          drawerSlug={drawerSlug}
+          onSave={onSave}
+          widget={widgetConfig}
+          widgetData={widgetData}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetEditControl.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/WidgetEditControl.tsx
@@ -30,11 +30,14 @@ export function WidgetEditControl({
   const drawerID = useId()
   const drawerSlug = `widget-editor-${drawerID}`
 
+  if (!hasEditableFields) {
+    return null
+  }
+
   return (
     <>
       <button
         className="widget-wrapper__edit-btn"
-        disabled={!hasEditableFields}
         onClick={() => {
           openModal(drawerSlug)
         }}
@@ -45,14 +48,12 @@ export function WidgetEditControl({
         </span>
         <EditIcon />
       </button>
-      {widgetConfig?.fields?.length ? (
-        <WidgetConfigDrawer
-          drawerSlug={drawerSlug}
-          onSave={onSave}
-          widget={widgetConfig}
-          widgetData={widgetData}
-        />
-      ) : null}
+      <WidgetConfigDrawer
+        drawerSlug={drawerSlug}
+        onSave={onSave}
+        widget={widgetConfig}
+        widgetData={widgetData}
+      />
     </>
   )
 }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/getItemsFromConfig.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/getItemsFromConfig.ts
@@ -1,0 +1,27 @@
+import type { DashboardConfig, PayloadRequest, Widget, WidgetInstance } from 'payload'
+
+import type { WidgetItem } from './index.client.js'
+
+export async function getItemsFromConfig(
+  defaultLayout: NonNullable<DashboardConfig['defaultLayout']>,
+  req: PayloadRequest,
+  widgets: Pick<Widget, 'maxWidth' | 'minWidth' | 'slug'>[],
+): Promise<WidgetItem[]> {
+  let widgetInstances: WidgetInstance[]
+  if (typeof defaultLayout === 'function') {
+    widgetInstances = await defaultLayout({ req })
+  } else {
+    widgetInstances = defaultLayout
+  }
+
+  return widgetInstances.map((widgetInstance, index) => {
+    const widget = widgets.find((w) => w.slug === widgetInstance.widgetSlug)
+    return {
+      id: `${widgetInstance.widgetSlug}-${index}`,
+      data: widgetInstance.data,
+      maxWidth: widget?.maxWidth ?? 'full',
+      minWidth: widget?.minWidth ?? 'x-small',
+      width: widgetInstance.width || 'x-small',
+    }
+  })
+}

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/getItemsFromPreferences.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/getItemsFromPreferences.ts
@@ -1,0 +1,27 @@
+import type { BasePayload, TypedUser } from 'payload'
+
+import { PREFERENCE_KEYS } from 'payload/shared'
+
+import type { WidgetItem } from './index.client.js'
+
+import { getPreferences } from '../../../../utilities/getPreferences.js'
+
+export async function getItemsFromPreferences(
+  payload: BasePayload,
+  user: TypedUser,
+): Promise<null | WidgetItem[]> {
+  const savedPreferences = await getPreferences(
+    PREFERENCE_KEYS.DASHBOARD_LAYOUT,
+    payload,
+    user.id,
+    user.collection,
+  )
+  if (
+    !savedPreferences?.value ||
+    typeof savedPreferences.value !== 'object' ||
+    !('layouts' in savedPreferences.value)
+  ) {
+    return null
+  }
+  return savedPreferences.value.layouts as null | WidgetItem[]
+}

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.client.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.client.tsx
@@ -28,8 +28,10 @@ import { DashboardStepNav } from './DashboardStepNav.js'
 import { useDashboardLayout } from './useDashboardLayout.js'
 import { closestInXAxis } from './utils/collisionDetection.js'
 import { useDashboardSensors } from './utils/sensors.js'
+import { WidgetEditControl } from './WidgetEditControl.js'
 
 export type WidgetItem = {
+  data?: Record<string, unknown>
   id: string
   maxWidth: WidgetWidth
   minWidth: WidgetWidth
@@ -76,6 +78,7 @@ export function ModularDashboardClient({
     resizeWidget,
     saveLayout,
     setIsEditing,
+    updateWidgetData,
   } = useDashboardLayout(initialLayout)
 
   const [activeDragId, setActiveDragId] = useState<null | string>(null)
@@ -166,6 +169,13 @@ export function ModularDashboardClient({
                       className="widget-wrapper__controls"
                       onPointerDown={(e) => e.stopPropagation()}
                     >
+                      <WidgetEditControl
+                        onSave={(data) => {
+                          updateWidgetData(widget.item.id, data)
+                        }}
+                        widgetData={widget.item.data}
+                        widgetID={widget.item.id}
+                      />
                       <WidgetWidthDropdown
                         currentWidth={widget.item.width}
                         maxWidth={widget.item.maxWidth}

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.client.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.client.tsx
@@ -269,12 +269,15 @@ function WidgetWidthDropdown({
 
   const isDisabled = validOptions.length <= 1
 
+  if (isDisabled) {
+    return null
+  }
+
   return (
     <Popup
       button={
         <button
           className="widget-wrapper__size-btn"
-          disabled={isDisabled}
           onPointerDown={(e) => e.stopPropagation()}
           type="button"
         >
@@ -283,7 +286,6 @@ function WidgetWidthDropdown({
         </button>
       }
       buttonType="custom"
-      disabled={isDisabled}
       render={({ close }) => (
         <PopupList.ButtonGroup>
           {validOptions.map((option) => {

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
@@ -54,8 +54,8 @@
     transition: opacity 0.2s ease;
   }
 
-  .widget:focus,
-  .widget:focus-within {
+  .widget:focus-visible,
+  .widget:has(:focus-visible) {
     .widget-wrapper__controls {
       opacity: 1;
     }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
@@ -141,15 +141,6 @@
         background: var(--theme-elevation-900);
       }
 
-      &:disabled {
-        cursor: not-allowed;
-        opacity: 0.5;
-
-        &:hover {
-          background: var(--theme-text);
-        }
-      }
-
       svg {
         pointer-events: none;
       }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
@@ -107,7 +107,8 @@
       gap: 8px;
     }
 
-    &__delete-btn {
+    &__delete-btn,
+    &__edit-btn {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -138,6 +139,15 @@
 
       &:active {
         background: var(--theme-elevation-900);
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+
+        &:hover {
+          background: var(--theme-text);
+        }
       }
 
       svg {

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
@@ -5,9 +5,9 @@ import type {
   DashboardConfig,
   PayloadRequest,
   TypedUser,
+  Widget,
   WidgetInstance,
   WidgetServerProps,
-  WidgetWidth,
 } from 'payload'
 
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
@@ -92,13 +92,8 @@ async function getItemsFromPreferences(
 async function getItemsFromConfig(
   defaultLayout: NonNullable<DashboardConfig['defaultLayout']>,
   req: PayloadRequest,
-  widgets: Array<{
-    maxWidth?: WidgetWidth
-    minWidth?: WidgetWidth
-    slug: string
-  }>,
+  widgets: Pick<Widget, 'maxWidth' | 'minWidth' | 'slug'>[],
 ): Promise<WidgetItem[]> {
-  // Handle function format
   let widgetInstances: WidgetInstance[]
   if (typeof defaultLayout === 'function') {
     widgetInstances = await defaultLayout({ req })
@@ -107,7 +102,7 @@ async function getItemsFromConfig(
   }
 
   return widgetInstances.map((widgetInstance, index) => {
-    const widget = widgets.find((widget) => widget.slug === widgetInstance.widgetSlug)
+    const widget = widgets.find((w) => w.slug === widgetInstance.widgetSlug)
     return {
       id: `${widgetInstance.widgetSlug}-${index}`,
       data: widgetInstance.data,
@@ -115,5 +110,5 @@ async function getItemsFromConfig(
       minWidth: widget?.minWidth ?? 'x-small',
       width: widgetInstance.width || 'x-small',
     }
-  }) as WidgetItem[]
+  })
 }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
@@ -115,5 +115,5 @@ async function getItemsFromConfig(
       minWidth: widget?.minWidth ?? 'x-small',
       width: widgetInstance.width || 'x-small',
     }
-  })
+  }) as WidgetItem[]
 }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
@@ -1,23 +1,14 @@
 import type { TFunction } from '@payloadcms/translations'
-import type {
-  BasePayload,
-  ClientWidget,
-  DashboardConfig,
-  PayloadRequest,
-  TypedUser,
-  Widget,
-  WidgetInstance,
-  WidgetServerProps,
-} from 'payload'
+import type { ClientWidget, WidgetServerProps } from 'payload'
 
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
-import { PREFERENCE_KEYS } from 'payload/shared'
 import React from 'react'
 
 import type { DashboardViewServerProps } from '../index.js'
-import type { WidgetInstanceClient, WidgetItem } from './index.client.js'
+import type { WidgetInstanceClient } from './index.client.js'
 
-import { getPreferences } from '../../../../utilities/getPreferences.js'
+import { getItemsFromConfig } from './getItemsFromConfig.js'
+import { getItemsFromPreferences } from './getItemsFromPreferences.js'
 import { ModularDashboardClient } from './index.client.js'
 import './index.scss'
 
@@ -67,48 +58,4 @@ export async function ModularDashboard(props: DashboardViewServerProps) {
       <ModularDashboardClient clientLayout={serverLayout} widgets={clientWidgets} />
     </div>
   )
-}
-
-async function getItemsFromPreferences(
-  payload: BasePayload,
-  user: TypedUser,
-): Promise<null | WidgetItem[]> {
-  const savedPreferences = await getPreferences(
-    PREFERENCE_KEYS.DASHBOARD_LAYOUT,
-    payload,
-    user.id,
-    user.collection,
-  )
-  if (
-    !savedPreferences?.value ||
-    typeof savedPreferences.value !== 'object' ||
-    !('layouts' in savedPreferences.value)
-  ) {
-    return null
-  }
-  return savedPreferences.value.layouts as null | WidgetItem[]
-}
-
-async function getItemsFromConfig(
-  defaultLayout: NonNullable<DashboardConfig['defaultLayout']>,
-  req: PayloadRequest,
-  widgets: Pick<Widget, 'maxWidth' | 'minWidth' | 'slug'>[],
-): Promise<WidgetItem[]> {
-  let widgetInstances: WidgetInstance[]
-  if (typeof defaultLayout === 'function') {
-    widgetInstances = await defaultLayout({ req })
-  } else {
-    widgetInstances = defaultLayout
-  }
-
-  return widgetInstances.map((widgetInstance, index) => {
-    const widget = widgets.find((w) => w.slug === widgetInstance.widgetSlug)
-    return {
-      id: `${widgetInstance.widgetSlug}-${index}`,
-      data: widgetInstance.data,
-      maxWidth: widget?.maxWidth ?? 'full',
-      minWidth: widget?.minWidth ?? 'x-small',
-      width: widgetInstance.width || 'x-small',
-    }
-  })
 }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.tsx
@@ -1,5 +1,5 @@
 import type { TFunction } from '@payloadcms/translations'
-import type { ClientWidget, WidgetServerProps } from 'payload'
+import type { ClientWidget, Field, WidgetServerProps } from 'payload'
 
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
 import React from 'react'
@@ -30,7 +30,7 @@ export async function ModularDashboard(props: DashboardViewServerProps) {
     const widgetSlug = layoutItem.id.slice(0, layoutItem.id.lastIndexOf('-'))
     const widgetConfig = widgets.find((widget) => widget.slug === widgetSlug)
     const widgetData = widgetConfig?.fields?.length
-      ? extractLocaleData(layoutItem.data || {}, req.locale || 'en', widgetConfig.fields)
+      ? extractLocaleData(layoutItem.data || {}, req.locale || 'en', widgetConfig.fields as Field[])
       : layoutItem.data || {}
 
     return {

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/RenderWidget.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/RenderWidget.tsx
@@ -15,12 +15,12 @@ export const RenderWidget: React.FC<{
   /**
    * Instance-specific data for this widget
    */
-  // TODO: widgetData?: Record<string, unknown>
+  widgetData?: Record<string, unknown>
   /**
    * Unique ID for this widget instance (format: "slug-timestamp")
    */
   widgetId: string
-}> = ({ /* widgetData, */ widgetId }) => {
+}> = ({ widgetData, widgetId }) => {
   const [Component, setComponent] = React.useState<null | React.ReactNode>(null)
   const { serverFunction } = useServerFunctions()
 
@@ -32,14 +32,13 @@ export const RenderWidget: React.FC<{
         const result = (await serverFunction({
           name: 'render-widget',
           args: {
-            // TODO: widgets will support state in the future
-            // widgetData,
+            widgetData,
             widgetSlug,
           } as RenderWidgetServerFnArgs,
         })) as RenderWidgetServerFnReturnType
 
         setComponent(result.component)
-      } catch (error) {
+      } catch (_error) {
         // Log error but don't expose details to console in production
 
         // Fallback error component
@@ -62,7 +61,7 @@ export const RenderWidget: React.FC<{
       }
     }
     void render()
-  }, [serverFunction, widgetId /* widgetData, */])
+  }, [serverFunction, widgetData, widgetId])
 
   const mounted = useRef(false)
 

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/RenderWidget.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/RenderWidget.tsx
@@ -28,6 +28,7 @@ export const RenderWidget: React.FC<{
   const renderWidget = useCallback(() => {
     async function render() {
       const requestID = ++requestIDRef.current
+      setComponent(null)
 
       try {
         const widgetSlug = widgetId.slice(0, widgetId.lastIndexOf('-'))
@@ -75,7 +76,6 @@ export const RenderWidget: React.FC<{
   }, [serverFunction, widgetData, widgetId])
 
   useEffect(() => {
-    setComponent(null)
     void renderWidget()
   }, [renderWidget])
 

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/getDefaultLayoutServerFn.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/getDefaultLayoutServerFn.ts
@@ -44,6 +44,7 @@ export const getDefaultLayoutHandler: ServerFunction<
           locale,
           permissions,
           req,
+          widgetData: layoutItem.data || {},
           widgetSlug,
         } satisfies WidgetServerProps,
       }),
@@ -71,6 +72,7 @@ async function getItemsFromConfig(
     const widget = widgets.find((w) => w.slug === widgetInstance.widgetSlug)
     return {
       id: `${widgetInstance.widgetSlug}-${index}`,
+      data: widgetInstance.data,
       maxWidth: widget?.maxWidth ?? 'full',
       minWidth: widget?.minWidth ?? 'x-small',
       width: widgetInstance.width || 'x-small',

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/getDefaultLayoutServerFn.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/getDefaultLayoutServerFn.ts
@@ -2,8 +2,8 @@ import type {
   DashboardConfig,
   PayloadRequest,
   ServerFunction,
+  Widget,
   WidgetServerProps,
-  WidgetWidth,
 } from 'payload'
 
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
@@ -58,13 +58,8 @@ export const getDefaultLayoutHandler: ServerFunction<
 async function getItemsFromConfig(
   defaultLayout: NonNullable<DashboardConfig['defaultLayout']>,
   req: PayloadRequest,
-  widgets: Array<{
-    maxWidth?: WidgetWidth
-    minWidth?: WidgetWidth
-    slug: string
-  }>,
+  widgets: Pick<Widget, 'maxWidth' | 'minWidth' | 'slug'>[],
 ): Promise<WidgetItem[]> {
-  // Handle function format
   let widgetInstances
   if (typeof defaultLayout === 'function') {
     widgetInstances = await defaultLayout({ req })

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/getDefaultLayoutServerFn.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/getDefaultLayoutServerFn.ts
@@ -2,8 +2,8 @@ import type {
   DashboardConfig,
   PayloadRequest,
   ServerFunction,
-  Widget,
   WidgetServerProps,
+  WidgetWidth,
 } from 'payload'
 
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
@@ -58,7 +58,11 @@ export const getDefaultLayoutHandler: ServerFunction<
 async function getItemsFromConfig(
   defaultLayout: NonNullable<DashboardConfig['defaultLayout']>,
   req: PayloadRequest,
-  widgets: Widget[],
+  widgets: Array<{
+    maxWidth?: WidgetWidth
+    minWidth?: WidgetWidth
+    slug: string
+  }>,
 ): Promise<WidgetItem[]> {
   // Handle function format
   let widgetInstances

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
@@ -1,4 +1,4 @@
-import type { ServerFunction, WidgetServerProps } from 'payload'
+import type { Field, ServerFunction, WidgetServerProps } from 'payload'
 
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
 import React from 'react'
@@ -59,7 +59,7 @@ export const renderWidgetHandler: ServerFunction<
 
   try {
     const localeFilteredData = widgetConfig.fields?.length
-      ? extractLocaleData(widgetData || {}, req.locale || 'en', widgetConfig.fields)
+      ? extractLocaleData(widgetData || {}, req.locale || 'en', widgetConfig.fields as Field[])
       : widgetData || {}
 
     const serverProps: WidgetServerProps = {

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
@@ -3,6 +3,8 @@ import type { ServerFunction, WidgetServerProps } from 'payload'
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
 import React from 'react'
 
+import { extractLocaleData } from '../utils/localeUtils.js'
+
 export type RenderWidgetServerFnArgs = {
   /**
    * Instance-specific data for this widget
@@ -56,13 +58,16 @@ export const renderWidgetHandler: ServerFunction<
   }
 
   try {
-    // Create server props for the widget
+    const localeFilteredData = widgetConfig.fields?.length
+      ? extractLocaleData(widgetData || {}, req.locale || 'en', widgetConfig.fields)
+      : widgetData || {}
+
     const serverProps: WidgetServerProps = {
       cookies,
       locale,
       permissions,
       req,
-      widgetData: widgetData || {},
+      widgetData: localeFilteredData,
       widgetSlug,
     }
 

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
@@ -7,8 +7,7 @@ export type RenderWidgetServerFnArgs = {
   /**
    * Instance-specific data for this widget
    */
-  // TODO: widgets will support state in the future
-  // widgetData?: Record<string, unknown>
+  widgetData?: Record<string, unknown>
   /**
    * The slug of the widget to render
    */
@@ -26,7 +25,7 @@ export type RenderWidgetServerFnReturnType = {
 export const renderWidgetHandler: ServerFunction<
   RenderWidgetServerFnArgs,
   RenderWidgetServerFnReturnType
-> = ({ cookies, locale, permissions, req, widgetSlug }) => {
+> = ({ cookies, locale, permissions, req, widgetData, widgetSlug }) => {
   if (!req.user) {
     throw new Error('Unauthorized')
   }
@@ -59,11 +58,11 @@ export const renderWidgetHandler: ServerFunction<
   try {
     // Create server props for the widget
     const serverProps: WidgetServerProps = {
-      req,
-      // TODO: widgetData: widgetData || {},
       cookies,
       locale,
       permissions,
+      req,
+      widgetData: widgetData || {},
       widgetSlug,
     }
 

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
@@ -31,7 +31,9 @@ export function useDashboardLayout(initialLayout: WidgetInstanceClient[]) {
     if (!isEditing) {
       setCurrentLayout(initialLayout)
     }
-  }, [initialLayout, isEditing])
+    // do not sync while editing. Depending on `isEditing` in this effect causes an
+    // unintended rollback when toggling from editing -> view mode after save.
+  }, [initialLayout])
 
   const saveLayout = useCallback(async () => {
     try {

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
@@ -74,7 +74,8 @@ export function useDashboardLayout(initialLayout: WidgetInstanceClient[]) {
         return (
           !initialWidget ||
           widget.item.id !== initialWidget.item.id ||
-          widget.item.width !== initialWidget.item.width
+          widget.item.width !== initialWidget.item.width ||
+          JSON.stringify(widget.item.data || {}) !== JSON.stringify(initialWidget.item.data || {})
         )
       })
 
@@ -111,11 +112,13 @@ export function useDashboardLayout(initialLayout: WidgetInstanceClient[]) {
       // Create a new widget instance using RenderWidget
       const newWidgetInstance: WidgetInstanceClient = {
         component: React.createElement(RenderWidget, {
+          widgetData: {},
           widgetId,
           // TODO: widgetData can be added here for custom props
         }),
         item: {
           id: widgetId,
+          data: {},
           maxWidth: widget?.maxWidth ?? 'full',
           minWidth: widget?.minWidth ?? 'x-small',
           width: widget?.minWidth ?? 'x-small',
@@ -180,6 +183,32 @@ export function useDashboardLayout(initialLayout: WidgetInstanceClient[]) {
     [isEditing],
   )
 
+  const updateWidgetData = useCallback(
+    (widgetId: string, data: Record<string, unknown>) => {
+      if (!isEditing) {
+        return
+      }
+
+      setCurrentLayout((prev) =>
+        prev.map((item) =>
+          item.item.id === widgetId
+            ? {
+                component: React.createElement(RenderWidget, {
+                  widgetData: data,
+                  widgetId,
+                }),
+                item: {
+                  ...item.item,
+                  data,
+                } satisfies WidgetItem,
+              }
+            : item,
+        ),
+      )
+    },
+    [isEditing],
+  )
+
   const cancelModal = React.createElement(ConfirmationModal, {
     body: 'You have unsaved changes to your dashboard layout. Are you sure you want to discard them?',
     confirmLabel: 'Discard',
@@ -200,6 +229,7 @@ export function useDashboardLayout(initialLayout: WidgetInstanceClient[]) {
     resizeWidget,
     saveLayout,
     setIsEditing,
+    updateWidgetData,
   }
 }
 

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/useDashboardLayout.ts
@@ -114,7 +114,6 @@ export function useDashboardLayout(initialLayout: WidgetInstanceClient[]) {
         component: React.createElement(RenderWidget, {
           widgetData: {},
           widgetId,
-          // TODO: widgetData can be added here for custom props
         }),
         item: {
           id: widgetId,

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/getItemsFromConfig.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/getItemsFromConfig.ts
@@ -1,6 +1,6 @@
 import type { DashboardConfig, PayloadRequest, Widget, WidgetInstance } from 'payload'
 
-import type { WidgetItem } from './index.client.js'
+import type { WidgetItem } from '../index.client.js'
 
 export async function getItemsFromConfig(
   defaultLayout: NonNullable<DashboardConfig['defaultLayout']>,

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/getItemsFromPreferences.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/getItemsFromPreferences.ts
@@ -2,9 +2,9 @@ import type { BasePayload, TypedUser } from 'payload'
 
 import { PREFERENCE_KEYS } from 'payload/shared'
 
-import type { WidgetItem } from './index.client.js'
+import type { WidgetItem } from '../index.client.js'
 
-import { getPreferences } from '../../../../utilities/getPreferences.js'
+import { getPreferences } from '../../../../../utilities/getPreferences.js'
 
 export async function getItemsFromPreferences(
   payload: BasePayload,

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/localeUtils.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/localeUtils.ts
@@ -1,28 +1,71 @@
+import type { ClientField, Field } from 'payload'
+
+import { fieldAffectsData, fieldHasSubFields, tabHasName } from 'payload/shared'
+
+type AnyField = ClientField | Field
+
+function isLocalized(field: AnyField): boolean {
+  return 'localized' in field && Boolean(field.localized)
+}
+
+function getObjectValue(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
 /**
  * Extracts locale-specific data from widget data stored in preferences.
  *
  * Localized fields are stored as `{ fieldName: { en: "Hello", de: "Hallo" } }` in preferences.
  * This function flattens them to `{ fieldName: "Hello" }` for the given locale,
  * which is the format the form state builder expects.
+ *
+ * Recursively handles nested field types (group, row, collapsible, tabs).
  */
 export function extractLocaleData(
   widgetData: Record<string, unknown>,
   locale: string,
-  fields: readonly object[],
+  fields: readonly AnyField[],
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {}
 
   for (const field of fields) {
-    if (!('name' in field) || typeof (field as any).name !== 'string') {
+    if (field.type === 'tabs') {
+      for (const tab of field.tabs) {
+        const tabFields = tab.fields as AnyField[]
+        if (tabHasName(tab)) {
+          result[tab.name] = extractLocaleData(
+            getObjectValue(widgetData[tab.name]),
+            locale,
+            tabFields,
+          )
+        } else {
+          Object.assign(result, extractLocaleData(widgetData, locale, tabFields))
+        }
+      }
       continue
     }
 
-    const name = (field as any).name as string
+    if (fieldHasSubFields(field) && !fieldAffectsData(field)) {
+      Object.assign(result, extractLocaleData(widgetData, locale, field.fields as AnyField[]))
+      continue
+    }
+
+    if (!fieldAffectsData(field)) {
+      continue
+    }
+
+    const { name } = field
     const value = widgetData[name]
 
+    if (fieldHasSubFields(field)) {
+      result[name] = extractLocaleData(getObjectValue(value), locale, field.fields as AnyField[])
+      continue
+    }
+
     if (
-      'localized' in field &&
-      (field as any).localized &&
+      isLocalized(field) &&
       value !== undefined &&
       typeof value === 'object' &&
       value !== null &&
@@ -42,28 +85,58 @@ export function extractLocaleData(
  *
  * Non-localized fields are stored directly. Localized fields are stored as
  * `{ fieldName: { en: "Hello", de: "Hallo" } }` so each locale's value is preserved independently.
+ *
+ * Recursively handles nested field types (group, row, collapsible, tabs).
  */
 export function mergeLocaleData(
   existingData: Record<string, unknown>,
   formData: Record<string, unknown>,
   locale: string,
-  fields: readonly object[],
+  fields: readonly AnyField[],
 ): Record<string, unknown> {
   const result: Record<string, unknown> = { ...existingData }
 
   for (const field of fields) {
-    if (!('name' in field) || typeof (field as any).name !== 'string') {
+    if (field.type === 'tabs') {
+      for (const tab of field.tabs) {
+        const tabFields = tab.fields as AnyField[]
+        if (tabHasName(tab)) {
+          result[tab.name] = mergeLocaleData(
+            getObjectValue(result[tab.name]),
+            getObjectValue(formData[tab.name]),
+            locale,
+            tabFields,
+          )
+        } else {
+          Object.assign(result, mergeLocaleData(result, formData, locale, tabFields))
+        }
+      }
       continue
     }
 
-    const name = (field as any).name as string
+    if (fieldHasSubFields(field) && !fieldAffectsData(field)) {
+      Object.assign(result, mergeLocaleData(result, formData, locale, field.fields as AnyField[]))
+      continue
+    }
 
-    if ('localized' in field && (field as any).localized) {
-      const existing =
-        typeof result[name] === 'object' && result[name] !== null && !Array.isArray(result[name])
-          ? (result[name] as Record<string, unknown>)
-          : {}
-      result[name] = { ...existing, [locale]: formData[name] }
+    if (!fieldAffectsData(field)) {
+      continue
+    }
+
+    const { name } = field
+
+    if (fieldHasSubFields(field)) {
+      result[name] = mergeLocaleData(
+        getObjectValue(result[name]),
+        getObjectValue(formData[name]),
+        locale,
+        field.fields as AnyField[],
+      )
+      continue
+    }
+
+    if (isLocalized(field)) {
+      result[name] = { ...getObjectValue(result[name]), [locale]: formData[name] }
     } else {
       result[name] = formData[name]
     }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/localeUtils.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/localeUtils.ts
@@ -1,0 +1,73 @@
+/**
+ * Extracts locale-specific data from widget data stored in preferences.
+ *
+ * Localized fields are stored as `{ fieldName: { en: "Hello", de: "Hallo" } }` in preferences.
+ * This function flattens them to `{ fieldName: "Hello" }` for the given locale,
+ * which is the format the form state builder expects.
+ */
+export function extractLocaleData(
+  widgetData: Record<string, unknown>,
+  locale: string,
+  fields: readonly object[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  for (const field of fields) {
+    if (!('name' in field) || typeof (field as any).name !== 'string') {
+      continue
+    }
+
+    const name = (field as any).name as string
+    const value = widgetData[name]
+
+    if (
+      'localized' in field &&
+      (field as any).localized &&
+      value !== undefined &&
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      result[name] = (value as Record<string, unknown>)[locale]
+    } else {
+      result[name] = value
+    }
+  }
+
+  return result
+}
+
+/**
+ * Merges locale-specific form data back into the full widget data structure.
+ *
+ * Non-localized fields are stored directly. Localized fields are stored as
+ * `{ fieldName: { en: "Hello", de: "Hallo" } }` so each locale's value is preserved independently.
+ */
+export function mergeLocaleData(
+  existingData: Record<string, unknown>,
+  formData: Record<string, unknown>,
+  locale: string,
+  fields: readonly object[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...existingData }
+
+  for (const field of fields) {
+    if (!('name' in field) || typeof (field as any).name !== 'string') {
+      continue
+    }
+
+    const name = (field as any).name as string
+
+    if ('localized' in field && (field as any).localized) {
+      const existing =
+        typeof result[name] === 'object' && result[name] !== null && !Array.isArray(result[name])
+          ? (result[name] as Record<string, unknown>)
+          : {}
+      result[name] = { ...existing, [locale]: formData[name] }
+    } else {
+      result[name] = formData[name]
+    }
+  }
+
+  return result
+}

--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -166,9 +166,16 @@ export type BuildFormStateArgs = {
       // Do not type it as never. This still makes it so that either collectionSlug or globalSlug is required, but makes it easier to provide both collectionSlug and globalSlug if it's
       // unclear which one is actually available.
       globalSlug?: string
+      widgetSlug?: string
     }
   | {
       collectionSlug?: string
       globalSlug: string
+      widgetSlug?: string
+    }
+  | {
+      collectionSlug?: string
+      globalSlug?: string
+      widgetSlug: string
     }
 )

--- a/packages/payload/src/admin/views/dashboard.ts
+++ b/packages/payload/src/admin/views/dashboard.ts
@@ -1,20 +1,21 @@
-import type { DataFromWidgetSlug, InitReqResult, WidgetSlug } from '../../index.js'
+import type { InitReqResult } from '../../index.js'
 
 export enum EntityType {
   collection = 'collections',
   global = 'globals',
 }
 
-type WidgetDataFromSlug<TSlug extends WidgetSlug> =
-  DataFromWidgetSlug<TSlug> extends {
-    data?: infer TData
-  }
-    ? TData
-    : DataFromWidgetSlug<TSlug>
+type WidgetDataFromWidget<TWidget> = TWidget extends {
+  data?: infer TData
+}
+  ? TData
+  : never
 
-export type WidgetServerProps<TSlug extends WidgetSlug = WidgetSlug> = {
-  widgetData?: WidgetDataFromSlug<TSlug> extends Record<string, unknown>
-    ? WidgetDataFromSlug<TSlug>
+export type WidgetServerProps<
+  TWidget extends { data?: unknown } = { data?: Record<string, unknown> },
+> = {
+  widgetData?: WidgetDataFromWidget<TWidget> extends Record<string, unknown>
+    ? WidgetDataFromWidget<TWidget>
     : Record<string, unknown>
-  widgetSlug: TSlug
+  widgetSlug: string
 } & Pick<InitReqResult, 'cookies' | 'locale' | 'permissions' | 'req'>

--- a/packages/payload/src/admin/views/dashboard.ts
+++ b/packages/payload/src/admin/views/dashboard.ts
@@ -1,4 +1,4 @@
-import type { InitReqResult } from '../../index.js'
+import type { InitReqResult, TypedWidget, WidgetSlug } from '../../index.js'
 
 export enum EntityType {
   collection = 'collections',
@@ -11,11 +11,19 @@ type WidgetDataFromWidget<TWidget> = TWidget extends {
   ? TData
   : never
 
-export type WidgetServerProps<
-  TWidget extends { data?: unknown } = { data?: Record<string, unknown> },
-> = {
-  widgetData?: WidgetDataFromWidget<TWidget> extends Record<string, unknown>
-    ? WidgetDataFromWidget<TWidget>
-    : Record<string, unknown>
-  widgetSlug: string
+type WidgetSlugFromWidget<TWidget extends { data?: unknown }> = {
+  [TSlug in WidgetSlug]: TypedWidget[TSlug] extends TWidget ? TSlug : never
+}[WidgetSlug]
+
+export type WidgetServerProps<TWidget extends { data?: unknown } | never = never> = {
+  widgetData?: [TWidget] extends [never]
+    ? Record<string, unknown>
+    : WidgetDataFromWidget<Exclude<TWidget, never>> extends Record<string, unknown>
+      ? WidgetDataFromWidget<Exclude<TWidget, never>>
+      : Record<string, unknown>
+  widgetSlug: [TWidget] extends [never]
+    ? string
+    : [WidgetSlugFromWidget<{ data?: unknown } & Exclude<TWidget, never>>] extends [never]
+      ? string
+      : WidgetSlugFromWidget<{ data?: unknown } & Exclude<TWidget, never>>
 } & Pick<InitReqResult, 'cookies' | 'locale' | 'permissions' | 'req'>

--- a/packages/payload/src/admin/views/dashboard.ts
+++ b/packages/payload/src/admin/views/dashboard.ts
@@ -1,11 +1,20 @@
-import type { InitReqResult } from '../../index.js'
+import type { DataFromWidgetSlug, InitReqResult, WidgetSlug } from '../../index.js'
 
 export enum EntityType {
   collection = 'collections',
   global = 'globals',
 }
 
-export type WidgetServerProps = {
-  widgetData?: Record<string, unknown>
-  widgetSlug: string
+type WidgetDataFromSlug<TSlug extends WidgetSlug> =
+  DataFromWidgetSlug<TSlug> extends {
+    data?: infer TData
+  }
+    ? TData
+    : DataFromWidgetSlug<TSlug>
+
+export type WidgetServerProps<TSlug extends WidgetSlug = WidgetSlug> = {
+  widgetData?: WidgetDataFromSlug<TSlug> extends Record<string, unknown>
+    ? WidgetDataFromSlug<TSlug>
+    : Record<string, unknown>
+  widgetSlug: TSlug
 } & Pick<InitReqResult, 'cookies' | 'locale' | 'permissions' | 'req'>

--- a/packages/payload/src/bin/generateImportMap/iterateConfig.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateConfig.ts
@@ -85,6 +85,16 @@ export function iterateConfig({
   if (config.admin?.dashboard?.widgets?.length) {
     for (const dashboardWidget of config.admin.dashboard.widgets) {
       addToImportMap(dashboardWidget.ComponentPath)
+      if (dashboardWidget.fields?.length) {
+        genImportMapIterateFields({
+          addToImportMap,
+          baseDir,
+          config,
+          fields: dashboardWidget.fields,
+          importMap,
+          imports,
+        })
+      }
     }
   }
 

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -207,6 +207,21 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
     validRelationships.push(config.folders!.slug)
   }
 
+  if (config.admin?.dashboard?.widgets?.length) {
+    for (const widget of config.admin.dashboard.widgets) {
+      if (widget.fields?.length) {
+        widget.fields = await sanitizeFields({
+          config: config as unknown as Config,
+          existingFieldNames: new Set(),
+          fields: widget.fields,
+          parentIsLocalized: false,
+          richTextSanitizationPromises,
+          validRelationships,
+        })
+      }
+    }
+  }
+
   /**
    * Blocks sanitization needs to happen before collections, as collection/global join field sanitization needs config.blocks
    * to be populated with the sanitized blocks

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -11,6 +11,7 @@ import type {
   LocalizationConfigWithNoLabels,
   SanitizedConfig,
   Timezone,
+  Widget,
   WidgetInstance,
 } from './types.js'
 
@@ -207,18 +208,18 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
     validRelationships.push(config.folders!.slug)
   }
 
-  if (config.admin?.dashboard?.widgets?.length) {
-    for (const widget of config.admin.dashboard.widgets) {
-      if (widget.fields?.length) {
-        widget.fields = await sanitizeFields({
-          config: config as unknown as Config,
-          existingFieldNames: new Set(),
-          fields: widget.fields,
-          parentIsLocalized: false,
-          richTextSanitizationPromises,
-          validRelationships,
-        })
-      }
+  const dashboardWidgets = config.admin?.dashboard?.widgets ?? ([] as Widget[])
+
+  for (const widget of dashboardWidgets) {
+    if (widget.fields?.length) {
+      widget.fields = await sanitizeFields({
+        config: config as unknown as Config,
+        existingFieldNames: new Set(),
+        fields: widget.fields,
+        parentIsLocalized: false,
+        richTextSanitizationPromises,
+        validRelationships,
+      })
     }
   }
 

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -785,15 +785,15 @@ export type WidgetInstance<TSlug extends WidgetSlug = WidgetSlug> = TSlug extend
         ? DataFromWidgetSlug<TSlug>
         : Record<string, unknown>
       widgetSlug: TSlug
-      width?: [
+      width: [
         Extract<
-          TypedWidget[TSlug] extends { width?: infer TWidth } ? TWidth : WidgetWidth,
+          TypedWidget[TSlug] extends { width: infer TWidth } ? TWidth : WidgetWidth,
           WidgetWidth
         >,
       ] extends [never]
         ? WidgetWidth
         : Extract<
-            TypedWidget[TSlug] extends { width?: infer TWidth } ? TWidth : WidgetWidth,
+            TypedWidget[TSlug] extends { width: infer TWidth } ? TWidth : WidgetWidth,
             WidgetWidth
           >
     }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -43,7 +43,9 @@ import type { RootFoldersConfiguration } from '../folders/types.js'
 import type { GlobalConfig, Globals, SanitizedGlobalConfig } from '../globals/config/types.js'
 import type {
   Block,
+  ClientField,
   DefaultDocumentIDType,
+  Field,
   FlattenedBlock,
   JobsConfig,
   KVAdapterResult,
@@ -749,6 +751,7 @@ export type WidgetWidth = 'full' | 'large' | 'medium' | 'small' | 'x-large' | 'x
 
 export type Widget = {
   ComponentPath: string
+  fields?: Field[]
   /**
    * Human-friendly label for the widget.
    * Supports i18n by passing an object with locale keys, or a function with `t` for translations.
@@ -758,8 +761,6 @@ export type Widget = {
   maxWidth?: WidgetWidth
   minWidth?: WidgetWidth
   slug: string
-  // TODO: Add fields
-  // fields?: Field[]
   // Maybe:
   // ImageURL?: string // similar to Block
 }
@@ -768,6 +769,7 @@ export type Widget = {
  * Client-side widget type with resolved label (no functions).
  */
 export type ClientWidget = {
+  fields?: ClientField[]
   label?: StaticLabel
   maxWidth?: WidgetWidth
   minWidth?: WidgetWidth
@@ -775,8 +777,7 @@ export type ClientWidget = {
 }
 
 export type WidgetInstance = {
-  // TODO: should be inferred from Widget Fields
-  // data: Record<string, any>
+  data?: Record<string, unknown>
   widgetSlug: string
   width?: WidgetWidth
 }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -44,6 +44,7 @@ import type { GlobalConfig, Globals, SanitizedGlobalConfig } from '../globals/co
 import type {
   Block,
   ClientField,
+  DataFromWidgetSlug,
   DefaultDocumentIDType,
   Field,
   FlattenedBlock,
@@ -53,6 +54,8 @@ import type {
   RequestContext,
   SelectField,
   TypedUser,
+  TypedWidget,
+  WidgetSlug,
 } from '../index.js'
 import type { QueryPreset, QueryPresetConstraints } from '../query-presets/types.js'
 import type { SanitizedJobsConfig } from '../queues/config/types/index.js'
@@ -776,11 +779,25 @@ export type ClientWidget = {
   slug: string
 }
 
-export type WidgetInstance = {
-  data?: Record<string, unknown>
-  widgetSlug: string
-  width?: WidgetWidth
-}
+export type WidgetInstance<TSlug extends WidgetSlug = WidgetSlug> = TSlug extends WidgetSlug
+  ? {
+      data?: DataFromWidgetSlug<TSlug> extends Record<string, unknown>
+        ? DataFromWidgetSlug<TSlug>
+        : Record<string, unknown>
+      widgetSlug: TSlug
+      width?: [
+        Extract<
+          TypedWidget[TSlug] extends { width?: infer TWidth } ? TWidth : WidgetWidth,
+          WidgetWidth
+        >,
+      ] extends [never]
+        ? WidgetWidth
+        : Extract<
+            TypedWidget[TSlug] extends { width?: infer TWidth } ? TWidth : WidgetWidth,
+            WidgetWidth
+          >
+    }
+  : never
 
 export type DashboardConfig = {
   defaultLayout?:

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -190,7 +190,7 @@ export interface PayloadTypesShape {
   jobs: unknown
   locale: unknown
   user: unknown
-  widgets: Record<string, unknown>
+  widgets?: Record<string, unknown>
 }
 
 /**
@@ -284,7 +284,13 @@ export type TypedCollection<T extends PayloadTypesShape = PayloadTypes> = T['col
 
 export type TypedBlock = PayloadTypes['blocks']
 
-export type TypedWidget<T extends PayloadTypesShape = PayloadTypes> = T['widgets']
+export type TypedWidget<T extends PayloadTypesShape = PayloadTypes> = T extends {
+  widgets: infer TWidgets
+}
+  ? TWidgets extends Record<string, unknown>
+    ? TWidgets
+    : Record<string, unknown>
+  : Record<string, unknown>
 
 export type TypedUploadCollection<T extends PayloadTypesShape = PayloadTypes> = NonNever<{
   [TSlug in keyof T['collections']]:
@@ -315,7 +321,7 @@ export type CollectionSlug<T extends PayloadTypesShape = PayloadTypes> = StringK
 
 export type BlockSlug = StringKeyOf<TypedBlock>
 
-export type WidgetSlug<T extends PayloadTypesShape = PayloadTypes> = StringKeyOf<T['widgets']>
+export type WidgetSlug<T extends PayloadTypesShape = PayloadTypes> = StringKeyOf<TypedWidget<T>>
 
 export type DataFromWidgetSlug<TSlug extends WidgetSlug> = TypedWidget[TSlug] extends {
   data?: infer TData

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -190,6 +190,7 @@ export interface PayloadTypesShape {
   jobs: unknown
   locale: unknown
   user: unknown
+  widgets: Record<string, unknown>
 }
 
 /**
@@ -254,6 +255,9 @@ export interface UntypedPayloadTypes {
   }
   locale: null | string
   user: UntypedUser
+  widgets: {
+    [slug: string]: JsonObject
+  }
 }
 
 /**
@@ -279,6 +283,8 @@ export type PayloadTypes = IsAugmented extends true
 export type TypedCollection<T extends PayloadTypesShape = PayloadTypes> = T['collections']
 
 export type TypedBlock = PayloadTypes['blocks']
+
+export type TypedWidget<T extends PayloadTypesShape = PayloadTypes> = T['widgets']
 
 export type TypedUploadCollection<T extends PayloadTypesShape = PayloadTypes> = NonNever<{
   [TSlug in keyof T['collections']]:
@@ -308,6 +314,14 @@ export type CollectionSlug<T extends PayloadTypesShape = PayloadTypes> = StringK
 >
 
 export type BlockSlug = StringKeyOf<TypedBlock>
+
+export type WidgetSlug<T extends PayloadTypesShape = PayloadTypes> = StringKeyOf<T['widgets']>
+
+export type DataFromWidgetSlug<TSlug extends WidgetSlug> = TypedWidget[TSlug] extends {
+  data?: infer TData
+}
+  ? TData
+  : TypedWidget[TSlug]
 
 export type UploadCollectionSlug<T extends PayloadTypesShape = PayloadTypes> = StringKeyOf<
   TypedUploadCollection<T>

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -209,6 +209,7 @@ function generateWidgetSchemas({
           enum: widthEnum,
         },
       },
+      required: ['width'],
     }
 
     properties[widget.slug] = {

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -10,6 +10,7 @@ import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import { MissingEditorProp } from '../errors/MissingEditorProp.js'
 import { fieldAffectsData } from '../fields/config/types.js'
 import { generateJobsJSONSchemas } from '../queues/config/generateJobsJSONSchemas.js'
+import { flattenAllFields } from './flattenAllFields.js'
 import { formatNames } from './formatLabels.js'
 import { getCollectionIDFieldTypes } from './getCollectionIDFieldTypes.js'
 import { optionsAreEqual } from './optionsAreEqual.js'
@@ -129,6 +130,100 @@ function generateCollectionJoinsSchemas(collections: SanitizedCollectionConfig[]
     additionalProperties: false,
     properties,
     required: Object.keys(properties),
+  }
+}
+
+const widgetWidths = ['x-small', 'small', 'medium', 'large', 'x-large', 'full'] as const
+
+function getAllowedWidgetWidths({
+  maxWidth,
+  minWidth,
+}: {
+  maxWidth?: (typeof widgetWidths)[number]
+  minWidth?: (typeof widgetWidths)[number]
+}): string[] {
+  const minIndex = minWidth ? widgetWidths.indexOf(minWidth) : 0
+  const maxIndex = maxWidth ? widgetWidths.indexOf(maxWidth) : widgetWidths.length - 1
+
+  if (minIndex === -1 || maxIndex === -1 || minIndex > maxIndex) {
+    return [...widgetWidths]
+  }
+
+  return widgetWidths.slice(minIndex, maxIndex + 1)
+}
+
+function generateWidgetSchemas({
+  collectionIDFieldTypes,
+  config,
+  i18n,
+  interfaceNameDefinitions,
+}: {
+  collectionIDFieldTypes: { [key: string]: 'number' | 'string' }
+  config: SanitizedConfig
+  i18n?: I18n
+  interfaceNameDefinitions: Map<string, JSONSchema4>
+}): {
+  definitions: Record<string, JSONSchema4>
+  schema: JSONSchema4
+} {
+  const widgets = config.admin?.dashboard?.widgets ?? []
+  const definitions: Record<string, JSONSchema4> = {}
+  const properties: Record<string, JSONSchema4> = {}
+
+  for (const widget of widgets) {
+    const definition = `${widget.slug}_widget`
+    const widthEnum = getAllowedWidgetWidths({
+      maxWidth: widget.maxWidth,
+      minWidth: widget.minWidth,
+    })
+    let dataSchema: JSONSchema4
+
+    if (widget.fields?.length) {
+      const widgetFieldSchemas = fieldsToJSONSchema(
+        collectionIDFieldTypes,
+        flattenAllFields({ fields: widget.fields }),
+        interfaceNameDefinitions,
+        config,
+        i18n,
+      )
+
+      dataSchema = {
+        type: 'object',
+        additionalProperties: false,
+        ...widgetFieldSchemas,
+      }
+    } else {
+      dataSchema = {
+        type: 'object',
+        additionalProperties: true,
+      }
+    }
+
+    definitions[definition] = {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        data: dataSchema,
+        width: {
+          type: 'string',
+          enum: widthEnum,
+        },
+      },
+    }
+
+    properties[widget.slug] = {
+      $ref: `#/definitions/${definition}`,
+    }
+  }
+
+  return {
+    definitions,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties,
+      required: Object.keys(properties),
+    },
   }
 }
 
@@ -1224,6 +1319,12 @@ export function configToJSONSchema(
   )
 
   const timezoneDefinitions = timezonesToJSONSchema(config.admin.timezones.supportedTimezones)
+  const widgetSchemas = generateWidgetSchemas({
+    collectionIDFieldTypes,
+    config,
+    i18n,
+    interfaceNameDefinitions,
+  })
 
   const authOperationDefinitions = [...config.collections]
     .filter(({ auth }) => Boolean(auth))
@@ -1288,6 +1389,7 @@ export function configToJSONSchema(
     definitions: {
       supportedTimezones: timezoneDefinitions,
       ...entityDefinitions,
+      ...widgetSchemas.definitions,
       ...Object.fromEntries(interfaceNameDefinitions),
       ...authOperationDefinitions,
     },
@@ -1304,6 +1406,7 @@ export function configToJSONSchema(
       globals: generateEntitySchemas(config.globals || []),
       globalsSelect: generateEntitySelectSchemas(config.globals || []),
       locale: generateLocaleEntitySchemas(config.localization),
+      widgets: widgetSchemas.schema,
       ...(config.typescript?.strictDraftTypes
         ? {
             strictDraftTypes: {
@@ -1328,6 +1431,7 @@ export function configToJSONSchema(
       'db',
       'jobs',
       'blocks',
+      'widgets',
     ],
     title: 'Config',
   }

--- a/packages/ui/src/utilities/buildClientFieldSchemaMap/index.ts
+++ b/packages/ui/src/utilities/buildClientFieldSchemaMap/index.ts
@@ -33,8 +33,9 @@ export const buildClientFieldSchemaMap = (args: {
   i18n: I18n
   payload: Payload
   schemaMap: FieldSchemaMap
+  widgetSlug?: string
 }): { clientFieldSchemaMap: ClientFieldSchemaMap } => {
-  const { collectionSlug, config, globalSlug, i18n, payload, schemaMap } = args
+  const { collectionSlug, config, globalSlug, i18n, payload, schemaMap, widgetSlug } = args
 
   const clientSchemaMap: ClientFieldSchemaMap = new Map()
 
@@ -83,6 +84,27 @@ export const buildClientFieldSchemaMap = (args: {
         i18n,
         parentIndexPath: '',
         parentSchemaPath: globalSlug,
+        payload,
+        schemaMap,
+      })
+    }
+  } else if (widgetSlug) {
+    const matchedWidget = config.admin?.dashboard?.widgets?.find(
+      (widget) => widget.slug === widgetSlug,
+    )
+
+    if (matchedWidget?.fields?.length) {
+      clientSchemaMap.set(widgetSlug, {
+        fields: matchedWidget.fields,
+      })
+
+      traverseFields({
+        clientSchemaMap,
+        config,
+        fields: matchedWidget.fields,
+        i18n,
+        parentIndexPath: '',
+        parentSchemaPath: widgetSlug,
         payload,
         schemaMap,
       })

--- a/packages/ui/src/utilities/buildFieldSchemaMap/index.ts
+++ b/packages/ui/src/utilities/buildFieldSchemaMap/index.ts
@@ -28,8 +28,9 @@ export const buildFieldSchemaMap = (args: {
   config: SanitizedConfig
   globalSlug?: string
   i18n: I18n
+  widgetSlug?: string
 }): { fieldSchemaMap: FieldSchemaMap } => {
-  const { collectionSlug, config, globalSlug, i18n } = args
+  const { collectionSlug, config, globalSlug, i18n, widgetSlug } = args
 
   const schemaMap: FieldSchemaMap = new Map()
 
@@ -75,6 +76,25 @@ export const buildFieldSchemaMap = (args: {
         i18n,
         parentIndexPath: '',
         parentSchemaPath: globalSlug,
+        schemaMap,
+      })
+    }
+  } else if (widgetSlug) {
+    const matchedWidget = config.admin?.dashboard?.widgets?.find(
+      (widget) => widget.slug === widgetSlug,
+    )
+
+    if (matchedWidget?.fields?.length) {
+      schemaMap.set(widgetSlug, {
+        fields: matchedWidget.fields,
+      })
+
+      traverseFields({
+        config,
+        fields: matchedWidget.fields,
+        i18n,
+        parentIndexPath: '',
+        parentSchemaPath: widgetSlug,
         schemaMap,
       })
     }

--- a/packages/ui/src/utilities/buildFieldSchemaMap/index.ts
+++ b/packages/ui/src/utilities/buildFieldSchemaMap/index.ts
@@ -83,15 +83,16 @@ export const buildFieldSchemaMap = (args: {
     const matchedWidget = config.admin?.dashboard?.widgets?.find(
       (widget) => widget.slug === widgetSlug,
     )
+    const widgetFields = matchedWidget?.fields as Field[] | undefined
 
-    if (matchedWidget?.fields?.length) {
+    if (widgetFields?.length) {
       schemaMap.set(widgetSlug, {
-        fields: matchedWidget.fields,
+        fields: widgetFields,
       })
 
       traverseFields({
         config,
-        fields: matchedWidget.fields,
+        fields: widgetFields,
         i18n,
         parentIndexPath: '',
         parentSchemaPath: widgetSlug,

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -104,7 +104,8 @@ export const buildFormState = async (
     returnLivePreviewURL,
     returnLockStatus,
     returnPreviewURL,
-    schemaPath = collectionSlug || globalSlug,
+    widgetSlug,
+    schemaPath = collectionSlug || globalSlug || widgetSlug,
     select,
     skipClientConfigAuth,
     skipValidation,
@@ -113,8 +114,8 @@ export const buildFormState = async (
 
   const selectMode = select ? getSelectMode(select) : undefined
 
-  if (!collectionSlug && !globalSlug) {
-    throw new Error('Either collectionSlug or globalSlug must be provided')
+  if (!collectionSlug && !globalSlug && !widgetSlug) {
+    throw new Error('Either collectionSlug, globalSlug, or widgetSlug must be provided')
   }
 
   const schemaMap = getSchemaMap({
@@ -122,6 +123,7 @@ export const buildFormState = async (
     config,
     globalSlug,
     i18n,
+    widgetSlug,
   })
 
   const clientSchemaMap = getClientSchemaMap({
@@ -136,6 +138,7 @@ export const buildFormState = async (
     i18n,
     payload,
     schemaMap,
+    widgetSlug,
   })
 
   const id = collectionSlug ? idFromArgs : undefined

--- a/packages/ui/src/utilities/getClientSchemaMap.ts
+++ b/packages/ui/src/utilities/getClientSchemaMap.ts
@@ -27,8 +27,7 @@ export const getClientSchemaMap = cache(
       cachedClientSchemaMap = new Map()
     }
 
-    const cacheKey =
-      collectionSlug || globalSlug || (widgetSlug ? `widget:${widgetSlug}` : undefined)
+    const cacheKey = collectionSlug || globalSlug || `widget:${widgetSlug}`
     let cachedEntityClientFieldMap = cachedClientSchemaMap.get(cacheKey)
 
     if (cachedEntityClientFieldMap) {

--- a/packages/ui/src/utilities/getClientSchemaMap.ts
+++ b/packages/ui/src/utilities/getClientSchemaMap.ts
@@ -19,14 +19,17 @@ export const getClientSchemaMap = cache(
     i18n: I18nClient
     payload: Payload
     schemaMap: FieldSchemaMap
+    widgetSlug?: string
   }): ClientFieldSchemaMap => {
-    const { collectionSlug, config, globalSlug, i18n, payload, schemaMap } = args
+    const { collectionSlug, config, globalSlug, i18n, payload, schemaMap, widgetSlug } = args
 
     if (!cachedClientSchemaMap || global._payload_doNotCacheClientSchemaMap) {
       cachedClientSchemaMap = new Map()
     }
 
-    let cachedEntityClientFieldMap = cachedClientSchemaMap.get(collectionSlug || globalSlug)
+    const cacheKey =
+      collectionSlug || globalSlug || (widgetSlug ? `widget:${widgetSlug}` : undefined)
+    let cachedEntityClientFieldMap = cachedClientSchemaMap.get(cacheKey)
 
     if (cachedEntityClientFieldMap) {
       return cachedEntityClientFieldMap
@@ -41,9 +44,10 @@ export const getClientSchemaMap = cache(
       i18n: i18n as I18n,
       payload,
       schemaMap,
+      widgetSlug,
     })
 
-    cachedClientSchemaMap.set(collectionSlug || globalSlug, entityClientFieldMap)
+    cachedClientSchemaMap.set(cacheKey, entityClientFieldMap)
 
     global._payload_clientSchemaMap = cachedClientSchemaMap
 

--- a/packages/ui/src/utilities/getSchemaMap.ts
+++ b/packages/ui/src/utilities/getSchemaMap.ts
@@ -17,14 +17,17 @@ export const getSchemaMap = cache(
     config: SanitizedConfig
     globalSlug?: string
     i18n: I18nClient
+    widgetSlug?: string
   }): FieldSchemaMap => {
-    const { collectionSlug, config, globalSlug, i18n } = args
+    const { collectionSlug, config, globalSlug, i18n, widgetSlug } = args
 
     if (!cachedSchemaMap || global._payload_doNotCacheSchemaMap) {
       cachedSchemaMap = new Map()
     }
 
-    let cachedEntityFieldMap = cachedSchemaMap.get(collectionSlug || globalSlug)
+    const cacheKey =
+      collectionSlug || globalSlug || (widgetSlug ? `widget:${widgetSlug}` : undefined)
+    let cachedEntityFieldMap = cachedSchemaMap.get(cacheKey)
 
     if (cachedEntityFieldMap) {
       return cachedEntityFieldMap
@@ -37,9 +40,10 @@ export const getSchemaMap = cache(
       config,
       globalSlug,
       i18n: i18n as I18n,
+      widgetSlug,
     })
 
-    cachedSchemaMap.set(collectionSlug || globalSlug, entityFieldMap)
+    cachedSchemaMap.set(cacheKey, entityFieldMap)
 
     global._payload_schemaMap = cachedSchemaMap
 

--- a/packages/ui/src/utilities/getSchemaMap.ts
+++ b/packages/ui/src/utilities/getSchemaMap.ts
@@ -25,8 +25,7 @@ export const getSchemaMap = cache(
       cachedSchemaMap = new Map()
     }
 
-    const cacheKey =
-      collectionSlug || globalSlug || (widgetSlug ? `widget:${widgetSlug}` : undefined)
+    const cacheKey = collectionSlug || globalSlug || `widget:${widgetSlug}`
     let cachedEntityFieldMap = cachedSchemaMap.get(cacheKey)
 
     if (cachedEntityFieldMap) {

--- a/test/dashboard/components/Configurable.tsx
+++ b/test/dashboard/components/Configurable.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable no-restricted-exports */
+import { type WidgetServerProps } from 'payload'
+
+import type { ConfigurableWidget } from '../payload-types.js'
+
+export default function Configurable({ widgetData }: WidgetServerProps<ConfigurableWidget>) {
+  const title = widgetData?.title || 'Untitled'
+  const description = widgetData?.description || ''
+  const relatedTicket =
+    typeof widgetData?.relatedTicket === 'string' ? widgetData.relatedTicket : undefined
+
+  return (
+    <div className="configurable-widget card" style={{ padding: '16px' }}>
+      <h3 data-testid="configurable-title" style={{ margin: 0 }}>
+        {title}
+      </h3>
+      {description && (
+        <p data-testid="configurable-description" style={{ margin: '8px 0 0' }}>
+          {description}
+        </p>
+      )}
+      {relatedTicket && (
+        <p data-testid="configurable-ticket" style={{ fontSize: '12px', margin: '8px 0 0' }}>
+          Ticket: {relatedTicket}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/test/dashboard/components/Configurable.tsx
+++ b/test/dashboard/components/Configurable.tsx
@@ -8,6 +8,7 @@ export default function Configurable({ widgetData }: WidgetServerProps<Configura
   const description = widgetData?.description || ''
   const relatedTicket =
     typeof widgetData?.relatedTicket === 'string' ? widgetData.relatedTicket : undefined
+  const nestedText = widgetData?.nestedGroup?.nestedText
 
   return (
     <div className="configurable-widget card" style={{ padding: '16px' }}>
@@ -22,6 +23,11 @@ export default function Configurable({ widgetData }: WidgetServerProps<Configura
       {relatedTicket && (
         <p data-testid="configurable-ticket" style={{ fontSize: '12px', margin: '8px 0 0' }}>
           Ticket: {relatedTicket}
+        </p>
+      )}
+      {nestedText && (
+        <p data-testid="configurable-nested-text" style={{ fontSize: '12px', margin: '8px 0 0' }}>
+          {nestedText}
         </p>
       )}
     </div>

--- a/test/dashboard/components/Count.tsx
+++ b/test/dashboard/components/Count.tsx
@@ -1,14 +1,20 @@
 /* eslint-disable no-restricted-exports */
 import { type WidgetServerProps } from 'payload'
 
-export default async function Count({ req }: WidgetServerProps) {
+export default async function Count({ req, widgetData }: WidgetServerProps) {
   let count = 0
   let error: null | string = null
 
-  // TODO: Dynamic collection counting using fields
-  const collection = 'tickets'
+  const typedWidgetData = widgetData as { collection?: string; title?: string } | undefined
+  const selectedCollection =
+    typeof typedWidgetData?.collection === 'string' && typedWidgetData.collection.length > 0
+      ? typedWidgetData.collection
+      : 'tickets'
   const payload = req.payload
-  const title = 'Tickets'
+  const title =
+    typeof typedWidgetData?.title === 'string' && typedWidgetData.title
+      ? typedWidgetData.title
+      : 'Tickets'
   const color = 'blue'
   const icon = '📊'
   const changePercent = 10
@@ -17,13 +23,16 @@ export default async function Count({ req }: WidgetServerProps) {
   try {
     const result = await payload.count({
       // @ts-expect-error - Dynamic collection counting
-      collection,
+      collection: selectedCollection,
     })
     count = result.totalDocs
   } catch (err) {
-    error = err instanceof Error ? err.message : 'Failed to fetch count'
+    error =
+      err instanceof Error
+        ? `${err.message} (${selectedCollection})`
+        : `Failed to fetch count (${selectedCollection})`
     // eslint-disable-next-line no-console
-    console.error(`Error fetching count for ${collection}:`, err)
+    console.error(`Error fetching count for ${selectedCollection}:`, err)
   }
 
   const getColorStyles = (color: 'blue' | 'green' | 'orange' | 'purple' | 'red') => {

--- a/test/dashboard/components/Count.tsx
+++ b/test/dashboard/components/Count.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable no-restricted-exports */
 import { type WidgetServerProps } from 'payload'
 
-export default async function Count({ req, widgetData }: WidgetServerProps<'count'>) {
+import type { CountWidget } from '../payload-types.js'
+
+export default async function Count({ req, widgetData }: WidgetServerProps<CountWidget>) {
   let count = 0
   let error: null | string = null
 

--- a/test/dashboard/components/Count.tsx
+++ b/test/dashboard/components/Count.tsx
@@ -1,20 +1,17 @@
 /* eslint-disable no-restricted-exports */
 import { type WidgetServerProps } from 'payload'
 
-export default async function Count({ req, widgetData }: WidgetServerProps) {
+export default async function Count({ req, widgetData }: WidgetServerProps<'count'>) {
   let count = 0
   let error: null | string = null
 
-  const typedWidgetData = widgetData as { collection?: string; title?: string } | undefined
   const selectedCollection =
-    typeof typedWidgetData?.collection === 'string' && typedWidgetData.collection.length > 0
-      ? typedWidgetData.collection
+    typeof widgetData?.collection === 'string' && widgetData.collection.length > 0
+      ? widgetData.collection
       : 'tickets'
   const payload = req.payload
   const title =
-    typeof typedWidgetData?.title === 'string' && typedWidgetData.title
-      ? typedWidgetData.title
-      : 'Tickets'
+    typeof widgetData?.title === 'string' && widgetData.title ? widgetData.title : 'Tickets'
   const color = 'blue'
   const icon = '📊'
   const changePercent = 10
@@ -22,7 +19,6 @@ export default async function Count({ req, widgetData }: WidgetServerProps) {
 
   try {
     const result = await payload.count({
-      // @ts-expect-error - Dynamic collection counting
       collection: selectedCollection,
     })
     count = result.totalDocs

--- a/test/dashboard/components/Revenue.tsx
+++ b/test/dashboard/components/Revenue.tsx
@@ -10,15 +10,14 @@ interface RevenueData {
   period: string
 }
 
-export default function Revenue({ widgetData }: WidgetServerProps) {
-  const typedWidgetData = widgetData as { timeframe?: string; title?: string } | undefined
+export default function Revenue({ widgetData }: WidgetServerProps<'revenue'>) {
   const timeframe =
-    typeof typedWidgetData?.timeframe === 'string' && typedWidgetData.timeframe
-      ? typedWidgetData.timeframe
+    typeof widgetData?.timeframe === 'string' && widgetData.timeframe
+      ? widgetData.timeframe
       : 'monthly'
   const title =
-    typeof typedWidgetData?.title === 'string' && typedWidgetData.title
-      ? typedWidgetData.title
+    typeof widgetData?.title === 'string' && widgetData.title
+      ? widgetData.title
       : 'Revenue Statistics'
   // Mock data for now - in real implementation, this would come from props or server-side fetch
   const mockData: RevenueData[] = [

--- a/test/dashboard/components/Revenue.tsx
+++ b/test/dashboard/components/Revenue.tsx
@@ -10,9 +10,16 @@ interface RevenueData {
   period: string
 }
 
-export default function Revenue(_props: WidgetServerProps) {
-  const timeframe = 'monthly'
-  const title = 'Revenue Statistics'
+export default function Revenue({ widgetData }: WidgetServerProps) {
+  const typedWidgetData = widgetData as { timeframe?: string; title?: string } | undefined
+  const timeframe =
+    typeof typedWidgetData?.timeframe === 'string' && typedWidgetData.timeframe
+      ? typedWidgetData.timeframe
+      : 'monthly'
+  const title =
+    typeof typedWidgetData?.title === 'string' && typedWidgetData.title
+      ? typedWidgetData.title
+      : 'Revenue Statistics'
   // Mock data for now - in real implementation, this would come from props or server-side fetch
   const mockData: RevenueData[] = [
     { amount: 20000, date: '2024-01', period: 'Jan' },

--- a/test/dashboard/components/Revenue.tsx
+++ b/test/dashboard/components/Revenue.tsx
@@ -4,13 +4,15 @@
 import { type WidgetServerProps } from 'payload'
 import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 
+import type { RevenueWidget } from '../payload-types.js'
+
 interface RevenueData {
   amount: number
   date: string
   period: string
 }
 
-export default function Revenue({ widgetData }: WidgetServerProps<'revenue'>) {
+export default function Revenue({ widgetData }: WidgetServerProps<RevenueWidget>) {
   const timeframe =
     typeof widgetData?.timeframe === 'string' && widgetData.timeframe
       ? widgetData.timeframe

--- a/test/dashboard/components/Revenue.tsx
+++ b/test/dashboard/components/Revenue.tsx
@@ -13,14 +13,8 @@ interface RevenueData {
 }
 
 export default function Revenue({ widgetData }: WidgetServerProps<RevenueWidget>) {
-  const timeframe =
-    typeof widgetData?.timeframe === 'string' && widgetData.timeframe
-      ? widgetData.timeframe
-      : 'monthly'
-  const title =
-    typeof widgetData?.title === 'string' && widgetData.title
-      ? widgetData.title
-      : 'Revenue Statistics'
+  const timeframe = typeof widgetData?.timeframe === 'string' ? widgetData.timeframe : 'monthly'
+  const title = typeof widgetData?.title === 'string' ? widgetData.title : 'Revenue Statistics'
   // Mock data for now - in real implementation, this would come from props or server-side fetch
   const mockData: RevenueData[] = [
     { amount: 20000, date: '2024-01', period: 'Jan' },

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -134,6 +134,17 @@ export default buildConfigWithDefaults({
               type: 'relationship',
               relationTo: 'tickets',
             },
+            {
+              name: 'nestedGroup',
+              type: 'group',
+              fields: [
+                {
+                  name: 'nestedText',
+                  type: 'text',
+                  localized: true,
+                },
+              ],
+            },
           ],
           label: 'Configurable Widget',
         },

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -33,12 +33,20 @@ export default buildConfigWithDefaults({
           },
           ...Array.from(
             { length: 4 },
-            (): WidgetInstance => ({
+            (_value, index): WidgetInstance => ({
+              data: {
+                collection: index % 2 === 0 ? 'tickets' : 'events',
+                title: index % 2 === 0 ? 'Tickets' : 'Events',
+              },
               widgetSlug: 'count',
               width: 'x-small',
             }),
           ),
           {
+            data: {
+              timeframe: 'monthly',
+              title: 'Revenue (Monthly)',
+            },
             widgetSlug: 'revenue',
             width: 'full',
           },
@@ -56,12 +64,31 @@ export default buildConfigWithDefaults({
         {
           slug: 'count',
           ComponentPath: './components/Count.tsx#default',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'collection',
+              type: 'select',
+              options: [
+                {
+                  label: 'Tickets',
+                  value: 'tickets',
+                },
+                {
+                  label: 'Events',
+                  value: 'events',
+                },
+              ],
+            },
+          ],
           label: {
             en: 'Count Widget',
             es: 'Widget de Conteo',
           },
           maxWidth: 'medium',
-          // fields: []
         },
         {
           slug: 'private',

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -1,6 +1,7 @@
+import type { WidgetInstance } from 'payload'
+
 import { fileURLToPath } from 'node:url'
 import path from 'path'
-import { type WidgetInstance } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Events } from './collections/Events.js'
@@ -33,7 +34,7 @@ export default buildConfigWithDefaults({
           },
           ...Array.from(
             { length: 4 },
-            (_value, index): WidgetInstance => ({
+            (_value, index): WidgetInstance<'count'> => ({
               data: {
                 collection: index % 2 === 0 ? 'tickets' : 'events',
                 title: index % 2 === 0 ? 'Tickets' : 'Events',

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -109,11 +109,43 @@ export default buildConfigWithDefaults({
           ComponentPath: './components/PageQuery.tsx#default',
           label: 'Page Query Widget',
         },
+        {
+          slug: 'configurable',
+          ComponentPath: './components/Configurable.tsx#default',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              required: true,
+              localized: true,
+            },
+            {
+              name: 'description',
+              type: 'textarea',
+              validate: (value) => {
+                if (value && value.length < 10) {
+                  return 'Description must be at least 10 characters'
+                }
+                return true
+              },
+            },
+            {
+              name: 'relatedTicket',
+              type: 'relationship',
+              relationTo: 'tickets',
+            },
+          ],
+          label: 'Configurable Widget',
+        },
       ],
     },
     importMap: {
       baseDir: path.resolve(dirname),
     },
+  },
+  localization: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
   },
   collections: [
     Tickets,

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -69,6 +69,7 @@ export default buildConfigWithDefaults({
             {
               name: 'title',
               type: 'text',
+              required: true,
             },
             {
               name: 'collection',

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -96,10 +96,13 @@ describe('Dashboard', () => {
   test('edit widget data', async ({ page }) => {
     const d = new DashboardHelper(page)
     await d.setEditing()
+    const secondWidget = d.widgetByPos(2)
+    const secondWidgetTitle = secondWidget.locator('.count-widget h3')
+    await expect(secondWidgetTitle).toHaveText('Tickets')
     await d.editWidget(2, 'Open Tickets')
-    await expect(page.locator('.count-widget').first().getByText('Open Tickets')).toBeVisible()
+    await expect(secondWidgetTitle).toHaveText('Open Tickets')
     await d.saveChangesAndValidate()
-    await expect(page.locator('.count-widget').first().getByText('Open Tickets')).toBeVisible()
+    await expect(secondWidgetTitle).toHaveText('Open Tickets')
   })
 
   test('empty dashboard - delete all widgets', async ({ page }) => {

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -93,16 +93,44 @@ describe('Dashboard', () => {
     await d.saveChangesAndValidate()
   })
 
-  test('edit widget data', async ({ page }) => {
+  test('edit widget data is reverted when dashboard editing is canceled', async ({ page }) => {
+    const d = new DashboardHelper(page)
+    await d.setEditing()
+    let secondWidget = d.widgetByPos(2)
+    let secondWidgetTitle = secondWidget.locator('.count-widget h3')
+    await expect(secondWidgetTitle).toHaveText('Tickets')
+
+    await d.editWidget(2, 'Open Tickets')
+    await expect(secondWidgetTitle).toHaveText('Open Tickets')
+
+    await d.cancelEditing()
+
+    secondWidget = d.widgetByPos(2)
+    secondWidgetTitle = secondWidget.locator('.count-widget h3')
+    await expect(secondWidgetTitle).toHaveText('Tickets')
+  })
+
+  test('edit widget data persists after dashboard save and reload', async ({ page }) => {
     const d = new DashboardHelper(page)
     await d.setEditing()
     const secondWidget = d.widgetByPos(2)
     const secondWidgetTitle = secondWidget.locator('.count-widget h3')
     await expect(secondWidgetTitle).toHaveText('Tickets')
+
     await d.editWidget(2, 'Open Tickets')
     await expect(secondWidgetTitle).toHaveText('Open Tickets')
-    await d.saveChangesAndValidate()
+
+    await d.stepNavLast.locator('button').nth(1).click()
     await expect(secondWidgetTitle).toHaveText('Open Tickets')
+
+    // Re-enter edit mode without page refresh and edit again.
+    await d.setEditing()
+    await expect(secondWidgetTitle).toHaveText('Open Tickets')
+    await d.editWidget(2, 'Title changed again')
+    await expect(secondWidgetTitle).toHaveText('Title changed again')
+
+    await d.saveChangesAndValidate()
+    await expect(secondWidgetTitle).toHaveText('Title changed again')
   })
 
   test('empty dashboard - delete all widgets', async ({ page }) => {

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -359,6 +359,12 @@ describe('Dashboard', () => {
     let titleInput = drawer.locator('input[name="title"]').first()
     await expect(titleInput).toBeVisible({ timeout: 60000 })
     await titleInput.fill('English Title')
+
+    // Fill nested localized field (inside a group)
+    let nestedInput = drawer.locator('input[name="nestedGroup.nestedText"]').first()
+    await expect(nestedInput).toBeVisible()
+    await nestedInput.fill('Nested English')
+
     // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(500)
     await drawer.getByRole('button', { name: 'Save Changes' }).click()
@@ -380,9 +386,14 @@ describe('Dashboard', () => {
 
     titleInput = drawer.locator('input[name="title"]').first()
     await expect(titleInput).toBeVisible({ timeout: 60000 })
-    // Localized field should be empty in Spanish (not set yet)
+    // Localized fields should be empty in Spanish (not set yet)
     await expect(titleInput).toHaveValue('')
+
+    nestedInput = drawer.locator('input[name="nestedGroup.nestedText"]').first()
+    await expect(nestedInput).toHaveValue('')
+
     await titleInput.fill('Título en Español')
+    await nestedInput.fill('Texto anidado')
     // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(500)
     await drawer.getByRole('button', { name: 'Save Changes' }).click()
@@ -390,7 +401,7 @@ describe('Dashboard', () => {
 
     await d2.saveChangesAndValidate()
 
-    // Switch back to English and verify original title persisted
+    // Switch back to English and verify original values persisted
     await page.goto(`${url.admin}?locale=en`)
     const d3 = new DashboardHelper(page)
     await d3.setEditing()
@@ -405,6 +416,9 @@ describe('Dashboard', () => {
     titleInput = drawer.locator('input[name="title"]').first()
     await expect(titleInput).toBeVisible({ timeout: 60000 })
     await expect(titleInput).toHaveValue('English Title')
+
+    nestedInput = drawer.locator('input[name="nestedGroup.nestedText"]').first()
+    await expect(nestedInput).toHaveValue('Nested English')
 
     await drawer.getByRole('button', { name: 'Save Changes' }).click()
     await expect(drawer).toBeHidden()

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -5,8 +5,8 @@ import { fileURLToPath } from 'url'
 
 import { ensureCompilationIsDone } from '../__helpers/e2e/helpers.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
-import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { DashboardHelper } from './utils.js'
 
@@ -91,6 +91,15 @@ describe('Dashboard', () => {
     await d.assertWidget(6, 'private', 'full')
     await expect(d.widgets).toHaveCount(6)
     await d.saveChangesAndValidate()
+  })
+
+  test('edit widget data', async ({ page }) => {
+    const d = new DashboardHelper(page)
+    await d.setEditing()
+    await d.editWidget(2, 'Open Tickets')
+    await expect(page.locator('.count-widget').first().getByText('Open Tickets')).toBeVisible()
+    await d.saveChangesAndValidate()
+    await expect(page.locator('.count-widget').first().getByText('Open Tickets')).toBeVisible()
   })
 
   test('empty dashboard - delete all widgets', async ({ page }) => {

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -221,6 +221,33 @@ describe('Dashboard', () => {
     }
   })
 
+  test('widget config drawer validates required fields on submit', async ({ page }) => {
+    const d = new DashboardHelper(page)
+    await d.setEditing()
+
+    const widget = d.widgetByPos(2)
+    await widget.hover()
+    await widget.locator('.widget-wrapper__edit-btn').click()
+
+    const drawer = page.locator('.drawer__content:visible')
+    await expect(drawer).toBeVisible()
+
+    const titleInput = drawer.locator('input[name="title"]').first()
+    await expect(titleInput).toBeVisible({ timeout: 60000 })
+
+    await titleInput.fill('')
+    await page.waitForTimeout(500)
+    await drawer.getByRole('button', { name: 'Save Changes' }).click()
+
+    await expect(drawer.locator('.field-error')).toBeVisible()
+    await expect(drawer).toBeVisible()
+
+    await titleInput.fill('Valid Title')
+    await page.waitForTimeout(500)
+    await drawer.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(drawer).toBeHidden()
+  })
+
   // TODO: reorder widgets with keyboard (for a11y reasons)
   // It's already working. But I'd like to test it properly with a screen reader and everything.
 

--- a/test/dashboard/int.spec.ts
+++ b/test/dashboard/int.spec.ts
@@ -1,0 +1,52 @@
+/* eslint-disable vitest/expect-expect */
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type {
+  CollectionsWidget,
+  Config,
+  ConfigurableWidget,
+  CountWidget,
+  PageQueryWidget,
+  PrivateWidget,
+  RevenueWidget,
+  Ticket,
+} from './payload-types.js'
+
+describe('Dashboard Widget Types', () => {
+  it('should add all widgets to Config', () => {
+    expectTypeOf<Config['widgets']>().toEqualTypeOf<{
+      collections: CollectionsWidget
+      configurable: ConfigurableWidget
+      count: CountWidget
+      'page-query': PageQueryWidget
+      private: PrivateWidget
+      revenue: RevenueWidget
+    }>()
+  })
+
+  it('should contain width and data on widget types', () => {
+    expectTypeOf<CountWidget>().toHaveProperty('data')
+    expectTypeOf<CountWidget>().toHaveProperty('width')
+    expectTypeOf<CountWidget['width']>().toEqualTypeOf<'medium' | 'small' | 'x-small' | undefined>()
+    expectTypeOf<CollectionsWidget['width']>().toEqualTypeOf<'full' | undefined>()
+  })
+
+  it('should mark widget data fields as required or optional', () => {
+    type CountData = NonNullable<CountWidget['data']>
+    type ConfigData = NonNullable<ConfigurableWidget['data']>
+
+    expectTypeOf<CountData['title']>().toEqualTypeOf<string>()
+    expectTypeOf<CountData['collection']>().toEqualTypeOf<
+      ('events' | 'tickets') | null | undefined
+    >()
+
+    expectTypeOf<ConfigData['title']>().toEqualTypeOf<string>()
+    expectTypeOf<ConfigData['description']>().toEqualTypeOf<null | string | undefined>()
+    expectTypeOf<ConfigData['relatedTicket']>().toEqualTypeOf<
+      (null | string) | Ticket | undefined
+    >()
+    expectTypeOf<NonNullable<ConfigData['nestedGroup']>['nestedText']>().toEqualTypeOf<
+      null | string | undefined
+    >()
+  })
+})

--- a/test/dashboard/int.spec.ts
+++ b/test/dashboard/int.spec.ts
@@ -27,8 +27,8 @@ describe('Dashboard Widget Types', () => {
   it('should contain width and data on widget types', () => {
     expectTypeOf<CountWidget>().toHaveProperty('data')
     expectTypeOf<CountWidget>().toHaveProperty('width')
-    expectTypeOf<CountWidget['width']>().toEqualTypeOf<'medium' | 'small' | 'x-small' | undefined>()
-    expectTypeOf<CollectionsWidget['width']>().toEqualTypeOf<'full' | undefined>()
+    expectTypeOf<CountWidget['width']>().toEqualTypeOf<'medium' | 'small' | 'x-small'>()
+    expectTypeOf<CollectionsWidget['width']>().toEqualTypeOf<'full'>()
   })
 
   it('should mark widget data fields as required or optional', () => {

--- a/test/dashboard/payload-types.ts
+++ b/test/dashboard/payload-types.ts
@@ -432,6 +432,9 @@ export interface ConfigurableWidget {
     title: string;
     description?: string | null;
     relatedTicket?: (string | null) | Ticket;
+    nestedGroup?: {
+      nestedText?: string | null;
+    };
   };
   width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }

--- a/test/dashboard/payload-types.ts
+++ b/test/dashboard/payload-types.ts
@@ -90,15 +90,16 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
-  fallbackLocale: null;
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es') | ('en' | 'es')[];
   globals: {};
   globalsSelect: {};
-  locale: null;
+  locale: 'en' | 'es';
   widgets: {
     count: CountWidget;
     private: PrivateWidget;
     revenue: RevenueWidget;
     'page-query': PageQueryWidget;
+    configurable: ConfigurableWidget;
     collections: CollectionsWidget;
   };
   user: User;
@@ -387,7 +388,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  */
 export interface CountWidget {
   data?: {
-    title?: string | null;
+    title: string;
     collection?: ('tickets' | 'events') | null;
   };
   width?: 'x-small' | 'small' | 'medium';
@@ -419,6 +420,18 @@ export interface RevenueWidget {
 export interface PageQueryWidget {
   data?: {
     [k: string]: unknown;
+  };
+  width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "configurable_widget".
+ */
+export interface ConfigurableWidget {
+  data?: {
+    title: string;
+    description?: string | null;
+    relatedTicket?: (string | null) | Ticket;
   };
   width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }

--- a/test/dashboard/payload-types.ts
+++ b/test/dashboard/payload-types.ts
@@ -391,7 +391,7 @@ export interface CountWidget {
     title: string;
     collection?: ('tickets' | 'events') | null;
   };
-  width?: 'x-small' | 'small' | 'medium';
+  width: 'x-small' | 'small' | 'medium';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -401,7 +401,7 @@ export interface PrivateWidget {
   data?: {
     [k: string]: unknown;
   };
-  width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -411,7 +411,7 @@ export interface RevenueWidget {
   data?: {
     [k: string]: unknown;
   };
-  width?: 'medium' | 'large' | 'x-large' | 'full';
+  width: 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -421,7 +421,7 @@ export interface PageQueryWidget {
   data?: {
     [k: string]: unknown;
   };
-  width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -436,7 +436,7 @@ export interface ConfigurableWidget {
       nestedText?: string | null;
     };
   };
-  width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -446,7 +446,7 @@ export interface CollectionsWidget {
   data?: {
     [k: string]: unknown;
   };
-  width?: 'full';
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/dashboard/payload-types.ts
+++ b/test/dashboard/payload-types.ts
@@ -94,6 +94,13 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
+  widgets: {
+    count: CountWidget;
+    private: PrivateWidget;
+    revenue: RevenueWidget;
+    'page-query': PageQueryWidget;
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -373,6 +380,57 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "count_widget".
+ */
+export interface CountWidget {
+  data?: {
+    title?: string | null;
+    collection?: ('tickets' | 'events') | null;
+  };
+  width?: 'x-small' | 'small' | 'medium';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "private_widget".
+ */
+export interface PrivateWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "revenue_widget".
+ */
+export interface RevenueWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width?: 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "page-query_widget".
+ */
+export interface PageQueryWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width?: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/dashboard/utils.ts
+++ b/test/dashboard/utils.ts
@@ -110,12 +110,12 @@ export class DashboardHelper {
     const widget = this.widgetByPos(arg.position)
     await widget.hover()
     const widthButton = widget.locator('.widget-wrapper__size-btn')
-    await expect(widthButton).toBeVisible()
-    if (await widthButton.isDisabled()) {
+    if ((await widthButton.count()) === 0) {
       await expect(widget).toHaveAttribute('data-width', arg.min)
       await expect(widget).toHaveAttribute('data-width', arg.max)
       return
     }
+    await expect(widthButton).toBeVisible()
     await widthButton.click()
     const activePopup = this.page.locator('.popup__content:visible')
     await expect(activePopup).toBeVisible()
@@ -198,7 +198,9 @@ export class DashboardHelper {
 
     const drawer = this.page.locator('.drawer__content:visible')
     await expect(drawer).toBeVisible()
-    await drawer.getByLabel('Title').fill(title)
+    const titleInput = drawer.locator('input[name="title"], input[name="data.title"]').first()
+    await expect(titleInput).toBeVisible({ timeout: 60000 })
+    await titleInput.fill(title)
     await drawer.getByRole('button', { name: 'Save Changes' }).click()
   }
 

--- a/test/dashboard/utils.ts
+++ b/test/dashboard/utils.ts
@@ -191,6 +191,17 @@ export class DashboardHelper {
     await expect(this.widgets).toHaveCount(widgetsCount - 1)
   }
 
+  editWidget = async (position: number, title: string) => {
+    const widget = this.widgetByPos(position)
+    await widget.hover()
+    await widget.locator('.widget-wrapper__edit-btn').click()
+
+    const drawer = this.page.locator('.drawer__content:visible')
+    await expect(drawer).toBeVisible()
+    await drawer.getByLabel('Title').fill(title)
+    await drawer.getByRole('button', { name: 'Save Changes' }).click()
+  }
+
   cancelEditing = async () => {
     await this.stepNavLast.locator('button').nth(2).click()
     const confirmButton = this.page.locator('#confirm-action')

--- a/test/dashboard/utils.ts
+++ b/test/dashboard/utils.ts
@@ -202,6 +202,7 @@ export class DashboardHelper {
     await expect(titleInput).toBeVisible({ timeout: 60000 })
     await titleInput.fill(title)
     await drawer.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(drawer).toBeHidden()
   }
 
   cancelEditing = async () => {

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
      */
     trace: CI ? 'on-first-retry' : 'retain-on-failure',
     video: 'off',
-    navigationTimeout: TEST_TIMEOUT/2
+    navigationTimeout: TEST_TIMEOUT / 2,
   },
   expect: {
     timeout: EXPECT_TIMEOUT,


### PR DESCRIPTION
## Summary

- Adds `fields` support to dashboard widgets, analogous to how Blocks work — widgets can now declare configurable fields
- Widget data is editable from a new drawer UI (edit icon) when in dashboard editing mode
- Full type generation: `WidgetInstance<T>` is now generic with typed `data` and `width` based on the widget's field schema and min/max width constraints
- `WidgetServerProps` is generic so widget components receive typed `widgetData`

## Usage

```ts
import { buildConfig } from 'payload'

export default buildConfig({
  admin: {
    dashboard: {
      widgets: [
        {
          slug: 'sales-summary',
          ComponentPath: './components/SalesSummary.tsx#default',
          fields: [
            { name: 'title', type: 'text' },
            {
              name: 'timeframe',
              type: 'select',
              options: ['daily', 'weekly', 'monthly', 'yearly'],
            },
            { name: 'showTrend', type: 'checkbox' },
          ],
          minWidth: 'small',
          maxWidth: 'medium',
        },
      ],
    },
  },
})
```

```tsx
import type { WidgetServerProps } from 'payload'

import type { SalesSummaryWidget } from '../payload-types'

export default async function SalesSummaryWidgetComponent({
  widgetData,
}: WidgetServerProps<SalesSummaryWidget>) {
  const title = widgetData?.title ?? 'Sales Summary'
  const timeframe = widgetData?.timeframe ?? 'monthly'

  return (
    <div className="card">
      <h3>
        {title} ({timeframe})
      </h3>
    </div>
  )
}
```

## Demo


https://github.com/user-attachments/assets/b24d3635-8635-4d5f-84af-a6dcf801aa4f

