### PR TITLE
fix(ui): drag and drop not working for sortable hasMany fields

### DIFF
--- a/packages/ui/src/elements/ReactSelect/MultiValue/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/MultiValue/index.tsx
@@ -40,6 +40,9 @@ export const MultiValue: React.FC<MultiValueProps<Option>> = (props) => {
     .filter(Boolean)
     .join(' ')
 
+  // Extract onMouseDown from listeners to preserve the MouseSensor handler
+  const { onMouseDown: listenersMouseDown, ...restListeners } = listeners || {}
+
   return (
     <React.Fragment>
       <SelectComponents.MultiValue
@@ -49,11 +52,16 @@ export const MultiValue: React.FC<MultiValueProps<Option>> = (props) => {
           ...(isSortable
             ? {
                 ...attributes,
-                ...listeners,
+                ...restListeners,
               }
             : {}),
           ...innerProps,
           onMouseDown: (e) => {
+            // Call the MouseSensor's handler first to enable mouse dragging
+            if (isSortable && listenersMouseDown) {
+              listenersMouseDown(e)
+            }
+
             if (!disableMouseDown) {
               // we need to prevent the dropdown from opening when clicking on the drag handle, but not when a modal is open (i.e. the 'Relationship' field component)
               e.stopPropagation()

--- a/test/fields/collections/Select/e2e.spec.ts
+++ b/test/fields/collections/Select/e2e.spec.ts
@@ -7,17 +7,17 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../../../__helpers/shared/sdk/index.js'
 import type { Config } from '../../payload-types.js'
 
+import { checkFocusIndicators } from '../../../__helpers/e2e/checkFocusIndicators.js'
 import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
   saveDocAndAssert,
   waitForFormReady,
 } from '../../../__helpers/e2e/helpers.js'
-import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
-import { checkFocusIndicators } from '../../../__helpers/e2e/checkFocusIndicators.js'
 import { runAxeScan } from '../../../__helpers/e2e/runAxeScan.js'
-import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
+import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../../../__helpers/shared/rest.js'
 import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 import { selectFieldsSlug } from '../../slugs.js'
@@ -128,6 +128,67 @@ describe('Select', () => {
     await field.locator('input').fill('On')
     await expect(options.locator('text=One')).toBeVisible()
     await expect(options.locator('text=Two')).toBeHidden()
+  })
+
+  test('should allow reordering hasMany select values with drag and drop', async () => {
+    await page.goto(url.create)
+    await waitForFormReady(page)
+
+    const field = page.locator('#field-selectHasMany')
+
+    // Select multiple options in order: one, two, three
+    await field.click({ delay: 100 })
+    await page.locator('.rs__option:has-text("Value One")').click()
+
+    await field.click({ delay: 100 })
+    await page.locator('.rs__option:has-text("Value Two")').click()
+
+    await field.click({ delay: 100 })
+    await page.locator('.rs__option:has-text("Value Three")').click()
+
+    // Verify initial order
+    const valueContainer = field.locator('.rs__value-container')
+    const pills = valueContainer.locator('.rs__multi-value')
+    await expect(pills).toHaveCount(3)
+    await expect(pills.nth(0)).toContainText('Value One')
+    await expect(pills.nth(1)).toContainText('Value Two')
+    await expect(pills.nth(2)).toContainText('Value Three')
+
+    // Get bounding boxes for drag operation
+    const firstPill = pills.nth(0)
+    const thirdPill = pills.nth(2)
+
+    const firstBox = (await firstPill.boundingBox())!
+    const thirdBox = (await thirdPill.boundingBox())!
+
+    // Drag first pill to the position of the third pill
+    await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + firstBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(thirdBox.x + thirdBox.width / 2, thirdBox.y + thirdBox.height / 2, {
+      steps: 10,
+    })
+    await page.mouse.up()
+
+    // Verify the order changed - first item should now be last
+    const updatedPills = valueContainer.locator('.rs__multi-value')
+    await expect(updatedPills.nth(0)).toContainText('Value Two')
+    await expect(updatedPills.nth(1)).toContainText('Value Three')
+    await expect(updatedPills.nth(2)).toContainText('Value One')
+
+    // Save and verify the order is persisted
+    await saveDocAndAssert(page)
+
+    const currentUrl = page.url()
+    const id = currentUrl.split('/').pop()!
+
+    // Reload the page to verify order persists
+    await page.goto(url.edit(id))
+    await waitForFormReady(page)
+
+    const reloadedPills = page.locator('#field-selectHasMany .rs__value-container .rs__multi-value')
+    await expect(reloadedPills.nth(0)).toContainText('Value Two')
+    await expect(reloadedPills.nth(1)).toContainText('Value Three')
+    await expect(reloadedPills.nth(2)).toContainText('Value One')
   })
 
   describe('A11y', () => {

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -164,6 +164,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: 'en' | 'es';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -400,24 +403,245 @@ export interface ArrayField {
  */
 export interface BlockField {
   id: string;
-  blocks: (ContentBlock | NoBlockname | NumberBlock | SubBlocksBlock | TabsBlock)[];
-  duplicate: (ContentBlock | NoBlockname | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  blocks: (
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'content';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'withIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'noBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'number';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'subBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'tabs';
+      }
+  )[];
+  duplicate: (
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'content';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'withIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'noBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'number';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'subBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'tabs';
+      }
+  )[];
   collapsedByDefaultBlocks: (
-    | LocalizedContentBlock
-    | LocalizedNoBlockname
-    | LocalizedNumberBlock
-    | LocalizedSubBlocksBlock
-    | LocalizedTabsBlock
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedContent';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedWithIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNoBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNumber';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedSubBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTabs';
+      }
   )[];
   disableSort: (
-    | LocalizedContentBlock
-    | LocalizedNoBlockname
-    | LocalizedNumberBlock
-    | LocalizedSubBlocksBlock
-    | LocalizedTabsBlock
+    | {
+        text: string;
+        richText?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedContent';
+      }
+    | {
+        title: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedWithIcon';
+      }
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNoBlockname';
+      }
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedNumber';
+      }
+    | {
+        subBlocks?:
+          | (
+              | {
+                  text: string;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'textRequired';
+                }
+              | {
+                  number: number;
+                  id?: string | null;
+                  blockName?: string | null;
+                  blockType: 'number';
+                }
+            )[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedSubBlocks';
+      }
+    | {
+        textInCollapsible?: string | null;
+        textInRow?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTabs';
+      }
   )[];
   localizedBlocks: (
     | LocalizedContentBlock
+    | LocalizedWithIconBlock
     | LocalizedNoBlockname
     | LocalizedNumberBlock
     | LocalizedSubBlocksBlock
@@ -544,10 +768,38 @@ export interface BlockField {
         blockType: 'text';
       }[]
     | null;
-  deduplicatedBlocks?: ConfigBlockTest[] | null;
-  deduplicatedBlocks2?: ConfigBlockTest[] | null;
-  localizedReferencesLocalizedBlock?: LocalizedTextReference[] | null;
-  localizedReferences?: LocalizedTextReference2[] | null;
+  deduplicatedBlocks?:
+    | {
+        deduplicatedText?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'ConfigBlockTest';
+      }[]
+    | null;
+  deduplicatedBlocks2?:
+    | {
+        deduplicatedText?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'ConfigBlockTest';
+      }[]
+    | null;
+  localizedReferencesLocalizedBlock?:
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTextReference';
+      }[]
+    | null;
+  localizedReferences?:
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'localizedTextReference2';
+      }[]
+    | null;
   /**
    * The purpose of this field is to test Block groups.
    */
@@ -640,72 +892,6 @@ export interface BlockField {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "ContentBlock".
- */
-export interface ContentBlock {
-  text: string;
-  richText?:
-    | {
-        [k: string]: unknown;
-      }[]
-    | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'content';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "NoBlockname".
- */
-export interface NoBlockname {
-  text?: string | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'noBlockname';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "NumberBlock".
- */
-export interface NumberBlock {
-  number: number;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'number';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "SubBlocksBlock".
- */
-export interface SubBlocksBlock {
-  subBlocks?:
-    | (
-        | {
-            text: string;
-            id?: string | null;
-            blockName?: string | null;
-            blockType: 'textRequired';
-          }
-        | NumberBlock
-      )[]
-    | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'subBlocks';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TabsBlock".
- */
-export interface TabsBlock {
-  textInCollapsible?: string | null;
-  textInRow?: string | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'tabs';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "localizedContentBlock".
  */
 export interface LocalizedContentBlock {
@@ -718,6 +904,16 @@ export interface LocalizedContentBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'localizedContent';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedWithIconBlock".
+ */
+export interface LocalizedWithIconBlock {
+  title: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'localizedWithIcon';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -752,7 +948,12 @@ export interface LocalizedSubBlocksBlock {
             blockName?: string | null;
             blockType: 'textRequired';
           }
-        | NumberBlock
+        | {
+            number: number;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'number';
+          }
       )[]
     | null;
   id?: string | null;
@@ -1627,7 +1828,19 @@ export interface TabsField {
     text: string;
     id?: string | null;
   }[];
-  blocks: (ContentBlock | NoBlockname | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  blocks: (
+    | ContentBlock
+    | WithIconBlock
+    | NoBlockname
+    | {
+        number: number;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'number';
+      }
+    | SubBlocksBlock
+    | TabsBlock
+  )[];
   group: {
     number: number;
   };
@@ -1679,6 +1892,82 @@ export interface TabsField {
   };
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ContentBlock".
+ */
+export interface ContentBlock {
+  text: string;
+  richText?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'content';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "WithIconBlock".
+ */
+export interface WithIconBlock {
+  title: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'withIcon';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "NoBlockname".
+ */
+export interface NoBlockname {
+  text?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'noBlockname';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SubBlocksBlock".
+ */
+export interface SubBlocksBlock {
+  subBlocks?:
+    | (
+        | {
+            text: string;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'textRequired';
+          }
+        | NumberBlock
+      )[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'subBlocks';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "NumberBlock".
+ */
+export interface NumberBlock {
+  number: number;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'number';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TabsBlock".
+ */
+export interface TabsBlock {
+  textInCollapsible?: string | null;
+  textInRow?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'tabs';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2246,6 +2535,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         content?: T | ContentBlockSelect<T>;
+        withIcon?: T | WithIconBlockSelect<T>;
         noBlockname?: T | NoBlocknameSelect<T>;
         number?: T | NumberBlockSelect<T>;
         subBlocks?: T | SubBlocksBlockSelect<T>;
@@ -2255,6 +2545,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         content?: T | ContentBlockSelect<T>;
+        withIcon?: T | WithIconBlockSelect<T>;
         noBlockname?: T | NoBlocknameSelect<T>;
         number?: T | NumberBlockSelect<T>;
         subBlocks?: T | SubBlocksBlockSelect<T>;
@@ -2264,6 +2555,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedWithIcon?: T | LocalizedWithIconBlockSelect<T>;
         localizedNoBlockname?: T | LocalizedNoBlocknameSelect<T>;
         localizedNumber?: T | LocalizedNumberBlockSelect<T>;
         localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
@@ -2273,6 +2565,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedWithIcon?: T | LocalizedWithIconBlockSelect<T>;
         localizedNoBlockname?: T | LocalizedNoBlocknameSelect<T>;
         localizedNumber?: T | LocalizedNumberBlockSelect<T>;
         localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
@@ -2282,6 +2575,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
     | T
     | {
         localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedWithIcon?: T | LocalizedWithIconBlockSelect<T>;
         localizedNoBlockname?: T | LocalizedNoBlocknameSelect<T>;
         localizedNumber?: T | LocalizedNumberBlockSelect<T>;
         localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
@@ -2544,6 +2838,15 @@ export interface ContentBlockSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "WithIconBlock_select".
+ */
+export interface WithIconBlockSelect<T extends boolean = true> {
+  title?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "NoBlockname_select".
  */
 export interface NoBlocknameSelect<T extends boolean = true> {
@@ -2597,6 +2900,15 @@ export interface TabsBlockSelect<T extends boolean = true> {
 export interface LocalizedContentBlockSelect<T extends boolean = true> {
   text?: T;
   richText?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedWithIconBlock_select".
+ */
+export interface LocalizedWithIconBlockSelect<T extends boolean = true> {
+  title?: T;
   id?: T;
   blockName?: T;
 }
@@ -3354,6 +3666,7 @@ export interface TabsFieldsSelect<T extends boolean = true> {
     | T
     | {
         content?: T | ContentBlockSelect<T>;
+        withIcon?: T | WithIconBlockSelect<T>;
         noBlockname?: T | NoBlocknameSelect<T>;
         number?: T | NumberBlockSelect<T>;
         subBlocks?: T | SubBlocksBlockSelect<T>;
@@ -3651,6 +3964,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What

Fixes drag-and-drop sorting for relationship and select fields with `hasMany` and `admin.isSortable: true`.

### Why

In v3.78.0, commit 418bb928ae replaced `PointerSensor` with `MouseSensor` + `TouchSensor`. The `MultiValue` component was overriding the `onMouseDown` handler from `listeners`, preventing the `MouseSensor` from detecting drag start events.

### How

Extract `onMouseDown` from `listeners` and call it explicitly before the custom `stopPropagation` logic. Touch and keyboard handlers remain unaffected.

Fixes #15843 