### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,10 +21,23 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
     ]
   },
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": ["playwright"],
+  "enabledMcpjsonServers": [
+    "playwright"
+  ],
   "permissions": {
     "allow": [
       "Bash(gh issue view:*)",


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing `PostToolUse` and permissions hooks.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing `PostToolUse`, `enabledPlugins`, `permissions`, and MCP server settings are preserved unchanged.

Closes #16005

---

_Disclosure: I am the author and maintainer of `block-no-verify`._