### PR TITLE
fix(drizzle): error when using contains operator on hasMany select fields

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -450,12 +450,25 @@ export const sanitizeQueryValue = ({
 
   if (path !== '_id' || (path === '_id' && hasCustomID && field.type === 'text')) {
     if (operator === 'contains' && !Types.ObjectId.isValid(formattedValue)) {
-      if (
-        'hasMany' in field &&
-        field.hasMany &&
-        ['number', 'select', 'text'].includes(field.type)
-      ) {
-        // For array fields, we need to use $elemMatch to search within array elements
+      if ('hasMany' in field && field.hasMany && field.type === 'select') {
+        // For hasMany select, "contains" means the array includes this exact value
+        if (typeof formattedValue === 'string') {
+          return {
+            rawQuery: {
+              [path]: formattedValue,
+            },
+          }
+        } else if (Array.isArray(formattedValue)) {
+          return {
+            rawQuery: {
+              $or: formattedValue.map((val) => ({
+                [path]: val,
+              })),
+            },
+          }
+        }
+      } else if ('hasMany' in field && field.hasMany && ['number', 'text'].includes(field.type)) {
+        // For hasMany text/number, "contains" means substring matching within array elements
         if (typeof formattedValue === 'string') {
           // Search for documents where any array element contains this string
           const escapedValue = escapeRegExp(formattedValue)

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -238,8 +238,8 @@ export const sanitizeQueryValue = ({
     }
   }
 
-  // For hasMany relationship/upload/select fields, contains should use equals operator
-  // These are stored as separate rows, so "contains" means "has a row with this value"
+  // hasMany relationship/upload/select fields are stored as separate rows in a join table.
+  // The JOIN already gives us individual rows, so "contains" becomes an equality check on each row's value.
   if (
     'hasMany' in field &&
     field.hasMany &&

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -238,12 +238,13 @@ export const sanitizeQueryValue = ({
     }
   }
 
-  // For hasMany relationship/upload fields, contains should use equals operator
+  // For hasMany relationship/upload/select fields, contains should use equals operator
+  // These are stored as separate rows, so "contains" means "has a row with this value"
   if (
     'hasMany' in field &&
     field.hasMany &&
     operator === 'contains' &&
-    (field.type === 'relationship' || field.type === 'upload')
+    (field.type === 'relationship' || field.type === 'upload' || field.type === 'select')
   ) {
     operator = 'equals'
   }

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -261,7 +261,7 @@ export const sanitizeQueryValue = ({
       Array.isArray(formattedValue) &&
       'hasMany' in field &&
       field.hasMany &&
-      ['number', 'select', 'text'].includes(field.type)
+      ['number', 'text'].includes(field.type)
     ) {
       // For hasMany text/number/select fields with array values, wrap each element with % for LIKE matching
       formattedValue = formattedValue.map((val) => `%${val}%`)

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -1025,6 +1025,12 @@ export const getConfig: () => Partial<Config> = () => ({
           hasMany: true,
           options: ['user', 'admin', 'editor'],
         },
+        {
+          name: 'food',
+          type: 'select',
+          hasMany: true,
+          options: ['apple', 'bananabread', 'banana'],
+        },
       ],
     },
   ],

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -1016,6 +1016,17 @@ export const getConfig: () => Partial<Config> = () => ({
         },
       ],
     },
+    {
+      slug: 'select-has-many',
+      fields: [
+        {
+          name: 'roles',
+          type: 'select',
+          hasMany: true,
+          options: ['user', 'admin', 'editor'],
+        },
+      ],
+    },
   ],
   globals: [
     {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -5548,4 +5548,26 @@ describe('database', () => {
       expect(collatedMappedResults).toEqual(expectedSortedItems)
     },
   )
+
+  it('should query hasMany select field with contains operator', async () => {
+    const { id } = await payload.create({
+      collection: 'select-has-many',
+      data: {
+        roles: ['admin'],
+      },
+    })
+
+    const result = await payload.find({
+      collection: 'select-has-many',
+      where: {
+        roles: {
+          contains: 'admin',
+        },
+      },
+    })
+
+    expect(result.docs.some((doc) => doc.id === id)).toBe(true)
+
+    await payload.delete({ collection: 'select-has-many', id })
+  })
 })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -692,6 +692,28 @@ describe('database', () => {
     })
   })
 
+  it('should query hasMany select field with contains operator', async () => {
+    const { id } = await payload.create({
+      collection: 'select-has-many',
+      data: {
+        roles: ['admin'],
+      },
+    })
+
+    const result = await payload.find({
+      collection: 'select-has-many',
+      where: {
+        roles: {
+          contains: 'admin',
+        },
+      },
+    })
+
+    expect(result.docs.some((doc) => doc.id === id)).toBe(true)
+
+    await payload.delete({ collection: 'select-has-many', id })
+  })
+
   describe('allow ID on create', () => {
     beforeAll(() => {
       payload.db.allowIDOnCreate = true
@@ -5548,26 +5570,4 @@ describe('database', () => {
       expect(collatedMappedResults).toEqual(expectedSortedItems)
     },
   )
-
-  it('should query hasMany select field with contains operator', async () => {
-    const { id } = await payload.create({
-      collection: 'select-has-many',
-      data: {
-        roles: ['admin'],
-      },
-    })
-
-    const result = await payload.find({
-      collection: 'select-has-many',
-      where: {
-        roles: {
-          contains: 'admin',
-        },
-      },
-    })
-
-    expect(result.docs.some((doc) => doc.id === id)).toBe(true)
-
-    await payload.delete({ collection: 'select-has-many', id })
-  })
 })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -708,8 +708,30 @@ describe('database', () => {
         },
       },
     })
+    expect(result.docs).toHaveLength(1)
 
     expect(result.docs.some((doc) => doc.id === id)).toBe(true)
+
+    await payload.delete({ collection: 'select-has-many', id })
+  })
+
+  it('ensure querying hasMany select field with contains operator does not do partial matching', async () => {
+    const { id } = await payload.create({
+      collection: 'select-has-many',
+      data: {
+        food: ['bananabread'],
+      },
+    })
+
+    const result = await payload.find({
+      collection: 'select-has-many',
+      where: {
+        food: {
+          contains: 'banana',
+        },
+      },
+    })
+    expect(result.docs).toHaveLength(0)
 
     await payload.delete({ collection: 'select-has-many', id })
   })

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -89,6 +89,7 @@ export interface Config {
     aliases: Alias;
     'blocks-docs': BlocksDoc;
     'unique-fields': UniqueField;
+    'select-has-many': SelectHasMany;
     'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
@@ -119,6 +120,7 @@ export interface Config {
     aliases: AliasesSelect<false> | AliasesSelect<true>;
     'blocks-docs': BlocksDocsSelect<false> | BlocksDocsSelect<true>;
     'unique-fields': UniqueFieldsSelect<false> | UniqueFieldsSelect<true>;
+    'select-has-many': SelectHasManySelect<false> | SelectHasManySelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -144,6 +146,9 @@ export interface Config {
     'virtual-relation-global': VirtualRelationGlobalSelect<false> | VirtualRelationGlobalSelect<true>;
   };
   locale: 'en' | 'es' | 'uk';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -695,6 +700,16 @@ export interface UniqueField {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "select-has-many".
+ */
+export interface SelectHasMany {
+  id: string;
+  roles?: ('user' | 'admin' | 'editor')[] | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -829,6 +844,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'unique-fields';
         value: string | UniqueField;
+      } | null)
+    | ({
+        relationTo: 'select-has-many';
+        value: string | SelectHasMany;
       } | null)
     | ({
         relationTo: 'users';
@@ -1332,6 +1351,15 @@ export interface UniqueFieldsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "select-has-many_select".
+ */
+export interface SelectHasManySelect<T extends boolean = true> {
+  roles?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -1539,6 +1567,16 @@ export interface VirtualRelationGlobalSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -705,6 +705,7 @@ export interface UniqueField {
 export interface SelectHasMany {
   id: string;
   roles?: ('user' | 'admin' | 'editor')[] | null;
+  food?: ('apple' | 'bananabread' | 'banana')[] | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1355,6 +1356,7 @@ export interface UniqueFieldsSelect<T extends boolean = true> {
  */
 export interface SelectHasManySelect<T extends boolean = true> {
   roles?: T;
+  food?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
Fixes `contains` operator on hasMany `select` fields in PostgreSQL. This was a regression introduced in #15671.

## The problem

Given a collection with a hasMany `select` field:

```typescript
{
  slug: 'users',
  fields: [
    {
      name: 'roles',
      type: 'select',
      hasMany: true,
      options: ['user', 'admin', 'editor'],
    },
  ],
}
```

Payload stores this across two PostgreSQL tables. For a user created with `roles: ['admin', 'editor']`:

**`users`**
| id | created_at | updated_at |
|----|------------|------------|
| 1  | 2026-03-05 | 2026-03-05 |

**`users_roles`**
| id | parent_id | value    | order |
|----|-----------|----------|-------|
| 1  | 1         | `admin`  | 1     |
| 2  | 1         | `editor` | 2     |

The `value` column is a PostgreSQL **enum type**, not a `varchar`.

When querying `{ roles: { contains: 'admin' } }`, Payload generated:

```sql
SELECT DISTINCT "users"."id"
FROM "users"
LEFT JOIN "users_roles"
  ON "users"."id" = "users_roles"."parent_id"
WHERE "users_roles"."value" ILIKE '%admin%'
-- ❌ PostgreSQL error: operator does not exist: enum_users_roles ~~* unknown
```

`ILIKE` does not work on PostgreSQL enum types.

## The fix

The LEFT JOIN already flattens the array into individual rows:

| users.id | users_roles.value |
|----------|-------------------|
| 1        | `admin`           |
| 1        | `editor`          |

So "contains admin" just means "has a row where value equals admin". The fix converts `contains` to `equals` for hasMany `select` fields, the same way it already works for hasMany `relationship` and `upload` fields:

```sql
SELECT DISTINCT "users"."id"
FROM "users"
LEFT JOIN "users_roles"
  ON "users"."id" = "users_roles"."parent_id"
WHERE "users_roles"."value" = 'admin'
-- ✅ Matches row 1, returns user id=1
```

## Why hasMany `text` fields are different

HasMany `text` fields store values as `varchar`, not as an enum. `ILIKE` works fine on `varchar` columns, so substring matching (`contains: 'adm'` matching `'admin'`) is valid there. Whether it's _desirable_ is a problem separate from this PR, being discussed internally [here](https://payloadcms.slack.com/archives/C049BR3QBHC/p1772680331359859)