### PR TITLE
templates: fix broken images on Next.js 16 by using relative paths for local media

### DIFF
--- a/templates/_template/next.config.ts
+++ b/templates/_template/next.config.ts
@@ -7,6 +7,13 @@ const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
 const nextConfig: NextConfig = {
+  images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
+  },
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],

--- a/templates/blank/next.config.ts
+++ b/templates/blank/next.config.ts
@@ -7,6 +7,13 @@ const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
 const nextConfig: NextConfig = {
+  images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
+  },
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],

--- a/templates/ecommerce/next.config.ts
+++ b/templates/ecommerce/next.config.ts
@@ -11,6 +11,11 @@ const NEXT_PUBLIC_SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://loc
 
 const nextConfig: NextConfig = {
   images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
     qualities: [90, 100],
     remotePatterns: [
       ...[NEXT_PUBLIC_SERVER_URL /* 'https://example.com' */].map((item) => {

--- a/templates/website/next.config.ts
+++ b/templates/website/next.config.ts
@@ -13,6 +13,11 @@ const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
 
 const nextConfig: NextConfig = {
   images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
     qualities: [100],
     remotePatterns: [
       ...[NEXT_PUBLIC_SERVER_URL /* 'https://example.com' */].map((item) => {

--- a/templates/website/src/utilities/getMediaUrl.ts
+++ b/templates/website/src/utilities/getMediaUrl.ts
@@ -5,6 +5,11 @@ import { getClientSideURL } from '@/utilities/getURL'
  * @param url The original URL from the resource
  * @param cacheTag Optional cache tag to append to the URL
  * @returns Properly formatted URL with cache tag if provided
+ *
+ * Local paths (e.g. `/api/media/file/image.webp`) are kept relative, to
+ * avoid private-IP blocks introduced in Next.js 16.
+ *
+ * External URLs are returned as-is.
  */
 export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | null): string => {
   if (!url) return ''
@@ -13,12 +18,11 @@ export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | 
     cacheTag = encodeURIComponent(cacheTag)
   }
 
-  // Check if URL already has http/https protocol
+  // External URLs are returned as-is
   if (url.startsWith('http://') || url.startsWith('https://')) {
     return cacheTag ? `${url}?${cacheTag}` : url
   }
 
-  // Otherwise prepend client-side URL
-  const baseUrl = getClientSideURL()
-  return cacheTag ? `${baseUrl}${url}?${cacheTag}` : `${baseUrl}${url}`
+  // Local paths stay relative, avoiding the private-IP blocks in Next 16.
+  return cacheTag ? `${url}?${cacheTag}` : url
 }

--- a/templates/website/src/utilities/getMediaUrl.ts
+++ b/templates/website/src/utilities/getMediaUrl.ts
@@ -1,15 +1,12 @@
-import { getClientSideURL } from '@/utilities/getURL'
-
 /**
  * Processes media resource URL to ensure proper formatting
  * @param url The original URL from the resource
  * @param cacheTag Optional cache tag to append to the URL
  * @returns Properly formatted URL with cache tag if provided
  *
- * Local paths (e.g. `/api/media/file/image.webp`) are kept relative, to
- * avoid private-IP blocks introduced in Next.js 16.
- *
- * External URLs are returned as-is.
+ * Local paths (e.g. `/api/media/file/image.webp`) are kept relative so
+ * Next.js image optimization treats them as local rather than fetching
+ * through `remotePatterns`, which blocks private IPs since Next.js 16.
  */
 export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | null): string => {
   if (!url) return ''
@@ -18,11 +15,5 @@ export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | 
     cacheTag = encodeURIComponent(cacheTag)
   }
 
-  // External URLs are returned as-is
-  if (url.startsWith('http://') || url.startsWith('https://')) {
-    return cacheTag ? `${url}?${cacheTag}` : url
-  }
-
-  // Local paths stay relative, avoiding the private-IP blocks in Next 16.
   return cacheTag ? `${url}?${cacheTag}` : url
 }

--- a/templates/with-cloudflare-d1/next.config.ts
+++ b/templates/with-cloudflare-d1/next.config.ts
@@ -2,6 +2,13 @@ import { withPayload } from '@payloadcms/next/withPayload'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
+  },
   // Packages with Cloudflare Workers (workerd) specific code
   // Read more: https://opennext.js.org/cloudflare/howtos/workerd
   serverExternalPackages: ['jose', 'pg-cloudflare'],

--- a/templates/with-postgres/next.config.ts
+++ b/templates/with-postgres/next.config.ts
@@ -7,6 +7,13 @@ const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
 const nextConfig: NextConfig = {
+  images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
+  },
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],

--- a/templates/with-vercel-mongodb/next.config.ts
+++ b/templates/with-vercel-mongodb/next.config.ts
@@ -7,6 +7,13 @@ const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
 const nextConfig: NextConfig = {
+  images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
+  },
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],

--- a/templates/with-vercel-postgres/next.config.ts
+++ b/templates/with-vercel-postgres/next.config.ts
@@ -7,6 +7,13 @@ const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
 const nextConfig: NextConfig = {
+  images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
+  },
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],

--- a/templates/with-vercel-website/next.config.ts
+++ b/templates/with-vercel-website/next.config.ts
@@ -13,6 +13,11 @@ const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
 
 const nextConfig: NextConfig = {
   images: {
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+      },
+    ],
     qualities: [100],
     remotePatterns: [
       ...[NEXT_PUBLIC_SERVER_URL /* 'https://example.com' */].map((item) => {

--- a/templates/with-vercel-website/src/utilities/getMediaUrl.ts
+++ b/templates/with-vercel-website/src/utilities/getMediaUrl.ts
@@ -5,6 +5,11 @@ import { getClientSideURL } from '@/utilities/getURL'
  * @param url The original URL from the resource
  * @param cacheTag Optional cache tag to append to the URL
  * @returns Properly formatted URL with cache tag if provided
+ *
+ * Local paths (e.g. `/api/media/file/image.webp`) are kept relative, to
+ * avoid private-IP blocks introduced in Next.js 16.
+ *
+ * External URLs are returned as-is.
  */
 export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | null): string => {
   if (!url) return ''
@@ -13,12 +18,11 @@ export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | 
     cacheTag = encodeURIComponent(cacheTag)
   }
 
-  // Check if URL already has http/https protocol
+  // External URLs are returned as-is
   if (url.startsWith('http://') || url.startsWith('https://')) {
     return cacheTag ? `${url}?${cacheTag}` : url
   }
 
-  // Otherwise prepend client-side URL
-  const baseUrl = getClientSideURL()
-  return cacheTag ? `${baseUrl}${url}?${cacheTag}` : `${baseUrl}${url}`
+  // Local paths stay relative, avoiding the private-IP blocks in Next 16.
+  return cacheTag ? `${url}?${cacheTag}` : url
 }

--- a/templates/with-vercel-website/src/utilities/getMediaUrl.ts
+++ b/templates/with-vercel-website/src/utilities/getMediaUrl.ts
@@ -1,15 +1,12 @@
-import { getClientSideURL } from '@/utilities/getURL'
-
 /**
  * Processes media resource URL to ensure proper formatting
  * @param url The original URL from the resource
  * @param cacheTag Optional cache tag to append to the URL
  * @returns Properly formatted URL with cache tag if provided
  *
- * Local paths (e.g. `/api/media/file/image.webp`) are kept relative, to
- * avoid private-IP blocks introduced in Next.js 16.
- *
- * External URLs are returned as-is.
+ * Local paths (e.g. `/api/media/file/image.webp`) are kept relative so
+ * Next.js image optimization treats them as local rather than fetching
+ * through `remotePatterns`, which blocks private IPs since Next.js 16.
  */
 export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | null): string => {
   if (!url) return ''
@@ -18,11 +15,5 @@ export const getMediaUrl = (url: string | null | undefined, cacheTag?: string | 
     cacheTag = encodeURIComponent(cacheTag)
   }
 
-  // External URLs are returned as-is
-  if (url.startsWith('http://') || url.startsWith('https://')) {
-    return cacheTag ? `${url}?${cacheTag}` : url
-  }
-
-  // Local paths stay relative, avoiding the private-IP blocks in Next 16.
   return cacheTag ? `${url}?${cacheTag}` : url
 }


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/16051

Next.js 16 tightened image security so that absolute URLs resolving to private IPs are now blocked. This broke all media in the templates because `getMediaUrl` was prepending `getClientSideURL()` to build absolute URLs like `http://localhost:3000/api/media/file/image.webp`, which then got rejected during image optimization.

This PR removes the `getClientSideURL()` prepend from `getMediaUrl` for local paths and adds a required `localPatterns` entry. External URLs from storage plugins are still returned as-is.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213794221084158
  - https://app.asana.com/0/0/1213807027473588