### PR TITLE
fix(plugin-import-export): fix exports in other non-latin scripts being broken when opened in excel

### DIFF
--- a/packages/plugin-import-export/src/components/ExportSaveButton/index.tsx
+++ b/packages/plugin-import-export/src/components/ExportSaveButton/index.tsx
@@ -99,24 +99,11 @@ export const ExportSaveButton: React.FC = () => {
         throw new Error(errorMsg)
       }
 
-      const fileStream = response.body
-      const reader = fileStream?.getReader()
-      const decoder = new TextDecoder()
-      let result = ''
-
-      while (reader) {
-        const { done, value } = await reader.read()
-        if (done) {
-          break
-        }
-        result += decoder.decode(value, { stream: true })
-      }
-
-      const blob = new Blob([result], { type: 'text/plain' })
+      const blob = await response.blob()
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `${data.name}.${data.format}`
+      a.download = `${data.name}-${data.collectionSlug}.${data.format}`
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)

--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -406,7 +406,7 @@ export const createExport = async (args: CreateExportArgs) => {
     return new Response(Readable.toWeb(stream) as ReadableStream, {
       headers: {
         'Content-Disposition': `attachment; filename="${name}"`,
-        'Content-Type': isCSV ? 'text/csv' : 'application/json',
+        'Content-Type': isCSV ? 'text/csv; charset=utf-8' : 'application/json',
       },
     })
   }
@@ -511,7 +511,7 @@ export const createExport = async (args: CreateExportArgs) => {
     req.file = {
       name,
       data: buffer,
-      mimetype: isCSV ? 'text/csv' : 'application/json',
+      mimetype: isCSV ? 'text/csv; charset=utf-8' : 'application/json',
       size: buffer.length,
     }
   } else {
@@ -522,7 +522,7 @@ export const createExport = async (args: CreateExportArgs) => {
         exportCollection,
         fileName: name,
         fileSize: buffer.length,
-        mimeType: isCSV ? 'text/csv' : 'application/json',
+        mimeType: isCSV ? 'text/csv; charset=utf-8' : 'application/json',
       })
     }
     try {
@@ -533,7 +533,7 @@ export const createExport = async (args: CreateExportArgs) => {
         file: {
           name,
           data: buffer,
-          mimetype: isCSV ? 'text/csv' : 'application/json',
+          mimetype: isCSV ? 'text/csv; charset=utf-8' : 'application/json',
           size: buffer.length,
         },
         // Override access only here so that we can be sure the export collection itself is updated as expected

--- a/test/plugin-import-export/config.ts
+++ b/test/plugin-import-export/config.ts
@@ -2,6 +2,7 @@ import { importExportPlugin } from '@payloadcms/plugin-import-export'
 import { s3Storage } from '@payloadcms/storage-s3'
 import { en } from '@payloadcms/translations/languages/en'
 import { es } from '@payloadcms/translations/languages/es'
+import { he } from '@payloadcms/translations/languages/he'
 import dotenv from 'dotenv'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
@@ -54,12 +55,18 @@ export default buildConfigWithDefaults({
   localization: {
     defaultLocale: 'en',
     fallback: true,
-    locales: ['en', 'es', 'de'],
+    locales: [
+      { code: 'en', label: 'English' },
+      { code: 'es', label: 'Spanish' },
+      { code: 'de', label: 'German' },
+      { code: 'he', label: 'Hebrew', rtl: true },
+    ],
   },
   i18n: {
     supportedLanguages: {
       en,
       es,
+      he,
     },
     fallbackLanguage: 'en',
   },

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -743,6 +743,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toMatch(/application\/json/)
 
+      const contentDisposition = response.headers.get('content-disposition')
+      expect(contentDisposition).toContain('-pages.json')
+
       const data = await response.json()
 
       expect(Array.isArray(data)).toBe(true)
@@ -2321,6 +2324,161 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data[0].excerpt).toBe(specialCharsExcerpt)
 
         await payload.delete({ collection: 'pages', id: page.id })
+      })
+
+      it('should preserve Hebrew characters in CSV download via streaming endpoint', async () => {
+        const hebrewTitle = 'Hebrew BOM Test'
+        const hebrewLocalized = 'בדיקה עברית'
+
+        const page = await payload.create({
+          collection: 'pages',
+          data: {
+            title: hebrewTitle,
+            localized: hebrewLocalized,
+            _status: 'published',
+          },
+          locale: 'he',
+        })
+
+        const response = await restClient.POST('/exports/download', {
+          body: JSON.stringify({
+            data: {
+              collectionSlug: 'pages',
+              fields: ['id', 'title', 'localized'],
+              format: 'csv',
+              locale: 'he',
+              where: { id: { equals: page.id } },
+            },
+          }),
+          headers: { 'Content-Type': 'application/json' },
+        })
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toMatch(/text\/csv/)
+        expect(response.headers.get('content-type')).toContain('charset=utf-8')
+
+        const contentDisposition = response.headers.get('content-disposition')
+        expect(contentDisposition).toContain('-pages.csv')
+
+        const buffer = Buffer.from(await response.arrayBuffer())
+
+        // Verify UTF-8 BOM is present
+        expect(buffer[0]).toBe(0xef)
+        expect(buffer[1]).toBe(0xbb)
+        expect(buffer[2]).toBe(0xbf)
+
+        // Verify Hebrew text is correctly encoded in the CSV body
+        const content = buffer.toString('utf-8')
+        expect(content).toContain(hebrewLocalized)
+
+        await payload.delete({ collection: 'pages', id: page.id })
+      })
+
+      it('should preserve Hebrew characters in job-created CSV export', async () => {
+        const hebrewTitle = 'Hebrew Jobs Test'
+        const hebrewLocalized = 'שלום עולם'
+
+        const page = await payload.create({
+          collection: 'pages',
+          data: {
+            title: hebrewTitle,
+            localized: hebrewLocalized,
+            _status: 'published',
+          },
+          locale: 'he',
+        })
+
+        let doc = await payload.create({
+          collection: 'exports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            fields: ['id', 'title', 'localized'],
+            format: 'csv',
+            locale: 'he',
+            where: { id: { equals: page.id } },
+          },
+        })
+
+        await payload.jobs.run()
+
+        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+
+        // Verify filename includes collection slug and csv extension
+        expect(doc.filename).toContain('-pages')
+        expect(doc.filename).toMatch(/\.csv$/)
+        expect(doc.mimeType).toContain('charset=utf-8')
+
+        const csvPath = path.join(dirname, './uploads', doc.filename as string)
+        const buffer = fs.readFileSync(csvPath)
+
+        // Verify UTF-8 BOM
+        expect(buffer[0]).toBe(0xef)
+        expect(buffer[1]).toBe(0xbb)
+        expect(buffer[2]).toBe(0xbf)
+
+        // Verify Hebrew text is readable
+        const content = buffer.toString('utf-8')
+        expect(content).toContain(hebrewLocalized)
+
+        // Verify via CSV parse
+        const data = await readCSV(csvPath)
+        expect(data[0].localized).toBe(hebrewLocalized)
+
+        await payload.delete({ collection: 'pages', id: page.id })
+      })
+
+      it('should preserve Hebrew characters in hook-created CSV export (no jobs queue)', async () => {
+        const hebrewTitle = 'Hebrew Hooks Test'
+        const hebrewContent = 'טקסט בעברית'
+
+        const post = await payload.create({
+          collection: 'posts',
+          data: {
+            title: hebrewTitle,
+            content: richTextData,
+            _status: 'published',
+          },
+        })
+
+        const doc = await payload.create({
+          collection: 'posts-export',
+          user,
+          data: {
+            collectionSlug: 'posts',
+            fields: ['id', 'title'],
+            format: 'csv',
+            where: { id: { equals: post.id } },
+          },
+        })
+
+        const exportDoc = await payload.findByID({
+          collection: 'posts-export',
+          id: doc.id,
+        })
+
+        // Verify filename includes collection slug and csv extension
+        expect(exportDoc.filename).toContain('-posts')
+        expect(exportDoc.filename).toMatch(/\.csv$/)
+        expect(exportDoc.mimeType).toContain('charset=utf-8')
+
+        const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
+        const buffer = fs.readFileSync(csvPath)
+
+        // Verify UTF-8 BOM
+        expect(buffer[0]).toBe(0xef)
+        expect(buffer[1]).toBe(0xbb)
+        expect(buffer[2]).toBe(0xbf)
+
+        // Verify Hebrew title is correctly encoded
+        const content = buffer.toString('utf-8')
+        expect(content).toContain(hebrewTitle)
+
+        // Verify via CSV parse
+        const data = await readCSV(csvPath)
+        expect(data[0].title).toBe(hebrewTitle)
+
+        await payload.delete({ collection: 'posts', id: post.id })
       })
     })
 

--- a/test/plugin-import-export/payload-types.ts
+++ b/test/plugin-import-export/payload-types.ts
@@ -123,10 +123,18 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
-  fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es' | 'de') | ('en' | 'es' | 'de')[];
+  fallbackLocale:
+    | ('false' | 'none' | 'null')
+    | false
+    | null
+    | ('en' | 'es' | 'de' | 'he')
+    | ('en' | 'es' | 'de' | 'he')[];
   globals: {};
   globalsSelect: {};
-  locale: 'en' | 'es' | 'de';
+  locale: 'en' | 'es' | 'de' | 'he';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: {
@@ -500,7 +508,7 @@ export interface Export {
   page?: number | null;
   sort?: string | null;
   sortOrder?: ('asc' | 'desc') | null;
-  locale?: ('all' | 'en' | 'es' | 'de') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
   drafts?: ('yes' | 'no') | null;
   selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
   fields?: string[] | null;
@@ -538,7 +546,7 @@ export interface PostsExport {
   page?: number | null;
   sort?: string | null;
   sortOrder?: ('asc' | 'desc') | null;
-  locale?: ('all' | 'en' | 'es' | 'de') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
   drafts?: ('yes' | 'no') | null;
   selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
   fields?: string[] | null;
@@ -576,7 +584,7 @@ export interface PostsNoJobsQueueExport {
   page?: number | null;
   sort?: string | null;
   sortOrder?: ('asc' | 'desc') | null;
-  locale?: ('all' | 'en' | 'es' | 'de') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
   drafts?: ('yes' | 'no') | null;
   selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
   fields?: string[] | null;
@@ -614,7 +622,7 @@ export interface PostsWithS3Export {
   page?: number | null;
   sort?: string | null;
   sortOrder?: ('asc' | 'desc') | null;
-  locale?: ('all' | 'en' | 'es' | 'de') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
   drafts?: ('yes' | 'no') | null;
   selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
   fields?: string[] | null;
@@ -652,7 +660,7 @@ export interface PostsWithLimitsExport {
   page?: number | null;
   sort?: string | null;
   sortOrder?: ('asc' | 'desc') | null;
-  locale?: ('all' | 'en' | 'es' | 'de') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
   drafts?: ('yes' | 'no') | null;
   selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
   fields?: string[] | null;
@@ -1560,6 +1568,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-import-export/seed/index.ts
+++ b/test/plugin-import-export/seed/index.ts
@@ -90,6 +90,26 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         },
         locale: 'es',
       })
+      await payload.update({
+        collection: 'pages',
+        id: doc.id,
+        data: {
+          localized: `בדיקה ${i}`,
+        },
+        locale: 'he',
+      })
+    }
+
+    // Seed Hebrew-only pages
+    for (let i = 0; i < 5; i++) {
+      await payload.create({
+        collection: 'pages',
+        data: {
+          title: `Hebrew ${i}`,
+          localized: `בדיקה ${i}`,
+        },
+        locale: 'he',
+      })
     }
     for (let i = 0; i < 5; i++) {
       await payload.create({


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/13929

We were not correctly marking the mime headers to our .csv files with UTF-8 encoding and as such when they were being downloaded it would affect the file's formatting.

After this PR when opening Hebrew exported in CSV it will look as expected in the software.

Tested manually with Microsoft Excel.

A side effect of this PR is also that Excel can now correctly prompt you to adjust the delimiting every time, for our files make sure you set it to `Comma` instead of tabs to have everything properly separated by columns.
<img width="583" height="447" alt="image" src="https://github.com/user-attachments/assets/322367a1-580c-4e7f-84c9-d9b9d857e5e3" />
