### PR TITLE
perf: skip validation for default timezones

### DIFF
--- a/packages/payload/src/utilities/validateTimezones.ts
+++ b/packages/payload/src/utilities/validateTimezones.ts
@@ -1,6 +1,10 @@
 import type { Timezone } from '../config/types.js'
 
 import { InvalidConfiguration } from '../errors/index.js'
+import { defaultTimezones } from '../fields/baseFields/timezone/defaultTimezones.js'
+
+// Pre-computed Set of default timezone values - skip validation for these
+const defaultTimezoneValues = new Set(defaultTimezones.map((tz) => tz.value))
 
 type ValidateTimezonesArgs = {
   /**
@@ -91,6 +95,10 @@ export const validateTimezones = ({ source, timezones }: ValidateTimezonesArgs):
   }
 
   for (const timezone of timezones) {
+    // Skip validation for known-valid default timezones
+    if (defaultTimezoneValues.has(timezone.value)) {
+      continue
+    }
     if (!isTimezoneSupported(timezone.value)) {
       const sourceText = source ? ` in ${source}` : ''
       throw new InvalidConfiguration(


### PR DESCRIPTION
**Sanitizes all payload configs ~9ms faster**

Payload's 48 hardcoded default timezones were being validated with `new Intl.DateTimeFormat()` on every cold start. This is unnecessary since they're known to be valid.

This change pre-computes a `Set` of default timezone values at module load and skips validation for any timezone in that set. Custom/user-provided timezones are still validated.

### Before/After

| Operation | Before | After |
|-----------|--------|-------|
| `validateTimezones` | 9.06ms | 0.03ms |