### PR TITLE
docs: improve main workflow readability (no functional change)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,16 @@ concurrency:
 env:
   DO_NOT_TRACK: 1 # Disable Turbopack telemetry
   NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
+  # CI reading path:
+  # 1) changes computes needs_build/needs_tests gates
+  # 2) lint always runs for fast feedback
+  # 3) build seeds cache keyed by commit sha
+  # 4) tests-* restore cache and run focused suites
+  # Local quick subset commands:
+  # pnpm lint -- --quiet
+  # pnpm run build:all
+  # pnpm test:unit
+  # pnpm test:types --target '>=5.7'
 
 jobs:
   changes:
@@ -687,6 +697,7 @@ jobs:
         run: pnpm dev:generate-graphql-schema graphql-schema-gen
 
   all-green:
+    # Aggregate gate: fail if any required upstream job failed or was cancelled.
     name: All Green
     if: always()
     runs-on: ubuntu-24.04
@@ -709,6 +720,7 @@ jobs:
   publish-canary:
     name: Publish Canary
     runs-on: ubuntu-24.04
+    # Canary publish is intentionally limited to successful main-branch runs.
     if: ${{ needs.all-green.result == 'success' && github.ref_name == 'main' }}
     needs:
       - all-green


### PR DESCRIPTION
## Summary
- add structured comments in `.github/workflows/main.yml` describing CI reading path and local quick subset commands
- clarify the aggregate all-green gate and canary publish condition
- no workflow behavior changes (comment-only update)

## Reading path comparison
Before: readers had to infer gating and execution flow by scanning many jobs. After: a top-level reading path maps from `changes` to build/test gates in one pass.

## Evidence
- queue item: `PR_QUEUE_1_2H.md` #3
- target file: https://github.com/payloadcms/payload/blob/main/.github/workflows/main.yml

## Local validation
- `git diff --name-only` confirms only `.github/workflows/main.yml`
- `npx --yes prettier --check .github/workflows/main.yml`

## Risk
- low risk: readability only
- no functional change
