### PR TITLE
fix(templates): enforce access control in archive block query

### DIFF
--- a/templates/website/src/blocks/ArchiveBlock/Component.tsx
+++ b/templates/website/src/blocks/ArchiveBlock/Component.tsx
@@ -30,6 +30,7 @@ export const ArchiveBlock: React.FC<
       collection: 'posts',
       depth: 1,
       limit,
+      overrideAccess: false,
       ...(flattenedCategories && flattenedCategories.length > 0
         ? {
             where: {


### PR DESCRIPTION
### What?
Added `overrideAccess: false` to the `payload.find()` call in the ArchiveBlock component.

### Why?
The ArchiveBlock fetches posts without `overrideAccess: false`, which means it bypasses access control and returns draft/unpublished posts. This causes unpublished posts to appear in the archive block on the home page, and clicking them leads to a 404 error.

### How?
Added `overrideAccess: false` to the `payload.find()` call in `templates/website/src/blocks/ArchiveBlock/Component.tsx`.

Fixes #15633 