### PR TITLE
feat(plugin-form-builder): added placeholder field to (most) items

### DIFF
--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -275,6 +275,7 @@ Maps to a `text` input in your front-end. Used to collect a simple string.
 | `name`         | string   | The name of the field.                               |
 | `label`        | string   | The label of the field.                              |
 | `defaultValue` | string   | The default value of the field.                      |
+| `placeholder`  | string   | The placeholder text for the field.                  |
 | `width`        | string   | The width of the field on the front-end.             |
 | `required`     | checkbox | Whether or not the field is required when submitted. |
 
@@ -287,6 +288,7 @@ Maps to a `textarea` input on your front-end. Used to collect a multi-line strin
 | `name`         | string   | The name of the field.                               |
 | `label`        | string   | The label of the field.                              |
 | `defaultValue` | string   | The default value of the field.                      |
+| `placeholder`  | string   | The placeholder text for the field.                  |
 | `width`        | string   | The width of the field on the front-end.             |
 | `required`     | checkbox | Whether or not the field is required when submitted. |
 
@@ -322,6 +324,7 @@ Maps to radio button inputs on your front-end. Used to allow users to select a s
 | `name`         | string   | The name of the field.                                                         |
 | `label`        | string   | The label of the field.                                                        |
 | `defaultValue` | string   | The default value of the field.                                                |
+| `placeholder`  | string   | The placeholder text for the field.                                            |
 | `width`        | string   | The width of the field on the front-end.                                       |
 | `required`     | checkbox | Whether or not the field is required when submitted.                           |
 | `options`      | array    | An array of objects that define the radio options. See below for more details. |
@@ -392,6 +395,7 @@ Maps to a `date` input on your front-end. Used to collect a date value.
 | `name`         | string   | The name of the field.                               |
 | `label`        | string   | The label of the field.                              |
 | `defaultValue` | date     | The default value of the field.                      |
+| `placeholder`  | string   | The placeholder text for the field.                  |
 | `width`        | string   | The width of the field on the front-end.             |
 | `required`     | checkbox | Whether or not the field is required when submitted. |
 
@@ -404,6 +408,7 @@ Maps to a `number` input on your front-end. Used to collect a number.
 | `name`         | string   | The name of the field.                               |
 | `label`        | string   | The label of the field.                              |
 | `defaultValue` | number   | The default value of the field.                      |
+| `placeholder`  | string   | The placeholder text for the field.                  |
 | `width`        | string   | The width of the field on the front-end.             |
 | `required`     | checkbox | Whether or not the field is required when submitted. |
 

--- a/packages/plugin-form-builder/src/collections/Forms/fields.ts
+++ b/packages/plugin-form-builder/src/collections/Forms/fields.ts
@@ -32,6 +32,14 @@ const placeholder: Field = {
   name: 'placeholder',
   type: 'text',
   label: 'Placeholder',
+  localized: true,
+}
+
+const defaultValue: Field = {
+  name: 'defaultValue',
+  type: 'text',
+  label: 'Default Value',
+  localized: true,
 }
 
 const Radio: Block = {
@@ -75,6 +83,23 @@ const Radio: Block = {
       ],
     },
     {
+      type: 'row',
+      fields: [
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...required,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
+    {
       name: 'options',
       type: 'array',
       fields: [
@@ -109,7 +134,6 @@ const Radio: Block = {
         singular: 'Option',
       },
     },
-    required,
   ],
   labels: {
     plural: 'Radio Fields',
@@ -162,6 +186,15 @@ const Select: Block = {
       fields: [
         {
           ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...required,
+          admin: {
+            width: '50%',
+          },
         },
       ],
     },
@@ -200,7 +233,6 @@ const Select: Block = {
         singular: 'Option',
       },
     },
-    required,
   ],
   labels: {
     plural: 'Select Fields',
@@ -238,17 +270,30 @@ const Text: Block = {
           },
         },
         {
-          name: 'defaultValue',
-          type: 'text',
+          ...defaultValue,
           admin: {
             width: '50%',
           },
-          label: 'Default Value',
-          localized: true,
         },
       ],
     },
-    required,
+    {
+      type: 'row',
+      fields: [
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...required,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
   ],
   labels: {
     plural: 'Text Fields',
@@ -296,7 +341,23 @@ const TextArea: Block = {
         },
       ],
     },
-    required,
+    {
+      type: 'row',
+      fields: [
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...required,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
   ],
   labels: {
     plural: 'Text Area Fields',
@@ -343,7 +404,23 @@ const Number: Block = {
         },
       ],
     },
-    required,
+    {
+      type: 'row',
+      fields: [
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...required,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
   ],
   labels: {
     plural: 'Number Fields',
@@ -371,7 +448,23 @@ const Email: Block = {
         },
       ],
     },
-    width,
+    {
+      type: 'row',
+      fields: [
+        {
+          ...width,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
     required,
   ],
   labels: {
@@ -400,7 +493,23 @@ const State: Block = {
         },
       ],
     },
-    width,
+    {
+      type: 'row',
+      fields: [
+        {
+          ...width,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
     required,
   ],
   labels: {
@@ -429,7 +538,23 @@ const Country: Block = {
         },
       ],
     },
-    width,
+    {
+      type: 'row',
+      fields: [
+        {
+          ...width,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
     required,
   ],
   labels: {
@@ -525,9 +650,21 @@ const Date: Block = {
       ],
     },
     {
-      name: 'defaultValue',
-      type: 'date',
-      label: 'Default Value',
+      type: 'row',
+      fields: [
+        {
+          ...defaultValue,
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          ...placeholder,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
     },
   ],
   labels: {
@@ -689,7 +826,23 @@ const Payment = (fieldConfig: PaymentFieldConfig): Block => {
           singular: 'Price Condition',
         },
       },
-      required,
+      {
+        type: 'row',
+        fields: [
+          {
+            ...placeholder,
+            admin: {
+              width: '50%',
+            },
+          },
+          {
+            ...required,
+            admin: {
+              width: '50%',
+            },
+          },
+        ],
+      },
     ].filter(Boolean) as Field[],
     labels: {
       plural: 'Payment Fields',

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -72,6 +72,7 @@ export interface TextField {
   defaultValue?: string
   label?: string
   name: string
+  placeholder?: string
   required?: boolean
   width?: number
 }
@@ -82,6 +83,7 @@ export interface TextAreaField {
   defaultValue?: string
   label?: string
   name: string
+  placeholder?: string
   required?: boolean
   width?: number
 }
@@ -132,6 +134,7 @@ export interface PaymentField {
   label?: string
   name: string
   paymentProcessor: string
+  placeholder?: string
   priceConditions: PriceCondition[]
   required?: boolean
   width?: number
@@ -143,6 +146,7 @@ export interface EmailField {
   defaultValue?: string
   label?: string
   name: string
+  placeholder?: string
   required?: boolean
   width?: number
 }
@@ -153,6 +157,7 @@ export interface DateField {
   defaultValue?: string
   label?: string
   name: string
+  placeholder?: string
   required?: boolean
   width?: number
 }
@@ -163,6 +168,7 @@ export interface StateField {
   defaultValue?: string
   label?: string
   name: string
+  placeholder?: string
   required?: boolean
   width?: number
 }
@@ -173,6 +179,7 @@ export interface CountryField {
   defaultValue?: string
   label?: string
   name: string
+  placeholder?: string
   required?: boolean
   width?: number
 }

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -187,6 +187,52 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       expect(testForm).toHaveProperty('custom', 'custom')
     })
+
+    it('should store placeholder on text field', async () => {
+      const testForm = await payload.create({
+        collection: formsSlug,
+        data: {
+          confirmationType: 'message',
+          confirmationMessage: {
+            root: {
+              children: [
+                {
+                  children: [
+                    {
+                      detail: 0,
+                      format: 0,
+                      mode: 'normal',
+                      style: '',
+                      text: 'Confirmed.',
+                      type: 'text',
+                      version: 1,
+                    },
+                  ],
+                  direction: 'ltr',
+                  format: '',
+                  indent: 0,
+                  type: 'paragraph',
+                  version: 1,
+                  textFormat: 0,
+                  textStyle: '',
+                },
+              ],
+              direction: 'ltr',
+              format: '',
+              indent: 0,
+              type: 'root',
+              version: 1,
+            },
+          },
+          title: 'Placeholder Test Form',
+          fields: [{ blockType: 'text', name: 'myField', placeholder: 'Enter value...' }],
+        },
+      })
+
+      expect(testForm.fields?.[0]).toMatchObject({ placeholder: 'Enter value...' })
+
+      await payload.delete({ collection: formsSlug, id: testForm.id })
+    })
   })
 
   describe('form submissions and validations', () => {

--- a/test/plugin-form-builder/payload-types.ts
+++ b/test/plugin-form-builder/payload-types.ts
@@ -153,6 +153,7 @@ export interface Form {
             name: string;
             label?: string | null;
             width?: number | null;
+            placeholder?: string | null;
             required?: boolean | null;
             id?: string | null;
             blockName?: string | null;
@@ -162,6 +163,7 @@ export interface Form {
             name: string;
             label?: string | null;
             width?: number | null;
+            placeholder?: string | null;
             required?: boolean | null;
             id?: string | null;
             blockName?: string | null;
@@ -192,6 +194,7 @@ export interface Form {
             label?: string | null;
             width?: number | null;
             defaultValue?: number | null;
+            placeholder?: string | null;
             required?: boolean | null;
             id?: string | null;
             blockName?: string | null;
@@ -213,6 +216,7 @@ export interface Form {
                   id?: string | null;
                 }[]
               | null;
+            placeholder?: string | null;
             required?: boolean | null;
             id?: string | null;
             blockName?: string | null;
@@ -224,6 +228,7 @@ export interface Form {
             width?: number | null;
             defaultValue?: string | null;
             placeholder?: string | null;
+            required?: boolean | null;
             options?:
               | {
                   label: string;
@@ -240,6 +245,7 @@ export interface Form {
             name: string;
             label?: string | null;
             width?: number | null;
+            placeholder?: string | null;
             required?: boolean | null;
             id?: string | null;
             blockName?: string | null;
@@ -250,6 +256,7 @@ export interface Form {
             label?: string | null;
             width?: number | null;
             defaultValue?: string | null;
+            placeholder?: string | null;
             required?: boolean | null;
             id?: string | null;
             blockName?: string | null;
@@ -260,6 +267,7 @@ export interface Form {
             label?: string | null;
             width?: number | null;
             defaultValue?: string | null;
+            placeholder?: string | null;
             required?: boolean | null;
             id?: string | null;
             blockName?: string | null;
@@ -280,7 +288,7 @@ export interface Form {
              * This is a date field
              */
             defaultValue?: string | null;
-            defaultValue_tz?: SupportedTimezones;
+            placeholder?: string | null;
             id?: string | null;
             blockName?: string | null;
             blockType: 'date';
@@ -552,6 +560,7 @@ export interface FormsSelect<T extends boolean = true> {
               name?: T;
               label?: T;
               width?: T;
+              placeholder?: T;
               required?: T;
               id?: T;
               blockName?: T;
@@ -562,6 +571,7 @@ export interface FormsSelect<T extends boolean = true> {
               name?: T;
               label?: T;
               width?: T;
+              placeholder?: T;
               required?: T;
               id?: T;
               blockName?: T;
@@ -580,6 +590,7 @@ export interface FormsSelect<T extends boolean = true> {
               label?: T;
               width?: T;
               defaultValue?: T;
+              placeholder?: T;
               required?: T;
               id?: T;
               blockName?: T;
@@ -602,6 +613,7 @@ export interface FormsSelect<T extends boolean = true> {
                     valueForOperator?: T;
                     id?: T;
                   };
+              placeholder?: T;
               required?: T;
               id?: T;
               blockName?: T;
@@ -631,6 +643,7 @@ export interface FormsSelect<T extends boolean = true> {
               name?: T;
               label?: T;
               width?: T;
+              placeholder?: T;
               required?: T;
               id?: T;
               blockName?: T;
@@ -642,6 +655,7 @@ export interface FormsSelect<T extends boolean = true> {
               label?: T;
               width?: T;
               defaultValue?: T;
+              placeholder?: T;
               required?: T;
               id?: T;
               blockName?: T;
@@ -653,6 +667,7 @@ export interface FormsSelect<T extends boolean = true> {
               label?: T;
               width?: T;
               defaultValue?: T;
+              placeholder?: T;
               required?: T;
               id?: T;
               blockName?: T;
@@ -672,7 +687,7 @@ export interface FormsSelect<T extends boolean = true> {
               width?: T;
               required?: T;
               defaultValue?: T;
-              defaultValue_tz?: T;
+              placeholder?: T;
               id?: T;
               blockName?: T;
             };


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

related to: https://github.com/payloadcms/payload/discussions/15979

### What
Addition of placeholder fields for the form builder
<img width="1336" height="680" alt="Screenshot 2026-03-17 at 20 51 14" src="https://github.com/user-attachments/assets/36325764-b87c-44a4-97df-82b9e149e2c4" />

### Why
Placeholder, like name and label are standardized fields used in web development and are currently missing from the form builder thus limiting CMS users.

### How
Simple, adding the field to most form item. Except for checkbox, which isn't a form of text input and already gets covered by the "checked" field