### PR TITLE
fix(ui): use correct translation key for collection version restore modal

### DIFF
--- a/packages/next/src/views/Version/Restore/index.tsx
+++ b/packages/next/src/views/Version/Restore/index.tsx
@@ -48,7 +48,6 @@ export const Restore: React.FC<Props> = ({
   const {
     config: {
       routes: { admin: adminRoute, api: apiRoute },
-      serverURL,
     },
   } = useConfig()
 
@@ -58,10 +57,13 @@ export const Restore: React.FC<Props> = ({
   const [draft, setDraft] = useState(false)
   const { startRouteTransition } = useRouteTransition()
 
-  const restoreMessage = t('version:aboutToRestoreGlobal', {
-    label: getTranslation(label, i18n),
-    versionDate: versionDateFormatted,
-  })
+  const restoreMessage = t(
+    globalConfig ? 'version:aboutToRestoreGlobal' : 'version:aboutToRestore',
+    {
+      label: getTranslation(label, i18n),
+      versionDate: versionDateFormatted,
+    },
+  )
 
   const canRestoreAsDraft = status !== 'draft' && collectionConfig?.versions?.drafts
 


### PR DESCRIPTION
### What?

Fixed the restore version confirmation modal always showing the "global document" message, even for collection documents.

### Why?

The `Restore` component unconditionally used the `version:aboutToRestoreGlobal` translation key. This caused the modal to display text like "Globale Dokument" (German) or "the global {label}" (English) when restoring a collection document version, which is incorrect.

### How?

Conditionally select the translation key based on whether `globalConfig` is present:
- `globalConfig` exists → `version:aboutToRestoreGlobal`
- Otherwise → `version:aboutToRestore`

Also removed an unused `serverURL` destructuring.