### PR TITLE
fix(plugin-ecommerce): return CartOperationResult and propagate errors in cart operations

### DIFF
--- a/packages/plugin-ecommerce/src/currencies/index.ts
+++ b/packages/plugin-ecommerce/src/currencies/index.ts
@@ -5,6 +5,8 @@ export const EUR: Currency = {
   decimals: 2,
   label: 'Euro',
   symbol: '€',
+  symbolPosition: 'before',
+  symbolSeparator: '',
 }
 
 export const USD: Currency = {
@@ -12,6 +14,8 @@ export const USD: Currency = {
   decimals: 2,
   label: 'US Dollar',
   symbol: '$',
+  symbolPosition: 'before',
+  symbolSeparator: '',
 }
 
 export const GBP: Currency = {
@@ -19,4 +23,6 @@ export const GBP: Currency = {
   decimals: 2,
   label: 'British Pound',
   symbol: '£',
+  symbolPosition: 'before',
+  symbolSeparator: '',
 }

--- a/packages/plugin-ecommerce/src/currencies/index.ts
+++ b/packages/plugin-ecommerce/src/currencies/index.ts
@@ -5,8 +5,6 @@ export const EUR: Currency = {
   decimals: 2,
   label: 'Euro',
   symbol: '€',
-  symbolPosition: 'before',
-  symbolSeparator: '',
 }
 
 export const USD: Currency = {
@@ -14,8 +12,6 @@ export const USD: Currency = {
   decimals: 2,
   label: 'US Dollar',
   symbol: '$',
-  symbolPosition: 'before',
-  symbolSeparator: '',
 }
 
 export const GBP: Currency = {
@@ -23,6 +19,4 @@ export const GBP: Currency = {
   decimals: 2,
   label: 'British Pound',
   symbol: '£',
-  symbolPosition: 'before',
-  symbolSeparator: '',
 }

--- a/packages/plugin-ecommerce/src/react/provider/index.tsx
+++ b/packages/plugin-ecommerce/src/react/provider/index.tsx
@@ -36,8 +36,6 @@ const defaultContext: EcommerceContextType = {
         decimals: 2,
         label: 'US Dollar',
         symbol: '$',
-        symbolPosition: 'before',
-        symbolSeparator: '',
       },
     ],
   },
@@ -46,8 +44,6 @@ const defaultContext: EcommerceContextType = {
     decimals: 2,
     label: 'US Dollar',
     symbol: '$',
-    symbolPosition: 'before',
-    symbolSeparator: '',
   },
   decrementItem: async () => {},
   incrementItem: async () => {},
@@ -83,8 +79,6 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
         decimals: 2,
         label: 'US Dollar',
         symbol: '$',
-        symbolPosition: 'before',
-        symbolSeparator: '',
       },
     ],
   },
@@ -1132,12 +1126,13 @@ export const useCurrency = () => {
         return value.toString()
       }
 
-      const { code, decimals } = currencyToUse
+      const { code, decimals, symbolDisplay } = currencyToUse
 
       const locale = options?.locale || 'en'
 
       return new Intl.NumberFormat(locale, {
         currency: code,
+        currencyDisplay: symbolDisplay || 'symbol',
         maximumFractionDigits: decimals,
         minimumFractionDigits: decimals,
         style: 'currency',

--- a/packages/plugin-ecommerce/src/react/provider/index.tsx
+++ b/packages/plugin-ecommerce/src/react/provider/index.tsx
@@ -36,6 +36,8 @@ const defaultContext: EcommerceContextType = {
         decimals: 2,
         label: 'US Dollar',
         symbol: '$',
+        symbolPosition: 'before',
+        symbolSeparator: '',
       },
     ],
   },
@@ -44,6 +46,8 @@ const defaultContext: EcommerceContextType = {
     decimals: 2,
     label: 'US Dollar',
     symbol: '$',
+    symbolPosition: 'before',
+    symbolSeparator: '',
   },
   decrementItem: async () => {},
   incrementItem: async () => {},
@@ -79,6 +83,8 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
         decimals: 2,
         label: 'US Dollar',
         symbol: '$',
+        symbolPosition: 'before',
+        symbolSeparator: '',
       },
     ],
   },
@@ -1116,26 +1122,26 @@ export const useCurrency = () => {
   const { currenciesConfig, currency, setCurrency } = useEcommerce()
 
   const formatCurrency = useCallback(
-    (value?: null | number, options?: { currency?: Currency }): string => {
+    (value?: null | number, options?: { currency?: Currency; locale?: string }): string => {
       if (value === undefined || value === null) {
         return ''
       }
 
       const currencyToUse = options?.currency || currency
-
       if (!currencyToUse) {
         return value.toString()
       }
 
-      if (value === 0) {
-        return `${currencyToUse.symbol}0.${'0'.repeat(currencyToUse.decimals)}`
-      }
+      const { code, decimals } = currencyToUse
 
-      // Convert from base value (e.g., cents) to decimal value (e.g., dollars)
-      const decimalValue = value / Math.pow(10, currencyToUse.decimals)
+      const locale = options?.locale || 'en'
 
-      // Format with the correct number of decimal places
-      return `${currencyToUse.symbol}${decimalValue.toFixed(currencyToUse.decimals)}`
+      return new Intl.NumberFormat(locale, {
+        currency: code,
+        maximumFractionDigits: decimals,
+        minimumFractionDigits: decimals,
+        style: 'currency',
+      }).format(value / Math.pow(10, decimals))
     },
     [currency],
   )

--- a/packages/plugin-ecommerce/src/react/provider/index.tsx
+++ b/packages/plugin-ecommerce/src/react/provider/index.tsx
@@ -15,8 +15,8 @@ import type {
 } from '../../types/index.js'
 
 const defaultContext: EcommerceContextType = {
-  addItem: async () => {},
-  clearCart: async () => {},
+  addItem: async () => ({ success: false, cart: null, message: ''}),
+  clearCart: async () => ({ success: false, cart: null, message: ''}),
   clearSession: () => {},
   config: {
     addressesSlug: 'addresses',
@@ -45,8 +45,8 @@ const defaultContext: EcommerceContextType = {
     label: 'US Dollar',
     symbol: '$',
   },
-  decrementItem: async () => {},
-  incrementItem: async () => {},
+  decrementItem: async () => ({ success: false, cart: null, message: ''}),
+  incrementItem: async () => ({ success: false, cart: null, message: ''}),
   initiatePayment: async () => {},
   isLoading: false,
   mergeCart: async () => {},
@@ -54,7 +54,7 @@ const defaultContext: EcommerceContextType = {
   onLogout: () => {},
   paymentMethods: [],
   refreshCart: async () => {},
-  removeItem: async () => {},
+  removeItem: async () => ({ success: false, cart: null, message: ''}),
   setCurrency: () => {},
   updateAddress: async () => {},
   user: null,
@@ -293,24 +293,28 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
             setCartID(undefined)
             setCart(undefined)
             setCartSecret(undefined)
-            return
+            return result
           }
 
           // Refresh cart with proper depth/populate settings for UI
           const refreshedCart = await getCart(cartID, { secret: cartSecret })
           setCart(refreshedCart)
+
+          return { ...result, cart: refreshedCart }
         } else {
           // If no cartID exists, create a new cart with the item
           const newCart = await createCart({ items: [{ ...item, quantity }] })
 
           setCartID(newCart.id)
           setCart(newCart)
+          return { success: true, cart: newCart}
         }
       } catch (error) {
         if (debug) {
           // eslint-disable-next-line no-console
           console.error('Error adding item to cart:', error)
         }
+        throw error
       } finally {
         setIsLoading(false)
       }
@@ -350,17 +354,19 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
           setCartID(undefined)
           setCart(undefined)
           setCartSecret(undefined)
-          return
+          return result
         }
 
         // Refresh cart with proper depth/populate settings for UI
         const refreshedCart = await getCart(cartID, { secret: cartSecret })
         setCart(refreshedCart)
+        return { ...result, cart: refreshedCart }
       } catch (error) {
         if (debug) {
           // eslint-disable-next-line no-console
           console.error('Error removing item from cart:', error)
         }
+        throw error
       } finally {
         setIsLoading(false)
       }
@@ -401,17 +407,19 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
           setCartID(undefined)
           setCart(undefined)
           setCartSecret(undefined)
-          return
+          return result
         }
 
         // Refresh cart with proper depth/populate settings for UI
         const refreshedCart = await getCart(cartID, { secret: cartSecret })
         setCart(refreshedCart)
+        return { ...result, cart: refreshedCart }
       } catch (error) {
         if (debug) {
           // eslint-disable-next-line no-console
           console.error('Error incrementing item quantity:', error)
         }
+        throw error
       } finally {
         setIsLoading(false)
       }
@@ -452,17 +460,19 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
           setCartID(undefined)
           setCart(undefined)
           setCartSecret(undefined)
-          return
+          return result
         }
 
         // Refresh cart with proper depth/populate settings for UI
         const refreshedCart = await getCart(cartID, { secret: cartSecret })
         setCart(refreshedCart)
+        return { ...result, cart: refreshedCart }
       } catch (error) {
         if (debug) {
           // eslint-disable-next-line no-console
           console.error('Error decrementing item quantity:', error)
         }
+        throw error
       } finally {
         setIsLoading(false)
       }
@@ -500,17 +510,19 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
         setCartID(undefined)
         setCart(undefined)
         setCartSecret(undefined)
-        return
+         return result
       }
 
       // Refresh cart with proper depth/populate settings for UI
       const refreshedCart = await getCart(cartID, { secret: cartSecret })
       setCart(refreshedCart)
+      return { ...result, cart: refreshedCart }
     } catch (error) {
       if (debug) {
         // eslint-disable-next-line no-console
         console.error('Error clearing cart:', error)
       }
+      throw error
     } finally {
       setIsLoading(false)
     }

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -253,15 +253,10 @@ export type Currency = {
    */
   symbol: string
   /**
-   * The position of the currency symbol relative to the amount.
-   * @example 'before' for '$10.00' or 'after' for '10.00€'
+   * The symbol display format
+   * @example 'symbol' | 'code'
    */
-  symbolPosition: 'after' | 'before'
-  /**
-   * The separator between the symbol and the amount.
-   * @example ' ' (a space) for '€ 10.00' or '' (empty string) for '$10.00'
-   */
-  symbolSeparator?: string
+  symbolDisplay?: 'code' | 'symbol'
 }
 
 /**

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -252,6 +252,16 @@ export type Currency = {
    * @example '$'
    */
   symbol: string
+  /**
+   * The position of the currency symbol relative to the amount.
+   * @example 'before' for '$10.00' or 'after' for '10.00€'
+   */
+  symbolPosition: 'after' | 'before'
+  /**
+   * The separator between the symbol and the amount.
+   * @example ' ' (a space) for '€ 10.00' or '' (empty string) for '$10.00'
+   */
+  symbolSeparator?: string
 }
 
 /**

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -17,6 +17,7 @@ import type {
 import type React from 'react'
 
 import type { TypedEcommerce } from './utilities.js'
+import { CartOperationResult } from '../collections/carts/operations/types.js'
 
 export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 
@@ -923,7 +924,7 @@ export type EcommerceContextType<T extends EcommerceCollections = EcommerceColle
   /**
    * Add an item to the cart.
    */
-  addItem: (item: CartItemArgument, quantity?: number) => Promise<void>
+  addItem: (item: CartItemArgument, quantity?: number) => Promise<CartOperationResult | undefined>
   /**
    * All current addresses for the current user.
    * This is used to manage shipping and billing addresses.
@@ -940,7 +941,7 @@ export type EcommerceContextType<T extends EcommerceCollections = EcommerceColle
   /**
    * Clear the cart, removing all items.
    */
-  clearCart: () => Promise<void>
+  clearCart: () => Promise<CartOperationResult | undefined>
   /**
    * Clears all ecommerce session data including cart, addresses, and user state.
    * Should be called when a user logs out.
@@ -978,12 +979,12 @@ export type EcommerceContextType<T extends EcommerceCollections = EcommerceColle
    * If quantity reaches 0, the item will be removed from the cart.
    * @param item - The cart item ID (always a string, as array item IDs are strings in Payload)
    */
-  decrementItem: (item: string) => Promise<void>
+  decrementItem: (item: string) => Promise<CartOperationResult | undefined>
   /**
    * Increment an item in the cart by its array item ID.
    * @param item - The cart item ID (always a string, as array item IDs are strings in Payload)
    */
-  incrementItem: (item: string) => Promise<void>
+  incrementItem: (item: string) => Promise<CartOperationResult | undefined>
   /**
    * Initiate a payment using the selected payment method.
    * This method should be called after the cart is ready for checkout.
@@ -1036,7 +1037,7 @@ export type EcommerceContextType<T extends EcommerceCollections = EcommerceColle
    * Remove an item from the cart by its array item ID.
    * @param item - The cart item ID (always a string, as array item IDs are strings in Payload)
    */
-  removeItem: (item: string) => Promise<void>
+  removeItem: (item: string) => Promise<CartOperationResult | undefined>
   /**
    * The name of the currently selected payment method.
    * This is used to determine which payment method to use when initiating a payment.

--- a/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
+++ b/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from '@payloadcms/ui'
 
 import type { CurrenciesConfig, Currency } from '../../types/index.js'
 
-import { convertFromBaseValue } from '../utilities.js'
+import { useCurrency } from '../../react/provider/index.js'
 
 type Props = {
   cellData?: number
@@ -18,7 +18,7 @@ type Props = {
 export const PriceCell: React.FC<Props> = (args) => {
   const { t } = useTranslation()
   const { cellData, currenciesConfig, currency: currencyFromProps, rowData } = args
-
+  const { formatCurrency } = useCurrency()
   const currency = currencyFromProps || currenciesConfig.supportedCurrencies[0]
 
   if (!currency) {
@@ -42,15 +42,7 @@ export const PriceCell: React.FC<Props> = (args) => {
 
   return (
     <div className="priceCell">
-      {currency.symbolPosition === 'before'
-        ? `<span className="currencySymbol">${currency.symbol}</span>`
-        : ''}
-      {currency.symbolPosition === 'before' && currency.symbolSeparator}
-      <span className="priceValue">{convertFromBaseValue({ baseValue: cellData, currency })}</span>
-      {currency.symbolPosition === 'after' && currency.symbolSeparator}
-      {currency.symbolPosition === 'after'
-        ? `<span className="currencySymbol">${currency.symbol}</span>`
-        : ''}
+      <span className="priceValue">{formatCurrency(cellData, { currency })}</span>
     </div>
   )
 }

--- a/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
+++ b/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
@@ -1,11 +1,73 @@
+// 'use client'
+// import type { DefaultCellComponentProps, TypedCollection } from 'payload'
+
+// import { useTranslation } from '@payloadcms/ui'
+
+// import type { CurrenciesConfig, Currency } from '../../types/index.js'
+
+// import { useCurrency } from '../../react/provider/index.js'
+
+// type Props = {
+//   cellData?: number
+//   currenciesConfig: CurrenciesConfig
+//   currency?: Currency
+//   path: string
+//   rowData: Partial<TypedCollection['products']>
+// } & DefaultCellComponentProps
+
+// export const PriceCell: React.FC<Props> = (args) => {
+//   const { t } = useTranslation()
+//   const { cellData, currenciesConfig, currency: currencyFromProps, rowData } = args
+//   const { formatCurrency } = useCurrency()
+//   const currency = currencyFromProps || currenciesConfig.supportedCurrencies[0]
+
+// const formatPrice = (
+//   baseValue: number,
+//   currency: Currency,
+//   locale = 'en',
+// ): string => {
+//   return new Intl.NumberFormat(locale, {
+//     style: 'currency',
+//     currency: currency.code,
+//     currencyDisplay: currency.symbolDisplay ?? 'symbol',
+//     minimumFractionDigits: currency.decimals,
+//     maximumFractionDigits: currency.decimals,
+//   }).format(baseValue / Math.pow(10, currency.decimals))
+// }
+
+//   if (!currency) {
+//     // @ts-expect-error - plugin translations are not typed yet
+//     return <span>{t('plugin-ecommerce:currencyNotSet')}</span>
+//   }
+
+//   if (
+//     (!cellData || typeof cellData !== 'number') &&
+//     'enableVariants' in rowData &&
+//     rowData.enableVariants
+//   ) {
+//     // @ts-expect-error - plugin translations are not typed yet
+//     return <span>{t('plugin-ecommerce:priceSetInVariants')}</span>
+//   }
+
+//   if (!cellData) {
+//     // @ts-expect-error - plugin translations are not typed yet
+//     return <span>{t('plugin-ecommerce:priceNotSet')}</span>
+//   }
+
+//   return (
+//     <div className="priceCell">
+//       <span className="priceValue">{formatCurrency(cellData, { currency })}</span>
+//     </div>
+//   )
+// }
+
 'use client'
+
 import type { DefaultCellComponentProps, TypedCollection } from 'payload'
 
 import { useTranslation } from '@payloadcms/ui'
 
 import type { CurrenciesConfig, Currency } from '../../types/index.js'
-
-import { useCurrency } from '../../react/provider/index.js'
 
 type Props = {
   cellData?: number
@@ -15,10 +77,26 @@ type Props = {
   rowData: Partial<TypedCollection['products']>
 } & DefaultCellComponentProps
 
+/**
+ * NOTE:
+ * This formatter intentionally duplicates logic used elsewhere (e.g. in react hooks)
+ * to keep PriceCell independent from the react bundle.
+ * Once bundling constraints are clarified, this can be extracted to a shared utility.
+ */
+const formatPrice = (baseValue: number, currency: Currency, locale = 'en'): string => {
+  return new Intl.NumberFormat(locale, {
+    currency: currency.code,
+    currencyDisplay: currency.symbolDisplay ?? 'symbol',
+    maximumFractionDigits: currency.decimals,
+    minimumFractionDigits: currency.decimals,
+    style: 'currency',
+  }).format(baseValue / Math.pow(10, currency.decimals))
+}
+
 export const PriceCell: React.FC<Props> = (args) => {
   const { t } = useTranslation()
   const { cellData, currenciesConfig, currency: currencyFromProps, rowData } = args
-  const { formatCurrency } = useCurrency()
+
   const currency = currencyFromProps || currenciesConfig.supportedCurrencies[0]
 
   if (!currency) {
@@ -27,7 +105,7 @@ export const PriceCell: React.FC<Props> = (args) => {
   }
 
   if (
-    (!cellData || typeof cellData !== 'number') &&
+    (cellData === undefined || typeof cellData !== 'number') &&
     'enableVariants' in rowData &&
     rowData.enableVariants
   ) {
@@ -35,14 +113,14 @@ export const PriceCell: React.FC<Props> = (args) => {
     return <span>{t('plugin-ecommerce:priceSetInVariants')}</span>
   }
 
-  if (!cellData) {
+  if (cellData === undefined) {
     // @ts-expect-error - plugin translations are not typed yet
     return <span>{t('plugin-ecommerce:priceNotSet')}</span>
   }
 
   return (
     <div className="priceCell">
-      <span className="priceValue">{formatCurrency(cellData, { currency })}</span>
+      <span className="priceValue">{formatPrice(cellData, currency)}</span>
     </div>
   )
 }

--- a/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
+++ b/packages/plugin-ecommerce/src/ui/PriceCell/index.tsx
@@ -41,9 +41,16 @@ export const PriceCell: React.FC<Props> = (args) => {
   }
 
   return (
-    <span>
-      {currency.symbol}
-      {convertFromBaseValue({ baseValue: cellData, currency })}
-    </span>
+    <div className="priceCell">
+      {currency.symbolPosition === 'before'
+        ? `<span className="currencySymbol">${currency.symbol}</span>`
+        : ''}
+      {currency.symbolPosition === 'before' && currency.symbolSeparator}
+      <span className="priceValue">{convertFromBaseValue({ baseValue: cellData, currency })}</span>
+      {currency.symbolPosition === 'after' && currency.symbolSeparator}
+      {currency.symbolPosition === 'after'
+        ? `<span className="currencySymbol">${currency.symbol}</span>`
+        : ''}
+    </div>
   )
 }


### PR DESCRIPTION
Previously, addItem, removeItem, incrementItem, decrementItem and clearCart
swallowed errors in catch blocks and returned void, making it impossible for
consumers to determine whether an operation succeeded or failed.

Changes:
- return CartOperationResult (including refreshed cart) on success
- re-throw errors in catch blocks so consumers can use try/catch
- update defaultContext placeholders to match new return types

This allows consumers to handle cart operation results:

```
  try {
   const result: CartOperationResult | undefined  = await addItem(newItem)
    // result contains the updated cart and success (true/false) flag
  } catch (error) {
    // handle failure
  }
```

usage:
```
    
        try {
          const result = await addItem(newItem)

          console.log(result)

          result?.success ? toast.success(t('addedToCart')) : toast.error(t('failedAddedToCart'))
        } catch (error) {
          toast.error(t('failedAddedToCart'))
        }


      
```