### PR TITLE
fix(plugin-multi-tenant): hasMany tenant fields double-wrap arrays in filterOptions

### DIFF
--- a/packages/plugin-multi-tenant/src/filters/filterDocumentsByTenants.ts
+++ b/packages/plugin-multi-tenant/src/filters/filterDocumentsByTenants.ts
@@ -11,8 +11,9 @@ type Args<ConfigType = unknown> = {
   /**
    * If the document this filter is run belongs to a tenant, the tenant ID should be passed here.
    * If set, this will be used instead of the tenant cookie
+   * Can be an array when hasMany is true
    */
-  docTenantID?: number | string
+  docTenantID?: number | number[] | string | string[]
   filterFieldName: string
   req: PayloadRequest
   tenantsArrayFieldName?: string
@@ -41,7 +42,7 @@ export const filterDocumentsByTenants = <ConfigType = unknown>({
   if (selectedTenant) {
     return {
       [filterFieldName]: {
-        in: [selectedTenant],
+        in: Array.isArray(selectedTenant) ? selectedTenant : [selectedTenant],
       },
     }
   }

--- a/test/plugin-multi-tenant/collections/MultiTenantPosts.ts
+++ b/test/plugin-multi-tenant/collections/MultiTenantPosts.ts
@@ -1,0 +1,22 @@
+import type { CollectionConfig } from 'payload'
+
+import { multiTenantPostsSlug } from '../shared.js'
+
+export const MultiTenantPosts: CollectionConfig = {
+  slug: multiTenantPostsSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'parent',
+      type: 'relationship',
+      relationTo: multiTenantPostsSlug,
+    },
+  ],
+}

--- a/test/plugin-multi-tenant/config.base.ts
+++ b/test/plugin-multi-tenant/config.base.ts
@@ -12,11 +12,18 @@ import type { Config as ConfigType } from './payload-types.js'
 import { AutosaveGlobal } from './collections/AutosaveGlobal.js'
 import { Menu } from './collections/Menu.js'
 import { MenuItems } from './collections/MenuItems.js'
+import { MultiTenantPosts } from './collections/MultiTenantPosts.js'
 import { Relationships } from './collections/Relationships.js'
 import { Tenants } from './collections/Tenants.js'
 import { Users } from './collections/Users/index.js'
 import { seed } from './seed/index.js'
-import { autosaveGlobalSlug, menuItemsSlug, menuSlug, notTenantedSlug } from './shared.js'
+import {
+  autosaveGlobalSlug,
+  menuItemsSlug,
+  menuSlug,
+  multiTenantPostsSlug,
+  notTenantedSlug,
+} from './shared.js'
 
 export const baseConfig: Partial<Config> = {
   collections: [
@@ -26,6 +33,7 @@ export const baseConfig: Partial<Config> = {
     Menu,
     AutosaveGlobal,
     Relationships,
+    MultiTenantPosts,
     {
       slug: notTenantedSlug,
       admin: {
@@ -76,8 +84,12 @@ export const baseConfig: Partial<Config> = {
         [autosaveGlobalSlug]: {
           isGlobal: true,
         },
-
         ['relationships']: {},
+        [multiTenantPostsSlug]: {
+          tenantFieldOverrides: {
+            hasMany: true,
+          },
+        },
       },
       i18n: {
         translations: {

--- a/test/plugin-multi-tenant/payload-types.ts
+++ b/test/plugin-multi-tenant/payload-types.ts
@@ -73,6 +73,7 @@ export interface Config {
     'food-menu': FoodMenu;
     'autosave-global': AutosaveGlobal;
     relationships: Relationship;
+    'multi-tenant-posts': MultiTenantPost;
     notTenanted: NotTenanted;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -91,6 +92,7 @@ export interface Config {
     'food-menu': FoodMenuSelect<false> | FoodMenuSelect<true>;
     'autosave-global': AutosaveGlobalSelect<false> | AutosaveGlobalSelect<true>;
     relationships: RelationshipsSelect<false> | RelationshipsSelect<true>;
+    'multi-tenant-posts': MultiTenantPostsSelect<false> | MultiTenantPostsSelect<true>;
     notTenanted: NotTenantedSelect<false> | NotTenantedSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -277,6 +279,18 @@ export interface AutosaveGlobal {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "multi-tenant-posts".
+ */
+export interface MultiTenantPost {
+  id: string;
+  tenant?: (string | Tenant)[] | null;
+  title: string;
+  parent?: (string | null) | MultiTenantPost;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -322,6 +336,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'relationships';
         value: string | Relationship;
+      } | null)
+    | ({
+        relationTo: 'multi-tenant-posts';
+        value: string | MultiTenantPost;
       } | null)
     | ({
         relationTo: 'notTenanted';
@@ -462,6 +480,17 @@ export interface RelationshipsSelect<T extends boolean = true> {
   tenant?: T;
   title?: T;
   relationship?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "multi-tenant-posts_select".
+ */
+export interface MultiTenantPostsSelect<T extends boolean = true> {
+  tenant?: T;
+  title?: T;
+  parent?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/plugin-multi-tenant/shared.ts
+++ b/test/plugin-multi-tenant/shared.ts
@@ -11,3 +11,5 @@ export const autosaveGlobalSlug = 'autosave-global'
 export const relationshipsSlug = 'relationships'
 
 export const notTenantedSlug = 'notTenanted'
+
+export const multiTenantPostsSlug = 'multi-tenant-posts'


### PR DESCRIPTION
### What

Fixes double-wrapped arrays in filterOptions queries when tenant field has `hasMany: true`

### Why

When a collection uses `hasMany: true` on the tenant field, documents store tenant IDs as arrays (e.g., `tenant: [id1, id2]`). 

The `filterDocumentsByTenants` function was always wrapping the tenant value in an array without checking configuration, causing `{ tenant: { in: [[id1, id2]] } }` instead of `{ tenant: { in: [id1, id2] } }`. 

This breaks relationship field filtering in the admin UI.

### How

Added explicit `hasMany` parameter threaded through `addFilterOptionsToFields` → `addRelationshipFilter` → `filterDocumentsByTenants`. 

When `hasMany` is true and `docTenantID` is provided, the value is used directly (already an array). Otherwise, it's wrapped in an array.

Fixes #15690