### PR TITLE
fix(drizzle): process bulk deletes sequentially to prevent silent data loss

### DIFF
--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -136,7 +136,7 @@ export const deleteOperation = async <
 
     const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
 
-    const promises = docs.map(async (doc) => {
+    const processDoc = async (doc: (typeof docs)[number]) => {
       let result
 
       const { id } = doc
@@ -307,18 +307,17 @@ export const deleteOperation = async <
         })
       }
       return null
-    })
+    }
 
-    // Process sequentially when using single transaction mode to avoid shared state issues
-    // Process in parallel when using one transaction for better performance
-    let awaitedDocs
-    if (req.payload.db.bulkOperationsSingleTransaction) {
-      awaitedDocs = []
-      for (const promise of promises) {
-        awaitedDocs.push(await promise)
-      }
-    } else {
-      awaitedDocs = await Promise.all(promises)
+    // Process documents sequentially to prevent concurrent deleteOne calls
+    // from interleaving queries on a shared transaction connection.
+    // Using .map(async ...) would eagerly start all callbacks, causing
+    // silent data loss even with for...of await (which only controls the
+    // order results are collected, not execution order).
+    // See: https://github.com/payloadcms/payload/issues/16075
+    const awaitedDocs = []
+    for (const doc of docs) {
+      awaitedDocs.push(await processDoc(doc))
     }
 
     // /////////////////////////////////////

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -15,6 +15,7 @@ import {
   migrateVersionsV1_V2,
 } from '@payloadcms/db-mongodb/migration-utils'
 import { randomUUID } from 'crypto'
+import { inArray } from 'drizzle-orm'
 import * as drizzlePg from 'drizzle-orm/pg-core'
 import * as drizzleSqlite from 'drizzle-orm/sqlite-core'
 import fs from 'fs'
@@ -2272,27 +2273,65 @@ describe('database', () => {
       }
     })
 
-    it('should bulk delete with bulkOperationsSingleTransaction: true', async () => {
-      const originalValue = payload.db.bulkOperationsSingleTransaction
-      payload.db.bulkOperationsSingleTransaction = true
+    it(
+      'should bulk delete every matched document in default transaction mode',
+      { db: (adapterType) => adapterType === 'postgres' },
+      async () => {
+        const originalValue = payload.db.bulkOperationsSingleTransaction
+        const docsPerIteration = 25
+        const iterationCount = 10
+        const testPrefix = `bulk-delete-${Date.now()}-${randomUUID()}`
 
-      try {
-        const posts = await Promise.all([
-          payload.create({ collection, data: { title: 'toDelete1' } }),
-          payload.create({ collection, data: { title: 'toDelete2' } }),
-        ])
+        payload.db.bulkOperationsSingleTransaction = false
 
-        const result = await payload.delete({
-          collection,
-          where: { id: { in: posts.map((p) => p.id) } },
-        })
+        try {
+          for (let iteration = 0; iteration < iterationCount; iteration++) {
+            const iterationPrefix = `${testPrefix}-${iteration}`
 
-        expect(result.docs).toHaveLength(2)
-        expect(result.errors).toHaveLength(0)
-      } finally {
-        payload.db.bulkOperationsSingleTransaction = originalValue
-      }
-    })
+            const docs = await Promise.all(
+              Array.from({ length: docsPerIteration }, (_, index) =>
+                payload.create({
+                  collection: 'simple',
+                  data: {
+                    number: index,
+                    text: `${iterationPrefix}-${index}`,
+                  },
+                }),
+              ),
+            )
+
+            const ids = docs.map((doc) => doc.id)
+
+            const result = await payload.delete({
+              collection: 'simple',
+              where: { id: { in: ids } },
+            })
+
+            const remainingRows = await payload.db.drizzle
+              .select({
+                id: payload.db.tables.simple.id,
+              })
+              .from(payload.db.tables.simple)
+              .where(inArray(payload.db.tables.simple.id, ids))
+
+            expect(result.docs).toHaveLength(docsPerIteration)
+            expect(result.errors).toHaveLength(0)
+            expect(remainingRows).toHaveLength(0)
+          }
+        } finally {
+          payload.db.bulkOperationsSingleTransaction = originalValue
+
+          await payload.delete({
+            collection: 'simple',
+            where: {
+              text: {
+                contains: testPrefix,
+              },
+            },
+          })
+        }
+      },
+    )
 
     it('should CRUD point field', async () => {
       const result = await payload.create({


### PR DESCRIPTION
## Summary

Fixes #16075

`payload.delete({ where })` silently fails to delete 1+ records. Payload reports success and returns the correct IDs, but the records remain in the database.

## Root Cause

The bulk delete operation in `delete.ts` uses `.map(async ...)` to create per-document promises, then either `Promise.all` or `for...of await` to process them. However, `.map(async ...)` eagerly starts **all** async callbacks immediately — `for...of await` only controls the order results are *collected*, not execution order.

This means all `deleteOne` calls run concurrently on a shared transaction connection. Each `deleteOne` performs 3 queries (`selectDistinct` → `findFirst` → `deleteWhere`) that interleave and silently drop deletes.

`bulkOperationsSingleTransaction: true` does **not** fix it because of the same `.map()` antipattern.

## Fix

Replace `.map(async ...)` + `for...of await` with a proper sequential `for...of` loop:

```ts
const processDoc = async (doc) => { /* existing body */ }

const awaitedDocs = []
for (const doc of docs) {
  awaitedDocs.push(await processDoc(doc))
}
```

## Reproduction

- Reproduces within 1-3 iterations on Payload 3.80.0 with `@payloadcms/db-postgres`
- Verified **not present** in 3.41.0 (regression)
- Drizzle direct `db.delete().where()` works perfectly — confirms the bug is in Payload's abstraction layer, not Drizzle or Postgres

See #16075 for full details, POC scripts, and proof.

Made with [Cursor](https://cursor.com)