### PR TITLE
feat: add `disableUnique` property to the slug field for better multi tenant plugin support

### DIFF
--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -212,16 +212,17 @@ export const ExampleCollection: CollectionConfig = {
 
 The slug field exposes a few top-level config options for easy customization:
 
-| Option         | Description                                                                                                                              |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`         | To be used as the slug field's name. Defaults to `slug`.                                                                                 |
-| `overrides`    | A function that receives the default fields so you can override on a granular level. See example below. [More details](#slug-overrides). |
-| `checkboxName` | To be used as the name for the `generateSlug` checkbox field. Defaults to `generateSlug`.                                                |
-| `useAsSlug`    | The name of the top-level field to use when generating the slug. This field must exist in the same collection. Defaults to `title`.      |
-| `localized`    | Enable localization on the `slug` and `generateSlug` fields. Defaults to `false`.                                                        |
-| `position`     | The position of the slug field. [More details](./overview#admin-options).                                                                |
-| `required`     | Require the slug field. Defaults to `true`.                                                                                              |
-| `slugify`      | Override the default slugify function. [More details](#custom-slugify-function).                                                         |
+| Option          | Description                                                                                                                                                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`          | To be used as the slug field's name. Defaults to `slug`.                                                                                                                                                                                |
+| `overrides`     | A function that receives the default fields so you can override on a granular level. See example below. [More details](#slug-overrides).                                                                                                |
+| `checkboxName`  | To be used as the name for the `generateSlug` checkbox field. Defaults to `generateSlug`.                                                                                                                                               |
+| `disableUnique` | Disables the unique index on the field. Useful when you want to add a compound unique index to the collection `indexes` config instead, for example with the multi-tenant plugin where the slug is only unique per tenant, not globally |
+| `useAsSlug`     | The name of the top-level field to use when generating the slug. This field must exist in the same collection. Defaults to `title`.                                                                                                     |
+| `localized`     | Enable localization on the `slug` and `generateSlug` fields. Defaults to `false`.                                                                                                                                                       |
+| `position`      | The position of the slug field. [More details](./overview#admin-options).                                                                                                                                                               |
+| `required`      | Require the slug field. Defaults to `true`.                                                                                                                                                                                             |
+| `slugify`       | Override the default slugify function. [More details](#custom-slugify-function).                                                                                                                                                        |
 
 ### Slug Overrides
 

--- a/packages/payload/src/fields/baseFields/slug/index.ts
+++ b/packages/payload/src/fields/baseFields/slug/index.ts
@@ -18,6 +18,13 @@ export type SlugFieldArgs = {
    */
   checkboxName?: string
   /**
+   * Disables the unique index on the field.
+   * This is useful if instead, you want to add a compound unique index to the collection `indexes` config,
+   * for example with the multi tenant plugin, where the slug is only unique per tenant, not globally.
+   * @default false
+   */
+  disableUnique?: boolean
+  /**
    * @deprecated use `useAsSlug` instead.
    */
   fieldToUse?: string
@@ -88,6 +95,7 @@ export type SlugFieldClientProps = SlugFieldClientPropsOnly & TextFieldClientPro
 export const slugField: SlugField = ({
   name: slugFieldName = 'slug',
   checkboxName = 'generateSlug',
+  disableUnique = false,
   fieldToUse,
   localized,
   overrides,
@@ -145,7 +153,7 @@ export const slugField: SlugField = ({
         index: true,
         localized,
         required,
-        unique: true,
+        unique: !disableUnique,
       },
     ],
   }


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/14938

This PR adds a new property `disableUnique` which is useful when you want to add a compound unique index to the collection `indexes` config instead, for example with the multi-tenant plugin where the slug is only unique per tenant, not globally.