### PR TITLE
fix(plugin-mcp): plugin can break next.js request handler because underlying Hono library modifies the global Request object

### DIFF
--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -63,9 +63,29 @@ export const initializeMCPHandler = (pluginOptions: PluginMCPServerConfig) => {
       ? await pluginOptions.overrideAuth(req, getDefaultMcpAccessSettings)
       : await getDefaultMcpAccessSettings()
 
+    // @modelcontextprotocol/sdk's StreamableHTTPServerTransport uses @hono/node-server's
+    // getRequestListener, which replaces global.Request and global.Response with Hono
+    // custom classes. Unfortunately, we cannot pass overrideGlobalObjects: false because the option is
+    // consumed inside the SDK transport and is not exposed to callers.
+    // Save originals here and restore after the handler resolves so that Next.js
+    // instanceof Response checks on subsequent route handlers keep working.
+    const globals = globalThis as Record<string, unknown>
+    const originalResponse = globals['Response']
+    const originalRequest = globals['Request']
+
     const handler = getMCPHandler(pluginOptions, mcpAccessSettings, req)
     const request = createRequestFromPayloadRequest(req)
-    return await handler(request)
+
+    try {
+      return await handler(request)
+    } finally {
+      if (globals['Response'] !== originalResponse) {
+        Object.defineProperty(globalThis, 'Response', { value: originalResponse })
+      }
+      if (globals['Request'] !== originalRequest) {
+        Object.defineProperty(globalThis, 'Request', { value: originalRequest })
+      }
+    }
   }
   return mcpHandler
 }

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -23,6 +23,13 @@ const dirname = path.dirname(filename)
 export const capturedMcpEvents: unknown[] = []
 
 export default buildConfigWithDefaults({
+  endpoints: [
+    {
+      handler: () => Response.json({ status: 'ok' }),
+      method: 'get',
+      path: '/health',
+    },
+  ],
   admin: {
     importMap: {
       baseDir: path.resolve(dirname),

--- a/test/plugin-mcp/e2e.spec.ts
+++ b/test/plugin-mcp/e2e.spec.ts
@@ -1,0 +1,118 @@
+import type { Page } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'crypto'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { ensureCompilationIsDone, initPageConsoleErrorCatch } from '../__helpers/e2e/helpers.js'
+import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
+import { devUser } from '../credentials.js'
+import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+test.describe('MCP Plugin', () => {
+  let page: Page
+  let serverURL: string
+  let apiKey: string
+
+  test.beforeAll(async ({ browser, request }, testInfo) => {
+    testInfo.setTimeout(TEST_TIMEOUT_LONG)
+
+    const { serverURL: serverFromInit } = await initPayloadE2ENoConfig({ dirname })
+    serverURL = serverFromInit
+
+    const context = await browser.newContext()
+    page = await context.newPage()
+    initPageConsoleErrorCatch(page)
+
+    await ensureCompilationIsDone({ page, serverURL })
+
+    // Login as dev user to get a JWT token for API key creation
+    const loginRes = await request.post(`${serverURL}/api/users/login`, {
+      data: { email: devUser.email, password: devUser.password },
+    })
+    expect(loginRes.ok()).toBeTruthy()
+    const loginData = await loginRes.json()
+    const token = loginData.token
+    const userId = loginData.user.id
+
+    // Create an API key with permissions to call tools/list
+    const createKeyRes = await request.post(`${serverURL}/api/payload-mcp-api-keys`, {
+      data: {
+        enableAPIKey: true,
+        label: 'E2E Test Key',
+        apiKey: randomUUID(),
+        user: userId,
+        posts: { create: true, find: true, update: true, delete: true },
+        products: { find: true },
+      },
+      headers: {
+        Authorization: `JWT ${token}`,
+      },
+    })
+    expect(createKeyRes.ok()).toBeTruthy()
+    const keyData = await createKeyRes.json()
+    apiKey = keyData.doc.apiKey
+  })
+
+  test('should not poison the Next.js runtime after MCP requests', async ({ request }) => {
+    // --- 1. Baseline: verify routes are healthy before any MCP calls ---
+
+    const healthBefore = await request.get(`${serverURL}/api/health`)
+    expect(healthBefore.status()).toBe(200)
+
+    const notFoundBefore = await request.get(`${serverURL}/api/nonexistent-mcp-test-route`)
+    expect(notFoundBefore.status()).toBe(404)
+
+    // --- 2. Send valid MCP requests ---
+    // These trigger @modelcontextprotocol/sdk's StreamableHTTPServerTransport which
+    // uses @hono/node-server's getRequestListener, replacing global.Request/Response.
+
+    const mcpHeaders = {
+      Accept: 'application/json, text/event-stream',
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    }
+
+    const initRes = await request.post(`${serverURL}/api/mcp`, {
+      data: {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: { name: 'e2e-test', version: '1.0.0' },
+          protocolVersion: '2024-11-05',
+        },
+      },
+      headers: mcpHeaders,
+    })
+    expect(initRes.ok()).toBeTruthy()
+
+    const toolsRes = await request.post(`${serverURL}/api/mcp`, {
+      data: {
+        id: 2,
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        params: {},
+      },
+      headers: mcpHeaders,
+    })
+    expect(toolsRes.ok()).toBeTruthy()
+
+    // --- 3. After MCP calls: routes must still respond correctly ---
+    // Regression check for: https://github.com/payloadcms/payload/issues/15856
+    // Without the fix, global.Response is permanently replaced by @hono/node-server,
+    // causing Next.js route handler validation to fail with:
+    // "Expected a Response object but received 'NextResponse'"
+
+    const healthAfter = await request.get(`${serverURL}/api/health`)
+    expect(healthAfter.status()).toBe(200)
+
+    const notFoundAfter = await request.get(`${serverURL}/api/nonexistent-mcp-test-route`)
+    expect(notFoundAfter.status()).toBe(404)
+  })
+})

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -111,6 +111,9 @@ export interface Config {
     'site-settings': SiteSettingsSelect<false> | SiteSettingsSelect<true>;
   };
   locale: 'en' | 'es' | 'fr';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User | PayloadMcpApiKey;
   jobs: {
     tasks: unknown;
@@ -225,6 +228,10 @@ export interface Post {
    * @maxItems 2
    */
   location?: [number, number] | null;
+  /**
+   * A virtual field that is computed and not stored in the database
+   */
+  computedTitle?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -745,6 +752,7 @@ export interface PostsSelect<T extends boolean = true> {
   content?: T;
   author?: T;
   location?: T;
+  computedTitle?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1016,6 +1024,16 @@ export interface SiteSettingsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/15856

Output from the added e2e test, before:
<img width="658" height="499" alt="image" src="https://github.com/user-attachments/assets/e1dd01e7-7341-4dec-a940-c35675324925" />
After:
<img width="657" height="457" alt="image" src="https://github.com/user-attachments/assets/575c00cf-bb06-43b4-a500-11de3c979ea9" />
