### PR TITLE
chore: prevent dev server from dirtying tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ web_modules/
 
 # Next.js build output
 .next
+next-env.d.ts
 out
 
 # Nuxt.js build / generate output

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export const defaultESLintIgnores = [
   '**/app',
   'src/**/*.spec.ts',
   'packages/payload/rollup.dts.config.mjs',
+  'scripts/**/*.js',
 ]
 
 /** @typedef {import('eslint').Linter.Config} Config */

--- a/examples/astro/payload/next-env.d.ts
+++ b/examples/astro/payload/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/auth/next-env.d.ts
+++ b/examples/auth/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/custom-components/next-env.d.ts
+++ b/examples/custom-components/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/custom-server/next-env.d.ts
+++ b/examples/custom-server/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/examples/draft-preview/next-env.d.ts
+++ b/examples/draft-preview/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/email/next-env.d.ts
+++ b/examples/email/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/examples/live-preview/next-env.d.ts
+++ b/examples/live-preview/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/localization/next-env.d.ts
+++ b/examples/localization/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/multi-tenant/next-env.d.ts
+++ b/examples/multi-tenant/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/remix/payload/next-env.d.ts
+++ b/examples/remix/payload/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/whitelabel/next-env.d.ts
+++ b/examples/whitelabel/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts'
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scripts/replacePayloadConfigPath.js
+++ b/scripts/replacePayloadConfigPath.js
@@ -1,0 +1,21 @@
+import fs from 'fs/promises'
+import { existsSync } from 'fs'
+import path from 'path'
+
+/**
+ * Replace the @payload-config path in tsconfig.base.json using string replacement
+ * to avoid reformatting the entire file.
+ */
+export async function replacePayloadConfigPath(rootDir, configPath) {
+  const tsConfigBasePath = path.resolve(rootDir, './tsconfig.base.json')
+  const tsConfigPath = existsSync(tsConfigBasePath)
+    ? tsConfigBasePath
+    : path.resolve(rootDir, './tsconfig.json')
+
+  const content = await fs.readFile(tsConfigPath, 'utf8')
+  const updated = content.replace(
+    /("@payload-config":\s*\[\s*)"[^"]*"(\s*\])/,
+    `$1"${configPath}"$2`,
+  )
+  await fs.writeFile(tsConfigPath, updated)
+}

--- a/scripts/reset-tsconfig.js
+++ b/scripts/reset-tsconfig.js
@@ -1,30 +1,17 @@
 // @ts-check
 
 /**
- * Parse tsconfig.json and ensure
- * - compilerOptions.paths['@payload-config'] is set to ['./test/_community/config.ts']
- * - Ends with a newline
+ * Reset @payload-config path in tsconfig.json back to the default community config.
+ * Used as a lint-staged hook to prevent committing modified paths.
  */
 
-import { parse, stringify } from 'comment-json'
-
-import path from 'path'
-import fs from 'fs/promises'
 import { fileURLToPath } from 'url'
-import { existsSync } from 'fs'
+import path from 'path'
+
+import { replacePayloadConfigPath } from './replacePayloadConfigPath.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+const rootDir = path.resolve(dirname, '..')
 
-const tsConfigBasePath = path.resolve(dirname, '../tsconfig.base.json')
-const tsConfigPath = existsSync(tsConfigBasePath)
-  ? tsConfigBasePath
-  : path.resolve(dirname, '../tsconfig.json')
-
-
-const tsConfigContent = await fs.readFile(tsConfigPath, 'utf8')
-const tsConfig = parse(tsConfigContent)
-
-tsConfig.compilerOptions.paths['@payload-config'] = ['./test/_community/config.ts']
-const output = stringify(tsConfig, null, 2) + `\n`
-await fs.writeFile(tsConfigPath, output)
+await replacePayloadConfigPath(rootDir, './test/_community/config.ts')

--- a/templates/plugin/dev/next-env.d.ts
+++ b/templates/plugin/dev/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/templates/website/next-env.d.ts
+++ b/templates/website/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/templates/with-vercel-website/next-env.d.ts
+++ b/templates/with-vercel-website/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/admin-bar/next-env.d.ts
+++ b/test/admin-bar/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/admin-root/next-env.d.ts
+++ b/test/admin-root/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/base-path/next-env.d.ts
+++ b/test/base-path/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/live-preview/next-env.d.ts
+++ b/test/live-preview/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/live-preview/prod/next-env.d.ts
+++ b/test/live-preview/prod/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/test/next-env.d.ts
+++ b/test/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/plugin-ecommerce/next-env.d.ts
+++ b/test/plugin-ecommerce/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/testHooks.ts
+++ b/test/testHooks.ts
@@ -1,26 +1,16 @@
-import { parse, stringify } from 'comment-json'
 import { existsSync, promises } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import { replacePayloadConfigPath } from '../scripts/replacePayloadConfigPath.js'
 import { getNextRootDir } from './__helpers/shared/getNextRootDir.js'
 
-const { readFile, writeFile, rm } = promises
+const { rm } = promises
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-export const createTestHooks = async (
-  testSuiteName = '_community',
-  testSuiteConfig = 'config.ts',
-) => {
+export const createTestHooks = (testSuiteName = '_community', testSuiteConfig = 'config.ts') => {
   const rootDir = getNextRootDir().rootDir
-  const tsConfigBasePath = path.resolve(rootDir, './tsconfig.base.json')
-  const tsConfigPath = existsSync(tsConfigBasePath)
-    ? tsConfigBasePath
-    : path.resolve(rootDir, './tsconfig.json')
-
-  const tsConfigContent = await readFile(tsConfigPath, 'utf8')
-  const tsConfig = parse(tsConfigContent)
 
   return {
     /**
@@ -33,15 +23,12 @@ export const createTestHooks = async (
         await rm(nextCache, { recursive: true })
       }
 
-      // Set '@payload-config' in tsconfig.json
-
-      // @ts-expect-error
-      tsConfig.compilerOptions.paths['@payload-config'] = [
+      const configPath =
         process.env.PAYLOAD_TEST_PROD === 'true'
           ? `./${testSuiteName}/${testSuiteConfig}`
-          : `./test/${testSuiteName}/${testSuiteConfig}`,
-      ]
-      await writeFile(tsConfigPath, stringify(tsConfig, null, 2) + '\n')
+          : `./test/${testSuiteName}/${testSuiteConfig}`
+
+      await replacePayloadConfigPath(rootDir, configPath)
 
       process.env.PAYLOAD_CONFIG_PATH = path.resolve(dirname, testSuiteName, testSuiteConfig)
     },

--- a/test/testHooks.ts
+++ b/test/testHooks.ts
@@ -2,12 +2,29 @@ import { existsSync, promises } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
-import { replacePayloadConfigPath } from '../scripts/replacePayloadConfigPath.js'
 import { getNextRootDir } from './__helpers/shared/getNextRootDir.js'
 
-const { rm } = promises
+const { readFile, rm, writeFile } = promises
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+
+/**
+ * Replace the @payload-config path in tsconfig.base.json using string replacement
+ * to avoid reformatting the entire file.
+ */
+async function replacePayloadConfigPath(rootDir: string, configPath: string) {
+  const tsConfigBasePath = path.resolve(rootDir, './tsconfig.base.json')
+  const tsConfigPath = existsSync(tsConfigBasePath)
+    ? tsConfigBasePath
+    : path.resolve(rootDir, './tsconfig.json')
+
+  const content = await readFile(tsConfigPath, 'utf8')
+  const updated = content.replace(
+    /("@payload-config":\s*\[\s*)"[^"]*"(\s*\])/,
+    `$1"${configPath}"$2`,
+  )
+  await writeFile(tsConfigPath, updated)
+}
 
 export const createTestHooks = (testSuiteName = '_community', testSuiteConfig = 'config.ts') => {
   const rootDir = getNextRootDir().rootDir


### PR DESCRIPTION
# Overview

Running `pnpm dev <suite>` modifies `tsconfig.base.json` and `next-env.d.ts` in ways that show up in `git status` but never belong in commits. This PR eliminates both sources of noise.

## Key Changes

- **`tsconfig.base.json` — string replacement instead of full reparse:** `comment-json`'s `stringify` was reformatting the entire file (expanding single-element arrays to multi-line) just to swap the `@payload-config` path. Replaced with a regex that only touches the `@payload-config` value, leaving all other formatting untouched. A shared utility (`scripts/replacePayloadConfigPath.js`) is used by `reset-tsconfig.js`, with an inlined copy in `test/testHooks.ts` (the `test/` tsconfig sets `rootDir` to `test/`, so it can't import from `../scripts/`).

- **`next-env.d.ts` — gitignored and untracked:** Next.js rewrites this file on every `next dev`, flipping between single/double quotes and adding/removing semicolons. Since it's auto-generated on first `next dev` or `next build`, it's a build artifact. Untracked all 22 copies across root, test suites, examples, and templates.

- **ESLint config:** Added `scripts/**/*.js` to the ignore list since the typescript-eslint project service doesn't cover standalone JS scripts.

## Design Decisions

The regex approach (`/"@payload-config":\s*\[\s*)"[^"]*"(\s*\])/`) was chosen over alternatives like `json-stringify-pretty-compact` or moving `@payload-config` resolution to a bundler alias. It's the smallest change that fully solves the problem — no new dependencies, no architecture changes, and the existing `reset-tsconfig.js` lint-staged hook continues to work as before.

The utility is duplicated between `scripts/replacePayloadConfigPath.js` and `test/testHooks.ts` because TypeScript's `rootDir` boundary prevents `test/` from importing `../scripts/`. Both copies are small (~10 lines) so the duplication is acceptable.