### PR TITLE
chore: migrate remaining chalk usage to miniChalk utility

### DIFF
--- a/packages/create-payload-app/package.json
+++ b/packages/create-payload-app/package.json
@@ -63,7 +63,6 @@
     "@sindresorhus/slugify": "^1.1.0",
     "@swc/core": "1.15.3",
     "arg": "^5.0.0",
-    "chalk": "^4.1.0",
     "comment-json": "^4.2.3",
     "esprima-next": "^6.0.3",
     "execa": "^5.0.0",

--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -1,5 +1,4 @@
 import * as p from '@clack/prompts'
-import chalk from 'chalk'
 import execa from 'execa'
 import fse from 'fs-extra'
 import { fileURLToPath } from 'node:url'
@@ -15,6 +14,7 @@ import type {
 
 import { tryInitRepoAndCommit } from '../utils/git.js'
 import { debug, error, info, warning } from '../utils/log.js'
+import { miniChalk } from '../utils/miniChalk.js'
 import { configurePayloadConfig } from './configure-payload-config.js'
 import { configurePluginProject } from './configure-plugin-project.js'
 import { downloadExample } from './download-example.js'
@@ -82,7 +82,7 @@ export async function createProject(
   const { cliArgs, dbDetails, packageManager, projectDir, projectName } = args
 
   if (cliArgs['--dry-run']) {
-    debug(`Dry run: Creating project in ${chalk.green(projectDir)}`)
+    debug(`Dry run: Creating project in ${miniChalk.green(projectDir)}`)
     return
   }
 

--- a/packages/create-payload-app/src/lib/wrap-next-config.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.ts
@@ -1,13 +1,13 @@
 import type { ExportDefaultExpression, ModuleItem } from '@swc/core'
 
 import { parse } from '@swc/core'
-import chalk from 'chalk'
 import { parseModule, Syntax } from 'esprima-next'
 import fs from 'fs'
 
 import type { NextConfigType } from '../types.js'
 
 import { log, warning } from '../utils/log.js'
+import { miniChalk } from '../utils/miniChalk.js'
 
 export const withPayloadStatement = {
   cjs: `const { withPayload } = require("@payloadcms/next/withPayload");`,
@@ -169,7 +169,7 @@ function warnUserWrapNotSuccessful(configType: NextConfigType) {
   // Output directions for user to update next.config.js
   const withPayloadMessage = `
 
-  ${chalk.bold(`Please manually wrap your existing Next config with the withPayload function. Here is an example:`)}
+  ${miniChalk.bold(`Please manually wrap your existing Next config with the withPayload function. Here is an example:`)}
 
   ${withPayloadStatement[configType]}
 

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -1,7 +1,6 @@
 import * as p from '@clack/prompts'
 import slugify from '@sindresorhus/slugify'
 import arg from 'arg'
-import chalk from 'chalk'
 import figures from 'figures'
 import path from 'path'
 
@@ -28,6 +27,7 @@ import {
   successfulNextInit,
   successMessage,
 } from './utils/messages.js'
+import { miniChalk } from './utils/miniChalk.js'
 
 export class Main {
   args: CliArgs
@@ -98,7 +98,7 @@ export class Main {
 
       // eslint-disable-next-line no-console
       console.log('\n')
-      p.intro(chalk.bgCyan(chalk.black(' create-payload-app ')))
+      p.intro(miniChalk.bgCyan(miniChalk.black(' create-payload-app ')))
       p.note("Welcome to Payload. Let's create a project!")
 
       // Detect if inside Next.js project
@@ -125,7 +125,7 @@ export class Main {
         p.log.warn(`Payload installation detected in current project.`)
         const shouldUpdate = await p.confirm({
           initialValue: false,
-          message: chalk.bold(`Upgrade Payload in this project?`),
+          message: miniChalk.bold(`Upgrade Payload in this project?`),
         })
 
         if (!p.isCancel(shouldUpdate) && shouldUpdate) {
@@ -154,12 +154,12 @@ export class Main {
 
       if (nextConfigPath) {
         p.log.step(
-          chalk.bold(`${chalk.bgBlack(` ${figures.triangleUp} Next.js `)} project detected!`),
+          miniChalk.bold(`${miniChalk.bgBlack(` ${figures.triangleUp} Next.js `)} project detected!`),
         )
 
         const proceed = await p.confirm({
           initialValue: true,
-          message: chalk.bold(`Install ${chalk.green('Payload')} in this project?`),
+          message: miniChalk.bold(`Install ${miniChalk.green('Payload')} in this project?`),
         })
         if (p.isCancel(proceed) || !proceed) {
           p.outro(feedbackOutro())
@@ -204,7 +204,7 @@ export class Main {
         })
 
         info('Payload project successfully initialized!')
-        p.note(successfulNextInit(), chalk.bgGreen(chalk.black(' Documentation ')))
+        p.note(successfulNextInit(), miniChalk.bgGreen(miniChalk.black(' Documentation ')))
         p.outro(feedbackOutro())
         return
       }
@@ -282,7 +282,7 @@ export class Main {
       }
 
       info('Payload project successfully created!')
-      p.log.step(chalk.bgGreen(chalk.black(' Next Steps ')))
+      p.log.step(miniChalk.bgGreen(miniChalk.black(' Next Steps ')))
       p.log.message(successMessage(projectDir, packageManager))
       p.outro(feedbackOutro())
     } catch (err: unknown) {

--- a/packages/create-payload-app/src/utils/log.ts
+++ b/packages/create-payload-app/src/utils/log.ts
@@ -1,21 +1,22 @@
 import * as p from '@clack/prompts'
-import chalk from 'chalk'
+
+import { miniChalk } from './miniChalk.js'
 
 export const warning = (message: string): void => {
-  p.log.warn(chalk.yellow('? ') + chalk.bold(message))
+  p.log.warn(miniChalk.yellow('? ') + miniChalk.bold(message))
 }
 
 export const info = (message: string): void => {
-  p.log.step(chalk.bold(message))
+  p.log.step(miniChalk.bold(message))
 }
 
 export const error = (message: string): void => {
-  p.log.error(chalk.bold(message))
+  p.log.error(miniChalk.bold(message))
 }
 
 export const debug = (message: string): void => {
   if (process.env.DEBUG === 'true') {
-    p.log.step(`${chalk.bgGray('[DEBUG]')} ${chalk.gray(message)}`)
+    p.log.step(`${miniChalk.bgGray('[DEBUG]')} ${miniChalk.gray(message)}`)
   }
 }
 

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -1,42 +1,42 @@
 /* eslint-disable no-console */
-import chalk from 'chalk'
 import path from 'path'
 import terminalLink from 'terminal-link'
 
 import type { PackageManager, ProjectTemplate } from '../types.js'
 
 import { getValidTemplates } from '../lib/templates.js'
+import { miniChalk } from './miniChalk.js'
 
-const header = (message: string): string => chalk.bold(message)
+const header = (message: string): string => miniChalk.bold(message)
 
-export const welcomeMessage = chalk`
-  {green Welcome to Payload. Let's create a project! }
+export const welcomeMessage = `
+  ${miniChalk.green("Welcome to Payload. Let's create a project! ")}
 `
 
 const spacer = ' '.repeat(8)
 
 export function helpMessage(): void {
   const validTemplates = getValidTemplates()
-  console.log(chalk`
-  {bold USAGE}
+  console.log(`
+  ${miniChalk.bold('USAGE')}
 
-      {dim Inside of an existing Next.js project}
+      ${miniChalk.dim('Inside of an existing Next.js project')}
 
-      {dim $} {bold npx create-payload-app}
+      ${miniChalk.dim('$')} ${miniChalk.bold('npx create-payload-app')}
 
-      {dim Create a new project from scratch}
+      ${miniChalk.dim('Create a new project from scratch')}
 
-      {dim $} {bold npx create-payload-app}
-      {dim $} {bold npx create-payload-app} my-project
-      {dim $} {bold npx create-payload-app} -n my-project -t template-name
+      ${miniChalk.dim('$')} ${miniChalk.bold('npx create-payload-app')}
+      ${miniChalk.dim('$')} ${miniChalk.bold('npx create-payload-app')} my-project
+      ${miniChalk.dim('$')} ${miniChalk.bold('npx create-payload-app')} -n my-project -t template-name
 
-  {bold OPTIONS}
+  ${miniChalk.bold('OPTIONS')}
 
-      -n     {underline my-payload-app}         Set project name
-      -t     {underline template_name}          Choose specific template
-      -e     {underline example_name}           Choose specific example
+      -n     ${miniChalk.underline('my-payload-app')}         Set project name
+      -t     ${miniChalk.underline('template_name')}          Choose specific template
+      -e     ${miniChalk.underline('example_name')}           Choose specific example
 
-        {dim Available templates: ${formatTemplates(validTemplates)}}
+        ${miniChalk.dim(`Available templates: ${formatTemplates(validTemplates)}`)}
 
       --use-npm                     Use npm to install dependencies
       --use-yarn                    Use yarn to install dependencies
@@ -88,9 +88,9 @@ ${header('Next Steps:')}
 
 Payload does not support a top-level layout.tsx file in the app directory.
 
-${chalk.bold('To continue:')}
+${miniChalk.bold('To continue:')}
 
-- Create a new directory in ./${relativeAppDir} such as ./${relativeAppDir}/${chalk.bold('(app)')}
+- Create a new directory in ./${relativeAppDir} such as ./${relativeAppDir}/${miniChalk.bold('(app)')}
 - Move all files from ./${relativeAppDir} into that directory
 
 It is recommended to do this from your IDE if your app has existing file references.
@@ -100,7 +100,7 @@ Once moved, rerun the create-payload-app command again.
 }
 
 export function feedbackOutro(): string {
-  return `${chalk.bgCyan(chalk.black(' Have feedback? '))} Visit us on ${createTerminalLink('GitHub', 'https://github.com/payloadcms/payload')}.`
+  return `${miniChalk.bgCyan(miniChalk.black(' Have feedback? '))} Visit us on ${createTerminalLink('GitHub', 'https://github.com/payloadcms/payload')}.`
 }
 
 // Create terminalLink with fallback for unsupported terminals

--- a/packages/create-payload-app/src/utils/miniChalk.ts
+++ b/packages/create-payload-app/src/utils/miniChalk.ts
@@ -1,0 +1,52 @@
+/**
+ * Lightweight chalk replacement using ANSI escape codes.
+ * Uses specific SGR close codes (not \x1b[0m) so nested calls
+ * preserve outer styles — matching chalk's nesting behavior.
+ */
+const styles: Record<string, { close: string; open: string }> = {
+  // modifiers
+  bold: { close: '\x1b[22m', open: '\x1b[1m' },
+  dim: { close: '\x1b[22m', open: '\x1b[2m' },
+  underline: { close: '\x1b[24m', open: '\x1b[4m' },
+
+  // foreground colors
+  black: { close: '\x1b[39m', open: '\x1b[30m' },
+  blue: { close: '\x1b[39m', open: '\x1b[34m' },
+  cyan: { close: '\x1b[39m', open: '\x1b[36m' },
+  gray: { close: '\x1b[39m', open: '\x1b[90m' },
+  green: { close: '\x1b[39m', open: '\x1b[32m' },
+  magenta: { close: '\x1b[39m', open: '\x1b[35m' },
+  red: { close: '\x1b[39m', open: '\x1b[31m' },
+  white: { close: '\x1b[39m', open: '\x1b[37m' },
+  yellow: { close: '\x1b[39m', open: '\x1b[33m' },
+
+  // background colors
+  bgBlack: { close: '\x1b[49m', open: '\x1b[40m' },
+  bgCyan: { close: '\x1b[49m', open: '\x1b[46m' },
+  bgGray: { close: '\x1b[49m', open: '\x1b[100m' },
+  bgGreen: { close: '\x1b[49m', open: '\x1b[42m' },
+}
+
+function colorize(str: string, style: keyof typeof styles) {
+  const { close, open } = styles[style]!
+  return `${open}${str}${close}`
+}
+
+export const miniChalk = {
+  bgBlack: (str: string) => colorize(str, 'bgBlack'),
+  bgCyan: (str: string) => colorize(str, 'bgCyan'),
+  bgGray: (str: string) => colorize(str, 'bgGray'),
+  bgGreen: (str: string) => colorize(str, 'bgGreen'),
+  black: (str: string) => colorize(str, 'black'),
+  blue: (str: string) => colorize(str, 'blue'),
+  bold: (str: string) => colorize(str, 'bold'),
+  cyan: (str: string) => colorize(str, 'cyan'),
+  dim: (str: string) => colorize(str, 'dim'),
+  gray: (str: string) => colorize(str, 'gray'),
+  green: (str: string) => colorize(str, 'green'),
+  magenta: (str: string) => colorize(str, 'magenta'),
+  red: (str: string) => colorize(str, 'red'),
+  underline: (str: string) => colorize(str, 'underline'),
+  white: (str: string) => colorize(str, 'white'),
+  yellow: (str: string) => colorize(str, 'yellow'),
+}

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -1,7 +1,6 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
 import type { CollectionConfig, Config } from 'payload'
 
-import chalk from 'chalk'
 import { hasAutosaveEnabled } from 'payload/shared'
 
 import type { PluginDefaultTranslationsObject } from './translations/types.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,9 +240,6 @@ importers:
       arg:
         specifier: ^5.0.0
         version: 5.0.2
-      chalk:
-        specifier: ^4.1.0
-        version: 4.1.2
       comment-json:
         specifier: ^4.2.3
         version: 4.5.1
@@ -2291,7 +2288,7 @@ importers:
     dependencies:
       recharts:
         specifier: 3.2.1
-        version: 3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1)
+        version: 3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.614.0
@@ -26105,7 +26102,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts@3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1):
+  recharts@3.2.1(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.9)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
       clsx: 2.1.1
@@ -26115,7 +26112,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@19.2.9)(react@19.2.4)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3


### PR DESCRIPTION
## Summary

Removes the `chalk` dependency from the published `create-payload-app` package and cleans up a dead `chalk` import left behind in `plugin-multi-tenant` after #14003.

- Adds a local `miniChalk` utility to `create-payload-app` following the same pattern already used in `packages/payload` and `packages/plugin-multi-tenant`
- Uses proper SGR close codes (`\x1b[39m`, `\x1b[49m`, `\x1b[22m`) instead of full reset (`\x1b[0m`) so nested calls like `miniChalk.bold(... miniChalk.green(...) ...)` preserve outer styles — matching chalk's nesting behavior
- Converts chalk tagged template literals in `messages.ts` to direct `miniChalk` function calls
- Removes `chalk` from `create-payload-app/package.json` dependencies

### Files changed

| File | Change |
|------|--------|
| `packages/create-payload-app/src/utils/miniChalk.ts` | New — lightweight chalk replacement with nested style support |
| `packages/create-payload-app/src/utils/log.ts` | chalk → miniChalk |
| `packages/create-payload-app/src/utils/messages.ts` | chalk → miniChalk, tagged templates → function calls |
| `packages/create-payload-app/src/lib/create-project.ts` | chalk → miniChalk |
| `packages/create-payload-app/src/lib/wrap-next-config.ts` | chalk → miniChalk |
| `packages/create-payload-app/src/main.ts` | chalk → miniChalk |
| `packages/plugin-multi-tenant/src/index.ts` | Remove unused `chalk` import (already uses miniChalk) |
| `packages/create-payload-app/package.json` | Remove `chalk` dependency |

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit`) for both `create-payload-app` and `plugin-multi-tenant`
- [x] ESLint passes with zero new errors on all changed files
- [ ] `npx create-payload-app` shows colored output correctly (bold labels, bg-colored badges, dim text)
- [ ] Nested styles render correctly (e.g. bold text containing green highlight in `Install Payload in this project?`)