### PR TITLE
test: fix flaky versions tests timing out on link clicks before hydration

### DIFF
--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -196,9 +196,9 @@ describe('Versions', () => {
 
     test('collection — has versions tab', async () => {
       await page.goto(url.list)
-      // Wait for hydration
-      await wait(1000)
-      await page.locator('tbody tr .cell-title a').first().click()
+      const firstRowLink = page.locator('tbody tr .cell-title a').first()
+      const docHref = await firstRowLink.getAttribute('href')
+      await page.goto(`${serverURL}${docHref}`)
 
       const versionsTab = page.locator('.doc-tab:has-text("Versions")')
       await versionsTab.waitFor({ state: 'visible' })
@@ -217,14 +217,14 @@ describe('Versions', () => {
     test('collection — tab displays proper number of versions', async () => {
       await page.goto(url.list)
       // Wait for hydration
-      await wait(1000)
       const linkToDoc = page
         .locator('tbody tr .cell-title a', {
           hasText: exactText('Title With Many Versions 11'),
         })
         .first()
       expect(linkToDoc).toBeTruthy()
-      await linkToDoc.click()
+      const linkHref = await linkToDoc.getAttribute('href')
+      await page.goto(`${serverURL}${linkHref}`)
       const versionsTab = page.locator('.doc-tab', {
         hasText: 'Versions',
       })
@@ -237,11 +237,9 @@ describe('Versions', () => {
 
     test('collection — has versions route', async () => {
       await page.goto(url.list)
-      // Wait for hydration
-      await wait(1000)
-      await page.locator('tbody tr .cell-title a').first().click()
-      await page.waitForSelector('.doc-header__title', { state: 'visible' })
-      await page.goto(`${page.url()}/versions`)
+      const firstRowLink = page.locator('tbody tr .cell-title a').first()
+      const docHref = await firstRowLink.getAttribute('href')
+      await page.goto(`${serverURL}${docHref}/versions`)
       await expect(() => {
         expect(page.url()).toMatch(/\/versions/)
       }).toPass({ timeout: 10000, intervals: [100] })
@@ -270,9 +268,9 @@ describe('Versions', () => {
 
     test('should show collection versions view level action in collection versions view', async () => {
       await page.goto(url.list)
-      // Wait for hydration
-      await wait(1000)
-      await page.locator('tbody tr .cell-title a').first().click()
+      const firstRowLink = page.locator('tbody tr .cell-title a').first()
+      const docHref = await firstRowLink.getAttribute('href')
+      await page.goto(`${serverURL}${docHref}`)
 
       // Wait for the document to load
       const versionsTab = page.locator('.doc-tab', {
@@ -725,8 +723,7 @@ describe('Versions', () => {
       await page.goto(autosaveURL.list)
       const secondRowLink = page.locator('tbody tr:nth-child(2) .cell-title a')
       const docURL = await secondRowLink.getAttribute('href')
-      await secondRowLink.click()
-      await page.waitForURL(`**${docURL}`)
+      await page.goto(`${serverURL}${docURL}`)
       await expect(page.locator('#field-title')).toHaveValue('first post title')
       await expect(page.locator('#field-description')).toHaveValue('first post description')
     })
@@ -739,9 +736,9 @@ describe('Versions', () => {
       await saveDocAndAssert(page)
 
       await page.goto(customIDURL.list)
-      // Wait for hydration
-      await wait(1000)
-      await page.locator('tbody tr .cell-id a').click()
+      const customIDLink = page.locator('tbody tr .cell-id a')
+      const docURL = await customIDLink.getAttribute('href')
+      await page.goto(`${serverURL}${docURL}`)
 
       await expect(page.locator('div.id-label')).toHaveText(/custom/)
       await expect(page.locator('#field-title')).toHaveValue('title')
@@ -972,11 +969,9 @@ describe('Versions', () => {
     describe('A11y', () => {
       test('Versions list view should have no accessibility violations', async ({}, testInfo) => {
         await page.goto(url.list)
-        // Wait for hydration
-        await wait(1000)
-        await page.locator('tbody tr .cell-title a').first().click()
-        await page.waitForSelector('.doc-header__title', { state: 'visible' })
-        await page.goto(`${page.url()}/versions`)
+        const firstRowLink = page.locator('tbody tr .cell-title a').first()
+        const docHref = await firstRowLink.getAttribute('href')
+        await page.goto(`${serverURL}${docHref}/versions`)
         await expect(() => {
           expect(page.url()).toMatch(/\/versions/)
         }).toPass({ timeout: 10000, intervals: [100] })
@@ -992,11 +987,9 @@ describe('Versions', () => {
 
       test('Versions list view elements have focus indicators', async ({}, testInfo) => {
         await page.goto(url.list)
-        // Wait for hydration
-        await wait(1000)
-        await page.locator('tbody tr .cell-title a').first().click()
-        await page.waitForSelector('.doc-header__title', { state: 'visible' })
-        await page.goto(`${page.url()}/versions`)
+        const firstRowLink = page.locator('tbody tr .cell-title a').first()
+        const docHref = await firstRowLink.getAttribute('href')
+        await page.goto(`${serverURL}${docHref}/versions`)
         await expect(() => {
           expect(page.url()).toMatch(/\/versions/)
         }).toPass({ timeout: 10000, intervals: [100] })
@@ -1013,16 +1006,16 @@ describe('Versions', () => {
 
       test.fixme('Version view should have no accessibility violations', async ({}, testInfo) => {
         await page.goto(url.list)
-        // Wait for hydration
-        await wait(1000)
-        await page.locator('tbody tr .cell-title a').first().click()
-        await page.waitForSelector('.doc-header__title', { state: 'visible' })
-        await page.goto(`${page.url()}/versions`)
+        const firstRowLink = page.locator('tbody tr .cell-title a').first()
+        const docHref = await firstRowLink.getAttribute('href')
+        await page.goto(`${serverURL}${docHref}/versions`)
         await expect(() => {
           expect(page.url()).toMatch(/\/versions/)
         }).toPass({ timeout: 10000, intervals: [100] })
 
-        await page.locator('.cell-updatedAt a').first().click()
+        const versionLink = page.locator('.cell-updatedAt a').first()
+        const versionHref = await versionLink.getAttribute('href')
+        await page.goto(`${serverURL}${versionHref}`)
 
         await page.locator('.view-version').waitFor()
 
@@ -1037,11 +1030,9 @@ describe('Versions', () => {
 
       test('Version view elements have focus indicators', async ({}, testInfo) => {
         await page.goto(url.list)
-        // Wait for hydration
-        await wait(1000)
-        await page.locator('tbody tr .cell-title a').first().click()
-        await page.waitForSelector('.doc-header__title', { state: 'visible' })
-        await page.goto(`${page.url()}/versions`)
+        const firstRowLink = page.locator('tbody tr .cell-title a').first()
+        const docHref = await firstRowLink.getAttribute('href')
+        await page.goto(`${serverURL}${docHref}/versions`)
         await expect(() => {
           expect(page.url()).toMatch(/\/versions/)
         }).toPass({ timeout: 10000, intervals: [100] })
@@ -1265,7 +1256,8 @@ describe('Versions', () => {
 
       const versionAnchor = versionsTable.locator('tbody tr.row-1 td.cell-updatedAt a')
       await expect(versionAnchor).toBeVisible()
-      await versionAnchor.click()
+      const versionHref = await versionAnchor.getAttribute('href')
+      await page.goto(`${serverURL}${versionHref}`)
 
       const compareFromContainer = page.locator(
         '.view-version__version-from .field-type.compare-version',
@@ -1865,7 +1857,7 @@ describe('Versions', () => {
 
       // press slower than the autosave interval, but not faster than the response and processing
       await titleField.pressSequentially('Initial', {
-        delay: 150,
+        delay: 100,
       })
 
       const drawer = page.locator('[id^=doc-drawer_autosave-posts_1_]')

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -148,6 +148,9 @@ export interface Config {
     'draft-unlimited-global': DraftUnlimitedGlobalSelect<false> | DraftUnlimitedGlobalSelect<true>;
   };
   locale: 'en' | 'es' | 'de';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: {
@@ -405,17 +408,25 @@ export interface LocalizedPost {
   text?: string | null;
   description?: string | null;
   blocks?:
-    | {
-        array?:
-          | {
-              relationship?: (string | null) | Post;
-              id?: string | null;
-            }[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'block';
-      }[]
+    | (
+        | {
+            array?:
+              | {
+                  relationship?: (string | null) | Post;
+                  id?: string | null;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'block';
+          }
+        | {
+            blockText?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'localizedTextBlock';
+          }
+      )[]
     | null;
   updatedAt: string;
   createdAt: string;
@@ -1123,6 +1134,13 @@ export interface LocalizedPostsSelect<T extends boolean = true> {
               id?: T;
               blockName?: T;
             };
+        localizedTextBlock?:
+          | T
+          | {
+              blockText?: T;
+              id?: T;
+              blockName?: T;
+            };
       };
   updatedAt?: T;
   createdAt?: T;
@@ -1572,6 +1590,16 @@ export interface DraftUnlimitedGlobalSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What

Fix flaky versions e2e tests that timeout when clicking table row and version links.

### Why

Since Next.js 16, clicking links before page hydration completes doesn't trigger navigation sometimes. The test finds the link and clicks it, but nothing happens, causing timeouts waiting for the page to load.

### How

Extract href attributes and navigate directly with `page.goto()` instead of clicking. Also reduced typing delay in autosave test to complete within timeout under CPU throttling.

