### PR TITLE
fix(plugin-import-export): fix imports with locales in a different column order than exported

### DIFF
--- a/packages/plugin-import-export/src/import/batchProcessor.ts
+++ b/packages/plugin-import-export/src/import/batchProcessor.ts
@@ -58,17 +58,18 @@ export interface ImportProcessOptions {
  * Separates multi-locale data from a document for sequential locale updates.
  *
  * When a field has locale-keyed values (e.g., { title: { en: 'Hello', es: 'Hola' } }),
- * this extracts the first locale's data for initial create/update, and stores
+ * this extracts the default locale's data for initial create/update, and stores
  * remaining locales for subsequent update calls.
  *
  * @returns
- * - flatData: Document with first locale values extracted (for initial operation)
+ * - flatData: Document with default locale values extracted (for initial operation)
  * - hasMultiLocale: Whether any multi-locale fields were found
  * - localeUpdates: Map of locale -> field data for follow-up updates
  */
 function extractMultiLocaleData(
   data: Record<string, unknown>,
   configuredLocales?: string[],
+  defaultLocale?: string,
 ): {
   flatData: Record<string, unknown>
   hasMultiLocale: boolean
@@ -91,11 +92,12 @@ function extractMultiLocaleData(
 
       if (localeKeys.length > 0) {
         hasMultiLocale = true
-        const firstLocale = localeKeys[0]
-        if (firstLocale) {
-          flatData[key] = valueObj[firstLocale]
+        const baseLocale =
+          defaultLocale && localeKeys.includes(defaultLocale) ? defaultLocale : localeKeys[0]
+        if (baseLocale) {
+          flatData[key] = valueObj[baseLocale]
           for (const locale of localeKeys) {
-            if (locale !== firstLocale) {
+            if (locale !== baseLocale) {
               if (!localeUpdates[locale]) {
                 localeUpdates[locale] = {}
               }
@@ -168,6 +170,10 @@ async function processImportBatch({
     ? req.payload.config.localization.localeCodes
     : undefined
 
+  const defaultLocale = req.payload.config.localization
+    ? req.payload.config.localization.defaultLocale
+    : undefined
+
   const startingRowNumber = batchIndex * options.batchSize
 
   for (let i = 0; i < batch.length; i++) {
@@ -217,16 +223,18 @@ async function processImportBatch({
         const { flatData, hasMultiLocale, localeUpdates } = extractMultiLocaleData(
           createData,
           configuredLocales,
+          defaultLocale,
         )
 
         if (hasMultiLocale) {
           // Create with default locale data
+          const defaultLocaleReq = defaultLocale ? { ...req, locale: defaultLocale } : req
           savedDocument = await req.payload.create({
             collection: collectionSlug,
             data: flatData,
             draft: draftOption,
             overrideAccess: false,
-            req,
+            req: defaultLocaleReq,
             user,
           })
 
@@ -343,6 +351,7 @@ async function processImportBatch({
           const { flatData, hasMultiLocale, localeUpdates } = extractMultiLocaleData(
             updateData,
             configuredLocales,
+            defaultLocale,
           )
 
           if (req.payload.config.debug) {
@@ -365,6 +374,7 @@ async function processImportBatch({
 
           if (hasMultiLocale) {
             // Update with default locale data
+            const defaultLocaleReq = defaultLocale ? { ...req, locale: defaultLocale } : req
             savedDocument = await req.payload.update({
               id: existingDoc.id as number | string,
               collection: collectionSlug,
@@ -372,7 +382,7 @@ async function processImportBatch({
               depth: 0,
               // Don't specify draft - this creates a new draft for versioned collections
               overrideAccess: false,
-              req,
+              req: defaultLocaleReq,
               user,
             })
 
@@ -474,16 +484,18 @@ async function processImportBatch({
           const { flatData, hasMultiLocale, localeUpdates } = extractMultiLocaleData(
             createData,
             configuredLocales,
+            defaultLocale,
           )
 
           if (hasMultiLocale) {
             // Create with default locale data
+            const defaultLocaleReq = defaultLocale ? { ...req, locale: defaultLocale } : req
             savedDocument = await req.payload.create({
               collection: collectionSlug,
               data: flatData,
               draft: draftOption,
               overrideAccess: false,
-              req,
+              req: defaultLocaleReq,
               user,
             })
 

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -3123,6 +3123,93 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPagesEs.docs[0]?.localized).toBe('Spanish text 1')
     })
 
+    it('should import localized fields correctly regardless of CSV column order', async () => {
+      // CSV columns intentionally put 'de' before 'en' (the defaultLocale)
+      // to verify the import uses defaultLocale, not CSV column order
+      const csvContent =
+        'title,localized_de,localized_en,localized_es\n' +
+        '"Locale Order Test 1","German text 1","English text 1","Spanish text 1"\n' +
+        '"Locale Order Test 2","German text 2","English text 2","Spanish text 2"'
+
+      const csvBuffer = Buffer.from(csvContent)
+
+      let importDoc = await payload.create({
+        collection: 'imports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          importMode: 'create',
+        },
+        file: {
+          data: csvBuffer,
+          mimetype: 'text/csv',
+          name: 'locale-order-test.csv',
+          size: csvBuffer.length,
+        },
+      })
+
+      await payload.jobs.run()
+
+      importDoc = await payload.findByID({
+        collection: 'imports',
+        id: importDoc.id,
+      })
+
+      expect(importDoc.status).toBe('completed')
+      expect(importDoc.summary?.imported).toBe(2)
+      expect(importDoc.summary?.issues).toBe(0)
+
+      // Verify English (defaultLocale) has the correct English values, not German
+      const importedPagesEn = await payload.find({
+        collection: 'pages',
+        where: {
+          title: { contains: 'Locale Order Test ' },
+        },
+        locale: 'en',
+        sort: 'title',
+      })
+
+      expect(importedPagesEn.docs).toHaveLength(2)
+      expect(importedPagesEn.docs[0]?.localized).toBe('English text 1')
+      expect(importedPagesEn.docs[1]?.localized).toBe('English text 2')
+
+      // Verify German has the correct German values, not missing
+      const importedPagesDe = await payload.find({
+        collection: 'pages',
+        where: {
+          title: { contains: 'Locale Order Test ' },
+        },
+        locale: 'de',
+        sort: 'title',
+      })
+
+      expect(importedPagesDe.docs).toHaveLength(2)
+      expect(importedPagesDe.docs[0]?.localized).toBe('German text 1')
+      expect(importedPagesDe.docs[1]?.localized).toBe('German text 2')
+
+      // Verify Spanish has the correct Spanish values
+      const importedPagesEs = await payload.find({
+        collection: 'pages',
+        where: {
+          title: { contains: 'Locale Order Test ' },
+        },
+        locale: 'es',
+        sort: 'title',
+      })
+
+      expect(importedPagesEs.docs).toHaveLength(2)
+      expect(importedPagesEs.docs[0]?.localized).toBe('Spanish text 1')
+      expect(importedPagesEs.docs[1]?.localized).toBe('Spanish text 2')
+
+      // Cleanup
+      await payload.delete({
+        collection: 'pages',
+        where: {
+          title: { contains: 'Locale Order Test ' },
+        },
+      })
+    })
+
     it('should import array fields from CSV', async () => {
       const csvContent =
         'title,array_0_field1,array_0_field2,array_1_field1,array_1_field2\n' +


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15804

There was an issue where if the localized columns were not in the same order as the data was exported it would import the data into the wrong locale as it wasn't reading the "defaultLocale" config and just using the first locale in the config.