### PR TITLE
fix: getFieldsToSign crashes when user missing group/tab fields

### DIFF
--- a/packages/payload/src/auth/getFieldsToSign.ts
+++ b/packages/payload/src/auth/getFieldsToSign.ts
@@ -28,15 +28,16 @@ const traverseFields = ({
       }
       case 'group': {
         if (fieldAffectsData(field)) {
+          const groupData: Record<string, unknown> =
+            (data[field.name] as Record<string, unknown>) ?? {}
           let targetResult
           if (typeof field.saveToJWT === 'string') {
             targetResult = field.saveToJWT
-            result[field.saveToJWT] = data[field.name]
+            result[field.saveToJWT] = groupData
           } else if (field.saveToJWT) {
             targetResult = field.name
-            result[field.name] = data[field.name]
+            result[field.name] = groupData
           }
-          const groupData: Record<string, unknown> = data[field.name] as Record<string, unknown>
           const groupResult = (targetResult ? result[targetResult] : result) as Record<
             string,
             unknown
@@ -59,15 +60,16 @@ const traverseFields = ({
       }
       case 'tab': {
         if (tabHasName(field)) {
+          const tabData: Record<string, unknown> =
+            (data[field.name] as Record<string, unknown>) ?? {}
           let targetResult
           if (typeof field.saveToJWT === 'string') {
             targetResult = field.saveToJWT
-            result[field.saveToJWT] = data[field.name]
+            result[field.saveToJWT] = tabData
           } else if (field.saveToJWT) {
             targetResult = field.name
-            result[field.name] = data[field.name]
+            result[field.name] = tabData
           }
-          const tabData: Record<string, unknown> = data[field.name] as Record<string, unknown>
           const tabResult = (targetResult ? result[targetResult] : result) as Record<
             string,
             unknown


### PR DESCRIPTION
### What

Fix crash in JWT generation when user documents are missing group or tab fields

### Why

When a user document was created before group/tab fields were added to the schema, logging in would crash with "Cannot read properties of undefined" because `getFieldsToSign` tried to traverse into undefined fields.

### How

Added nullish coalescing (`?? {}`) to default missing group/tab data to empty objects, consistent with how `afterRead/promise.ts` handles this case.

Fixes #15734 
