### PR TITLE
feat(plugin-mcp): allow annotations to be set on custom MCP tools

### DIFF
--- a/packages/plugin-mcp/src/mcp/getMcpHandler.ts
+++ b/packages/plugin-mcp/src/mcp/getMcpHandler.ts
@@ -285,6 +285,7 @@ export const getMCPHandler = (
               server.registerTool(
                 tool.name,
                 {
+                  annotations: tool.annotations,
                   description: tool.description,
                   inputSchema: tool.parameters,
                 },

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -272,6 +272,16 @@ export type PluginMCPServerConfig = {
      */
     tools?: {
       /**
+       * Set the annotations of the tool. This is used by MCP clients to determine the behavior of the tool.
+       */
+      annotations?: {
+        destructiveHint?: boolean
+        idempotentHint?: boolean
+        openWorldHint?: boolean
+        readOnlyHint?: boolean
+        title?: string
+      }
+      /**
        * Set the description of the tool. This is used by MCP clients to determine when to use the tool.
        */
       description: string


### PR DESCRIPTION
### What?

Allow custom mcp tools to define standard annotations to be passed to `registerTool`

### Why?

MCP submission to OpenAI requires "Tool justification"

> Please note you must set these annotations accurately for your app to be approved. If they are not set on the server, our system will assume that the tool is readOnlyHint = false, openWorldHint = true, and destructiveHint = true.

### How?

Add optional config value for tool definitions