### PR TITLE
fix(ui): skip non-field rich text schema entries

### DIFF
--- a/packages/ui/src/utilities/buildClientFieldSchemaMap/traverseFields.ts
+++ b/packages/ui/src/utilities/buildClientFieldSchemaMap/traverseFields.ts
@@ -148,6 +148,10 @@ export const traverseFields = ({
           // check if fields is the only key in the subField object
           const isFieldsOnly = Object.keys(subField).length === 1 && 'fields' in subField
 
+          if (!isFieldsOnly && !('type' in subField)) {
+            continue
+          }
+
           const clientFields = createClientFields({
             defaultIDType: payload.config.db.defaultIDType,
             disableAddingID: true,


### PR DESCRIPTION
## Summary
- prevent `buildClientFieldSchemaMap` from coercing non-field rich text schema map entries into client fields
- skip entries that are not `{ fields: ... }` wrappers and do not have a `type`, which can occur for nested block config entries
- fixes admin crashes in Lexical `BlocksFeature` when a block contains nested `blocks` fields, due to server-only/function properties leaking into client serialization

## Related
- Closes #15509

## Testing
- Reproduced with nested Lexical blocks setup (block containing a nested `blocks` field); admin no longer crashes during schema/client form-state build.