### PR TITLE
fix(ui): isolate join table column preferences from list view

### DIFF
--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -224,7 +224,7 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
           </h4>
         }
         parent={
-          Array.isArray(collection)
+          typeof docID !== 'undefined'
             ? {
                 id: docID,
                 collectionSlug: docConfig.slug,

--- a/packages/ui/src/utilities/buildTableState.ts
+++ b/packages/ui/src/utilities/buildTableState.ts
@@ -116,10 +116,12 @@ const buildTableState: ServerFunction<
     }
   }
 
+  const preferencesKey = parent
+    ? `${parent.collectionSlug}-${parent.joinPath}`
+    : `collection-${collectionSlug}`
+
   const collectionPreferences = await upsertPreferences<CollectionPreferences>({
-    key: Array.isArray(collectionSlug)
-      ? `${parent.collectionSlug}-${parent.joinPath}`
-      : `collection-${collectionSlug}`,
+    key: preferencesKey,
     req,
     value: {
       columns: columnsFromArgs,

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../__helpers/shared/sdk/index.js'
 import type { Config } from './payload-types.js'
 
+import { reorderColumns } from '../__helpers/e2e/columns/index.js'
 import {
   changeLocale,
   ensureCompilationIsDone,
@@ -16,11 +17,10 @@ import {
   saveDocAndAssert,
   // throttleTest,
 } from '../__helpers/e2e/helpers.js'
-import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
-import { reorderColumns } from '../__helpers/e2e/columns/index.js'
 import { navigateToDoc } from '../__helpers/e2e/navigateToDoc.js'
-import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
+import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../__helpers/shared/rest.js'
 import { EXPECT_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import {
@@ -356,6 +356,21 @@ describe('Join Field', () => {
     expect(innerText.indexOf('ID')).toBeLessThan(innerText.indexOf('Created At'))
     // eslint-disable-next-line payload/no-flaky-assertions
     expect(innerText.indexOf('Created At')).toBeLessThan(innerText.indexOf('Title'))
+  })
+
+  test('should not overwrite list view columns when rendering relationship table with default columns', async () => {
+    await page.goto(new AdminUrlUtil(serverURL, postsSlug).list)
+    await expect(page.locator('#heading-id')).toBeHidden()
+
+    await page.goto(categoriesURL.edit(categoryID))
+    const joinField = page.locator('#field-group__relatedPosts.field-type.join')
+    const joinThead = joinField.locator('.relationship-table thead')
+    await expect(joinThead).toContainText('ID')
+    await expect(joinThead).toContainText('Created At')
+    await expect(joinThead).toContainText('Title')
+
+    await page.goto(new AdminUrlUtil(serverURL, postsSlug).list)
+    await expect(page.locator('#heading-id')).toBeHidden()
   })
 
   test('should update relationship table when new document is created', async () => {


### PR DESCRIPTION
## Summary
- Isolate join field relationship table preferences from collection list preferences by keying join table state off the parent document field path.
- Ensure join fields always pass parent metadata to table state resolution, including monomorphic joins.
- Add an e2e regression test proving that opening a join table with `admin.defaultColumns` does not overwrite the related collection list columns.

## Changes

Join relationship tables were persisting column preferences under the related collection key (for example, `collection-posts`), which is also used by the main collection list view. This caused join table defaults to overwrite list view columns. The fix scopes join table preferences to the parent join path and provides parent metadata for all join fields so monomorphic joins are isolated as well.

## Testing

- Failing (before fix):
  - `pnpm test:e2e joins --grep "should not overwrite list view columns when rendering relationship table with default columns"`
  - Error: `expect(locator('#heading-id')).toBeHidden() failed` (ID column became visible after visiting the join field table)
- Passing (with this PR):
  - `pnpm test:e2e joins --grep "should not overwrite list view columns when rendering relationship table with default columns"`
