### PR TITLE
fix(plugin-mcp): add error handling to convertCollectionSchemaToZod

### DIFF
--- a/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.ts
+++ b/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.ts
@@ -9,31 +9,44 @@ import { simplifyRelationshipFields } from './simplifyRelationshipFields.js'
 import { transformPointFieldsForMCP } from './transformPointFields.js'
 
 export const convertCollectionSchemaToZod = (schema: JSONSchema4) => {
-  // Clone to avoid mutating the original schema (used elsewhere for tool listing)
-  const schemaClone = JSON.parse(JSON.stringify(schema)) as JSONSchema4
+  try {
+    // Clone to avoid mutating the original schema (used elsewhere for tool listing)
+    const schemaClone = JSON.parse(JSON.stringify(schema)) as JSONSchema4
 
-  const sanitized = sanitizeJsonSchema(schemaClone)
-  const pointTransformed = transformPointFieldsForMCP(sanitized)
-  const zodSchemaAsString = jsonSchemaToZod(simplifyRelationshipFields(pointTransformed))
+    const sanitized = sanitizeJsonSchema(schemaClone)
+    const pointTransformed = transformPointFieldsForMCP(sanitized)
+    const zodSchemaAsString = jsonSchemaToZod(simplifyRelationshipFields(pointTransformed))
 
-  // Transpile TypeScript to JavaScript
-  const transpileResult = ts.transpileModule(zodSchemaAsString, {
-    compilerOptions: {
-      module: ts.ModuleKind.CommonJS,
-      removeComments: true,
-      strict: false,
-      target: ts.ScriptTarget.ES2018,
-    },
-  })
+    // Transpile TypeScript to JavaScript
+    const transpileResult = ts.transpileModule(zodSchemaAsString, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        removeComments: true,
+        strict: false,
+        target: ts.ScriptTarget.ES2018,
+      },
+    })
 
-  /**
-   * This Function evaluation is safe because:
-   * 1. The input schema comes from Payload's collection configuration, which is controlled by the application developer
-   * 2. The jsonSchemaToZod library converts JSON Schema to Zod schema definitions, producing only type validation code
-   * 3. The transpiled output contains only Zod schema definitions (z.string(), z.number(), etc.) - no executable logic
-   * 4. The resulting Zod schema is used only for parameter validation in MCP tools, not for data processing
-   * 5. No user input or external data is involved in the schema generation process
-   */
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  return new Function('z', `return ${transpileResult.outputText}`)(z)
+    /**
+     * This Function evaluation is safe because:
+     * 1. The input schema comes from Payload's collection configuration, which is controlled by the application developer
+     * 2. The jsonSchemaToZod library converts JSON Schema to Zod schema definitions, producing only type validation code
+     * 3. The transpiled output contains only Zod schema definitions (z.string(), z.number(), etc.) - no executable logic
+     * 4. The resulting Zod schema is used only for parameter validation in MCP tools, not for data processing
+     * 5. No user input or external data is involved in the schema generation process
+     */
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    return new Function('z', `return ${transpileResult.outputText}`)(z)
+  } catch (error) {
+    // If schema conversion fails (e.g., due to Zod v4 toJSONSchema null-check bug
+    // with record schemas that have undefined valueType, or bundler transforms
+    // stripping Zod internals), return a permissive schema so tools/list doesn't
+    // crash entirely. The tool will still be listed but without strict validation.
+    // See: https://github.com/colinhacks/zod/issues/5821
+    console.warn(
+      `[plugin-mcp] Schema conversion failed, using permissive fallback:`,
+      error instanceof Error ? error.message : error,
+    )
+    return z.record(z.any())
+  }
 }


### PR DESCRIPTION
## Summary

Wraps `convertCollectionSchemaToZod` in a try/catch so that a single collection's schema conversion failure doesn't crash the entire `tools/list` MCP response.

## Problem

The schema conversion pipeline (`JSON Schema → json-schema-to-zod → TypeScript transpile → eval`) can fail for collections with complex nested schemas. When it does, the error propagates up to the MCP SDK's `tools/list` handler, crashing the entire response and making **all** MCP tools inaccessible — not just the one with the problematic schema.

The most common trigger is a Zod v4 bug where `toJSONSchema` crashes with `TypeError: Cannot read properties of undefined (reading '_zod')` on record schemas with undefined `valueType` (see [colinhacks/zod#5821](https://github.com/colinhacks/zod/issues/5821), PR [colinhacks/zod#5822](https://github.com/colinhacks/zod/pull/5822)).

## Fix

```typescript
try {
  // existing conversion pipeline...
  return new Function('z', `return ${transpileResult.outputText}`)(z)
} catch (error) {
  console.warn(`[plugin-mcp] Schema conversion failed, using permissive fallback:`, error.message)
  return z.record(z.any())
}
```

When conversion fails:
- The tool is still listed in `tools/list` (with a permissive `z.record(z.any())` schema)
- Other tools with valid schemas are completely unaffected
- A warning is logged to help diagnose which collections have problematic schemas

## Impact

Without this fix, any project with 20+ collections (where at least one has a complex nested block schema) will have a completely non-functional MCP server — `tools/list` returns an error instead of the tool list. With this fix, only the affected collection loses strict parameter validation; everything else works normally.

## Testing

Verified in production with a 22-collection Payload CMS deployment on Vercel. Before the fix, `tools/list` crashed entirely. After, all tools are listed and functional.