### PR TITLE
fix(ui): re-evaluate filterOptions on subsequent drawer opens for relationship fields

### DIFF
--- a/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
@@ -136,10 +136,17 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
   )
 
   useEffect(() => {
-    if (!ListView) {
+    if (!ListView && isOpen) {
       void refresh({ slug: selectedOption?.value })
     }
-  }, [refresh, ListView, selectedOption.value])
+  }, [refresh, ListView, selectedOption.value, isOpen])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setListView(undefined)
+      setIsLoading(true)
+    }
+  }, [isOpen])
 
   const onCreateNew = useCallback(
     ({ doc }) => {

--- a/packages/ui/src/elements/ListDrawer/index.tsx
+++ b/packages/ui/src/elements/ListDrawer/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useModal } from '@faceless-ui/modal'
-import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import type { ListDrawerProps, ListTogglerProps, UseListDrawer } from './types.js'
 
@@ -119,6 +119,12 @@ export const useListDrawer: UseListDrawer = ({
     openModal(drawerSlug)
   }, [drawerSlug, openModal])
 
+  // Use a ref so that filterOptions updates don't recreate MemoizedDrawer.
+  // A new MemoizedDrawer reference causes React to unmount/remount ListDrawerContent,
+  // which resets its internal state (e.g. selectedOption) — breaking polymorphic drawers.
+  const filterOptionsRef = useRef(filterOptions)
+  filterOptionsRef.current = filterOptions
+
   const MemoizedDrawer = useMemo(() => {
     return (props) => (
       <ListDrawer
@@ -126,13 +132,13 @@ export const useListDrawer: UseListDrawer = ({
         closeDrawer={closeDrawer}
         collectionSlugs={collectionSlugs}
         drawerSlug={drawerSlug}
-        filterOptions={filterOptions}
+        filterOptions={filterOptionsRef.current}
         key={drawerSlug}
         selectedCollection={selectedCollection}
         uploads={uploads}
       />
     )
-  }, [drawerSlug, collectionSlugs, uploads, closeDrawer, selectedCollection, filterOptions])
+  }, [drawerSlug, collectionSlugs, uploads, closeDrawer, selectedCollection])
 
   const MemoizedDrawerToggler = useMemo(() => {
     return (props) => <ListDrawerToggler {...props} drawerSlug={drawerSlug} />

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -133,7 +133,9 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
         }
 
         const existingFilter =
-          typeof filterOptions?.[relation] === 'object' ? filterOptions[relation] : {}
+          filterOptions?.[relation] && typeof filterOptions[relation] === 'object'
+            ? filterOptions[relation]
+            : {}
 
         newFilterOptions = {
           ...(newFilterOptions || {}),

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'payload'
 
 import { dequal } from 'dequal/lite'
-import { formatAdminURL, wordBoundariesRegex } from 'payload/shared'
+import { formatAdminURL, hoistQueryParamsToAnd, wordBoundariesRegex } from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 
@@ -128,18 +128,18 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
       }, {})
 
       ;(Array.isArray(relationTo) ? relationTo : [relationTo]).forEach((relation) => {
+        if (!valuesByRelation[relation]) {
+          return
+        }
+
+        const existingFilter =
+          typeof filterOptions?.[relation] === 'object' ? filterOptions[relation] : {}
+
         newFilterOptions = {
           ...(newFilterOptions || {}),
-          [relation]: {
-            ...(typeof filterOptions?.[relation] === 'object' ? filterOptions[relation] : {}),
-            ...(valuesByRelation[relation]
-              ? {
-                  id: {
-                    not_in: valuesByRelation[relation],
-                  },
-                }
-              : {}),
-          },
+          [relation]: hoistQueryParamsToAnd(existingFilter, {
+            id: { not_in: valuesByRelation[relation] },
+          }),
         }
       })
     }

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -128,10 +128,6 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
       }, {})
 
       ;(Array.isArray(relationTo) ? relationTo : [relationTo]).forEach((relation) => {
-        if (!valuesByRelation[relation]) {
-          return
-        }
-
         const existingFilter =
           filterOptions?.[relation] && typeof filterOptions[relation] === 'object'
             ? filterOptions[relation]
@@ -139,9 +135,9 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
         newFilterOptions = {
           ...(newFilterOptions || {}),
-          [relation]: hoistQueryParamsToAnd(existingFilter, {
-            id: { not_in: valuesByRelation[relation] },
-          }),
+          [relation]: valuesByRelation[relation]
+            ? hoistQueryParamsToAnd(existingFilter, { id: { not_in: valuesByRelation[relation] } })
+            : existingFilter,
         }
       })
     }

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -1064,7 +1064,6 @@ describe('relationship', () => {
     await loadCreatePage()
 
     const listDrawerContent = page.locator('.list-drawer').locator('.drawer__content')
-    const rows = listDrawerContent.locator('table tbody tr')
 
     // Select doc1 in sibling1 drawer
     await page.locator('#field-relationshipDrawerFilterBySibling1').click()
@@ -1075,7 +1074,7 @@ describe('relationship', () => {
     // First open of sibling2 drawer: doc1 should be filtered out by filterOptions
     await page.locator('#field-relationshipDrawerFilterBySibling2').click()
     await expect(listDrawerContent).toBeVisible()
-    await expect(rows).toHaveCount(1)
+    await expect(listDrawerContent.getByText(doc1.text)).toBeHidden()
     await expect(listDrawerContent.getByText(doc2.text)).toBeVisible()
 
     // Select doc2 and close drawer
@@ -1083,11 +1082,10 @@ describe('relationship', () => {
     await expect(listDrawerContent).toBeHidden()
 
     // Second open: filterOptions must be re-evaluated
-    // doc1 is excluded by filterOptions (sibling1 = doc1)
-    // doc2 is excluded because it is already selected
+    // Without the fix, the cached ListView reappears and doc1 would be visible again
     await page.locator('#field-relationshipDrawerFilterBySibling2').click()
     await expect(listDrawerContent).toBeVisible()
-    await expect(rows).toHaveCount(0)
+    await expect(listDrawerContent.getByText(doc1.text)).toBeHidden()
   })
 
   describe('A11y', () => {

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -24,8 +24,8 @@ import {
 } from '../../../__helpers/e2e/helpers.js'
 import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
 import { assertToastErrors } from '../../../__helpers/shared/assertToastErrors.js'
-import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 import { relationshipFieldsSlug, textFieldsSlug } from '../../slugs.js'
 
@@ -1056,6 +1056,38 @@ describe('relationship', () => {
     await expect(
       page.locator('#field-relationshipDrawer .relationship--single-value__text'),
     ).toHaveText('new text')
+  })
+
+  test('should re-evaluate `filterOptions` on subsequent drawer opens when a value has already been set', async () => {
+    const doc1 = await createTextFieldDoc({ text: 'filterBySibling doc 1' })
+    const doc2 = await createTextFieldDoc({ text: 'filterBySibling doc 2' })
+    await loadCreatePage()
+
+    const listDrawerContent = page.locator('.list-drawer').locator('.drawer__content')
+    const rows = listDrawerContent.locator('table tbody tr')
+
+    // Select doc1 in sibling1 drawer
+    await page.locator('#field-relationshipDrawerFilterBySibling1').click()
+    await expect(listDrawerContent).toBeVisible()
+    await listDrawerContent.getByText(doc1.text, { exact: true }).click()
+    await expect(listDrawerContent).toBeHidden()
+
+    // First open of sibling2 drawer: doc1 should be filtered out by filterOptions
+    await page.locator('#field-relationshipDrawerFilterBySibling2').click()
+    await expect(listDrawerContent).toBeVisible()
+    await expect(rows).toHaveCount(1)
+    await expect(listDrawerContent.getByText(doc2.text)).toBeVisible()
+
+    // Select doc2 and close drawer
+    await listDrawerContent.getByText(doc2.text, { exact: true }).click()
+    await expect(listDrawerContent).toBeHidden()
+
+    // Second open: filterOptions must be re-evaluated
+    // doc1 is excluded by filterOptions (sibling1 = doc1)
+    // doc2 is excluded because it is already selected
+    await page.locator('#field-relationshipDrawerFilterBySibling2').click()
+    await expect(listDrawerContent).toBeVisible()
+    await expect(rows).toHaveCount(0)
   })
 
   describe('A11y', () => {

--- a/test/fields/collections/Relationship/index.ts
+++ b/test/fields/collections/Relationship/index.ts
@@ -191,6 +191,27 @@ const RelationshipFields: CollectionConfig = {
         }
       },
     },
+    {
+      name: 'relationshipDrawerFilterBySibling1',
+      admin: { appearance: 'drawer' },
+      type: 'relationship',
+      relationTo: 'text-fields',
+    },
+    {
+      name: 'relationshipDrawerFilterBySibling2',
+      admin: { appearance: 'drawer' },
+      type: 'relationship',
+      relationTo: 'text-fields',
+      filterOptions: ({ siblingData }) => {
+        const sibling1 = siblingData?.relationshipDrawerFilterBySibling1 as string | undefined
+
+        if (sibling1) {
+          return { id: { not_equals: sibling1 } }
+        }
+
+        return true
+      },
+    },
   ],
   slug: relationshipFieldsSlug,
 }

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1557,6 +1557,8 @@ export interface RelationshipField {
     relationTo: 'text-fields';
     value: string | TextField;
   } | null;
+  relationshipDrawerFilterBySibling1?: (string | null) | TextField;
+  relationshipDrawerFilterBySibling2?: (string | null) | TextField;
   updatedAt: string;
   createdAt: string;
 }
@@ -3327,6 +3329,8 @@ export interface RelationshipFieldsSelect<T extends boolean = true> {
   relationshipDrawerHasManyPolymorphic?: T;
   relationshipDrawerWithAllowCreateFalse?: T;
   relationshipDrawerWithFilterOptions?: T;
+  relationshipDrawerFilterBySibling1?: T;
+  relationshipDrawerFilterBySibling2?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?

When a `relationship` field uses `admin.appearance: 'drawer'` with a `filterOptions` function that depends on sibling field values, the filter stops being applied after the user selects a value and reopens the drawer. This is specific to the drawer appearance — the default `select` appearance works correctly.

### Why?

Three bugs compound to produce the issue:

**Bug 1 — ListView caching (`DrawerContent.tsx`)**

`DrawerContent` caches the rendered server list in `ListView` state and only calls `refresh()` (which re-fetches with the current `filterOptions`) when `ListView` is null. On first open, `ListView` is null so the fetch runs correctly. On any subsequent open, `ListView` is already set, so `refresh()` is skipped and the stale cached list is shown — meaning `filterOptions` is never re-evaluated against the updated form state.

**Bug 2 — `id` filter overwrite (`Input.tsx`)**

`listDrawerFilterOptions` combines the user's `filterOptions` result with a `not_in` exclusion for already-selected values using object spread. When both produce an `id` condition (e.g. `id: { not_equals: sibling1Id }` from `filterOptions` and `id: { not_in: [selectedId] }` from the exclusion logic), the spread silently overwrites the user's condition. This means the user's filter is dropped from the server query once a value is selected in the field.

**Bug 3 — `MemoizedDrawer` remount on `filterOptions` change (`index.tsx`)**

`MemoizedDrawer` in `useListDrawer` had `filterOptions` in its `useMemo` dependency array. After a value is selected, `listDrawerFilterOptions` in `Input.tsx` produces a new object reference (with the selected value excluded via `not_in`). This causes `MemoizedDrawer` to receive a new function reference, which React treats as a new component type — **unmounting and remounting** `ListDrawerContent`. This resets its `selectedOption` state back to the first collection, breaking the polymorphic drawer filter entirely.

### How?

**Fix 1 — Clear `ListView` on drawer close**

Added an effect that resets `ListView` to `undefined` and restores the loading state whenever the drawer closes. This ensures every subsequent open triggers a fresh `refresh()` call with the latest `filterOptions`.

Also added an `isOpen` guard to the existing `!ListView` effect to prevent a wasted server round-trip when `refresh` is recreated as a side effect of `isOpen` changing to false.

```tsx
// existing effect — added isOpen guard
useEffect(() => {
  if (!ListView && isOpen) {
    void refresh({ slug: selectedOption?.value })
  }
}, [refresh, ListView, selectedOption.value, isOpen])

// new effect — invalidate cache on close
useEffect(() => {
  if (!isOpen) {
    setListView(undefined)
    setIsLoading(true)
  }
}, [isOpen])
```

**Fix 2 — Merge `id` conditions with `and` logic**

Replaced the object spread in `listDrawerFilterOptions` with `hoistQueryParamsToAnd` (already used elsewhere in the codebase) so both `id` conditions are preserved:

```tsx
// before — silently overwrites id: { not_equals: ... } with id: { not_in: [...] }
[relation]: {
  ...(typeof filterOptions?.[relation] === 'object' ? filterOptions[relation] : {}),
  ...(valuesByRelation[relation] ? { id: { not_in: valuesByRelation[relation] } } : {}),
}

// after — combines both conditions with and
[relation]: hoistQueryParamsToAnd(existingFilter, { id: { not_in: valuesByRelation[relation] } })
```

**Fix 3 — Stabilize `MemoizedDrawer` with a ref**

Used a `useRef` to hold the latest `filterOptions` value, updated synchronously during render. The ref itself (not `ref.current`) is captured in the memoized component, so each render reads the current value without recreating the function. `filterOptions` is removed from the `useMemo` dependency array, preventing remounts:

```tsx
const filterOptionsRef = useRef(filterOptions)
filterOptionsRef.current = filterOptions

const MemoizedDrawer = useMemo(() => {
  return (props) => (
    <ListDrawer
      {...props}
      filterOptions={filterOptionsRef.current}
      // ...
    />
  )
}, [drawerSlug, collectionSlugs, uploads, closeDrawer, selectedCollection]) // filterOptions removed
```

Fixes #15971
