### PR TITLE
fix: localized array,group,blocks fields duplicate with empty values

### DIFF
--- a/packages/payload/src/utilities/filterDataToSelectedLocales.spec.ts
+++ b/packages/payload/src/utilities/filterDataToSelectedLocales.spec.ts
@@ -111,6 +111,7 @@ describe('filterDataToSelectedLocales', () => {
         configBlockReferences: [
           {
             slug: 'content',
+            flattenedFields: [],
             fields: [
               {
                 name: 'body',
@@ -137,6 +138,245 @@ describe('filterDataToSelectedLocales', () => {
       expect(result.layout[0].blockType).toBe('content')
       expect(result.layout[0].id).toBe('ref123')
       expect(result.layout[0].body).toEqual({ en: 'English' })
+    })
+  })
+
+  describe('localized arrays', () => {
+    it('should filter localized array to selected locales and recurse into rows', () => {
+      const fields: Field[] = [
+        {
+          name: 'items',
+          type: 'array',
+          localized: true,
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+          ],
+        },
+      ]
+
+      const docWithLocales = {
+        items: {
+          en: [{ title: 'English Item' }],
+          es: [{ title: 'Spanish Item' }],
+          de: [{ title: 'German Item' }],
+        },
+      }
+
+      const result = filterDataToSelectedLocales({
+        configBlockReferences: [],
+        docWithLocales,
+        fields,
+        selectedLocales,
+      })
+
+      expect(result.items).toEqual({
+        en: [{ title: 'English Item' }],
+      })
+    })
+
+    it('should handle non-localized array with localized children', () => {
+      const fields: Field[] = [
+        {
+          name: 'items',
+          type: 'array',
+          fields: [
+            {
+              name: 'label',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'value',
+              type: 'text',
+            },
+          ],
+        },
+      ]
+
+      const docWithLocales = {
+        items: [
+          { label: { en: 'English', es: 'Spanish' }, value: 'one' },
+          { label: { en: 'English 2', es: 'Spanish 2' }, value: 'two' },
+        ],
+      }
+
+      const result = filterDataToSelectedLocales({
+        configBlockReferences: [],
+        docWithLocales,
+        fields,
+        selectedLocales,
+      })
+
+      expect(result.items).toEqual([
+        { label: { en: 'English' }, value: 'one' },
+        { label: { en: 'English 2' }, value: 'two' },
+      ])
+    })
+  })
+
+  describe('localized blocks', () => {
+    it('should filter localized blocks field to selected locales', () => {
+      const fields: Field[] = [
+        {
+          name: 'layout',
+          type: 'blocks',
+          localized: true,
+          blocks: [
+            {
+              slug: 'hero',
+              fields: [
+                {
+                  name: 'heading',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const docWithLocales = {
+        layout: {
+          en: [{ blockType: 'hero', id: '1', blockName: 'Hero EN', heading: 'Hello' }],
+          es: [{ blockType: 'hero', id: '2', blockName: 'Hero ES', heading: 'Hola' }],
+          de: [{ blockType: 'hero', id: '3', blockName: 'Hero DE', heading: 'Hallo' }],
+        },
+      }
+
+      const result = filterDataToSelectedLocales({
+        configBlockReferences: [],
+        docWithLocales,
+        fields,
+        selectedLocales,
+      })
+
+      expect(result.layout).toEqual({
+        en: [{ blockType: 'hero', id: '1', blockName: 'Hero EN', heading: 'Hello' }],
+      })
+    })
+
+    it('should filter localized blocks with multiple selected locales', () => {
+      const fields: Field[] = [
+        {
+          name: 'layout',
+          type: 'blocks',
+          localized: true,
+          blocks: [
+            {
+              slug: 'text',
+              fields: [
+                {
+                  name: 'body',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const docWithLocales = {
+        layout: {
+          en: [{ blockType: 'text', id: '1', blockName: 'Text EN', body: 'English' }],
+          es: [{ blockType: 'text', id: '2', blockName: 'Text ES', body: 'Spanish' }],
+          de: [{ blockType: 'text', id: '3', blockName: 'Text DE', body: 'German' }],
+        },
+      }
+
+      const result = filterDataToSelectedLocales({
+        configBlockReferences: [],
+        docWithLocales,
+        fields,
+        selectedLocales: ['en', 'es'],
+      })
+
+      expect(result.layout).toEqual({
+        en: [{ blockType: 'text', id: '1', blockName: 'Text EN', body: 'English' }],
+        es: [{ blockType: 'text', id: '2', blockName: 'Text ES', body: 'Spanish' }],
+      })
+    })
+  })
+
+  describe('localized groups', () => {
+    it('should filter localized group to selected locales and recurse into children', () => {
+      const fields: Field[] = [
+        {
+          name: 'meta',
+          type: 'group',
+          localized: true,
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'description',
+              type: 'text',
+            },
+          ],
+        },
+      ]
+
+      const docWithLocales = {
+        meta: {
+          en: { title: 'English Title', description: 'English Desc' },
+          es: { title: 'Spanish Title', description: 'Spanish Desc' },
+          de: { title: 'German Title', description: 'German Desc' },
+        },
+      }
+
+      const result = filterDataToSelectedLocales({
+        configBlockReferences: [],
+        docWithLocales,
+        fields,
+        selectedLocales,
+      })
+
+      expect(result.meta).toEqual({
+        en: { title: 'English Title', description: 'English Desc' },
+      })
+    })
+
+    it('should handle non-localized group with localized children', () => {
+      const fields: Field[] = [
+        {
+          name: 'seo',
+          type: 'group',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'slug',
+              type: 'text',
+            },
+          ],
+        },
+      ]
+
+      const docWithLocales = {
+        seo: {
+          title: { en: 'English SEO', es: 'Spanish SEO' },
+          slug: 'my-page',
+        },
+      }
+
+      const result = filterDataToSelectedLocales({
+        configBlockReferences: [],
+        docWithLocales,
+        fields,
+        selectedLocales,
+      })
+
+      expect(result.seo).toEqual({
+        title: { en: 'English SEO' },
+        slug: 'my-page',
+      })
     })
   })
 

--- a/packages/payload/src/utilities/filterDataToSelectedLocales.ts
+++ b/packages/payload/src/utilities/filterDataToSelectedLocales.ts
@@ -13,6 +13,27 @@ type FilterDataToSelectedLocalesArgs = {
 }
 
 /**
+ * Filters a locale map to selected locales and applies a transform to each locale's value.
+ */
+function filterLocaleMap(
+  localeMap: Record<string, unknown>,
+  selectedLocales: string[],
+  transform: (value: unknown) => unknown,
+): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {}
+  const localesToInclude =
+    selectedLocales && selectedLocales.length > 0 ? selectedLocales : Object.keys(localeMap)
+
+  for (const locale of localesToInclude) {
+    if (locale in localeMap) {
+      filtered[locale] = transform(localeMap[locale])
+    }
+  }
+
+  return Object.keys(filtered).length > 0 ? filtered : {}
+}
+
+/**
  * Filters localized field data to only include specified locales.
  * For non-localized fields, returns all data as-is.
  * For localized fields, if selectedLocales is provided, returns only those locales.
@@ -37,8 +58,30 @@ export function filterDataToSelectedLocales({
 
       switch (field.type) {
         case 'array': {
-          if (Array.isArray(docWithLocales[field.name])) {
-            result[field.name] = docWithLocales[field.name].map((item: JsonObject) =>
+          if (!(field.name in docWithLocales)) {
+            break
+          }
+
+          const arrayValue = docWithLocales[field.name]
+
+          if (fieldIsLocalized) {
+            if (arrayValue && typeof arrayValue === 'object' && !Array.isArray(arrayValue)) {
+              result[field.name] = filterLocaleMap(arrayValue, selectedLocales, (localeRows) =>
+                Array.isArray(localeRows)
+                  ? localeRows.map((item: JsonObject) =>
+                      filterDataToSelectedLocales({
+                        configBlockReferences,
+                        docWithLocales: item,
+                        fields: field.fields,
+                        parentIsLocalized: fieldIsLocalized,
+                        selectedLocales,
+                      }),
+                    )
+                  : localeRows,
+              )
+            }
+          } else if (Array.isArray(arrayValue)) {
+            result[field.name] = arrayValue.map((item: JsonObject) =>
               filterDataToSelectedLocales({
                 configBlockReferences,
                 docWithLocales: item,
@@ -48,12 +91,23 @@ export function filterDataToSelectedLocales({
               }),
             )
           }
+
           break
         }
 
         case 'blocks': {
-          if (field.name in docWithLocales && Array.isArray(docWithLocales[field.name])) {
-            result[field.name] = docWithLocales[field.name].map((blockData: JsonObject) => {
+          if (!(field.name in docWithLocales)) {
+            break
+          }
+
+          const blocksValue = docWithLocales[field.name]
+
+          const processBlockRows = (rows: unknown): unknown => {
+            if (!Array.isArray(rows)) {
+              return rows
+            }
+
+            return rows.map((blockData: JsonObject) => {
               let block: Block | FlattenedBlock | undefined
               if (configBlockReferences && field.blockReferences) {
                 for (const blockOrReference of field.blockReferences) {
@@ -88,23 +142,52 @@ export function filterDataToSelectedLocales({
               return blockData
             })
           }
+
+          if (fieldIsLocalized) {
+            if (blocksValue && typeof blocksValue === 'object' && !Array.isArray(blocksValue)) {
+              result[field.name] = filterLocaleMap(blocksValue, selectedLocales, (localeRows) =>
+                processBlockRows(localeRows),
+              )
+            }
+          } else if (Array.isArray(blocksValue)) {
+            result[field.name] = processBlockRows(blocksValue)
+          }
+
           break
         }
 
         case 'group': {
-          // Named groups create a nested data structure
-          if (
-            fieldAffectsData(field) &&
-            field.name in docWithLocales &&
-            typeof docWithLocales[field.name] === 'object'
-          ) {
-            result[field.name] = filterDataToSelectedLocales({
-              configBlockReferences,
-              docWithLocales: docWithLocales[field.name] as JsonObject,
-              fields: field.fields,
-              parentIsLocalized: fieldIsLocalized,
-              selectedLocales,
-            })
+          if (field.name in docWithLocales && typeof docWithLocales[field.name] === 'object') {
+            const groupValue = docWithLocales[field.name]
+
+            if (fieldIsLocalized) {
+              if (groupValue && typeof groupValue === 'object' && !Array.isArray(groupValue)) {
+                result[field.name] = filterLocaleMap(groupValue, selectedLocales, (localeValue) => {
+                  if (
+                    localeValue &&
+                    typeof localeValue === 'object' &&
+                    !Array.isArray(localeValue)
+                  ) {
+                    return filterDataToSelectedLocales({
+                      configBlockReferences,
+                      docWithLocales: localeValue as JsonObject,
+                      fields: field.fields,
+                      parentIsLocalized: fieldIsLocalized,
+                      selectedLocales,
+                    })
+                  }
+                  return localeValue
+                })
+              }
+            } else if (typeof groupValue === 'object' && !Array.isArray(groupValue)) {
+              result[field.name] = filterDataToSelectedLocales({
+                configBlockReferences,
+                docWithLocales: groupValue as JsonObject,
+                fields: field.fields,
+                parentIsLocalized: fieldIsLocalized,
+                selectedLocales,
+              })
+            }
           } else {
             // Unnamed groups pass through the same data level
             const nestedResult = filterDataToSelectedLocales({
@@ -120,29 +203,18 @@ export function filterDataToSelectedLocales({
         }
 
         default: {
-          // For all other data-affecting fields (text, number, select, etc.)
           if (field.name in docWithLocales) {
             const value = docWithLocales[field.name]
 
-            // If the field is localized and has locale data
-            if (fieldIsLocalized && value && typeof value === 'object' && !Array.isArray(value)) {
-              // If selectedLocales is provided, filter to only those locales
-              if (selectedLocales && selectedLocales.length > 0) {
-                const filtered: Record<string, unknown> = {}
-                for (const locale of selectedLocales) {
-                  if (locale in value) {
-                    filtered[locale] = value[locale]
-                  }
-                }
-                if (Object.keys(filtered).length > 0) {
-                  result[field.name] = filtered
-                }
-              } else {
-                // If no selectedLocales, include all locales
-                result[field.name] = value
+            if (fieldIsLocalized) {
+              if (value && typeof value === 'object' && !Array.isArray(value)) {
+                result[field.name] = filterLocaleMap(
+                  value,
+                  selectedLocales,
+                  (localeValue) => localeValue,
+                )
               }
             } else {
-              // Non-localized field or non-object value
               result[field.name] = value
             }
           }

--- a/packages/payload/src/utilities/filterDataToSelectedLocales.ts
+++ b/packages/payload/src/utilities/filterDataToSelectedLocales.ts
@@ -225,6 +225,7 @@ export function filterDataToSelectedLocales({
       // Layout-only fields that don't affect data structure
       switch (field.type) {
         case 'collapsible':
+        case 'group':
         case 'row': {
           // These pass through the same data level
           const nestedResult = filterDataToSelectedLocales({


### PR DESCRIPTION
### What?
  Localized blocks, array, and group fields are empty when           
  duplicating a selected locale.

### Why?
filterDataToSelectedLocales assumed field types (blocks,
  array, group) always stored data directly as arrays. When
  these fields are localized, data is wrapped in a locale map ({ en:
  [...], de: [...] }), which was not being unwrapped before
  processing.

### How?
 - Added locale-aware branching for blocks, array, and group field
  types — when the field is localized, the locale map is filtered
  first, then each locale's value is recursed into
  - Extracted a filterLocaleMap helper to consistently filter and
  transform locale maps across all field types
  - Added unit tests

Fixes #15847 