### PR TITLE
chore(plugin-mcp): improve schema sanitization and test coverage

### DIFF
--- a/packages/plugin-mcp/src/utils/schemaConversion/sanitizeJsonSchema.ts
+++ b/packages/plugin-mcp/src/utils/schemaConversion/sanitizeJsonSchema.ts
@@ -4,6 +4,11 @@ import type { JSONSchema4 } from 'json-schema'
  * Removes internal Payload properties (id, createdAt, updatedAt) from a
  * JSON Schema so they don't appear in the generated Zod validation schema.
  * Also strips `id` from the `required` array when present.
+ *
+ * Additionally normalizes nullable type arrays (e.g. `['array', 'null']` →
+ * `'array'`) throughout the schema tree. Without this, `json-schema-to-zod`
+ * emits a Zod union which the MCP SDK serialises back as `anyOf`, stripping
+ * the concrete `type` from the output and breaking schema introspection.
  */
 export function sanitizeJsonSchema(schema: JSONSchema4): JSONSchema4 {
   delete schema?.properties?.id
@@ -17,5 +22,41 @@ export function sanitizeJsonSchema(schema: JSONSchema4): JSONSchema4 {
     }
   }
 
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const key of Object.keys(schema.properties)) {
+      const prop = schema.properties[key] as JSONSchema4
+      if (!prop || typeof prop !== 'object') {
+        continue
+      }
+      normalizeNullableType(prop)
+      if (prop.properties) {
+        sanitizeJsonSchema(prop)
+      }
+      if (prop.items && typeof prop.items === 'object' && !Array.isArray(prop.items)) {
+        sanitizeJsonSchema(prop.items)
+      }
+    }
+  }
+
   return schema
+}
+
+/**
+ * Strips `'null'` from a `type` array only when the remaining type is a
+ * complex structural type (`array` or `object`).
+ *
+ * Simple scalar types (`string`, `number`, `boolean`) are intentionally
+ * preserved as `['string', 'null']` so that the MCP SDK serialises them as a
+ * compact inline `type` array. Complex types however cause `zodToJsonSchema`
+ * to emit `anyOf: [{ type: 'array', items: ... }, { type: 'null' }]`, which
+ * has no top-level `type` property and breaks schema introspection by clients.
+ */
+function normalizeNullableType(schema: JSONSchema4): void {
+  if (!Array.isArray(schema.type)) {
+    return
+  }
+  const nonNullTypes = schema.type.filter((t) => t !== 'null')
+  if (nonNullTypes.length === 1 && (nonNullTypes[0] === 'array' || nonNullTypes[0] === 'object')) {
+    schema.type = nonNullTypes[0]
+  }
 }

--- a/test/plugin-mcp/collections/FieldTypes.ts
+++ b/test/plugin-mcp/collections/FieldTypes.ts
@@ -1,0 +1,210 @@
+import type { CollectionConfig } from 'payload'
+
+export const fieldTypesSlug = 'field-types'
+
+export const FieldTypes: CollectionConfig = {
+  slug: fieldTypesSlug,
+  fields: [
+    // Atomic data fields
+    {
+      name: 'textField',
+      type: 'text',
+      admin: {
+        description: 'A simple text field',
+      },
+    },
+    {
+      name: 'textareaField',
+      type: 'textarea',
+      admin: {
+        description: 'A textarea field',
+      },
+    },
+    {
+      name: 'numberField',
+      type: 'number',
+      admin: {
+        description: 'A number field',
+      },
+    },
+    {
+      name: 'emailField',
+      type: 'email',
+      admin: {
+        description: 'An email field',
+      },
+    },
+    {
+      name: 'checkboxField',
+      type: 'checkbox',
+      admin: {
+        description: 'A checkbox field',
+      },
+    },
+    {
+      name: 'dateField',
+      type: 'date',
+      admin: {
+        description: 'A date field',
+      },
+    },
+    {
+      name: 'codeField',
+      type: 'code',
+      admin: {
+        description: 'A code field',
+      },
+    },
+    {
+      name: 'jsonField',
+      type: 'json',
+      admin: {
+        description: 'A JSON field',
+      },
+    },
+    {
+      name: 'selectField',
+      type: 'select',
+      admin: {
+        description: 'A select field',
+      },
+      options: [
+        { label: 'Option One', value: 'option1' },
+        { label: 'Option Two', value: 'option2' },
+        { label: 'Option Three', value: 'option3' },
+      ],
+    },
+    {
+      name: 'radioField',
+      type: 'radio',
+      admin: {
+        description: 'A radio field',
+      },
+      options: [
+        { label: 'Radio One', value: 'radio1' },
+        { label: 'Radio Two', value: 'radio2' },
+        { label: 'Radio Three', value: 'radio3' },
+      ],
+    },
+
+    // Array field
+    {
+      name: 'arrayField',
+      type: 'array',
+      admin: {
+        description: 'An array field with nested items',
+      },
+      fields: [
+        {
+          name: 'item',
+          type: 'text',
+        },
+        {
+          name: 'itemNumber',
+          type: 'number',
+        },
+      ],
+    },
+
+    // Group field (stored as nested object)
+    {
+      name: 'groupField',
+      type: 'group',
+      admin: {
+        description: 'A group field with nested properties',
+      },
+      fields: [
+        {
+          name: 'groupText',
+          type: 'text',
+        },
+        {
+          name: 'groupNumber',
+          type: 'number',
+        },
+      ],
+    },
+
+    // Upload field
+    {
+      name: 'uploadField',
+      type: 'upload',
+      admin: {
+        description: 'An upload field',
+      },
+      relationTo: 'media',
+    },
+
+    // UI field (display-only, not stored, should be absent from create/update schema)
+    {
+      name: 'uiField',
+      type: 'ui',
+      admin: {
+        components: {},
+      },
+    },
+
+    // Collapsible layout field (children are flattened to top level in the document)
+    {
+      type: 'collapsible',
+      label: 'Collapsible Section',
+      fields: [
+        {
+          name: 'collapsibleText',
+          type: 'text',
+          admin: {
+            description: 'Text field inside a collapsible container',
+          },
+        },
+      ],
+    },
+
+    // Row layout field (children are flattened to top level in the document)
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'rowText',
+          type: 'text',
+          admin: {
+            description: 'Text field inside a row container',
+          },
+        },
+      ],
+    },
+
+    // Tabs field with both named and unnamed tabs
+    {
+      type: 'tabs',
+      tabs: [
+        // Named tab - stored as a nested object at `namedTab.namedTabText`
+        {
+          name: 'namedTab',
+          label: 'Named Tab',
+          fields: [
+            {
+              name: 'namedTabText',
+              type: 'text',
+              admin: {
+                description: 'Text field inside a named tab',
+              },
+            },
+          ],
+        },
+        // Unnamed tab - children are flattened to the top level of the document
+        {
+          label: 'Unnamed Tab',
+          fields: [
+            {
+              name: 'unnamedTabText',
+              type: 'text',
+              admin: {
+                description: 'Text field inside an unnamed tab',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url'
 import { z } from 'zod'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { FieldTypes } from './collections/FieldTypes.js'
 import { Media } from './collections/Media.js'
 import { ModifiedPrompts } from './collections/ModifiedPrompts.js'
 import { Pages } from './collections/Pages.js'
@@ -27,7 +28,17 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media, Posts, Products, Rolls, ModifiedPrompts, ReturnedResources, Pages],
+  collections: [
+    Users,
+    Media,
+    Posts,
+    Products,
+    Rolls,
+    ModifiedPrompts,
+    ReturnedResources,
+    Pages,
+    FieldTypes,
+  ],
   localization: {
     defaultLocale: 'en',
     fallback: true,
@@ -95,6 +106,15 @@ export default buildConfigWithDefaults({
       collections: {
         [Products.slug]: {
           enabled: true,
+        },
+        'field-types': {
+          enabled: {
+            find: true,
+            create: true,
+            update: true,
+            delete: true,
+          },
+          description: 'A collection covering all Payload field types for MCP schema testing.',
         },
         pages: {
           enabled: {

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -51,6 +51,12 @@ async function parseStreamResponse(response: Response): Promise<any> {
   }
 }
 
+function extractJsonBlock(text: string): any {
+  const match = text.match(/```json\n([\s\S]*?)\n```/)
+  expect(match).toBeDefined()
+  return JSON.parse(match![1]!)
+}
+
 const getApiKey = async (
   enableUpdate: boolean = false,
   enableDelete: boolean = false,
@@ -1103,9 +1109,7 @@ describe('@payloadcms/plugin-mcp', () => {
         'Document updated successfully in collection "posts"!',
       )
 
-      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
-      expect(jsonMatch).toBeDefined()
-      const updatedDoc = JSON.parse(jsonMatch[1])
+      const updatedDoc = extractJsonBlock(json.result.content[0].text)
       expect(updatedDoc.author).toBe(userId)
 
       await payload.delete({ id: post.id, collection: 'posts' })
@@ -1230,9 +1234,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[0].type).toBe('text')
       expect(json.result.content[0].text).toContain('Resource created successfully')
 
-      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
-      expect(jsonMatch).toBeDefined()
-      const createdDoc = JSON.parse(jsonMatch[1])
+      const createdDoc = extractJsonBlock(json.result.content[0].text)
 
       expect(createdDoc.location).toEqual([-74.006, 40.7128])
 
@@ -1284,9 +1286,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[0].type).toBe('text')
       expect(json.result.content[0].text).toContain('Document updated successfully')
 
-      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
-      expect(jsonMatch).toBeDefined()
-      const updatedDoc = JSON.parse(jsonMatch[1])
+      const updatedDoc = extractJsonBlock(json.result.content[0].text)
 
       expect(updatedDoc.location).toEqual([-0.1278, 51.5074])
 
@@ -1354,10 +1354,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[0].text).toContain('"blockType": "hero"')
       expect(json.result.content[0].text).toContain('"heading": "Welcome to our site"')
 
-      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
-      if (jsonMatch) {
-        createdPageIds.push(JSON.parse(jsonMatch[1]).id)
-      }
+      createdPageIds.push(extractJsonBlock(json.result.content[0].text).id)
     })
 
     it('should create a page with multiple block types', async () => {
@@ -1402,10 +1399,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.content[0].text).toContain('"heading": "Page Hero"')
       expect(json.result.content[0].text).toContain('"body": "This is the body text."')
 
-      const jsonMatch = json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)
-      if (jsonMatch) {
-        createdPageIds.push(JSON.parse(jsonMatch[1]).id)
-      }
+      createdPageIds.push(extractJsonBlock(json.result.content[0].text).id)
     })
 
     it('should update a page layout that contains blocks', async () => {
@@ -1937,6 +1931,853 @@ describe('@payloadcms/plugin-mcp', () => {
         '"title": "English Only Title (MCP Hook Override)"',
       )
       expect(json.result.content[0].text).toContain('"content": "Hello World."')
+    })
+  })
+
+  describe('Field Types', () => {
+    const createdFieldTypeIds: (number | string)[] = []
+
+    const getFieldTypesApiKey = async (enableUpdate = false, enableDelete = false) => {
+      const doc = await payload.create({
+        collection: 'payload-mcp-api-keys',
+        data: {
+          enableAPIKey: true,
+          label: 'Field Types API Key',
+          fieldTypes: {
+            create: true,
+            find: true,
+            update: enableUpdate,
+            delete: enableDelete,
+          },
+          apiKey: randomUUID(),
+          user: userId,
+        },
+      })
+      return doc.apiKey as string
+    }
+
+    describe('Schema validation', () => {
+      it('should not include ui field in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result.tools).toBeDefined()
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        expect(createTool).toBeDefined()
+
+        const inputProps = createTool.inputSchema.properties
+        expect(inputProps).not.toHaveProperty('uiField')
+      })
+
+      it('should include group field as nested object in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const inputProps = createTool.inputSchema.properties
+
+        expect(inputProps.groupField).toBeDefined()
+        expect(inputProps.groupField.type).toBe('object')
+        expect(inputProps.groupField.properties).toBeDefined()
+        expect(inputProps.groupField.properties.groupText).toBeDefined()
+        expect(inputProps.groupField.properties.groupNumber).toBeDefined()
+      })
+
+      it('should include collapsible children as top-level fields in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const inputProps = createTool.inputSchema.properties
+
+        // Children of collapsible appear at the top level, not under a `collapsible` key
+        expect(inputProps.collapsibleText).toBeDefined()
+        expect(inputProps.collapsibleText.type).toContain('string')
+      })
+
+      it('should include row children as top-level fields in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const inputProps = createTool.inputSchema.properties
+
+        // Children of row appear at the top level, not under a `row` key
+        expect(inputProps.rowText).toBeDefined()
+        expect(inputProps.rowText.type).toContain('string')
+      })
+
+      it('should include named tab as nested object and unnamed tab children at top level in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const inputProps = createTool.inputSchema.properties
+
+        // Named tab appears as a nested object
+        expect(inputProps.namedTab).toBeDefined()
+        expect(inputProps.namedTab.type).toBe('object')
+        expect(inputProps.namedTab.properties).toBeDefined()
+        expect(inputProps.namedTab.properties.namedTabText).toBeDefined()
+
+        // Unnamed tab children appear at the top level
+        expect(inputProps.unnamedTabText).toBeDefined()
+        expect(inputProps.unnamedTabText.type).toContain('string')
+      })
+
+      it('should include select field with enum values in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const inputProps = createTool.inputSchema.properties
+
+        expect(inputProps.selectField).toBeDefined()
+        expect(inputProps.selectField.enum).toBeDefined()
+        expect(inputProps.selectField.enum).toContain('option1')
+        expect(inputProps.selectField.enum).toContain('option2')
+        expect(inputProps.selectField.enum).toContain('option3')
+      })
+
+      it('should include radio field with enum values in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const inputProps = createTool.inputSchema.properties
+
+        expect(inputProps.radioField).toBeDefined()
+        expect(inputProps.radioField.enum).toBeDefined()
+        expect(inputProps.radioField.enum).toContain('radio1')
+        expect(inputProps.radioField.enum).toContain('radio2')
+        expect(inputProps.radioField.enum).toContain('radio3')
+      })
+
+      it('should include array field with item schema in create tool schema', async () => {
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/list',
+            params: {},
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const inputProps = createTool.inputSchema.properties
+
+        expect(inputProps.arrayField).toBeDefined()
+        expect(inputProps.arrayField.type).toContain('array')
+        expect(inputProps.arrayField.items).toBeDefined()
+        expect(inputProps.arrayField.items.properties).toBeDefined()
+        expect(inputProps.arrayField.items.properties.item).toBeDefined()
+        expect(inputProps.arrayField.items.properties.itemNumber).toBeDefined()
+      })
+    })
+
+    describe('Create + round-trip', () => {
+      it('should create and find document with atomic data fields (text, textarea, number, email, checkbox)', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Hello MCP',
+                textareaField: 'Multi-line\ntext content',
+                numberField: 42,
+                emailField: 'test@example.com',
+                checkboxField: true,
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+        expect(json.result.content[0].type).toBe('text')
+        expect(json.result.content[0].text).toContain(
+          'Resource created successfully in collection "field-types"!',
+        )
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.textField).toBe('Hello MCP')
+        expect(doc.textareaField).toBe('Multi-line\ntext content')
+        expect(doc.numberField).toBe(42)
+        expect(doc.emailField).toBe('test@example.com')
+        expect(doc.checkboxField).toBe(true)
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with date, code, and json fields', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const testDate = '2024-01-15T10:30:00.000Z'
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Date/Code/JSON test',
+                dateField: testDate,
+                codeField: 'const x = 42;',
+                jsonField: { key: 'value', nested: { count: 1 } },
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.codeField).toBe('const x = 42;')
+        expect(doc.jsonField).toMatchObject({ key: 'value', nested: { count: 1 } })
+        expect(doc.dateField).toBeDefined()
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with select field', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Select test',
+                selectField: 'option2',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.selectField).toBe('option2')
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with radio field', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Radio test',
+                radioField: 'radio3',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.radioField).toBe('radio3')
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with group field (nested object)', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Group test',
+                groupField: {
+                  groupText: 'Inside the group',
+                  groupNumber: 99,
+                },
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.groupField).toBeDefined()
+        expect(doc.groupField.groupText).toBe('Inside the group')
+        expect(doc.groupField.groupNumber).toBe(99)
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with collapsible children at top level', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Collapsible test',
+                collapsibleText: 'Text inside collapsible',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        // collapsibleText is stored at the top level of the document
+        expect(doc.collapsibleText).toBe('Text inside collapsible')
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with row children at top level', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Row test',
+                rowText: 'Text inside row',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        // rowText is stored at the top level of the document
+        expect(doc.rowText).toBe('Text inside row')
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with tabs fields (named tab as object, unnamed tab children at top level)', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Tabs test',
+                namedTab: {
+                  namedTabText: 'Inside named tab',
+                },
+                unnamedTabText: 'Inside unnamed tab',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        // Named tab stored as nested object
+        expect(doc.namedTab).toBeDefined()
+        expect(doc.namedTab.namedTabText).toBe('Inside named tab')
+
+        // Unnamed tab child stored at document top level
+        expect(doc.unnamedTabText).toBe('Inside unnamed tab')
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create document with array field', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'Array test',
+                arrayField: [
+                  { item: 'First item', itemNumber: 1 },
+                  { item: 'Second item', itemNumber: 2 },
+                ],
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.arrayField).toHaveLength(2)
+        expect(doc.arrayField[0].item).toBe('First item')
+        expect(doc.arrayField[0].itemNumber).toBe(1)
+        expect(doc.arrayField[1].item).toBe('Second item')
+        expect(doc.arrayField[1].itemNumber).toBe(2)
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should find documents in field-types collection', async () => {
+        const created = await (payload as any).create({
+          collection: 'field-types',
+          data: { textField: 'Findable doc', numberField: 7 },
+        })
+        createdFieldTypeIds.push(created.id)
+
+        const apiKey = await getFieldTypesApiKey()
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'findFieldTypes',
+              arguments: {
+                where: '{"textField": {"equals": "Findable doc"}}',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+        expect(json.result.content[0].text).toContain('Collection: "field-types"')
+        expect(json.result.content[0].text).toContain('"textField": "Findable doc"')
+        expect(json.result.content[0].text).toContain('"numberField": 7')
+      })
+    })
+
+    describe('Update', () => {
+      it('should update document with group field', async () => {
+        const created = await (payload as any).create({
+          collection: 'field-types',
+          data: {
+            textField: 'Group update test',
+            groupField: { groupText: 'Original', groupNumber: 1 },
+          },
+        })
+        createdFieldTypeIds.push(created.id)
+
+        const apiKey = await getFieldTypesApiKey(true, false)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'updateFieldTypes',
+              arguments: {
+                id: created.id,
+                groupField: {
+                  groupText: 'Updated group text',
+                  groupNumber: 100,
+                },
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+        expect(json.result.content[0].text).toContain(
+          'Document updated successfully in collection "field-types"!',
+        )
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.groupField.groupText).toBe('Updated group text')
+        expect(doc.groupField.groupNumber).toBe(100)
+      })
+
+      it('should update document with collapsible field (children at top level)', async () => {
+        const created = await (payload as any).create({
+          collection: 'field-types',
+          data: {
+            textField: 'Collapsible update test',
+            collapsibleText: 'Original collapsible text',
+          },
+        })
+        createdFieldTypeIds.push(created.id)
+
+        const apiKey = await getFieldTypesApiKey(true, false)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'updateFieldTypes',
+              arguments: {
+                id: created.id,
+                collapsibleText: 'Updated collapsible text',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.collapsibleText).toBe('Updated collapsible text')
+      })
+
+      it('should update document with array field', async () => {
+        const created = await (payload as any).create({
+          collection: 'field-types',
+          data: {
+            textField: 'Array update test',
+            arrayField: [{ item: 'Original item', itemNumber: 0 }],
+          },
+        })
+        createdFieldTypeIds.push(created.id)
+
+        const apiKey = await getFieldTypesApiKey(true, false)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'updateFieldTypes',
+              arguments: {
+                id: created.id,
+                arrayField: [
+                  { item: 'Updated item A', itemNumber: 10 },
+                  { item: 'Updated item B', itemNumber: 20 },
+                  { item: 'Updated item C', itemNumber: 30 },
+                ],
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        expect(doc.arrayField).toHaveLength(3)
+        expect(doc.arrayField[0].item).toBe('Updated item A')
+        expect(doc.arrayField[2].itemNumber).toBe(30)
+      })
+    })
+
+    describe('Display field safety', () => {
+      it('should create document with ui field present without errors and ui field absent from response', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+
+        // Create a doc without passing any `uiField` value (it has no stored data)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'UI field safety test',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+        expect(json.result.content[0].text).toContain('Resource created successfully')
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        // uiField has no stored data and should not appear in the document
+        expect(doc).not.toHaveProperty('uiField')
+
+        createdFieldTypeIds.push(doc.id)
+      })
+
+      it('should create and find document with all structural layout fields populated', async () => {
+        const apiKey = await getFieldTypesApiKey(false, true)
+        const response = await restClient.POST('/mcp', {
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'createFieldTypes',
+              arguments: {
+                textField: 'All layout fields test',
+                groupField: { groupText: 'Group value', groupNumber: 5 },
+                collapsibleText: 'Collapsible value',
+                rowText: 'Row value',
+                namedTab: { namedTabText: 'Named tab value' },
+                unnamedTabText: 'Unnamed tab value',
+              },
+            },
+          }),
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const json = await parseStreamResponse(response)
+
+        expect(json.result).toBeDefined()
+        expect(json.result.isError).toBeFalsy()
+
+        const doc = extractJsonBlock(json.result.content[0].text)
+
+        // All data fields are stored correctly regardless of their container type
+        expect(doc.groupField.groupText).toBe('Group value')
+        expect(doc.groupField.groupNumber).toBe(5)
+        expect(doc.collapsibleText).toBe('Collapsible value')
+        expect(doc.rowText).toBe('Row value')
+        expect(doc.namedTab.namedTabText).toBe('Named tab value')
+        expect(doc.unnamedTabText).toBe('Unnamed tab value')
+
+        // UI field is never present in stored documents
+        expect(doc).not.toHaveProperty('uiField')
+
+        createdFieldTypeIds.push(doc.id)
+      })
     })
   })
 })

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -76,6 +76,7 @@ export interface Config {
     'modified-prompts': ModifiedPrompt;
     'returned-resources': ReturnedResource;
     pages: Page;
+    'field-types': FieldType;
     'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -92,6 +93,7 @@ export interface Config {
     'modified-prompts': ModifiedPromptsSelect<false> | ModifiedPromptsSelect<true>;
     'returned-resources': ReturnedResourcesSelect<false> | ReturnedResourcesSelect<true>;
     pages: PagesSelect<false> | PagesSelect<true>;
+    'field-types': FieldTypesSelect<false> | FieldTypesSelect<true>;
     'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -335,6 +337,102 @@ export interface HeroBlock {
   blockType: 'hero';
 }
 /**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "field-types".
+ */
+export interface FieldType {
+  id: string;
+  /**
+   * A simple text field
+   */
+  textField?: string | null;
+  /**
+   * A textarea field
+   */
+  textareaField?: string | null;
+  /**
+   * A number field
+   */
+  numberField?: number | null;
+  /**
+   * An email field
+   */
+  emailField?: string | null;
+  /**
+   * A checkbox field
+   */
+  checkboxField?: boolean | null;
+  /**
+   * A date field
+   */
+  dateField?: string | null;
+  /**
+   * A code field
+   */
+  codeField?: string | null;
+  /**
+   * A JSON field
+   */
+  jsonField?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * A select field
+   */
+  selectField?: ('option1' | 'option2' | 'option3') | null;
+  /**
+   * A radio field
+   */
+  radioField?: ('radio1' | 'radio2' | 'radio3') | null;
+  /**
+   * An array field with nested items
+   */
+  arrayField?:
+    | {
+        item?: string | null;
+        itemNumber?: number | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * A group field with nested properties
+   */
+  groupField?: {
+    groupText?: string | null;
+    groupNumber?: number | null;
+  };
+  /**
+   * An upload field
+   */
+  uploadField?: (string | null) | Media;
+  /**
+   * Text field inside a collapsible container
+   */
+  collapsibleText?: string | null;
+  /**
+   * Text field inside a row container
+   */
+  rowText?: string | null;
+  namedTab?: {
+    /**
+     * Text field inside a named tab
+     */
+    namedTabText?: string | null;
+  };
+  /**
+   * Text field inside an unnamed tab
+   */
+  unnamedTabText?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * API keys control which collections, resources, tools, and prompts MCP clients can access
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -369,6 +467,24 @@ export interface PayloadMcpApiKey {
     update?: boolean | null;
     /**
      * Allow clients to delete products.
+     */
+    delete?: boolean | null;
+  };
+  fieldTypes?: {
+    /**
+     * Allow clients to find field-types.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create field-types.
+     */
+    create?: boolean | null;
+    /**
+     * Allow clients to update field-types.
+     */
+    update?: boolean | null;
+    /**
+     * Allow clients to delete field-types.
      */
     delete?: boolean | null;
   };
@@ -516,6 +632,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'pages';
         value: string | Page;
+      } | null)
+    | ({
+        relationTo: 'field-types';
+        value: string | FieldType;
       } | null)
     | ({
         relationTo: 'payload-mcp-api-keys';
@@ -706,6 +826,46 @@ export interface HeroBlockSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "field-types_select".
+ */
+export interface FieldTypesSelect<T extends boolean = true> {
+  textField?: T;
+  textareaField?: T;
+  numberField?: T;
+  emailField?: T;
+  checkboxField?: T;
+  dateField?: T;
+  codeField?: T;
+  jsonField?: T;
+  selectField?: T;
+  radioField?: T;
+  arrayField?:
+    | T
+    | {
+        item?: T;
+        itemNumber?: T;
+        id?: T;
+      };
+  groupField?:
+    | T
+    | {
+        groupText?: T;
+        groupNumber?: T;
+      };
+  uploadField?: T;
+  collapsibleText?: T;
+  rowText?: T;
+  namedTab?:
+    | T
+    | {
+        namedTabText?: T;
+      };
+  unnamedTabText?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-mcp-api-keys_select".
  */
 export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
@@ -713,6 +873,14 @@ export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
   label?: T;
   description?: T;
   products?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+        update?: T;
+        delete?: T;
+      };
+  fieldTypes?:
     | T
     | {
         find?: T;


### PR DESCRIPTION
- Improve Schema validation — verifies that the MCP tools/list response generates correct input schemas for each field type (correct type, enum values, nested properties, layout field flattening, etc.)

- Adds a new FieldTypes collection test suite covering the full range of Payload field types over MCP

