### PR TITLE
fix: updateJobs returns undefined when runHooks is true and job is updated by ID

### DIFF
--- a/packages/payload/src/queues/utilities/updateJob.ts
+++ b/packages/payload/src/queues/utilities/updateJob.ts
@@ -56,19 +56,29 @@ export async function updateJobs({
   sort,
   where: whereArg,
 }: RunJobsArgs): Promise<Job[] | null> {
-  const limit = id ? 1 : limitArg
-  const where = id ? { id: { equals: id } } : whereArg
-
   if (depth || req.payload.config?.jobs?.runHooks) {
+    if (id) {
+      const result = await req.payload.update({
+        id,
+        collection: jobsCollectionSlug,
+        data,
+        depth,
+        disableTransaction,
+        req,
+      })
+      if (returning === false || !result) {
+        return null
+      }
+      return [result as unknown as Job]
+    }
     const result = await req.payload.update({
-      id,
       collection: jobsCollectionSlug,
       data,
       depth,
       disableTransaction,
-      limit,
+      limit: limitArg,
       req,
-      where,
+      where: whereArg,
     } as ManyOptions<any, any>)
     if (returning === false || !result) {
       return null
@@ -97,11 +107,11 @@ export async function updateJobs({
       }
     : {
         data,
-        limit,
+        limit: limitArg,
         req: jobReq,
         returning,
         sort,
-        where: where as Where,
+        where: whereArg as Where,
       }
 
   const updatedJobs: Job[] | null = await req.payload.db.updateJobs(args)

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -14,8 +14,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
-import { devUser } from '../credentials.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { devUser } from '../credentials.js'
 import { clearAndSeedEverything } from './seed.js'
 import { waitUntilAutorunIsDone } from './utilities.js'
 
@@ -1347,6 +1347,38 @@ describe('Queues - Payload', () => {
 
     expect(allCompletedJobs.totalDocs).toBe(1)
     expect(allCompletedJobs.docs[0]?.id).toBe(lastJobID)
+  })
+
+  it('ensure payload.jobs.runByID executes the task and marks the job complete when jobs.runHooks is true', async () => {
+    payload.config.jobs.deleteJobOnComplete = false
+    payload.config.jobs.runHooks = true
+
+    const job = await payload.jobs.queue({
+      task: 'CreateSimple',
+      input: {
+        message: 'runHooks test',
+      },
+    })
+
+    await payload.jobs.runByID({
+      id: job.id,
+      silent: true,
+    })
+
+    const simples = await payload.find({
+      collection: 'simple',
+      where: { title: { equals: 'runHooks test' } },
+    })
+
+    const completedJob = await payload.findByID({
+      collection: 'payload-jobs',
+      id: job.id,
+    })
+
+    payload.config.jobs.runHooks = false
+
+    expect(simples.totalDocs).toBe(1)
+    expect(completedJob?.completedAt).toBeTruthy()
   })
 
   it('ensure where query for input data in payload.jobs.run works and only runs the specified job', async () => {


### PR DESCRIPTION
**What?**
When `jobs.runHooks: true`, calling `payload.jobs.runByID()` silently does nothing — the task handler never executes and the job is left stuck with `processing: true` forever.

**Why?**
Inside `updateJobs()`, the `runHooks` branch called `payload.update()` cast to `ManyOptions` and accessed `result.docs`. But `payload.update()` by ID returns a single document, not a `{ docs: [...] }` object — so `result.docs` was always `undefined`. The very first internal `updateJob` call (to mark the job as `processing: true`) returned `undefined`, causing the runner to see an empty jobs array and exit immediately with `{ noJobsRemaining: true }`.

**How?**
Added an `if (id)` branch inside the `runHooks` block that calls `payload.update()` with `id` (single-doc path) and wraps the result in an array. This mirrors the structure of the non-`runHooks` direct-DB path which already handled the two cases separately.

Fixes #15825