### PR TITLE
fix: return 400 for malformed JSON request bodies

### DIFF
--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -16,20 +16,18 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
     const bodyByteSize = parseInt(req.headers.get('Content-Length') || '0', 10)
 
     if (contentType === 'application/json') {
-      let data = {}
       try {
         const text = await req.text?.()
-        data = text ? JSON.parse(text) : {}
+        const data = text ? JSON.parse(text) : {}
+        req.data = data
+        // @ts-expect-error attach json method to request
+        req.json = () => Promise.resolve(data)
       } catch (error) {
         if (error instanceof SyntaxError) {
           throw new APIError('Invalid JSON', 400)
         }
         req.payload.logger.error(error)
         throw error
-      } finally {
-        req.data = data
-        // @ts-expect-error attach json method to request
-        req.json = () => Promise.resolve(data)
       }
     } else if (bodyByteSize && contentType?.includes('multipart/')) {
       const { error, fields, files } = await processMultipartFormdata({

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -21,7 +21,11 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
         const text = await req.text?.()
         data = text ? JSON.parse(text) : {}
       } catch (error) {
+        if (error instanceof SyntaxError) {
+          throw new APIError('Invalid JSON', 400)
+        }
         req.payload.logger.error(error)
+        throw error
       } finally {
         req.data = data
         // @ts-expect-error attach json method to request

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -54,6 +54,18 @@ describe('collections-rest', () => {
       expect(doc).toMatchObject(data)
     })
 
+    it('should return 400 when request body contains malformed JSON', async () => {
+      const response = await restClient.POST(`/${postsSlug}`, {
+        body: '{ invalid json',
+      })
+
+      expect(response.status).toEqual(400)
+      const result: any = await response.json()
+
+      expect(result.errors).toBeDefined()
+      expect(result.errors[0].message).toEqual('Invalid JSON')
+    })
+
     it('should find', async () => {
       const post1 = await createPost()
       const post2 = await createPost()


### PR DESCRIPTION
Fixes #15635

Wraps `JSON.parse` in `addDataAndFileToRequest` with error handling to return 400 Bad Request for malformed JSON bodies instead of an unhandled 500 Internal Server Error.