### PR TITLE
feat(plugin-import-export): add mapHeaders option for CSV column renaming

### DIFF
--- a/docs/plugins/import-export.mdx
+++ b/docs/plugins/import-export.mdx
@@ -129,6 +129,7 @@ Each item in the `collections` array can have the following properties:
 | `disableSave`        | boolean              | Disable save button for this collection.                                                         |
 | `format`             | string               | Force format (`csv` or `json`) for this collection.                                              |
 | `limit`              | `number \| function` | Maximum documents to export. Set to `0` for unlimited (default). Overrides global `exportLimit`. |
+| `mapHeaders`         | function             | Transform CSV column header names during export. [More details](#mapping-csv-headers).           |
 | `overrideCollection` | function             | Override the export collection config for this specific target.                                  |
 
 ### ImportConfig Options
@@ -488,6 +489,69 @@ const pages: CollectionConfig = {
   ],
 }
 ```
+
+### Mapping CSV Headers
+
+By default, CSV column headers use the programmatic field `name` (e.g. `firstName`, `orderStatus`). The `mapHeaders` option in [ExportConfig](#exportconfig-options) lets you transform these into human-readable names.
+
+The function receives an object with:
+
+| Property     | Type            | Description                                                                                                                             |
+| ------------ | --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `columnName` | string          | The original column key (e.g. `firstName`, `group_value`).                                                                              |
+| `field`      | FlattenedField? | The field definition that produced this column, when one can be resolved. `undefined` for system columns, `toCSV`-derived columns, etc. |
+
+Return the desired header string. Returning the original `columnName` keeps it unchanged.
+
+#### Use field labels as headers
+
+```ts
+importExportPlugin({
+  collections: [
+    {
+      slug: 'orders',
+      export: {
+        mapHeaders: ({ columnName, field }) => {
+          if (field?.label) {
+            return typeof field.label === 'string'
+              ? field.label
+              : (field.label['en'] ?? columnName)
+          }
+          return columnName
+        },
+      },
+    },
+  ],
+})
+```
+
+With a collection that has `{ name: 'firstName', label: 'First Name' }`, the CSV header changes from `firstName` to `First Name`.
+
+#### Static header mapping
+
+```ts
+const headerMap: Record<string, string> = {
+  firstName: 'First Name',
+  lastName: 'Last Name',
+  createdAt: 'Created',
+}
+
+importExportPlugin({
+  collections: [
+    {
+      slug: 'users',
+      export: {
+        mapHeaders: ({ columnName }) => headerMap[columnName] ?? columnName,
+      },
+    },
+  ],
+})
+```
+
+<Banner type="info">
+  `mapHeaders` only affects CSV exports. JSON exports preserve the original
+  field structure.
+</Banner>
 
 ### Virtual Fields
 

--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -1,10 +1,14 @@
 /* eslint-disable perfectionist/sort-objects */
+import type { ColumnOption } from 'csv-stringify'
 import type { PayloadRequest, Sort, TypedUser, Where } from 'payload'
 
 import { stringify } from 'csv-stringify/sync'
 import { APIError } from 'payload'
 import { Readable } from 'stream'
 
+import type { MapHeadersFunction } from '../types.js'
+
+import { applyMapHeaders } from '../utilities/applyMapHeaders.js'
 import { buildDisabledFieldRegex } from '../utilities/buildDisabledFieldRegex.js'
 import { flattenObject } from '../utilities/flattenObject.js'
 import { getExportFieldFunctions } from '../utilities/getExportFieldFunctions.js'
@@ -203,6 +207,9 @@ export const createExport = async (args: CreateExportArgs) => {
     fields: collectionConfig.flattenedFields,
   })
 
+  const mapHeaders: MapHeadersFunction | undefined =
+    collectionConfig.custom?.['plugin-import-export']?.exportMapHeaders
+
   const disabledFields =
     collectionConfig.admin?.custom?.['plugin-import-export']?.disabledFields ?? []
 
@@ -366,10 +373,23 @@ export const createExport = async (args: CreateExportArgs) => {
             return fullRow
           })
 
+          let csvColumns: readonly ColumnOption[] | readonly string[] = allColumns
+          if (typeof mapHeaders === 'function') {
+            const { mappedColumns } = applyMapHeaders({
+              collectionConfig,
+              columns: allColumns,
+              mapHeaders,
+            })
+            csvColumns = allColumns.map((col, i) => ({
+              key: col,
+              header: mappedColumns[i]!,
+            }))
+          }
+
           const csvString = stringify(paddedRows, {
             bom: isFirstBatch,
             header: isFirstBatch,
-            columns: allColumns,
+            columns: csvColumns,
           })
 
           this.push(encoder.encode(csvString))
@@ -482,12 +502,25 @@ export const createExport = async (args: CreateExportArgs) => {
       return fullRow
     })
 
+    let csvColumns: readonly ColumnOption[] | readonly string[] = finalColumns
+    if (typeof mapHeaders === 'function') {
+      const { mappedColumns } = applyMapHeaders({
+        collectionConfig,
+        columns: finalColumns,
+        mapHeaders,
+      })
+      csvColumns = finalColumns.map((col, i) => ({
+        key: col,
+        header: mappedColumns[i]!,
+      }))
+    }
+
     // Always output CSV with header, even if empty
     outputData.push(
       stringify(paddedRows, {
         bom: true,
         header: true,
-        columns: finalColumns,
+        columns: csvColumns,
       }),
     )
   } else {

--- a/packages/plugin-import-export/src/export/handlePreview.ts
+++ b/packages/plugin-import-export/src/export/handlePreview.ts
@@ -3,7 +3,7 @@ import type { FlattenedField, PayloadRequest, Where } from 'payload'
 import { addDataAndFileToRequest } from 'payload'
 import { getObjectDotNotation } from 'payload/shared'
 
-import type { ExportPreviewResponse } from '../types.js'
+import type { ExportPreviewResponse, MapHeadersFunction } from '../types.js'
 
 import {
   DEFAULT_PREVIEW_LIMIT,
@@ -11,6 +11,7 @@ import {
   MIN_PREVIEW_LIMIT,
   MIN_PREVIEW_PAGE,
 } from '../constants.js'
+import { applyMapHeaders } from '../utilities/applyMapHeaders.js'
 import { flattenObject } from '../utilities/flattenObject.js'
 import { getExportFieldFunctions } from '../utilities/getExportFieldFunctions.js'
 import { getFlattenedFieldKeys } from '../utilities/getFlattenedFieldKeys.js'
@@ -251,6 +252,27 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
 
   const hasNextPage = previewPage < previewTotalPages
   const hasPrevPage = previewPage > 1
+
+  const mapHeaders: MapHeadersFunction | undefined =
+    targetCollection.config.custom?.['plugin-import-export']?.exportMapHeaders
+
+  if (typeof mapHeaders === 'function' && columns && columns.length > 0) {
+    const { mappedColumns, originalToMapped } = applyMapHeaders({
+      collectionConfig: targetCollection.config,
+      columns,
+      mapHeaders,
+    })
+    columns = mappedColumns
+
+    for (const row of transformed) {
+      for (const [original, mapped] of originalToMapped) {
+        if (original !== mapped && original in row) {
+          row[mapped] = row[original]
+          delete row[original]
+        }
+      }
+    }
+  }
 
   const response: ExportPreviewResponse = {
     columns,

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -7,6 +7,7 @@ import type {
   FromCSVFunction,
   ImportExportPluginConfig,
   Limit,
+  MapHeadersFunction,
   PluginCollectionConfig,
   ToCSVFunction,
 } from './types.js'
@@ -139,6 +140,7 @@ export const importExportPlugin =
       const exportBatchSize = exportConfig?.batchSize
       const exportDisableSave = exportConfig?.disableSave
       const exportDisableDownload = exportConfig?.disableDownload
+      const exportMapHeaders = exportConfig?.mapHeaders
 
       const importConfig =
         typeof collectionPluginConfig?.import === 'object'
@@ -172,6 +174,7 @@ export const importExportPlugin =
             exportDisableJobsQueue,
           }),
           ...(exportBatchSize !== undefined && { exportBatchSize }),
+          ...(exportMapHeaders !== undefined && { exportMapHeaders }),
           ...(importLimit !== undefined && { importLimit }),
           ...(importDisableJobsQueue !== undefined && {
             importDisableJobsQueue,
@@ -280,6 +283,11 @@ declare module 'payload' {
        * Stored in collection.custom (server-only) since functions cannot be serialized to client.
        */
       exportLimit?: Limit
+      /**
+       * Transform CSV column header names during export.
+       * Stored in collection.custom (server-only) since functions cannot be serialized to client.
+       */
+      exportMapHeaders?: MapHeadersFunction
       /**
        * Number of documents to process in each batch during import.
        * @default 100

--- a/packages/plugin-import-export/src/types.ts
+++ b/packages/plugin-import-export/src/types.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig, CollectionSlug, PayloadRequest } from 'payload'
+import type { CollectionConfig, CollectionSlug, FlattenedField, PayloadRequest } from 'payload'
 
 /**
  * Function to dynamically determine the limit based on request context
@@ -55,6 +55,24 @@ export type ExportConfig = {
    * Set to 0 for unlimited (default). Overrides the global exportLimit if set.
    */
   limit?: Limit
+  /**
+   * Transform CSV column header names during export.
+   *
+   * Called once per column with the original column key and (when available) the
+   * field definition that produced it. Return the desired display name for the
+   * CSV header row.
+   *
+   * @example
+   * ```ts
+   * mapHeaders: ({ columnName, field }) => {
+   *   if (field?.label) {
+   *     return typeof field.label === 'string' ? field.label : field.label['en'] ?? columnName
+   *   }
+   *   return columnName
+   * }
+   * ```
+   */
+  mapHeaders?: MapHeadersFunction
   /**
    * Override the export collection for this collection.
    *
@@ -178,6 +196,25 @@ export type ImportExportPluginConfig = {
    */
   overrideImportCollection?: CollectionOverride
 }
+
+/**
+ * Custom function to transform CSV column header names during export.
+ *
+ * Called once per column after columns are finalized.
+ * Return the desired header string, or the original `columnName` to keep it unchanged.
+ */
+export type MapHeadersFunction = (args: {
+  /**
+   * The original column key (e.g. `firstName`, `group_value`, `array_0_field1`)
+   */
+  columnName: string
+  /**
+   * The field definition that produced this column, when one can be resolved.
+   * `undefined` for system columns (`id`, `createdAt`, …), `toCSV`-derived columns,
+   * and array indices beyond the first.
+   */
+  field?: FlattenedField
+}) => string
 
 /**
  * Custom function used to modify the outgoing csv data by manipulating the data, siblingData or by returning the desired value

--- a/packages/plugin-import-export/src/utilities/applyMapHeaders.ts
+++ b/packages/plugin-import-export/src/utilities/applyMapHeaders.ts
@@ -1,0 +1,41 @@
+import type { FlattenedField, SanitizedCollectionConfig } from 'payload'
+
+import type { MapHeadersFunction } from '../types.js'
+
+import { buildColumnToFieldMap } from './buildColumnToFieldMap.js'
+
+type ApplyMapHeadersArgs = {
+  collectionConfig: SanitizedCollectionConfig
+  columns: string[]
+  mapHeaders: MapHeadersFunction
+}
+
+export type ColumnMapping = {
+  mappedColumns: string[]
+  originalToMapped: Map<string, string>
+}
+
+/**
+ * Applies a `mapHeaders` function to a list of column names.
+ *
+ * Returns the mapped column names alongside a mapping from original to mapped
+ * so callers can remap row keys or build `{ key, header }` pairs for csv-stringify.
+ */
+export const applyMapHeaders = ({
+  collectionConfig,
+  columns,
+  mapHeaders,
+}: ApplyMapHeadersArgs): ColumnMapping => {
+  const fieldMap = buildColumnToFieldMap(collectionConfig.flattenedFields)
+
+  const mappedColumns: string[] = []
+  const originalToMapped = new Map<string, string>()
+
+  for (const col of columns) {
+    const mapped = mapHeaders({ columnName: col, field: fieldMap.get(col) })
+    mappedColumns.push(mapped)
+    originalToMapped.set(col, mapped)
+  }
+
+  return { mappedColumns, originalToMapped }
+}

--- a/packages/plugin-import-export/src/utilities/buildColumnToFieldMap.ts
+++ b/packages/plugin-import-export/src/utilities/buildColumnToFieldMap.ts
@@ -1,0 +1,94 @@
+import { type FlattenedField } from 'payload'
+
+type FieldWithPresentational =
+  | {
+      fields?: FlattenedField[]
+      name?: string
+      tabs?: {
+        fields: FlattenedField[]
+        name?: string
+      }[]
+      type: 'collapsible' | 'row' | 'tabs'
+    }
+  | FlattenedField
+
+/**
+ * Walks the field tree with the same prefix logic as `getFlattenedFieldKeys`
+ * and produces a map from CSV column key to the source field definition.
+ *
+ * Only schema-derivable keys are mapped (index 0 for arrays/blocks).
+ * `toCSV`-derived columns and higher array indices will not appear in the map.
+ */
+export const buildColumnToFieldMap = (
+  fields: FieldWithPresentational[],
+  prefix = '',
+): Map<string, FlattenedField> => {
+  const map = new Map<string, FlattenedField>()
+
+  fields.forEach((field) => {
+    const isDisabled =
+      'custom' in field &&
+      typeof field.custom === 'object' &&
+      field.custom?.['plugin-import-export']?.disabled === true
+
+    if (isDisabled) {
+      return
+    }
+
+    const name = 'name' in field && typeof field.name === 'string' ? field.name : undefined
+    const fullKey = name && prefix ? `${prefix}_${name}` : (name ?? prefix)
+
+    switch (field.type) {
+      case 'array': {
+        const subMap = buildColumnToFieldMap(field.fields as FlattenedField[], `${fullKey}_0`)
+        for (const [k, v] of subMap) {
+          map.set(k, v)
+        }
+        break
+      }
+      case 'blocks': {
+        field.blocks.forEach((block) => {
+          if (typeof block === 'string') {
+            return
+          }
+          const blockPrefix = `${fullKey}_0_${block.slug}`
+          const subMap = buildColumnToFieldMap(block.flattenedFields ?? block.fields, blockPrefix)
+          for (const [k, v] of subMap) {
+            map.set(k, v)
+          }
+        })
+        break
+      }
+      case 'collapsible':
+      case 'group':
+      case 'row': {
+        const subMap = buildColumnToFieldMap(field.fields as FlattenedField[], fullKey)
+        for (const [k, v] of subMap) {
+          map.set(k, v)
+        }
+        break
+      }
+      case 'tabs': {
+        field.tabs?.forEach((tab) => {
+          const tabPrefix = tab.name ? `${fullKey}_${tab.name}` : fullKey
+          const subMap = buildColumnToFieldMap(tab.fields || [], tabPrefix)
+          for (const [k, v] of subMap) {
+            map.set(k, v)
+          }
+        })
+        break
+      }
+      default: {
+        if (!name) {
+          break
+        }
+        if ('type' in field) {
+          map.set(fullKey, field as FlattenedField)
+        }
+        break
+      }
+    }
+  })
+
+  return map
+}

--- a/test/plugin-import-export/collections/PostsWithMapHeaders.ts
+++ b/test/plugin-import-export/collections/PostsWithMapHeaders.ts
@@ -1,0 +1,28 @@
+import type { CollectionConfig } from 'payload'
+
+import { postsWithMapHeadersSlug } from '../shared.js'
+
+export const PostsWithMapHeaders: CollectionConfig = {
+  slug: postsWithMapHeadersSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      label: 'Post Title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'summary',
+      label: 'Short Summary',
+      type: 'text',
+    },
+    {
+      name: 'views',
+      label: 'View Count',
+      type: 'number',
+    },
+  ],
+}

--- a/test/plugin-import-export/config.ts
+++ b/test/plugin-import-export/config.ts
@@ -18,10 +18,11 @@ import { PostsExportsOnly } from './collections/PostsExportsOnly.js'
 import { PostsImportsOnly } from './collections/PostsImportsOnly.js'
 import { PostsNoJobsQueue } from './collections/PostsNoJobsQueue.js'
 import { PostsWithLimits } from './collections/PostsWithLimits.js'
+import { PostsWithMapHeaders } from './collections/PostsWithMapHeaders.js'
 import { PostsWithS3 } from './collections/PostsWithS3.js'
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
-import { customIdPagesSlug, postsWithS3Slug } from './shared.js'
+import { customIdPagesSlug, postsWithMapHeadersSlug, postsWithS3Slug } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -49,6 +50,7 @@ export default buildConfigWithDefaults({
     PostsNoJobsQueue,
     PostsWithLimits,
     PostsWithS3,
+    PostsWithMapHeaders,
     Media,
     CustomIdPages,
   ],
@@ -214,6 +216,24 @@ export default buildConfigWithDefaults({
               return collection
             },
           },
+        },
+        {
+          slug: postsWithMapHeadersSlug,
+          export: {
+            disableJobsQueue: true,
+            mapHeaders: ({ columnName, field }) => {
+              if (field?.label) {
+                return typeof field.label === 'string' ? field.label : columnName
+              }
+              return columnName
+            },
+            overrideCollection: ({ collection }) => {
+              collection.slug = 'posts-with-map-headers-export'
+              collection.upload.staticDir = path.resolve(dirname, 'uploads')
+              return collection
+            },
+          },
+          import: false,
         },
         {
           slug: 'media',

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -14,7 +14,7 @@ import { devUser, regularUser } from '../credentials.js'
 import { clearTestBucket, createTestBucket } from '../storage-s3/test-utils.js'
 import { readCSV, readJSON } from './helpers.js'
 import { richTextData } from './seed/richTextData.js'
-import { customIdPagesSlug, postsWithS3Slug } from './shared.js'
+import { customIdPagesSlug, postsWithMapHeadersSlug, postsWithS3Slug } from './shared.js'
 
 let payload: Payload
 let restClient: NextRESTClient
@@ -2833,6 +2833,82 @@ describe('@payloadcms/plugin-import-export', () => {
           'Export JSON Page 1',
         )
       })
+    })
+  })
+
+  describe('mapHeaders', () => {
+    const createdIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of createdIDs) {
+        await payload.delete({ collection: postsWithMapHeadersSlug, id }).catch(() => null)
+      }
+      createdIDs.length = 0
+    })
+
+    it('should use field labels as CSV column headers via mapHeaders', async () => {
+      const doc = await payload.create({
+        collection: postsWithMapHeadersSlug,
+        data: { title: 'Map Headers Test', summary: 'A summary', views: 42 },
+      })
+      createdIDs.push(doc.id)
+
+      const exportDoc = await payload.create({
+        collection: 'posts-with-map-headers-export',
+        user,
+        data: {
+          collectionSlug: postsWithMapHeadersSlug,
+          name: 'map-headers-test',
+          format: 'csv',
+          fields: ['id', 'title', 'summary', 'views'],
+        },
+      })
+
+      const exportPath = path.join(dirname, './uploads', exportDoc.filename as string)
+      const rawCsv = fs.readFileSync(exportPath, 'utf-8')
+      const headerLine = rawCsv.split('\n')[0]!.replace(/\r$/, '')
+
+      expect(headerLine).toContain('Post Title')
+      expect(headerLine).toContain('Short Summary')
+      expect(headerLine).toContain('View Count')
+      expect(headerLine).not.toContain('title')
+      expect(headerLine).not.toContain('summary')
+      expect(headerLine).not.toContain('views')
+      // 'id' has no label, so it stays as 'id'
+      expect(headerLine).toContain('id')
+
+      const data = await readCSV(exportPath)
+
+      expect(data).toHaveLength(1)
+      expect(data[0]!['Post Title']).toBe('Map Headers Test')
+      expect(data[0]!['Short Summary']).toBe('A summary')
+      expect(data[0]!['View Count']).toBe('42')
+    })
+
+    it('should return mapped column headers in export preview', async () => {
+      const doc = await payload.create({
+        collection: postsWithMapHeadersSlug,
+        data: { title: 'Preview Map Test', summary: 'Preview summary', views: 7 },
+      })
+      createdIDs.push(doc.id)
+
+      const response = await restClient
+        .POST(`/posts-with-map-headers-export/export-preview`, {
+          body: JSON.stringify({
+            collectionSlug: postsWithMapHeadersSlug,
+            format: 'csv',
+            fields: ['id', 'title', 'summary', 'views'],
+          }),
+          headers: { 'Content-Type': 'application/json' },
+        })
+        .then((res) => res.json())
+
+      expect(response.columns).toContain('Post Title')
+      expect(response.columns).toContain('Short Summary')
+      expect(response.columns).toContain('View Count')
+      expect(response.columns).not.toContain('title')
+
+      expect(response.docs[0]?.['Post Title']).toBe('Preview Map Test')
     })
   })
 

--- a/test/plugin-import-export/shared.ts
+++ b/test/plugin-import-export/shared.ts
@@ -19,3 +19,5 @@ export const postsWithS3ExportSlug = 'posts-with-s3-export'
 export const mediaSlug = 'media'
 
 export const customIdPagesSlug = 'custom-id-pages'
+
+export const postsWithMapHeadersSlug = 'posts-with-map-headers'


### PR DESCRIPTION
## Summary

- Adds a `mapHeaders` option to `ExportConfig` that allows transforming CSV column header names during export
- The function receives the original column key and the source field definition (when available), making it easy to use field labels instead of programmatic names
- Works with both the download (streaming) and save (buffered) export paths, as well as the export preview

## Changes

CSV exports currently use programmatic field names as column headers (e.g. `firstName`, `orderStatus`). Users who share exports with non-technical stakeholders need human-readable headers. This adds a `mapHeaders` function to `ExportConfig` that transforms column names at export time without affecting the underlying data keys.

The most common use case is mapping to field labels:

```ts
export: {
  mapHeaders: ({ columnName, field }) => {
    if (field?.label) {
      return typeof field.label === 'string' ? field.label : field.label['en'] ?? columnName
    }
    return columnName
  },
}
```

Internally, the header mapping is applied after columns are finalized (after `mergeColumns`). For the actual CSV output, `csv-stringify`'s `{ key, header }` column format is used so row data keys remain unchanged while only the header row is transformed. For the preview endpoint, both column names and row keys are remapped so the preview accurately reflects the exported CSV.

A `buildColumnToFieldMap` utility walks the field tree with the same prefix logic as `getFlattenedFieldKeys` to provide the `field` argument to `mapHeaders`. System columns like `id` or `toCSV`-derived columns have `field: undefined`.

## Testing

```bash
pnpm run test:int plugin-import-export -- -t "mapHeaders"
```

Two integration tests verify:
1. Exported CSV file uses mapped headers and data is accessible under mapped keys
2. Export preview endpoint returns mapped column names and row data

Without the implementation, both tests fail with `expect(headerLine).toContain('Post Title')` because the CSV header row contains the programmatic name `title` instead.