### PR TITLE
test: fix flaky localization tests with race conditions

### DIFF
--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -338,7 +338,8 @@ describe('Localization', () => {
       await page.locator('#field-title').fill(englishTitle)
       await page.locator('#field-nav__layout .blocks-field__drawer-toggler').click()
       await page.locator('button[title="Text"]').click()
-      await page.fill('#field-nav__layout__0__text', 'test')
+      await page.locator('#field-nav__layout__0__text').waitFor({ state: 'visible' })
+      await page.locator('#field-nav__layout__0__text').fill('test')
       await expect(page.locator('#field-nav__layout__0__text')).toHaveValue('test')
       await saveDocAndAssert(page)
       const originalID = await page.locator('.id-label').innerText()
@@ -496,8 +497,8 @@ describe('Localization', () => {
       const overwriteCheckbox = page.locator('#field-overwriteExisting')
       await overwriteCheckbox.click()
       await runCopy({ page, toLocale: spanishLocale })
+      await page.locator('#field-title').waitFor({ state: 'visible' })
       await expect(page.locator('#field-title')).toHaveValue(englishTitle)
-      await changeLocale(page, defaultLocale)
     })
 
     test('should not include current locale in toLocale options', async () => {


### PR DESCRIPTION
### What

Fixed two flaky localization tests that were consistently timing out in CI.

<img width="1257" height="575" alt="Screenshot 2026-02-26 at 3 36 09 PM" src="https://github.com/user-attachments/assets/50ab01d4-72b9-4022-a056-b0f6ae91b5f8" />

### Why

Tests were failing on slow networks (CI with CPU throttling) because elements weren't fully ready for interaction after navigation or dynamic rendering. Interactions were attempted before elements were hydrated, causing timeouts.

### How

- Added `waitFor({ state: 'visible' })` before filling blocks field in duplicate test
- Added `waitFor({ state: 'visible' })` after navigation in copy locale overwrite test  
- Removed unnecessary final `changeLocale` call that served no testing purpose
