### PR TITLE
fix(plugin-cloud-storage): generateFileURL for thumbnailURL

### DIFF
--- a/packages/plugin-cloud-storage/src/fields/getFields.ts
+++ b/packages/plugin-cloud-storage/src/fields/getFields.ts
@@ -92,6 +92,39 @@ export const getFields = ({
     } as TextField)
   }
 
+  let existingThumbnailURLFieldIndex = -1
+
+  const existingThumbnailURLField = fields.find((existingField, i) => {
+    if ('name' in existingField && existingField.name === 'thumbnailURL') {
+      existingThumbnailURLFieldIndex = i
+      return true
+    }
+    return false
+  }) as TextField
+
+  if (existingThumbnailURLField && adapter) {
+    fields.splice(existingThumbnailURLFieldIndex, 1)
+
+    fields.push({
+      ...existingThumbnailURLField,
+      hooks: {
+        afterRead: [
+          getAfterReadHook({ adapter, collection, disablePayloadAccessControl, generateFileURL }),
+          ...(existingThumbnailURLField?.hooks?.afterRead || []),
+        ],
+        beforeChange: [
+          getBeforeChangeHook({
+            adapter,
+            collection,
+            disablePayloadAccessControl,
+            generateFileURL,
+          }),
+          ...(existingThumbnailURLField.hooks?.beforeChange || []),
+        ],
+      },
+    } as TextField)
+  }
+
   if (typeof collection.upload === 'object' && collection.upload.imageSizes) {
     let existingSizesFieldIndex = -1
 


### PR DESCRIPTION
### What?

This PR adds two hooks to the `thumbnailURL` field of an upload collection. These hooks generate the URL using the `generateFileURL` function or, if none is provided, the adapter. This aligns the behavior with the `url` field.

### Why?

While the `url` and `sizes.<size>.url` fields are considering the `generateFileURL`, the `thumbnailURL` field does not. I could not find any related issue and assume that this is unintentional behavior.

### How?

Checks if the `thumbnailURL` field exists and if yes, applies the two hooks that are also used for the `url` field. This aligns to the behavior of the `url` field, modulo the fact that if the `thumbnailURL` field does not exist, we do not add it.