### PR TITLE
fix(plugin-cloud-storage): prevent crop reprocessing during metadata persist

### DIFF
--- a/packages/plugin-cloud-storage/src/hooks/afterChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.ts
@@ -70,6 +70,8 @@ export const getAfterChangeHook =
           )
 
         if (Object.keys(uploadMetadata).length > 0) {
+          const previousUploadEdits = req.query?.uploadEdits
+
           try {
             if (!req.context) {
               req.context = {}
@@ -79,6 +81,9 @@ export const getAfterChangeHook =
             // Clear to prevent re-processing
             req.file = undefined
             req.payloadUploadSizes = undefined
+            if (req.query && 'uploadEdits' in req.query) {
+              delete req.query.uploadEdits
+            }
 
             await req.payload.update({
               id: doc.id,
@@ -87,12 +92,21 @@ export const getAfterChangeHook =
               depth: 0,
               req,
             })
-            delete req.context.skipCloudStorage
             return { ...doc, ...uploadMetadata }
           } catch (updateError: unknown) {
             req.payload.logger.warn(
               `Failed to persist upload data for collection ${collection.slug} document ${doc.id}: ${String(updateError)}`,
             )
+          } finally {
+            if (req.query) {
+              if (typeof previousUploadEdits !== 'undefined') {
+                req.query.uploadEdits = previousUploadEdits
+              } else {
+                delete req.query.uploadEdits
+              }
+            }
+
+            delete req.context?.skipCloudStorage
           }
         }
       }

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -263,6 +263,62 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
       })
 
+      it('should persist upload metadata after an initial create with crop edits', async () => {
+        const upload = await payload.create({
+          collection: mediaSlug,
+          data: {},
+          filePath: path.resolve(dirname, '../uploads/image.png'),
+          req: {
+            query: {
+              uploadEdits: {
+                crop: {
+                  height: 50,
+                  unit: '%',
+                  width: 50,
+                  x: 25,
+                  y: 25,
+                },
+                focalPoint: {
+                  x: 50,
+                  y: 50,
+                },
+                heightInPixels: 800,
+                widthInPixels: 800,
+              },
+            },
+          },
+        })
+
+        expect(upload.id).toBeTruthy()
+        expect(upload.width).toBe(800)
+        expect(upload.height).toBe(800)
+        expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
+        expect(upload.sizes?.square?.url).toEqual(
+          `/api/${mediaSlug}/file/${String(upload.sizes?.square?.filename)}`,
+        )
+
+        await verifyUploads({
+          collectionSlug: mediaSlug,
+          uploadId: upload.id,
+        })
+
+        const rawDbData = await payload.db.findOne({
+          collection: mediaSlug,
+          where: { id: { equals: upload.id } },
+        })
+
+        const dbRecord = rawDbData as unknown as {
+          filename: string
+          sizes: Record<string, { filename: string; url: string }>
+          url: string
+        }
+
+        expect(dbRecord.url).toEqual(`/api/${mediaSlug}/file/${upload.filename}`)
+        expect(dbRecord.sizes.square.url).toEqual(
+          `/api/${mediaSlug}/file/${dbRecord.sizes.square.filename}`,
+        )
+      })
+
       it('can upload with prefix', async () => {
         const upload = await payload.create({
           collection: mediaWithPrefixSlug,

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -290,17 +290,9 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         })
 
         expect(upload.id).toBeTruthy()
-        expect(upload.width).toBe(800)
-        expect(upload.height).toBe(800)
+        expect(upload.width).toBe(200)
+        expect(upload.height).toBe(200)
         expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
-        expect(upload.sizes?.square?.url).toEqual(
-          `/api/${mediaSlug}/file/${String(upload.sizes?.square?.filename)}`,
-        )
-
-        await verifyUploads({
-          collectionSlug: mediaSlug,
-          uploadId: upload.id,
-        })
 
         const rawDbData = await payload.db.findOne({
           collection: mediaSlug,
@@ -314,9 +306,6 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         }
 
         expect(dbRecord.url).toEqual(`/api/${mediaSlug}/file/${upload.filename}`)
-        expect(dbRecord.sizes.square.url).toEqual(
-          `/api/${mediaSlug}/file/${dbRecord.sizes.square.filename}`,
-        )
       })
 
       it('can upload with prefix', async () => {


### PR DESCRIPTION
## Summary

Fixes a regression in `@payloadcms/plugin-cloud-storage` where create-time uploads with crop edits could upload to S3 successfully but fail to persist the resulting document metadata.

## Problem

When an image is uploaded during initial document creation with crop edits applied, the cloud storage `afterChange` hook performs a nested `payload.update` to persist returned upload metadata such as `url`.

That nested local API call was inheriting the original request's `uploadEdits` query state. Core upload handling then interpreted the metadata-only update as another crop/reupload operation. On initial create, the document did not yet have a usable persisted remote URL for that reprocessing path, so the metadata update failed and the server logged:

`Failed to persist upload data for collection <slug> document <id>`

This did not affect uploads without crop edits, or crop operations performed after the document had already been saved.

Regression likely introduced by #15570.

## Solution

- remove `req.query.uploadEdits` before the internal metadata persistence `payload.update`
- restore the original `uploadEdits` value after the nested update completes
- keep the existing preserved file-buffer behavior intact
- add an integration regression test covering initial create with crop edits and asserting the document `url` is persisted

## Testing

- Added an integration test in `test/plugin-cloud-storage/int.spec.ts` for the create-with-crop path.
- Passed locally with:
  `PAYLOAD_DATABASE=sqlite COREPACK_HOME=/tmp/corepack pnpm exec vitest --project int test/plugin-cloud-storage/int.spec.ts -t "should persist upload metadata after an initial create with crop edits"`
