### PR TITLE
fix(ui): open folder items in new tab on CMD/Shift+double-click

### DIFF
--- a/packages/ui/src/providers/Folders/index.tsx
+++ b/packages/ui/src/providers/Folders/index.tsx
@@ -240,6 +240,7 @@ export function FolderProvider({
   const [breadcrumbs, setBreadcrumbs] =
     React.useState<FolderContextValue['breadcrumbs']>(_breadcrumbsFromProps)
   const lastClickTime = React.useRef<null | number>(null)
+  const lastClickItemKey = React.useRef<FolderDocumentItemKey | null>(null)
   const totalCount = subfolders.length + documents.length
 
   const clearSelections = React.useCallback(() => {
@@ -320,10 +321,33 @@ export function FolderProvider({
   }, [selectedItemKeys, getItem])
 
   const navigateAfterSelection = React.useCallback(
-    ({ collectionSlug, docID }: { collectionSlug: string; docID?: number | string }) => {
+    ({
+      collectionSlug,
+      docID,
+      newTab,
+    }: {
+      collectionSlug: string
+      docID?: number | string
+      newTab?: boolean
+    }) => {
       if (drawerDepth === 1) {
         // not in a drawer (default is 1)
-        if (collectionSlug === folderCollectionSlug) {
+        if (newTab) {
+          // CMD/Shift + double-click: open in a new browser tab
+          const url =
+            collectionSlug === folderCollectionSlug
+              ? getFolderRoute(docID)
+              : collectionSlug
+                ? formatAdminURL({
+                    adminRoute: config.routes.admin,
+                    path: `/collections/${collectionSlug}/${docID}`,
+                  })
+                : null
+          if (url) {
+            window.open(url, '_blank')
+            clearSelections()
+          }
+        } else if (collectionSlug === folderCollectionSlug) {
           // clicked on folder, take the user to the folder view
           startRouteTransition(() => {
             router.push(getFolderRoute(docID))
@@ -584,12 +608,33 @@ export function FolderProvider({
 
   const onItemClick: FolderContextValue['onItemClick'] = React.useCallback(
     ({ event, item: clickedItem }) => {
-      let doubleClicked: boolean = false
       const isCtrlPressed = event.ctrlKey || event.metaKey
       const isShiftPressed = event.shiftKey
       const isCurrentlySelected = selectedItemKeys.has(clickedItem.itemKey)
       const allItems = [...subfolders, ...documents]
       const currentItemIndex = allItems.findIndex((item) => item.itemKey === clickedItem.itemKey)
+
+      // Double-click detection: runs before modifier-key checks so that
+      // CMD/Shift+double-click can open in a new tab rather than triggering
+      // multi-select. We track last-clicked item in a dedicated ref so that
+      // modifier-key single-clicks (which don't reach the else branch) still
+      // count toward the next double-click.
+      const now = Date.now()
+      const doubleClicked =
+        event.type !== 'pointermove' &&
+        now - lastClickTime.current < 400 &&
+        lastClickItemKey.current === clickedItem.itemKey
+      lastClickTime.current = now
+      lastClickItemKey.current = clickedItem.itemKey
+
+      if (doubleClicked) {
+        navigateAfterSelection({
+          collectionSlug: clickedItem.relationTo,
+          docID: extractID(clickedItem.value),
+          newTab: isCtrlPressed || isShiftPressed,
+        })
+        return
+      }
 
       if (allowMultiSelection && isCtrlPressed) {
         event.preventDefault()
@@ -632,24 +677,11 @@ export function FolderProvider({
         }
         setDragOverlayItem(getItem(clickedItem.itemKey))
       } else {
-        // Normal click - select single item
-        const now = Date.now()
-        doubleClicked =
-          now - lastClickTime.current < 400 && dragOverlayItem?.itemKey === clickedItem.itemKey
-        lastClickTime.current = now
-        if (!doubleClicked) {
-          updateSelections({
-            indexes: isCurrentlySelected && selectedItemKeys.size === 1 ? [] : [currentItemIndex],
-          })
-        }
-        setDragOverlayItem(getItem(clickedItem.itemKey))
-      }
-
-      if (doubleClicked) {
-        navigateAfterSelection({
-          collectionSlug: clickedItem.relationTo,
-          docID: extractID(clickedItem.value),
+        // Normal single click - select item
+        updateSelections({
+          indexes: isCurrentlySelected && selectedItemKeys.size === 1 ? [] : [currentItemIndex],
         })
+        setDragOverlayItem(getItem(clickedItem.itemKey))
       }
     },
     [
@@ -657,7 +689,7 @@ export function FolderProvider({
       subfolders,
       documents,
       allowMultiSelection,
-      dragOverlayItem,
+      lastClickItemKey,
       getItem,
       updateSelections,
       navigateAfterSelection,


### PR DESCRIPTION
## What I did

Fixes #15837

When navigating the folder view, holding CMD or Shift while **double-clicking** a file card or table row now opens the item in a new browser tab.

## Root cause

Two things were broken:

**1. No new-tab support in `navigateAfterSelection`** — navigation always went through `router.push()`, which navigates in-place. Folder cards and draggable table rows are `div`/`tr` elements with pointer event handlers, not `<a>` tags, so the browser's native new-tab behaviour never fired.

**2. Modifier-key double-click was undetectable** — the double-click check only ran in the `else` branch (normal click), after the `isCtrlPressed`/`isShiftPressed` checks. So CMD/Shift+double-click was intercepted for multi-selection before double-click detection ever ran. Also, the previous detection used `dragOverlayItem` as a proxy for "last clicked item", but `dragOverlayItem` isn't reliably set during modifier-key clicks.

## Fix

**`providers/Folders/index.tsx`**

1. Add a `lastClickItemKey` ref to reliably track the last-clicked item, independent of `dragOverlayItem`.
2. Move double-click detection to before the modifier-key branches, so CMD/Shift+double-click is caught first.
3. Add `newTab?: boolean` to `navigateAfterSelection` — when `true`, calls `window.open(url, '_blank')` instead of `router.push()`.

## Behaviour

| Action | Before | After |
| ------ | ------ | ----- |
| Single click | select item | select item (unchanged) |
| Double click | navigate in same tab | navigate in same tab (unchanged) |
| CMD/Shift + single click | multi-select | multi-select (unchanged) |
| CMD/Shift + double click | multi-select (broken) | open in new tab ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)