### PR TITLE
fix(ui): array field add button margin not applying consistently

### DIFF
--- a/packages/ui/src/fields/Array/index.scss
+++ b/packages/ui/src/fields/Array/index.scss
@@ -74,7 +74,7 @@
       margin-bottom: 0;
     }
 
-    &__add-row {
+    &__add-row.btn {
       align-self: flex-start;
       margin: 2px 0;
       --btn-color: var(--theme-elevation-400);


### PR DESCRIPTION
### What

Array field "Add" button has excessive margin in some environments

### Why

CSS load order caused base button margin to override array field margin due to equal specificity

### How

Increased selector specificity to `.array-field__add-row.btn` to ensure the reduced margin always applies

Fixes #15721
