### PR TITLE
fix(core): process bulk deletes sequentially to prevent silent data loss

### DIFF
--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -136,9 +136,10 @@ export const deleteOperation = async <
 
     const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
 
-    const promises = docs.map(async (doc) => {
-      let result
+    const docsToProcess = docs
+    const awaitedDocs: BulkOperationResult<TSlug, TSelect>['docs'] = []
 
+    for (const doc of docsToProcess) {
       const { id } = doc
 
       try {
@@ -227,11 +228,11 @@ export const deleteOperation = async <
         // afterRead - Fields
         // /////////////////////////////////////
 
-        result = await afterRead({
+        let result = await afterRead({
           collection: collectionConfig,
           context: req.context,
           depth: depth!,
-          doc: result || doc,
+          doc,
           // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
           draft: undefined,
           fallbackLocale: fallbackLocale!,
@@ -262,7 +263,7 @@ export const deleteOperation = async <
               (await hook({
                 collection: collectionConfig,
                 context: req.context,
-                doc: result || doc,
+                doc: result,
                 overrideAccess,
                 req,
               })) || result
@@ -293,7 +294,7 @@ export const deleteOperation = async <
           await commitTransaction(req)
         }
 
-        return result
+        awaitedDocs.push(result)
       } catch (error) {
         const isPublic = error instanceof Error ? isErrorPublic(error, config) : false
 
@@ -306,19 +307,6 @@ export const deleteOperation = async <
           message: error instanceof Error ? error.message : 'Unknown error',
         })
       }
-      return null
-    })
-
-    // Process sequentially when using single transaction mode to avoid shared state issues
-    // Process in parallel when using one transaction for better performance
-    let awaitedDocs
-    if (req.payload.db.bulkOperationsSingleTransaction) {
-      awaitedDocs = []
-      for (const promise of promises) {
-        awaitedDocs.push(await promise)
-      }
-    } else {
-      awaitedDocs = await Promise.all(promises)
     }
 
     // /////////////////////////////////////


### PR DESCRIPTION
Fixes #16075. Modifies deleteOperation to process documents sequentially instead of concurrently. This prevents race conditions on database adapters with shared transaction connections (like Drizzle) that were causing silent data deletion failures.