### PR TITLE
fix(ui): equal column widths for block-drawer blocks

### DIFF
--- a/packages/ui/src/fields/Blocks/BlockSelector/index.scss
+++ b/packages/ui/src/fields/Blocks/BlockSelector/index.scss
@@ -11,7 +11,7 @@
       padding: 0;
       list-style: none;
       display: grid;
-      grid-template-columns: repeat(6, (minmax(0, 1fr)));
+      grid-template-columns: repeat(6, minmax(0, 1fr));
       gap: base(1);
     }
 
@@ -59,7 +59,7 @@
 
     @include large-break {
       &__blocks {
-        grid-template-columns: repeat(5, (minmax(0, 1fr)));
+        grid-template-columns: repeat(5, minmax(0, 1fr));
       }
     }
 
@@ -69,7 +69,7 @@
       }
 
       &__blocks {
-        grid-template-columns: repeat(3, (minmax(0, 1fr)));
+        grid-template-columns: repeat(3, minmax(0, 1fr));
       }
 
       &__block-groups {
@@ -87,7 +87,7 @@
       }
 
       &__blocks {
-        grid-template-columns: repeat(2, (minmax(0, 1fr)));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
       &__block-groups {

--- a/packages/ui/src/fields/Blocks/BlockSelector/index.scss
+++ b/packages/ui/src/fields/Blocks/BlockSelector/index.scss
@@ -11,7 +11,7 @@
       padding: 0;
       list-style: none;
       display: grid;
-      grid-template-columns: repeat(6, 1fr);
+      grid-template-columns: repeat(6, (minmax(0, 1fr)));
       gap: base(1);
     }
 
@@ -59,7 +59,7 @@
 
     @include large-break {
       &__blocks {
-        grid-template-columns: repeat(5, 1fr);
+        grid-template-columns: repeat(5, (minmax(0, 1fr)));
       }
     }
 
@@ -69,7 +69,7 @@
       }
 
       &__blocks {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(3, (minmax(0, 1fr)));
       }
 
       &__block-groups {
@@ -87,7 +87,7 @@
       }
 
       &__blocks {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(2, (minmax(0, 1fr)));
       }
 
       &__block-groups {


### PR DESCRIPTION
# What?

Fixes unequal block-drawer column widths causing layout breaking with long block labels

## Before
<img width="1330" height="1319" alt="image" src="https://github.com/user-attachments/assets/9281cf3b-994f-47c9-bc25-001b40e61282" />

## After
<img width="1321" height="1298" alt="image" src="https://github.com/user-attachments/assets/85dc44c7-cfd3-4591-96f2-ef9cf41de46c" />