### PR TITLE
fix: improved request origin retrieval

### DIFF
--- a/packages/graphql/src/resolvers/auth/forgotPassword.ts
+++ b/packages/graphql/src/resolvers/auth/forgotPassword.ts
@@ -12,8 +12,6 @@ export function forgotPassword(collection: Collection): any {
         email: args.email,
         username: args.username,
       },
-      disableEmail: args.disableEmail,
-      expiration: args.expiration,
       req: isolateObjectProperty(context.req, 'transactionID'),
     }
 

--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -550,8 +550,6 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
           graphqlResult.Mutation.fields[`forgotPassword${singularName}`] = {
             type: new GraphQLNonNull(GraphQLBoolean),
             args: {
-              disableEmail: { type: GraphQLBoolean },
-              expiration: { type: GraphQLInt },
               ...authArgs,
             },
             resolve: forgotPassword(collection),

--- a/packages/payload/src/auth/endpoints/forgotPassword.ts
+++ b/packages/payload/src/auth/endpoints/forgotPassword.ts
@@ -23,8 +23,6 @@ export const forgotPasswordHandler: PayloadHandler = async (req) => {
   await forgotPasswordOperation({
     collection,
     data: authData,
-    disableEmail: Boolean(req.data?.disableEmail),
-    expiration: typeof req.data?.expiration === 'number' ? req.data.expiration : undefined,
     req,
   })
 

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto'
 import { status as httpStatus } from 'http-status'
-import { URL } from 'url'
 
 import type {
   AuthOperationsFromCollectionSlug,
@@ -16,6 +15,7 @@ import { Forbidden } from '../../index.js'
 import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { formatAdminURL } from '../../utilities/formatAdminURL.js'
+import { getRequestOrigin } from '../../utilities/getRequestOrigin.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { getLoginOptions } from '../getLoginOptions.js'
@@ -155,11 +155,7 @@ export const forgotPasswordOperation = async <TSlug extends AuthCollectionSlug>(
     })
 
     if (!disableEmail && user.email) {
-      const protocol = new URL(req.url!).protocol // includes the final :
-      const serverURL =
-        config.serverURL !== null && config.serverURL !== ''
-          ? config.serverURL
-          : `${protocol}//${req.headers.get('host')}`
+      const serverURL = getRequestOrigin({ config, req })
       const forgotURL = formatAdminURL({
         adminRoute: config.routes.admin,
         path: `${config.admin.routes.reset}/${token}`,

--- a/packages/payload/src/auth/sendVerificationEmail.ts
+++ b/packages/payload/src/auth/sendVerificationEmail.ts
@@ -1,5 +1,3 @@
-import { URL } from 'url'
-
 import type { Collection } from '../collections/config/types.js'
 import type { SanitizedConfig } from '../config/types.js'
 import type { InitializedEmailAdapter } from '../email/types.js'
@@ -8,6 +6,7 @@ import type { PayloadRequest } from '../types/index.js'
 import type { VerifyConfig } from './types.js'
 
 import { formatAdminURL } from '../utilities/formatAdminURL.js'
+import { getRequestOrigin } from '../utilities/getRequestOrigin.js'
 
 type Args = {
   collection: Collection
@@ -32,11 +31,7 @@ export async function sendVerificationEmail(args: Args): Promise<void> {
   } = args
 
   if (!disableEmail) {
-    const protocol = new URL(req.url!).protocol // includes the final :
-    const serverURL =
-      config.serverURL !== null && config.serverURL !== ''
-        ? config.serverURL
-        : `${protocol}//${req.headers.get('host')}`
+    const serverURL = getRequestOrigin({ config, req })
 
     const verificationURL = formatAdminURL({
       adminRoute: config.routes.admin,

--- a/packages/payload/src/utilities/getRequestOrigin.spec.ts
+++ b/packages/payload/src/utilities/getRequestOrigin.spec.ts
@@ -1,0 +1,115 @@
+import type { PayloadRequest } from '../types/index.js'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { getRequestOrigin } from './getRequestOrigin'
+
+type MinimalReq = Pick<PayloadRequest, 'headers' | 'payload' | 'url'>
+
+const makeReq = (url: string, hostOverride?: string): MinimalReq => {
+  let host = hostOverride
+  if (host === undefined) {
+    try {
+      host = new URL(url).host
+    } catch {
+      host = undefined
+    }
+  }
+  return {
+    url,
+    headers: new Headers(host !== undefined ? { host } : {}),
+    payload: {},
+  } as unknown as MinimalReq
+}
+
+describe('getRequestOrigin', () => {
+  describe('when config.serverURL is set', () => {
+    it('should return serverURL regardless of Host header', () => {
+      const req = makeReq('https://ignored.com/api/forgot-password', 'attacker.com')
+      const result = getRequestOrigin({
+        config: { serverURL: 'https://myapp.com', cors: '*', csrf: [] },
+        req,
+      })
+      expect(result).toBe('https://myapp.com')
+    })
+  })
+
+  describe('when config.serverURL is not set', () => {
+    describe('CORS allowlist validation', () => {
+      it('should return origin when Host header matches a CORS string array entry', () => {
+        const req = makeReq('https://myapp.com/api/forgot-password')
+        const result = getRequestOrigin({
+          config: { serverURL: '', cors: ['https://myapp.com', 'https://other.com'], csrf: [] },
+          req,
+        })
+        expect(result).toBe('https://myapp.com')
+      })
+
+      it('should return origin when Host header matches a CORSConfig origins entry', () => {
+        const req = makeReq('https://myapp.com/api/verify')
+        const result = getRequestOrigin({
+          config: {
+            serverURL: '',
+            cors: { headers: [], origins: ['https://myapp.com'] },
+            csrf: [],
+          },
+          req,
+        })
+        expect(result).toBe('https://myapp.com')
+      })
+
+      it('should not return a trusted origin when Host header is forged and not in CORS allowlist', () => {
+        const req = makeReq('https://myapp.com/api/forgot-password', 'attacker.com')
+        const result = getRequestOrigin({
+          config: { serverURL: '', cors: ['https://myapp.com'], csrf: [] },
+          req,
+        })
+        expect(result).not.toBe('https://myapp.com')
+      })
+    })
+
+    describe('CSRF allowlist validation', () => {
+      it('should return origin when Host header matches a CSRF entry', () => {
+        const req = makeReq('https://myapp.com/api/verify')
+        const result = getRequestOrigin({
+          config: { serverURL: '', cors: [], csrf: ['https://myapp.com'] },
+          req,
+        })
+        expect(result).toBe('https://myapp.com')
+      })
+
+      it('should return origin when Host header is in CSRF but not in CORS', () => {
+        const req = makeReq('https://myapp.com/api/verify')
+        const result = getRequestOrigin({
+          config: {
+            serverURL: '',
+            cors: ['https://other.com'],
+            csrf: ['https://myapp.com'],
+          },
+          req,
+        })
+        expect(result).toBe('https://myapp.com')
+      })
+    })
+
+    describe('malformed or missing Host header', () => {
+      it('should return empty string when req.url is not a valid URL', () => {
+        const req = makeReq('not-a-url')
+        const result = getRequestOrigin({
+          config: { serverURL: '', cors: [], csrf: [] },
+          req,
+        })
+        expect(result).toBe('')
+      })
+
+      it('should return empty string when Host header is absent', () => {
+        const req = makeReq('https://myapp.com/api/forgot-password', '')
+        const result = getRequestOrigin({
+          config: { serverURL: '', cors: ['https://myapp.com'], csrf: [] },
+          req,
+        })
+        expect(result).toBe('')
+      })
+    })
+  })
+})

--- a/packages/payload/src/utilities/getRequestOrigin.spec.ts
+++ b/packages/payload/src/utilities/getRequestOrigin.spec.ts
@@ -1,6 +1,6 @@
 import type { PayloadRequest } from '../types/index.js'
 
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { getRequestOrigin } from './getRequestOrigin'
 

--- a/packages/payload/src/utilities/getRequestOrigin.spec.ts
+++ b/packages/payload/src/utilities/getRequestOrigin.spec.ts
@@ -58,13 +58,13 @@ describe('getRequestOrigin', () => {
         expect(result).toBe('https://myapp.com')
       })
 
-      it('should not return a trusted origin when Host header is forged and not in CORS allowlist', () => {
+      it('should return empty string when Host header is forged and not in CORS allowlist', () => {
         const req = makeReq('https://myapp.com/api/forgot-password', 'attacker.com')
         const result = getRequestOrigin({
           config: { serverURL: '', cors: ['https://myapp.com'], csrf: [] },
           req,
         })
-        expect(result).not.toBe('https://myapp.com')
+        expect(result).toBe('')
       })
     })
 

--- a/packages/payload/src/utilities/getRequestOrigin.spec.ts
+++ b/packages/payload/src/utilities/getRequestOrigin.spec.ts
@@ -18,7 +18,11 @@ const makeReq = (url: string, hostOverride?: string): MinimalReq => {
   return {
     url,
     headers: new Headers(host !== undefined ? { host } : {}),
-    payload: {},
+    payload: {
+      logger: {
+        warn: () => {},
+      },
+    },
   } as unknown as MinimalReq
 }
 

--- a/packages/payload/src/utilities/getRequestOrigin.ts
+++ b/packages/payload/src/utilities/getRequestOrigin.ts
@@ -61,5 +61,5 @@ export const getRequestOrigin = ({
     return origin
   }
 
-  return origin
+  return ''
 }

--- a/packages/payload/src/utilities/getRequestOrigin.ts
+++ b/packages/payload/src/utilities/getRequestOrigin.ts
@@ -1,0 +1,65 @@
+import type { CORSConfig, SanitizedConfig } from '../config/types.js'
+import type { PayloadRequest } from '../types/index.js'
+
+const getTrustedOrigins = (config: Pick<SanitizedConfig, 'cors' | 'csrf'>): null | string[] => {
+  const origins = new Set<string>()
+
+  const { cors, csrf } = config
+
+  if (cors === '*') {
+    return null
+  }
+
+  if (Array.isArray(cors)) {
+    cors.forEach((o) => origins.add(o))
+  } else if (cors && typeof cors === 'object') {
+    const corsOrigins = (cors as CORSConfig).origins
+    if (corsOrigins === '*') {
+      return null
+    }
+    if (Array.isArray(corsOrigins)) {
+      corsOrigins.forEach((o) => origins.add(o))
+    }
+  }
+
+  if (Array.isArray(csrf)) {
+    csrf.forEach((o) => origins.add(o))
+  }
+
+  return [...origins]
+}
+
+/**
+ * Returns a trusted request origin
+ */
+export const getRequestOrigin = ({
+  config,
+  req,
+}: {
+  config: Pick<SanitizedConfig, 'cors' | 'csrf' | 'serverURL'>
+  req: Pick<PayloadRequest, 'headers' | 'payload' | 'url'>
+}): string => {
+  if (config.serverURL !== null && config.serverURL !== '') {
+    return config.serverURL
+  }
+
+  let origin = ''
+  try {
+    const protocol = new URL(req.url!).protocol
+    const host = req.headers?.get('host')
+    if (host) {
+      origin = `${protocol}//${host}`
+    }
+  } catch {
+    // req.url is malformed; origin stays empty
+  }
+
+  const trustedOrigins = getTrustedOrigins(config)
+
+  if (trustedOrigins !== null && origin && trustedOrigins.includes(origin)) {
+    // Host header value is explicitly listed in the CORS/CSRF allowlist — safe to use.
+    return origin
+  }
+
+  return origin
+}

--- a/packages/payload/src/utilities/getRequestOrigin.ts
+++ b/packages/payload/src/utilities/getRequestOrigin.ts
@@ -61,5 +61,9 @@ export const getRequestOrigin = ({
     return origin
   }
 
+  req.payload.logger.warn(
+    `Request origin "${origin}" is not in the CORS/CSRF allowlist. Falling back to empty string as request origin. It is recommended to explicitly set the serverURL in the config to avoid this warning and ensure correct request origin is used.`,
+  )
+
   return ''
 }

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -86,7 +86,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   fallbackLocale: null;
   globals: {
@@ -128,7 +128,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: number;
+  id: string;
   title?: string | null;
   content?: {
     root: {
@@ -153,7 +153,7 @@ export interface Post {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -197,7 +197,7 @@ export interface Media {
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
-  id: number;
+  id: string;
   key: string;
   data:
     | {
@@ -214,7 +214,7 @@ export interface PayloadKv {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -239,24 +239,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'posts';
-        value: number | Post;
+        value: string | Post;
       } | null)
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -266,10 +266,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -289,7 +289,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -423,7 +423,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: number;
+  id: string;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -86,7 +86,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   fallbackLocale: null;
   globals: {
@@ -96,6 +96,9 @@ export interface Config {
     menu: MenuSelect<false> | MenuSelect<true>;
   };
   locale: null;
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -125,7 +128,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   title?: string | null;
   content?: {
     root: {
@@ -150,7 +153,7 @@ export interface Post {
  * via the `definition` "media".
  */
 export interface Media {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -194,7 +197,7 @@ export interface Media {
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
-  id: string;
+  id: number;
   key: string;
   data:
     | {
@@ -211,7 +214,7 @@ export interface PayloadKv {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -236,24 +239,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'media';
-        value: string | Media;
+        value: number | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -263,10 +266,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -286,7 +289,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -420,7 +423,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: string;
+  id: number;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -434,6 +437,16 @@ export interface MenuSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Adds a new function `getRequestOrigin` that properly retrieves the origin of the request, either from `serverURL` or a valid `host` header