### PR TITLE
fix: in slugField let position: undefined correctly reset admin.position

### DIFF
--- a/packages/payload/src/fields/baseFields/slug/index.ts
+++ b/packages/payload/src/fields/baseFields/slug/index.ts
@@ -85,18 +85,21 @@ export type SlugFieldClientProps = SlugFieldClientPropsOnly & TextFieldClientPro
  *
  * @experimental This field is experimental and may change or be removed in the future. Use at your own risk.
  */
-export const slugField: SlugField = ({
-  name: slugFieldName = 'slug',
-  checkboxName = 'generateSlug',
-  fieldToUse,
-  localized,
-  overrides,
-  position = 'sidebar',
-  required = true,
-  slugify,
-  useAsSlug: useAsSlugFromArgs = 'title',
-} = {}) => {
+export const slugField: SlugField = (options = {}) => {
+  const {
+    name: slugFieldName = 'slug',
+    checkboxName = 'generateSlug',
+    fieldToUse,
+    localized,
+    overrides,
+    position: providedPosition,
+    required = true,
+    slugify,
+    useAsSlug: useAsSlugFromArgs = 'title',
+  } = options
+
   const useAsSlug = fieldToUse || useAsSlugFromArgs
+  const position = 'position' in options ? providedPosition : 'sidebar'
 
   const baseField: RowField = {
     type: 'row',


### PR DESCRIPTION
## Problem

The `slugField` provides the option `position` which accepts `'sidebar' | undefined`.
This option is used to populate `admin.position`.

Per default the `slugField` adds `sidebar` when destructuring, making it render in the sidebar.
However providing `undefined`, with the intent to **not** render it in the sidebar, does not change this behavior.

```ts
slugField({
  position: undefined,
})
```

The default assignment of `position = 'sidebar'` while destructuring takes precedence over a provided `undefined`.

Since the `position` option exists, it should work with both valid values `'sidebar'` and `undefined`, which currently it does not.

## Workaround

A possible workaround before this fix was to use the `overrides` option of `slugField` like this:

```ts
slugField({
  overrides: (field) => {
    delete field.admin?.position
    return field
  },
}),
```

## Fix

My fix checks the provided options for `'position' in options`. Therefore allowing `undefined` to be passed successfully and not be overriden with `sidebar`.

```ts
const position = 'position' in options ? providedPosition : 'sidebar'
```

This allows `undefined` to be passed to `admin.position` and therefore render the slugfield correctly.

## Discord community help source

https://discord.com/channels/967097582721572934/1475457110119546942