### PR TITLE
fix(ui): use consistent empty state styling in relationship table

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from '../../providers/Translation/index.js'
 import { AnimateHeight } from '../AnimateHeight/index.js'
 import { ColumnSelector } from '../ColumnSelector/index.js'
 import { useDocumentDrawer } from '../DocumentDrawer/index.js'
+import { NoListResults } from '../NoListResults/index.js'
 import { RelationshipProvider } from '../Table/RelationshipProvider/index.js'
 import { AddNewButton } from './AddNewButton.js'
 import { DrawerLink } from './cells/DrawerLink/index.js'
@@ -332,29 +333,41 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
       ) : (
         <Fragment>
           {data?.docs && data.docs.length === 0 && (
-            <div className={`${baseClass}__no-results`}>
-              <p>
-                {i18n.t('general:noResults', {
-                  label: isPolymorphic
-                    ? i18n.t('general:documents')
-                    : getTranslation(collectionConfig?.labels?.plural, i18n),
-                })}
-              </p>
-              <AddNewButton
-                allowCreate={canCreate}
-                baseClass={baseClass}
-                collections={config.collections}
-                i18n={i18n}
-                label={i18n.t('general:createNewLabel', {
-                  label: isPolymorphic
-                    ? i18n.t('general:document')
-                    : getTranslation(collectionConfig?.labels?.singular, i18n),
-                })}
-                onClick={isPolymorphic ? setSelectedCollection : openDrawer}
-                permissions={permissions}
-                relationTo={relationTo}
-              />
-            </div>
+            <NoListResults
+              Actions={
+                canCreate
+                  ? [
+                      <AddNewButton
+                        allowCreate={canCreate}
+                        baseClass={baseClass}
+                        collections={config.collections}
+                        i18n={i18n}
+                        key="create"
+                        label={i18n.t('general:createNewLabel', {
+                          label: isPolymorphic
+                            ? i18n.t('general:document')
+                            : getTranslation(collectionConfig?.labels?.singular, i18n),
+                        })}
+                        onClick={isPolymorphic ? setSelectedCollection : openDrawer}
+                        permissions={permissions}
+                        relationTo={relationTo}
+                      />,
+                    ]
+                  : []
+              }
+              Message={
+                <>
+                  <h3>{i18n.t('general:noResultsFound')}</h3>
+                  <p>
+                    {i18n.t('general:noResults', {
+                      label: isPolymorphic
+                        ? i18n.t('general:documents')
+                        : getTranslation(collectionConfig?.labels?.plural, i18n),
+                    })}
+                  </p>
+                </>
+              }
+            />
           )}
           {data?.docs && data.docs.length > 0 && (
             <RelationshipProvider>

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -201,6 +201,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: 'en' | 'es';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -1453,6 +1456,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
# Overview

Applies the same empty state styling fix from #15555 to the `RelationshipTable` component.

## Key Changes

- Replaced inline empty state div with shared `NoListResults` component
  - `RelationshipTable` was using its own inline implementation with different styling
  - Now uses the same centered, dashed-border design as List, Folder, and Browse-by-Folder views

- Restructured empty state to use `Message` and `Actions` props
  - Message includes heading ("No Results.") and description
  - Actions conditionally includes the AddNewButton when user has create permission

## Design Decisions

Follows the exact pattern from #15555 where all list views were standardized to use the `NoListResults` component. `RelationshipTable` was missed in that PR and had the same inconsistent left-aligned, no-border styling.

The shared component ensures visual consistency across all empty states in the admin UI.

### Before
<img width="1329" height="142" alt="Screenshot 2026-03-11 at 1 53 19 PM" src="https://github.com/user-attachments/assets/f85284a0-8abf-49f7-b6bf-6058e514ad1a" />

### After
<img width="1313" height="188" alt="Screenshot 2026-03-11 at 2 23 02 PM" src="https://github.com/user-attachments/assets/aa84c3b7-ae01-44ae-a767-b2c14a87fe71" />
