### PR TITLE
fix(plugin-nested-docs): await populateBreadcrumbs in resaveChildren

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -71,7 +71,7 @@ export const resaveChildren =
           await req.payload.update({
             id: child.id,
             collection: collection.slug,
-            data: populateBreadcrumbs({
+            data: await populateBreadcrumbs({
               collection,
               data: child,
               generateLabel: pluginConfig.generateLabel,


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?

Add missing `await` before `populateBreadcrumbs()` in `resaveChildren.ts`.

### Why?

`populateBreadcrumbs()` is `async` (returns `Promise<Data>`), but the call in `resaveChildren.ts` is not awaited. The unresolved Promise is passed as `data` to `req.payload.update()` instead of the resolved breadcrumb data, which can cause validation errors or silent data corruption when child documents are resaved after a parent change.

### How?

Add `await` before `populateBreadcrumbs()` on [this line](https://github.com/payloadcms/payload/blob/main/packages/plugin-nested-docs/src/hooks/resaveChildren.ts#L74).