### PR TITLE
fix(ui): polymorphic search continues when a collection's useAsTitle is a number field

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -194,6 +194,10 @@ export const sanitizeQueryValue = ({
   if (field.type === 'number') {
     if (typeof formattedValue === 'string' && operator !== 'exists') {
       formattedValue = Number(val)
+
+      if (Number.isNaN(formattedValue)) {
+        return undefined
+      }
     }
 
     if (operator === 'exists') {

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -221,6 +221,8 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
         if (!errorLoading) {
           await relationsToFetch.reduce(async (priorRelation, relation) => {
+            await priorRelation
+
             const relationFilterOption = filterOptions?.[relation]
 
             let lastLoadedPageToUse
@@ -229,116 +231,120 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
             } else {
               lastLoadedPageToUse = (lastLoadedPageArg[relation] || 0) + 1
             }
-            await priorRelation
 
             if (relationFilterOption === false) {
               setLastFullyLoadedRelation(relations.indexOf(relation))
-              return Promise.resolve()
+              return
             }
 
             if (resultsFetched < 10) {
-              const collection = getEntityConfig({ collectionSlug: relation })
-              const fieldToSearch = collection?.admin?.useAsTitle || 'id'
-              let fieldToSort = collection?.defaultSort || 'id'
-              if (typeof sortOptions === 'string') {
-                fieldToSort = sortOptions
-              } else if (sortOptions?.[relation]) {
-                fieldToSort = sortOptions[relation]
-              }
-
-              const query: {
-                [key: string]: unknown
-                where: Where
-              } = {
-                depth: 0,
-                draft: true,
-                limit: maxResultsPerRequest,
-                locale,
-                page: lastLoadedPageToUse,
-                select: {
-                  [fieldToSearch]: true,
-                },
-                sort: fieldToSort,
-                where: {
-                  and: [
-                    {
-                      id: {
-                        not_in: relationMap[relation],
-                      },
-                    },
-                  ],
-                },
-              }
-
-              if (searchArg) {
-                query.where.and.push({
-                  [fieldToSearch]: {
-                    like: searchArg,
-                  },
-                })
-              }
-
-              if (relationFilterOption && typeof relationFilterOption !== 'boolean') {
-                query.where.and.push(relationFilterOption)
-              }
-
-              sanitizeFilterOptionsQuery(query.where)
-
-              const response = await fetch(
-                formatAdminURL({
-                  apiRoute: api,
-                  path: `/${relation}`,
-                }),
-                {
-                  body: qs.stringify(query),
-                  credentials: 'include',
-                  headers: {
-                    'Accept-Language': i18n.language,
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'X-Payload-HTTP-Method-Override': 'GET',
-                  },
-                  method: 'POST',
-                },
-              )
-
-              if (response.ok) {
-                const data: PaginatedDocs<unknown> = await response.json()
-                setLastLoadedPage((prevState) => {
-                  return {
-                    ...prevState,
-                    [relation]: lastLoadedPageToUse,
-                  }
-                })
-
-                if (!data.nextPage) {
-                  setLastFullyLoadedRelation(relations.indexOf(relation))
+              try {
+                const collection = getEntityConfig({ collectionSlug: relation })
+                const fieldToSearch = collection?.admin?.useAsTitle || 'id'
+                let fieldToSort = collection?.defaultSort || 'id'
+                if (typeof sortOptions === 'string') {
+                  fieldToSort = sortOptions
+                } else if (sortOptions?.[relation]) {
+                  fieldToSort = sortOptions[relation]
                 }
 
-                if (data.docs.length > 0) {
-                  resultsFetched += data.docs.length
+                const query: {
+                  [key: string]: unknown
+                  where: Where
+                } = {
+                  depth: 0,
+                  draft: true,
+                  limit: maxResultsPerRequest,
+                  locale,
+                  page: lastLoadedPageToUse,
+                  select: {
+                    [fieldToSearch]: true,
+                  },
+                  sort: fieldToSort,
+                  where: {
+                    and: [
+                      {
+                        id: {
+                          not_in: relationMap[relation],
+                        },
+                      },
+                    ],
+                  },
+                }
 
+                if (searchArg) {
+                  query.where.and.push({
+                    [fieldToSearch]: {
+                      like: searchArg,
+                    },
+                  })
+                }
+
+                if (relationFilterOption && typeof relationFilterOption !== 'boolean') {
+                  query.where.and.push(relationFilterOption)
+                }
+
+                sanitizeFilterOptionsQuery(query.where)
+
+                const response = await fetch(
+                  formatAdminURL({
+                    apiRoute: api,
+                    path: `/${relation}`,
+                  }),
+                  {
+                    body: qs.stringify(query),
+                    credentials: 'include',
+                    headers: {
+                      'Accept-Language': i18n.language,
+                      'Content-Type': 'application/x-www-form-urlencoded',
+                      'X-Payload-HTTP-Method-Override': 'GET',
+                    },
+                    method: 'POST',
+                  },
+                )
+
+                if (response.ok) {
+                  const data: PaginatedDocs<unknown> = await response.json()
+                  setLastLoadedPage((prevState) => {
+                    return {
+                      ...prevState,
+                      [relation]: lastLoadedPageToUse,
+                    }
+                  })
+
+                  if (!data.nextPage) {
+                    setLastFullyLoadedRelation(relations.indexOf(relation))
+                  }
+
+                  if (data.docs.length > 0) {
+                    resultsFetched += data.docs.length
+
+                    dispatchOptions({
+                      type: 'ADD',
+                      collection,
+                      config,
+                      docs: data.docs,
+                      i18n,
+                      sort,
+                    })
+                  }
+                } else if (response.status === 403) {
+                  setLastFullyLoadedRelation(relations.indexOf(relation))
                   dispatchOptions({
                     type: 'ADD',
                     collection,
                     config,
-                    docs: data.docs,
+                    docs: [],
                     i18n,
+                    ids: relationMap[relation],
                     sort,
                   })
+                } else {
+                  setLastFullyLoadedRelation(relations.indexOf(relation))
                 }
-              } else if (response.status === 403) {
-                setLastFullyLoadedRelation(relations.indexOf(relation))
-                dispatchOptions({
-                  type: 'ADD',
-                  collection,
-                  config,
-                  docs: [],
-                  i18n,
-                  ids: relationMap[relation],
-                  sort,
-                })
-              } else {
+              } catch (_err) {
                 setErrorLoading(t('error:unspecific'))
+                setLastFullyLoadedRelation(relations.indexOf(relation))
               }
             }
           }, Promise.resolve())

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -5864,6 +5864,72 @@ describe('database', () => {
   })
 
   it(
+    'should return undefined when searching a number field with a non-numeric string',
+    { db: 'mongo' },
+    () => {
+      const res = sanitizeQueryValue({
+        field: {
+          name: 'amount',
+          type: 'number',
+        },
+        hasCustomID: false,
+        operator: 'like',
+        parentIsLocalized: false,
+        path: 'amount',
+        payload,
+        val: 'abc',
+      })
+
+      expect(res).toBeUndefined()
+    },
+  )
+
+  it(
+    'should return a valid value when searching a number field with a numeric string',
+    { db: 'mongo' },
+    () => {
+      const res = sanitizeQueryValue({
+        field: {
+          name: 'amount',
+          type: 'number',
+        },
+        hasCustomID: false,
+        operator: 'like',
+        parentIsLocalized: false,
+        path: 'amount',
+        payload,
+        val: '42',
+      })
+
+      expect(res).toBeDefined()
+      expect(res?.val).toBe(42)
+    },
+  )
+
+  it('should not throw when using like operator on number field with text value', async () => {
+    await payload.create({
+      collection: 'simple',
+      data: { number: 123, text: 'test-number-like' },
+    })
+
+    const result = await payload.find({
+      collection: 'simple',
+      where: {
+        number: {
+          like: 'abc',
+        },
+      },
+    })
+
+    expect(result.docs).toBeDefined()
+
+    await payload.delete({
+      collection: 'simple',
+      where: { text: { equals: 'test-number-like' } },
+    })
+  })
+
+  it(
     'ensure mongodb respects collation when using collection in the config',
     { db: 'mongo' },
     async () => {


### PR DESCRIPTION
## Summary

Fixes #15686

When a polymorphic relationship search includes a collection with a `number` field as `useAsTitle`, typing text (e.g. `"a"`) caused the entire search to silently abort — subsequent collections were never queried, and valid text matches from those collections were not displayed.

### Root cause

1. **Backend (MongoDB):** `sanitizeQueryValue` converts `Number("abc")` → `NaN` and passes it through, producing a broken query (`{ number: NaN }`)
2. **Frontend:** The polymorphic search uses a serial `reduce` loop. When one collection's API request fails, the unhandled error cascades through `await priorRelation`, preventing all subsequent collections from being queried

### Changes

- **`packages/db-mongodb/src/queries/sanitizeQueryValue.ts`** — Return `undefined` when `Number()` conversion produces `NaN`, gracefully skipping the constraint. This matches the existing Drizzle adapter behavior where `sanitizedQueryValue === null` causes a `break`.
- **`packages/ui/src/fields/Relationship/Input.tsx`** — Wrap each collection's fetch in `try-catch` within the `reduce` loop so one collection's failure doesn't abort the entire search. Move `await priorRelation` before the try block to prevent cascading promise rejections. Mark failed collections as fully loaded and continue.
- **`test/database/int.spec.ts`** — Added 3 tests:
  - Unit: `sanitizeQueryValue` returns `undefined` for non-numeric strings on number fields
  - Unit: `sanitizeQueryValue` returns valid value for numeric strings
  - Integration: `payload.find()` with `like: 'abc'` on a number field doesn't throw

## Test plan

- [x] `pnpm turbo run build --filter=@payloadcms/db-mongodb --force` — builds cleanly
- [x] `pnpm turbo run build --filter=@payloadcms/ui --force` — builds cleanly (TypeScript passes)
- [x] `npx eslint` on changed source files — 0 new errors/warnings
- [x] `pnpm run test:int database` — 162 tests pass (including 3 new), 0 failures
- [x] `pnpm run test:int relationships` — 59 tests pass (all polymorphic relationship tests), 0 failures
- [x] Verified numeric string searches still work correctly (`like: '42'` → matches number 42)