### PR TITLE
fix(plugin-multi-tenant): infinite api calling loop on user switch

### DIFF
--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -251,14 +251,12 @@ export const TenantSelectionProviderClient = ({
         // user logging out
         setSelectedTenantID(undefined)
         deleteTenantCookie()
-        if (tenantOptions.length > 0) {
-          setTenantOptions([])
-        }
+        setTenantOptions((prev) => (prev.length > 0 ? [] : prev))
         router.refresh()
       }
       prevUserID.current = userID
     }
-  }, [userID, userChanged, syncTenants, tenantOptions, initialValue, router])
+  }, [userID, userChanged, syncTenants, initialValue, router])
 
   /**
    * If there is no initial value, clear the tenant and refresh the router.


### PR DESCRIPTION
Previously, using the `multi-tenant` example you were able to reproduce the following:
* Login as `super-admin` `demo@payloadcms.com` `demo`
* Logout and login as `tenant1` `tenant1@payloadcms.com` `demo`
* Logout and login as `tenant2` `tenant2@payloadcms.com` `demo`

You'd see an infinite spam of requests to `/tenants/populate-tenant-options` because of `useEffect` in `TenantSelectionProvider/index.client.tsx`

Why?
Login as Tenant 2 → userChanged=true → syncTenants() fetches data
→ setTenantOptions(new array) → tenantOptions reference changes
→ effect re-runs (tenantOptions in deps) → stale initialValue ≠ cookie
→ syncTenants() again → new array reference again → ∞

This PR makes the `setTenantOptions` call stable (avoid a new reference when not changed) and removes `tenantOptions` from the dependency array (the tenant options selector still updates correctly when logging out / logging in as a different user)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213822464852864