### PR TITLE
fix(richtext-lexical): link markdown regex should not match similar looking image markdown

### DIFF
--- a/packages/richtext-lexical/src/features/link/markdownTransformer.ts
+++ b/packages/richtext-lexical/src/features/link/markdownTransformer.ts
@@ -29,8 +29,8 @@ export const LinkMarkdownTransformer: TextMatchTransformer = {
 
     return linkContent
   },
-  importRegExp: /\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)/,
-  regExp: /\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)$/,
+  importRegExp: /(?<!\!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)/,
+  regExp: /(?<!\!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)$/,
   replace: (textNode, match) => {
     const [, linkText, linkUrl] = match
     const linkNode = $createLinkNode({

--- a/packages/richtext-lexical/src/features/link/markdownTransformer.ts
+++ b/packages/richtext-lexical/src/features/link/markdownTransformer.ts
@@ -29,8 +29,8 @@ export const LinkMarkdownTransformer: TextMatchTransformer = {
 
     return linkContent
   },
-  importRegExp: /(?<!\!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)/,
-  regExp: /(?<!\!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)$/,
+  importRegExp: /(?<!!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)/,
+  regExp: /(?<!!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)$/,
   replace: (textNode, match) => {
     const [, linkText, linkUrl] = match
     const linkNode = $createLinkNode({

--- a/test/lexical-mdx/int.spec.ts
+++ b/test/lexical-mdx/int.spec.ts
@@ -248,6 +248,17 @@ describe('Lexical MDX', () => {
       expect(text).toMatch(/alt|image\.jpg|\/uploads\//)
     })
   })
+
+  describe('link markdown: should not match image markdown', () => {
+    it('should not parse image markdown as a link node', () => {
+      const markdown = '![Alt text](https://example.com/image.jpg)'
+      const result = mdxToEditorJSON({ mdxWithFrontmatter: markdown, editorConfig })
+      const serialized = JSON.stringify(result.editorState)
+      expect(serialized).toContain('"text":"![Alt text](https://example.com/image.jpg)"')
+
+      expect(serialized).not.toContain('"type":"link"')
+    })
+  })
 })
 
 function removeUndefinedAndIDRecursively(obj: object) {


### PR DESCRIPTION
The current regex matches the link markdown correctly:

```
[This is a link](https://example.com/foo/bar)
```

But it also matches the image markdown:
```
![This is an image](https://example.com/foo/image.jpg)
```

To fix this, a negative lookbehind is added which confirms that no `!` is present before the match.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
