### PR TITLE
fix: skip default validation for virtual fields

### DIFF
--- a/packages/payload/src/fields/config/sanitize.spec.ts
+++ b/packages/payload/src/fields/config/sanitize.spec.ts
@@ -605,4 +605,98 @@ describe('sanitizeFields', () => {
       expect(sanitizedBlock.admin?.disableBlockName).toStrictEqual(undefined)
     })
   })
+
+  describe('virtual fields', () => {
+    it('should assign a noop validate for virtual: true fields', async () => {
+      const fields: Field[] = [
+        {
+          name: 'virtualText',
+          type: 'text',
+          virtual: true,
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.validate).toBeDefined()
+      expect(sanitizedField.validate!('', {} as any)).toBe(true)
+      expect(sanitizedField.validate!(undefined as any, {} as any)).toBe(true)
+    })
+
+    it('should assign a noop validate for virtual: "string" fields', async () => {
+      const fields: Field[] = [
+        {
+          name: 'virtualRef',
+          type: 'text',
+          virtual: 'post.title',
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.validate).toBeDefined()
+      expect(sanitizedField.validate!(undefined as any, {} as any)).toBe(true)
+    })
+
+    it('should not override an explicit validate on a virtual field', async () => {
+      const customValidate = () => true as const
+      const fields: Field[] = [
+        {
+          name: 'virtualText',
+          type: 'text',
+          virtual: true,
+          validate: customValidate,
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.validate).toBe(customValidate)
+    })
+
+    it('should assign default type-based validate for non-virtual fields', async () => {
+      const fields: Field[] = [
+        {
+          name: 'normalText',
+          type: 'text',
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.validate).toBeDefined()
+      // Non-virtual text field should use the text validator which checks required/minLength/etc.
+      // Passing undefined with required should fail
+      const result = sanitizedField.validate!(undefined as any, { required: true, req: { payload: { config: {} }, t: ((v: string) => v) as any } } as any)
+      expect(result).not.toBe(true)
+    })
+  })
 })

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -271,12 +271,16 @@ export const sanitizeFields = async ({
       }
 
       if (typeof field.validate === 'undefined') {
-        const defaultValidate = validations[field.type as keyof typeof validations]
-        if (defaultValidate) {
-          field.validate = (val: any, options: any) =>
-            defaultValidate(val, { ...field, ...options })
-        } else {
+        if ('virtual' in field && field.virtual) {
           field.validate = (): true => true
+        } else {
+          const defaultValidate = validations[field.type as keyof typeof validations]
+          if (defaultValidate) {
+            field.validate = (val: any, options: any) =>
+              defaultValidate(val, { ...field, ...options })
+          } else {
+            field.validate = (): true => true
+          }
         }
       }
 


### PR DESCRIPTION
### What?

Virtual fields (`virtual: true` or `virtual: "path"`) no longer get a default type-based validator during field sanitization. They receive a noop validator instead.

### Why?

Virtual fields are populated server-side (via hooks, built-in population, or plugins), so their value is `undefined` in form state. The default validator causes false validation errors in the admin UI that users cannot resolve.

### How?

In `sanitize.ts`, when assigning a default validator, check if the field is virtual first. If so, assign `() => true` instead of the type-based validator. Explicit `validate` functions are still preserved.

Fixes #16012
Related #16013

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213743778134481