### PR TITLE
fix(ui): radio field does not trigger admin.condition re-evaluation

### DIFF
--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -20,7 +20,6 @@ const baseClass = 'radio-group'
 
 const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
   const {
-    disableModifyingForm: disableModifyingFormFromProps,
     field,
     field: {
       admin: {
@@ -118,7 +117,7 @@ const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
                     }
 
                     if (!(readOnly || disabled)) {
-                      setValue(optionValue, !!disableModifyingFormFromProps)
+                      setValue(optionValue)
                     }
                   }}
                   option={optionIsObject(option) ? option : { label: option, value: option }}

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -64,6 +64,19 @@ const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
 
   const value = valueFromContext || valueFromProps
 
+  const onChange = useCallback(
+    (optionValue: string) => {
+      if (typeof onChangeFromProps === 'function') {
+        onChangeFromProps(optionValue)
+      }
+
+      if (!(readOnly || disabled)) {
+        setValue(optionValue)
+      }
+    },
+    [readOnly, disabled, setValue, onChangeFromProps],
+  )
+
   const styles = useMemo(() => mergeFieldStyles(field), [field])
 
   return (
@@ -111,15 +124,7 @@ const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
                 <Radio
                   id={id}
                   isSelected={isSelected}
-                  onChange={() => {
-                    if (typeof onChangeFromProps === 'function') {
-                      onChangeFromProps(optionValue)
-                    }
-
-                    if (!(readOnly || disabled)) {
-                      setValue(optionValue)
-                    }
-                  }}
+                  onChange={onChange}
                   option={optionIsObject(option) ? option : { label: option, value: option }}
                   path={path}
                   readOnly={readOnly || disabled}

--- a/test/fields/collections/ConditionalLogic/e2e.spec.ts
+++ b/test/fields/collections/ConditionalLogic/e2e.spec.ts
@@ -212,6 +212,27 @@ describe('Conditional Logic', () => {
     await expect(toggledField).toBeVisible()
   })
 
+  test('should toggle conditional field when radio value changes', async () => {
+    await page.goto(url.create)
+
+    const conditionalField = page.locator('#field-fieldConditionalOnRadio')
+
+    // Default is 'radioOne', so the conditional field should be hidden
+    await expect(conditionalField).toBeHidden()
+
+    // Click 'Radio Two' to show the conditional field
+    const radioTwo = page.locator('label[for*="field-radioSelection-radioTwo"]')
+    await radioTwo.click()
+
+    await expect(conditionalField).toBeVisible()
+
+    // Click 'Radio One' to hide the conditional field again
+    const radioOne = page.locator('label[for*="field-radioSelection-radioOne"]')
+    await radioOne.click()
+
+    await expect(conditionalField).toBeHidden()
+  })
+
   test('should show conditional field based on siblingData', async () => {
     await page.goto(url.create)
 

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -129,6 +129,22 @@ const ConditionalLogic: CollectionConfig = {
       },
     },
     {
+      name: 'radioSelection',
+      type: 'radio',
+      defaultValue: 'radioOne',
+      options: [
+        { label: 'Radio One', value: 'radioOne' },
+        { label: 'Radio Two', value: 'radioTwo' },
+      ],
+    },
+    {
+      name: 'fieldConditionalOnRadio',
+      type: 'text',
+      admin: {
+        condition: ({ radioSelection }) => radioSelection === 'radioTwo',
+      },
+    },
+    {
       name: 'groupSelection',
       type: 'select',
       options: ['group1', 'group2'],


### PR DESCRIPTION
## Problem

Radio fields inside blocks don't trigger `admin.condition` re-evaluation on sibling fields. Changing the radio value has no effect on conditional fields. Select fields with the same config work correctly.

## Fix

Removed the `disableModifyingFormFromProps` passthrough from RadioGroup's `setValue()` call in the onChange handler. Radio was calling `setValue(optionValue, !!disableModifyingFormFromProps)` which could suppress `setModified(true)`, breaking the form state -> server -> condition re-evaluation chain. Select calls `setValue(newValue)` without a second argument.

This works because `setModified(true)` is what triggers the debounced `executeOnChange` effect, which sends form state to the server for condition re-evaluation. By removing the second argument, Radio now always marks the form as modified on user interaction, matching Select's behavior.

## Tests

- Existing Radio e2e tests pass
- TypeScript compiles clean (`tsc --noEmit`)

Fixes #15929
Closes #15929