### PR TITLE
fix: throw error for unknown query operators

### DIFF
--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -101,6 +101,8 @@ export async function validateQueryPaths({
                 versionFields,
               }),
             )
+          } else if (typeof val !== 'object' || val === null) {
+            errors.push({ path: `${path}.${operator}` })
           }
         }
       }

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -8,9 +8,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Category, Config, DepthJoins1, DepthJoins3, Post, Singular } from './payload-types.js'
 
-import { devUser } from '../credentials.js'
 import { idToString } from '../__helpers/shared/idToString.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { devUser } from '../credentials.js'
 import {
   categoriesJoinRestrictedSlug,
   categoriesSlug,
@@ -1892,6 +1892,63 @@ describe('Joins Field', () => {
     })
     expect(found.docs).toHaveLength(1)
     expect(found.docs[0].id).toBe(category.id)
+  })
+
+  describe('Polymorphic join query validation', () => {
+    const isPostgres = process.env.PAYLOAD_DATABASE === 'postgres'
+
+    it.skipIf(!isPostgres)('should reject unknown operators and not delay response', async () => {
+      const startTime = Date.now()
+
+      const response = await restClient.GET('/categories', {
+        query: {
+          limit: 1,
+          joins: {
+            polymorphicJoin: {
+              limit: 1,
+              where: { x: { $raw: 'EXISTS(SELECT 1 FROM pg_sleep(3))' } },
+            },
+          },
+        },
+      })
+
+      const elapsedSeconds = (Date.now() - startTime) / 1000
+
+      expect(response.status).toBe(400)
+      expect(elapsedSeconds).toBeLessThan(1)
+    })
+
+    it('should reject unknown operators in polymorphic join where', async () => {
+      const response = await restClient.GET('/categories', {
+        query: {
+          limit: 1,
+          joins: {
+            polymorphicJoin: {
+              limit: 1,
+              where: { x: { $raw: 'true' } },
+            },
+          },
+        },
+      })
+
+      expect(response.status).toBe(400)
+    })
+
+    it('should allow valid operators in polymorphic join where', async () => {
+      const response = await restClient.GET('/categories', {
+        query: {
+          limit: 1,
+          joins: {
+            polymorphicJoin: {
+              limit: 1,
+              where: { title: { equals: 'test' } },
+            },
+          },
+        },
+      })
+
+      expect(response.status).toBe(200)
+    })
   })
 })
 


### PR DESCRIPTION
### What
Ensures unknown query operators are properly rejected during query validation.

### Why
Previously, unrecognized operators in where clauses were silently ignored. This could lead to unexpected behavior. Query validation should fail-closed and only accept known operators.

### How
Added an `else` in validateQueryPaths.ts to push an error for any operator not in the valid operator set.

Test added to `joins > int`