### PR TITLE
fix(storage-azure): fix azure storage mime type handling for streaming uploads

### DIFF
--- a/packages/storage-azure/src/handleUpload.ts
+++ b/packages/storage-azure/src/handleUpload.ts
@@ -35,6 +35,7 @@ export const getHandleUpload = ({ getStorageClient, prefix = '' }: Args): Handle
 
     await blockBlobClient.uploadStream(fileBufferOrStream, 4 * 1024 * 1024, 4, {
       abortSignal: AbortController.timeout(30 * 60 * 1000),
+      blobHTTPHeaders: { blobContentType: file.mimeType },
     })
 
     return data

--- a/test/storage-azure/streamingUploads.config.ts
+++ b/test/storage-azure/streamingUploads.config.ts
@@ -1,0 +1,58 @@
+import { azureStorage } from '@payloadcms/storage-azure'
+import dotenv from 'dotenv'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { devUser } from '../credentials.js'
+import { Media } from './collections/Media.js'
+import { MediaWithPrefix } from './collections/MediaWithPrefix.js'
+import { Users } from './collections/Users.js'
+import { mediaSlug, mediaWithPrefixSlug, prefix } from './shared.js'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+let uploadOptions
+
+// Load config to work with emulated services
+dotenv.config({
+  path: path.resolve(dirname, '../plugin-cloud-storage/.env.emulated'),
+})
+
+export default buildConfigWithDefaults({
+  admin: {
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+  },
+  collections: [Media, MediaWithPrefix, Users],
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
+  },
+  plugins: [
+    azureStorage({
+      collections: {
+        [mediaSlug]: true,
+        [mediaWithPrefixSlug]: {
+          prefix,
+        },
+      },
+      allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
+      baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL,
+      connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+      containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
+    }),
+  ],
+  upload: {
+    useTempFiles: true,
+  },
+  typescript: {
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  },
+})

--- a/test/storage-azure/streamingUploads.int.spec.ts
+++ b/test/storage-azure/streamingUploads.int.spec.ts
@@ -18,12 +18,17 @@ const dirname = path.dirname(filename)
 let restClient: NextRESTClient
 let payload: Payload
 
-describe('@payloadcms/storage-azure', () => {
+describe('@payloadcms/storage-azure streamingUploads', () => {
   let TEST_CONTAINER: string
   let client: ContainerClient
 
   beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+    ;({ payload, restClient } = await initPayloadInt(
+      dirname,
+      undefined,
+      undefined,
+      path.resolve(dirname, 'streamingUploads.config.ts'),
+    ))
     TEST_CONTAINER = process.env.AZURE_STORAGE_CONTAINER_NAME!
 
     const blobServiceClient = BlobServiceClient.fromConnectionString(
@@ -44,10 +49,10 @@ describe('@payloadcms/storage-azure', () => {
   })
 
   it('preserves mime type when uploaded via rest endpoint', async () => {
-    const fileBuffer = await readFile(`${dirname}/../uploads/image.png`)
+    const fileBuffer = await readFile(path.resolve(dirname, '../uploads/image.png'))
 
     const data = new FormData()
-    data.append('file', new Blob([fileBuffer], { type: 'image/png' }), 'image2.png')
+    data.append('file', new Blob([fileBuffer], { type: 'image/png' }), 'image1.png')
     const newMedia: { doc: { url: string } } = await (
       await restClient.POST('/media', {
         body: data,


### PR DESCRIPTION
The fix itself is quite simple, the code was just missing the content type header when uploading via streams.

I think the actual code review is more about the testing. I'm not sure if I did everything right.  
I've duplicated the current azure storage tests and made sure to run them with `useTempFiles: true` which causes all uploads to be streaming uploads. I've also added the test for the mime type handling to the original test suite just to be sure that it is also tested for non-streaming uploads.

closes #15948