### PR TITLE
docs(examples): clarify MongoDB prerequisites in Mongo-backed examples

### DIFF
--- a/examples/auth/.env.example
+++ b/examples/auth/.env.example
@@ -1,5 +1,5 @@
 # Database connection string
-DATABASE_URL=mongodb://127.0.0.1/payload-draft-preview-example
+DATABASE_URL=mongodb://127.0.0.1/payload-example-auth
 
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -10,13 +10,20 @@ To spin up this example locally, follow the steps below:
 
 - `npx create-payload-app --example auth`
 
-2. Start the server:
+2. Ensure MongoDB is running:
+
+   - This example uses the MongoDB adapter and requires an accessible MongoDB instance.
+   - Configure `DATABASE_URL` in your `.env` (you can start from `.env.example`), for example:
+     - `DATABASE_URL=mongodb://127.0.0.1/payload-draft-preview-example`
+   - If your MongoDB instance requires authentication, include your credentials in `DATABASE_URL`.
+
+3. Start the server:
    - Depending on your package manager, run `pnpm dev`, `yarn dev` or `npm run dev`
    - When prompted, type `y` then `enter` to seed the database with sample data
-3. Access the application:
+4. Access the application:
    - Open your browser and navigate to `http://localhost:3000` to access the homepage.
    - Open `http://localhost:3000/admin` to access the admin panel.
-4. Login:
+5. Login:
 
 - Use the following credentials to log into the admin panel:
   > `Email: demo@payloadcms.com` > `Password: demo`

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -14,7 +14,7 @@ To spin up this example locally, follow the steps below:
 
    - This example uses the MongoDB adapter and requires an accessible MongoDB instance.
    - Configure `DATABASE_URL` in your `.env` (you can start from `.env.example`), for example:
-     - `DATABASE_URL=mongodb://127.0.0.1/payload-draft-preview-example`
+     - `DATABASE_URL=mongodb://127.0.0.1/payload-example-auth`
    - If your MongoDB instance requires authentication, include your credentials in `DATABASE_URL`.
 
 3. Start the server:

--- a/examples/custom-components/.env.example
+++ b/examples/custom-components/.env.example
@@ -1,3 +1,3 @@
-DATABASE_URL=mongodb://127.0.0.1/payload-example-custom-fields
+DATABASE_URL=mongodb://127.0.0.1/payload-example-custom-components
 PAYLOAD_SECRET=PAYLOAD_CUSTOM_FIELDS_EXAMPLE_SECRET_KEY
 PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000

--- a/examples/custom-components/README.md
+++ b/examples/custom-components/README.md
@@ -10,13 +10,20 @@ To spin up this example locally, follow the steps below:
 
 - `npx create-payload-app --example custom-components`
 
-2. Start the server:
+2. Ensure MongoDB is running:
+
+   - This example uses the MongoDB adapter and requires an accessible MongoDB instance.
+   - Configure `DATABASE_URL` in your `.env` (you can start from `.env.example`), for example:
+     - `DATABASE_URL=mongodb://127.0.0.1/payload-example-custom-fields`
+   - If your MongoDB instance requires authentication, include your credentials in `DATABASE_URL`.
+
+3. Start the server:
    - Depending on your package manager, run `pnpm dev`, `yarn dev` or `npm run dev`
    - When prompted, type `y` then `enter` to seed the database with sample data
-3. Access the application:
+4. Access the application:
    - Open your browser and navigate to `http://localhost:3000` to access the homepage.
    - Open `http://localhost:3000/admin` to access the admin panel.
-4. Login:
+5. Login:
 
 - Use the following credentials to log into the admin panel:
   > `Email: demo@payloadcms.com` > `Password: demo`

--- a/examples/custom-components/README.md
+++ b/examples/custom-components/README.md
@@ -14,7 +14,7 @@ To spin up this example locally, follow the steps below:
 
    - This example uses the MongoDB adapter and requires an accessible MongoDB instance.
    - Configure `DATABASE_URL` in your `.env` (you can start from `.env.example`), for example:
-     - `DATABASE_URL=mongodb://127.0.0.1/payload-example-custom-fields`
+     - `DATABASE_URL=mongodb://127.0.0.1/payload-example-custom-components`
    - If your MongoDB instance requires authentication, include your credentials in `DATABASE_URL`.
 
 3. Start the server:

--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -4,7 +4,7 @@ Run the following command to create a project from the example:
 
 - `npx create-payload-app --example custom-server`
 
-Before starting the server, ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-custom-server`).
+Before starting the server, ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-custom-server`).
 
 Uses a [Next.js Custom Server](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server) with express.
 

--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -4,6 +4,8 @@ Run the following command to create a project from the example:
 
 - `npx create-payload-app --example custom-server`
 
+Before starting the server, ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-custom-server`).
+
 Uses a [Next.js Custom Server](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server) with express.
 
 Made from official [examples/custom-server](https://github.com/vercel/next.js/tree/canary/examples/custom-server) from Next.js repository.

--- a/examples/draft-preview/.env.example
+++ b/examples/draft-preview/.env.example
@@ -1,5 +1,5 @@
 # Database connection string
-DATABASE_URL=mongodb://127.0.0.1/payload-draft-preview-example
+DATABASE_URL=mongodb://127.0.0.1/payload-example-draft-preview
 
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE

--- a/examples/draft-preview/README.md
+++ b/examples/draft-preview/README.md
@@ -11,9 +11,10 @@ To spin up this example locally, follow these steps:
 - `npx create-payload-app --example draft-preview`
 
 2. `cp .env.example .env` to copy the example environment variables
-3. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
-4. `open http://localhost:3000/admin` to access the admin panel
-5. Login with email `demo@payloadcms.com` and password `demo`
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-draft-preview-example`)
+4. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
+5. `open http://localhost:3000/admin` to access the admin panel
+6. Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details.
 

--- a/examples/draft-preview/README.md
+++ b/examples/draft-preview/README.md
@@ -11,7 +11,7 @@ To spin up this example locally, follow these steps:
 - `npx create-payload-app --example draft-preview`
 
 2. `cp .env.example .env` to copy the example environment variables
-3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-draft-preview-example`)
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-draft-preview`)
 4. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
 5. `open http://localhost:3000/admin` to access the admin panel
 6. Login with email `demo@payloadcms.com` and password `demo`

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -11,9 +11,10 @@ To spin up this example locally, follow these steps:
 - `npx create-payload-app --example email`
 
 2. `cp .env.example .env` to copy the example environment variables
-3. `pnpm install && pnpm dev` to install dependencies and start the dev server
-4. open `http://localhost:3000/admin` to access the admin panel
-5. Create your first user
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-email`)
+4. `pnpm install && pnpm dev` to install dependencies and start the dev server
+5. open `http://localhost:3000/admin` to access the admin panel
+6. Create your first user
 
 ## How it works
 

--- a/examples/form-builder/.env.example
+++ b/examples/form-builder/.env.example
@@ -1,3 +1,3 @@
-DATABASE_URL=mongodb://127.0.0.1/payload-form-builder-example
+DATABASE_URL=mongodb://127.0.0.1/payload-example-form-builder
 PAYLOAD_SECRET=YOUR_SECRET_HERE
 NEXT_PUBLIC_PAYLOAD_URL=http://localhost:3000

--- a/examples/form-builder/README.md
+++ b/examples/form-builder/README.md
@@ -11,11 +11,12 @@ The [Payload Form Builder Example](https://github.com/payloadcms/payload/tree/ma
 - `npx create-payload-app --example form-builder`
 
 2. `cp .env.example .env` to copy the example environment variables
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-form-builder-example`)
 
-3. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
+4. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
    - Press `y` when prompted to seed the database
-4. `open http://localhost:3000` to access the home page
-5. `open http://localhost:3000/admin` to access the admin panel
+5. `open http://localhost:3000` to access the home page
+6. `open http://localhost:3000/admin` to access the admin panel
    - Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be

--- a/examples/form-builder/README.md
+++ b/examples/form-builder/README.md
@@ -11,7 +11,7 @@ The [Payload Form Builder Example](https://github.com/payloadcms/payload/tree/ma
 - `npx create-payload-app --example form-builder`
 
 2. `cp .env.example .env` to copy the example environment variables
-3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-form-builder-example`)
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-form-builder`)
 
 4. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
    - Press `y` when prompted to seed the database

--- a/examples/live-preview/README.md
+++ b/examples/live-preview/README.md
@@ -11,11 +11,12 @@ The [Payload Live Preview Example](https://github.com/payloadcms/payload/tree/ma
 - `npx create-payload-app --example live-preview`
 
 2. `cp .env.example .env` to copy the example environment variables
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-live-preview`)
 
-3. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
+4. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
    - Press `y` when prompted to seed the database
-4. `open http://localhost:3000` to access the home page
-5. `open http://localhost:3000/admin` to access the admin panel
+5. `open http://localhost:3000` to access the home page
+6. `open http://localhost:3000/admin` to access the admin panel
    - Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details.

--- a/examples/localization/.env.example
+++ b/examples/localization/.env.example
@@ -1,5 +1,5 @@
 # Database connection string
-DATABASE_URL=mongodb://127.0.0.1/payload-template-website
+DATABASE_URL=mongodb://127.0.0.1/payload-example-localization
 
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE

--- a/examples/localization/README.md
+++ b/examples/localization/README.md
@@ -13,7 +13,7 @@ To facilitate the localization process, this example uses the next-intl library.
 - `npx create-payload-app --example localization`
 
 2. `cp .env.example .env` (copy the .env.example file to .env)
-3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-template-website`)
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-localization`)
 4. `pnpm install`
 5. `pnpm run dev`
 6. Seed your database in the admin panel (see below)

--- a/examples/localization/README.md
+++ b/examples/localization/README.md
@@ -13,9 +13,10 @@ To facilitate the localization process, this example uses the next-intl library.
 - `npx create-payload-app --example localization`
 
 2. `cp .env.example .env` (copy the .env.example file to .env)
-3. `pnpm install`
-4. `pnpm run dev`
-5. Seed your database in the admin panel (see below)
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-template-website`)
+4. `pnpm install`
+5. `pnpm run dev`
+6. Seed your database in the admin panel (see below)
 
 ## Seed
 

--- a/examples/tailwind-shadcn-ui/.env.example
+++ b/examples/tailwind-shadcn-ui/.env.example
@@ -1,2 +1,2 @@
-DATABASE_URL=mongodb://127.0.0.1/payload-template-blank-3-0
+DATABASE_URL=mongodb://127.0.0.1/payload-example-tailwind-shadcn-ui
 PAYLOAD_SECRET=YOUR_SECRET_HERE

--- a/examples/tailwind-shadcn-ui/README.md
+++ b/examples/tailwind-shadcn-ui/README.md
@@ -16,7 +16,7 @@ To spin up this example locally, follow these steps:
 
    > Adjust `PAYLOAD_PUBLIC_SITE_URL` in the `.env` if your front-end is running on a separate domain or port.
 
-3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-template-blank-3-0`)
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-tailwind-shadcn-ui`)
 
 4. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
    - Press `y` when prompted to seed the database

--- a/examples/tailwind-shadcn-ui/README.md
+++ b/examples/tailwind-shadcn-ui/README.md
@@ -16,9 +16,11 @@ To spin up this example locally, follow these steps:
 
    > Adjust `PAYLOAD_PUBLIC_SITE_URL` in the `.env` if your front-end is running on a separate domain or port.
 
-3. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-template-blank-3-0`)
+
+4. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
    - Press `y` when prompted to seed the database
-4. `open http://localhost:3000` to access the home page
-5. `open http://localhost:3000/admin` to access the admin panel
+5. `open http://localhost:3000` to access the home page
+6. `open http://localhost:3000/admin` to access the admin panel
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details.

--- a/examples/whitelabel/README.md
+++ b/examples/whitelabel/README.md
@@ -11,9 +11,10 @@ To spin up this example locally, follow these steps:
 - `npx create-payload-app --example whitelabel`
 
 2. `cp .env.example .env` to copy the example environment variables
-3. `pnpm install && pnpm dev` to install dependencies and start the dev server
-4. `open http://localhost:3000/admin` to access the admin panel
-5. Login with email `dev@payloadcms.com` and password `test`
+3. Ensure MongoDB is running and `DATABASE_URL` points to it (for example `mongodb://127.0.0.1/payload-example-whitelabel`)
+4. `pnpm install && pnpm dev` to install dependencies and start the dev server
+5. `open http://localhost:3000/admin` to access the admin panel
+6. Login with email `dev@payloadcms.com` and password `test`
 
 ## Re-branding walkthrough
 


### PR DESCRIPTION
## Summary
Clarifies local setup instructions so MongoDB-backed examples explicitly state that a running MongoDB instance is required before starting the app.

Closes #15857

## Related
payloadcms/payload#15857

## Changes
- Adds explicit MongoDB prerequisite guidance to `examples/custom-components` Quick Start.
- Applies the same guidance to other MongoDB-backed examples with missing setup notes (`auth`, `custom-server`, `draft-preview`, `email`, `form-builder`, `live-preview`, `localization`, `tailwind-shadcn-ui`, `whitelabel`).
- Aligns example setup messaging more closely with template README conventions for local database prerequisites.

## Testing
- Not run (documentation-only changes).