### PR TITLE
ci: fix localstack startup

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -124,7 +124,7 @@ services:
   # ── LocalStack (S3 emulator) ────────────────────────────────
   localstack:
     profiles: [all, storage]
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.14.0
     container_name: localstack_demo
     ports:
       - '4563-4599:4563-4599'
@@ -133,8 +133,7 @@ services:
       - SERVICES=s3
       - DEBUG=1
       - DATA_DIR=/tmp/localstack/data
-      # TODO: Temporary bypass of auth token requirement, expires April 6, 2026.
-      # Options: 1) set LOCALSTACK_AUTH_TOKEN CI secret, 2) pin older image, 3) switch to MinIO.
+      # TODO: Temporary bypass of auth token requirement, expires April 6, 2026. Replace with LOCALSTACK_AUTH_TOKEN secret or switch to MinIO.
       - LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
     volumes:
       - localstack_data:/var/lib/localstack

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -133,6 +133,7 @@ services:
       - SERVICES=s3
       - DEBUG=1
       - DATA_DIR=/tmp/localstack/data
+      - LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
     volumes:
       - localstack_data:/var/lib/localstack
       - '/var/run/docker.sock:/var/run/docker.sock'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -133,6 +133,8 @@ services:
       - SERVICES=s3
       - DEBUG=1
       - DATA_DIR=/tmp/localstack/data
+      # TODO: Temporary bypass of auth token requirement, expires April 6, 2026.
+      # Options: 1) set LOCALSTACK_AUTH_TOKEN CI secret, 2) pin older image, 3) switch to MinIO.
       - LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
     volumes:
       - localstack_data:/var/lib/localstack

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -133,8 +133,7 @@ services:
       - SERVICES=s3
       - DEBUG=1
       - DATA_DIR=/tmp/localstack/data
-      # TODO: Temporary bypass of auth token requirement, expires April 6, 2026. Replace with LOCALSTACK_AUTH_TOKEN secret or switch to MinIO.
-      - LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
+
     volumes:
       - localstack_data:/var/lib/localstack
       - '/var/run/docker.sock:/var/run/docker.sock'


### PR DESCRIPTION
LocalStack introduced an auth token requirement in recent versions — https://blog.localstack.cloud/localstack-for-aws-release-2026-03-0/

This PR pins LocalStack to `4.14.0` — a version that does not have the auth gate, so no token or bypass env var is needed.

Fixes those tests:
<img width="549" height="389" alt="image" src="https://github.com/user-attachments/assets/1572371c-e959-4100-a0e2-068268c0b580" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213815640035521