### PR TITLE
ci: add audit-dependencies claude skill

### DIFF
--- a/.claude/skills/audit-dependencies/SKILL.md
+++ b/.claude/skills/audit-dependencies/SKILL.md
@@ -3,7 +3,7 @@ name: audit-dependencies
 description: Use when fixing dependency vulnerabilities, running pnpm audit, or when the audit-dependencies CI check fails
 user-invocable: true
 disable-model-invocation: true
-argument-hint: "[severity=high]"
+argument-hint: "critical|high|moderate|low"
 ---
 
 # Audit Dependencies

--- a/.claude/skills/audit-dependencies/SKILL.md
+++ b/.claude/skills/audit-dependencies/SKILL.md
@@ -2,8 +2,8 @@
 name: audit-dependencies
 description: Use when fixing dependency vulnerabilities, running pnpm audit, or when the audit-dependencies CI check fails
 user-invocable: true
-agent-auto-detect: false
-arguments: "[severity=high] - audit level passed to audit-dependencies.sh (e.g. low, moderate, high, critical)"
+disable-model-invocation: true
+argument-hint: "[severity=high]"
 ---
 
 # Audit Dependencies
@@ -51,10 +51,10 @@ digraph audit {
 ### 1. Run the Audit Script
 
 ```bash
-./.github/workflows/audit-dependencies.sh $severity
+./.github/workflows/audit-dependencies.sh $ARGUMENTS
 ```
 
-`$severity` comes from the skill argument (defaults to `high`). The script runs `pnpm audit --prod --json` and filters for actionable vulnerabilities (those with a patched version available). `high` includes `critical`.
+`$ARGUMENTS` is the severity passed to the skill (defaults to `high` if omitted). The script runs `pnpm audit --prod --json` and filters for actionable vulnerabilities (those with a patched version available). `high` includes `critical`.
 
 Parse the output to build a deduplicated list of vulnerable packages with:
 
@@ -124,7 +124,7 @@ pnpm install --ignore-scripts
 Then re-run the audit script with the same severity:
 
 ```bash
-./.github/workflows/audit-dependencies.sh $severity
+./.github/workflows/audit-dependencies.sh $ARGUMENTS
 ```
 
 The audit script must exit 0. If vulnerabilities remain, check for additional instances of the same dependency in other workspace packages.
@@ -157,7 +157,7 @@ For each fixed vulnerability, find the GitHub Security Advisory (GHSA):
 Commit with conventional commit format:
 
 ```
-fix(deps): resolve $severity severity audit vulnerabilities
+fix(deps): resolve $ARGUMENTS severity audit vulnerabilities
 ```
 
 Create PR using `gh pr create` with this body structure:

--- a/.claude/skills/audit-dependencies/SKILL.md
+++ b/.claude/skills/audit-dependencies/SKILL.md
@@ -3,6 +3,7 @@ name: audit-dependencies
 description: Use when fixing dependency vulnerabilities, running pnpm audit, or when the audit-dependencies CI check fails
 user-invocable: true
 agent-auto-detect: false
+arguments: "[severity=high] - audit level passed to audit-dependencies.sh (e.g. low, moderate, high, critical)"
 ---
 
 # Audit Dependencies
@@ -50,10 +51,10 @@ digraph audit {
 ### 1. Run the Audit Script
 
 ```bash
-./.github/workflows/audit-dependencies.sh <severity>
+./.github/workflows/audit-dependencies.sh $severity
 ```
 
-Use the severity the user specifies, or default to `high`. The script runs `pnpm audit --prod --json` and filters for actionable vulnerabilities (those with a patched version available). `high` includes `critical`.
+`$severity` comes from the skill argument (defaults to `high`). The script runs `pnpm audit --prod --json` and filters for actionable vulnerabilities (those with a patched version available). `high` includes `critical`.
 
 Parse the output to build a deduplicated list of vulnerable packages with:
 
@@ -123,7 +124,7 @@ pnpm install --ignore-scripts
 Then re-run the audit script with the same severity:
 
 ```bash
-./.github/workflows/audit-dependencies.sh <severity>
+./.github/workflows/audit-dependencies.sh $severity
 ```
 
 The audit script must exit 0. If vulnerabilities remain, check for additional instances of the same dependency in other workspace packages.
@@ -155,7 +156,7 @@ For each fixed vulnerability, search for the CVE identifiers:
 Commit with conventional commit format:
 
 ```
-fix(deps): resolve <severity> severity audit vulnerabilities
+fix(deps): resolve $severity severity audit vulnerabilities
 ```
 
 Create PR using `gh pr create` with this body structure:

--- a/.claude/skills/audit-dependencies/SKILL.md
+++ b/.claude/skills/audit-dependencies/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: audit-dependencies
+description: Use when fixing dependency vulnerabilities, running pnpm audit, or when the audit-dependencies CI check fails
+user-invocable: true
+agent-auto-detect: false
+---
+
+# Audit Dependencies
+
+## Overview
+
+Fix dependency vulnerabilities reported by `.github/workflows/audit-dependencies.sh`. Always prefer direct dependency bumps over pnpm overrides. Every override requires justification for why a direct bump isn't feasible.
+
+## Core Workflow
+
+```dot
+digraph audit {
+    "Run audit script" [shape=box];
+    "Group by package" [shape=box];
+    "Trace dependency chain" [shape=box];
+    "Can bump direct dep?" [shape=diamond];
+    "Research breaking changes" [shape=box];
+    "Breaking changes acceptable?" [shape=diamond];
+    "Apply direct bump" [shape=box];
+    "Apply pnpm override" [shape=box];
+    "More packages?" [shape=diamond];
+    "Install and verify" [shape=box];
+    "Build and verify" [shape=box];
+    "Commit and create PR" [shape=box];
+
+    "Run audit script" -> "Group by package";
+    "Group by package" -> "Trace dependency chain";
+    "Trace dependency chain" -> "Can bump direct dep?";
+    "Can bump direct dep?" -> "Research breaking changes" [label="yes"];
+    "Can bump direct dep?" -> "Apply pnpm override" [label="no - explain why"];
+    "Research breaking changes" -> "Breaking changes acceptable?";
+    "Breaking changes acceptable?" -> "Apply direct bump" [label="yes"];
+    "Breaking changes acceptable?" -> "Apply pnpm override" [label="no - explain why"];
+    "Apply direct bump" -> "More packages?";
+    "Apply pnpm override" -> "More packages?";
+    "More packages?" -> "Trace dependency chain" [label="yes"];
+    "More packages?" -> "Install and verify" [label="no"];
+    "Install and verify" -> "Build and verify";
+    "Build and verify" -> "Commit and create PR";
+}
+```
+
+## Step-by-Step
+
+### 1. Run the Audit Script
+
+```bash
+./.github/workflows/audit-dependencies.sh <severity>
+```
+
+Use the severity the user specifies, or default to `high`. The script runs `pnpm audit --prod --json` and filters for actionable vulnerabilities (those with a patched version available). `high` includes `critical`.
+
+Parse the output to build a deduplicated list of vulnerable packages with:
+
+- Package name and current version
+- Fixed version requirement
+- Full dependency chain (e.g., `packages/plugin-sentry > @sentry/nextjs > rollup`)
+
+### 2. For Each Vulnerable Package
+
+#### Trace the dependency chain
+
+Identify whether the vulnerable package is:
+
+- **Direct dependency**: Listed in a workspace package's `package.json`
+- **Transitive dependency**: Pulled in by another package
+
+#### Try direct bump first
+
+For transitive deps, walk up the chain to find the nearest package you control:
+
+1. Check if bumping the **parent package** resolves the vulnerability
+   - `pnpm view <parent>@latest dependencies.<vulnerable-pkg>`
+   - Check intermediate versions too (the fix may exist in a minor bump)
+2. If the parent bump resolves it, research breaking changes:
+   - Check changelogs/release notes
+   - Search GitHub issues for compatibility problems
+   - Review the API surface used in this repo (read the source files)
+   - Check if the version range crosses a major version boundary
+3. Present findings to user with risk assessment
+
+**Parallelize research**: When multiple packages need breaking change analysis, dispatch parallel agents (one per package) to research simultaneously.
+
+#### Fall back to override only when justified
+
+Add a scoped pnpm override in root `package.json` only when:
+
+- No version of the parent package fixes the vulnerability
+- The parent bump has high breaking change risk (major API changes, no test coverage, requires code changes across many files)
+- The user explicitly decides to defer the parent bump to a separate PR
+
+Override format: `"<parent>><vulnerable-pkg>": "<fixed-version>"`
+
+Before adding any override, verify the target version exists:
+
+```bash
+pnpm view <pkg>@<version> version
+```
+
+### 3. Apply Fixes
+
+- Edit `package.json` files for direct bumps
+- Edit root `package.json` `pnpm.overrides` for overrides (keep alphabetical)
+- If a direct bump changes behavior, update consuming code (e.g., adding `allowOverwrite: true` when an API default changes)
+
+### 4. Install and Verify
+
+```bash
+pnpm install
+```
+
+If install fails due to native build errors (e.g., `better-sqlite3`), fall back to:
+
+```bash
+pnpm install --ignore-scripts
+```
+
+Then re-run the audit script with the same severity:
+
+```bash
+./.github/workflows/audit-dependencies.sh <severity>
+```
+
+The audit script must exit 0. If vulnerabilities remain, check for additional instances of the same dependency in other workspace packages.
+
+### 5. Build and Verify
+
+```bash
+pnpm run build:core
+```
+
+For packages with changed dependencies, also run their specific build:
+
+```bash
+pnpm run build:<package-name>
+```
+
+### 6. Look Up CVEs
+
+For each fixed vulnerability, search for the CVE identifiers:
+
+- Check `https://github.com/<org>/<repo>/security/advisories` for each package
+- Search the web for `<package-name> CVE <fixed-version>`
+- Record: CVE ID, severity, one-line description
+
+**Parallelize CVE lookups**: Dispatch parallel agents to search for CVEs across all packages simultaneously.
+
+### 7. Commit and Create PR
+
+Commit with conventional commit format:
+
+```
+fix(deps): resolve <severity> severity audit vulnerabilities
+```
+
+Create PR using `gh pr create` with this body structure:
+
+```markdown
+# Overview
+
+[What the PR fixes, mention `pnpm audit --prod`]
+
+## Key Changes
+
+- **[Package name] in [workspace path]**
+  - [old version] → [new version]. Fixes [CVE-XXXX-XXXXX](https://nvd.nist.gov/vuln/detail/CVE-XXXX-XXXXX) ([description]).
+  - [Why this approach: direct bump because X / override because Y]
+  - [Any code changes required by the bump]
+
+## Design Decisions
+
+[Why direct bumps were preferred, justification for any remaining overrides]
+```
+
+## Common Mistakes
+
+| Mistake                                 | Fix                                                                                                                     |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Jumping straight to overrides           | Always check if bumping the parent resolves it first                                                                    |
+| Not checking all workspace packages     | Same dep may appear in multiple `package.json` files (e.g., `changelogen` in both `tools/releaser` and `tools/scripts`) |
+| Overriding with a nonexistent version   | Verify the target version exists with `pnpm view` before installing                                                     |
+| Not falling back to `--ignore-scripts`  | Pre-existing native build failures block `pnpm install`; use `--ignore-scripts` to get lockfile updated                 |
+| Missing code changes for breaking bumps | If a bump changes API defaults, update the calling code                                                                 |
+| Forgetting CVE links in PR              | Always look up and include CVE identifiers with NVD links                                                               |

--- a/.claude/skills/audit-dependencies/SKILL.md
+++ b/.claude/skills/audit-dependencies/SKILL.md
@@ -143,11 +143,12 @@ pnpm run build:<package-name>
 
 ### 6. Look Up CVEs
 
-For each fixed vulnerability, search for the CVE identifiers:
+For each fixed vulnerability, find the GitHub Security Advisory (GHSA):
 
 - Check `https://github.com/<org>/<repo>/security/advisories` for each package
-- Search the web for `<package-name> CVE <fixed-version>`
-- Record: CVE ID, severity, one-line description
+- Search the web for `<package-name> GHSA <fixed-version>`
+- Record: GHSA ID, CVE ID, severity, one-line description
+- Prefer GHSA links (`https://github.com/advisories/GHSA-xxxx-xxxx-xxxx`) over NVD links
 
 **Parallelize CVE lookups**: Dispatch parallel agents to search for CVEs across all packages simultaneously.
 
@@ -169,7 +170,7 @@ Create PR using `gh pr create` with this body structure:
 ## Key Changes
 
 - **[Package name] in [workspace path]**
-  - [old version] → [new version]. Fixes [CVE-XXXX-XXXXX](https://nvd.nist.gov/vuln/detail/CVE-XXXX-XXXXX) ([description]).
+  - [old version] → [new version]. Fixes [GHSA-xxxx-xxxx-xxxx](https://github.com/advisories/GHSA-xxxx-xxxx-xxxx) ([description]).
   - [Why this approach: direct bump because X / override because Y]
   - [Any code changes required by the bump]
 
@@ -187,4 +188,4 @@ Create PR using `gh pr create` with this body structure:
 | Overriding with a nonexistent version   | Verify the target version exists with `pnpm view` before installing                                                     |
 | Not falling back to `--ignore-scripts`  | Pre-existing native build failures block `pnpm install`; use `--ignore-scripts` to get lockfile updated                 |
 | Missing code changes for breaking bumps | If a bump changes API defaults, update the calling code                                                                 |
-| Forgetting CVE links in PR              | Always look up and include CVE identifiers with NVD links                                                               |
+| Forgetting advisory links in PR         | Always look up and include GHSA links for each vulnerability                                                               |

--- a/.github/workflows/audit-dependencies.sh
+++ b/.github/workflows/audit-dependencies.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+valid_severities=("low" "moderate" "high" "critical")
 severity=${1:-"high"}
 output_file="audit_output.json"
+
+if [[ ! " ${valid_severities[*]} " =~ " ${severity} " ]]; then
+  echo "Error: invalid severity '${severity}'"
+  echo "Valid values: ${valid_severities[*]}"
+  exit 2
+fi
 
 echo "Auditing for ${severity} vulnerabilities..."
 

--- a/.github/workflows/audit-dependencies.sh
+++ b/.github/workflows/audit-dependencies.sh
@@ -4,7 +4,7 @@ valid_severities=("low" "moderate" "high" "critical")
 severity=${1:-"high"}
 output_file="audit_output.json"
 
-if [[ ! " ${valid_severities[*]} " =~ " ${severity} " ]]; then
+if [[ ! " ${valid_severities[*]} " =~ \ ${severity}\  ]]; then
   echo "Error: invalid severity '${severity}'"
   echo "Valid values: ${valid_severities[*]}"
   exit 2


### PR DESCRIPTION
# Overview

Adds a Claude Code skill for fixing dependency audit vulnerabilities, and adds input validation to the audit script. Invoked manually via `/audit-dependencies [severity]` (defaults to `high`).

## Key Changes

- **New skill at `.claude/skills/audit-dependencies/SKILL.md`**
  - User-invocable only (`disable-model-invocation: true`), so Claude won't auto-detect or load it.
  - Accepts an optional severity argument (`critical|high|moderate|low`), defaults to `high`.
  - Codifies the workflow: run audit script, trace dependency chains, prefer direct bumps over pnpm overrides, research breaking changes, install/build/verify, look up advisories, commit, and create a PR.
  - Includes a graphviz decision flowchart for the bump-vs-override decision.
  - Calls out parallel agent dispatch for breaking change research and advisory lookups.
  - Uses GHSA links (`github.com/advisories/GHSA-...`) over NVD links in PR bodies.

- **Severity validation in `audit-dependencies.sh`**
  - Validates the severity argument against `low`, `moderate`, `high`, `critical`. Exits with code 2 on invalid input.

## Design Decisions

The skill enforces "direct bump first, override as last resort" because overrides hide version mismatches and can silently break when the parent package updates. Each override requires explicit justification (no patched parent version available, high breaking change risk, or user defers to separate PR).