### PR TITLE
fix: validate relative URLs in getExternalFile

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -2,6 +2,7 @@ import type { PayloadRequest } from '../types/index.js'
 import type { File, FileData, UploadConfig } from './types.js'
 
 import { APIError } from '../errors/index.js'
+import { getRequestOrigin } from '../utilities/getRequestOrigin.js'
 import { isURLAllowed } from '../utilities/isURLAllowed.js'
 import { safeFetch } from './safeFetch.js'
 
@@ -17,9 +18,20 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
   if (typeof url === 'string') {
     let fileURL = url
     if (!url.startsWith('http')) {
-      // URL points to the same server - we can send any cookies safely to our server.
+      if (!url.startsWith('/')) {
+        throw new APIError('Invalid file url: relative URLs must start with /', 400)
+      }
+
+      const baseUrl = getRequestOrigin({ config: req.payload.config, req })
+      if (!baseUrl) {
+        throw new APIError(
+          'Cannot resolve file URL. Configure serverURL in your Payload config.',
+          500,
+        )
+      }
+
+      // URL is same-origin, safe to forward cookies
       trimAuthCookies = false
-      const baseUrl = req.headers.get('origin') || `${req.protocol}://${req.headers.get('host')}`
       fileURL = `${baseUrl}${url}`
     }
 

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -931,6 +931,25 @@ describe('Collections - Uploads', () => {
 
         fetchSpy.mockRestore()
       })
+
+      it('should reject relative URLs that do not start with / to prevent SSRF via Origin header manipulation', async () => {
+        const req = await createPayloadRequest({
+          config: payload.config,
+          request: new Request('http://localhost:3000', {
+            headers: new Headers({
+              origin: 'https://attacker.example',
+            }),
+          }),
+        })
+
+        await expect(
+          getExternalFile({
+            data: { url: 'malicious-path' },
+            req,
+            uploadConfig: { skipSafeFetch: true },
+          }),
+        ).rejects.toThrow('Invalid file url: relative URLs must start with /')
+      })
     })
 
     describe('filters', () => {


### PR DESCRIPTION
## Summary
- Validates that relative URLs start with `/` before processing
- Uses `getRequestOrigin` for consistent base URL resolution

## Test plan
- Added test case for URL validation