### PR TITLE
feat(storage-vercel-blob): add allowOverwrite option

### DIFF
--- a/packages/storage-vercel-blob/src/client/VercelBlobClientUploadHandler.ts
+++ b/packages/storage-vercel-blob/src/client/VercelBlobClientUploadHandler.ts
@@ -5,6 +5,7 @@ import { formatAdminURL } from 'payload/shared'
 
 export type VercelBlobClientUploadHandlerExtra = {
   addRandomSuffix: boolean
+  allowOverwrite: boolean
   baseURL: string
   prefix: string
 }
@@ -14,7 +15,7 @@ export const VercelBlobClientUploadHandler =
     handler: async ({
       apiRoute,
       collectionSlug,
-      extra: { addRandomSuffix, baseURL, prefix = '' },
+      extra: { addRandomSuffix, allowOverwrite, baseURL, prefix = '' },
       file,
       serverHandlerPath,
       serverURL,

--- a/packages/storage-vercel-blob/src/getClientUploadRoute.ts
+++ b/packages/storage-vercel-blob/src/getClientUploadRoute.ts
@@ -9,6 +9,7 @@ type Args = {
     req: PayloadRequest
   }) => boolean | Promise<boolean>
   addRandomSuffix?: boolean
+  allowOverwrite?: boolean
   cacheControlMaxAge?: number
   token: string
 }
@@ -16,7 +17,7 @@ type Args = {
 const defaultAccess: Args['access'] = ({ req }) => !!req.user
 
 export const getClientUploadRoute =
-  ({ access = defaultAccess, addRandomSuffix, cacheControlMaxAge, token }: Args): PayloadHandler =>
+  ({ access = defaultAccess, addRandomSuffix, allowOverwrite, cacheControlMaxAge, token }: Args): PayloadHandler =>
   async (req) => {
     const body = (await req.json!()) as HandleUploadBody
 
@@ -34,6 +35,7 @@ export const getClientUploadRoute =
 
           return Promise.resolve({
             addRandomSuffix,
+            allowOverwrite,
             cacheControlMaxAge,
           })
         },

--- a/packages/storage-vercel-blob/src/handleUpload.ts
+++ b/packages/storage-vercel-blob/src/handleUpload.ts
@@ -13,6 +13,7 @@ type HandleUploadArgs = {
 export const getHandleUpload = ({
   access = 'public',
   addRandomSuffix,
+  allowOverwrite,
   baseUrl,
   cacheControlMaxAge,
   prefix = '',
@@ -24,6 +25,7 @@ export const getHandleUpload = ({
     const result = await put(fileKey, buffer, {
       access,
       addRandomSuffix,
+      allowOverwrite,
       cacheControlMaxAge,
       contentType: mimeType,
       token,

--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -35,6 +35,21 @@ export type VercelBlobStorageOptions = {
   addRandomSuffix?: boolean
 
   /**
+   * Allow overwriting existing blobs with the same pathname.
+   *
+   * When `false` (the default), uploading a file with the same name as an
+   * existing blob will throw an error. This commonly happens when a previous
+   * upload fails partway through (the blob is created but the Payload record
+   * is not), leaving an orphan blob that blocks subsequent uploads of the
+   * same file.
+   *
+   * Set to `true` to silently overwrite the existing blob instead of erroring.
+   *
+   * @default false
+   */
+  allowOverwrite?: boolean
+
+  /**
    * When enabled, fields (like the prefix field) will always be inserted into
    * the collection schema regardless of whether the plugin is enabled. This
    * ensures a consistent schema across all environments.
@@ -82,6 +97,7 @@ export type VercelBlobStorageOptions = {
 const defaultUploadOptions: Partial<VercelBlobStorageOptions> = {
   access: 'public',
   addRandomSuffix: false,
+  allowOverwrite: false,
   cacheControlMaxAge: 60 * 60 * 24 * 365, // 1 year
   enabled: true,
 }
@@ -130,6 +146,7 @@ export const vercelBlobStorage: VercelBlobStoragePlugin =
         access:
           typeof options.clientUploads === 'object' ? options.clientUploads.access : undefined,
         addRandomSuffix: optionsWithDefaults.addRandomSuffix,
+        allowOverwrite: optionsWithDefaults.allowOverwrite,
         cacheControlMaxAge: options.cacheControlMaxAge,
         token: options.token ?? '',
       }),
@@ -185,7 +202,7 @@ function vercelBlobStorageInternal(
   options: { baseUrl: string } & VercelBlobStorageOptions,
 ): Adapter {
   return ({ collection, prefix }): GeneratedAdapter => {
-    const { access, addRandomSuffix, baseUrl, cacheControlMaxAge, clientUploads, token } = options
+    const { access, addRandomSuffix, allowOverwrite, baseUrl, cacheControlMaxAge, clientUploads, token } = options
 
     if (!token) {
       throw new Error('Vercel Blob storage token is required')
@@ -199,6 +216,7 @@ function vercelBlobStorageInternal(
       handleUpload: getHandleUpload({
         access,
         addRandomSuffix,
+        allowOverwrite,
         baseUrl,
         cacheControlMaxAge,
         prefix,

--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -138,6 +138,7 @@ export const vercelBlobStorage: VercelBlobStoragePlugin =
       enabled: !isPluginDisabled && Boolean(options.clientUploads),
       extraClientHandlerProps: (collection) => ({
         addRandomSuffix: !!optionsWithDefaults.addRandomSuffix,
+        allowOverwrite: !!optionsWithDefaults.allowOverwrite,
         baseURL: baseUrl,
         prefix:
           (typeof collection === 'object' && collection.prefix && `${collection.prefix}/`) || '',


### PR DESCRIPTION
## Summary

Adds a new `allowOverwrite` option to `VercelBlobStorageOptions` that passes through to all `@vercel/blob` `put()` calls — both server-side uploads (`handleUpload.ts`) and client upload token generation (`getClientUploadRoute.ts`).

## Problem

When using `clientUploads: true` with `addRandomSuffix: false`, failed uploads leave orphan blobs in Vercel Blob storage. The blob is created successfully, but Payload's server-side processing (image size generation, `generateFileData`) can fail with a 400 error — leaving a blob without a corresponding Payload media record.

Subsequent uploads of the same filename then fail with:

```
Vercel Blob: This blob already exists, use allowOverwrite: true if you want to overwrite it.
```

This is particularly frustrating because the user has no way to clean up the orphan blob through the Payload admin — the media record was never created, so there's nothing to delete.

Related: #14709

## Solution

The `@vercel/blob` SDK already supports `allowOverwrite: true` on `put()` calls, but the Payload adapter didn't expose this option. This PR adds it as a top-level config option:

```ts
vercelBlobStorage({
  token: process.env.BLOB_READ_WRITE_TOKEN,
  collections: { media: true },
  allowOverwrite: true, // new option
})
```

### Changes

- **`index.ts`**: Added `allowOverwrite` to `VercelBlobStorageOptions` type with JSDoc documentation. Passes it through to both `getHandleUpload` and `getClientUploadRoute`.
- **`handleUpload.ts`**: Passes `allowOverwrite` to the `put()` call for server-side uploads.
- **`getClientUploadRoute.ts`**: Passes `allowOverwrite` in the `onBeforeGenerateToken` return value for client-side uploads.

### Default behavior

`allowOverwrite` defaults to `false`, preserving the current behavior. No breaking changes.