### PR TITLE
fix(ui): open folder/document items in new tab on modifier click

### DIFF
--- a/packages/ui/src/providers/Folders/index.tsx
+++ b/packages/ui/src/providers/Folders/index.tsx
@@ -320,26 +320,40 @@ export function FolderProvider({
   }, [selectedItemKeys, getItem])
 
   const navigateAfterSelection = React.useCallback(
-    ({ collectionSlug, docID }: { collectionSlug: string; docID?: number | string }) => {
+    ({
+      collectionSlug,
+      docID,
+      openInNewTab = false,
+    }: {
+      collectionSlug: string
+      docID?: number | string
+      openInNewTab?: boolean
+    }) => {
       if (drawerDepth === 1) {
         // not in a drawer (default is 1)
+        let targetURL: string | undefined
+
         if (collectionSlug === folderCollectionSlug) {
           // clicked on folder, take the user to the folder view
-          startRouteTransition(() => {
-            router.push(getFolderRoute(docID))
-            clearSelections()
-          })
+          targetURL = getFolderRoute(docID)
         } else if (collectionSlug) {
-          // clicked on document, take the user to the documet view
-          startRouteTransition(() => {
-            router.push(
-              formatAdminURL({
-                adminRoute: config.routes.admin,
-                path: `/collections/${collectionSlug}/${docID}`,
-              }),
-            )
-            clearSelections()
+          // clicked on document, take the user to the document view
+          targetURL = formatAdminURL({
+            adminRoute: config.routes.admin,
+            path: `/collections/${collectionSlug}/${docID}`,
           })
+        }
+
+        if (targetURL) {
+          if (openInNewTab) {
+            window.open(targetURL, '_blank', 'noopener,noreferrer')
+            clearSelections()
+          } else {
+            startRouteTransition(() => {
+              router.push(targetURL)
+              clearSelections()
+            })
+          }
         }
       } else {
         clearSelections()
@@ -590,6 +604,16 @@ export function FolderProvider({
       const isCurrentlySelected = selectedItemKeys.has(clickedItem.itemKey)
       const allItems = [...subfolders, ...documents]
       const currentItemIndex = allItems.findIndex((item) => item.itemKey === clickedItem.itemKey)
+
+      if ((isCtrlPressed || isShiftPressed) && event.type !== 'pointermove') {
+        event.preventDefault()
+        navigateAfterSelection({
+          collectionSlug: clickedItem.relationTo,
+          docID: extractID(clickedItem.value),
+          openInNewTab: true,
+        })
+        return
+      }
 
       if (allowMultiSelection && isCtrlPressed) {
         event.preventDefault()


### PR DESCRIPTION
## Summary

Fix folder/document navigation in folder views so modifier-click behaves like normal links.

`cmd` / `ctrl` / `shift` + click on folder cards or list rows currently routes in-place via `router.push`, which prevents opening in a new tab.

This PR adds modifier-aware behavior:

- `cmd` / `ctrl` / `shift` + click opens the target in a new tab
- regular click/double-click behavior still navigates in the current tab

## Changes

- Extended `navigateAfterSelection` with an `openInNewTab` option.
- Unified target URL building and route handling.
- For modifier-clicks, uses `window.open(targetURL, '_blank', 'noopener,noreferrer')`.
- Updated item click handling to route modifier-clicks through `openInNewTab`.

## Validation

- `pnpm exec eslint packages/ui/src/providers/Folders/index.tsx`

Closes #15837
