### PR TITLE
fix(drizzle): support filtering polymorphic hasMany relationship fields

### DIFF
--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -747,8 +747,12 @@ export const getTableColumnFromPath = ({
               },
               table: aliasRelationshipTable,
             }
-          } else if (isPolymorphicRelationship(value)) {
-            const { relationTo } = value
+          } else if (
+            isPolymorphicRelationship(value) ||
+            (Array.isArray(value) && value.length === 1 && isPolymorphicRelationship(value[0]))
+          ) {
+            const polymorphicVal = Array.isArray(value) ? value[0] : value
+            const { relationTo } = polymorphicVal
 
             const relationTableName = adapter.tableNameMap.get(
               toSnakeCase(adapter.payload.collections[relationTo].config.slug),
@@ -758,6 +762,16 @@ export const getTableColumnFromPath = ({
               constraints,
               field,
               rawColumn: sql.raw(`"${aliasRelationshipTableName}"."${relationTableName}_id"`),
+              table: aliasRelationshipTable,
+            }
+          } else if (
+            newCollectionPath === '' &&
+            (value === true || value === false || value === 'true' || value === 'false')
+          ) {
+            return {
+              columnName: 'parent',
+              constraints,
+              field,
               table: aliasRelationshipTable,
             }
           } else if (value === DistinctSymbol) {

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -140,6 +140,9 @@ export const sanitizeQueryValue = ({
   }
 
   if (field.type === 'relationship' || field.type === 'upload') {
+    const polymorphicVal =
+      Array.isArray(val) && val.length === 1 && isPolymorphicRelationship(val[0]) ? val[0] : val
+
     if (val === 'null') {
       formattedValue = null
     } else if (!(formattedValue === null || typeof formattedValue === 'boolean')) {
@@ -151,7 +154,7 @@ export const sanitizeQueryValue = ({
           collection: adapter.payload.collections[field.relationTo],
         })
       } else {
-        if (isPolymorphicRelationship(val)) {
+        if (isPolymorphicRelationship(polymorphicVal)) {
           if (operator !== 'equals') {
             throw new APIError(
               `Only 'equals' operator is supported for polymorphic relationship object notation. Given - ${operator}`,
@@ -159,18 +162,19 @@ export const sanitizeQueryValue = ({
           }
           idType = getCollectionIdType({
             adapter,
-            collection: adapter.payload.collections[val.relationTo],
+            collection: adapter.payload.collections[polymorphicVal.relationTo],
           })
 
-          if (isRawConstraint(val.value)) {
+          if (isRawConstraint(polymorphicVal.value)) {
             return {
               operator,
-              value: val.value.value,
+              value: polymorphicVal.value.value,
             }
           }
           return {
             operator,
-            value: idType === 'number' ? Number(val.value) : String(val.value),
+            value:
+              idType === 'number' ? Number(polymorphicVal.value) : String(polymorphicVal.value),
           }
         }
 


### PR DESCRIPTION
### what?

- Support filtering polymorphic hasMany relationship fields in REST and the admin list view.

### Why?

- Filtering on polymorphic hasMany fields (e.g. where[authors][exists]=true or polymorphic equals) caused APIError: Not supported because the path resolution logic didn’t handle these cases.

### How?
- In getTableColumnFromPath.ts: handle the exists filter by returning the relationship table’s parent column, and support polymorphic equals when the value is an array (e.g. from the admin UI).
- In sanitizeQueryValue.ts: normalize polymorphic values when they come as a single-element array so the equals logic works correctly.

Fixes #15909