### PR TITLE
fix(storage-vercel-blob): skip server-side upload when client already uploaded

### DIFF
--- a/packages/storage-vercel-blob/src/handleUpload.ts
+++ b/packages/storage-vercel-blob/src/handleUpload.ts
@@ -18,7 +18,13 @@ export const getHandleUpload = ({
   prefix = '',
   token,
 }: HandleUploadArgs): HandleUpload => {
-  return async ({ data, file: { buffer, filename, mimeType } }) => {
+  return async ({ clientUploadContext, data, file: { buffer, filename, mimeType } }) => {
+    // When the file was already uploaded directly by the client, skip the
+    // redundant server-side upload to avoid double-writes and race conditions.
+    if (clientUploadContext) {
+      return data
+    }
+
     const fileKey = path.posix.join(data.prefix || prefix, filename)
 
     const result = await put(fileKey, buffer, {


### PR DESCRIPTION
## Summary

When `clientUpload` is enabled, files are uploaded directly from the browser to Vercel Blob. However, the `handleUpload` function is still called server-side afterward, causing a redundant second upload. This can lead to race conditions and intermittent failures (CDN propagation delays overwriting the client-uploaded file).

This PR adds an early return in `handleUpload` when `clientUploadContext` is present, skipping the unnecessary server-side upload.

## Details

The `HandleUpload` type in `@payloadcms/plugin-cloud-storage` already includes `clientUploadContext` as a parameter:

```typescript
export type HandleUpload = (args: {
  clientUploadContext: unknown
  collection: CollectionConfig
  data: any
  file: File
  req: PayloadRequest
}) => ...
```

But the `storage-vercel-blob` adapter does not destructure or use it. This one-line fix brings the implementation in line with the type contract.

**Note:** The same issue exists in `storage-s3`, `storage-azure`, and `storage-gcs` — they also ignore `clientUploadContext`. Happy to submit fixes for those as well if this approach looks good.

Fixes #14709