### PR TITLE
fix(template): enforce access control in archive block query

### DIFF
--- a/templates/website/src/blocks/ArchiveBlock/Component.tsx
+++ b/templates/website/src/blocks/ArchiveBlock/Component.tsx
@@ -30,6 +30,7 @@ export const ArchiveBlock: React.FC<
       collection: 'posts',
       depth: 1,
       limit,
+      overrideAccess: false,
       ...(flattenedCategories && flattenedCategories.length > 0
         ? {
             where: {


### PR DESCRIPTION
Fixes #15633

Adds `overrideAccess: false` to the `payload.find()` call in the website template's ArchiveBlock so unpublished posts are excluded when rendered on the frontend.