### PR TITLE
fix(next): respect canAccessAdmin when a custom dashboard view is configured

### DIFF
--- a/packages/next/src/utilities/isCustomAdminView.spec.ts
+++ b/packages/next/src/utilities/isCustomAdminView.spec.ts
@@ -1,0 +1,109 @@
+import type { SanitizedConfig } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { isCustomAdminView } from './isCustomAdminView.js'
+
+describe('isCustomAdminView', () => {
+  const adminRoute = '/admin'
+
+  const configWithCustomDashboard = {
+    admin: {
+      components: {
+        views: {
+          dashboard: {
+            path: '/',
+          },
+        },
+      },
+    },
+  } as unknown as SanitizedConfig
+
+  it('should not bypass admin access for the root admin route even with a custom dashboard view', () => {
+    // The root path '/' maps to the dashboard — it is not a public custom view.
+    // canAccessAdmin must still be enforced for the admin root.
+    const result = isCustomAdminView({
+      adminRoute,
+      config: configWithCustomDashboard,
+      route: '/admin',
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('should not match collection routes as custom dashboard views when dashboard path is "/"', () => {
+    const result = isCustomAdminView({
+      adminRoute,
+      config: configWithCustomDashboard,
+      route: '/admin/collections/tickets',
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('should not match document routes as custom dashboard views when dashboard path is "/"', () => {
+    const result = isCustomAdminView({
+      adminRoute,
+      config: configWithCustomDashboard,
+      route: '/admin/collections/tickets/123',
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false when no custom views are configured', () => {
+    const config = {} as SanitizedConfig
+
+    const result = isCustomAdminView({
+      adminRoute,
+      config,
+      route: '/admin/collections/tickets',
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true for a custom view with a non-root path', () => {
+    const config = {
+      admin: {
+        components: {
+          views: {
+            myCustomView: {
+              path: '/my-custom-view',
+            },
+          },
+        },
+      },
+    } as unknown as SanitizedConfig
+
+    const result = isCustomAdminView({
+      adminRoute,
+      config,
+      route: '/admin/my-custom-view',
+    })
+
+    expect(result).toBe(true)
+  })
+
+  it('should not match collection routes when a non-root custom view path is set', () => {
+    const config = {
+      admin: {
+        components: {
+          views: {
+            myCustomView: {
+              path: '/my-custom-view',
+            },
+          },
+        },
+      },
+    } as unknown as SanitizedConfig
+
+    const result = isCustomAdminView({
+      adminRoute,
+      config,
+      route: '/admin/collections/tickets',
+    })
+
+    expect(result).toBe(false)
+  })
+})

--- a/packages/next/src/utilities/isCustomAdminView.ts
+++ b/packages/next/src/utilities/isCustomAdminView.ts
@@ -23,7 +23,11 @@ export const isCustomAdminView = ({
           return true
         }
       } else {
-        if (routeWithoutAdmin.startsWith(view.path)) {
+        if (
+          view.path &&
+          view.path !== '/' &&
+          (routeWithoutAdmin === view.path || routeWithoutAdmin.startsWith(view.path + '/'))
+        ) {
           return true
         }
       }

--- a/test/access-control/CustomDashboard.tsx
+++ b/test/access-control/CustomDashboard.tsx
@@ -1,0 +1,3 @@
+export default function CustomDashboard() {
+  return <div id="custom-dashboard">Custom Dashboard</div>
+}

--- a/test/access-control/CustomDashboard.tsx
+++ b/test/access-control/CustomDashboard.tsx
@@ -1,3 +1,1 @@
-export default function CustomDashboard() {
-  return <div id="custom-dashboard">Custom Dashboard</div>
-}
+export { DefaultDashboard as default } from '@payloadcms/next/views'

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -781,6 +781,30 @@ describe('Access Control', () => {
       await expect(page.locator('form.login__form')).toBeVisible()
     })
 
+    test('non-admin users should not be able to bypass admin access by navigating directly to a collection with a custom dashboard view set', async () => {
+      await page.goto(url.logout)
+
+      await login({
+        data: {
+          email: nonAdminEmail,
+          password: 'test',
+        },
+        page,
+        serverURL,
+      })
+
+      // Navigate directly to a collection URL, bypassing the dashboard
+      await page.goto(new AdminUrlUtil(serverURL, readOnlySlug).list)
+
+      // Should be redirected to unauthorized, not the collection list
+      await page.waitForURL(/\/unauthorized/)
+      await expect(page.locator('.unauthorized .form-header h1')).toHaveText(
+        'Unauthorized, this user does not have access to the admin panel.',
+      )
+
+      await page.goto(url.logout)
+    })
+
     test('public users should not have access to access admin', async () => {
       await page.goto(url.logout)
 

--- a/test/access-control/getConfig.ts
+++ b/test/access-control/getConfig.ts
@@ -85,6 +85,14 @@ export const getConfig: () => Partial<Config> = () => ({
   admin: {
     autoLogin: false,
     user: 'users',
+    components: {
+      views: {
+        dashboard: {
+          Component: './CustomDashboard.js#default',
+          path: '/',
+        },
+      },
+    },
     importMap: {
       baseDir: path.resolve(dirname),
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,7 +32,7 @@
     ],
     "paths": {
       "@payloadcms/figma": ["../enterprise-plugins/packages/figma/src/index.ts"],
-      "@payload-config": ["./test/evals/config.ts"],
+      "@payload-config": ["./test/_community/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],


### PR DESCRIPTION
# Overview

Ensures `canAccessAdmin` is respected when a custom dashboard view is configured with `path: "/"`. 

Previously, navigating directly to a collection URL would skip the access check, while navigating to `/admin` worked as expected.

## Key Changes

The issue was in `isCustomAdminView` - the `startsWith` check caused any route starting with `/` to match a custom dashboard view, skipping the `canAccessAdmin` redirect for collection and document routes.

## Design Decisions

The `isCustomAdminView` bypass exists for custom non-root views (e.g. a public page at `/status`) that handle their own access logic. The root path `/` is a special case - it always goes through the `canAccessAdmin` check regardless of whether it has been overridden.

```typescript
// Before — matched every route when dashboard path was '/'
if (routeWithoutAdmin.startsWith(view.path)) {
  return true
}

// After — root path always enforces canAccessAdmin; non-root uses safe exact/prefix match
if (
  view.path &&
  view.path !== '/' &&
  (routeWithoutAdmin === view.path || routeWithoutAdmin.startsWith(view.path + '/'))
) {
  return true
}
```

Fixes #16097 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213862851143618
  - https://app.asana.com/0/0/1213862770589076