### PR TITLE
fix: update broken custom components docs link in config types jsdoc

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -854,7 +854,7 @@ export type Config = {
     /**
      * Add extra and/or replace built-in components with custom components
      *
-     * @see https://payloadcms.com/docs/admin/custom-components/overview
+     * @see https://payloadcms.com/docs/custom-components/overview
      */
     components?: {
       /**


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?

Fix a broken documentation link in the `Config` type JSDoc for admin custom components.

- Updated:
  - `https://payloadcms.com/docs/admin/custom-components/overview`
- To:
  - `https://payloadcms.com/docs/custom-components/overview`

### Why?

The previous URL was broken/outdated, so developers reading type definitions were sent to an invalid docs path.

### How?

Changed the `@see` link in:

- `packages/payload/src/config/types.ts`

No runtime behavior or API logic changed; this is a docs-link correction only.
