### PR TITLE
feat(ui): adds dashed button style

### DIFF
--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -22,7 +22,6 @@
     &--style-primary {
       --color: var(--theme-elevation-0);
       --bg-color: var(--theme-elevation-800);
-      --box-shadow: none;
       --hover-bg: var(--theme-elevation-600);
       --hover-color: var(--color);
 
@@ -37,14 +36,14 @@
     &--style-secondary {
       --color: var(--theme-text);
       --bg-color: transparent;
-      --box-shadow: inset 0 0 0 1px var(--theme-elevation-800);
+      --btn-border: 1px solid var(--theme-elevation-800);
       --hover-color: var(--theme-elevation-600);
-      --hover-box-shadow: inset 0 0 0 1px var(--theme-elevation-400);
+      --hover-btn-border: 1px solid var(--theme-elevation-400);
 
       &.btn--disabled {
         --color: var(--theme-elevation-200);
-        --box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
-        --hover-box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
+        --btn-border: 1px solid var(--theme-elevation-200);
+        --hover-btn-border: 1px solid var(--theme-elevation-200);
         --hover-color: var(--color);
       }
     }
@@ -86,12 +85,12 @@
       --color: var(--theme-text);
       --bg-color: var(--theme-elevation-100);
       --hover-bg: var(--theme-elevation-150);
-      --box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
-      --hover-box-shadow: inset 0 0 0 1px var(--theme-elevation-250);
+      --btn-border: 1px solid var(--theme-elevation-200);
+      --hover-btn-border: 1px solid var(--theme-elevation-250);
 
       &.btn--disabled {
         --color: var(--theme-elevation-450);
-        --hover-box-shadow: var(--box-shadow);
+        --hover-btn-border: var(--btn-border);
         --hover-bg: var(--bg-color);
         --hover-color: var(--color);
       }
@@ -105,7 +104,6 @@
 
       &.btn--disabled {
         --btn-font-weight: 600;
-        --hover-box-shadow: var(--box-shadow);
         --bg-color: var(--theme-elevation-100);
         --hover-bg: var(--bg-color);
         --hover-color: var(--color);
@@ -121,7 +119,7 @@
     .popup-button {
       color: var(--color, inherit);
       background-color: var(--bg-color);
-      box-shadow: var(--box-shadow);
+      border: var(--btn-border, 1px solid transparent);
       border-radius: $style-radius-m;
       align-items: center;
 
@@ -143,7 +141,14 @@
       &:active {
         background-color: var(--hover-bg);
         color: var(--hover-color);
-        box-shadow: var(--hover-box-shadow);
+        border: var(--hover-btn-border, 1px solid transparent);
+
+        .btn__icon .stroke {
+          stroke: var(--hover-color, currentColor);
+        }
+        .btn__icon .fill {
+          fill: var(--hover-color, currentColor);
+        }
       }
     }
   }
@@ -155,7 +160,6 @@
     &:focus,
     &:active {
       color: var(--hover-color);
-      box-shadow: var(--hover-box-shadow);
       background-color: var(--hover-bg);
     }
   }
@@ -176,7 +180,8 @@
     --btn-icon-padding: 0px; // This will be needed when we make icons go edge to edge instead of having built in padding in the svg code
     --btn-icon-content-gap: calc(var(--base) * 0.4);
     --margin-block: calc(var(--base) * 1.2);
-    --btn-line-height: calc(var(--base) * 1.2);
+    --btn-line-height: calc(var(--base) * 1.1);
+    --btn-base-transition: 100ms cubic-bezier(0, 0.2, 0.2, 1);
 
     border-radius: var(--style-radius-s);
     font-size: var(--base-body-size);
@@ -187,14 +192,11 @@
     border: 0;
     cursor: pointer;
     text-decoration: none;
-    transition-property: border, color, box-shadow, background;
-    transition-duration: 100ms;
-    transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
+    transition: border, color, background, var(--btn-base-transition);
     padding: var(--btn-padding-block-start) var(--btn-padding-inline-end)
       var(--btn-padding-block-end) var(--btn-padding-inline-start);
     color: var(--color, inherit);
     background-color: var(--bg-color, transparent);
-    box-shadow: var(--box-shadow, none);
 
     &__icon {
       width: 100%;
@@ -271,11 +273,11 @@
       --btn-padding-inline-start: calc(var(--base) * 0.4);
       --btn-padding-block-end: 0;
 
-      &.btn--icon-position-left {
+      &:not(.btn--icon-only).btn--icon-position-left {
         --btn-padding-inline-start: calc(var(--base) * 0.3);
       }
 
-      &.btn--icon-position-right {
+      &:not(.btn--icon-only).btn--icon-position-right {
         --btn-padding-inline-end: calc(var(--base) * 0.3);
       }
 
@@ -292,10 +294,10 @@
       --btn-padding-inline-end: calc(var(--base) * 0.3);
       --btn-padding-inline-start: calc(var(--base) * 0.3);
       --btn-padding-block-end: 0;
-      &.btn--icon-position-left {
+      &:not(.btn--icon-only).btn--icon-position-left {
         --btn-padding-inline-start: calc(var(--base) * 0.2);
       }
-      &.btn--icon-position-right {
+      &:not(.btn--icon-only).btn--icon-position-right {
         --btn-padding-inline-end: calc(var(--base) * 0.2);
       }
       &.btn--icon-style-with-border {
@@ -312,11 +314,11 @@
       --btn-padding-block-end: calc(var(--base) * 0.2);
       --btn-padding-inline-start: calc(var(--base) * 0.6);
 
-      &.btn--icon-position-left {
+      &:not(.btn--icon-only).btn--icon-position-left {
         --btn-padding-inline-start: calc(var(--base) * 0.4);
       }
 
-      &.btn--icon-position-right {
+      &:not(.btn--icon-only).btn--icon-position-right {
         --btn-padding-inline-end: calc(var(--base) * 0.4);
       }
 
@@ -334,11 +336,11 @@
       --btn-padding-inline-start: calc(var(--base) * 0.8);
       --btn-padding-block-end: calc(var(--base) * 0.4);
 
-      &.btn--icon-position-left {
+      &:not(.btn--icon-only).btn--icon-position-left {
         --btn-padding-inline-start: calc(var(--base) * 0.6);
       }
 
-      &.btn--icon-position-right {
+      &:not(.btn--icon-only).btn--icon-position-right {
         --btn-padding-inline-end: calc(var(--base) * 0.6);
       }
 

--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -48,6 +48,22 @@
       }
     }
 
+    &--style-dashed {
+      --color: var(--theme-elevation-500);
+      --bg-color: transparent;
+      --hover-color: var(--theme-text);
+      --btn-border: 1px dashed var(--theme-elevation-200);
+      --hover-btn-border: 1px dashed var(--theme-elevation-400);
+
+      &.btn--disabled {
+        --color: var(--theme-elevation-250);
+        --hover-color: var(--color);
+        --hover-bg: transparent;
+        --btn-border: 1px dashed var(--theme-elevation-200);
+        --hover-btn-border: var(--btn-border);
+      }
+    }
+
     &--style-pill {
       --bg-color: var(--theme-elevation-150);
       --color: var(--theme-elevation-800);
@@ -161,6 +177,7 @@
     &:active {
       color: var(--hover-color);
       background-color: var(--hover-bg);
+      border: var(--hover-btn-border, var(--btn-border, 1px solid transparent));
     }
   }
 
@@ -189,7 +206,7 @@
     font-weight: var(--btn-font-weight, normal);
     margin-block: var(--margin-block);
     line-height: var(--btn-line-height);
-    border: 0;
+    border: var(--btn-border, 1px solid transparent);
     cursor: pointer;
     text-decoration: none;
     transition: border, color, background, var(--btn-base-transition);
@@ -307,7 +324,7 @@
 
     &--size-medium {
       // --btn-icon-padding: 0px;
-      --btn-icon-size: calc(var(--base) * 1.2);
+      --btn-icon-size: calc(var(--base) * 1.1);
       --btn-icon-content-gap: calc(var(--base) * 0.2);
       --btn-padding-block-start: calc(var(--base) * 0.2);
       --btn-padding-inline-end: calc(var(--base) * 0.6);

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -10,6 +10,7 @@ export type Props = {
   'aria-label'?: string
   buttonId?: string
   buttonStyle?:
+    | 'dashed'
     | 'error'
     | 'icon-label'
     | 'none'

--- a/test/admin/components/AfterNavLinks/index.tsx
+++ b/test/admin/components/AfterNavLinks/index.tsx
@@ -61,6 +61,14 @@ export const AfterNavLinks: PayloadClientReactComponent<
             Minimal Template
           </Link>
         </p>
+        <p className="nav__link" style={{ margin: 0 }}>
+          <Link
+            href={`${adminRoute}/button-styles`}
+            style={{ color: '#1976d2', textDecoration: 'none' }}
+          >
+            Button Styles
+          </Link>
+        </p>
         <div id="custom-css" />
       </div>
     </div>

--- a/test/admin/components/views/ButtonStyles/index.tsx
+++ b/test/admin/components/views/ButtonStyles/index.tsx
@@ -13,6 +13,7 @@ const buttonStyles = [
   'icon-label',
   'transparent',
   'subtle',
+  'dashed',
   'error',
   'tab',
   'none',

--- a/test/admin/components/views/ButtonStyles/index.tsx
+++ b/test/admin/components/views/ButtonStyles/index.tsx
@@ -13,9 +13,7 @@ const buttonStyles = [
   'icon-label',
   'transparent',
   'subtle',
-  'dashed',
   'error',
-  'muted-text',
   'tab',
   'none',
 ] as const
@@ -130,7 +128,7 @@ export const ButtonStyles: React.FC = () => {
                   key={size}
                   style={{ borderBottom: '1px solid var(--theme-elevation-100)', padding: '8px' }}
                 >
-                  <Button buttonStyle={style} icon="plus" margin={false} size={size}>
+                  <Button buttonStyle={style} icon="edit" margin={false} size={size}>
                     Button
                   </Button>
                 </td>
@@ -185,9 +183,9 @@ export const ButtonStyles: React.FC = () => {
                   style={{ borderBottom: '1px solid var(--theme-elevation-100)', padding: '8px' }}
                 >
                   <Button
-                    aria-label="Add"
+                    aria-label="Edit"
                     buttonStyle={style}
-                    icon="plus"
+                    icon="edit"
                     margin={false}
                     size={size}
                   />

--- a/test/admin/components/views/ButtonStyles/index.tsx
+++ b/test/admin/components/views/ButtonStyles/index.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { Button } from '@payloadcms/ui'
+import LinkImport from 'next/link.js'
 import React from 'react'
+
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 const buttonStyles = [
   'primary',
@@ -21,10 +24,13 @@ const sizes = ['large', 'medium', 'small', 'xsmall'] as const
 
 export const ButtonStyles: React.FC = () => {
   return (
-    <div style={{ marginTop: 'calc(var(--base) * 2)', padding: 'var(--gutter-h)' }}>
-      <h1>Button Styles</h1>
+    <div style={{ padding: 'var(--gutter-h)' }}>
+      <Link href="/admin">Dashboard</Link>
+      <h1 style={{ marginTop: 'var(--base)' }}>Buttons</h1>
 
-      <h2 style={{ marginTop: 'calc(var(--base) * 2)' }}>Styles × Sizes</h2>
+      <h2 style={{ marginBottom: 'calc(var(--base) * 1)', marginTop: 'calc(var(--base) * 2)' }}>
+        Styles × Sizes
+      </h2>
       <table style={{ borderCollapse: 'collapse', width: '100%' }}>
         <thead>
           <tr>
@@ -78,7 +84,9 @@ export const ButtonStyles: React.FC = () => {
         </tbody>
       </table>
 
-      <h2 style={{ marginTop: 'calc(var(--base) * 3)' }}>With Icons</h2>
+      <h2 style={{ marginBottom: 'calc(var(--base) * 1)', marginTop: 'calc(var(--base) * 3)' }}>
+        With Icons
+      </h2>
       <table style={{ borderCollapse: 'collapse', width: '100%' }}>
         <thead>
           <tr>
@@ -122,7 +130,7 @@ export const ButtonStyles: React.FC = () => {
                   key={size}
                   style={{ borderBottom: '1px solid var(--theme-elevation-100)', padding: '8px' }}
                 >
-                  <Button buttonStyle={style} icon="plus" size={size}>
+                  <Button buttonStyle={style} icon="plus" margin={false} size={size}>
                     Button
                   </Button>
                 </td>
@@ -176,7 +184,13 @@ export const ButtonStyles: React.FC = () => {
                   key={size}
                   style={{ borderBottom: '1px solid var(--theme-elevation-100)', padding: '8px' }}
                 >
-                  <Button aria-label="Add" buttonStyle={style} icon="plus" size={size} />
+                  <Button
+                    aria-label="Add"
+                    buttonStyle={style}
+                    icon="plus"
+                    margin={false}
+                    size={size}
+                  />
                 </td>
               ))}
             </tr>
@@ -184,19 +198,14 @@ export const ButtonStyles: React.FC = () => {
         </tbody>
       </table>
 
-      <h2 style={{ marginTop: 'calc(var(--base) * 3)' }}>Disabled States</h2>
+      <h2 style={{ marginBottom: 'calc(var(--base) * 1)', marginTop: 'calc(var(--base) * 3)' }}>
+        Disabled States
+      </h2>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
         {buttonStyles.map((style) => (
-          <Button buttonStyle={style} disabled key={style}>
+          <Button buttonStyle={style} disabled key={style} margin={false}>
             {style}
           </Button>
-        ))}
-      </div>
-
-      <h2 style={{ marginTop: 'calc(var(--base) * 3)' }}>Round Buttons</h2>
-      <div style={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-        {sizes.map((size) => (
-          <Button aria-label="Add" icon="plus" key={size} round size={size} />
         ))}
       </div>
     </div>

--- a/test/admin/components/views/ButtonStyles/index.tsx
+++ b/test/admin/components/views/ButtonStyles/index.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { Button } from '@payloadcms/ui'
+import React from 'react'
+
+const buttonStyles = [
+  'primary',
+  'secondary',
+  'pill',
+  'icon-label',
+  'transparent',
+  'subtle',
+  'dashed',
+  'error',
+  'muted-text',
+  'tab',
+  'none',
+] as const
+
+const sizes = ['large', 'medium', 'small', 'xsmall'] as const
+
+export const ButtonStyles: React.FC = () => {
+  return (
+    <div style={{ marginTop: 'calc(var(--base) * 2)', padding: 'var(--gutter-h)' }}>
+      <h1>Button Styles</h1>
+
+      <h2 style={{ marginTop: 'calc(var(--base) * 2)' }}>Styles × Sizes</h2>
+      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th
+              style={{
+                borderBottom: '1px solid var(--theme-elevation-200)',
+                padding: '8px',
+                textAlign: 'left',
+              }}
+            >
+              Style
+            </th>
+            {sizes.map((size) => (
+              <th
+                key={size}
+                style={{
+                  borderBottom: '1px solid var(--theme-elevation-200)',
+                  padding: '8px',
+                  textAlign: 'left',
+                }}
+              >
+                {size}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {buttonStyles.map((style) => (
+            <tr key={style}>
+              <td
+                style={{
+                  borderBottom: '1px solid var(--theme-elevation-100)',
+                  fontFamily: 'monospace',
+                  padding: '8px',
+                }}
+              >
+                {style}
+              </td>
+              {sizes.map((size) => (
+                <td
+                  key={size}
+                  style={{ borderBottom: '1px solid var(--theme-elevation-100)', padding: '8px' }}
+                >
+                  <Button buttonStyle={style} margin={false} size={size}>
+                    Button
+                  </Button>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 style={{ marginTop: 'calc(var(--base) * 3)' }}>With Icons</h2>
+      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th
+              style={{
+                borderBottom: '1px solid var(--theme-elevation-200)',
+                padding: '8px',
+                textAlign: 'left',
+              }}
+            >
+              Style
+            </th>
+            {sizes.map((size) => (
+              <th
+                key={size}
+                style={{
+                  borderBottom: '1px solid var(--theme-elevation-200)',
+                  padding: '8px',
+                  textAlign: 'left',
+                }}
+              >
+                {size}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {buttonStyles.map((style) => (
+            <tr key={style}>
+              <td
+                style={{
+                  borderBottom: '1px solid var(--theme-elevation-100)',
+                  fontFamily: 'monospace',
+                  padding: '8px',
+                }}
+              >
+                {style}
+              </td>
+              {sizes.map((size) => (
+                <td
+                  key={size}
+                  style={{ borderBottom: '1px solid var(--theme-elevation-100)', padding: '8px' }}
+                >
+                  <Button buttonStyle={style} icon="plus" size={size}>
+                    Button
+                  </Button>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 style={{ marginTop: 'calc(var(--base) * 3)' }}>Icon Only</h2>
+      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th
+              style={{
+                borderBottom: '1px solid var(--theme-elevation-200)',
+                padding: '8px',
+                textAlign: 'left',
+              }}
+            >
+              Style
+            </th>
+            {sizes.map((size) => (
+              <th
+                key={size}
+                style={{
+                  borderBottom: '1px solid var(--theme-elevation-200)',
+                  padding: '8px',
+                  textAlign: 'left',
+                }}
+              >
+                {size}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {buttonStyles.map((style) => (
+            <tr key={style}>
+              <td
+                style={{
+                  borderBottom: '1px solid var(--theme-elevation-100)',
+                  fontFamily: 'monospace',
+                  padding: '8px',
+                }}
+              >
+                {style}
+              </td>
+              {sizes.map((size) => (
+                <td
+                  key={size}
+                  style={{ borderBottom: '1px solid var(--theme-elevation-100)', padding: '8px' }}
+                >
+                  <Button aria-label="Add" buttonStyle={style} icon="plus" size={size} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 style={{ marginTop: 'calc(var(--base) * 3)' }}>Disabled States</h2>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+        {buttonStyles.map((style) => (
+          <Button buttonStyle={style} disabled key={style}>
+            {style}
+          </Button>
+        ))}
+      </div>
+
+      <h2 style={{ marginTop: 'calc(var(--base) * 3)' }}>Round Buttons</h2>
+      <div style={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+        {sizes.map((size) => (
+          <Button aria-label="Add" icon="plus" key={size} round size={size} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -134,6 +134,10 @@ export default buildConfigWithDefaults({
           path: publicCustomViewPath,
           strict: true,
         },
+        ButtonShowcase: {
+          Component: '/components/views/ButtonStyles/index.js#ButtonStyles',
+          path: '/button-styles',
+        },
       },
     },
     dependencies: {


### PR DESCRIPTION
This PR adds a new `dashed` button style property.

Changes:
- removes box-shadow from buttons and replaces it with border
  - adds "always on" 1px solid transparent border
  - reduces line-height by 2px from `calc(var(--base) * 1.2)` to `calc(var(--base) * 1.1)` (.1 --base is 2px) to account for new "always on" border

Fixes button with icon-only had incorrect padding set, should be equal left and right.

Adds custom page in the admin test suite `/admin/button-styles` so we can quickly see all button variations. (as you can see we support styles that do not have any default styles, like `error`). Updating all of those is out of scope for this PR but I think this custom view will help us with button updates in the future.

<img width="2021" height="1261" alt="CleanShot 2026-02-23 at 11 15 45" src="https://github.com/user-attachments/assets/8d97fb19-51c3-46a3-9148-c54b15d49723" />
