### PR TITLE
fix(plugin-ecommerce): allow custom amount override in Stripe payment adapter

### DIFF
--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -69,6 +69,7 @@ export const initiatePaymentHandler: InitiatePayment =
     let currency: string = currenciesConfig.defaultCurrency
     let cartID: DefaultDocumentIDType = data?.cartID
     let cart = undefined
+    const amount = data?.amount
     const billingAddress = data?.billingAddress
     const shippingAddress = data?.shippingAddress
     const cartSecret = data?.secret
@@ -315,6 +316,7 @@ export const initiatePaymentHandler: InitiatePayment =
       const paymentResponse = await paymentMethod.initiatePayment({
         customersSlug,
         data: {
+          amount,
           billingAddress,
           cart,
           currency,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.spec.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { initiatePayment } from './initiatePayment.js'
+
+const mockPaymentIntentsCreate = vi.fn().mockResolvedValue({
+  amount: 3000,
+  client_secret: 'pi_secret_test',
+  currency: 'usd',
+  id: 'pi_test_123',
+})
+
+vi.mock('stripe', () => {
+  return {
+    default: class StripeMock {
+      customers = {
+        create: vi.fn().mockResolvedValue({ id: 'cus_test_123' }),
+        list: vi.fn().mockResolvedValue({ data: [{ id: 'cus_test_123' }] }),
+      }
+
+      paymentIntents = {
+        create: mockPaymentIntentsCreate,
+      }
+    },
+  }
+})
+
+const baseData = {
+  billingAddress: {} as any,
+  cart: {
+    id: 'cart_1',
+    items: [{ id: 'item_1', product: 'prod_1', quantity: 1 }],
+    subtotal: 3000,
+  },
+  currency: 'usd',
+  customerEmail: 'test@example.com',
+}
+
+const baseArgs = {
+  customersSlug: 'users',
+  req: {
+    payload: {
+      create: vi.fn().mockResolvedValue({}),
+      logger: { error: vi.fn() },
+    },
+    user: { id: 'user_1' },
+  } as any,
+  transactionsSlug: 'transactions',
+}
+
+describe('initiatePayment - amount override', () => {
+  it('should use cart.subtotal when no amount override is provided', async () => {
+    mockPaymentIntentsCreate.mockClear()
+
+    const handler = initiatePayment({ secretKey: 'sk_test_123' })
+
+    await handler({
+      ...baseArgs,
+      data: { ...baseData },
+    })
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 3000,
+      }),
+    )
+  })
+
+  it('should use data.amount when provided', async () => {
+    mockPaymentIntentsCreate.mockClear()
+
+    const handler = initiatePayment({ secretKey: 'sk_test_123' })
+
+    await handler({
+      ...baseArgs,
+      data: { ...baseData, amount: 5500 },
+    })
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 5500,
+      }),
+    )
+  })
+})

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -18,7 +18,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
     const customerEmail = data.customerEmail
     const currency = data.currency
     const cart = data.cart
-    const amount = cart.subtotal
+    const amount = data.amount ?? cart.subtotal
     const billingAddressFromData = data.billingAddress
     const shippingAddressFromData = data.shippingAddress
 

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -61,6 +61,12 @@ type InitiatePayment = (args: {
   customersSlug?: string
   data: {
     /**
+     * Optional override for the payment amount. When provided, this value
+     * is used instead of `cart.subtotal`. Useful for including shipping,
+     * taxes, or applying discounts like gift cards.
+     */
+    amount?: number
+    /**
      * Billing address for the payment.
      */
     billingAddress: TypedCollection['addresses']


### PR DESCRIPTION
## Summary

Fixes #15784

The Stripe adapter hardcodes the PaymentIntent amount to `cart.subtotal`, making it impossible to include shipping fees, taxes, or apply discounts (e.g. gift cards) without forking the entire adapter.

This PR adds an optional `amount` field to the `InitiatePayment` data type. When provided in the request body, it overrides `cart.subtotal`. When omitted, existing behavior is preserved.

## Changes

- **`types/index.ts`** — Added optional `amount?: number` to `InitiatePayment` data type
- **`endpoints/initiatePayment.ts`** — Extract `amount` from request body and forward to adapter
- **`stripe/initiatePayment.ts`** — `data.amount ?? cart.subtotal`
- **`initiatePayment.spec.ts`** — Unit tests for default and override behavior

## Usage

```ts
// POST /api/payments/stripe/initiate
{
  "cartID": "abc123",
  "amount": 5500, // subtotal + shipping - gift card
  "billingAddress": { ... }
}
```

## Test plan

- [x] Unit tests pass for both default (`cart.subtotal`) and override (`data.amount`) paths
- [x] All 134 existing plugin-ecommerce tests pass
- [x] Lint-staged passes