### PR TITLE
fix(drizzle): pass uuidMap in recursive insertArrays call

### DIFF
--- a/packages/drizzle/src/upsertRow/insertArrays.ts
+++ b/packages/drizzle/src/upsertRow/insertArrays.ts
@@ -120,6 +120,7 @@ export const insertArrays = async ({
         arrays: row.arrays,
         db,
         parentRows: insertedRows,
+        uuidMap,
       })
     }
   }


### PR DESCRIPTION
### What does this PR do?

Passes the `uuidMap` parameter through the recursive `insertArrays` call for sub-arrays, fixing a bug where `hasMany` select/relationship fields nested 3+ levels deep in versioned collections fail to save.

### Describe the Bug

When saving a document with a `hasMany: true` select (or relationship) field nested 3+ levels deep (blocks -> array -> sub-array) in a versioned collection, PostgreSQL rejects the insert:

```
invalid input syntax for type uuid: "69a16a831deaff58ca6ac371"
```

`insertArrays` builds a `uuidMap` that maps `_uuid` hex strings to database-generated `id` values. This map is needed so that junction table rows (for `hasMany` fields) receive the correct database UUID as `parent_id`. However, the recursive call for sub-arrays at line ~117 does **not** pass `uuidMap`, so at depth 3+:

- The junction table INSERT receives a raw 24-char `_uuid` hex string instead of a proper UUID
- PostgreSQL rejects it because the `parent_id` column expects UUID type

### The Fix

One-line change — pass `uuidMap` to the recursive call:

```diff
       await insertArrays({
         adapter,
         arrays: row.arrays,
         db,
         parentRows: insertedRows,
+        uuidMap,
       })
```

### How to reproduce

1. Create a versioned collection (`versions: { drafts: true }`)
2. Add a blocks field containing an array, containing a sub-array
3. In the sub-array, add a `hasMany: true` select field
4. Create a document, populate all levels including the hasMany field
5. Save -> error

Example schema that triggers this:

```
Page (versioned, drafts: true)
  -> layout (blocks)
    -> HeroCarousel (block)
      -> slides (array)
        -> actions (array)            <-- depth 3
          -> rel (hasMany select)     <-- junction table INSERT fails
```

### Related

- #15354 reports a similar UUID error for hasMany fields in versioned collections, but on the query/filter path rather than the insert path
- #10829 fixed hasMany select inside arrays and blocks with versions for the read path — this PR addresses the remaining write path issue at deeper nesting