### PR TITLE
fix: skip id search condition when value is not a valid id format

### DIFF
--- a/packages/payload/src/utilities/mergeListSearchAndWhere.ts
+++ b/packages/payload/src/utilities/mergeListSearchAndWhere.ts
@@ -40,11 +40,21 @@ export const mergeListSearchAndWhere = ({ collectionConfig, search, where = {} }
 
     const searchAsConditions = (
       collectionConfig.admin.listSearchableFields || [collectionConfig.admin?.useAsTitle || 'id']
-    ).map((fieldName) => ({
-      [fieldName]: {
-        like: search,
-      },
-    }))
+    )
+      .filter((fieldName) => {
+        if (fieldName === 'id') {
+          const trimmed = search.trim()
+          const isNumeric = /^\d+$/.test(trimmed)
+          const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed)
+          return isNumeric || isUUID
+        }
+        return true
+      })
+      .map((fieldName) => ({
+        [fieldName]: {
+          like: search,
+        },
+      }))
 
     if (searchAsConditions.length > 0) {
       copyOfWhere = hoistQueryParamsToAnd(copyOfWhere, {


### PR DESCRIPTION
## Summary
Fixes #15648.

**Root cause:** `mergeListSearchAndWhere()` builds `{ id: { like: search } }` for every searchable field including `id`. When the search term is non-numeric (e.g. "test"), the drizzle query layer converts `like` to `equals` for number fields and coerces the value to `Number("test")` = `NaN`. With versioned collections, this `NaN` reaches PostgreSQL as `parent_id = NaN`, causing `invalid input syntax for type integer: "NaN"`.

**Fix:** Filter out `id` from search conditions when the search value is not a valid integer or UUID, preventing `NaN` from ever reaching the database.

## Changes
- `packages/payload/src/utilities/mergeListSearchAndWhere.ts`: Added a filter step that skips `id` from search conditions when the search value doesn't match a numeric or UUID pattern.

## Testing
- Verified fix prevents NaN from reaching the database for non-numeric searches
- Numeric ID searches (e.g. "123") continue to work
- UUID ID searches continue to work
- Other searchable fields (e.g. "title") are unaffected

Made with [Cursor](https://cursor.com)