### PR TITLE
fix: trashed documents still show as IDs in relationship responses

### DIFF
--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -107,6 +107,9 @@ const batchAndLoadDocs =
 
       req.transactionID = transactionID
 
+      const enableTrash = Boolean(payload.collections?.[collection]?.config?.trash)
+      const selectWithDeletedAt = enableTrash && select ? { ...select, deletedAt: true } : select
+
       const result = await payload.find({
         collection,
         currentDepth,
@@ -119,8 +122,9 @@ const batchAndLoadDocs =
         pagination: false,
         populate,
         req,
-        select,
+        select: selectWithDeletedAt,
         showHiddenFields: Boolean(showHiddenFields),
+        ...(enableTrash ? { trash: true } : {}),
         where: {
           id: {
             in: ids,

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -94,13 +94,13 @@ const populate = async ({
       )
     }
 
-    if (!relationshipValue) {
-      if (shouldPopulate && relatedCollection.config.trash) {
+    if (relatedCollection.config.trash && relationshipValue) {
+      if ((relationshipValue as Record<string, unknown>).deletedAt) {
         relationshipValue = null
-      } else {
-        // ids are visible regardless of access controls
-        relationshipValue = id
       }
+    } else if (!relationshipValue) {
+      // ids are visible regardless of access controls
+      relationshipValue = id
     }
     if (typeof index === 'number' && typeof key === 'string') {
       if (field.type !== 'join' && Array.isArray(field.relationTo)) {

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -95,8 +95,12 @@ const populate = async ({
     }
 
     if (!relationshipValue) {
-      // ids are visible regardless of access controls
-      relationshipValue = id
+      if (shouldPopulate && relatedCollection.config.trash) {
+        relationshipValue = null
+      } else {
+        // ids are visible regardless of access controls
+        relationshipValue = id
+      }
     }
     if (typeof index === 'number' && typeof key === 'string') {
       if (field.type !== 'join' && Array.isArray(field.relationTo)) {
@@ -276,4 +280,25 @@ export const relationshipPopulationPromise = async ({
     })
   }
   await Promise.all(rowPromises)
+
+  if (field.type !== 'join' && fieldSupportsMany(field) && field.hasMany) {
+    const notNull = Array.isArray(field.relationTo)
+      ? (v: unknown) => v !== null && (v as Record<string, unknown>)?.value !== null
+      : (v: unknown) => v !== null
+
+    if (
+      fieldShouldBeLocalized({ field, parentIsLocalized }) &&
+      locale === 'all' &&
+      typeof resultingDoc[field.name] === 'object' &&
+      resultingDoc[field.name] !== null
+    ) {
+      for (const localeKey of Object.keys(resultingDoc[field.name])) {
+        if (Array.isArray(resultingDoc[field.name][localeKey])) {
+          resultingDoc[field.name][localeKey] = resultingDoc[field.name][localeKey].filter(notNull)
+        }
+      }
+    } else if (Array.isArray(resultingDoc[field.name])) {
+      resultingDoc[field.name] = (resultingDoc[field.name] as unknown[]).filter(notNull)
+    }
+  }
 }

--- a/test/trash/collections/Pages/index.ts
+++ b/test/trash/collections/Pages/index.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { postsSlug } from '../Posts/index.js'
+
 export const pagesSlug = 'pages'
 
 export const Pages: CollectionConfig = {
@@ -12,6 +14,12 @@ export const Pages: CollectionConfig = {
     {
       name: 'title',
       type: 'text',
+    },
+    {
+      name: 'relatedPosts',
+      type: 'relationship',
+      relationTo: postsSlug,
+      hasMany: true,
     },
   ],
   versions: {

--- a/test/trash/collections/Pages/index.ts
+++ b/test/trash/collections/Pages/index.ts
@@ -21,6 +21,11 @@ export const Pages: CollectionConfig = {
       relationTo: postsSlug,
       hasMany: true,
     },
+    {
+      name: 'featuredPost',
+      type: 'relationship',
+      relationTo: postsSlug,
+    },
   ],
   versions: {
     drafts: true,

--- a/test/trash/int.spec.ts
+++ b/test/trash/int.spec.ts
@@ -2254,6 +2254,44 @@ describe('trash', () => {
       expect((result.relatedPosts as Post[])[0]?.id).toBe(postsDocOne.id)
     })
 
+    it('should return null for a trashed document in a single relationship', async () => {
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with featured post',
+          featuredPost: postsDocTwo.id,
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 1,
+      })
+
+      expect(result.featuredPost).toBeNull()
+    })
+
+    it('should populate a non-trashed document in a single relationship', async () => {
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with featured post',
+          featuredPost: postsDocOne.id,
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 1,
+      })
+
+      expect((result.featuredPost as Post)?.id).toBe(postsDocOne.id)
+    })
+
     it('should include trashed documents in relationship when depth=0', async () => {
       // At depth=0, relationships are returned as IDs - but trashed IDs should still be filtered
       const page = await payload.create({

--- a/test/trash/int.spec.ts
+++ b/test/trash/int.spec.ts
@@ -11,6 +11,7 @@ import { idToString } from '../__helpers/shared/idToString.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser, regularUser } from '../credentials.js'
 import { differentiatedTrashCollectionSlug } from './collections/DifferentiatedTrashCollection/index.js'
+import { pagesSlug } from './collections/Pages/index.js'
 import { postsSlug } from './collections/Posts/index.js'
 import { restrictedCollectionSlug } from './collections/RestrictedCollection/index.js'
 import { usersSlug } from './collections/Users/index.js'
@@ -2216,6 +2217,65 @@ describe('trash', () => {
 
         expect(res.data.countPosts.totalDocs).toBe(1)
       })
+    })
+  })
+
+  describe('Relationship population', () => {
+    const createdPageIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of createdPageIDs) {
+        await payload.delete({ collection: pagesSlug, id })
+      }
+      createdPageIDs.length = 0
+    })
+
+    it('should not include trashed document IDs in hasMany relationship population', async () => {
+      // postsDocOne is non-trashed, postsDocTwo is trashed
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with related posts',
+          relatedPosts: [postsDocOne.id, postsDocTwo.id],
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 1,
+      })
+
+      // The trashed post (postsDocTwo) should be absent from the relationship array
+      // Non-trashed post (postsDocOne) should be populated as an object
+      expect(Array.isArray(result.relatedPosts)).toBe(true)
+      expect(result.relatedPosts).toHaveLength(1)
+      expect((result.relatedPosts as Post[])[0]?.id).toBe(postsDocOne.id)
+    })
+
+    it('should include trashed documents in relationship when depth=0', async () => {
+      // At depth=0, relationships are returned as IDs - but trashed IDs should still be filtered
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with related posts depth 0',
+          relatedPosts: [postsDocOne.id, postsDocTwo.id],
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 0,
+      })
+
+      // At depth=0, no population occurs - raw IDs are returned as stored
+      // The trashed post ID should still be visible at depth=0
+      const relatedPosts = result.relatedPosts as (number | string)[]
+      expect(Array.isArray(relatedPosts)).toBe(true)
+      expect(relatedPosts).toHaveLength(2)
     })
   })
 })

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -131,6 +131,7 @@ export interface Page {
   id: string;
   title?: string | null;
   relatedPosts?: (string | Post)[] | null;
+  featuredPost?: (string | null) | Post;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -293,6 +294,7 @@ export interface PayloadMigration {
 export interface PagesSelect<T extends boolean = true> {
   title?: T;
   relatedPosts?: T;
+  featuredPost?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -130,6 +130,7 @@ export interface UserAuthOperations {
 export interface Page {
   id: string;
   title?: string | null;
+  relatedPosts?: (string | Post)[] | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -291,6 +292,7 @@ export interface PayloadMigration {
  */
 export interface PagesSelect<T extends boolean = true> {
   title?: T;
+  relatedPosts?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;


### PR DESCRIPTION
# Overview

When a relationship points to a collection with `trash: true`, soft-deleted documents were showing as raw IDs in responses instead of being omitted.

## Key Changes

In the dataloader, trash-enabled collections now fetch with `trash: true` so soft-deleted documents are returned alongside live ones. `deletedAt` is merged into the select to ensure it's always present in the result.

In `populate()`, the returned doc is checked for `deletedAt`. If set, the doc is trashed and `relationshipValue` is set to null. For hasMany, null entries are filtered from the array after all row promises settle. For single relationships, the field is set to null.

This correctly distinguishes trashed documents from inaccessible ones — access-denied or permanently deleted documents still fall back to the raw ID, unchanged from existing behavior. `depth: 0` is also unaffected.


Fixes #16022

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213860470196517