### PR TITLE
fix(plugin-multi-tenant): modal container blocks clicks on create-first-user page

### DIFF
--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -109,13 +109,24 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
   }, [unique, options, selectedTenantID, setTenant, value, setEntityType, entityType])
 
   React.useEffect(() => {
-    if (unique) {
+    if (unique || debug || isEditManyModalOpen) {
       return
     }
-    if ((!isFormValid && showError && showField) || (!value && !selectedTenantID)) {
+    if (showField && ((!isFormValid && showError) || (!value && !selectedTenantID))) {
       openModal(assignTenantModalSlug)
     }
-  }, [isFormValid, showError, showField, openModal, value, docID, selectedTenantID, unique])
+  }, [
+    debug,
+    isEditManyModalOpen,
+    isFormValid,
+    showError,
+    showField,
+    openModal,
+    value,
+    docID,
+    selectedTenantID,
+    unique,
+  ])
 
   if (showField) {
     if (debug || isEditManyModalOpen) {

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -135,6 +135,9 @@ export const multiTenantPlugin =
       [string[], string[]]
     >(
       (acc, slug) => {
+        if (slug === adminUsersCollection.slug) {
+          return acc
+        }
         if (pluginConfig?.collections?.[slug]?.isGlobal) {
           acc[1].push(slug)
         } else {
@@ -336,6 +339,13 @@ export const multiTenantPlugin =
           }),
         ]
       } else if (pluginConfig.collections?.[collection.slug]) {
+        if (collection.slug === adminUsersCollection.slug) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[plugin-multi-tenant] The admin users collection "${collection.slug}" should not be listed in pluginConfig.collections — it is already handled by the plugin. Skipping tenant-field processing for this collection to avoid double access control and validation errors.`,
+          )
+          return
+        }
         multiTenantCollectionsFound.push(collection.slug)
         const isGlobal = Boolean(pluginConfig.collections[collection.slug]?.isGlobal)
 


### PR DESCRIPTION
# Overview

Fixes the `@faceless-ui/modal` container blocking clicks on the `/admin/create-first-user` page when the multi-tenant plugin is active. Also guards against the admin users collection being listed in `pluginConfig.collections`.

## Key Changes

- Gate `openModal` behind `showField` and early-return in `debug`/`isEditManyModalOpen` modes — modal only opens when there are tenant options to display
- Skip Pass 2 for the admin users collection if listed in `pluginConfig.collections`, with a `console.warn` — prevents double access control, conflicting tenant fields, and validation errors on user creation
- Exclude admin users slug from `collectionSlugs` upfront to suppress the spurious missing-collections warning

## Design Decisions

`(!value && !selectedTenantID)` had no `showField` guard, so `openModal` fired even with zero tenants. On `create-first-user` this left the modal container active with `pointer-events: all` and no content, blocking form clicks.

`users: {}` in `pluginConfig.collections` is always a misconfiguration — Pass 1 already handles users via `tenantsArrayField`. Pass 2 processing them again adds a conflicting `tenantField` and breaks user creation. Warn-and-skip was chosen over a hard throw to stay non-breaking.

Fixes #15288 