### PR TITLE
fix: restoreVersion validation for localized required fields

### DIFF
--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -143,7 +143,9 @@ export const restoreVersionOperation = async <
     })
 
     // originalDoc with hoisted localized data
-    const validationLocale = payload.config.localization?.defaultLocale || locale
+    const validationLocale = payload.config.localization
+      ? payload.config.localization.defaultLocale
+      : locale!
 
     const originalDoc = await afterRead({
       collection: collectionConfig,

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -80,7 +80,7 @@ export const restoreVersionOperation = async <
     const { docs: versionDocs } = await req.payload.db.findVersions({
       collection: collectionConfig.slug,
       limit: 1,
-      locale: locale!,
+      locale: 'all',
       pagination: false,
       req,
       where: { id: { equals: id } },
@@ -109,7 +109,7 @@ export const restoreVersionOperation = async <
 
     const findOneArgs: FindOneArgs = {
       collection: collectionConfig.slug,
-      locale: locale!,
+      locale: 'all',
       req,
       where: combineQueries({ id: { equals: parentDocID } }, accessResults),
     }
@@ -143,6 +143,8 @@ export const restoreVersionOperation = async <
     })
 
     // originalDoc with hoisted localized data
+    const validationLocale = payload.config.localization?.defaultLocale || locale
+
     const originalDoc = await afterRead({
       collection: collectionConfig,
       context: req.context,
@@ -151,13 +153,13 @@ export const restoreVersionOperation = async <
       draft: draftArg,
       fallbackLocale: null,
       global: null,
-      locale: locale!,
+      locale: validationLocale,
       overrideAccess: true,
       req,
       showHiddenFields: true,
     })
 
-    // version data with hoisted localized data
+    // Use locale-hoisted version data for validation while preserving all locales in docWithLocales.
     const prevVersionDoc = await afterRead({
       collection: collectionConfig,
       context: req.context,
@@ -166,7 +168,7 @@ export const restoreVersionOperation = async <
       draft: draftArg,
       fallbackLocale: null,
       global: null,
-      locale: locale!,
+      locale: validationLocale,
       overrideAccess: true,
       req,
       showHiddenFields: true,
@@ -175,6 +177,11 @@ export const restoreVersionOperation = async <
     // /////////////////////////////////////
     // beforeValidate - Fields
     // /////////////////////////////////////
+
+    const reqWithAllLocales = Object.assign(Object.create(req), req, {
+      fallbackLocale: null,
+      locale: validationLocale,
+    })
 
     let data = await beforeValidate({
       id: parentDocID,
@@ -185,7 +192,7 @@ export const restoreVersionOperation = async <
       global: null,
       operation: 'update',
       overrideAccess,
-      req,
+      req: reqWithAllLocales,
     })
 
     // /////////////////////////////////////
@@ -201,7 +208,7 @@ export const restoreVersionOperation = async <
             data,
             operation: 'update',
             originalDoc,
-            req,
+            req: reqWithAllLocales,
           })) || data
       }
     }
@@ -219,7 +226,7 @@ export const restoreVersionOperation = async <
             data,
             operation: 'update',
             originalDoc,
-            req,
+            req: reqWithAllLocales,
           })) || data
       }
     }
@@ -238,7 +245,7 @@ export const restoreVersionOperation = async <
       global: null,
       operation: 'update',
       overrideAccess,
-      req,
+      req: reqWithAllLocales,
       skipValidation: draftArg && !hasDraftValidationEnabled(collectionConfig),
     })
 
@@ -261,7 +268,7 @@ export const restoreVersionOperation = async <
         id: parentDocID,
         collection: collectionConfig.slug,
         data: result,
-        req,
+        req: reqWithAllLocales,
         select,
       })
     }
@@ -278,7 +285,7 @@ export const restoreVersionOperation = async <
       draft: draftArg,
       operation: 'restoreVersion',
       payload,
-      req,
+      req: reqWithAllLocales,
       select,
     })
 

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -178,7 +178,7 @@ export const restoreVersionOperation = async <
     // beforeValidate - Fields
     // /////////////////////////////////////
 
-    const reqWithAllLocales = Object.assign(Object.create(req), req, {
+    const reqWithValidationLocale = Object.assign(Object.create(req), req, {
       fallbackLocale: null,
       locale: validationLocale,
     })
@@ -192,7 +192,7 @@ export const restoreVersionOperation = async <
       global: null,
       operation: 'update',
       overrideAccess,
-      req: reqWithAllLocales,
+      req: reqWithValidationLocale,
     })
 
     // /////////////////////////////////////
@@ -208,7 +208,7 @@ export const restoreVersionOperation = async <
             data,
             operation: 'update',
             originalDoc,
-            req: reqWithAllLocales,
+            req: reqWithValidationLocale,
           })) || data
       }
     }
@@ -226,7 +226,7 @@ export const restoreVersionOperation = async <
             data,
             operation: 'update',
             originalDoc,
-            req: reqWithAllLocales,
+            req: reqWithValidationLocale,
           })) || data
       }
     }
@@ -245,7 +245,7 @@ export const restoreVersionOperation = async <
       global: null,
       operation: 'update',
       overrideAccess,
-      req: reqWithAllLocales,
+      req: reqWithValidationLocale,
       skipValidation: draftArg && !hasDraftValidationEnabled(collectionConfig),
     })
 
@@ -268,7 +268,7 @@ export const restoreVersionOperation = async <
         id: parentDocID,
         collection: collectionConfig.slug,
         data: result,
-        req: reqWithAllLocales,
+        req: reqWithValidationLocale,
         select,
       })
     }
@@ -285,7 +285,7 @@ export const restoreVersionOperation = async <
       draft: draftArg,
       operation: 'restoreVersion',
       payload,
-      req: reqWithAllLocales,
+      req: reqWithValidationLocale,
       select,
     })
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -780,6 +780,48 @@ describe('Versions', () => {
       expect(restoredVersion.title).toStrictEqual('v1')
     })
 
+    it('should restore a published version when required localized fields are empty in a non-default locale', async () => {
+      const originalPost = await payload.create({
+        collection: draftCollectionSlug,
+        data: {
+          _status: 'published',
+          description: 'description v1',
+          title: 'title v1 en',
+        },
+      })
+
+      await payload.update({
+        id: originalPost.id,
+        collection: draftCollectionSlug,
+        data: {
+          _status: 'published',
+          description: 'description v2',
+          title: 'title v2 en',
+        },
+        draft: true,
+      })
+
+      const versions = await payload.findVersions({
+        collection: draftCollectionSlug,
+        where: {
+          parent: {
+            equals: originalPost.id,
+          },
+        },
+      })
+
+      const oldestVersion = versions.docs[versions.docs.length - 1]
+
+      const restoredVersion = await payload.restoreVersion({
+        id: oldestVersion!.id,
+        collection: draftCollectionSlug,
+        fallbackLocale: false,
+        locale: 'de',
+      })
+
+      expect(restoredVersion.id).toStrictEqual(originalPost.id)
+    })
+
     it('findVersions - pagination should work correctly', async () => {
       const post = await payload.create({
         collection: draftCollectionSlug,


### PR DESCRIPTION
## Summary
- fix collection `restoreVersion` to read version/current docs with all locales before restore processing
- validate restore data in the default locale context while preserving full locale data for persistence
- add an integration regression test for restoring versions when required localized fields are empty in a non-default locale

Closes #15698

## Related
payloadcms/payload#15698

## Changes
- update `packages/payload/src/collections/operations/restoreVersion.ts`
- add coverage in `test/versions/int.spec.ts`

## Testing
- [x] `PAYLOAD_DATABASE=sqlite NODE_OPTIONS="--no-deprecation --no-experimental-strip-types" NODE_NO_WARNINGS=1 DISABLE_LOGGING=true pnpm exec vitest --project int test/versions/int.spec.ts -t "should restore published version with correct data|should restore a published version when required localized fields are empty in a non-default locale"`