### PR TITLE
fix(ui): flash of border on list selection buttons

### DIFF
--- a/packages/ui/src/elements/ListSelection/index.scss
+++ b/packages/ui/src/elements/ListSelection/index.scss
@@ -16,7 +16,6 @@
     &__button {
       color: var(--theme-elevation-800);
       background: unset;
-      border: none;
       text-decoration: underline;
       cursor: pointer;
       padding: 0;


### PR DESCRIPTION
The list selection had it's own `border: none` which overwrote the un-hovered state of the selection buttons. This is unnecessary and arose from https://github.com/payloadcms/payload/pull/15728.