### PR TITLE
fix(richtext-lexical): prevent invalid h0 heading nodes when all heading sizes are disabled

### DIFF
--- a/packages/richtext-lexical/src/features/heading/server/index.ts
+++ b/packages/richtext-lexical/src/features/heading/server/index.ts
@@ -39,7 +39,8 @@ export const HeadingFeature = createServerFeature<
       ClientFeature: '@payloadcms/richtext-lexical/client#HeadingFeatureClient',
       clientFeatureProps: props,
       i18n,
-      markdownTransformers: [MarkdownTransformer(enabledHeadingSizes)],
+      markdownTransformers:
+        enabledHeadingSizes.length > 0 ? [MarkdownTransformer(enabledHeadingSizes)] : [],
       nodes: [
         createNode({
           converters: {


### PR DESCRIPTION
## What

Fixes `HeadingFeature({ enabledHeadingSizes: [] })` creating invalid `h0` heading nodes that corrupt stored data.

Closes #15899

## Why

When `enabledHeadingSizes` is an empty array, the heading markdown transformer builds its regex from an empty alternation group:

```
pattern = "^()\\s"   // matches ANY leading whitespace
```

This regex matches any line starting with a space or tab. The empty capture group produces `match[1] = ""`, so:

```js
tag = 'h' + match[1]?.length  // 'h' + 0 = 'h0'
```

An invalid `h0` heading node is created and persisted to the database. If the HeadingFeature is later removed, these nodes cause a runtime error (`parseEditorState: type "heading" not found`).

## Changes

Skip registering the heading markdown transformer when `enabledHeadingSizes` is empty. No heading sizes enabled means no heading markdown shortcuts should be active.

## Testing

- `npx tsc --noEmit` passes
- Lint passes
- With this fix, `HeadingFeature({ enabledHeadingSizes: [] })` registers zero markdown transformers, so no heading conversion can occur