### PR TITLE
fix(ui): split only on first colon in toast error messages

### DIFF
--- a/packages/ui/src/elements/Toasts/fieldErrors.spec.ts
+++ b/packages/ui/src/elements/Toasts/fieldErrors.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { createErrorsFromMessage } from './fieldErrors.js'
+
+describe('createErrorsFromMessage', () => {
+  it('should return the full message when there is no colon', () => {
+    const result = createErrorsFromMessage('Something went wrong')
+
+    expect(result).toEqual({ message: 'Something went wrong' })
+  })
+
+  it('should split a single field error after the colon', () => {
+    const result = createErrorsFromMessage('Validation failed: email')
+
+    expect(result).toEqual({ errors: ['email'], message: 'Validation failed: ' })
+  })
+
+  it('should split multiple comma-separated field errors after the colon', () => {
+    const result = createErrorsFromMessage('The following fields are invalid: email, name')
+
+    expect(result).toEqual({
+      errors: ['email', 'name'],
+      message: 'The following fields are invalid (2):',
+    })
+  })
+
+  it('should preserve the full message when it contains multiple colons', () => {
+    const result = createErrorsFromMessage('With: multiple: colons')
+
+    expect(result).toEqual({ errors: ['multiple: colons'], message: 'With: ' })
+  })
+
+  it('should replace " > " with " → " in error paths', () => {
+    const result = createErrorsFromMessage('Invalid: parent > child')
+
+    expect(result).toEqual({ errors: ['parent → child'], message: 'Invalid: ' })
+  })
+
+  it('should group similar errors and count them', () => {
+    const result = createErrorsFromMessage('Invalid: blocks > 0, blocks > 1, other')
+
+    expect(result).toEqual({
+      errors: ['blocks → 0', 'blocks → 1', 'other'],
+      message: 'Invalid (3):',
+    })
+  })
+})

--- a/packages/ui/src/elements/Toasts/fieldErrors.tsx
+++ b/packages/ui/src/elements/Toasts/fieldErrors.tsx
@@ -33,7 +33,9 @@ export function createErrorsFromMessage(message: string): {
   errors?: string[]
   message: string
 } {
-  const [intro, errorsString] = message.split(':')
+  const colonIndex = message.indexOf(':')
+  const intro = colonIndex >= 0 ? message.slice(0, colonIndex) : message
+  const errorsString = colonIndex >= 0 ? message.slice(colonIndex + 1) : undefined
 
   if (!errorsString) {
     return {

--- a/packages/ui/src/elements/Toasts/fieldErrors.tsx
+++ b/packages/ui/src/elements/Toasts/fieldErrors.tsx
@@ -29,7 +29,7 @@ function groupSimilarErrors(items: string[]): string[] {
   return result
 }
 
-function createErrorsFromMessage(message: string): {
+export function createErrorsFromMessage(message: string): {
   errors?: string[]
   message: string
 } {


### PR DESCRIPTION
## Summary

Toast notifications truncate error messages that contain multiple colons. For example, `throw new APIError('With: multiple: colons', 400, undefined, true)` only displays "With: multiple" in the toast — everything after the second colon is dropped.

## Changes

`createErrorsFromMessage` in `packages/ui/src/elements/Toasts/fieldErrors.tsx` used `message.split(':')` and destructured only the first two elements, discarding anything after the second colon. Replaced with `indexOf`/`slice` to split only on the first colon, so the full message is preserved.

## Testing

```bash
pnpm vitest run packages/ui/src/elements/Toasts/fieldErrors.spec.ts
```

Without the fix, the test "should preserve the full message when it contains multiple colons" fails with:

```
- Expected: { errors: ['multiple: colons'], message: 'With: ' }
+ Received: { errors: ['multiple'], message: 'With: ' }
```