### PR TITLE
fix(db-mongodb): virtual fields within blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "test:eval:rest-api:low-power": "cross-env EVAL_VARIANT=low-power NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 pnpm exec vitest --run --project eval eval.rest-api.spec",
     "test:eval:rest-api:skill": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 pnpm exec vitest --run --project eval eval.rest-api.spec",
     "test:eval:skill": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 vitest --run --project eval",
-    "test:int": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 DISABLE_LOGGING=true vitest --project int",
+    "test:int": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 DISABLE_LOGGING=true vitest --project int --no-cache",
     "test:int:firestore": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 PAYLOAD_DATABASE=firestore DISABLE_LOGGING=true vitest --project int",
     "test:int:postgres": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 PAYLOAD_DATABASE=postgres DISABLE_LOGGING=true vitest --project int",
     "test:int:sqlite": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" NODE_NO_WARNINGS=1 PAYLOAD_DATABASE=sqlite DISABLE_LOGGING=true vitest --project int",

--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -268,6 +268,10 @@ const blocks: FieldSchemaGenerator<BlocksField> = (
     }
 
     block.fields.forEach((blockField) => {
+      if (fieldIsVirtual(blockField)) {
+        return
+      }
+
       const addFieldSchema = getSchemaGenerator(blockField.type)
 
       if (addFieldSchema) {

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -832,6 +832,26 @@ export const getConfig: () => Partial<Config> = () => ({
             },
           ],
         },
+        {
+          name: 'blockWithVirtual',
+          type: 'blocks',
+          blocks: [
+            {
+              slug: 'blockWithVirtual',
+              fields: [
+                {
+                  name: 'text',
+                  type: 'text',
+                },
+                {
+                  name: 'virtualField',
+                  type: 'text',
+                  virtual: true,
+                },
+              ],
+            },
+          ],
+        },
       ],
     },
     {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3290,6 +3290,32 @@ describe('database', () => {
       expect(res.textWithinTabs).toBeUndefined()
     })
 
+    it('should not save a virtual field inside a block to the db', async () => {
+      const created = await payload.create({
+        collection: fieldsPersistanceSlug,
+        data: {
+          blockWithVirtual: [
+            {
+              blockType: 'blockWithVirtual',
+              text: 'some text',
+              virtualField: 'should not be saved',
+            },
+          ],
+        },
+      })
+
+      const resDb = (await payload.db.findOne({
+        collection: fieldsPersistanceSlug,
+        req: {} as PayloadRequest,
+        where: { id: { equals: created.id } },
+      })) as Record<string, unknown>
+
+      const block = (resDb.blockWithVirtual as Record<string, unknown>[])?.[0]
+
+      expect(block?.virtualField).toBeUndefined()
+      expect(block?.text).toBe('some text')
+    })
+
     it('should allow virtual field with reference', async () => {
       const post = await payload.create({ collection: 'posts', data: { title: 'my-title' } })
       const { id } = await payload.create({


### PR DESCRIPTION
Virtual fields within blocks are persisting to the database unexpectedly.

For example, consider the following config:

```ts
import type { CollectionConfig } from 'payload'

export const Customers: CollectionConfig = {
  slug: 'posts',
  fields: [
    {
      name: 'blockWithVirtual',
      type: 'blocks',
      blocks: [
        {
          slug: 'blockWithVirtual',
          fields: [
            {
              name: 'text',
              type: 'text',
            },
            {
              name: 'virtualField',
              type: 'text',
              virtual: true,
            },
          ],
        },
      ],
    },
  ]
}
```

When posting a document containing a value on the virtual field, the virtual field is saved to the database.

For example:

```ts
const doc = await payload.create({
  collection: 'posts',
  data: {
    blockWithVirtual: [
      {
        blockType: 'blockWithVirtual',
        text: 'some text',
        virtualField: 'should not be saved',
      },
    ],
  },
})

const docFromDB = await payload.db.findOne({
  collection: 'posts',
  where: {
    id: {
      equals: created.id
    }
  },
})

// {
//   "createdAt": "2026-03-30T20:55:43.551Z",
//   "updatedAt": "2026-03-30T20:55:43.551Z",
//   "blockWithVirtual": [
//     {
//       "blockType": "blockWithVirtual",
//       "text": "some text",
//       "id": "69cae34f92d21769bbb7ab83",
//       "virtualField": "should not be saved" // THIS SHOULD NOT BE SAVED TO THE DB
//     }
//   ],
//   "id": "69cae34fc960c2d4d84f220a"
// }
```

