### PR TITLE
fix: before validate return type

### DIFF
--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -191,7 +191,7 @@ export type BeforeValidateHook<T extends TypeWithID = any> = (args: {
    */
   originalDoc?: T
   req: PayloadRequest
-}) => any
+}) => Partial<T> | Promise<Partial<T> | undefined> | undefined
 
 export type BeforeChangeHook<T extends TypeWithID = any> = (args: {
   /** The collection which this hook is being run on */


### PR DESCRIPTION
### What?
Added a explicit return value to the `CollectionBeforeValidateHook`.

### Why?
I believe it is more correct, as payload actually uses the return value.

Relevant code: https://github.com/payloadcms/payload/blob/71be0ca6262b5aa434a4e8652bbf57c071456314/packages/payload/src/fields/hooks/beforeValidate/promise.ts#L287-L315 and https://github.com/payloadcms/payload/blob/71be0ca6262b5aa434a4e8652bbf57c071456314/packages/payload/src/collections/operations/create.ts#L196-L207

### How?
Changing types.
