### PR TITLE
fix: draft doc validation when duplicating docs

### DIFF
--- a/packages/payload/src/collections/endpoints/duplicate.ts
+++ b/packages/payload/src/collections/endpoints/duplicate.ts
@@ -11,7 +11,8 @@ import { duplicateOperation } from '../operations/duplicate.js'
 export const duplicateHandler: PayloadHandler = async (req) => {
   const { id, collection } = getRequestCollectionWithID(req)
 
-  const { depth, draft, populate, select, selectedLocales } = parseParams(req.query)
+  const { depth, draft: draftParam, populate, select, selectedLocales } = parseParams(req.query)
+  const draft = draftParam ?? true
 
   const doc = await duplicateOperation({
     id,

--- a/packages/payload/src/collections/endpoints/duplicate.ts
+++ b/packages/payload/src/collections/endpoints/duplicate.ts
@@ -11,8 +11,7 @@ import { duplicateOperation } from '../operations/duplicate.js'
 export const duplicateHandler: PayloadHandler = async (req) => {
   const { id, collection } = getRequestCollectionWithID(req)
 
-  const { depth, draft: draftParam, populate, select, selectedLocales } = parseParams(req.query)
-  const draft = draftParam ?? true
+  const { depth, draft = true, populate, select, selectedLocales } = parseParams(req.query)
 
   const doc = await duplicateOperation({
     id,

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -96,6 +96,9 @@ export interface Config {
     menu: MenuSelect<false> | MenuSelect<true>;
   };
   locale: null;
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -434,6 +437,16 @@ export interface MenuSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -96,9 +96,6 @@ export interface Config {
     menu: MenuSelect<false> | MenuSelect<true>;
   };
   locale: null;
-  widgets: {
-    collections: CollectionsWidget;
-  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -437,16 +434,6 @@ export interface MenuSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "collections_widget".
- */
-export interface CollectionsWidget {
-  data?: {
-    [k: string]: unknown;
-  };
-  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -476,6 +476,63 @@ describe('Versions', () => {
         })
 
         expect(duplicatedDoc._status).toBe('draft')
+
+        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+      })
+
+      it('should duplicate a draft document with empty required fields via local API', async () => {
+        const originalDoc = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            title: 'Draft with partial data',
+            _status: 'draft',
+          },
+          draft: true,
+        })
+
+        // description is required but missing — duplicate should still succeed as a draft
+        const duplicatedDoc = await payload.duplicate({
+          id: originalDoc.id,
+          collection: draftCollectionSlug,
+          draft: true,
+        })
+
+        expect(duplicatedDoc._status).toBe('draft')
+        expect(duplicatedDoc.id).not.toEqual(originalDoc.id)
+        expect(duplicatedDoc.title).toContain('Draft with partial data')
+
+        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+      })
+
+      it('should duplicate a draft document with empty required fields via REST API without explicit draft param', async () => {
+        const originalDoc = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            title: 'REST draft partial',
+            _status: 'draft',
+          },
+          draft: true,
+        })
+
+        // Mimics the admin UI: POST to /:collection/:id/duplicate
+        // with { _status: 'draft' } in body and NO draft query parameter
+        const response = await restClient.POST(
+          `/${draftCollectionSlug}/${originalDoc.id}/duplicate`,
+          {
+            body: JSON.stringify({ _status: 'draft' }),
+          },
+        )
+
+        const { doc } = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(doc._status).toBe('draft')
+        expect(doc.id).not.toEqual(originalDoc.id)
+
+        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
       })
     })
 


### PR DESCRIPTION
### What?
This PR defaults the `draft` value to true when it is not set during a duplicate operation.

### Why?
It validates the required fields even if the user is trying to duplicate a draft doc.

The regression was introduced when [`packages/payload/src/collections/endpoints/duplicate.ts`](https://github.com/payloadcms/payload/blob/v3.77.0/packages/payload/src/collections/endpoints/duplicate.ts) was refactored to use the shared `parseParams` utility instead of manually parsing query parameters.

**v3.62.0 (working)** — In [v3.62.0 of `duplicate.ts`](https://github.com/payloadcms/payload/blob/v3.62.0/packages/payload/src/collections/endpoints/duplicate.ts), the `draft` parameter was explicitly defaulted to `true`:

```typescript
// draft defaults to true, unless explicitly set requested as false
// to prevent the newly duplicated document from being published
const draft = searchParams.get('draft') !== 'false'
```

**v3.77.0 (broken)** — In [v3.77.0 of `duplicate.ts`](https://github.com/payloadcms/payload/blob/v3.77.0/packages/payload/src/collections/endpoints/duplicate.ts), the endpoint uses [`parseParams`](https://github.com/payloadcms/payload/blob/v3.77.0/packages/payload/src/utilities/parseParams/index.ts):

```typescript
const { depth, draft, populate, select, selectedLocales } = parseParams(req.query)
```

`parseParams` only sets `draft` to `true` if the query string explicitly contains `?draft=true`. The admin UI's [`DuplicateDocument`](https://github.com/payloadcms/payload/blob/v3.77.0/packages/ui/src/elements/DuplicateDocument/index.tsx) component does **not** send `?draft=true` as a query parameter, so `draft` is `undefined`.

The UI does send `{ _status: 'draft' }` in the request body, but that does not influence the `draft` flag. In [`createOperation`](https://github.com/payloadcms/payload/blob/v3.77.0/packages/payload/src/collections/operations/create.ts), the validation skip logic depends entirely on the `draft` argument:

```typescript
const isSavingDraft = Boolean(draft && hasDraftsEnabled(collectionConfig) && !publishAllLocales)
// ...
skipValidation: isSavingDraft && !hasDraftValidationEnabled(collectionConfig),
```

Since `draft` is `undefined`, `isSavingDraft` is `false`, `skipValidation` is `false`, and full validation runs — rejecting the duplicate when any required fields are empty.

### How?
By setting the `draft` value as `true` by default when it is not set during a duplicate operation:

Fixes #15815
