### PR TITLE
fix(ui): fix duplicate options in relationship filter when switching operators

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/optionsReducer.ts
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/optionsReducer.ts
@@ -9,7 +9,7 @@ const reduceToIDs = (options) =>
       return [...ids, ...reduceToIDs(option.options)]
     }
 
-    return [...ids, option.id]
+    return [...ids, option.value]
   }, [])
 
 const optionsReducer = (state: Option[], action: Action): Option[] => {


### PR DESCRIPTION
## Summary

Fixes the `reduceToIDs` helper in the WhereBuilder relationship filter's `optionsReducer` to correctly deduplicate options, preventing duplicate entries from appearing in the dropdown when switching operators.

## Root cause

The `reduceToIDs` function reads `option.id` to build the set of already-loaded IDs, but the `Option` type only has `{ label, value }` — there is no `id` property. This meant `reduceToIDs` always returned `[undefined, undefined, ...]`, making the deduplication check in the `ADD` action ineffective.

When switching from "equals" to "is in", the options reload but existing options weren't properly deduplicated against the new batch, causing every option to appear twice.

## Fix

**1 line changed** — read `option.value` instead of `option.id` in `reduceToIDs`.

This is consistent with the field-level Relationship `optionsReducer` (`packages/ui/src/fields/Relationship/optionsReducer.ts`), which already correctly uses `option.value` for deduplication.

## Test plan

- [x] Reproduce: open Products list → filter by category with "equals" → select value → switch to "is in" → observe duplicates
- [x] Apply fix → same steps → no duplicates
- [x] Verify normal filter behavior (search, pagination, multi-relation) still works
- [x] ESLint passes on changed file

Fixes #15947