### PR TITLE
fix: sanitize filenames in storage adapters

### DIFF
--- a/packages/payload/src/exports/shared.ts
+++ b/packages/payload/src/exports/shared.ts
@@ -134,6 +134,8 @@ export {
 
 export { reduceFieldsToValues } from '../utilities/reduceFieldsToValues.js'
 
+export { sanitizeFilename } from '../utilities/sanitizeFilename.js'
+
 export { sanitizeUserDataForEmail } from '../utilities/sanitizeUserDataForEmail.js'
 
 export { setsAreEqual } from '../utilities/setsAreEqual.js'

--- a/packages/payload/src/utilities/sanitizeFilename.ts
+++ b/packages/payload/src/utilities/sanitizeFilename.ts
@@ -1,0 +1,27 @@
+import { APIError } from '../errors/APIError.js'
+
+/**
+ * Strips directory components and control characters from a filename,
+ * leaving only the base filename.
+ */
+export function sanitizeFilename(filename: string): string {
+  let sanitized = filename.replace(/\\/g, '/')
+
+  const lastSlash = sanitized.lastIndexOf('/')
+  if (lastSlash !== -1) {
+    sanitized = sanitized.slice(lastSlash + 1)
+  }
+
+  if (sanitized === '.' || sanitized === '..') {
+    sanitized = ''
+  }
+
+  // eslint-disable-next-line no-control-regex
+  sanitized = sanitized.replace(/[\x00-\x1f\x80-\x9f]/g, '')
+
+  if (!sanitized) {
+    throw new APIError('Invalid filename', 400)
+  }
+
+  return sanitized
+}

--- a/packages/storage-azure/src/generateSignedURL.ts
+++ b/packages/storage-azure/src/generateSignedURL.ts
@@ -5,6 +5,7 @@ import type { PayloadHandler } from 'payload'
 import { BlobSASPermissions, generateBlobSASQueryParameters } from '@azure/storage-blob'
 import path from 'path'
 import { APIError, Forbidden } from 'payload'
+import { sanitizeFilename } from 'payload/shared'
 
 import type { AzureStorageOptions } from './index.js'
 
@@ -45,7 +46,8 @@ export const getGenerateSignedURLHandler = ({
       throw new Forbidden()
     }
 
-    const fileKey = path.posix.join(prefix, filename)
+    const sanitizedFilename = sanitizeFilename(filename)
+    const fileKey = path.posix.join(prefix, sanitizedFilename)
 
     const blobClient = getStorageClient().getBlobClient(fileKey)
 

--- a/packages/storage-gcs/src/generateSignedURL.ts
+++ b/packages/storage-gcs/src/generateSignedURL.ts
@@ -4,6 +4,7 @@ import type { PayloadHandler } from 'payload'
 
 import path from 'path'
 import { APIError, Forbidden } from 'payload'
+import { sanitizeFilename } from 'payload/shared'
 
 import type { GcsStorageOptions } from './index.js'
 
@@ -45,7 +46,8 @@ export const getGenerateSignedURLHandler = ({
       throw new Forbidden()
     }
 
-    const fileKey = path.posix.join(prefix, filename)
+    const sanitizedFilename = sanitizeFilename(filename)
+    const fileKey = path.posix.join(prefix, sanitizedFilename)
 
     const [url] = await getStorageClient()
       .bucket(bucket)

--- a/packages/storage-r2/src/handleMultiPartUpload.ts
+++ b/packages/storage-r2/src/handleMultiPartUpload.ts
@@ -3,6 +3,7 @@ import type { PayloadHandler } from 'payload'
 
 import path from 'path'
 import { APIError, Forbidden } from 'payload'
+import { sanitizeFilename } from 'payload/shared'
 
 import type { R2StorageOptions } from './index.js'
 import type { R2Bucket, R2StorageMultipartUploadHandlerParams } from './types.js'
@@ -51,7 +52,8 @@ export const getHandleMultiPartUpload =
     }
 
     const prefix = (typeof collectionConfig === 'object' && collectionConfig.prefix) || ''
-    const fileKey = path.posix.join(prefix, params.fileName)
+    const sanitizedFilename = sanitizeFilename(params.fileName)
+    const fileKey = path.posix.join(prefix, sanitizedFilename)
 
     const multipartId = params.multipartId
     const multipartKey = params.multipartKey

--- a/packages/storage-s3/src/generateSignedURL.ts
+++ b/packages/storage-s3/src/generateSignedURL.ts
@@ -5,6 +5,7 @@ import * as AWS from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import path from 'path'
 import { APIError, Forbidden, ValidationError } from 'payload'
+import { sanitizeFilename } from 'payload/shared'
 
 import type { S3StorageOptions } from './index.js'
 
@@ -58,7 +59,8 @@ export const getGenerateSignedURLHandler = ({
       throw new Forbidden()
     }
 
-    const fileKey = path.posix.join(prefix, filename)
+    const sanitizedFilename = sanitizeFilename(filename)
+    const fileKey = path.posix.join(prefix, sanitizedFilename)
 
     const signableHeaders = new Set<string>()
 

--- a/test/storage-s3/clientUploads.config.ts
+++ b/test/storage-s3/clientUploads.config.ts
@@ -6,8 +6,9 @@ import path from 'path'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { Media } from './collections/Media.js'
+import { MediaWithPrefix } from './collections/MediaWithPrefix.js'
 import { Users } from './collections/Users.js'
-import { mediaSlug } from './shared.js'
+import { mediaSlug, mediaWithPrefixSlug } from './shared.js'
 import { MB } from './test-utils.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -23,7 +24,7 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Media, Users],
+  collections: [Media, MediaWithPrefix, Users],
   onInit: async (payload) => {
     await payload.create({
       collection: 'users',
@@ -37,6 +38,9 @@ export default buildConfigWithDefaults({
     s3Storage({
       collections: {
         [mediaSlug]: true,
+        [mediaWithPrefixSlug]: {
+          prefix: 'test-prefix',
+        },
       },
       bucket: process.env.S3_BUCKET!,
       clientUploads: {

--- a/test/storage-s3/clientUploads.int.spec.ts
+++ b/test/storage-s3/clientUploads.int.spec.ts
@@ -204,6 +204,73 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(uploadResponse.status).toBe(403) // S3 should reject the upload
   })
 
+  describe('filename handling', () => {
+    it('should sanitize special characters in filename', async () => {
+      const file = readFileSync(path.resolve(dirname, '../uploads/image.png'))
+
+      const { url } = await restClient
+        .POST(signedURLEndpoint, {
+          body: signedURLBody('media-with-prefix', '../photo.png', file.length, 'image/png'),
+        })
+        .then((res) => res.json<{ url: string }>())
+
+      expect(url).toBeDefined()
+      expect(url).toContain('test-prefix')
+      expect(url).toContain('photo.png')
+      expect(url).not.toContain('..')
+    })
+
+    it('should sanitize deeply nested special characters in filename', async () => {
+      const file = readFileSync(path.resolve(dirname, '../uploads/image.png'))
+
+      const { url } = await restClient
+        .POST(signedURLEndpoint, {
+          body: signedURLBody(
+            'media-with-prefix',
+            '../../other-prefix/document.js',
+            file.length,
+            'image/png',
+          ),
+        })
+        .then((res) => res.json<{ url: string }>())
+
+      expect(url).toBeDefined()
+      expect(url).toContain('test-prefix')
+      expect(url).toContain('document.js')
+      expect(url).not.toContain('..')
+      expect(url).not.toContain('other-prefix')
+    })
+
+    it('should sanitize backslash characters in filename', async () => {
+      const file = readFileSync(path.resolve(dirname, '../uploads/image.png'))
+
+      const { url } = await restClient
+        .POST(signedURLEndpoint, {
+          body: signedURLBody('media-with-prefix', '..\\..\\photo.png', file.length, 'image/png'),
+        })
+        .then((res) => res.json<{ url: string }>())
+
+      expect(url).toBeDefined()
+      expect(url).toContain('test-prefix')
+      expect(url).toContain('photo.png')
+      expect(url).not.toContain('..')
+    })
+
+    it('should allow normal filenames with prefix', async () => {
+      const file = readFileSync(path.resolve(dirname, '../uploads/image.png'))
+
+      const { url } = await restClient
+        .POST(signedURLEndpoint, {
+          body: signedURLBody('media-with-prefix', 'safe-image.png', file.length, 'image/png'),
+        })
+        .then((res) => res.json<{ url: string }>())
+
+      expect(url).toBeDefined()
+      expect(url).toContain('test-prefix')
+      expect(url).toContain('safe-image.png')
+    })
+  })
+
   afterAll(async () => {
     await payload.destroy()
   })


### PR DESCRIPTION
### What
Adds filename + prefix sanitization to all storage adapters (S3, GCS, Azure, R2).

### Why
Storage adapter uploads pass filenames directly to `path.posix.join(prefix, filename)` without sanitization. Regular uploads don't have this issue because they go through `generateFileData`, which already sanitizes filenames via the `sanitize-filename` package. This brings storage adapter filename handling in line with the rest of the upload pipeline.

### How
Exported `sanitizeFilename` from `payload` to reuse in the storage adapters.

#### Testing
Added tests to `test/storage-s3/clientUploads.int.spec.ts`