### PR TITLE
fix: default virtual fields to readOnly in admin UI

### DIFF
--- a/packages/payload/src/fields/config/sanitize.spec.ts
+++ b/packages/payload/src/fields/config/sanitize.spec.ts
@@ -695,8 +695,95 @@ describe('sanitizeFields', () => {
       expect(sanitizedField.validate).toBeDefined()
       // Non-virtual text field should use the text validator which checks required/minLength/etc.
       // Passing undefined with required should fail
-      const result = sanitizedField.validate!(undefined as any, { required: true, req: { payload: { config: {} }, t: ((v: string) => v) as any } } as any)
+      const result = sanitizedField.validate!(
+        undefined as any,
+        { required: true, req: { payload: { config: {} }, t: ((v: string) => v) as any } } as any,
+      )
       expect(result).not.toBe(true)
+    })
+
+    it('should default readOnly to true for virtual: true fields', async () => {
+      const fields: Field[] = [
+        {
+          name: 'virtualText',
+          type: 'text',
+          virtual: true,
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.admin?.readOnly).toBe(true)
+    })
+
+    it('should default readOnly to true for virtual: "string" fields', async () => {
+      const fields: Field[] = [
+        {
+          name: 'virtualRef',
+          type: 'text',
+          virtual: 'post.title',
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.admin?.readOnly).toBe(true)
+    })
+
+    it('should not override readOnly: false on virtual fields', async () => {
+      const fields: Field[] = [
+        {
+          name: 'virtualText',
+          type: 'text',
+          virtual: true,
+          admin: { readOnly: false },
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.admin?.readOnly).toBe(false)
+    })
+
+    it('should not set readOnly on non-virtual fields', async () => {
+      const fields: Field[] = [
+        {
+          name: 'normalText',
+          type: 'text',
+        },
+      ]
+
+      const sanitizedField = (
+        await sanitizeFields({
+          config,
+          collectionConfig,
+          fields,
+          validRelationships: [],
+        })
+      )[0] as TextField
+
+      expect(sanitizedField.admin?.readOnly).toBeUndefined()
     })
   })
 })

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -356,6 +356,10 @@ export const sanitizeField = async ({
     field.admin = {}
   }
 
+  if ('virtual' in field && field.virtual && field.admin.readOnly !== false && fieldAffectsData) {
+    field.admin.readOnly = true
+  }
+
   // Make sure that the richText field has an editor
   if (field.type === 'richText') {
     const sanitizeRichText = async (_config: SanitizedConfig) => {


### PR DESCRIPTION
### What?

Virtual fields (`virtual: true` or `virtual: "path"`) now default to `admin.readOnly: true` during field sanitization.

### Why?

Virtual fields are populated server-side and not persisted from user input. Without `readOnly`, users can type into them but edits are silently discarded on save — confusing UX with no indication the field is virtual.

### How?

In `sanitize.ts`, after initializing `field.admin`, set `readOnly: true` for virtual fields unless the user has explicitly set `readOnly: false`.

Fixes #16013
Related #16012

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213743633176017