### PR TITLE
fix(ui): document status shows changed after publishing specific locale

### DIFF
--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -235,10 +235,22 @@ export function PublishButton({
       })
 
       if (result) {
+        setUnpublishedVersionCount(0)
+        setMostRecentVersionIsAutosaved(false)
         setHasPublishedDoc(true)
       }
     },
-    [api, collectionSlug, globalSlug, id, setHasPublishedDoc, submit, uploadStatus],
+    [
+      api,
+      collectionSlug,
+      globalSlug,
+      id,
+      setHasPublishedDoc,
+      setMostRecentVersionIsAutosaved,
+      setUnpublishedVersionCount,
+      submit,
+      uploadStatus,
+    ],
   )
 
   // Publish to all locales unless there are localized fields AND defaultLocalePublishOption is 'active'

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -746,6 +746,26 @@ describe('Document View', () => {
       await expect(publishButton).toContainText('Publish changes')
       await expect(publishButton).not.toContainText('Publish in')
     })
+
+    test('should show published status after publishing specific locale', async () => {
+      await page.goto(localizedURL.create)
+      const status = page.locator('.status__value')
+
+      await page.locator('#field-title').fill('Published title')
+      await saveDocAndAssert(page)
+
+      await expect(status).toContainText('Published')
+
+      await page.locator('#field-title').fill('Draft change')
+      await saveDocAndAssert(page, '#action-save-draft')
+
+      await expect(status).toContainText('Changed')
+
+      await page.locator('#field-title').fill('Published again')
+      await saveDocAndAssert(page)
+
+      await expect(status).toContainText('Published')
+    })
   })
 
   describe('reserved field names', () => {


### PR DESCRIPTION
### What?

When `localizeStatus` is enabled and `defaultLocalePublishOption` is set to `active`, publishing a specific locale leaves the document status showing "Changed" instead of "Published" until the page is refreshed.

### Why?

The `publishSpecificLocale` callback in `PublishButton` only called `setHasPublishedDoc(true)` on success, but did not reset `unpublishedVersionCount` or `mostRecentVersionIsAutosaved`. The `Status` component uses `unpublishedVersionCount > 0 && hasPublishedDoc` to render "Changed", so the stale count kept the status incorrect.

The `publish` (all locales) callback already handled this correctly, `publishSpecificLocale` was just missing the same state resets.

### How?

Added `setUnpublishedVersionCount(0)` and `setMostRecentVersionIsAutosaved(false)` to the `publishSpecificLocale` success handler, matching what `publish` already does. Added an e2e test that reproduces the issue.