### PR TITLE
fix(graphql): force nullable for relationships to avoid errors when the related document is related

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -654,7 +654,8 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       type: withNullableType({
         type: hasManyValues ? new GraphQLList(new GraphQLNonNull(type)) : type,
         field,
-        forceNullable,
+        // can be null if the related doc is deleted even if the field is required, unless hasMany
+        forceNullable: !field.hasMany,
         parentIsLocalized,
       }) as GraphQLOutputType,
       args: relationshipArgs,
@@ -1072,7 +1073,8 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       type: withNullableType({
         type: hasManyValues ? new GraphQLList(new GraphQLNonNull(type)) : type,
         field,
-        forceNullable,
+        // can be null if the related doc is deleted even if the field is required, unless hasMany
+        forceNullable: !field.hasMany,
         parentIsLocalized,
       }) as GraphQLOutputType,
       args: relationshipArgs,

--- a/test/graphql/config.ts
+++ b/test/graphql/config.ts
@@ -40,6 +40,31 @@ export default buildConfigWithDefaults({
       ],
     },
   ],
+  globals: [
+    {
+      slug: 'home',
+      versions: { drafts: true },
+      fields: [
+        {
+          name: 'topPosts',
+          type: 'array',
+          required: true,
+          fields: [
+            {
+              name: 'post',
+              type: 'relationship',
+              relationTo: 'posts',
+              required: true,
+            },
+            {
+              name: 'caption',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    },
+  ],
   admin: {
     importMap: {
       baseDir: path.resolve(dirname),

--- a/test/graphql/int.spec.ts
+++ b/test/graphql/int.spec.ts
@@ -217,5 +217,56 @@ query {
         id: createdPost.id,
       })
     })
+
+    it('should not error when querying a global with a deleted relationship in an array', async () => {
+      const post1 = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'Post 1',
+        },
+      })
+
+      await payload.updateGlobal({
+        slug: 'home',
+        data: {
+          topPosts: [
+            {
+              post: post1.id,
+              caption: 'The best post out there',
+            },
+          ],
+        },
+      })
+
+      const query = `query {
+        Home {
+          topPosts {
+            post {
+              title
+            }
+          }
+        }
+      }`
+
+      const beforeDelete = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        .then((res) => res.json())
+
+      expect(beforeDelete.errors).toBeUndefined()
+      expect(beforeDelete.data.Home.topPosts).toEqual([
+        expect.objectContaining({ post: { title: 'Post 1' } }),
+      ])
+
+      await payload.delete({
+        collection: 'posts',
+        id: post1.id,
+      })
+
+      const afterDelete = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        .then((res) => res.json())
+
+      expect(afterDelete.errors).toBeUndefined()
+    })
   })
 })

--- a/test/graphql/payload-types.ts
+++ b/test/graphql/payload-types.ts
@@ -87,9 +87,16 @@ export interface Config {
     defaultIDType: string;
   };
   fallbackLocale: null;
-  globals: {};
-  globalsSelect: {};
+  globals: {
+    home: Home;
+  };
+  globalsSelect: {
+    home: HomeSelect<false> | HomeSelect<true>;
+  };
   locale: null;
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -123,6 +130,14 @@ export interface Post {
   title?: string | null;
   'hyphenated-name'?: string | null;
   relationToSelf?: (string | null) | Post;
+  contentBlockField?:
+    | {
+        text?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'content';
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -233,6 +248,17 @@ export interface PostsSelect<T extends boolean = true> {
   title?: T;
   'hyphenated-name'?: T;
   relationToSelf?: T;
+  contentBlockField?:
+    | T
+    | {
+        content?:
+          | T
+          | {
+              text?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
   updatedAt?: T;
   createdAt?: T;
 }
@@ -297,6 +323,48 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "home".
+ */
+export interface Home {
+  id: string;
+  topPosts: {
+    post: string | Post;
+    caption?: string | null;
+    id?: string | null;
+  }[];
+  _status?: ('draft' | 'published') | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "home_select".
+ */
+export interface HomeSelect<T extends boolean = true> {
+  topPosts?:
+    | T
+    | {
+        post?: T;
+        caption?: T;
+        id?: T;
+      };
+  _status?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9788

In a situation when you have a relationship field and the related document is deleted, in Postgres the value of this field (if the related document can be deleted) will be set to `NULL`, even if the field is required.

This causes issues in GraphQL because of its schema strictness it just throws an error when it sees `null`. The PR forces `nullable` for relationship/upload fields (excluding the ones with `hasMany: true` since they'd have an empty array instead)