### PR TITLE
test: adjust total test count to exclude all skipped tests in summary output

### DIFF
--- a/test/runTestsWithSummary.ts
+++ b/test/runTestsWithSummary.ts
@@ -145,7 +145,7 @@ function parseTestResults(output: string): { passed: number; total: number } {
         if (typeof data.numPassedTests === 'number' && typeof data.numTotalTests === 'number') {
           return {
             passed: data.numPassedTests,
-            total: data.numTotalTests - (data.numTodoTests || 0),
+            total: data.numTotalTests - (data.numPendingTests || 0),
           }
         }
       } catch (e) {

--- a/test/runTestsWithSummary.ts
+++ b/test/runTestsWithSummary.ts
@@ -145,7 +145,7 @@ function parseTestResults(output: string): { passed: number; total: number } {
         if (typeof data.numPassedTests === 'number' && typeof data.numTotalTests === 'number') {
           return {
             passed: data.numPassedTests,
-            total: data.numTotalTests - (data.numPendingTests || 0),
+            total: data.numTotalTests - (data.numPendingTests || 0) - (data.numTodoTests || 0),
           }
         }
       } catch (e) {


### PR DESCRIPTION
The runTestsWithSummary.ts script was counting:
- .skip tests,
- tests that return early for non drizzle/non-mongo db adapters
 
in the total but not in passed, so they showed up as failures. These tests are now excluded from the total count.