### PR TITLE
fix(ui): avoid unstable form-state reconciliation while editing

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -854,7 +854,21 @@ export const Form: React.FC<FormProps> = (props) => {
 
   useDebouncedEffect(
     () => {
-      if ((isFirstRenderRef.current || !dequal(formState, prevFormState.current)) && modified) {
+      const comparableFormState = deepCopyObjectSimpleWithoutReactComponents(formState, {
+        excludeFiles: true,
+      })
+
+      const previousComparableFormState = deepCopyObjectSimpleWithoutReactComponents(
+        prevFormState.current,
+        {
+          excludeFiles: true,
+        },
+      )
+
+      if (
+        (isFirstRenderRef.current || !dequal(comparableFormState, previousComparableFormState)) &&
+        modified
+      ) {
         executeOnChange(submitted)
       }
 

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -464,6 +464,12 @@ export function DefaultEditView({
 
   const onChange: FormProps['onChange'][0] = useCallback(
     async ({ formState: prevFormState, submitted }) => {
+      // Autosave-enabled docs already reconcile server state through the autosave submit path.
+      // Running the edit-view form-state request during typing can race that flow and revert local edits.
+      if (autosaveEnabled) {
+        return null
+      }
+
       const controller = handleAbortRef(abortOnChangeRef)
 
       // Sync originalUpdatedAt with current data if it's NEWER (e.g., after router.refresh())

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1830,6 +1830,44 @@ describe('Versions', () => {
       await expect(computedTitleField).toHaveValue('Initial')
     })
 
+    test('- with autosave - does not override lexical rich text changes after autosave runs', async () => {
+      const url = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
+      await page.goto(url.create)
+      await waitForFormReady(page)
+
+      await page.locator('#field-title').fill('Initial')
+      await page.locator('#field-description').fill('Description')
+      await waitForAutoSaveToRunAndComplete(page)
+
+      const lastModified = page.locator('li').filter({ hasText: 'Last Modified:' }).first()
+      const initialLastModified = await lastModified.textContent()
+
+      const richTextField = page.locator('.rich-text-lexical').first()
+      const contentEditable = richTextField
+        .locator('.ContentEditable__root[data-lexical-editor="true"]')
+        .first()
+
+      await contentEditable.click()
+      await page.keyboard.type('Initial rich text', {
+        delay: 150,
+      })
+
+      await expect
+        .poll(async () => await lastModified.textContent(), { timeout: POLL_TOPASS_TIMEOUT })
+        .not.toBe(initialLastModified)
+
+      await expect(contentEditable).toContainText('Initial rich text')
+
+      await page.reload()
+      await waitForFormReady(page)
+
+      await expect(
+        page
+          .locator('.rich-text-lexical .ContentEditable__root[data-lexical-editor="true"]')
+          .first(),
+      ).toContainText('Initial rich text')
+    })
+
     test('- with autosave - does not override local changes to form state after autosave runs within document drawer', async () => {
       await payload.create({
         collection: autosaveCollectionSlug,


### PR DESCRIPTION
### What?

This fixes an admin UI regression where editing could trigger unstable `form-state` reconciliation during typing, causing local edits to revert instead of settling in the form.

For autosave-enabled versioned documents, it also avoids a second competing reconciliation path that could race the autosave submit flow.

It also adds an e2e regression test covering the Lexical rich text path that reproduced the bug.

### Why?

`Form` was comparing raw form state objects that included unstable React/component metadata, which could retrigger background `onChange` processing even when meaningful form data had not changed.

Separately, autosave-enabled documents already reconcile through the autosave submit flow, but the edit view was still running its own background `getFormState` reconciliation path during typing.

In combination, that could cause:
- repeated background `form-state` requests
- local edits reverting during typing
- drafts not saving reliably

### How?

- In `Form`, compare sanitized form state snapshots before triggering debounced `onChange`, so transient React/component metadata does not retrigger change detection.
- In `Edit`, skip the background `getFormState` reconciliation path for autosave-enabled docs, since autosave already reconciles through submit.
- Add an e2e regression test for autosave + Lexical rich text to verify content is not reverted and persists after reload.

### Before / After

Before:
- typing could retrigger unstable `form-state` reconciliation
- autosave-enabled edits could also race a second edit-view reconciliation path
- local text could immediately revert
- drafts would not reliably persist

After:
- transient UI metadata no longer retriggers background reconciliation
- autosave typing no longer races edit-view `form-state` reconciliation
- rich text edits remain in place
- drafts persist normally

### Validation

- Added e2e coverage in `test/versions/e2e.spec.ts`
- Verified locally with:
  `pnpm test:e2e versions --grep "lexical rich text changes after autosave runs"`

Fixes #15511
