### PR TITLE
fix(plugin-ecommerce): render 0 prices in PriceCell

### DIFF
--- a/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
+++ b/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
@@ -20,23 +20,17 @@ export const PriceCell: React.FC<Props> = (args) => {
   const { cellData, currenciesConfig, currency: currencyFromProps, rowData } = args
 
   const currency = currencyFromProps || currenciesConfig.supportedCurrencies[0]
+  const hasValidCellData = typeof cellData === 'number' && !Number.isNaN(cellData)
 
   if (!currency) {
-    // @ts-expect-error - plugin translations are not typed yet
     return <span>{t('plugin-ecommerce:currencyNotSet')}</span>
   }
 
-  if (
-    (!cellData || typeof cellData !== 'number') &&
-    'enableVariants' in rowData &&
-    rowData.enableVariants
-  ) {
-    // @ts-expect-error - plugin translations are not typed yet
+  if (!hasValidCellData && 'enableVariants' in rowData && rowData.enableVariants) {
     return <span>{t('plugin-ecommerce:priceSetInVariants')}</span>
   }
 
-  if (!cellData) {
-    // @ts-expect-error - plugin translations are not typed yet
+  if (!hasValidCellData) {
     return <span>{t('plugin-ecommerce:priceNotSet')}</span>
   }
 


### PR DESCRIPTION
### what?
- Fix PriceCell treating 0 as “price not set”.

### Why?
- 0 is a valid price/balance and should display formatted output.

### How?
- Replace falsy checks with a valid-number check (typeof === 'number' and not NaN).
- Before/After: Before 0 showed “price not set”; after 0 formats as €0.00 (currency-dependent).

###Related: 

Fixes #15861