### PR TITLE
fix(plugin-cloud-storage): fall back to default prefix during create

### DIFF
--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -56,6 +56,22 @@ export async function getFilePrefix({
       ],
     },
   })
-  const prefix = files?.docs?.[0]?.prefix
-  return prefix ? sanitizePrefix(prefix as string) : ''
+
+  if (files?.docs?.length) {
+    const prefix = files.docs[0].prefix
+    return prefix ? sanitizePrefix(prefix as string) : ''
+  }
+
+  // Document not found — likely mid-create transaction.
+  // Fall back to the collection's configured default prefix.
+  for (const field of collection.fields) {
+    if ('name' in field && field.name === 'prefix' && 'defaultValue' in field) {
+      const defaultPrefix = field.defaultValue
+      if (typeof defaultPrefix === 'string' && defaultPrefix) {
+        return sanitizePrefix(defaultPrefix)
+      }
+    }
+  }
+
+  return ''
 }


### PR DESCRIPTION
### What?
`getFilePrefix()` returns `''` when the document hasn't been committed yet, so S3 lookups use the wrong key and 404.

### Why?
During create with crop enabled, Payload fetches the just-uploaded file through the static handler. That handler calls `getFilePrefix()`, which queries the DB by filename. The document isn't committed yet so the query returns nothing and the prefix resolves to `''`. S3 then looks for `filename` instead of `prefix/filename`.

### How?
When the DB query returns no documents, `getFilePrefix` now checks the collection's `prefix` field definition for its `defaultValue`. This is the same value the plugin sets via `getFields` from the adapter config, so it matches what was used during upload.

Existing behavior is unchanged when:
- `clientUploadContext.prefix` is present (checked first)
- The document exists in the DB (checked second)

The new fallback only activates when both paths miss.

Fixes #15989