### PR TITLE
fix: add field-level access control to internal auth fields

### DIFF
--- a/packages/payload/src/auth/baseFields/accountLock.ts
+++ b/packages/payload/src/auth/baseFields/accountLock.ts
@@ -4,12 +4,20 @@ export const accountLockFields: Field[] = [
   {
     name: 'loginAttempts',
     type: 'number',
+    access: {
+      create: () => false,
+      update: () => false,
+    },
     defaultValue: 0,
     hidden: true,
   },
   {
     name: 'lockUntil',
     type: 'date',
+    access: {
+      create: () => false,
+      update: () => false,
+    },
     hidden: true,
   },
 ] as Field[]

--- a/packages/payload/src/auth/baseFields/auth.ts
+++ b/packages/payload/src/auth/baseFields/auth.ts
@@ -4,21 +4,37 @@ export const baseAuthFields: Field[] = [
   {
     name: 'resetPasswordToken',
     type: 'text',
+    access: {
+      create: () => false,
+      update: () => false,
+    },
     hidden: true,
   },
   {
     name: 'resetPasswordExpiration',
     type: 'date',
+    access: {
+      create: () => false,
+      update: () => false,
+    },
     hidden: true,
   },
   {
     name: 'salt',
     type: 'text',
+    access: {
+      create: () => false,
+      update: () => false,
+    },
     hidden: true,
   },
   {
     name: 'hash',
     type: 'text',
+    access: {
+      create: () => false,
+      update: () => false,
+    },
     hidden: true,
   },
 ]

--- a/packages/payload/src/auth/baseFields/verification.ts
+++ b/packages/payload/src/auth/baseFields/verification.ts
@@ -1,5 +1,7 @@
 import type { Field, FieldHook } from '../../fields/config/types.js'
 
+import { defaultAccess } from '../defaultAccess.js'
+
 const autoRemoveVerificationToken: FieldHook = ({ data, operation, originalDoc, value }) => {
   // If a user manually sets `_verified` to true,
   // and it was `false`, set _verificationToken to `null`.
@@ -20,9 +22,9 @@ export const verificationFields: Field[] = [
     name: '_verified',
     type: 'checkbox',
     access: {
-      create: ({ req: { user } }) => Boolean(user),
-      read: ({ req: { user } }) => Boolean(user),
-      update: ({ req: { user } }) => Boolean(user),
+      create: defaultAccess,
+      read: defaultAccess,
+      update: defaultAccess,
     },
     admin: {
       components: {
@@ -34,6 +36,10 @@ export const verificationFields: Field[] = [
   {
     name: '_verificationToken',
     type: 'text',
+    access: {
+      create: () => false,
+      update: () => false,
+    },
     hidden: true,
     hooks: {
       beforeChange: [autoRemoveVerificationToken],


### PR DESCRIPTION
Adds field-level access control to internal auth fields (`hash`, `salt`, `resetPasswordToken`, `resetPasswordExpiration`, `loginAttempts`, `lockUntil`, `_verificationToken`) to prevent external writes.

This is a preventative measure. Users should configure collection-level access control on auth collections (e.g., restricting who can update users) rather than relying solely on field-level protections. Internal auth operations are unaffected as they use direct DB operations.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213885887366085