### PR TITLE
fix(plugin-multi-tenant): forbidden error when logging in as a user with no tenant and no access to all tenants

### DIFF
--- a/packages/plugin-multi-tenant/src/utilities/getTenantOptions.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getTenantOptions.ts
@@ -39,6 +39,10 @@ export const getTenantOptions = async ({
       })
     : undefined
 
+  if (userTenantIds !== undefined && userTenantIds.length === 0) {
+    return tenantOptions
+  }
+
   const tenants = await payload.find({
     collection: tenantsCollectionSlug,
     depth: 0,

--- a/test/plugin-multi-tenant/collections/Tenants.ts
+++ b/test/plugin-multi-tenant/collections/Tenants.ts
@@ -33,9 +33,12 @@ const tenantAccess: Access = ({ req }) => {
         ],
       }
     }
+
+    // authenticated user with no tenants has no access
+    return false
   }
 
-  // if the user has no assigned tenants, return a filter that allows access to public tenants
+  // unauthenticated — allow access to public tenants only
   return {
     isPublic: {
       equals: true,

--- a/test/plugin-multi-tenant/credentials.ts
+++ b/test/plugin-multi-tenant/credentials.ts
@@ -7,6 +7,10 @@ export const credentials = {
     email: 'jane@blue-dog.com',
     password: 'test',
   },
+  noTenant: {
+    email: 'notenants@example.com',
+    password: 'test',
+  },
   owner: {
     email: 'owner@anchorAndBlueDog.com',
     password: 'test',

--- a/test/plugin-multi-tenant/e2e.spec.ts
+++ b/test/plugin-multi-tenant/e2e.spec.ts
@@ -703,6 +703,24 @@ test.describe('Multi Tenant', () => {
         .toEqual(['Blue Dog', 'Anchor Bar'].sort())
     })
 
+    test('should not throw forbidden error when user has no tenants assigned', async () => {
+      await loginClientSide({
+        data: credentials.noTenant,
+        page,
+        serverURL,
+      })
+
+      // Navigate to a page that triggers getTenantOptions - previously caused a
+      // "Runtime Forbidden" error because payload.find() was called with an empty
+      // userTenantIds array and overrideAccess: false
+      await page.goto(menuItemsURL.list)
+
+      // Ensure the Next.js runtime error overlay is not shown
+      await expect(page.locator('body')).not.toContainText(
+        'You are not allowed to perform this action.',
+      )
+    })
+
     test('should not show public tenants to users with assigned tenants', async () => {
       await loginClientSide({
         data: credentials.owner,

--- a/test/plugin-multi-tenant/payload-types.ts
+++ b/test/plugin-multi-tenant/payload-types.ts
@@ -106,6 +106,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: 'en' | 'es' | 'fr';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -542,6 +545,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-multi-tenant/seed/index.ts
+++ b/test/plugin-multi-tenant/seed/index.ts
@@ -227,4 +227,13 @@ export const seed = async (payload: Payload) => {
       ],
     },
   })
+
+  await payload.create({
+    collection: usersSlug,
+    data: {
+      ...credentials.noTenant,
+      roles: ['user'],
+      // tenants: [],
+    },
+  })
 }


### PR DESCRIPTION
Previously, if you logged in as a user without:
* Any tenant value
* `userHasAccessToAllTenants` is not defined / the condition does not meet for this user

You'd see this error (the admin panel crashes):
<img width="1904" height="600" alt="image" src="https://github.com/user-attachments/assets/ff4f3358-8697-400c-adae-5e512369f386" />
Why? because the call uses `overrideAccess: false` and that user does not have access to the `tenants` collection. Now we early return `[]` in that case

Added an E2E test that previously failed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213815640035525