### PR TITLE
fix(plugin-ecommerce): pass req to Payload API calls in Stripe adapter

### DIFF
--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
@@ -60,6 +60,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
       // Find our existing transaction by the payment intent ID
       const transactionsResults = await payload.find({
         collection: transactionsSlug,
+        req,
         where: {
           'stripe.paymentIntentID': {
             equals: paymentIntentID,
@@ -104,6 +105,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
           status: 'processing',
           transactions: [transaction.id],
         },
+        req,
       })
 
       const timestamp = new Date().toISOString()
@@ -114,6 +116,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
         data: {
           purchasedAt: timestamp,
         },
+        req,
       })
 
       await payload.update({
@@ -123,6 +126,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
           order: order.id,
           status: 'succeeded',
         },
+        req,
       })
 
       return {
@@ -132,7 +136,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
         ...(order.accessToken ? { accessToken: order.accessToken } : {}),
       }
     } catch (error) {
-      payload.logger.error(error, 'Error initiating payment with Stripe')
+      payload.logger.error({ err: error, msg: 'Error confirming order with Stripe' })
 
       throw new Error(error instanceof Error ? error.message : 'Unknown error initiating payment')
     }

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -119,6 +119,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
             paymentIntentID: paymentIntent.id,
           },
         },
+        req,
       })
 
       const returnData: InitiatePaymentReturnType = {
@@ -129,7 +130,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
 
       return returnData
     } catch (error) {
-      payload.logger.error(error, 'Error initiating payment with Stripe')
+      payload.logger.error({ err: error, msg: 'Error initiating payment with Stripe' })
 
       throw new Error(error instanceof Error ? error.message : 'Unknown error initiating payment')
     }


### PR DESCRIPTION
### What?

Adds the missing `req` parameter to all `payload.find()`, `payload.create()`, and `payload.update()` calls in the Stripe adapter's `confirmOrder.ts` and `initiatePayment.ts`.

### Why?

Without `req`, hooks on transactions/orders/carts receive an empty request context, and each database call runs in an isolated session — breaking transactional consistency (e.g. order created but cart not marked as purchased on failure).

### How?

Pass the existing `req` (already available in scope) to each Payload API call. Also fixes `payload.logger.error` calls to use the correct object form per project conventions.

Fixes #15836