### PR TITLE
fix: run `sanitizeWhereQuery` for join query access result

### DIFF
--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -5,6 +5,7 @@ import { executeAccess } from '../auth/executeAccess.js'
 import { QueryError } from '../errors/QueryError.js'
 import { combineQueries } from './combineQueries.js'
 import { validateQueryPaths } from './queryValidation/validateQueryPaths.js'
+import { sanitizeWhereQuery } from './sanitizeWhereQuery.js'
 
 type Args = {
   collectionConfig: SanitizedCollectionConfig
@@ -76,6 +77,11 @@ const sanitizeJoinFieldQuery = async ({
   )
 
   if (typeof accessResult === 'object') {
+    sanitizeWhereQuery({
+      fields: joinCollectionConfig.flattenedFields,
+      payload: req.payload,
+      where: accessResult,
+    })
     joinQuery.where = combineQueries(joinQuery.where, accessResult)
   }
 }

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -1033,6 +1033,59 @@ export const getConfig: () => Partial<Config> = () => ({
         },
       ],
     },
+    {
+      slug: 'virtual-linked-tenants',
+      fields: [
+        {
+          name: 'slug',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+    {
+      slug: 'virtual-linked-roles',
+      access: {
+        read: () => ({
+          tenantSlug: {
+            exists: true,
+          },
+        }),
+      },
+      fields: [
+        {
+          name: 'project',
+          type: 'relationship',
+          relationTo: 'virtual-linked-projects',
+          required: true,
+        },
+        {
+          name: 'tenant',
+          type: 'relationship',
+          relationTo: 'virtual-linked-tenants',
+          required: true,
+        },
+        {
+          name: 'tenantSlug',
+          type: 'text',
+          virtual: 'tenant.slug',
+        },
+      ],
+    },
+    {
+      slug: 'virtual-linked-projects',
+      access: {
+        read: () => true,
+      },
+      fields: [
+        {
+          name: 'roles',
+          type: 'join',
+          collection: 'virtual-linked-roles',
+          on: 'project',
+        },
+      ],
+    },
   ],
   globals: [
     {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3648,6 +3648,31 @@ describe('database', () => {
       })
       expect(res.postCategoriesTitles).toEqual(['category 1', 'category 2'])
     })
+
+    it('should not error when using a virtual linked field in access control of a join target collection', async () => {
+      const tenant = await payload.create({
+        collection: 'virtual-linked-tenants',
+        data: { slug: 'my-tenant' },
+      })
+
+      const project = await payload.create({
+        collection: 'virtual-linked-projects',
+        data: {},
+      })
+
+      await payload.create({
+        collection: 'virtual-linked-roles',
+        data: { project: project.id, tenant: tenant.id },
+      })
+
+      const result = await payload.find({
+        collection: 'virtual-linked-projects',
+        overrideAccess: false,
+      })
+
+      expect(result.docs).toHaveLength(1)
+      expect(result.docs[0]?.id).toBe(project.id)
+    })
   })
 
   it('should convert numbers to text', async () => {

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -90,13 +90,20 @@ export interface Config {
     'blocks-docs': BlocksDoc;
     'unique-fields': UniqueField;
     'select-has-many': SelectHasMany;
+    'virtual-linked-tenants': VirtualLinkedTenant;
+    'virtual-linked-roles': VirtualLinkedRole;
+    'virtual-linked-projects': VirtualLinkedProject;
     'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
-  collectionsJoins: {};
+  collectionsJoins: {
+    'virtual-linked-projects': {
+      roles: 'virtual-linked-roles';
+    };
+  };
   collectionsSelect: {
     noTimeStamps: NoTimeStampsSelect<false> | NoTimeStampsSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
@@ -121,6 +128,9 @@ export interface Config {
     'blocks-docs': BlocksDocsSelect<false> | BlocksDocsSelect<true>;
     'unique-fields': UniqueFieldsSelect<false> | UniqueFieldsSelect<true>;
     'select-has-many': SelectHasManySelect<false> | SelectHasManySelect<true>;
+    'virtual-linked-tenants': VirtualLinkedTenantsSelect<false> | VirtualLinkedTenantsSelect<true>;
+    'virtual-linked-roles': VirtualLinkedRolesSelect<false> | VirtualLinkedRolesSelect<true>;
+    'virtual-linked-projects': VirtualLinkedProjectsSelect<false> | VirtualLinkedProjectsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -711,6 +721,42 @@ export interface SelectHasMany {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-linked-tenants".
+ */
+export interface VirtualLinkedTenant {
+  id: string;
+  slug: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-linked-roles".
+ */
+export interface VirtualLinkedRole {
+  id: string;
+  project: string | VirtualLinkedProject;
+  tenant: string | VirtualLinkedTenant;
+  tenantSlug?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-linked-projects".
+ */
+export interface VirtualLinkedProject {
+  id: string;
+  roles?: {
+    docs?: (string | VirtualLinkedRole)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -849,6 +895,18 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'select-has-many';
         value: string | SelectHasMany;
+      } | null)
+    | ({
+        relationTo: 'virtual-linked-tenants';
+        value: string | VirtualLinkedTenant;
+      } | null)
+    | ({
+        relationTo: 'virtual-linked-roles';
+        value: string | VirtualLinkedRole;
+      } | null)
+    | ({
+        relationTo: 'virtual-linked-projects';
+        value: string | VirtualLinkedProject;
       } | null)
     | ({
         relationTo: 'users';
@@ -1357,6 +1415,35 @@ export interface UniqueFieldsSelect<T extends boolean = true> {
 export interface SelectHasManySelect<T extends boolean = true> {
   roles?: T;
   food?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-linked-tenants_select".
+ */
+export interface VirtualLinkedTenantsSelect<T extends boolean = true> {
+  slug?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-linked-roles_select".
+ */
+export interface VirtualLinkedRolesSelect<T extends boolean = true> {
+  project?: T;
+  tenant?: T;
+  tenantSlug?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "virtual-linked-projects_select".
+ */
+export interface VirtualLinkedProjectsSelect<T extends boolean = true> {
+  roles?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
This PR properly runs `sanitizeWhereQuery` for joined collections which is important specifically for virtual relationship fields path transformation.

Fixes https://github.com/payloadcms/payload/issues/15332