### PR TITLE
fix: unpublish updates existing version instead of creating a new one

### DIFF
--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -385,6 +385,7 @@ export const updateDocument = async <
       publishSpecificLocale,
       req,
       snapshot: snapshotToSave,
+      unpublish: unpublishAllLocales,
     })
   }
 

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -379,6 +379,7 @@ export const updateOperation = async <
         req,
         select,
         snapshot: snapshotToSave,
+        unpublish: unpublishAllLocales,
       })
 
       result = {

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -27,6 +27,89 @@ type Args<T extends JsonObject = JsonObject> = {
   unpublish?: boolean
 }
 
+async function findAndUpdateLatestVersion<TData extends JsonObject>({
+  id,
+  collection,
+  global,
+  now,
+  payload,
+  req,
+  shouldUpdate,
+  versionData,
+}: {
+  collection?: SanitizedCollectionConfig
+  global?: SanitizedGlobalConfig
+  id?: number | string
+  now: string
+  payload: Payload
+  req?: PayloadRequest
+  shouldUpdate: (latestVersion: JsonObject) => boolean
+  versionData: TData
+}): Promise<{ result?: JsonObject; updated: boolean }> {
+  let docs
+  const findVersionArgs = {
+    limit: 1,
+    pagination: false,
+    req,
+    sort: '-updatedAt',
+  }
+
+  if (collection) {
+    ;({ docs } = await payload.db.findVersions<TData>({
+      ...findVersionArgs,
+      collection: collection.slug,
+      where: {
+        parent: {
+          equals: id,
+        },
+      },
+    }))
+  } else {
+    ;({ docs } = await payload.db.findGlobalVersions<TData>({
+      ...findVersionArgs,
+      global: global!.slug,
+    }))
+  }
+
+  const [latestVersion] = docs
+
+  if (!latestVersion || !shouldUpdate(latestVersion)) {
+    return { updated: false }
+  }
+
+  const updateVersionArgs = {
+    id: latestVersion.id,
+    req,
+    versionData: {
+      createdAt: new Date(latestVersion.createdAt).toISOString(),
+      latest: true,
+      parent: id,
+      updatedAt: now,
+      version: {
+        ...versionData,
+      },
+    },
+  }
+
+  let result: JsonObject | undefined
+
+  if (collection) {
+    result = await payload.db.updateVersion<TData>({
+      ...updateVersionArgs,
+      collection: collection.slug,
+      req,
+    })
+  } else {
+    result = await payload.db.updateGlobalVersion<TData>({
+      ...updateVersionArgs,
+      global: global!.slug,
+      req,
+    })
+  }
+
+  return { result, updated: true }
+}
+
 export async function saveVersion<TData extends JsonObject = JsonObject>(
   args: { returning: false } & Args<TData>,
 ): Promise<null>
@@ -70,130 +153,38 @@ export async function saveVersion<TData extends JsonObject = JsonObject>({
 
   try {
     if (unpublish) {
-      let docs
-      const findVersionArgs = {
-        limit: 1,
-        pagination: false,
+      const overwrite = await findAndUpdateLatestVersion({
+        id,
+        collection,
+        global,
+        now,
+        payload,
         req,
-        sort: '-updatedAt',
-      }
+        shouldUpdate: () => true,
+        versionData,
+      })
 
-      if (collection) {
-        ;({ docs } = await payload.db.findVersions<TData>({
-          ...findVersionArgs,
-          collection: collection.slug,
-          where: {
-            parent: {
-              equals: id,
-            },
-          },
-        }))
-      } else {
-        ;({ docs } = await payload.db.findGlobalVersions<TData>({
-          ...findVersionArgs,
-          global: global!.slug,
-        }))
-      }
-
-      const [latestVersion] = docs
-
-      if (latestVersion) {
+      if (overwrite.updated) {
         createNewVersion = false
-
-        const updateVersionArgs = {
-          id: latestVersion.id,
-          req,
-          versionData: {
-            createdAt: new Date(latestVersion.createdAt).toISOString(),
-            latest: true,
-            parent: id,
-            updatedAt: now,
-            version: {
-              ...versionData,
-            },
-          },
-        }
-
-        if (collection) {
-          result = await payload.db.updateVersion<TData>({
-            ...updateVersionArgs,
-            collection: collection.slug,
-            req,
-          })
-        } else {
-          result = await payload.db.updateGlobalVersion<TData>({
-            ...updateVersionArgs,
-            global: global!.slug,
-            req,
-          })
-        }
+        result = overwrite.result
       }
     }
 
-    if (autosave) {
-      let docs
-      const findVersionArgs = {
-        limit: 1,
-        pagination: false,
+    if (autosave && createNewVersion) {
+      const overwrite = await findAndUpdateLatestVersion({
+        id,
+        collection,
+        global,
+        now,
+        payload,
         req,
-        sort: '-updatedAt',
-      }
+        shouldUpdate: (v) => 'autosave' in v && v.autosave === true,
+        versionData,
+      })
 
-      if (collection) {
-        ;({ docs } = await payload.db.findVersions<TData>({
-          ...findVersionArgs,
-          collection: collection.slug,
-          limit: 1,
-          pagination: false,
-          req,
-          where: {
-            parent: {
-              equals: id,
-            },
-          },
-        }))
-      } else {
-        ;({ docs } = await payload.db.findGlobalVersions<TData>({
-          ...findVersionArgs,
-          global: global!.slug,
-          limit: 1,
-          pagination: false,
-          req,
-        }))
-      }
-      const [latestVersion] = docs
-
-      // overwrite the latest version if it's set to autosave
-      if (latestVersion && 'autosave' in latestVersion && latestVersion.autosave === true) {
+      if (overwrite.updated) {
         createNewVersion = false
-
-        const updateVersionArgs = {
-          id: latestVersion.id,
-          req,
-          versionData: {
-            createdAt: new Date(latestVersion.createdAt).toISOString(),
-            latest: true,
-            parent: id,
-            updatedAt: now,
-            version: {
-              ...versionData,
-            },
-          },
-        }
-
-        if (collection) {
-          result = await payload.db.updateVersion<TData>({
-            ...updateVersionArgs,
-            collection: collection.slug,
-            req,
-          })
-        } else {
-          result = await payload.db.updateGlobalVersion<TData>({
-            ...updateVersionArgs,
-            global: global!.slug,
-            req,
-          })
-        }
+        result = overwrite.result
       }
     }
 

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -9,6 +9,7 @@ import { sanitizeInternalFields } from '../utilities/sanitizeInternalFields.js'
 import { getQueryDraftsSelect } from './drafts/getQueryDraftsSelect.js'
 import { enforceMaxVersions } from './enforceMaxVersions.js'
 import { saveSnapshot } from './saveSnapshot.js'
+import { updateLatestVersion } from './updateLatestVersion.js'
 
 type Args<T extends JsonObject = JsonObject> = {
   autosave?: boolean
@@ -53,7 +54,7 @@ export async function saveVersion<TData extends JsonObject = JsonObject>({
   unpublish,
 }: Args<TData>): Promise<JsonObject | null> {
   let result: JsonObject | undefined
-  let createNewVersion = true
+  let createdNewVersion = false
   const now = new Date().toISOString()
   const versionData: {
     _status?: 'draft'
@@ -69,135 +70,22 @@ export async function saveVersion<TData extends JsonObject = JsonObject>({
   }
 
   try {
-    if (unpublish) {
-      let docs
-      const findVersionArgs = {
-        limit: 1,
-        pagination: false,
+    if (unpublish || autosave) {
+      result = await updateLatestVersion({
+        id,
+        collection,
+        global,
+        now,
+        payload,
         req,
-        sort: '-updatedAt',
-      }
-
-      if (collection) {
-        ;({ docs } = await payload.db.findVersions<TData>({
-          ...findVersionArgs,
-          collection: collection.slug,
-          where: {
-            parent: {
-              equals: id,
-            },
-          },
-        }))
-      } else {
-        ;({ docs } = await payload.db.findGlobalVersions<TData>({
-          ...findVersionArgs,
-          global: global!.slug,
-        }))
-      }
-
-      const [latestVersion] = docs
-
-      if (latestVersion) {
-        createNewVersion = false
-
-        const updateVersionArgs = {
-          id: latestVersion.id,
-          req,
-          versionData: {
-            createdAt: new Date(latestVersion.createdAt).toISOString(),
-            latest: true,
-            parent: id,
-            updatedAt: now,
-            version: {
-              ...versionData,
-            },
-          },
-        }
-
-        if (collection) {
-          result = await payload.db.updateVersion<TData>({
-            ...updateVersionArgs,
-            collection: collection.slug,
-            req,
-          })
-        } else {
-          result = await payload.db.updateGlobalVersion<TData>({
-            ...updateVersionArgs,
-            global: global!.slug,
-            req,
-          })
-        }
-      }
+        shouldUpdate: autosave ? (v) => 'autosave' in v && v.autosave === true : undefined,
+        versionData,
+      })
     }
 
-    if (autosave) {
-      let docs
-      const findVersionArgs = {
-        limit: 1,
-        pagination: false,
-        req,
-        sort: '-updatedAt',
-      }
+    if (!result) {
+      createdNewVersion = true
 
-      if (collection) {
-        ;({ docs } = await payload.db.findVersions<TData>({
-          ...findVersionArgs,
-          collection: collection.slug,
-          limit: 1,
-          pagination: false,
-          req,
-          where: {
-            parent: {
-              equals: id,
-            },
-          },
-        }))
-      } else {
-        ;({ docs } = await payload.db.findGlobalVersions<TData>({
-          ...findVersionArgs,
-          global: global!.slug,
-          limit: 1,
-          pagination: false,
-          req,
-        }))
-      }
-      const [latestVersion] = docs
-
-      // overwrite the latest version if it's set to autosave
-      if (latestVersion && 'autosave' in latestVersion && latestVersion.autosave === true) {
-        createNewVersion = false
-
-        const updateVersionArgs = {
-          id: latestVersion.id,
-          req,
-          versionData: {
-            createdAt: new Date(latestVersion.createdAt).toISOString(),
-            latest: true,
-            parent: id,
-            updatedAt: now,
-            version: {
-              ...versionData,
-            },
-          },
-        }
-
-        if (collection) {
-          result = await payload.db.updateVersion<TData>({
-            ...updateVersionArgs,
-            collection: collection.slug,
-            req,
-          })
-        } else {
-          result = await payload.db.updateGlobalVersion<TData>({
-            ...updateVersionArgs,
-            global: global!.slug,
-            req,
-          })
-        }
-      }
-    }
-
-    if (createNewVersion) {
       const createVersionArgs = {
         autosave: Boolean(autosave),
         collectionSlug: undefined as string | undefined,
@@ -251,7 +139,7 @@ export async function saveVersion<TData extends JsonObject = JsonObject>({
 
   const max = getVersionsMax(collection || global!)
 
-  if (createNewVersion && max > 0) {
+  if (createdNewVersion && max > 0) {
     await enforceMaxVersions({
       id,
       collection,

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -24,6 +24,7 @@ type Args<T extends JsonObject = JsonObject> = {
   returning?: boolean
   select?: SelectType
   snapshot?: any
+  unpublish?: boolean
 }
 
 export async function saveVersion<TData extends JsonObject = JsonObject>(
@@ -49,6 +50,7 @@ export async function saveVersion<TData extends JsonObject = JsonObject>({
   returning,
   select,
   snapshot,
+  unpublish,
 }: Args<TData>): Promise<JsonObject | null> {
   let result: JsonObject | undefined
   let createNewVersion = true
@@ -67,6 +69,67 @@ export async function saveVersion<TData extends JsonObject = JsonObject>({
   }
 
   try {
+    if (unpublish) {
+      let docs
+      const findVersionArgs = {
+        limit: 1,
+        pagination: false,
+        req,
+        sort: '-updatedAt',
+      }
+
+      if (collection) {
+        ;({ docs } = await payload.db.findVersions<TData>({
+          ...findVersionArgs,
+          collection: collection.slug,
+          where: {
+            parent: {
+              equals: id,
+            },
+          },
+        }))
+      } else {
+        ;({ docs } = await payload.db.findGlobalVersions<TData>({
+          ...findVersionArgs,
+          global: global!.slug,
+        }))
+      }
+
+      const [latestVersion] = docs
+
+      if (latestVersion) {
+        createNewVersion = false
+
+        const updateVersionArgs = {
+          id: latestVersion.id,
+          req,
+          versionData: {
+            createdAt: new Date(latestVersion.createdAt).toISOString(),
+            latest: true,
+            parent: id,
+            updatedAt: now,
+            version: {
+              ...versionData,
+            },
+          },
+        }
+
+        if (collection) {
+          result = await payload.db.updateVersion<TData>({
+            ...updateVersionArgs,
+            collection: collection.slug,
+            req,
+          })
+        } else {
+          result = await payload.db.updateGlobalVersion<TData>({
+            ...updateVersionArgs,
+            global: global!.slug,
+            req,
+          })
+        }
+      }
+    }
+
     if (autosave) {
       let docs
       const findVersionArgs = {

--- a/packages/payload/src/versions/updateLatestVersion.ts
+++ b/packages/payload/src/versions/updateLatestVersion.ts
@@ -1,0 +1,92 @@
+import type { SanitizedCollectionConfig } from '../collections/config/types.js'
+import type { SanitizedGlobalConfig } from '../globals/config/types.js'
+import type { Payload } from '../index.js'
+import type { JsonObject, PayloadRequest } from '../types/index.js'
+
+type Args<TData extends JsonObject> = {
+  collection?: SanitizedCollectionConfig
+  global?: SanitizedGlobalConfig
+  id?: number | string
+  now: string
+  payload: Payload
+  req?: PayloadRequest
+  shouldUpdate?: (latestVersion: JsonObject) => boolean
+  versionData: TData
+}
+
+/**
+ * Finds the latest version and updates it in place if `shouldUpdate` returns true.
+ * Used by both the unpublish and autosave paths in `saveVersion` to avoid creating
+ * a redundant new version.
+ *
+ * Returns the updated version result, or `undefined` if no update was performed.
+ */
+export async function updateLatestVersion<TData extends JsonObject>({
+  id,
+  collection,
+  global,
+  now,
+  payload,
+  req,
+  shouldUpdate = () => true,
+  versionData,
+}: Args<TData>): Promise<JsonObject | undefined> {
+  let docs
+  const findVersionArgs = {
+    limit: 1,
+    pagination: false,
+    req,
+    sort: '-updatedAt',
+  }
+
+  if (collection) {
+    ;({ docs } = await payload.db.findVersions<TData>({
+      ...findVersionArgs,
+      collection: collection.slug,
+      where: {
+        parent: {
+          equals: id,
+        },
+      },
+    }))
+  } else {
+    ;({ docs } = await payload.db.findGlobalVersions<TData>({
+      ...findVersionArgs,
+      global: global!.slug,
+    }))
+  }
+
+  const [latestVersion] = docs
+
+  if (!latestVersion || !shouldUpdate(latestVersion)) {
+    return undefined
+  }
+
+  const updateVersionArgs = {
+    id: latestVersion.id,
+    req,
+    versionData: {
+      createdAt: new Date(latestVersion.createdAt).toISOString(),
+      latest: true,
+      parent: id,
+      updatedAt: now,
+      version: {
+        ...versionData,
+      },
+    },
+  }
+
+  if (collection) {
+    return await payload.db.updateVersion<TData>({
+      ...updateVersionArgs,
+      collection: collection.slug,
+      req,
+    })
+  }
+
+  return await payload.db.updateGlobalVersion<TData>({
+    ...updateVersionArgs,
+    global: global!.slug,
+    req,
+  })
+}

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1367,6 +1367,105 @@ describe('Versions', () => {
       })
     })
 
+    describe('Unpublish', () => {
+      afterEach(async () => {
+        await cleanupDocuments({
+          collectionSlugs: [draftCollectionSlug],
+          payload,
+        })
+      })
+
+      it('should not create a new version when unpublishing a collection document', async () => {
+        const doc = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            _status: 'published',
+            description: 'test',
+            title: 'unpublish test',
+          },
+        })
+
+        const initialVersions = await payload.findVersions({
+          collection: draftCollectionSlug,
+          where: { parent: { equals: doc.id } },
+        })
+
+        expect(initialVersions.docs).toHaveLength(1)
+        expect(initialVersions.docs[0].version._status).toBe('published')
+
+        const unpublished = await payload.update({
+          id: doc.id,
+          collection: draftCollectionSlug,
+          data: { _status: 'draft' },
+          unpublishAllLocales: true,
+        })
+
+        expect(unpublished._status).toBe('draft')
+
+        const afterVersions = await payload.findVersions({
+          collection: draftCollectionSlug,
+          where: { parent: { equals: doc.id } },
+        })
+
+        expect(afterVersions.docs).toHaveLength(1)
+        expect(afterVersions.docs[0].version._status).toBe('draft')
+      })
+
+      it('should not create a new version when unpublishing a global', async () => {
+        await payload.updateGlobal({
+          slug: draftGlobalSlug,
+          data: { _status: 'published', title: 'unpublish global test' },
+        })
+
+        const initialVersions = await payload.findGlobalVersions({
+          slug: draftGlobalSlug,
+        })
+
+        const initialCount = initialVersions.docs.length
+
+        await payload.updateGlobal({
+          slug: draftGlobalSlug,
+          data: { _status: 'draft' },
+          unpublishAllLocales: true,
+        })
+
+        const afterVersions = await payload.findGlobalVersions({
+          slug: draftGlobalSlug,
+        })
+
+        expect(afterVersions.docs).toHaveLength(initialCount)
+        expect(afterVersions.docs[0].version._status).toBe('draft')
+
+        await cleanupGlobal({ payload, globalSlug: draftGlobalSlug })
+      })
+
+      it('should update main table _status to draft when unpublishing', async () => {
+        const doc = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            _status: 'published',
+            description: 'test',
+            title: 'main table unpublish test',
+          },
+        })
+
+        await payload.update({
+          id: doc.id,
+          collection: draftCollectionSlug,
+          data: { _status: 'draft' },
+          unpublishAllLocales: true,
+        })
+
+        const found = await payload.findByID({
+          id: doc.id,
+          collection: draftCollectionSlug,
+          draft: false,
+        })
+
+        expect(found._status).toBe('draft')
+      })
+    })
+
     describe('Draft Types', () => {
       afterEach(async () => {
         await cleanupDocuments({


### PR DESCRIPTION
## Summary

Unpublishing a document currently creates a new version in the versions table, even though the content hasn't changed. Only `_status` transitions from `published` to `draft`. This clutters the version history with redundant entries and has been a source of confusion (see #10838, #12342, #15125).

This PR makes unpublish update the latest existing version in-place instead of creating a new one, for both collections and globals.

Closes #10838 (again)

## Related

#10838
#12342
#15125 (Discussion)

## Changes

- `saveVersion` now accepts an `unpublish` flag. When set, it finds the latest version and updates it in-place (same pattern as the existing autosave overwrite path) instead of creating a new version.
- Collection and global update operations pass `unpublish: unpublishAllLocales` to `saveVersion`.

No UI or `next` package changes are needed. The admin UI already sends `unpublishAllLocales=true` in the query string when the user clicks "Unpublish." This parameter already flowed through the endpoint handler, the operation, and into `updateDocument`. The only thing missing was that `saveVersion` didn't use it. This PR makes `saveVersion` check for it.

For normal updates (saving drafts, publishing, editing content), `unpublishAllLocales` is `undefined`, so `!!undefined` evaluates to `false` and the new code path is skipped entirely.

## Scope and limitations

This PR covers the main "Unpublish" action, which sends `unpublishAllLocales=true` even for non-localized collections. This is the case reported in #10838 and #12342.

Single-locale unpublish (the "Unpublish in [locale]" button, available when `localizeStatus` is enabled) is **not** covered by this PR. That flow does not send `unpublishAllLocales=true`. Instead, it falls into the single-locale publish/unpublish code path, which involves data merging and snapshots. The current code does not distinguish between "publish locale X" and "unpublish locale X," so fixing it requires a new flag (e.g. `unpublishLocale`) that the UI would need to send. This should be addressed in a follow-up PR.

## Testing

Run the new tests with:

```
PAYLOAD_DATABASE=postgres pnpm run test:int versions -- --testNamePattern="Unpublish"
```

Without this PR's changes, 2 of the 3 tests fail:

```
FAIL  should not create a new version when unpublishing a collection document
AssertionError: expected [ { id: 249, parent: 24, …(6) }, …(1) ] to have a length of 1 but got 2

FAIL  should not create a new version when unpublishing a global
AssertionError: expected [ …(2) ] to have a length of 1 but got 2
```

The third test (`should update main table _status to draft when unpublishing`) passes both before and after, confirming the main table was already updated correctly.