### PR TITLE
test(ui): add data-testid attributes for stable e2e selectors

### DIFF
--- a/packages/next/src/elements/Nav/NavWrapper/index.tsx
+++ b/packages/next/src/elements/Nav/NavWrapper/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useNav } from '@payloadcms/ui'
+import { testIds } from '@payloadcms/ui/shared'
 import React from 'react'
 
 import './index.scss'
@@ -25,6 +26,7 @@ export const NavWrapper: React.FC<{
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={testIds.nav.sidebar}
       inert={!navOpen ? true : undefined}
     >
       <div className={`${baseClass}__scroll`} ref={navRef}>

--- a/packages/next/src/elements/Nav/index.client.tsx
+++ b/packages/next/src/elements/Nav/index.client.tsx
@@ -5,7 +5,7 @@ import type { NavPreferences } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import { BrowseByFolderButton, Link, NavGroup, useConfig, useTranslation } from '@payloadcms/ui'
-import { EntityType } from '@payloadcms/ui/shared'
+import { EntityType, testIds } from '@payloadcms/ui/shared'
 import { usePathname } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'
 import React, { Fragment } from 'react'
@@ -73,14 +73,26 @@ export const DefaultNavClient: React.FC<{
               // If the URL matches the link exactly
               if (pathname === href) {
                 return (
-                  <div className={`${baseClass}__link`} id={id} key={i}>
+                  <div
+                    className={`${baseClass}__link`}
+                    data-testid={testIds.nav.menuItem(slug)}
+                    id={id}
+                    key={i}
+                  >
                     {Label}
                   </div>
                 )
               }
 
               return (
-                <Link className={`${baseClass}__link`} href={href} id={id} key={i} prefetch={false}>
+                <Link
+                  className={`${baseClass}__link`}
+                  data-testid={testIds.nav.menuItem(slug)}
+                  href={href}
+                  id={id}
+                  key={i}
+                  prefetch={false}
+                >
                   {Label}
                 </Link>
               )

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -12,6 +12,7 @@ import { useRelatedCollections } from '../../hooks/useRelatedCollections.js'
 import { PlusIcon } from '../../icons/Plus/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { Button } from '../Button/index.js'
 import { useDocumentDrawer } from '../DocumentDrawer/index.js'
 import { Popup } from '../Popup/index.js'
@@ -151,6 +152,7 @@ export const AddNewRelation: React.FC<Props> = ({
             ]
               .filter(Boolean)
               .join(' ')}
+            data-testid={testIds.relationship.addNew(path)}
             onClick={() => {
               setShowTooltip(false)
             }}
@@ -181,6 +183,7 @@ export const AddNewRelation: React.FC<Props> = ({
                 <Button
                   buttonStyle="none"
                   className={`${baseClass}__add-button`}
+                  data-testid={testIds.relationship.addNew(path)}
                   tooltip={popupOpen ? undefined : t('fields:addNew')}
                 >
                   <PlusIcon />

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -183,7 +183,7 @@ export const AddNewRelation: React.FC<Props> = ({
                 <Button
                   buttonStyle="none"
                   className={`${baseClass}__add-button`}
-                  data-testid={testIds.relationship.addNew(path)}
+                  extraButtonProps={{ 'data-testid': testIds.relationship.addNew(path) }}
                   tooltip={popupOpen ? undefined : t('fields:addNew')}
                 >
                   <PlusIcon />

--- a/packages/ui/src/elements/AnimateHeight/index.tsx
+++ b/packages/ui/src/elements/AnimateHeight/index.tsx
@@ -4,13 +4,15 @@ import React, { useEffect, useRef } from 'react'
 import { usePatchAnimateHeight } from './usePatchAnimateHeight.js'
 import './index.scss'
 
-export const AnimateHeight: React.FC<{
-  children: React.ReactNode
-  className?: string
-  duration?: number
-  height?: 'auto' | number
-  id?: string
-}> = ({ id, children, className, duration = 300, height }) => {
+export const AnimateHeight: React.FC<
+  {
+    children: React.ReactNode
+    className?: string
+    duration?: number
+    height?: 'auto' | number
+    id?: string
+  } & React.HTMLAttributes<HTMLDivElement>
+> = ({ id, children, className, duration = 300, height, ...rest }) => {
   const [open, setOpen] = React.useState(() => Boolean(height))
 
   const prevIsOpen = useRef(open)
@@ -94,6 +96,7 @@ export const AnimateHeight: React.FC<{
         overflow: parentOverflow,
         transition: `height ${duration}ms ease`,
       }}
+      {...rest}
     >
       <div ref={contentRef} {...(childrenDisplay ? { style: { display: childrenDisplay } } : {})}>
         {children}

--- a/packages/ui/src/elements/ArrayAction/index.tsx
+++ b/packages/ui/src/elements/ArrayAction/index.tsx
@@ -7,6 +7,7 @@ import { MoreIcon } from '../../icons/More/index.js'
 import { PlusIcon } from '../../icons/Plus/index.js'
 import { XIcon } from '../../icons/X/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { ClipboardActionLabel } from '../ClipboardAction/ClipboardActionLabel.js'
 import './index.scss'
 import { Popup, PopupList } from '../Popup/index.js'
@@ -52,6 +53,7 @@ export const ArrayAction: React.FC<Props> = ({
             {isSortable && index !== 0 && (
               <PopupList.Button
                 className={`${baseClass}__action ${baseClass}__move-up`}
+                data-testid={testIds.arrayAction.moveUp}
                 onClick={() => {
                   moveRow(index, index - 1)
                   close()
@@ -66,6 +68,7 @@ export const ArrayAction: React.FC<Props> = ({
             {isSortable && index < rowCount - 1 && (
               <PopupList.Button
                 className={`${baseClass}__action`}
+                data-testid={testIds.arrayAction.moveDown}
                 onClick={() => {
                   moveRow(index, index + 1)
                   close()
@@ -81,6 +84,7 @@ export const ArrayAction: React.FC<Props> = ({
               <React.Fragment>
                 <PopupList.Button
                   className={`${baseClass}__action ${baseClass}__add`}
+                  data-testid={testIds.arrayAction.add}
                   onClick={() => {
                     void addRow(index + 1)
                     close()
@@ -91,6 +95,7 @@ export const ArrayAction: React.FC<Props> = ({
                 </PopupList.Button>
                 <PopupList.Button
                   className={`${baseClass}__action ${baseClass}__duplicate`}
+                  data-testid={testIds.arrayAction.duplicate}
                   onClick={() => {
                     duplicateRow(index)
                     close()
@@ -103,6 +108,7 @@ export const ArrayAction: React.FC<Props> = ({
             )}
             <PopupList.Button
               className={`${baseClass}__action ${baseClass}__copy`}
+              data-testid={testIds.arrayAction.copyField}
               onClick={() => {
                 copyRow(index)
                 close()
@@ -112,6 +118,7 @@ export const ArrayAction: React.FC<Props> = ({
             </PopupList.Button>
             <PopupList.Button
               className={`${baseClass}__action ${baseClass}__paste`}
+              data-testid={testIds.arrayAction.pasteField}
               onClick={() => {
                 pasteRow(index)
                 close()
@@ -121,6 +128,7 @@ export const ArrayAction: React.FC<Props> = ({
             </PopupList.Button>
             <PopupList.Button
               className={`${baseClass}__action ${baseClass}__remove`}
+              data-testid={testIds.arrayAction.remove}
               onClick={() => {
                 removeRow(index)
                 close()

--- a/packages/ui/src/elements/Collapsible/index.tsx
+++ b/packages/ui/src/elements/Collapsible/index.tsx
@@ -6,6 +6,7 @@ import type { DragHandleProps } from '../DraggableSortable/DraggableSortableItem
 import { ChevronIcon } from '../../icons/Chevron/index.js'
 import { DragHandleIcon } from '../../icons/DragHandle/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import './index.scss'
 import { AnimateHeight } from '../AnimateHeight/index.js'
 import { CollapsibleProvider, useCollapsible } from './provider.js'
@@ -95,6 +96,7 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
               ]
                 .filter(Boolean)
                 .join(' ')}
+              data-testid={testIds.collapsible.toggle('')}
               onClick={toggleCollapsible}
               type="button"
             >

--- a/packages/ui/src/elements/Collapsible/index.tsx
+++ b/packages/ui/src/elements/Collapsible/index.tsx
@@ -6,7 +6,6 @@ import type { DragHandleProps } from '../DraggableSortable/DraggableSortableItem
 import { ChevronIcon } from '../../icons/Chevron/index.js'
 import { DragHandleIcon } from '../../icons/DragHandle/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
-import { testIds } from '../../testIds.js'
 import './index.scss'
 import { AnimateHeight } from '../AnimateHeight/index.js'
 import { CollapsibleProvider, useCollapsible } from './provider.js'
@@ -96,7 +95,6 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
               ]
                 .filter(Boolean)
                 .join(' ')}
-              data-testid={testIds.collapsible.toggle('')}
               onClick={toggleCollapsible}
               type="button"
             >

--- a/packages/ui/src/elements/ConfirmationModal/index.tsx
+++ b/packages/ui/src/elements/ConfirmationModal/index.tsx
@@ -3,6 +3,7 @@ import { Modal, useModal } from '@faceless-ui/modal'
 import React, { useCallback } from 'react'
 
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { Button } from '../Button/index.js'
 import { drawerZBase, useDrawerDepth } from '../Drawer/index.js'
 import './index.scss'
@@ -88,6 +89,7 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
         <div className={`${baseClass}__controls`}>
           <Button
             buttonStyle="secondary"
+            data-testid={testIds.confirm.cancel}
             disabled={confirming}
             id="confirm-cancel"
             onClick={onCancel}
@@ -96,7 +98,12 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
           >
             {cancelLabel || t('general:cancel')}
           </Button>
-          <Button id="confirm-action" onClick={onConfirm} size="large">
+          <Button
+            data-testid={testIds.confirm.action}
+            id="confirm-action"
+            onClick={onConfirm}
+            size="large"
+          >
             {confirming
               ? confirmingLabel || `${t('general:loading')}...`
               : confirmLabel || t('general:confirm')}

--- a/packages/ui/src/elements/DeleteDocument/index.tsx
+++ b/packages/ui/src/elements/DeleteDocument/index.tsx
@@ -17,6 +17,7 @@ import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
 import { useRouteTransition } from '../../providers/RouteTransition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { requests } from '../../utilities/api.js'
 import { shouldPermanentlyDelete } from '../../utilities/shouldPermanentlyDelete.js'
 import { ConfirmationModal } from '../ConfirmationModal/index.js'
@@ -162,6 +163,7 @@ export const DeleteDocument: React.FC<Props> = (props) => {
     return (
       <Fragment>
         <PopupList.Button
+          data-testid={testIds.action.delete}
           id={buttonId}
           onClick={() => {
             openModal(modalSlug)

--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -16,6 +16,7 @@ import { useLocale } from '../../providers/Locale/index.js'
 import { useRouteCache } from '../../providers/RouteCache/index.js'
 import { SelectAllStatus, useSelection } from '../../providers/Selection/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { requests } from '../../utilities/api.js'
 import { parseSearchParams } from '../../utilities/parseSearchParams.js'
 import { shouldPermanentlyDelete } from '../../utilities/shouldPermanentlyDelete.js'
@@ -426,6 +427,7 @@ export function DeleteMany_v4({
       <ListSelectionButton
         aria-label={t('general:delete')}
         className="delete-documents__toggle"
+        data-testid={testIds.list.deleteMany}
         onClick={() => {
           openModal(confirmManyDeleteDrawerSlug)
         }}

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -19,6 +19,7 @@ import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useLivePreviewContext } from '../../providers/LivePreview/context.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { formatDate } from '../../utilities/formatDocTitle/formatDateTitle.js'
 import { Autosave } from '../Autosave/index.js'
 import { Button } from '../Button/index.js'
@@ -338,7 +339,7 @@ export const DocumentControls: React.FC<{
           {showDotMenu && !readOnlyForIncomingUser && (
             <Popup
               button={
-                <div className={`${baseClass}__dots`}>
+                <div className={`${baseClass}__dots`} data-testid={testIds.docControls.menu}>
                   <div />
                   <div />
                   <div />

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -6,6 +6,7 @@ import type { Props, TogglerProps } from './types.js'
 
 import { XIcon } from '../../icons/X/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { Gutter } from '../Gutter/index.js'
 import './index.scss'
 
@@ -90,12 +91,14 @@ export const Drawer: React.FC<Props> = ({
           <button
             aria-label={t('general:close')}
             className={`${baseClass}__close`}
+            data-testid={testIds.drawer.close(slug)}
             id={`close-drawer__${slug}`}
             onClick={() => closeModal(slug)}
             type="button"
           />
           <div
             className={`${baseClass}__content`}
+            data-testid={testIds.drawer.content(slug)}
             style={{
               width: `calc(100% - (${drawerDepth} * var(--gutter-h)))`,
             }}
@@ -114,6 +117,7 @@ export const Drawer: React.FC<Props> = ({
                   <button
                     aria-label={t('general:close')}
                     className={`${baseClass}__header__close`}
+                    data-testid={testIds.drawer.close(slug)}
                     id={`close-drawer__${slug}`}
                     onClick={() => closeModal(slug)}
                     type="button"

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -17,6 +17,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useRouteTransition } from '../../providers/RouteTransition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { requests } from '../../utilities/api.js'
 import { traverseForLocalizedFields } from '../../utilities/traverseForLocalizedFields.js'
 import { ConfirmationModal } from '../ConfirmationModal/index.js'
@@ -171,6 +172,7 @@ export const DuplicateDocument: React.FC<Props> = ({
     return (
       <React.Fragment>
         <PopupList.Button
+          data-testid={testIds.action.duplicate}
           id={`action-duplicate${isDuplicateByLocaleEnabled ? `-locales` : ''}`}
           onClick={() => {
             if (modified) {

--- a/packages/ui/src/elements/EditMany/index.tsx
+++ b/packages/ui/src/elements/EditMany/index.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../../providers/Auth/index.js'
 import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { SelectAllStatus, useSelection } from '../../providers/Selection/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { Drawer } from '../Drawer/index.js'
 import { ListSelectionButton } from '../ListSelection/index.js'
 import { EditManyDrawerContent } from './DrawerContent.js'
@@ -67,6 +68,7 @@ export const EditMany_v4: React.FC<
     <div className={[baseClass, `${baseClass}__toggle`].filter(Boolean).join(' ')}>
       <ListSelectionButton
         aria-label={t('general:edit')}
+        data-testid={testIds.list.editMany}
         onClick={() => {
           openModal(drawerSlug)
           setSelectedFields([])

--- a/packages/ui/src/elements/GroupByBuilder/index.tsx
+++ b/packages/ui/src/elements/GroupByBuilder/index.tsx
@@ -9,6 +9,7 @@ import { SelectInput } from '../../fields/Select/Input.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useListQuery } from '../../providers/ListQuery/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { reduceFieldsToOptions } from '../../utilities/reduceFieldsToOptions.js'
 import { ReactSelect } from '../ReactSelect/index.js'
 
@@ -154,6 +155,7 @@ export const GroupByBuilder: React.FC<Props> = ({
         {groupByRaw && (
           <button
             className={`${baseClass}__clear-button`}
+            data-testid={testIds.groupBy.reset}
             id="group-by--reset"
             onClick={() => void handleClear()}
             type="button"
@@ -164,6 +166,7 @@ export const GroupByBuilder: React.FC<Props> = ({
       </div>
       <div className={`${baseClass}__inputs`}>
         <ReactSelect
+          data-testid={testIds.groupBy.fieldSelect}
           filterOption={(option, inputValue) =>
             ((option?.data?.plainTextLabel as string) || option.label)
               .toLowerCase()

--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -13,6 +13,7 @@ import { ChevronIcon } from '../../icons/Chevron/index.js'
 import { Dots } from '../../icons/Dots/index.js'
 import { useListQuery } from '../../providers/ListQuery/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { AnimateHeight } from '../AnimateHeight/index.js'
 import { ColumnSelector } from '../ColumnSelector/index.js'
 import { GroupByBuilder } from '../GroupByBuilder/index.js'
@@ -141,6 +142,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
               aria-controls={`${baseClass}-columns`}
               aria-expanded={visibleDrawer === 'columns'}
               className={`${baseClass}__toggle-columns`}
+              data-testid={testIds.list.columns}
               icon={<ChevronIcon direction={visibleDrawer === 'columns' ? 'up' : 'down'} />}
               id="toggle-list-columns"
               key="toggle-list-columns"
@@ -156,6 +158,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
               aria-controls={`${baseClass}-where`}
               aria-expanded={visibleDrawer === 'where'}
               className={`${baseClass}__toggle-where`}
+              data-testid={testIds.list.filters}
               icon={<ChevronIcon direction={visibleDrawer === 'where' ? 'up' : 'down'} />}
               id="toggle-list-filters"
               key="toggle-list-filters"

--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -158,7 +158,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
               aria-controls={`${baseClass}-where`}
               aria-expanded={visibleDrawer === 'where'}
               className={`${baseClass}__toggle-where`}
-              data-testid={testIds.list.filters}
+              data-testid={testIds.filterControls.toggle}
               icon={<ChevronIcon direction={visibleDrawer === 'where' ? 'up' : 'down'} />}
               id="toggle-list-filters"
               key="toggle-list-filters"
@@ -189,6 +189,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
               aria-controls={`${baseClass}-group-by`}
               aria-expanded={visibleDrawer === 'group-by'}
               className={`${baseClass}__toggle-group-by`}
+              data-testid={testIds.groupBy.toggle}
               icon={<ChevronIcon direction={visibleDrawer === 'group-by' ? 'up' : 'down'} />}
               id="toggle-group-by"
               key="toggle-group-by"
@@ -207,6 +208,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
             <Popup
               button={<Dots ariaLabel={t('general:moreOptions')} />}
               className={`${baseClass}__popup`}
+              data-testid={testIds.list.menu}
               horizontalAlign="right"
               id="list-menu"
               key="list-menu"
@@ -237,6 +239,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
       )}
       <AnimateHeight
         className={`${baseClass}__where`}
+        data-testid={testIds.filterControls.container}
         height={visibleDrawer === 'where' ? 'auto' : 0}
         id={`${baseClass}-where`}
       >
@@ -251,6 +254,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
       {collectionConfig.admin.groupBy && (
         <AnimateHeight
           className={`${baseClass}__group-by`}
+          data-testid={testIds.groupBy.container}
           height={visibleDrawer === 'group-by' ? 'auto' : 0}
           id={`${baseClass}-group-by`}
         >

--- a/packages/ui/src/elements/LivePreview/Toggler/index.tsx
+++ b/packages/ui/src/elements/LivePreview/Toggler/index.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { EyeIcon } from '../../../icons/Eye/index.js'
 import { useLivePreviewContext } from '../../../providers/LivePreview/context.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import { testIds } from '../../../testIds.js'
 import './index.scss'
 
 const baseClass = 'live-preview-toggler'
@@ -19,6 +20,7 @@ export const LivePreviewToggler: React.FC = () => {
     <button
       aria-label={isLivePreviewing ? t('general:exitLivePreview') : t('general:livePreview')}
       className={[baseClass, isLivePreviewing && `${baseClass}--active`].filter(Boolean).join(' ')}
+      data-testid={testIds.livePreview.toggler}
       id="live-preview-toggler"
       onClick={() => {
         setIsLivePreviewing(!isLivePreviewing)

--- a/packages/ui/src/elements/LivePreview/Toolbar/Controls/index.tsx
+++ b/packages/ui/src/elements/LivePreview/Toolbar/Controls/index.tsx
@@ -9,6 +9,7 @@ import { ExternalLinkIcon } from '../../../../icons/ExternalLink/index.js'
 import { XIcon } from '../../../../icons/X/index.js'
 import { useLivePreviewContext } from '../../../../providers/LivePreview/context.js'
 import { useTranslation } from '../../../../providers/Translation/index.js'
+import { testIds } from '../../../../testIds.js'
 import { Popup, PopupList } from '../../../Popup/index.js'
 import { PreviewFrameSizeInput } from '../SizeInput/index.js'
 import './index.scss'
@@ -40,6 +41,7 @@ export const ToolbarControls: React.FC<EditViewProps> = () => {
             </React.Fragment>
           }
           className={`${baseClass}__breakpoint`}
+          data-testid={testIds.livePreview.breakpoint}
           horizontalAlign="right"
           render={({ close }) => (
             <PopupList.ButtonGroup>
@@ -90,6 +92,7 @@ export const ToolbarControls: React.FC<EditViewProps> = () => {
           </React.Fragment>
         }
         className={`${baseClass}__zoom`}
+        data-testid={testIds.livePreview.zoom}
         horizontalAlign="right"
         render={({ close }) => (
           <PopupList.ButtonGroup>

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -8,6 +8,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useLocale, useLocaleLoading } from '../../providers/Locale/index.js'
 import { useRouteTransition } from '../../providers/RouteTransition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { Popup, PopupList } from '../Popup/index.js'
 import './index.scss'
 import { LocalizerLabel } from './LocalizerLabel/index.js'
@@ -34,7 +35,10 @@ export const Localizer: React.FC<{
     const { locales } = localization
 
     return (
-      <div className={[baseClass, className].filter(Boolean).join(' ')}>
+      <div
+        className={[baseClass, className].filter(Boolean).join(' ')}
+        data-testid={testIds.locale.selector}
+      >
         <Popup
           button={<LocalizerLabel />}
           horizontalAlign="right"
@@ -46,6 +50,7 @@ export const Localizer: React.FC<{
                 return (
                   <PopupList.Button
                     active={locale.code === localeOption.code}
+                    data-testid={testIds.locale.option(localeOption.code)}
                     disabled={locale.code === localeOption.code}
                     key={localeOption.code}
                     onClick={() => {

--- a/packages/ui/src/elements/Logout/index.tsx
+++ b/packages/ui/src/elements/Logout/index.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { LogOutIcon } from '../../icons/LogOut/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { Link } from '../Link/index.js'
 
 const baseClass = 'nav'
@@ -32,6 +33,7 @@ export const Logout: React.FC<{
     <Link
       aria-label={t('authentication:logOut')}
       className={`${baseClass}__log-out`}
+      data-testid={testIds.nav.logoutButton}
       href={formatAdminURL({
         adminRoute,
         path: logoutRoute,

--- a/packages/ui/src/elements/Nav/NavToggler/index.tsx
+++ b/packages/ui/src/elements/Nav/NavToggler/index.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 
 import { usePreferences } from '../../../providers/Preferences/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import { testIds } from '../../../testIds.js'
 import { useNav } from '../context.js'
 import './index.scss'
 
@@ -34,6 +35,7 @@ export const NavToggler: React.FC<{
       className={[baseClass, navOpen && `${baseClass}--is-open`, className]
         .filter(Boolean)
         .join(' ')}
+      data-testid={testIds.nav.toggler}
       id={id}
       onClick={async () => {
         setNavOpen(!navOpen)

--- a/packages/ui/src/elements/Pill/index.tsx
+++ b/packages/ui/src/elements/Pill/index.tsx
@@ -23,6 +23,7 @@ export type PillProps = {
   'aria-label'?: string
   children?: React.ReactNode
   className?: string
+  'data-testid'?: string
   draggable?: boolean
   elementProps?: {
     ref: React.RefCallback<HTMLElement>
@@ -85,6 +86,7 @@ const StaticPill: React.FC<PillProps> = (props) => {
     'aria-label': ariaLabel,
     children,
     className,
+    'data-testid': dataTestId,
     draggable,
     elementProps,
     icon,
@@ -136,6 +138,7 @@ const StaticPill: React.FC<PillProps> = (props) => {
       aria-expanded={ariaExpanded}
       aria-label={ariaLabel}
       className={classes}
+      data-testid={dataTestId}
       disabled={isButton ? !isHydrated : undefined}
       href={to || null}
       id={id}

--- a/packages/ui/src/elements/Popup/PopupButtonList/index.tsx
+++ b/packages/ui/src/elements/Popup/PopupButtonList/index.tsx
@@ -32,6 +32,7 @@ type MenuButtonProps = {
   active?: boolean
   children: React.ReactNode
   className?: string
+  'data-testid'?: string
   disabled?: boolean
   href?: LinkProps['href']
   id?: string
@@ -43,6 +44,7 @@ export const Button: React.FC<MenuButtonProps> = ({
   active,
   children,
   className,
+  'data-testid': dataTestId,
   disabled,
   href,
   onClick,
@@ -61,6 +63,7 @@ export const Button: React.FC<MenuButtonProps> = ({
       return (
         <Link
           className={classes}
+          data-testid={dataTestId}
           href={href}
           id={id}
           onClick={(e) => {
@@ -79,6 +82,7 @@ export const Button: React.FC<MenuButtonProps> = ({
       return (
         <button
           className={classes}
+          data-testid={dataTestId}
           id={id}
           onClick={(e) => {
             if (onClick) {
@@ -94,7 +98,7 @@ export const Button: React.FC<MenuButtonProps> = ({
   }
 
   return (
-    <div className={classes} id={id}>
+    <div className={classes} data-testid={dataTestId} id={id}>
       {children}
     </div>
   )

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { useEffectEvent } from '../../hooks/useEffectEvent.js'
+import { testIds } from '../../testIds.js'
 import './index.scss'
 import { PopupTrigger } from './PopupTrigger/index.js'
 
@@ -448,6 +449,7 @@ export const Popup: React.FC<PopupProps> = (props) => {
                     `${baseClass}__hidden-content`
               }
               data-popup-id={id || undefined}
+              {...(active ? { 'data-testid': testIds.popup.content } : {})}
               ref={popupRef}
             >
               <div

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -263,9 +263,9 @@ export function PublishButton({
     <React.Fragment>
       <FormSubmit
         buttonId="action-save"
-        data-testid={testIds.action.publish}
         disabled={!canPublish}
         enableSubMenu={canSchedulePublish}
+        extraButtonProps={{ 'data-testid': testIds.action.publish }}
         onClick={isDefaultPublishAll ? publish : () => publishSpecificLocale(activeLocale.code)}
         size="medium"
         SubMenuPopupContent={

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -22,6 +22,7 @@ import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { traverseForLocalizedFields } from '../../utilities/traverseForLocalizedFields.js'
 import { PopupList } from '../Popup/index.js'
 import { ScheduleDrawer } from './ScheduleDrawer/index.js'
@@ -262,6 +263,7 @@ export function PublishButton({
     <React.Fragment>
       <FormSubmit
         buttonId="action-save"
+        data-testid={testIds.action.publish}
         disabled={!canPublish}
         enableSubMenu={canSchedulePublish}
         onClick={isDefaultPublishAll ? publish : () => publishSpecificLocale(activeLocale.code)}

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -286,6 +286,7 @@ export function PublishButton({
                     {isSpecificLocalePublishEnabled && (
                       <PopupList.ButtonGroup>
                         <PopupList.Button
+                          data-testid={testIds.action.publishLocale}
                           id="publish-locale"
                           onClick={
                             isDefaultPublishAll

--- a/packages/ui/src/elements/RenderTitle/index.tsx
+++ b/packages/ui/src/elements/RenderTitle/index.tsx
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react'
 
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
+import { testIds } from '../../testIds.js'
 import { IDLabel } from '../IDLabel/index.js'
 import './index.scss'
 
@@ -37,6 +38,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
         .filter(Boolean)
         .join(' ')}
       data-doc-id={id}
+      data-testid={testIds.docHeader.title}
       title={title}
     >
       {isInitializing ? (

--- a/packages/ui/src/elements/RestoreButton/index.tsx
+++ b/packages/ui/src/elements/RestoreButton/index.tsx
@@ -17,6 +17,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
 import { useRouteTransition } from '../../providers/RouteTransition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { requests } from '../../utilities/api.js'
 import { Button } from '../Button/index.js'
 import { ConfirmationModal } from '../ConfirmationModal/index.js'
@@ -164,6 +165,7 @@ export const RestoreButton: React.FC<Props> = (props) => {
       <Fragment>
         <Button
           buttonStyle="primary"
+          data-testid={testIds.action.restore}
           id={buttonId}
           key={buttonId}
           onClick={() => {

--- a/packages/ui/src/elements/SaveButton/index.tsx
+++ b/packages/ui/src/elements/SaveButton/index.tsx
@@ -48,8 +48,8 @@ export function SaveButton({ label: labelProp }: SaveButtonClientProps) {
   return (
     <FormSubmit
       buttonId="action-save"
-      data-testid={testIds.action.save}
       disabled={disabled}
+      extraButtonProps={{ 'data-testid': testIds.action.save }}
       onClick={handleSubmit}
       ref={ref}
       size="medium"

--- a/packages/ui/src/elements/SaveButton/index.tsx
+++ b/packages/ui/src/elements/SaveButton/index.tsx
@@ -11,6 +11,7 @@ import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 
 export function SaveButton({ label: labelProp }: SaveButtonClientProps) {
   const { uploadStatus } = useDocumentInfo()
@@ -47,6 +48,7 @@ export function SaveButton({ label: labelProp }: SaveButtonClientProps) {
   return (
     <FormSubmit
       buttonId="action-save"
+      data-testid={testIds.action.save}
       disabled={disabled}
       onClick={handleSubmit}
       ref={ref}

--- a/packages/ui/src/elements/SaveDraftButton/index.tsx
+++ b/packages/ui/src/elements/SaveDraftButton/index.tsx
@@ -14,6 +14,7 @@ import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 
 const baseClass = 'save-draft'
 
@@ -92,6 +93,7 @@ export function SaveDraftButton(props: SaveDraftButtonClientProps) {
       buttonId="action-save-draft"
       buttonStyle="secondary"
       className={baseClass}
+      data-testid={testIds.action.saveDraft}
       disabled={disabled}
       onClick={() => {
         return void saveDraft()

--- a/packages/ui/src/elements/SaveDraftButton/index.tsx
+++ b/packages/ui/src/elements/SaveDraftButton/index.tsx
@@ -93,8 +93,8 @@ export function SaveDraftButton(props: SaveDraftButtonClientProps) {
       buttonId="action-save-draft"
       buttonStyle="secondary"
       className={baseClass}
-      data-testid={testIds.action.saveDraft}
       disabled={disabled}
+      extraButtonProps={{ 'data-testid': testIds.action.saveDraft }}
       onClick={() => {
         return void saveDraft()
       }}

--- a/packages/ui/src/elements/SearchFilter/index.tsx
+++ b/packages/ui/src/elements/SearchFilter/index.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import type { SearchFilterProps } from './types.js'
 
 import { useDebounce } from '../../hooks/useDebounce.js'
+import { testIds } from '../../testIds.js'
 import './index.scss'
 
 const baseClass = 'search-filter'
@@ -55,6 +56,7 @@ export function SearchFilter(props: SearchFilterProps) {
       <input
         aria-label={label}
         className={`${baseClass}__input`}
+        data-testid={testIds.list.search}
         id="search-filter-input"
         onChange={(e) => {
           shouldUpdateState.current = true

--- a/packages/ui/src/elements/SelectAll/index.tsx
+++ b/packages/ui/src/elements/SelectAll/index.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { CheckboxInput } from '../../fields/Checkbox/Input.js'
 import { SelectAllStatus, useSelection } from '../../providers/Selection/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import './index.scss'
 
 const baseClass = 'select-all'
@@ -24,6 +25,7 @@ export const SelectAll: React.FC = () => {
         selectAll === SelectAllStatus.AllInPage || selectAll === SelectAllStatus.AllAvailable
       }
       className={[baseClass, `${baseClass}__checkbox`].join(' ')}
+      data-testid={testIds.table.selectAll}
       id="select-all"
       name="select-all"
       onToggle={() => toggleAll()}

--- a/packages/ui/src/elements/StepNav/index.tsx
+++ b/packages/ui/src/elements/StepNav/index.tsx
@@ -8,6 +8,7 @@ import type { StepNavItem } from './types.js'
 import { PayloadIcon } from '../../graphics/Icon/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { Link } from '../Link/index.js'
 import { RenderCustomComponent } from '../RenderCustomComponent/index.js'
 import { StepNavProvider, useStepNav } from './context.js'
@@ -54,7 +55,11 @@ const StepNav: React.FC<{
             const isLast = stepNav.length === i + 1
 
             const Step = isLast ? (
-              <span className={`${baseClass}__last`} key={i}>
+              <span
+                className={`${baseClass}__last`}
+                data-testid={testIds.docHeader.breadcrumb}
+                key={i}
+              >
                 {StepLabel}
               </span>
             ) : (

--- a/packages/ui/src/elements/Table/index.tsx
+++ b/packages/ui/src/elements/Table/index.tsx
@@ -60,7 +60,7 @@ export const Table: React.FC<Props> = ({ appearance, BeforeTable, columns, data 
                     return (
                       <td
                         className={`cell-${accessor.replace(/\./g, '__')}`}
-                        data-testid={testIds.table.cell(accessor.replace(/\./g, '__'))}
+                        data-testid={testIds.table.cell(accessor)}
                         key={colIndex}
                       >
                         {col.renderedCells[rowIndex]}

--- a/packages/ui/src/elements/Table/index.tsx
+++ b/packages/ui/src/elements/Table/index.tsx
@@ -4,6 +4,7 @@ import type { Column } from 'payload'
 
 import React from 'react'
 
+import { testIds } from '../../testIds.js'
 import './index.scss'
 
 const baseClass = 'table'
@@ -46,6 +47,7 @@ export const Table: React.FC<Props> = ({ appearance, BeforeTable, columns, data 
                 <tr
                   className={`row-${rowIndex + 1}`}
                   data-id={row.id}
+                  data-testid={testIds.table.row(rowIndex + 1)}
                   key={
                     typeof row.id === 'string' || typeof row.id === 'number'
                       ? String(row.id)
@@ -56,7 +58,11 @@ export const Table: React.FC<Props> = ({ appearance, BeforeTable, columns, data 
                     const { accessor } = col
 
                     return (
-                      <td className={`cell-${accessor.replace(/\./g, '__')}`} key={colIndex}>
+                      <td
+                        className={`cell-${accessor.replace(/\./g, '__')}`}
+                        data-testid={testIds.table.cell(accessor.replace(/\./g, '__'))}
+                        key={colIndex}
+                      >
                         {col.renderedCells[rowIndex]}
                       </td>
                     )

--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -30,6 +30,7 @@ import type { Option } from '../../ReactSelect/index.js'
 import { useDebounce } from '../../../hooks/useDebounce.js'
 import { useEffectEvent } from '../../../hooks/useEffectEvent.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import { testIds } from '../../../testIds.js'
 import { Button } from '../../Button/index.js'
 import { ReactSelect } from '../../ReactSelect/index.js'
 import { DefaultFilter } from './DefaultFilter/index.js'
@@ -141,7 +142,7 @@ export const Condition: React.FC<Props> = (props) => {
     <div className={baseClass}>
       <div className={`${baseClass}__wrap`}>
         <div className={`${baseClass}__inputs`}>
-          <div className={`${baseClass}__field`}>
+          <div className={`${baseClass}__field`} data-testid={testIds.whereBuilder.condition.field}>
             <ReactSelect
               disabled={disabled}
               filterOption={(option, inputValue) =>
@@ -159,7 +160,10 @@ export const Condition: React.FC<Props> = (props) => {
               }
             />
           </div>
-          <div className={`${baseClass}__operator`}>
+          <div
+            className={`${baseClass}__operator`}
+            data-testid={testIds.whereBuilder.condition.operator}
+          >
             <ReactSelect
               disabled={disabled}
               isClearable={false}
@@ -168,7 +172,7 @@ export const Condition: React.FC<Props> = (props) => {
               value={reducedField?.operators.find((o) => operator === o.value) || null}
             />
           </div>
-          <div className={`${baseClass}__value`}>
+          <div className={`${baseClass}__value`} data-testid={testIds.whereBuilder.condition.value}>
             {RenderedFilter || (
               <DefaultFilter
                 booleanSelect={booleanSelect}

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useListQuery } from '../../providers/ListQuery/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { reduceFieldsToOptions } from '../../utilities/reduceFieldsToOptions.js'
 import { Button } from '../Button/index.js'
 import { Condition } from './Condition/index.js'
@@ -170,7 +171,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
   )
 
   return (
-    <div className={baseClass}>
+    <div className={baseClass} data-testid={testIds.whereBuilder.root}>
       {conditions.length > 0 && (
         <React.Fragment>
           <p className={`${baseClass}__label`}>
@@ -223,6 +224,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
           <Button
             buttonStyle="icon-label"
             className={`${baseClass}__add-or`}
+            data-testid={testIds.whereBuilder.addOr}
             icon="plus"
             iconPosition="left"
             iconStyle="with-border"
@@ -245,6 +247,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
           <Button
             buttonStyle="icon-label"
             className={`${baseClass}__add-first-filter`}
+            data-testid={testIds.whereBuilder.addFirstFilter}
             icon="plus"
             iconPosition="left"
             iconStyle="with-border"

--- a/packages/ui/src/exports/shared/index.ts
+++ b/packages/ui/src/exports/shared/index.ts
@@ -8,6 +8,7 @@ export { PayloadLogo } from '../../graphics/Logo/index.js'
 // IMPORTANT: the shared.ts file CANNOT contain any Server Components _that import client components_.
 export { filterFields } from '../../providers/TableColumns/buildColumnState/filterFields.js'
 export { getInitialColumns } from '../../providers/TableColumns/getInitialColumns.js'
+export { testIds } from '../../testIds.js'
 export { abortAndIgnore, handleAbortRef } from '../../utilities/abortAndIgnore.js'
 export { requests } from '../../utilities/api.js'
 export { findLocaleFromCode } from '../../utilities/findLocaleFromCode.js'

--- a/packages/ui/src/fields/Array/ArrayRow.tsx
+++ b/packages/ui/src/fields/Array/ArrayRow.tsx
@@ -106,7 +106,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
 
   return (
     <div
-      data-testid={testIds.array.row(parentPath.split('.').join('-'), rowIndex)}
+      data-testid={testIds.array.row(parentPath, rowIndex)}
       id={`${parentPath.split('.').join('-')}-row-${rowIndex}`}
       key={`${parentPath}-row-${row.id}`}
       ref={setNodeRef}

--- a/packages/ui/src/fields/Array/ArrayRow.tsx
+++ b/packages/ui/src/fields/Array/ArrayRow.tsx
@@ -21,6 +21,7 @@ import { RenderFields } from '../../forms/RenderFields/index.js'
 import { RowLabel } from '../../forms/RowLabel/index.js'
 import { useThrottledValue } from '../../hooks/useThrottledValue.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import './index.scss'
 
 const baseClass = 'array-field'
@@ -105,6 +106,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
 
   return (
     <div
+      data-testid={testIds.array.row(parentPath.split('.').join('-'), rowIndex)}
       id={`${parentPath.split('.').join('-')}-row-${rowIndex}`}
       key={`${parentPath}-row-${row.id}`}
       ref={setNodeRef}
@@ -143,10 +145,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
             : undefined
         }
         header={
-          <div
-            className={`${baseClass}__row-header`}
-            id={`${scrollIdPrefix}-row-${rowIndex}`}
-          >
+          <div className={`${baseClass}__row-header`} id={`${scrollIdPrefix}-row-${rowIndex}`}>
             {isLoading ? (
               <ShimmerEffect height="1rem" width="8rem" />
             ) : (

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -317,6 +317,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={testIds.field(path)}
       id={`field-${path.replace(/\./g, '__')}`}
       style={styles}
     >

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -35,6 +35,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { scrollToID } from '../../utilities/scrollToID.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
@@ -474,6 +475,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
         <Button
           buttonStyle="icon-label"
           className={`${baseClass}__add-row`}
+          data-testid={testIds.array.addRow(path)}
           disabled={disabled}
           icon="plus"
           iconPosition="left"

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -475,8 +475,8 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
         <Button
           buttonStyle="icon-label"
           className={`${baseClass}__add-row`}
-          data-testid={testIds.array.addRow(path)}
           disabled={disabled}
+          extraButtonProps={{ 'data-testid': testIds.array.addRow(path) }}
           icon="plus"
           iconPosition="left"
           iconStyle="with-border"

--- a/packages/ui/src/fields/Blocks/BlockRow.tsx
+++ b/packages/ui/src/fields/Blocks/BlockRow.tsx
@@ -16,6 +16,7 @@ import { RenderFields } from '../../forms/RenderFields/index.js'
 import { RowLabel } from '../../forms/RowLabel/index.js'
 import { useThrottledValue } from '../../hooks/useThrottledValue.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { RowActions } from './RowActions.js'
 import { SectionTitle } from './SectionTitle/index.js'
 
@@ -132,6 +133,7 @@ export const BlockRow: React.FC<BlocksFieldProps> = ({
 
   return (
     <div
+      data-testid={testIds.blocks.row(parentPath?.split('.').join('-') ?? '', rowIndex)}
       id={`${parentPath?.split('.').join('-')}-row-${rowIndex}`}
       key={`${parentPath}-row-${rowIndex}`}
       ref={setNodeRef}

--- a/packages/ui/src/fields/Blocks/BlockRow.tsx
+++ b/packages/ui/src/fields/Blocks/BlockRow.tsx
@@ -133,7 +133,7 @@ export const BlockRow: React.FC<BlocksFieldProps> = ({
 
   return (
     <div
-      data-testid={testIds.blocks.row(parentPath?.split('.').join('-') ?? '', rowIndex)}
+      data-testid={testIds.blocks.row(parentPath ?? '', rowIndex)}
       id={`${parentPath?.split('.').join('-')}-row-${rowIndex}`}
       key={`${parentPath}-row-${rowIndex}`}
       ref={setNodeRef}

--- a/packages/ui/src/fields/Blocks/BlockSelector/index.tsx
+++ b/packages/ui/src/fields/Blocks/BlockSelector/index.tsx
@@ -10,6 +10,7 @@ import { DefaultBlockImage } from '../../../graphics/DefaultBlockImage/index.js'
 import { useControllableState } from '../../../hooks/useControllableState.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import { testIds } from '../../../testIds.js'
 import { BlockSearch } from './BlockSearch/index.js'
 import './index.scss'
 
@@ -117,7 +118,11 @@ export const BlockSelector: React.FC<Props> = (props) => {
                         : imageAltText
 
                     return (
-                      <li className={`${baseClass}__block`} key={index}>
+                      <li
+                        className={`${baseClass}__block`}
+                        data-testid={testIds.blocks.blockOption(slug)}
+                        key={index}
+                      >
                         <ThumbnailCard
                           alignLabel="center"
                           label={getTranslation(blockLabels?.singular, i18n)}

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -325,6 +325,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={path ? testIds.field(path) : undefined}
       id={`field-${path?.replace(/\./g, '__')}`}
       style={styles}
     >

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -30,6 +30,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { scrollToID } from '../../utilities/scrollToID.js'
 import './index.scss'
 import { FieldDescription } from '../FieldDescription/index.js'
@@ -495,6 +496,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
         <Fragment>
           <DrawerToggler
             className={`${baseClass}__drawer-toggler`}
+            data-testid={testIds.blocks.addButton(path)}
             disabled={readOnly || disabled}
             slug={drawerSlug}
           >

--- a/packages/ui/src/fields/Collapsible/index.tsx
+++ b/packages/ui/src/fields/Collapsible/index.tsx
@@ -16,6 +16,7 @@ import { withCondition } from '../../forms/withCondition/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { usePreferences } from '../../providers/Preferences/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import './index.scss'
 import { fieldBaseClass } from '../shared/index.js'
@@ -123,6 +124,7 @@ const CollapsibleFieldComponent: CollapsibleFieldClientComponent = (props) => {
         ]
           .filter(Boolean)
           .join(' ')}
+        data-testid={testIds.field(fieldPreferencesKey)}
         id={`field-${fieldPreferencesKey}`}
         style={styles}
       >

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -18,6 +18,7 @@ import './index.scss'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
 
@@ -181,7 +182,11 @@ const DateTimeFieldComponent: DateFieldClientComponent = (props) => {
           <FieldLabel label={label} localized={localized} path={path} required={required} />
         }
       />
-      <div className={`${fieldBaseClass}__wrap`} id={`field-${path.replace(/\./g, '__')}`}>
+      <div
+        className={`${fieldBaseClass}__wrap`}
+        data-testid={testIds.field(path)}
+        id={`field-${path.replace(/\./g, '__')}`}
+      >
         <RenderCustomComponent
           CustomComponent={Error}
           Fallback={<FieldError path={path} showError={showError} />}

--- a/packages/ui/src/fields/Email/index.tsx
+++ b/packages/ui/src/fields/Email/index.tsx
@@ -75,6 +75,7 @@ const EmailFieldComponent: EmailFieldClientComponent = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={testIds.field(path)}
       style={styles}
     >
       <RenderCustomComponent

--- a/packages/ui/src/fields/Email/index.tsx
+++ b/packages/ui/src/fields/Email/index.tsx
@@ -14,6 +14,7 @@ import { FieldError } from '../../fields/FieldError/index.js'
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { FieldLabel } from '../FieldLabel/index.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
@@ -92,6 +93,7 @@ const EmailFieldComponent: EmailFieldClientComponent = (props) => {
         {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
         <input
           autoComplete={autoComplete}
+          data-testid={testIds.field(path)}
           disabled={readOnly || disabled}
           id={`field-${path.replace(/\./g, '__')}`}
           name={path}

--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -16,6 +16,7 @@ import { RenderFields } from '../../forms/RenderFields/index.js'
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import './index.scss'
 import { useRow } from '../Row/provider.js'
@@ -74,6 +75,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={path ? testIds.field(path) : undefined}
       id={`field-${path?.replace(/\./g, '__')}`}
       style={styles}
     >

--- a/packages/ui/src/fields/Hidden/index.tsx
+++ b/packages/ui/src/fields/Hidden/index.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from 'react'
 
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
+import { testIds } from '../../testIds.js'
 
 /**
  * Renders an input with `type="hidden"`.
@@ -27,6 +28,7 @@ const HiddenFieldComponent: React.FC<HiddenFieldProps> = (props) => {
 
   return (
     <input
+      data-testid={path ? testIds.field(path) : undefined}
       id={`field-${path?.replace(/\./g, '__')}`}
       name={path}
       onChange={setValue}

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -19,6 +19,7 @@ import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
+import { testIds } from '../../testIds.js'
 import { FieldDescription } from '../FieldDescription/index.js'
 import { FieldError } from '../FieldError/index.js'
 import { FieldLabel } from '../FieldLabel/index.js'
@@ -200,6 +201,7 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
   return (
     <div
       className={[fieldBaseClass, showError && 'error', 'join'].filter(Boolean).join(' ')}
+      data-testid={path ? testIds.field(path) : undefined}
       id={`field-${path?.replace(/\./g, '__')}`}
     >
       <RenderCustomComponent

--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -12,11 +12,12 @@ import { RenderCustomComponent } from '../../elements/RenderCustomComponent/inde
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { FieldDescription } from '../FieldDescription/index.js'
 import { FieldError } from '../FieldError/index.js'
 import { FieldLabel } from '../FieldLabel/index.js'
-import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import './index.scss'
+import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
 
 const NumberFieldComponent: NumberFieldClientComponent = (props) => {
@@ -183,6 +184,7 @@ const NumberFieldComponent: NumberFieldClientComponent = (props) => {
         ) : (
           <div>
             <input
+              data-testid={testIds.field(path)}
               disabled={readOnly || disabled}
               id={`field-${path.replace(/\./g, '__')}`}
               max={max}

--- a/packages/ui/src/fields/Password/input.tsx
+++ b/packages/ui/src/fields/Password/input.tsx
@@ -11,6 +11,7 @@ import { FieldDescription } from '../../fields/FieldDescription/index.js'
 import { FieldError } from '../../fields/FieldError/index.js'
 import { FieldLabel } from '../../fields/FieldLabel/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { fieldBaseClass } from '../shared/index.js'
 import './index.scss'
 
@@ -75,6 +76,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = (props) => {
             aria-label={getTranslation(label, i18n)}
             autoComplete={autoComplete}
             data-rtl={rtl}
+            data-testid={testIds.field(path)}
             disabled={readOnly}
             id={`field-${path.replace(/\./g, '__')}`}
             name={path}

--- a/packages/ui/src/fields/Password/input.tsx
+++ b/packages/ui/src/fields/Password/input.tsx
@@ -54,6 +54,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={testIds.field(path)}
       style={{
         ...style,
         width,

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -11,8 +11,9 @@ import { FieldLabel } from '../../fields/FieldLabel/index.js'
 import { useForm } from '../../forms/Form/context.js'
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
-import { mergeFieldStyles } from '../mergeFieldStyles.js'
+import { testIds } from '../../testIds.js'
 import './index.scss'
+import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
 import { Radio } from './Radio/index.js'
 
@@ -93,7 +94,11 @@ const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
       />
       <div className={`${fieldBaseClass}__wrap`}>
         {BeforeInput}
-        <ul className={`${baseClass}--group`} id={`field-${path.replace(/\./g, '__')}`}>
+        <ul
+          className={`${baseClass}--group`}
+          data-testid={testIds.field(path)}
+          id={`field-${path.replace(/\./g, '__')}`}
+        >
           {options.map((option) => {
             let optionValue = ''
 

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -33,6 +33,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentEvents } from '../../providers/DocumentEvents/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { sanitizeFilterOptionsQuery } from '../../utilities/sanitizeFilterOptionsQuery.js'
 import { fieldBaseClass } from '../shared/index.js'
 import { createRelationMap } from './createRelationMap.js'
@@ -758,6 +759,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={testIds.field(path)}
       id={`field-${path.replace(/\./g, '__')}`}
       style={style}
     >

--- a/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
@@ -11,6 +11,7 @@ import { Tooltip } from '../../../../elements/Tooltip/index.js'
 import { EditIcon } from '../../../../icons/Edit/index.js'
 import { useAuth } from '../../../../providers/Auth/index.js'
 import { useTranslation } from '../../../../providers/Translation/index.js'
+import { testIds } from '../../../../testIds.js'
 import './index.scss'
 
 const baseClass = 'relationship--single-value'
@@ -44,6 +45,7 @@ export const SingleValue: React.FC<
               <button
                 aria-label={t('general:editLabel', { label })}
                 className={`${baseClass}__drawer-toggler`}
+                data-testid={testIds.relationship.drawerToggle(relationTo)}
                 onClick={(event) => {
                   setShowTooltip(false)
                   onDocumentOpen({

--- a/packages/ui/src/fields/Select/Input.tsx
+++ b/packages/ui/src/fields/Select/Input.tsx
@@ -12,6 +12,7 @@ import { FieldDescription } from '../../fields/FieldDescription/index.js'
 import { FieldError } from '../../fields/FieldError/index.js'
 import { FieldLabel } from '../../fields/FieldLabel/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { fieldBaseClass } from '../shared/index.js'
 import './index.scss'
 
@@ -105,6 +106,7 @@ export const SelectInput: React.FC<SelectInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={testIds.field(path)}
       id={`field-${path.replace(/\./g, '__')}`}
       style={style}
     >

--- a/packages/ui/src/fields/Tabs/Tab/index.tsx
+++ b/packages/ui/src/fields/Tabs/Tab/index.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react'
 import { ErrorPill } from '../../../elements/ErrorPill/index.js'
 import { WatchChildErrors } from '../../../forms/WatchChildErrors/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import { testIds } from '../../../testIds.js'
 import './index.scss'
 
 const baseClass = 'tabs-field__tab-button'
@@ -51,6 +52,7 @@ export const TabComponent: React.FC<TabProps> = ({
         ]
           .filter(Boolean)
           .join(' ')}
+        data-testid={testIds.tab(tabHasName(tab) ? tab.name : '')}
         onClick={setIsActive}
         type="button"
       >

--- a/packages/ui/src/fields/Text/Input.tsx
+++ b/packages/ui/src/fields/Text/Input.tsx
@@ -13,6 +13,7 @@ import { FieldDescription } from '../../fields/FieldDescription/index.js'
 import { FieldError } from '../../fields/FieldError/index.js'
 import { FieldLabel } from '../../fields/FieldLabel/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { fieldBaseClass } from '../shared/index.js'
 import './index.scss'
 
@@ -155,6 +156,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
         ) : (
           <input
             data-rtl={rtl}
+            data-testid={path ? testIds.field(path) : undefined}
             disabled={readOnly}
             id={`field-${path?.replace(/\./g, '__')}`}
             name={path}

--- a/packages/ui/src/fields/Textarea/Input.tsx
+++ b/packages/ui/src/fields/Textarea/Input.tsx
@@ -11,6 +11,7 @@ import { FieldDescription } from '../../fields/FieldDescription/index.js'
 import { FieldError } from '../../fields/FieldError/index.js'
 import { FieldLabel } from '../../fields/FieldLabel/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { fieldBaseClass } from '../shared/index.js'
 import './index.scss'
 
@@ -73,6 +74,7 @@ export const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
         <div className="textarea-outer">
           <textarea
             data-rtl={rtl}
+            data-testid={testIds.field(path)}
             disabled={readOnly}
             id={`field-${path.replace(/\./g, '__')}`}
             name={path}

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -34,6 +34,7 @@ import { FieldLabel } from '../../fields/FieldLabel/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { normalizeRelationshipValue } from '../../utilities/normalizeRelationshipValue.js'
 import { fieldBaseClass } from '../shared/index.js'
 import { UploadComponentHasMany } from './HasMany/index.js'
@@ -655,6 +656,7 @@ export function UploadInput(props: UploadInputProps) {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-testid={path ? testIds.field(path) : undefined}
       id={`field-${path?.replace(/\./g, '__')}`}
       style={style}
     >

--- a/packages/ui/src/forms/NullifyField/index.tsx
+++ b/packages/ui/src/forms/NullifyField/index.tsx
@@ -7,6 +7,7 @@ import { CheckboxField } from '../../fields/Checkbox/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { testIds } from '../../testIds.js'
 import { useForm } from '../Form/context.js'
 import './index.scss'
 
@@ -79,6 +80,7 @@ export const NullifyLocaleField: React.FC<NullifyLocaleFieldProps> = ({
       ) : (
         <CheckboxField
           checked={checked}
+          data-testid={testIds.field(path)}
           field={{
             name: '',
             label: t('general:fallbackToDefaultLocale'),

--- a/packages/ui/src/providers/ToastContainer/index.tsx
+++ b/packages/ui/src/providers/ToastContainer/index.tsx
@@ -4,6 +4,7 @@ import type { ClientConfig } from 'payload'
 import React from 'react'
 import { Toaster } from 'sonner'
 
+import { testIds } from '../../testIds.js'
 import { Error } from './icons/Error.js'
 import { Info } from './icons/Info.js'
 import { Success } from './icons/Success.js'
@@ -18,6 +19,7 @@ export const ToastContainer: React.FC<{
     <Toaster
       className="payload-toast-container"
       closeButton
+      data-testid={testIds.toast.container}
       // @ts-expect-error
       dir="undefined"
       duration={duration ?? 4000}

--- a/packages/ui/src/providers/ToastContainer/index.tsx
+++ b/packages/ui/src/providers/ToastContainer/index.tsx
@@ -4,7 +4,6 @@ import type { ClientConfig } from 'payload'
 import React from 'react'
 import { Toaster } from 'sonner'
 
-import { testIds } from '../../testIds.js'
 import { Error } from './icons/Error.js'
 import { Info } from './icons/Info.js'
 import { Success } from './icons/Success.js'
@@ -19,7 +18,6 @@ export const ToastContainer: React.FC<{
     <Toaster
       className="payload-toast-container"
       closeButton
-      data-testid={testIds.toast.container}
       // @ts-expect-error
       dir="undefined"
       duration={duration ?? 4000}

--- a/packages/ui/src/testIds.ts
+++ b/packages/ui/src/testIds.ts
@@ -1,3 +1,6 @@
+/** Normalize field path separators: dots → double underscores to match HTML ID conventions */
+const n = (fieldPath: string) => fieldPath.replace(/\./g, '__')
+
 export const testIds = {
   // Navigation
   nav: {
@@ -19,19 +22,11 @@ export const testIds = {
   },
 
   // Fields (dynamic by path)
-  field: (path: string) => `field-${path.replace(/\./g, '__')}`,
-
-  // Toast notifications
-  toast: {
-    closeButton: 'toast-close-button',
-    container: 'toast-container',
-    error: 'toast-error',
-    success: 'toast-success',
-  },
+  field: (path: string) => `field-${n(path)}`,
 
   // Table/List
   table: {
-    cell: (fieldName: string) => `cell-${fieldName}`,
+    cell: (fieldName: string) => `cell-${n(fieldName)}`,
     row: (index: number) => `table-row-${index}`,
     selectAll: 'select-all',
     selectRow: (index: number) => `select-row-${index}`,
@@ -45,17 +40,17 @@ export const testIds = {
 
   // Array fields
   array: {
-    addRow: (fieldName: string) => `${fieldName}-add-row`,
-    row: (fieldName: string, index: number) => `${fieldName}-row-${index}`,
-    rowActions: (fieldName: string, index: number) => `${fieldName}-row-actions-${index}`,
+    addRow: (fieldName: string) => `${n(fieldName)}-add-row`,
+    row: (fieldName: string, index: number) => `${n(fieldName)}-row-${index}`,
+    rowActions: (fieldName: string, index: number) => `${n(fieldName)}-row-actions-${index}`,
   },
 
   // Block fields
   blocks: {
-    addButton: (fieldName: string) => `${fieldName}-blocks-add`,
+    addButton: (fieldName: string) => `${n(fieldName)}-blocks-add`,
     blockOption: (blockSlug: string) => `block-option-${blockSlug}`,
     drawer: 'blocks-drawer',
-    row: (fieldName: string, index: number) => `${fieldName}-block-${index}`,
+    row: (fieldName: string, index: number) => `${n(fieldName)}-block-${index}`,
   },
 
   // List controls
@@ -81,9 +76,9 @@ export const testIds = {
 
   // Relationship
   relationship: {
-    addNew: (fieldName: string) => `${fieldName}-add-new`,
-    drawerToggle: (fieldName: string) => `${fieldName}-drawer-toggle`,
-    value: (fieldName: string) => `${fieldName}-value`,
+    addNew: (fieldName: string) => `${n(fieldName)}-add-new`,
+    drawerToggle: (fieldName: string) => `${n(fieldName)}-drawer-toggle`,
+    value: (fieldName: string) => `${n(fieldName)}-value`,
   },
 
   // Tabs
@@ -102,7 +97,7 @@ export const testIds = {
 
   // Upload
   upload: {
-    field: (fieldName: string) => `${fieldName}-upload`,
-    filename: (fieldName: string) => `${fieldName}-filename`,
+    field: (fieldName: string) => `${n(fieldName)}-upload`,
+    filename: (fieldName: string) => `${n(fieldName)}-filename`,
   },
 } as const

--- a/packages/ui/src/testIds.ts
+++ b/packages/ui/src/testIds.ts
@@ -100,4 +100,59 @@ export const testIds = {
     field: (fieldName: string) => `${n(fieldName)}-upload`,
     filename: (fieldName: string) => `${n(fieldName)}-filename`,
   },
+
+  // Popup
+  popup: {
+    content: 'popup-content',
+  },
+
+  // Array/Block row action menu items
+  arrayAction: {
+    add: 'array-action-add',
+    copyField: 'array-action-copy',
+    duplicate: 'array-action-duplicate',
+    moveDown: 'array-action-move-down',
+    moveUp: 'array-action-move-up',
+    pasteField: 'array-action-paste',
+    remove: 'array-action-remove',
+  },
+
+  // Where builder / filters
+  whereBuilder: {
+    addFirstFilter: 'where-builder-add-first',
+    addOr: 'where-builder-add-or',
+    condition: {
+      field: 'condition-field',
+      operator: 'condition-operator',
+      value: 'condition-value',
+    },
+    root: 'where-builder',
+  },
+
+  // Live preview
+  livePreview: {
+    breakpoint: 'live-preview-breakpoint',
+    toggler: 'live-preview-toggler',
+    zoom: 'live-preview-zoom',
+  },
+
+  // Confirmation modals
+  confirm: {
+    action: 'confirm-action',
+    cancel: 'confirm-cancel',
+  },
+
+  // Group by
+  groupBy: {
+    container: 'list-controls-group-by',
+    fieldSelect: 'group-by-field-select',
+    reset: 'group-by-reset',
+    toggle: 'toggle-group-by',
+  },
+
+  // Filter controls
+  filterControls: {
+    container: 'list-controls-where',
+    toggle: 'toggle-list-filters',
+  },
 } as const

--- a/packages/ui/src/testIds.ts
+++ b/packages/ui/src/testIds.ts
@@ -1,0 +1,108 @@
+export const testIds = {
+  // Navigation
+  nav: {
+    logoutButton: 'nav-logout',
+    menuItem: (slug: string) => `nav-item-${slug}`,
+    sidebar: 'nav-sidebar',
+    toggler: 'nav-toggler',
+  },
+
+  // Document actions
+  action: {
+    delete: 'action-delete',
+    duplicate: 'action-duplicate',
+    publish: 'action-publish',
+    publishLocale: 'publish-locale',
+    restore: 'action-restore',
+    save: 'action-save',
+    saveDraft: 'action-save-draft',
+  },
+
+  // Fields (dynamic by path)
+  field: (path: string) => `field-${path.replace(/\./g, '__')}`,
+
+  // Toast notifications
+  toast: {
+    closeButton: 'toast-close-button',
+    container: 'toast-container',
+    error: 'toast-error',
+    success: 'toast-success',
+  },
+
+  // Table/List
+  table: {
+    cell: (fieldName: string) => `cell-${fieldName}`,
+    row: (index: number) => `table-row-${index}`,
+    selectAll: 'select-all',
+    selectRow: (index: number) => `select-row-${index}`,
+  },
+
+  // Drawers
+  drawer: {
+    close: (id: string) => `drawer-close-${id}`,
+    content: (id: string) => `drawer-content-${id}`,
+  },
+
+  // Array fields
+  array: {
+    addRow: (fieldName: string) => `${fieldName}-add-row`,
+    row: (fieldName: string, index: number) => `${fieldName}-row-${index}`,
+    rowActions: (fieldName: string, index: number) => `${fieldName}-row-actions-${index}`,
+  },
+
+  // Block fields
+  blocks: {
+    addButton: (fieldName: string) => `${fieldName}-blocks-add`,
+    blockOption: (blockSlug: string) => `block-option-${blockSlug}`,
+    drawer: 'blocks-drawer',
+    row: (fieldName: string, index: number) => `${fieldName}-block-${index}`,
+  },
+
+  // List controls
+  list: {
+    columns: 'list-columns',
+    deleteMany: 'delete-many',
+    editMany: 'edit-many',
+    filters: 'list-filters',
+    menu: 'list-menu',
+    search: 'list-search',
+  },
+
+  // Locale
+  locale: {
+    option: (code: string) => `locale-option-${code}`,
+    selector: 'locale-selector',
+  },
+
+  // Collapsible
+  collapsible: {
+    toggle: (label: string) => `collapsible-${label}`,
+  },
+
+  // Relationship
+  relationship: {
+    addNew: (fieldName: string) => `${fieldName}-add-new`,
+    drawerToggle: (fieldName: string) => `${fieldName}-drawer-toggle`,
+    value: (fieldName: string) => `${fieldName}-value`,
+  },
+
+  // Tabs
+  tab: (label: string) => `tab-${label}`,
+
+  // Doc header
+  docHeader: {
+    breadcrumb: 'breadcrumb-last',
+    title: 'doc-header-title',
+  },
+
+  // Doc controls
+  docControls: {
+    menu: 'doc-controls-menu',
+  },
+
+  // Upload
+  upload: {
+    field: (fieldName: string) => `${fieldName}-upload`,
+    filename: (fieldName: string) => `${fieldName}-filename`,
+  },
+} as const

--- a/test/__helpers/e2e/auth/login.ts
+++ b/test/__helpers/e2e/auth/login.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test'
 import type { Config } from 'payload'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 import { formatAdminURL, wait } from 'payload/shared'
 
@@ -55,8 +56,8 @@ export async function login(args: LoginArgs): Promise<void> {
 
   await page.goto(loginRoute)
   await wait(500)
-  await page.fill('#field-email', data.email)
-  await page.fill('#field-password', data.password)
+  await page.getByTestId(testIds.field('email')).locator('input').fill(data.email)
+  await page.getByTestId(testIds.field('password')).locator('input').fill(data.password)
   await wait(500)
   await page.click('[type=submit]')
   await page.waitForURL(adminRoute)
@@ -92,22 +93,22 @@ export async function loginClientSide(args: LoginArgs): Promise<void> {
     path: createFirstUser,
   })
 
-  if ((await page.locator('#nav-toggler').count()) > 0) {
+  if ((await page.getByTestId(testIds.nav.toggler).count()) > 0) {
     // a user is already logged in - log them out
     await openNav(page)
-    await expect(page.locator('.nav__controls [aria-label="Log out"]')).toBeVisible()
-    await page.locator('.nav__controls [aria-label="Log out"]').click()
+    await expect(page.getByTestId(testIds.nav.logoutButton)).toBeVisible()
+    await page.getByTestId(testIds.nav.logoutButton).click()
 
     if (await page.locator('dialog#leave-without-saving').isVisible()) {
-      await page.locator('dialog#leave-without-saving #confirm-action').click()
+      await page.locator('dialog#leave-without-saving').getByTestId(testIds.confirm.action).click()
     }
 
     await page.waitForURL(loginRoute)
   }
 
   await wait(500)
-  await page.fill('#field-email', data.email)
-  await page.fill('#field-password', data.password)
+  await page.getByTestId(testIds.field('email')).locator('input').fill(data.email)
+  await page.getByTestId(testIds.field('password')).locator('input').fill(data.password)
   await wait(500)
   await page.click('[type=submit]')
 

--- a/test/__helpers/e2e/copyPasteField.ts
+++ b/test/__helpers/e2e/copyPasteField.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 import { wait } from 'payload/shared'
 
@@ -17,7 +18,7 @@ export async function copyPasteField({
   rowIndex?: number
 }) {
   const isCopy = action === 'copy'
-  const field = page.locator(`#field-${fieldName}`)
+  const field = page.getByTestId(testIds.field(fieldName))
   const rowAction = typeof rowIndex === 'number'
   await expect(field).toBeVisible()
 
@@ -25,10 +26,12 @@ export async function copyPasteField({
     await wait(1000)
   }
 
-  const popupBtnSelector = rowAction
-    ? `#${fieldName}-row-${rowIndex} .collapsible__actions button.array-actions__button`
-    : 'header .clipboard-action__popup button.popup-button'
-  const popupBtn = field.locator(popupBtnSelector).first()
+  const popupBtn = rowAction
+    ? page
+        .getByTestId(testIds.array.row(fieldName, rowIndex))
+        .locator('.collapsible__actions button.array-actions__button')
+        .first()
+    : field.locator('header .clipboard-action__popup button.popup-button').first()
   await expect(popupBtn).toBeVisible()
   await popupBtn.click()
 

--- a/test/__helpers/e2e/fields/array/addArrayRow.ts
+++ b/test/__helpers/e2e/fields/array/addArrayRow.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 import { wait } from 'payload/shared'
 
@@ -9,7 +10,7 @@ import { openArrayRowActions } from './openArrayRowActions.js'
  * Does not wait after adding the row for the row to appear and fully load in. Simply clicks the primary "Add Row" button and moves on.
  */
 export const addArrayRowAsync = async (page: Page, fieldName: string) => {
-  await page.locator(`#field-${fieldName} > .array-field__add-row`).first().click()
+  await page.getByTestId(testIds.array.addRow(fieldName)).first().click()
 }
 
 /**

--- a/test/__helpers/e2e/fields/array/addArrayRow.ts
+++ b/test/__helpers/e2e/fields/array/addArrayRow.ts
@@ -20,7 +20,7 @@ export const addArrayRow = async (
   page: Page,
   { fieldName }: Omit<Parameters<typeof openArrayRowActions>[1], 'rowIndex'>,
 ) => {
-  const rowLocator = page.locator(`#field-${fieldName} .array-field__row`)
+  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.array-field__row')
   const numberOfPrevRows = await rowLocator.count()
 
   await addArrayRowAsync(page, fieldName)
@@ -35,7 +35,7 @@ export const addArrayRowBelow = async (
   page: Page,
   { fieldName, rowIndex = 0 }: Parameters<typeof openArrayRowActions>[1],
 ): Promise<{ popupContentLocator: Locator; rowActionsButtonLocator: Locator }> => {
-  const rowLocator = page.locator(`#field-${fieldName} .array-field__row`)
+  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.array-field__row')
   const numberOfPrevRows = await rowLocator.count()
 
   const { popupContentLocator, rowActionsButtonLocator } = await openArrayRowActions(page, {
@@ -43,7 +43,7 @@ export const addArrayRowBelow = async (
     rowIndex,
   })
 
-  await popupContentLocator.locator('.array-actions__action.array-actions__add').click()
+  await popupContentLocator.getByTestId(testIds.arrayAction.add).click()
 
   await expect(rowLocator).toHaveCount(numberOfPrevRows + 1)
 

--- a/test/__helpers/e2e/fields/array/duplicateArrayRow.ts
+++ b/test/__helpers/e2e/fields/array/duplicateArrayRow.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { openArrayRowActions } from './openArrayRowActions.js'
@@ -14,7 +15,9 @@ export const duplicateArrayRow = async (
   popupContentLocator: Locator
   rowActionsButtonLocator: Locator
 }> => {
-  const rowLocator = page.locator(`#field-${fieldName} > .array-field__draggable-rows > *`)
+  const rowLocator = page
+    .getByTestId(testIds.field(fieldName))
+    .locator('.array-field__draggable-rows > *')
 
   const numberOfPrevRows = await rowLocator.count()
 
@@ -23,7 +26,7 @@ export const duplicateArrayRow = async (
     rowIndex,
   })
 
-  await popupContentLocator.locator('.array-actions__action.array-actions__duplicate').click()
+  await popupContentLocator.getByTestId(testIds.arrayAction.duplicate).click()
 
   expect(await rowLocator.count()).toBe(numberOfPrevRows + 1)
 

--- a/test/__helpers/e2e/fields/array/duplicateArrayRow.ts
+++ b/test/__helpers/e2e/fields/array/duplicateArrayRow.ts
@@ -17,7 +17,7 @@ export const duplicateArrayRow = async (
 }> => {
   const rowLocator = page
     .getByTestId(testIds.field(fieldName))
-    .locator('.array-field__draggable-rows > *')
+    .locator(':scope > .array-field__draggable-rows > *')
 
   const numberOfPrevRows = await rowLocator.count()
 

--- a/test/__helpers/e2e/fields/array/openArrayRowActions.ts
+++ b/test/__helpers/e2e/fields/array/openArrayRowActions.ts
@@ -20,11 +20,8 @@ export const openArrayRowActions = async (
   popupContentLocator: Locator
   rowActionsButtonLocator: Locator
 }> => {
-  // replace double underscores with single hyphens for the row ID
-  const formattedRowID = fieldName.toString().replace(/__/g, '-')
-
   const rowActions = page
-    .getByTestId(testIds.array.row(formattedRowID, rowIndex))
+    .getByTestId(testIds.array.row(fieldName, rowIndex))
     .locator('.array-actions')
     .first()
 

--- a/test/__helpers/e2e/fields/array/openArrayRowActions.ts
+++ b/test/__helpers/e2e/fields/array/openArrayRowActions.ts
@@ -11,19 +11,23 @@ export const openArrayRowActions = async (
   page: Page,
   {
     fieldName,
+    fieldType = 'array',
     rowIndex = 0,
   }: {
     fieldName: string
+    fieldType?: 'array' | 'blocks'
     rowIndex?: number
   },
 ): Promise<{
   popupContentLocator: Locator
   rowActionsButtonLocator: Locator
 }> => {
-  const rowActions = page
-    .getByTestId(testIds.array.row(fieldName, rowIndex))
-    .locator('.array-actions')
-    .first()
+  const rowTestId =
+    fieldType === 'blocks'
+      ? testIds.blocks.row(fieldName, rowIndex)
+      : testIds.array.row(fieldName, rowIndex)
+
+  const rowActions = page.getByTestId(rowTestId).locator('.array-actions').first()
 
   const popupContentLocator = page.locator('.popup__content')
 

--- a/test/__helpers/e2e/fields/array/openArrayRowActions.ts
+++ b/test/__helpers/e2e/fields/array/openArrayRowActions.ts
@@ -29,7 +29,7 @@ export const openArrayRowActions = async (
 
   const rowActions = page.getByTestId(rowTestId).locator('.array-actions').first()
 
-  const popupContentLocator = page.locator('.popup__content')
+  const popupContentLocator = page.getByTestId(testIds.popup.content)
 
   if (await popupContentLocator.isVisible()) {
     throw new Error(`Row actions for field "${fieldName}" at index ${rowIndex} are already open.`)

--- a/test/__helpers/e2e/fields/array/openArrayRowActions.ts
+++ b/test/__helpers/e2e/fields/array/openArrayRowActions.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 /**
@@ -23,7 +24,8 @@ export const openArrayRowActions = async (
   const formattedRowID = fieldName.toString().replace(/__/g, '-')
 
   const rowActions = page
-    .locator(`#field-${fieldName} #${formattedRowID}-row-${rowIndex} .array-actions`)
+    .getByTestId(testIds.array.row(formattedRowID, rowIndex))
+    .locator('.array-actions')
     .first()
 
   const popupContentLocator = page.locator('.popup__content')

--- a/test/__helpers/e2e/fields/array/removeArrayRow.ts
+++ b/test/__helpers/e2e/fields/array/removeArrayRow.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { openArrayRowActions } from './openArrayRowActions.js'
@@ -14,7 +15,7 @@ export const removeArrayRow = async (
   popupContentLocator: Locator
   rowActionsButtonLocator: Locator
 }> => {
-  const rowLocator = page.locator(`#field-${fieldName} .array-field__row`)
+  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.array-field__row')
   const numberOfPrevRows = await rowLocator.count()
 
   const { popupContentLocator, rowActionsButtonLocator } = await openArrayRowActions(page, {
@@ -22,7 +23,7 @@ export const removeArrayRow = async (
     rowIndex,
   })
 
-  await popupContentLocator.locator('.array-actions__action.array-actions__remove').click()
+  await popupContentLocator.getByTestId(testIds.arrayAction.remove).click()
 
   expect(await rowLocator.count()).toBe(numberOfPrevRows - 1)
 

--- a/test/__helpers/e2e/fields/blocks/addBlock.ts
+++ b/test/__helpers/e2e/fields/blocks/addBlock.ts
@@ -84,6 +84,7 @@ export const addBlockBelow = async (
 
   const { popupContentLocator, rowActionsButtonLocator } = await openArrayRowActions(page, {
     fieldName,
+    fieldType: 'blocks',
     rowIndex,
   })
 

--- a/test/__helpers/e2e/fields/blocks/addBlock.ts
+++ b/test/__helpers/e2e/fields/blocks/addBlock.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { exactText } from '../../helpers.js'
@@ -37,9 +38,7 @@ export const addBlock = async ({
   fieldName: string
   page: Page
 }) => {
-  const rowLocator = page.locator(
-    `#field-${fieldName} > .blocks-field__rows > div > .blocks-field__row`,
-  )
+  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.blocks-field__row')
 
   const numberOfPrevRows = await rowLocator.count()
 
@@ -76,9 +75,7 @@ export const addBlockBelow = async (
     rowIndex?: number
   },
 ) => {
-  const rowLocator = page.locator(
-    `#field-${fieldName} > .blocks-field__rows > div > .blocks-field__row`,
-  )
+  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.blocks-field__row')
 
   const numberOfPrevRows = await rowLocator.count()
 
@@ -88,7 +85,7 @@ export const addBlockBelow = async (
     rowIndex,
   })
 
-  await popupContentLocator.locator('.array-actions__action.array-actions__add').click()
+  await popupContentLocator.getByTestId(testIds.arrayAction.add).click()
 
   const blocksDrawer = page.locator('[id^=drawer_1_blocks-drawer-]')
 

--- a/test/__helpers/e2e/fields/blocks/addBlock.ts
+++ b/test/__helpers/e2e/fields/blocks/addBlock.ts
@@ -38,7 +38,9 @@ export const addBlock = async ({
   fieldName: string
   page: Page
 }) => {
-  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.blocks-field__row')
+  const rowLocator = page
+    .getByTestId(testIds.field(fieldName))
+    .locator(':scope > .blocks-field__rows > div > .blocks-field__row')
 
   const numberOfPrevRows = await rowLocator.count()
 
@@ -75,7 +77,9 @@ export const addBlockBelow = async (
     rowIndex?: number
   },
 ) => {
-  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.blocks-field__row')
+  const rowLocator = page
+    .getByTestId(testIds.field(fieldName))
+    .locator(':scope > .blocks-field__rows > div > .blocks-field__row')
 
   const numberOfPrevRows = await rowLocator.count()
 

--- a/test/__helpers/e2e/fields/blocks/duplicateBlock.ts
+++ b/test/__helpers/e2e/fields/blocks/duplicateBlock.ts
@@ -16,7 +16,9 @@ export const duplicateBlock = async (
   rowActionsButtonLocator: Locator
   rowCount: number
 }> => {
-  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.blocks-field__row')
+  const rowLocator = page
+    .getByTestId(testIds.field(fieldName))
+    .locator(':scope > .blocks-field__rows > div > .blocks-field__row')
 
   const numberOfPrevRows = await rowLocator.count()
 

--- a/test/__helpers/e2e/fields/blocks/duplicateBlock.ts
+++ b/test/__helpers/e2e/fields/blocks/duplicateBlock.ts
@@ -23,6 +23,7 @@ export const duplicateBlock = async (
 
   const { popupContentLocator, rowActionsButtonLocator } = await openArrayRowActions(page, {
     fieldName,
+    fieldType: 'blocks',
     rowIndex,
   })
 

--- a/test/__helpers/e2e/fields/blocks/duplicateBlock.ts
+++ b/test/__helpers/e2e/fields/blocks/duplicateBlock.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { openArrayRowActions } from '../array/openArrayRowActions.js'
@@ -15,9 +16,7 @@ export const duplicateBlock = async (
   rowActionsButtonLocator: Locator
   rowCount: number
 }> => {
-  const rowLocator = page.locator(
-    `#field-${fieldName} > .blocks-field__rows > div > .blocks-field__row`,
-  )
+  const rowLocator = page.getByTestId(testIds.field(fieldName)).locator('.blocks-field__row')
 
   const numberOfPrevRows = await rowLocator.count()
 
@@ -27,7 +26,7 @@ export const duplicateBlock = async (
     rowIndex,
   })
 
-  await popupContentLocator.locator('.array-actions__action.array-actions__duplicate').click()
+  await popupContentLocator.getByTestId(testIds.arrayAction.duplicate).click()
   const numberOfCurrentRows = await rowLocator.count()
 
   expect(numberOfCurrentRows).toBe(numberOfPrevRows + 1)

--- a/test/__helpers/e2e/fields/blocks/openBlocksDrawer.ts
+++ b/test/__helpers/e2e/fields/blocks/openBlocksDrawer.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 export const openBlocksDrawer = async ({
@@ -12,7 +13,7 @@ export const openBlocksDrawer = async ({
   const blocksDrawer = page.locator('[id^=drawer_1_blocks-drawer-]')
 
   if (!(await blocksDrawer.isVisible())) {
-    const addButton = page.locator(`#field-${fieldName} > .blocks-field__drawer-toggler`)
+    const addButton = page.getByTestId(testIds.blocks.addButton(fieldName))
     await addButton.click()
   }
 

--- a/test/__helpers/e2e/fields/blocks/removeAllBlocks.ts
+++ b/test/__helpers/e2e/fields/blocks/removeAllBlocks.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 export const removeAllBlocks = async ({
@@ -9,7 +10,7 @@ export const removeAllBlocks = async ({
   fieldName: string
   page: Page
 }) => {
-  const blocksField = page.locator(`#field-${fieldName}`)
+  const blocksField = page.getByTestId(testIds.field(fieldName))
 
   const blocks = blocksField.locator(`[id^="${fieldName}-row-"]`)
   const count = await blocks.count()
@@ -20,6 +21,6 @@ export const removeAllBlocks = async ({
     // delete in reverse order to avoid index issues
     const block = blocksField.locator(`[id^="${fieldName}-row-${count - i - 1}"]`)
     await block.locator('.array-actions__button').first().click()
-    await block.locator('.array-actions__action.array-actions__remove').first().click()
+    await page.getByTestId(testIds.arrayAction.remove).click()
   }
 }

--- a/test/__helpers/e2e/fields/relationship/openRelationshipFieldDrawer.ts
+++ b/test/__helpers/e2e/fields/relationship/openRelationshipFieldDrawer.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 import { wait } from 'payload/shared'
 
@@ -37,7 +38,7 @@ export async function openRelationshipFieldDrawer({
   await wait(300)
 
   // Click the relationship field to open the list drawer
-  const relationshipField = page.locator(`#field-${fieldName}`)
+  const relationshipField = page.getByTestId(testIds.field(fieldName))
   await relationshipField.click()
 
   // Wait for list drawer to be visible

--- a/test/__helpers/e2e/filters/addListFilter.ts
+++ b/test/__helpers/e2e/filters/addListFilter.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { selectInput } from '../selectInput.js'
@@ -30,9 +31,9 @@ export const addListFilter = async ({
 }> => {
   await openListFilters(page, {})
 
-  const whereBuilder = page.locator('.where-builder')
+  const whereBuilder = page.getByTestId(testIds.whereBuilder.root)
 
-  const addFirst = whereBuilder.locator('.where-builder__add-first-filter')
+  const addFirst = whereBuilder.getByTestId(testIds.whereBuilder.addFirstFilter)
   const initializedEmpty = await addFirst.isVisible()
 
   if (initializedEmpty) {
@@ -44,7 +45,7 @@ export const addListFilter = async ({
 
   // If there were already filter(s), need to add another and manipulate _that_ instead of the existing one
   if (!initializedEmpty) {
-    const addFilterButtons = whereBuilder.locator('.where-builder__add-or')
+    const addFilterButtons = whereBuilder.getByTestId(testIds.whereBuilder.addOr)
     await addFilterButtons.last().click()
     await expect(filters).toHaveCount(2)
   }
@@ -52,13 +53,13 @@ export const addListFilter = async ({
   const condition = filters.last()
 
   await selectInput({
-    selectLocator: condition.locator('.condition__field'),
+    selectLocator: condition.getByTestId(testIds.whereBuilder.condition.field),
     multiSelect: false,
     option: fieldLabel,
   })
 
   await selectInput({
-    selectLocator: condition.locator('.condition__operator'),
+    selectLocator: condition.getByTestId(testIds.whereBuilder.condition.operator),
     multiSelect: false,
     option: operatorLabel,
   })
@@ -68,13 +69,13 @@ export const addListFilter = async ({
       (response) =>
         response.url().includes(encodeURIComponent('where[or')) && response.status() === 200,
     )
-    const valueLocator = condition.locator('.condition__value')
+    const valueLocator = condition.getByTestId(testIds.whereBuilder.condition.value)
     const valueInput = valueLocator.locator('input')
     await valueInput.fill(value)
     await expect(valueInput).toHaveValue(value)
 
     if ((await valueLocator.locator('input.rs__input').count()) > 0) {
-      const valueOptions = condition.locator('.condition__value .rs__option')
+      const valueOptions = valueLocator.locator('.rs__option')
       const createValue = valueOptions.locator(`text=Create "${value}"`)
       if ((await createValue.count()) > 0) {
         await createValue.click()

--- a/test/__helpers/e2e/filters/openListFilters.ts
+++ b/test/__helpers/e2e/filters/openListFilters.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 /**
@@ -9,25 +10,34 @@ import { expect } from '@playwright/test'
 export const openListFilters = async (
   page: Page,
   {
-    togglerSelector = '#toggle-list-filters',
-    filterContainerSelector = '#list-controls-where',
+    togglerSelector,
+    filterContainerSelector,
   }: {
     filterContainerSelector?: string
     togglerSelector?: string
-  },
+  } = {},
 ): Promise<{
   filterContainer: Locator
 }> => {
-  await expect(page.locator(togglerSelector)).toBeVisible()
-  const filterContainer = page.locator(filterContainerSelector).first()
+  const toggler = togglerSelector
+    ? page.locator(togglerSelector)
+    : page.getByTestId(testIds.filterControls.toggle)
+
+  await expect(toggler).toBeVisible()
+
+  const filterContainer = filterContainerSelector
+    ? page.locator(filterContainerSelector).first()
+    : page.getByTestId(testIds.filterControls.container).first()
 
   const isAlreadyOpen = await filterContainer.isVisible()
 
   if (!isAlreadyOpen) {
-    await page.locator(togglerSelector).first().click()
+    await toggler.first().click()
   }
 
-  await expect(page.locator(`${filterContainerSelector}.rah-static--height-auto`)).toBeVisible()
+  const containerSelector =
+    filterContainerSelector ?? `[data-testid="${testIds.filterControls.container}"]`
+  await expect(page.locator(`${containerSelector}.rah-static--height-auto`)).toBeVisible()
 
   return { filterContainer }
 }

--- a/test/__helpers/e2e/folders/createFolderDoc.ts
+++ b/test/__helpers/e2e/folders/createFolderDoc.ts
@@ -1,3 +1,4 @@
+import { testIds } from '@payloadcms/ui/shared'
 import { expect, type Page } from '@playwright/test'
 
 import { closeAllToasts } from '../helpers.js'
@@ -12,12 +13,12 @@ export const createFolderDoc = async ({
   page: Page
 }) => {
   const drawer = page.locator('dialog .collection-edit--payload-folders')
-  await drawer.locator('input#field-name').fill(folderName)
+  await drawer.getByTestId(testIds.field('name')).locator('input').fill(folderName)
 
   await selectInput({
     multiSelect: true,
     options: folderType,
-    selectLocator: drawer.locator('#field-folderType'),
+    selectLocator: drawer.getByTestId(testIds.field('folderType')),
   })
 
   const createButton = drawer.getByRole('button', { name: 'Save' })

--- a/test/__helpers/e2e/groupBy/addGroupBy.ts
+++ b/test/__helpers/e2e/groupBy/addGroupBy.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { exactText } from '../helpers.js'
@@ -10,7 +11,7 @@ export const addGroupBy = async (
   { fieldLabel, fieldPath }: { fieldLabel: string; fieldPath: string },
 ): Promise<{ field: Locator; groupByContainer: Locator }> => {
   const { groupByContainer } = await openGroupBy(page)
-  const field = groupByContainer.locator('#group-by--field-select')
+  const field = groupByContainer.getByTestId(testIds.groupBy.fieldSelect)
 
   await field.click()
   await field.locator('.rs__option', { hasText: exactText(fieldLabel) })?.click()

--- a/test/__helpers/e2e/groupBy/clearGroupBy.ts
+++ b/test/__helpers/e2e/groupBy/clearGroupBy.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { openGroupBy } from './openGroupBy.js'
@@ -7,13 +8,15 @@ import { openGroupBy } from './openGroupBy.js'
 export const clearGroupBy = async (page: Page): Promise<{ groupByContainer: Locator }> => {
   const { groupByContainer } = await openGroupBy(page)
 
-  await groupByContainer.locator('#group-by--reset').click()
-  const field = groupByContainer.locator('#group-by--field-select')
+  await groupByContainer.getByTestId(testIds.groupBy.reset).click()
+  const field = groupByContainer.getByTestId(testIds.groupBy.fieldSelect)
 
   await expect(field.locator('.react-select--single-value')).toHaveText('Select a value')
-  await expect(groupByContainer.locator('#group-by--reset')).toBeHidden()
+  await expect(groupByContainer.getByTestId(testIds.groupBy.reset)).toBeHidden()
   await expect(page).not.toHaveURL(/&groupBy=/)
-  await expect(groupByContainer.locator('#field-direction input')).toBeDisabled()
+  await expect(
+    groupByContainer.getByTestId(testIds.field('direction')).locator('input'),
+  ).toBeDisabled()
   await expect(page.locator('.table-wrap')).toHaveCount(1)
   await expect(page.locator('.group-by-header')).toHaveCount(0)
 

--- a/test/__helpers/e2e/groupBy/toggleGroupBy.ts
+++ b/test/__helpers/e2e/groupBy/toggleGroupBy.ts
@@ -1,11 +1,12 @@
 import type { Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 export type ToggleOptions = {
-  groupByContainerSelector: string
+  groupByContainerSelector?: string
   targetState: 'closed' | 'open'
-  togglerSelector: string
+  togglerSelector?: string
 }
 
 /**
@@ -13,24 +14,29 @@ export type ToggleOptions = {
  */
 export const toggleGroupBy = async (
   page: Page,
-  {
-    targetState = 'open',
-    togglerSelector = '#toggle-group-by',
-    groupByContainerSelector = '#list-controls-group-by',
-  }: ToggleOptions,
+  { targetState = 'open', togglerSelector, groupByContainerSelector }: ToggleOptions,
 ) => {
-  const groupByContainer = page.locator(groupByContainerSelector).first()
+  const toggler = togglerSelector
+    ? page.locator(togglerSelector)
+    : page.getByTestId(testIds.groupBy.toggle)
+
+  const groupByContainer = groupByContainerSelector
+    ? page.locator(groupByContainerSelector).first()
+    : page.getByTestId(testIds.groupBy.container).first()
+
+  const containerSelector =
+    groupByContainerSelector ?? `[data-testid="${testIds.groupBy.container}"]`
 
   const isAlreadyOpen = await groupByContainer.isVisible()
 
   if (!isAlreadyOpen && targetState === 'open') {
-    await page.locator(togglerSelector).first().click()
-    await expect(page.locator(`${groupByContainerSelector}.rah-static--height-auto`)).toBeVisible()
+    await toggler.first().click()
+    await expect(page.locator(`${containerSelector}.rah-static--height-auto`)).toBeVisible()
   }
 
   if (isAlreadyOpen && targetState === 'closed') {
-    await page.locator(togglerSelector).first().click()
-    await expect(page.locator(`${groupByContainerSelector}.rah-static--height-auto`)).toBeHidden()
+    await toggler.first().click()
+    await expect(page.locator(`${containerSelector}.rah-static--height-auto`)).toBeHidden()
   }
 
   return { groupByContainer }

--- a/test/__helpers/e2e/helpers.ts
+++ b/test/__helpers/e2e/helpers.ts
@@ -8,6 +8,7 @@ import type {
 } from '@playwright/test'
 import type { Config, SanitizedConfig } from 'payload'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 import { defaults } from 'payload'
 import { formatAdminURL, wait } from 'payload/shared'
@@ -202,7 +203,7 @@ export async function saveDocHotkeyAndAssert(page: Page): Promise<void> {
   } else {
     await page.keyboard.up('Control')
   }
-  await expect(page.locator('.payload-toast-container')).toContainText('successfully')
+  await expect(page.getByTestId(testIds.toast.container)).toContainText('successfully')
   await closeAllToasts(page)
 }
 
@@ -231,10 +232,10 @@ export async function saveDocAndAssert(
   await page.click(selector, { delay: 100 })
 
   if (expectation === 'success') {
-    await expect(page.locator('.payload-toast-container')).toContainText('successfully')
+    await expect(page.getByTestId(testIds.toast.container)).toContainText('successfully')
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).not.toContain('/create')
   } else {
-    await expect(page.locator('.payload-toast-container .toast-error')).toBeVisible()
+    await expect(page.getByTestId(testIds.toast.error)).toBeVisible()
   }
 
   // Close all toasts to prevent them from interfering with subsequent tests. E.g. the following could happen
@@ -248,12 +249,14 @@ export async function saveDocAndAssert(
 }
 
 export async function closeAllToasts(page: Locator | Page): Promise<void> {
-  const toastCloseSelector = '.payload-toast-container button.payload-toast-close-button'
-  let count = await page.locator(toastCloseSelector).count()
+  const closeButtons = page
+    .getByTestId(testIds.toast.container)
+    .locator('button.payload-toast-close-button')
+  let count = await closeButtons.count()
 
   while (count > 0) {
-    await page.locator(toastCloseSelector).first().click()
-    await expect(page.locator(toastCloseSelector)).toHaveCount(count - 1)
+    await closeButtons.first().click()
+    await expect(closeButtons).toHaveCount(count - 1)
     count--
   }
 }
@@ -275,7 +278,8 @@ export async function openCreateDocDrawer(page: Page, fieldSelector: string): Pr
 }
 
 export async function openLocaleSelector(page: Page): Promise<void> {
-  const button = page.locator('.localizer button.popup-button')
+  const localeSelector = page.getByTestId(testIds.locale.selector)
+  const button = localeSelector.locator('button.popup-button')
   const popup = page.locator('.popup__content')
 
   if (!(await popup.isVisible())) {
@@ -301,11 +305,7 @@ export async function changeLocale(page: Page, newLocale: string) {
     .textContent()
 
   if (currentlySelectedLocale !== `(${newLocale})`) {
-    const localeToSelect = page
-      .locator('.popup__content .popup-button-list__button')
-      .locator('.localizer__locale-code', {
-        hasText: `${newLocale}`,
-      })
+    const localeToSelect = page.getByTestId(testIds.locale.option(newLocale))
 
     await expect(async () => await expect(localeToSelect).toBeEnabled()).toPass({
       timeout: POLL_TOPASS_TIMEOUT,
@@ -340,7 +340,7 @@ export function exactText(text: string) {
 
 export const checkPageTitle = async (page: Page, title: string) => {
   await expect
-    .poll(async () => await page.locator('.doc-header__title.render-title')?.first()?.innerText(), {
+    .poll(async () => await page.getByTestId(testIds.docHeader.title)?.first()?.innerText(), {
       timeout: POLL_TOPASS_TIMEOUT,
     })
     .toBe(title)
@@ -348,12 +348,9 @@ export const checkPageTitle = async (page: Page, title: string) => {
 
 export const checkBreadcrumb = async (page: Page, text: string) => {
   await expect
-    .poll(
-      async () => await page.locator('.step-nav.app-header__step-nav .step-nav__last')?.innerText(),
-      {
-        timeout: POLL_TOPASS_TIMEOUT,
-      },
-    )
+    .poll(async () => await page.getByTestId(testIds.docHeader.breadcrumb)?.innerText(), {
+      timeout: POLL_TOPASS_TIMEOUT,
+    })
     .toBe(text)
 }
 
@@ -369,7 +366,7 @@ export const findTableCell = async (
   rowTitle?: string,
 ): Promise<Locator> => {
   const parentEl = rowTitle ? await findTableRow(page, rowTitle) : page.locator('tbody tr')
-  const cell = parentEl.locator(`td.cell-${fieldName}`)
+  const cell = parentEl.locator(`td[data-testid="${testIds.table.cell(fieldName)}"]`)
   await expect(cell).toBeVisible()
   return cell
 }
@@ -387,7 +384,7 @@ export async function switchTab(page: Page, selector: string) {
 }
 
 export const openColumnControls = async (page: Page) => {
-  await page.locator('.list-controls__toggle-columns').click()
+  await page.getByTestId(testIds.list.columns).click()
   await expect(page.locator('.list-controls__columns.rah-static--height-auto')).toBeVisible()
 }
 

--- a/test/__helpers/e2e/helpers.ts
+++ b/test/__helpers/e2e/helpers.ts
@@ -465,6 +465,14 @@ export function initPageConsoleErrorCatch(page: Page, options?: { ignoreCORS?: b
   }
 }
 
+export async function waitForListLoad(page: Page) {
+  await expect(page.locator('.shimmer-effect')).toHaveCount(0)
+}
+
+export async function openDocControlsMenu(page: Page) {
+  await page.getByTestId(testIds.docControls.menu).click()
+}
+
 export function getRoutes({
   customAdminRoutes,
   customRoutes,

--- a/test/__helpers/e2e/helpers.ts
+++ b/test/__helpers/e2e/helpers.ts
@@ -280,7 +280,7 @@ export async function openCreateDocDrawer(page: Page, fieldSelector: string): Pr
 export async function openLocaleSelector(page: Page): Promise<void> {
   const localeSelector = page.getByTestId(testIds.locale.selector)
   const button = localeSelector.locator('button.popup-button')
-  const popup = page.locator('.popup__content')
+  const popup = page.getByTestId(testIds.popup.content)
 
   if (!(await popup.isVisible())) {
     await button.click()
@@ -289,7 +289,7 @@ export async function openLocaleSelector(page: Page): Promise<void> {
 }
 
 export async function closeLocaleSelector(page: Page): Promise<void> {
-  const popup = page.locator('.popup__content')
+  const popup = page.getByTestId(testIds.popup.content)
 
   if (await popup.isVisible()) {
     await page.click('body', { position: { x: 0, y: 0 } })

--- a/test/__helpers/e2e/helpers.ts
+++ b/test/__helpers/e2e/helpers.ts
@@ -203,7 +203,7 @@ export async function saveDocHotkeyAndAssert(page: Page): Promise<void> {
   } else {
     await page.keyboard.up('Control')
   }
-  await expect(page.getByTestId(testIds.toast.container)).toContainText('successfully')
+  await expect(page.locator('.payload-toast-container')).toContainText('successfully')
   await closeAllToasts(page)
 }
 
@@ -232,10 +232,10 @@ export async function saveDocAndAssert(
   await page.click(selector, { delay: 100 })
 
   if (expectation === 'success') {
-    await expect(page.getByTestId(testIds.toast.container)).toContainText('successfully')
+    await expect(page.locator('.payload-toast-container')).toContainText('successfully')
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).not.toContain('/create')
   } else {
-    await expect(page.getByTestId(testIds.toast.error)).toBeVisible()
+    await expect(page.locator('.payload-toast-container .toast-error')).toBeVisible()
   }
 
   // Close all toasts to prevent them from interfering with subsequent tests. E.g. the following could happen
@@ -250,7 +250,7 @@ export async function saveDocAndAssert(
 
 export async function closeAllToasts(page: Locator | Page): Promise<void> {
   const closeButtons = page
-    .getByTestId(testIds.toast.container)
+    .locator('.payload-toast-container')
     .locator('button.payload-toast-close-button')
   let count = await closeButtons.count()
 

--- a/test/__helpers/e2e/live-preview/toggleLivePreview.ts
+++ b/test/__helpers/e2e/live-preview/toggleLivePreview.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 export const toggleLivePreview = async (
@@ -8,7 +9,7 @@ export const toggleLivePreview = async (
     targetState?: 'off' | 'on'
   },
 ): Promise<void> => {
-  const toggler = page.locator('#live-preview-toggler')
+  const toggler = page.getByTestId(testIds.livePreview.toggler)
   await expect(toggler).toBeVisible()
 
   const isActive = await toggler.evaluate((el) =>

--- a/test/__helpers/e2e/openDocControls.ts
+++ b/test/__helpers/e2e/openDocControls.ts
@@ -1,9 +1,10 @@
+import { testIds } from '@payloadcms/ui/shared'
 import { expect, type Locator, type Page } from '@playwright/test'
 
 export async function openDocControls(
   page: Locator | Page,
   mainPage?: Locator | Page,
 ): Promise<void> {
-  await page.locator('.doc-controls__popup .popup-button').click()
+  await page.getByTestId(testIds.docControls.menu).locator('.popup-button').click()
   await expect((mainPage ?? page).locator('.popup__content')).toBeVisible()
 }

--- a/test/__helpers/e2e/openDocControls.ts
+++ b/test/__helpers/e2e/openDocControls.ts
@@ -5,6 +5,6 @@ export async function openDocControls(
   page: Locator | Page,
   mainPage?: Locator | Page,
 ): Promise<void> {
-  await page.getByTestId(testIds.docControls.menu).locator('.popup-button').click()
+  await page.getByTestId(testIds.docControls.menu).click()
   await expect((mainPage ?? page).locator('.popup__content')).toBeVisible()
 }

--- a/test/__helpers/e2e/toggleCollapsible.ts
+++ b/test/__helpers/e2e/toggleCollapsible.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 /**
@@ -52,7 +53,7 @@ export const toggleBlockOrArrayRow = async ({
   rowIndex: number
   targetState?: 'collapsed' | 'open'
 }) => {
-  const row = page.locator(`#${fieldName}-row-${rowIndex}`)
+  const row = page.getByTestId(testIds.array.row(fieldName, rowIndex))
 
   const toggler = row.locator('button.collapsible__toggle')
 

--- a/test/__helpers/e2e/toggleListMenu.ts
+++ b/test/__helpers/e2e/toggleListMenu.ts
@@ -1,13 +1,14 @@
 import type { Page } from '@playwright/test'
 
+import { testIds } from '@payloadcms/ui/shared'
 import { expect } from '@playwright/test'
 
 import { exactText } from './helpers.js'
 
 export async function openListMenu({ page }: { page: Page }) {
-  const listMenu = page.locator('#list-menu')
+  const listMenu = page.getByTestId(testIds.list.menu)
   await listMenu.locator('button.popup-button').click()
-  await expect(listMenu.locator('.popup__content')).toBeVisible()
+  await expect(page.getByTestId(testIds.popup.content)).toBeVisible()
 }
 
 export async function clickListMenuItem({
@@ -17,7 +18,7 @@ export async function clickListMenuItem({
   menuItemLabel: string
   page: Page
 }) {
-  const menuItem = page.locator('.popup__content').locator('button', {
+  const menuItem = page.getByTestId(testIds.popup.content).locator('button', {
     hasText: exactText(menuItemLabel),
   })
 


### PR DESCRIPTION
## Overview

Adds `data-testid` attributes to Payload admin UI components and migrates e2e test helpers from brittle CSS class / ID selectors to `page.getByTestId()`. This gives tests stable selectors that survive styling refactors.

## Key Changes

- **Centralized `testIds` module:** New `packages/ui/src/testIds.ts` with constants for every testable element — nav, actions, fields, tables, drawers, arrays, blocks, popups, filters, live preview, confirmation modals, group-by, and more. Exported via `@payloadcms/ui/shared`.

- **Component instrumentation:** 50+ React components now render `data-testid` attributes using the centralized constants. Field components add `data-testid` alongside their existing `id` attributes. Components span `packages/ui/` and `packages/next/`.

- **Helper migration:** 20+ e2e helper files migrated from CSS/ID selectors to `getByTestId()`. Covers auth, array fields, block fields, list controls, filters, group-by, collapsible, copy-paste, folders, live preview, and relationship drawers.

- **Bug fixes during testing:** Fixed `openArrayRowActions` to distinguish array vs block rows via `fieldType` parameter. Fixed `openDocControls` where the testId was on a child element but the helper looked for a parent.

## Design Decisions

Two-pass approach: instrument components first (supply), then migrate helpers (demand). This isolates risk — component changes are low-risk prop additions, while helper changes are where test breakage happens. Each pass was committed separately for easy bisection.

Third-party selectors (React Select `.rs__*`, sonner toast `.payload-toast-container`) are intentionally kept as CSS selectors since we can't add `data-testid` to library internals. Structural selectors (`.shimmer-effect`, `tbody tr`, `.template-default`) are also kept — they test DOM structure intentionally.

The `testIds.field(path)` function normalizes dots to double underscores to match existing HTML ID conventions (`field.name` becomes `field-field__name`).

## Overall Flow

```mermaid
sequenceDiagram
    participant T as testIds.ts
    participant C as React Components
    participant H as E2E Helpers
    participant P as Playwright Tests

    T->>C: Constants imported
    C->>C: data-testid={testIds.x} rendered
    H->>T: Constants imported
    H->>P: page.getByTestId(testIds.x)
    P->>C: Matches data-testid attribute
```