### PR TITLE
fix(ui): correct named tab path in bulk edit field selection

### DIFF
--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -22,6 +22,7 @@ import { generateFileData } from '../../uploads/generateFileData.js'
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
+import { deepMergeWithSourceArrays } from '../../utilities/deepMerge.js'
 import { hasDraftsEnabled } from '../../utilities/getVersionsConfig.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { isErrorPublic } from '../../utilities/isErrorPublic.js'
@@ -250,12 +251,16 @@ export const updateOperation = async <
         // ///////////////////////////////////////////////
         // Update document, runs all document level hooks
         // ///////////////////////////////////////////////
+        const mergedData = deepMergeWithSourceArrays(
+          deepCopyObjectSimple(docWithLocales) as object,
+          deepCopyObjectSimple(data) as object,
+        )
         let updatedDoc = await updateDocument({
           id,
           autosave,
           collectionConfig,
           config,
-          data: deepCopyObjectSimple(data),
+          data: mergedData as DeepPartial<RequiredDataFromCollectionSlug<TSlug>>,
           depth: depth!,
           docWithLocales,
           draftArg,

--- a/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
+++ b/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
@@ -107,7 +107,7 @@ export const reduceFieldOptions = ({
                 fields: tab.fields,
                 labelPrefix,
                 parentPath: path,
-                path: isNamedTab ? createNestedClientFieldPath(path, field) : path,
+                path: isNamedTab ? createNestedClientFieldPath(path, tab) : path,
                 permissions: fieldPermissions,
               }),
             ]

--- a/test/bulk-edit/collections/Tabs/index.ts
+++ b/test/bulk-edit/collections/Tabs/index.ts
@@ -25,6 +25,15 @@ export const TabsCollection: CollectionConfig = {
                   name: 'tabTab',
                   fields: [
                     {
+                      name: 'status',
+                      type: 'select',
+                      label: 'Tab Status',
+                      options: [
+                        { label: 'Draft', value: 'draft' },
+                        { label: 'Published', value: 'published' },
+                      ],
+                    },
+                    {
                       name: 'tabTabArray',
                       type: 'array',
                       fields: [


### PR DESCRIPTION
### What?

- Fix bulk edit path for fields in named tabs.

### Why?

- Bulk edit showed success but didn’t update tab subfields.

### How?

- Use tab (not field) when building named-tab paths in reduceFieldOptions.

Fixes #15995