### PR TITLE
fix(ui): falling back to UTC timezones in timezone picker

### DIFF
--- a/packages/ui/src/elements/TimezonePicker/index.tsx
+++ b/packages/ui/src/elements/TimezonePicker/index.tsx
@@ -30,7 +30,7 @@ export const TimezonePicker: React.FC<Props> = (props) => {
   const selectedTimezone = useMemo(() => {
     return options.find((t) => {
       const value = typeof t === 'string' ? t : t.value
-      return value === (selectedTimezoneFromProps || 'UTC')
+      return value === selectedTimezoneFromProps
     })
   }, [options, selectedTimezoneFromProps])
 

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -15,8 +15,8 @@ import {
   saveDocAndAssert,
 } from '../../../__helpers/e2e/helpers.js'
 import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
-import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../../../__helpers/shared/rest.js'
 import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 import { dateFieldsSlug } from '../../slugs.js'
@@ -602,6 +602,28 @@ describe('Date', () => {
 
       // eslint-disable-next-line payload/no-flaky-assertions
       expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
+    })
+
+    test('should not show UTC in timezone picker when no defaultTimezone is configured', async () => {
+      await page.goto(url.create)
+
+      const valueContainer = page.locator('#field-dateWithTimezoneNoDefault .rs__value-container')
+
+      await expect(valueContainer).toBeVisible()
+
+      const singleValue = page.locator('#field-dateWithTimezoneNoDefault .rs__single-value')
+
+      await expect(singleValue).toBeHidden()
+    })
+
+    test('should show configured defaultTimezone in timezone picker on create', async () => {
+      await page.goto(url.create)
+
+      const selectedTimezone = page.locator(
+        '#field-dayAndTimeWithTimezoneRequired .rs__value-container',
+      )
+
+      await expect(selectedTimezone).toContainText('Eastern Time')
     })
   })
 

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -231,6 +231,22 @@ const DateFields: CollectionConfig = {
       },
     },
     {
+      name: 'dateWithTimezoneNoDefault',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+      timezone: {
+        supportedTimezones: [
+          { label: 'New York', value: 'America/New_York' },
+          { label: 'London', value: 'Europe/London' },
+          { label: 'UTC', value: 'UTC' },
+        ],
+      },
+    },
+    {
       name: 'dateWithTimezoneWithDisabledColumns',
       type: 'date',
       timezone: {

--- a/test/fields/collections/Date/shared.ts
+++ b/test/fields/collections/Date/shared.ts
@@ -37,6 +37,9 @@ export const dateDoc: Partial<DateField> = {
   // Mixed IANA + offset timezones - 2027-08-12 10:00 AM in America/New_York (UTC-4 in summer) = 14:00 UTC
   dateWithMixedTimezones: '2027-08-12T14:00:00.000+00:00',
   dateWithMixedTimezones_tz: 'America/New_York',
+  // Date with timezone but no defaultTimezone configured
+  dateWithTimezoneNoDefault: '2027-08-12T14:00:00.000+00:00',
+  dateWithTimezoneNoDefault_tz: 'America/New_York',
   // Date with timezone where timezone column is hidden via override
   dateWithTimezoneWithDisabledColumns: '2027-08-12T14:00:00.000+00:00',
   dateWithTimezoneWithDisabledColumns_tz: 'America/New_York',

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -4812,5 +4812,35 @@ describe('Fields', () => {
       )
       expect(disabledColumnsTzField?.label).toEqual('Date With Timezone With Disabled Columns Tz')
     })
+
+    it('should not silently default timezone to UTC when no defaultTimezone is configured', async () => {
+      const { dateWithTimezoneNoDefault_tz: _, ...dataWithoutNoDefaultTz } = dateDoc
+
+      const doc = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dataWithoutNoDefaultTz,
+          dateWithTimezoneNoDefault: '2027-08-12T14:00:00.000Z',
+        },
+        draft: true,
+      })
+
+      expect(doc.dateWithTimezoneNoDefault_tz).toBeFalsy()
+    })
+
+    it('should use configured defaultTimezone when set', async () => {
+      const { dateWithMixedTimezones_tz: _, ...dataWithoutMixedTz } = dateDoc
+
+      const doc = await payload.create({
+        collection: dateFieldsSlug,
+        data: {
+          ...dataWithoutMixedTz,
+          dateWithMixedTimezones: '2027-08-12T14:00:00.000Z',
+        },
+        draft: true,
+      })
+
+      expect(doc.dateWithMixedTimezones_tz).toEqual('America/New_York')
+    })
   })
 })

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -164,6 +164,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: 'en' | 'es';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -400,24 +403,245 @@ export interface ArrayField {
  */
 export interface BlockField {
   id: string;
-  blocks: (ContentBlock | NoBlockname | NumberBlock | SubBlocksBlock | TabsBlock)[];
-  duplicate: (ContentBlock | NoBlockname | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  blocks: (
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'content';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'withIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'noBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'number';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'subBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'tabs';
+      }
+  )[];
+  duplicate: (
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'content';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'withIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'noBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'number';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'subBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'tabs';
+      }
+  )[];
   collapsedByDefaultBlocks: (
-    | LocalizedContentBlock
-    | LocalizedNoBlockname
-    | LocalizedNumberBlock
-    | LocalizedSubBlocksBlock
-    | LocalizedTabsBlock
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedContent';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedWithIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNoBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNumber';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedSubBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTabs';
+      }
   )[];
   disableSort: (
-    | LocalizedContentBlock
-    | LocalizedNoBlockname
-    | LocalizedNumberBlock
-    | LocalizedSubBlocksBlock
-    | LocalizedTabsBlock
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedContent';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedWithIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNoBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNumber';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedSubBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTabs';
+      }
   )[];
   localizedBlocks: (
     | LocalizedContentBlock
+    | LocalizedWithIconBlock
     | LocalizedNoBlockname
     | LocalizedNumberBlock
     | LocalizedSubBlocksBlock
@@ -544,10 +768,38 @@ export interface BlockField {
         blockType: 'text';
       }[]
     | null;
-  deduplicatedBlocks?: ConfigBlockTest[] | null;
-  deduplicatedBlocks2?: ConfigBlockTest[] | null;
-  localizedReferencesLocalizedBlock?: LocalizedTextReference[] | null;
-  localizedReferences?: LocalizedTextReference2[] | null;
+  deduplicatedBlocks?:
+    | {
+        deduplicatedText?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'ConfigBlockTest';
+      }[]
+    | null;
+  deduplicatedBlocks2?:
+    | {
+        deduplicatedText?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'ConfigBlockTest';
+      }[]
+    | null;
+  localizedReferencesLocalizedBlock?:
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTextReference';
+      }[]
+    | null;
+  localizedReferences?:
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTextReference2';
+      }[]
+    | null;
   /**
    * The purpose of this field is to test Block groups.
    */
@@ -640,72 +892,6 @@ export interface BlockField {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "ContentBlock".
- */
-export interface ContentBlock {
-  text: string;
-  richText?:
-    | {
-        [k: string]: unknown;
-      }[]
-    | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'content';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "NoBlockname".
- */
-export interface NoBlockname {
-  text?: string | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'noBlockname';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "NumberBlock".
- */
-export interface NumberBlock {
-  number: number;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'number';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "SubBlocksBlock".
- */
-export interface SubBlocksBlock {
-  subBlocks?:
-    | (
-        | {
-            text: string;
-            id?: string | null;
-            blockName?: string | null;
-            blockType: 'textRequired';
-          }
-        | NumberBlock
-      )[]
-    | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'subBlocks';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TabsBlock".
- */
-export interface TabsBlock {
-  textInCollapsible?: string | null;
-  textInRow?: string | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'tabs';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "localizedContentBlock".
  */
 export interface LocalizedContentBlock {
@@ -718,6 +904,16 @@ export interface LocalizedContentBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'localizedContent';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedWithIconBlock".
+ */
+export interface LocalizedWithIconBlock {
+  title: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'localizedWithIcon';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -752,7 +948,12 @@ export interface LocalizedSubBlocksBlock {
             blockName?: string | null;
             blockType: 'textRequired';
           }
-        | NumberBlock
+        | {
+            number: number;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'number';
+          }
       )[]
     | null;
   id?: string | null;
@@ -1066,6 +1267,8 @@ export interface DateField {
   dateWithOffsetTimezone_tz?: ('+05:30' | '-08:00' | '+00:00') | null;
   dateWithMixedTimezones?: string | null;
   dateWithMixedTimezones_tz?: ('America/New_York' | '+05:30' | 'UTC') | null;
+  dateWithTimezoneNoDefault?: string | null;
+  dateWithTimezoneNoDefault_tz?: ('America/New_York' | 'Europe/London' | 'UTC') | null;
   dateWithTimezoneWithDisabledColumns?: string | null;
   dateWithTimezoneWithDisabledColumns_tz?: SupportedTimezones;
   updatedAt: string;
@@ -1627,7 +1830,19 @@ export interface TabsField {
     text: string;
     id?: string | null;
   }[];
-  blocks: (ContentBlock | NoBlockname | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  blocks: (
+    | ContentBlock
+    | WithIconBlock
+    | NoBlockname
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'number';
+      }
+    | SubBlocksBlock
+    | TabsBlock
+  )[];
   group: {
     number: number;
   };
@@ -1679,6 +1894,82 @@ export interface TabsField {
   };
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ContentBlock".
+ */
+export interface ContentBlock {
+  text: string;
+  richText?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'content';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "WithIconBlock".
+ */
+export interface WithIconBlock {
+  title: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'withIcon';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "NoBlockname".
+ */
+export interface NoBlockname {
+  text?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'noBlockname';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SubBlocksBlock".
+ */
+export interface SubBlocksBlock {
+  subBlocks?:
+    | (
+        | {
+            text: string;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'textRequired';
+          }
+        | NumberBlock
+      )[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'subBlocks';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "NumberBlock".
+ */
+export interface NumberBlock {
+  number: number;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'number';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TabsBlock".
+ */
+export interface TabsBlock {
+  textInCollapsible?: string | null;
+  textInRow?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'tabs';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2246,6 +2537,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         content?: T | ContentBlockSelect<T>;
+        withIcon?: T | WithIconBlockSelect<T>;
         noBlockname?: T | NoBlocknameSelect<T>;
         number?: T | NumberBlockSelect<T>;
         subBlocks?: T | SubBlocksBlockSelect<T>;
@@ -2255,6 +2547,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         content?: T | ContentBlockSelect<T>;
+        withIcon?: T | WithIconBlockSelect<T>;
         noBlockname?: T | NoBlocknameSelect<T>;
         number?: T | NumberBlockSelect<T>;
         subBlocks?: T | SubBlocksBlockSelect<T>;
@@ -2264,6 +2557,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedWithIcon?: T | LocalizedWithIconBlockSelect<T>;
         localizedNoBlockname?: T | LocalizedNoBlocknameSelect<T>;
         localizedNumber?: T | LocalizedNumberBlockSelect<T>;
         localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
@@ -2273,6 +2567,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedWithIcon?: T | LocalizedWithIconBlockSelect<T>;
         localizedNoBlockname?: T | LocalizedNoBlocknameSelect<T>;
         localizedNumber?: T | LocalizedNumberBlockSelect<T>;
         localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
@@ -2282,6 +2577,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedWithIcon?: T | LocalizedWithIconBlockSelect<T>;
         localizedNoBlockname?: T | LocalizedNoBlocknameSelect<T>;
         localizedNumber?: T | LocalizedNumberBlockSelect<T>;
         localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
@@ -2544,6 +2840,15 @@ export interface ContentBlockSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "WithIconBlock_select".
+ */
+export interface WithIconBlockSelect<T extends boolean = true> {
+  title?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "NoBlockname_select".
  */
 export interface NoBlocknameSelect<T extends boolean = true> {
@@ -2597,6 +2902,15 @@ export interface TabsBlockSelect<T extends boolean = true> {
 export interface LocalizedContentBlockSelect<T extends boolean = true> {
   text?: T;
   richText?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedWithIconBlock_select".
+ */
+export interface LocalizedWithIconBlockSelect<T extends boolean = true> {
+  title?: T;
   id?: T;
   blockName?: T;
 }
@@ -2882,6 +3196,8 @@ export interface DateFieldsSelect<T extends boolean = true> {
   dateWithOffsetTimezone_tz?: T;
   dateWithMixedTimezones?: T;
   dateWithMixedTimezones_tz?: T;
+  dateWithTimezoneNoDefault?: T;
+  dateWithTimezoneNoDefault_tz?: T;
   dateWithTimezoneWithDisabledColumns?: T;
   dateWithTimezoneWithDisabledColumns_tz?: T;
   updatedAt?: T;
@@ -3354,6 +3670,7 @@ export interface TabsFieldsSelect<T extends boolean = true> {
     | T
     | {
         content?: T | ContentBlockSelect<T>;
+        withIcon?: T | WithIconBlockSelect<T>;
         noBlockname?: T | NoBlocknameSelect<T>;
         number?: T | NumberBlockSelect<T>;
         subBlocks?: T | SubBlocksBlockSelect<T>;
@@ -3651,6 +3968,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
We were accidentally falling back to UTC values in the timezone picker when in reality we shouldn't fallback to any timezone unless its specified.

Now no timezone will be defaulted to unless its explicitly set as `defaultTimezone`