### PR TITLE
docs: add warning about unique fields with drafts enabled

### DIFF
--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -313,13 +313,12 @@ const MyCollection: CollectionConfig = {
       index: true,
       validate: async (value, { req, id }) => {
         if (!value) return true
-        const existing = await req.payload.find({
+        const existing = await req.payload.count({
           collection: 'my-collection',
           where: {
             slug: { equals: value },
             id: { not_equals: id || 0 },
           },
-          limit: 1,
         })
         if (existing.totalDocs > 0) {
           return 'This value is already in use'

--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -32,6 +32,10 @@ Collections and Globals both support the same options for configuring drafts. Yo
 
 By enabling drafts on a collection or a global, Payload will **automatically inject a new field into your schema** called `_status`. The `_status` field is used internally by Payload to store if a document is set to `draft` or `published`.
 
+<Banner type="warning">
+  **`unique` fields and Drafts:** Using `unique: true` on fields in collections with drafts enabled can cause silent failures. When a document is created, Payload writes to both the main collection table and the versions table (`_collectionSlug_v`). Because the initial draft is created with empty or default values before the user fills in the form, a database-level unique constraint will fail on the second document creation — since the first empty-value draft already exists. The Admin UI may redirect to a `?notFound=` URL without showing an error. To work around this, replace `unique: true` with `index: true` and enforce uniqueness at the application level using a custom `validate` function. See [Unique Fields with Drafts](#unique-fields-with-drafts) below.
+</Banner>
+
 **Admin UI status indication**
 
 Within the Admin UI, if drafts are enabled, a document can be shown with one of three "statuses":
@@ -276,3 +280,58 @@ If a document is published, the Payload Admin UI will be updated to show an "unp
 ## Reverting to published
 
 If a document is published, and you have made further changes which are saved as a draft, Payload will show a "revert to published" button at the top of the sidebar which will allow you to reject your draft changes and "revert" back to the published state of the document. Your drafts will still be saved, but a new version will be created that will reflect the last published state of the document.
+
+## Unique fields with Drafts
+
+When using `unique: true` on fields in a collection that has `versions.drafts` enabled, you may encounter silent document creation failures. This is a known limitation ([#953](https://github.com/payloadcms/payload/issues/953), [#12628](https://github.com/payloadcms/payload/issues/12628)).
+
+### The problem
+
+When Payload creates a new document in a drafts-enabled collection, it writes to both the main collection table and the versions table. The database-level `UNIQUE` constraint on the main table can conflict with the draft creation process — particularly when:
+
+- Multiple documents are created before unique field values are filled in (autosave creates rows with empty values)
+- The versions system attempts to write to both tables within the same operation
+
+The result is a silent failure where the Admin UI redirects to `?notFound=<id>` instead of showing the newly created document, with no visible error message.
+
+### Workaround
+
+Replace `unique: true` with `index: true` and enforce uniqueness at the application level using a custom `validate` function:
+
+```ts
+const MyCollection: CollectionConfig = {
+  slug: 'my-collection',
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      name: 'slug',
+      type: 'text',
+      required: true,
+      // Use index instead of unique to avoid DB-level constraint conflicts with drafts
+      index: true,
+      validate: async (value, { req, id }) => {
+        if (!value) return true
+        const existing = await req.payload.find({
+          collection: 'my-collection',
+          where: {
+            slug: { equals: value },
+            id: { not_equals: id || 0 },
+          },
+          limit: 1,
+        })
+        if (existing.totalDocs > 0) {
+          return 'This value is already in use'
+        }
+        return true
+      },
+    },
+  ],
+}
+```
+
+This approach:
+- Preserves the index for query performance
+- Validates uniqueness before save, providing a clear error message in the Admin UI
+- Avoids the database-level constraint that conflicts with the drafts version system

--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -345,13 +345,12 @@ const MyCollection: CollectionConfig = {
       index: true,
       validate: async (value, { req, id }) => {
         if (!value) return true
-        const existing = await req.payload.find({
+        const existing = await req.payload.count({
           collection: 'my-collection',
           where: {
             slug: { equals: value },
             id: { not_equals: id || 0 },
           },
-          limit: 1,
         })
         if (existing.totalDocs > 0) {
           return 'This value is already in use'

--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -31,6 +31,10 @@ Collections and Globals both support the same options for configuring drafts. Yo
 
 By enabling drafts on a collection or a global, Payload will **automatically inject a new field into your schema** called `_status`. The `_status` field is used internally by Payload to store if a document is set to `draft` or `published`.
 
+<Banner type="warning">
+  **`unique` fields and Drafts:** Using `unique: true` on fields in collections with drafts enabled can cause silent failures. When a document is created, Payload writes to both the main collection table and the versions table (`_collectionSlug_v`). Because the initial draft is created with empty or default values before the user fills in the form, a database-level unique constraint will fail on the second document creation — since the first empty-value draft already exists. The Admin UI may redirect to a `?notFound=` URL without showing an error. To work around this, replace `unique: true` with `index: true` and enforce uniqueness at the application level using a custom `validate` function. See [Unique Fields with Drafts](#unique-fields-with-drafts) below.
+</Banner>
+
 **Admin UI status indication**
 
 Within the Admin UI, if drafts are enabled, a document can be shown with one of three "statuses":
@@ -308,3 +312,58 @@ If a document is published, the Payload Admin UI will be updated to show an "unp
 ## Reverting to published
 
 If a document is published, and you have made further changes which are saved as a draft, Payload will show a "revert to published" button at the top of the sidebar which will allow you to reject your draft changes and "revert" back to the published state of the document. Your drafts will still be saved, but a new version will be created that will reflect the last published state of the document.
+
+## Unique fields with Drafts
+
+When using `unique: true` on fields in a collection that has `versions.drafts` enabled, you may encounter silent document creation failures. This is a known limitation ([#953](https://github.com/payloadcms/payload/issues/953), [#12628](https://github.com/payloadcms/payload/issues/12628)).
+
+### The problem
+
+When Payload creates a new document in a drafts-enabled collection, it writes to both the main collection table and the versions table. The database-level `UNIQUE` constraint on the main table can conflict with the draft creation process — particularly when:
+
+- Multiple documents are created before unique field values are filled in (autosave creates rows with empty values)
+- The versions system attempts to write to both tables within the same operation
+
+The result is a silent failure where the Admin UI redirects to `?notFound=<id>` instead of showing the newly created document, with no visible error message.
+
+### Workaround
+
+Replace `unique: true` with `index: true` and enforce uniqueness at the application level using a custom `validate` function:
+
+```ts
+const MyCollection: CollectionConfig = {
+  slug: 'my-collection',
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      name: 'slug',
+      type: 'text',
+      required: true,
+      // Use index instead of unique to avoid DB-level constraint conflicts with drafts
+      index: true,
+      validate: async (value, { req, id }) => {
+        if (!value) return true
+        const existing = await req.payload.find({
+          collection: 'my-collection',
+          where: {
+            slug: { equals: value },
+            id: { not_equals: id || 0 },
+          },
+          limit: 1,
+        })
+        if (existing.totalDocs > 0) {
+          return 'This value is already in use'
+        }
+        return true
+      },
+    },
+  ],
+}
+```
+
+This approach:
+- Preserves the index for query performance
+- Validates uniqueness before save, providing a clear error message in the Admin UI
+- Avoids the database-level constraint that conflicts with the drafts version system


### PR DESCRIPTION
## What

Adds documentation about a known limitation where `unique: true` fields on collections with `versions.drafts` enabled cause **silent document creation failures**.

## The Problem

When a drafts-enabled collection has fields with `unique: true`, creating new documents can fail silently:

1. User clicks "Save" or "Publish" on a new document
2. Payload attempts to write to both the main table and the versions table (`_collection_v`)
3. The database-level `UNIQUE` constraint conflicts during the draft creation process
4. The Admin UI redirects to `?notFound=<id>` with **no visible error message**

This affects **all database adapters** (PostgreSQL/Drizzle and MongoDB) and has been reported multiple times:
- #953 (Aug 2022)
- #12628 (May 2025)
- #3576 (Discussion)

## What This PR Adds

1. **Warning banner** in the "Database changes" section of the Drafts docs
2. **New section**: "Unique fields with Drafts" with:
   - Clear problem explanation
   - Recommended workaround: replace `unique: true` with `index: true` + application-level `validate` function
   - Complete code example

## The Workaround

```ts
{
  name: 'slug',
  type: 'text',
  // Use index instead of unique
  index: true,
  validate: async (value, { req, id }) => {
    if (!value) return true
    const existing = await req.payload.find({
      collection: 'my-collection',
      where: {
        slug: { equals: value },
        id: { not_equals: id || 0 },
      },
      limit: 1,
    })
    if (existing.totalDocs > 0) return 'This value is already in use'
    return true
  },
}
```

## Context

We hit this in production on a legal CMS (Payload 3.64.0 + PostgreSQL on Fly.io) with 5,000+ tags. The collection had `versions.drafts` enabled with `unique: true` on both `name` and `slug` fields. Tag creation was completely broken with no error feedback — just a `?notFound=` redirect. Replacing the DB-level unique constraint with an application-level validate function resolved it immediately.

Ideally Payload would handle this gracefully at the framework level (e.g., deferring unique validation for draft documents, or surfacing a clear error), but until then, this documentation helps others avoid the same trap.