### PR TITLE
fix: import-export-override-collection

### DIFF
--- a/packages/plugin-import-export/src/utilities/getPluginCollections.ts
+++ b/packages/plugin-import-export/src/utilities/getPluginCollections.ts
@@ -231,6 +231,43 @@ export const getPluginCollections = async ({
         },
       }
     }
+
+    // disableJobsQueue affects hook closures captured at collection creation time, so the
+    // base collection must be regenerated rather than patched via admin.custom
+    if (mergedExportSettings.disableJobsQueue !== undefined) {
+      const filteredSlugs = baseExportSlugs.filter((slug) => !customExportSlugMap.has(slug))
+      baseExportCollection = getExportCollection({
+        collectionSlugs: filteredSlugs,
+        config,
+        exportConfig: mergedExportSettings,
+        pluginConfig,
+      })
+      if (
+        pluginConfig.overrideExportCollection &&
+        typeof pluginConfig.overrideExportCollection === 'function'
+      ) {
+        baseExportCollection = await pluginConfig.overrideExportCollection({
+          collection: baseExportCollection,
+        })
+      }
+    }
+
+    if (mergedImportSettings.disableJobsQueue !== undefined) {
+      const filteredSlugs = baseImportSlugs.filter((slug) => !customImportSlugMap.has(slug))
+      baseImportCollection = getImportCollection({
+        collectionSlugs: filteredSlugs,
+        importConfig: mergedImportSettings,
+        pluginConfig,
+      })
+      if (
+        pluginConfig.overrideImportCollection &&
+        typeof pluginConfig.overrideImportCollection === 'function'
+      ) {
+        baseImportCollection = await pluginConfig.overrideImportCollection({
+          collection: baseImportCollection,
+        })
+      }
+    }
   }
 
   // Filter out slugs that have custom export/import collections from the base collections


### PR DESCRIPTION
Uncovered this bug while creating a demo for import/export plugin:

`disableJobsQueue` only works by being captured in a closure when `getImportCollection`/`getExportCollection` are called. If a user set it per-collection without `overrideCollection`, the merged settings were computed but never used to regenerate the base collection — so `disableJobsQueue` was always effectively `false`.  So you'd have to do this in your plugin config:

```
importExportPlugin({
  debug: true,
  collections: [
    {
      slug: 'companies',
      import: { disableJobsQueue: true, overrideCollection: ({ collection }) => collection },
      export: { disableJobsQueue: true, overrideCollection: ({ collection }) => collection },
    },
    {
      slug: 'contacts',
      import: { disableJobsQueue: true, overrideCollection: ({ collection }) => collection },
      export: { disableJobsQueue: true, overrideCollection: ({ collection }) => collection },
    },
  ],
}),
```

Fix in `getPluginCollections.ts` - After computing `mergedExportSettings`/`mergedImportSettings`, if `disableJobsQueue` is present, regenerate the base collection with the merged config (and re-apply `overrideExportCollection`/`overrideImportCollection` if present). The `admin.custom.collectionSlugs` are still correctly set by the existing step that follows.