### PR TITLE
fix(ui): prevent re-render cascade in UploadHandlersProvider

### DIFF
--- a/packages/ui/src/providers/UploadHandlers/index.tsx
+++ b/packages/ui/src/providers/UploadHandlers/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { UploadCollectionSlug } from 'payload'
 
-import React, { useState } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 
 type UploadHandler = (args: {
   file: File
@@ -19,26 +19,28 @@ export type UploadHandlersContext = {
 const Context = React.createContext<null | UploadHandlersContext>(null)
 
 export const UploadHandlersProvider = ({ children }) => {
-  const [uploadHandlers, setUploadHandlers] = useState<Map<UploadCollectionSlug, UploadHandler>>(
-    () => new Map(),
+  const uploadHandlersRef = useRef<Map<UploadCollectionSlug, UploadHandler>>(new Map())
+
+  const getUploadHandler: UploadHandlersContext['getUploadHandler'] = useCallback(
+    ({ collectionSlug }) => {
+      return uploadHandlersRef.current.get(collectionSlug) ?? null
+    },
+    [],
   )
 
-  const getUploadHandler: UploadHandlersContext['getUploadHandler'] = ({ collectionSlug }) => {
-    return uploadHandlers.get(collectionSlug)
-  }
+  const setUploadHandler: UploadHandlersContext['setUploadHandler'] = useCallback(
+    ({ collectionSlug, handler }) => {
+      uploadHandlersRef.current.set(collectionSlug, handler)
+    },
+    [],
+  )
 
-  const setUploadHandler: UploadHandlersContext['setUploadHandler'] = ({
-    collectionSlug,
-    handler,
-  }) => {
-    setUploadHandlers((uploadHandlers) => {
-      const clone = new Map(uploadHandlers)
-      clone.set(collectionSlug, handler)
-      return clone
-    })
-  }
+  const value = useMemo(
+    () => ({ getUploadHandler, setUploadHandler }),
+    [getUploadHandler, setUploadHandler],
+  )
 
-  return <Context value={{ getUploadHandler, setUploadHandler }}>{children}</Context>
+  return <Context value={value}>{children}</Context>
 }
 
 export const useUploadHandlers = (): UploadHandlersContext => {


### PR DESCRIPTION
## What

Fixes the memory leak / browser crash when using multiple collections with a cloud storage plugin (e.g. `s3Storage`, `azureStorage`, `gcsStorage`).

Closes #16039

## Why

`UploadHandlersProvider` used `useState` to store the handlers map. Each `ClientUploadHandler` provider (one per upload collection) calls `setUploadHandler` on mount, which triggers `setState` → a full re-render of the admin tree below it. With N collections, that's N state updates each causing a cascading re-render of the entire admin panel, plus N Map clone allocations.

The handlers map doesn't need to trigger re-renders — `getUploadHandler` is only called during form submission, never during rendering.

## Changes

- Replaced `useState` with `useRef` for the upload handlers map — registering a handler no longer triggers a re-render
- Wrapped `getUploadHandler` and `setUploadHandler` in `useCallback` for stable references
- Memoized the context value with `useMemo` to prevent unnecessary consumer re-renders

## Testing

- `pnpm run build:ui` passes with no errors
- Verified that `getUploadHandler` is only consumed during form submission (`Form/index.tsx:582`) and bulk upload (`FormsManager/index.tsx:362`), never during render — so switching from state to ref is safe
- The context type signature (`UploadHandlersContext`) and public API are unchanged