### PR TITLE
fix(templates): add generated files to ESLint ignores

### DIFF
--- a/templates/_template/eslint.config.mjs
+++ b/templates/_template/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 

--- a/templates/blank/eslint.config.mjs
+++ b/templates/blank/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 

--- a/templates/ecommerce/eslint.config.mjs
+++ b/templates/ecommerce/eslint.config.mjs
@@ -30,6 +30,9 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
+  },
 ]
 
 export default eslintConfig

--- a/templates/website/eslint.config.mjs
+++ b/templates/website/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 

--- a/templates/with-cloudflare-d1/eslint.config.mjs
+++ b/templates/with-cloudflare-d1/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 

--- a/templates/with-postgres/eslint.config.mjs
+++ b/templates/with-postgres/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 

--- a/templates/with-vercel-mongodb/eslint.config.mjs
+++ b/templates/with-vercel-mongodb/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 

--- a/templates/with-vercel-postgres/eslint.config.mjs
+++ b/templates/with-vercel-postgres/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 

--- a/templates/with-vercel-website/eslint.config.mjs
+++ b/templates/with-vercel-website/eslint.config.mjs
@@ -31,7 +31,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: ['.next/'],
+    ignores: ['.next/', 'src/payload-types.ts', 'src/payload-generated-schema.ts'],
   },
 ]
 


### PR DESCRIPTION
Add payload-types.ts and payload-generated-schema.ts to ESLint ignores across all template eslint.config.mjs files to suppress 
'Unused eslint-disable directive' warnings from auto-generated files.
<img width="488" height="163" alt="image" src="https://github.com/user-attachments/assets/9e00dfc7-0b07-40cf-b4d0-15c85d76f963" />
