### PR TITLE
fix: improve mobile touch support for dnd

### DIFF
--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/sensors.ts
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/utils/sensors.ts
@@ -1,6 +1,13 @@
 import type { KeyboardCoordinateGetter, KeyboardSensorOptions } from '@dnd-kit/core'
 
-import { KeyboardCode, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import {
+  KeyboardCode,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
 
 type DroppablePosition = {
   centerX: number
@@ -307,9 +314,15 @@ class DirectFocusKeyboardSensor extends KeyboardSensor {
 
 export function useDashboardSensors() {
   return useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: {
         distance: 5,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 5,
       },
     }),
     useSensor(DirectFocusKeyboardSensor, {

--- a/packages/ui/src/elements/DraggableSortable/index.tsx
+++ b/packages/ui/src/elements/DraggableSortable/index.tsx
@@ -5,7 +5,8 @@ import {
   closestCenter,
   DndContext,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useDroppable,
   useSensor,
   useSensors,
@@ -28,9 +29,15 @@ export const DraggableSortable: React.FC<Props> = (props) => {
   })
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: {
         distance: 5,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 5,
       },
     }),
     useSensor(KeyboardSensor, {


### PR DESCRIPTION
replaces` PointerSensor` with `MouseSensor` + `TouchSensor` (200ms press-and-hold delay) in both modular dashboard widget drag and `DraggableSortable` component, so touch gestures no longer conflict with scrolling on mobile devices