### PR TITLE
fix: text field validation rejecting localized object values

### DIFF
--- a/packages/payload/src/fields/validations.spec.ts
+++ b/packages/payload/src/fields/validations.spec.ts
@@ -87,6 +87,19 @@ describe('Field Validations', () => {
       const result = text(val, { ...options, hasMany: true, required: true })
       expect(result).toBe(true)
     })
+    it('should accept localized object value when required', () => {
+      const val = { en: 'English text', es: 'Spanish text' }
+      const result = text(val as any, { ...options, required: true })
+      expect(result).toBe(true)
+    })
+    it('should reject null when required', () => {
+      const result = text(null as any, { ...options, required: true })
+      expect(result).toBe('validation:required')
+    })
+    it('should reject empty string when required', () => {
+      const result = text('', { ...options, required: true })
+      expect(result).toBe('validation:required')
+    })
   })
 
   describe('textarea', () => {

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -94,7 +94,7 @@ export const text: TextFieldValidation = (
   }
 
   if (required) {
-    if (!(typeof value === 'string' || Array.isArray(value)) || value?.length === 0) {
+    if (!value || ((typeof value === 'string' || Array.isArray(value)) && value.length === 0)) {
       return t('validation:required')
     }
   }

--- a/test/fields/collections/Text/index.ts
+++ b/test/fields/collections/Text/index.ts
@@ -53,6 +53,13 @@ const TextFields: CollectionConfig = {
       localized: true,
     },
     {
+      name: 'localizedRequiredText',
+      type: 'text',
+      localized: true,
+      required: true,
+      defaultValue: 'default',
+    },
+    {
       name: 'i18nText',
       type: 'text',
       admin: {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -136,6 +136,34 @@ describe('Fields', () => {
       expect(localizedDoc.localizedHasMany.en).toEqual(localizedHasMany)
     })
 
+    it('should validate localized required text field with locale all', async () => {
+      const doc = await payload.create({
+        collection: 'text-fields',
+        data: {
+          text: 'required',
+          // @ts-expect-error locale 'all' accepts object values for localized fields
+          localizedRequiredText: {
+            en: 'English text',
+            es: 'Spanish text',
+          },
+        },
+        locale: 'all',
+      })
+
+      const allLocales = await payload.findByID({
+        id: doc.id,
+        collection: 'text-fields',
+        locale: 'all',
+      })
+
+      // @ts-expect-error
+      expect(allLocales.localizedRequiredText.en).toEqual('English text')
+      // @ts-expect-error
+      expect(allLocales.localizedRequiredText.es).toEqual('Spanish text')
+
+      await payload.delete({ collection: 'text-fields', id: doc.id })
+    })
+
     it('should query hasMany in', async () => {
       const hit = await payload.create({
         collection: 'text-fields',


### PR DESCRIPTION
## Summary

Fixes #15828

When using `locale: 'all'` with a required localized text field, the `text` validator incorrectly rejects the value. This happens because:

1. With `locale: 'all'`, the value passed to the validator is an object like `{en: "Hello", es: "World"}` (locale unflattening via `mergeLocaleActions` happens *after* validation in `promise.ts`)
2. The old condition `!(typeof value === 'string' || Array.isArray(value))` evaluates to `true` for objects, triggering the required error
3. The `textarea` validator already handles this correctly by using `!value` (objects are truthy)

### Fix

Changed the text validator's required check from:
```ts
if (!(typeof value === 'string' || Array.isArray(value)) || value?.length === 0)
```
to:
```ts
if (!value || ((typeof value === 'string' || Array.isArray(value)) && value.length === 0))
```

This aligns with the textarea validator's approach:
- `!value` catches `null`, `undefined`, and empty string `""`
- The second clause catches empty arrays `[]` (truthy but length 0)
- Localized objects like `{en: "Hello"}` pass because `!obj` is `false`

### Changes

- **`packages/payload/src/fields/validations.ts`** — 1-line fix to the required check condition
- **`packages/payload/src/fields/validations.spec.ts`** — 3 unit tests (localized object accepted, null rejected, empty string rejected)
- **`test/fields/collections/Text/index.ts`** — Added `localizedRequiredText` test field
- **`test/fields/int.spec.ts`** — Integration test verifying `locale: 'all'` with required localized text

## Test plan

- [x] Unit tests: 88/88 passed (85 existing + 3 new)
- [x] Integration tests (SQLite): 154/154 passed
- [ ] CI passes on all database adapters