### PR TITLE
fix(ui): prevent duplicate options in relationship filter dropdown

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/optionsReducer.ts
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/optionsReducer.ts
@@ -3,13 +3,13 @@ import { getTranslation } from '@payloadcms/translations'
 
 import type { Action, Option } from './types.js'
 
-const reduceToIDs = (options) =>
+const collectLoadedValues = (options) =>
   options.reduce((ids, option) => {
     if (option.options) {
-      return [...ids, ...reduceToIDs(option.options)]
+      return [...ids, ...collectLoadedValues(option.options)]
     }
 
-    return [...ids, option.id]
+    return [...ids, option.value]
   }, [])
 
 const optionsReducer = (state: Option[], action: Action): Option[] => {
@@ -19,7 +19,7 @@ const optionsReducer = (state: Option[], action: Action): Option[] => {
 
       const labelKey = collection.admin.useAsTitle || 'id'
 
-      const loadedIDs = reduceToIDs(state)
+      const loadedIDs = collectLoadedValues(state)
 
       if (!hasMultipleRelations) {
         return [


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
**What?**
Fix duplicate options appearing in the relationship filter dropdown (WhereBuilder) when a value is already selected and the dropdown is reopened — specifically when using condition operator "equals".

**Why?**
`optionsReducer` used `option.id` for deduplication, but options are shaped as { label , value } where the value is the id.

**How?**
changed `optionsReducer` from `option.id` to `option.value`

<hr/>

**Before:** 

https://github.com/user-attachments/assets/8442e8f5-b37b-4354-95cd-89152a934e2d


**After:** 

https://github.com/user-attachments/assets/b5a88151-284e-4a0b-9532-2ca10d0919e8

