### PR TITLE
chore: make test:e2e agent-friendly with --grep support and dev server reuse

### DIFF
--- a/test/runE2E.ts
+++ b/test/runE2E.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import globby from 'globby'
 import minimist from 'minimist'
+import { createServer } from 'net'
 import path from 'path'
 import shelljs from 'shelljs'
 import slash from 'slash'
@@ -31,6 +32,7 @@ const {
   _: args,
   bail,
   'fully-parallel': fullyParallel,
+  grep,
   part,
   shard,
   workers,
@@ -74,7 +76,7 @@ if (!suiteName) {
     if (!baseTestFolder) {
       throw new Error(`No base test folder found for ${file}`)
     }
-    executePlaywright(file, baseTestFolder, bail)
+    await executePlaywright(file, baseTestFolder, bail)
   }
 } else {
   let inputSuitePath: string | undefined = suiteName
@@ -107,7 +109,7 @@ if (!suiteName) {
 
   // Run all spec files in the folder with a single dev server and playwright invocation
   // This avoids port conflicts when multiple spec files exist in the same folder
-  executePlaywright(
+  await executePlaywright(
     allSuitesInFolder,
     baseTestFolder,
     false,
@@ -115,6 +117,7 @@ if (!suiteName) {
     shard,
     fullyParallel,
     workers,
+    grep,
   )
 }
 
@@ -127,7 +130,7 @@ console.log('\n')
 // baseTestFolder is the most top level folder of the test suite, that contains the payload config.
 // We need this because pnpm dev for a given test suite will always be run from the top level test folder,
 // not from a nested suite folder.
-function executePlaywright(
+async function executePlaywright(
   suitePaths: string | string[],
   baseTestFolder: string,
   bail = false,
@@ -135,6 +138,7 @@ function executePlaywright(
   shardArg?: string,
   fullyParallelArg?: boolean,
   workersArg?: number,
+  grepArg?: string,
 ) {
   const paths = Array.isArray(suitePaths) ? suitePaths : [suitePaths]
   console.log(`Executing ${paths.join(', ')}...`)
@@ -158,19 +162,33 @@ function executePlaywright(
 
   process.env.START_MEMORY_DB = 'true'
 
-  const child = spawn('pnpm', spawnDevArgs, {
-    cwd: path.resolve(dirname, '..'),
-    env: {
-      ...process.env,
-    },
-    stdio: 'inherit',
+  const portInUse = await new Promise<boolean>((resolve) => {
+    const server = createServer()
+    server.once('error', () => resolve(true))
+    server.once('listening', () => server.close(() => resolve(false)))
+    server.listen(3000)
   })
+
+  let child: ReturnType<typeof spawn> | undefined
+
+  if (portInUse) {
+    console.log('Port 3000 is already in use — reusing existing dev server.')
+  } else {
+    child = spawn('pnpm', spawnDevArgs, {
+      cwd: path.resolve(dirname, '..'),
+      env: {
+        ...process.env,
+      },
+      stdio: 'inherit',
+    })
+  }
 
   const shardFlag = shardArg ? ` --shard=${shardArg}` : ''
   const fullyParallelFlag = fullyParallelArg ? ' --fully-parallel' : ''
   const workersFlag = workersArg !== undefined ? ` --workers=${workersArg}` : ''
+  const grepFlag = grepArg ? ` --grep="${grepArg}"` : ''
   const cmd = slash(
-    `${playwrightBin} test ${paths.join(' ')} -c ${playwrightCfg}${shardFlag}${fullyParallelFlag}${workersFlag}`,
+    `${playwrightBin} test ${paths.join(' ')} -c ${playwrightCfg}${shardFlag}${fullyParallelFlag}${workersFlag}${grepFlag}`,
   )
   console.log('\n', cmd)
   const { code, stdout } = shelljs.exec(cmd, {
@@ -183,10 +201,10 @@ function executePlaywright(
     if (bail) {
       console.error(`TEST FAILURE DURING ${suite} suite.`)
     }
-    child.kill(1)
+    child?.kill(1)
     process.exit(1)
   } else {
-    child.kill()
+    child?.kill()
   }
   testRunCodes.push(results)
 


### PR DESCRIPTION
AI agents consistently struggle with two aspects of the e2e test workflow:

1. **`--grep` not supported by `test:e2e`** - Agents default to passing `--grep` to `pnpm test:e2e` even when instructed to invoke Playwright directly. Rather than fighting this, just support it.

2. **Duplicate dev servers** - Agents frequently run `test:e2e` multiple times without stopping previous dev servers, leading to port conflicts, stalled processes, and minutes of wasted time before they realize the server never started. They are **not** smart enough to make sure to reliably close old dev servers themselves.

### Changes

- Forward the `--grep` flag from `test:e2e` to the underlying Playwright command
- Before spawning a new dev server, check if port 3000 is already in use - if so, skip spawning and reuse the existing server