### PR TITLE
chore: extract sanitizeField from sanitizeFields

### DIFF
--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -1,4 +1,5 @@
 import type { Config, SanitizedConfig } from '../../config/types.js'
+import type { OrderableJoinInfo } from '../../fields/config/sanitizeJoinField.js'
 import type {
   CollectionConfig,
   SanitizedCollectionConfig,
@@ -38,6 +39,10 @@ export const sanitizeCollection = async (
    */
   richTextSanitizationPromises?: Array<(config: SanitizedConfig) => Promise<void>>,
   _validRelationships?: string[],
+  /**
+   * Tracker for orderable join fields - populated during sanitization
+   */
+  orderableJoins?: OrderableJoinInfo[],
 ): Promise<SanitizedCollectionConfig> => {
   if (collection._sanitized) {
     return collection as SanitizedCollectionConfig
@@ -67,6 +72,7 @@ export const sanitizeCollection = async (
     fields: sanitized.fields,
     joinPath: '',
     joins,
+    orderableJoins,
     parentIsLocalized: false,
     polymorphicJoins,
     richTextSanitizationPromises,

--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -1,98 +1,31 @@
 import { status as httpStatus } from 'http-status'
 
 import type { BeforeChangeHook, CollectionConfig } from '../../collections/config/types.js'
-import type { Field } from '../../fields/config/types.js'
+import type { Config } from '../../config/types.js'
+import type { Field, TextField } from '../../fields/config/types.js'
 import type { Endpoint, PayloadHandler, SanitizedConfig } from '../types.js'
 
 import { executeAccess } from '../../auth/executeAccess.js'
 import { APIError } from '../../errors/index.js'
+import { sanitizeField } from '../../fields/config/sanitize.js'
 import { combineWhereConstraints } from '../../utilities/combineWhereConstraints.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
-import { traverseFields } from '../../utilities/traverseFields.js'
 import { generateKeyBetween, generateNKeysBetween } from './fractional-indexing.js'
 import { getJoinScopeContext } from './utils/getJoinScopeContext.js'
 import { getJoinScopeWhereFromDocData } from './utils/getJoinScopeWhereFromDocData.js'
 import { resolvePendingTargetKey } from './utils/resolvePendingTargetKey.js'
 
-/**
- * This function creates:
- * - N fields per collection, named `_order` or `_<collection>_<joinField>_order`
- * - 1 hook per collection
- * - 1 endpoint per app
- *
- * Also, if collection.defaultSort or joinField.defaultSort is not set, it will be set to the orderable field.
- */
-export const setupOrderable = (config: SanitizedConfig) => {
-  const fieldsToAdd = new Map<CollectionConfig, string[]>()
-  const joinFieldPathsByCollection = new Map<string, Map<string, string>>()
-
-  config.collections.forEach((collection) => {
-    if (collection.orderable) {
-      const currentFields = fieldsToAdd.get(collection) || []
-      fieldsToAdd.set(collection, [...currentFields, '_order'])
-      collection.defaultSort = collection.defaultSort ?? '_order'
-    }
-
-    traverseFields({
-      callback: ({ field, parentRef, ref }) => {
-        if (field.type === 'array' || field.type === 'blocks') {
-          return false
-        }
-        if (field.type === 'group' || field.type === 'tab') {
-          // @ts-expect-error ref is untyped
-          const parentPrefix = parentRef?.prefix ? `${parentRef.prefix}_` : ''
-          // @ts-expect-error ref is untyped
-          ref.prefix = `${parentPrefix}${field.name}`
-        }
-        if (field.type === 'join' && field.orderable === true) {
-          if (Array.isArray(field.collection)) {
-            throw new APIError(
-              'Orderable joins must target a single collection',
-              httpStatus.BAD_REQUEST,
-              {},
-              true,
-            )
-          }
-          const relationshipCollection = config.collections.find((c) => c.slug === field.collection)
-          if (!relationshipCollection) {
-            return false
-          }
-          field.defaultSort = field.defaultSort ?? `_${field.collection}_${field.name}_order`
-          const currentFields = fieldsToAdd.get(relationshipCollection) || []
-          // @ts-expect-error ref is untyped
-          const prefix = parentRef?.prefix ? `${parentRef.prefix}_` : ''
-          const joinOrderableFieldName = `_${field.collection}_${prefix}${field.name}_order`
-          fieldsToAdd.set(relationshipCollection, [...currentFields, joinOrderableFieldName])
-
-          const currentJoinFieldPaths =
-            joinFieldPathsByCollection.get(relationshipCollection.slug) || new Map<string, string>()
-          currentJoinFieldPaths.set(joinOrderableFieldName, field.on)
-          joinFieldPathsByCollection.set(relationshipCollection.slug, currentJoinFieldPaths)
-        }
-      },
-      fields: collection.fields,
-    })
-  })
-
-  Array.from(fieldsToAdd.entries()).forEach(([collection, orderableFields]) => {
-    addOrderableFieldsAndHook(collection, orderableFields, joinFieldPathsByCollection)
-  })
-
-  if (fieldsToAdd.size > 0) {
-    addOrderableEndpoint(config, joinFieldPathsByCollection)
-  }
-}
-
-export const addOrderableFieldsAndHook = (
+export const addOrderableFieldsAndHook = async (
   collection: CollectionConfig,
+  config: Config,
   orderableFieldNames: string[],
   joinFieldPathsByCollection?: Map<string, Map<string, string>>,
 ) => {
-  // 1. Add field
-  orderableFieldNames.forEach((orderableFieldName) => {
-    const orderField: Field = {
+  // 1. Add fields
+  for (const orderableFieldName of orderableFieldNames) {
+    const orderField: TextField = {
       name: orderableFieldName,
       type: 'text',
       admin: {
@@ -114,8 +47,24 @@ export const addOrderableFieldsAndHook = (
       index: true,
     }
 
+    // Sanitize the field using the standard sanitization logic
+    await sanitizeField({
+      collectionConfig: collection,
+      config,
+      existingFieldNames: new Set(),
+      field: orderField,
+      index: 0,
+      isTopLevelField: true,
+      joinPath: '',
+      parentIndexPath: '',
+      parentIsLocalized: false,
+      parentSchemaPath: '',
+      requireFieldLevelRichTextEditor: false,
+      validRelationships: null,
+    })
+
     collection.fields.unshift(orderField)
-  })
+  }
 
   // 2. Add hook
   if (!collection.hooks) {

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -3,6 +3,7 @@ import type { AcceptedLanguages } from '@payloadcms/translations'
 import { en } from '@payloadcms/translations/languages/en'
 import { deepMergeSimple } from '@payloadcms/translations/utilities'
 
+import type { OrderableJoinInfo } from '../fields/config/sanitizeJoinField.js'
 import type { CollectionSlug, GlobalSlug, SanitizedCollectionConfig } from '../index.js'
 import type { SanitizedJobsConfig } from '../queues/config/types/index.js'
 import type {
@@ -33,12 +34,12 @@ import { getPreferencesCollection, preferencesCollectionSlug } from '../preferen
 import { getQueryPresetsConfig, queryPresetsCollectionSlug } from '../query-presets/config.js'
 import { getDefaultJobsCollection, jobsCollectionSlug } from '../queues/config/collection.js'
 import { getJobStatsGlobal } from '../queues/config/global.js'
-import { flattenBlock } from '../utilities/flattenAllFields.js'
+import { flattenAllFields, flattenBlock } from '../utilities/flattenAllFields.js'
 import { hasScheduledPublishEnabled } from '../utilities/getVersionsConfig.js'
 import { validateTimezones } from '../utilities/validateTimezones.js'
 import { getSchedulePublishTask } from '../versions/schedule/job.js'
 import { addDefaultsToConfig } from './defaults.js'
-import { setupOrderable } from './orderable/index.js'
+import { addOrderableEndpoint, addOrderableFieldsAndHook } from './orderable/index.js'
 
 const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig> => {
   const sanitizedConfig = { ...configToSanitize }
@@ -117,9 +118,6 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
   const configWithDefaults = addDefaultsToConfig(incomingConfig)
 
   const config: Partial<SanitizedConfig> = sanitizeAdminConfig(configWithDefaults)
-
-  // Add orderable fields
-  setupOrderable(config as SanitizedConfig)
 
   if (!config.endpoints) {
     config.endpoints = []
@@ -261,6 +259,9 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
 
   const folderEnabledCollections: SanitizedCollectionConfig[] = []
 
+  // Track orderable join fields during sanitization
+  const orderableJoins: OrderableJoinInfo[] = []
+
   for (let i = 0; i < config.collections!.length; i++) {
     if (collectionSlugs.has(config.collections![i]!.slug)) {
       throw new DuplicateCollection('slug', config.collections![i]!.slug)
@@ -296,11 +297,58 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
       config.collections![i]!,
       richTextSanitizationPromises,
       validRelationships,
+      orderableJoins,
     )
 
     if (config.folders !== false && config.collections![i]!.folders) {
       folderEnabledCollections.push(config.collections![i]!)
     }
+  }
+
+  // Process orderable features after all collections are sanitized
+  const fieldsToAdd = new Map<SanitizedCollectionConfig, string[]>()
+  const joinFieldPathsByCollection = new Map<string, Map<string, string>>()
+
+  // Handle collection.orderable
+  for (const collection of config.collections!) {
+    if (collection.orderable) {
+      const currentFields = fieldsToAdd.get(collection) || []
+      fieldsToAdd.set(collection, [...currentFields, '_order'])
+      collection.defaultSort = collection.defaultSort ?? '_order'
+    }
+  }
+
+  // Handle orderable join fields (tracked during sanitization)
+  for (const joinInfo of orderableJoins) {
+    const targetCollection = config.collections!.find(
+      (c) => c.slug === joinInfo.targetCollectionSlug,
+    )
+    if (targetCollection) {
+      const currentFields = fieldsToAdd.get(targetCollection) || []
+      fieldsToAdd.set(targetCollection, [...currentFields, joinInfo.orderFieldName])
+
+      const currentJoinFieldPaths =
+        joinFieldPathsByCollection.get(targetCollection.slug) || new Map<string, string>()
+      currentJoinFieldPaths.set(joinInfo.orderFieldName, joinInfo.joinFieldOn)
+      joinFieldPathsByCollection.set(targetCollection.slug, currentJoinFieldPaths)
+    }
+  }
+
+  // Add fields, hooks, and update flattenedFields
+  for (const [collection, orderableFields] of fieldsToAdd) {
+    await addOrderableFieldsAndHook(
+      collection,
+      config as unknown as Config,
+      orderableFields,
+      joinFieldPathsByCollection,
+    )
+    // Regenerate flattenedFields since we added new fields
+    collection.flattenedFields = flattenAllFields({ fields: collection.fields })
+  }
+
+  // Add endpoint if any orderable features exist
+  if (fieldsToAdd.size > 0) {
+    addOrderableEndpoint(config as SanitizedConfig, joinFieldPathsByCollection)
   }
 
   if (config.globals!.length > 0) {

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../collections/config/types.js'
 import type { Config, SanitizedConfig } from '../../config/types.js'
 import type { GlobalConfig } from '../../globals/config/types.js'
+import type { OrderableJoinInfo } from './sanitizeJoinField.js'
 import type { Field } from './types.js'
 
 import {
@@ -52,6 +53,10 @@ type SanitizeFieldsArgs = {
    * When not passed in, assume that join are not supported (globals, arrays, blocks)
    */
   joins?: SanitizedJoins
+  /**
+   * Tracker for orderable join fields - populated during sanitization
+   */
+  orderableJoins?: OrderableJoinInfo[]
   /**
    * A string of '-' separated indexes representing where
    * to find this field in a given field schema array.
@@ -100,6 +105,10 @@ export type SanitizeFieldArgs = {
    * When not passed in, assume that joins are not supported (globals, arrays, blocks)
    */
   joins?: SanitizedJoins
+  /**
+   * Tracker for orderable join fields - populated during sanitization
+   */
+  orderableJoins?: OrderableJoinInfo[]
   parentIndexPath: string
   parentIsLocalized: boolean
   parentSchemaPath: string
@@ -135,6 +144,7 @@ export const sanitizeField = async ({
   isTopLevelField,
   joinPath,
   joins,
+  orderableJoins,
   parentIndexPath,
   parentIsLocalized,
   parentSchemaPath,
@@ -231,6 +241,7 @@ export const sanitizeField = async ({
       field,
       joinPath,
       joins,
+      orderableJoins,
       parentIsLocalized,
       polymorphicJoins,
     })
@@ -429,6 +440,7 @@ export const sanitizeField = async ({
       isTopLevelField: isTopLevelField && !fieldAffectsData,
       joinPath: fieldAffectsData ? `${joinPath ? joinPath + '.' : ''}${field.name}` : joinPath,
       joins,
+      orderableJoins,
       parentIndexPath: fieldAffectsData ? '' : indexPath,
       parentIsLocalized: parentIsLocalized || fieldIsLocalized(field),
       parentSchemaPath: schemaPath,
@@ -473,6 +485,7 @@ export const sanitizeField = async ({
         isTopLevelField: isTopLevelField && !isNamedTab,
         joinPath: isNamedTab ? `${joinPath ? joinPath + '.' : ''}${tab.name}` : joinPath,
         joins,
+        orderableJoins,
         parentIndexPath: isNamedTab ? '' : tabIndexPath,
         parentIsLocalized: parentIsLocalized || (isNamedTab && tab.localized)!,
         parentSchemaPath: tabSchemaPath,
@@ -606,6 +619,7 @@ export const sanitizeFields = async ({
   isTopLevelField = true,
   joinPath = '',
   joins,
+  orderableJoins,
   parentIndexPath = '',
   parentIsLocalized,
   parentSchemaPath = '',
@@ -631,6 +645,7 @@ export const sanitizeFields = async ({
       isTopLevelField,
       joinPath,
       joins,
+      orderableJoins,
       parentIndexPath,
       parentIsLocalized,
       parentSchemaPath,

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -35,14 +35,9 @@ import {
   reservedVerifyFieldNames,
 } from './reservedFieldNames.js'
 import { sanitizeJoinField } from './sanitizeJoinField.js'
-import {
-  fieldAffectsData as _fieldAffectsData,
-  fieldIsLocalized,
-  fieldIsVirtual,
-  tabHasName,
-} from './types.js'
+import { fieldAffectsData as _fieldAffectsData, fieldIsLocalized, tabHasName } from './types.js'
 
-type Args = {
+type SanitizeFieldsArgs = {
   collectionConfig?: CollectionConfig
   config: Config
   existingFieldNames?: Set<string>
@@ -86,6 +81,522 @@ type Args = {
   validRelationships: null | string[]
 }
 
+export type SanitizeFieldArgs = {
+  collectionConfig?: CollectionConfig
+  config: Config
+  existingFieldNames: Set<string>
+  field: Field
+  globalConfig?: GlobalConfig
+  /**
+   * The index of this field in the parent fields array
+   */
+  index: number
+  /**
+   * Used to prevent unnecessary sanitization of fields that are not top-level.
+   */
+  isTopLevelField: boolean
+  joinPath: string
+  /**
+   * When not passed in, assume that joins are not supported (globals, arrays, blocks)
+   */
+  joins?: SanitizedJoins
+  parentIndexPath: string
+  parentIsLocalized: boolean
+  parentSchemaPath: string
+  polymorphicJoins?: SanitizedJoin[]
+  requireFieldLevelRichTextEditor: boolean
+  richTextSanitizationPromises?: Array<(config: SanitizedConfig) => Promise<void>>
+  validRelationships: null | string[]
+}
+
+type SanitizeFieldResult = {
+  /**
+   * Fields to insert after this field (e.g., timezone field)
+   */
+  fieldsToInsert?: Field[]
+}
+
+/**
+ * Sanitize a single field. Handles all per-field logic including:
+ * - Validation setup
+ * - Hooks/access/admin defaults
+ * - Type-specific handling
+ * - Recursive sanitization of nested fields
+ *
+ * @returns Result containing any fields to insert after this one
+ */
+export const sanitizeField = async ({
+  collectionConfig,
+  config,
+  existingFieldNames,
+  field,
+  globalConfig,
+  index,
+  isTopLevelField,
+  joinPath,
+  joins,
+  parentIndexPath,
+  parentIsLocalized,
+  parentSchemaPath,
+  polymorphicJoins,
+  requireFieldLevelRichTextEditor,
+  richTextSanitizationPromises,
+  validRelationships,
+}: SanitizeFieldArgs): Promise<SanitizeFieldResult> => {
+  const result: SanitizeFieldResult = {}
+
+  if ('_sanitized' in field && field._sanitized === true) {
+    return result
+  }
+
+  if ('_sanitized' in field) {
+    field._sanitized = true
+  }
+
+  if (!field.type) {
+    throw new MissingFieldType(field)
+  }
+
+  const fieldAffectsData = _fieldAffectsData(field)
+
+  const { indexPath, schemaPath } = getFieldPaths({
+    field,
+    index,
+    parentIndexPath,
+    parentSchemaPath,
+  })
+
+  // Reserved field name checks
+  if (isTopLevelField && fieldAffectsData && field.name) {
+    if (collectionConfig && collectionConfig.upload) {
+      if (reservedBaseUploadFieldNames.includes(field.name)) {
+        throw new ReservedFieldName(field, field.name)
+      }
+    }
+
+    if (
+      collectionConfig &&
+      collectionConfig.auth &&
+      typeof collectionConfig.auth === 'object' &&
+      !collectionConfig.auth.disableLocalStrategy
+    ) {
+      if (reservedBaseAuthFieldNames.includes(field.name)) {
+        throw new ReservedFieldName(field, field.name)
+      }
+
+      if (collectionConfig.auth.verify) {
+        // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+        if (reservedAPIKeyFieldNames.includes(field.name)) {
+          throw new ReservedFieldName(field, field.name)
+        }
+
+        // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+        if (reservedVerifyFieldNames.includes(field.name)) {
+          throw new ReservedFieldName(field, field.name)
+        }
+      }
+    }
+  }
+
+  // Invalid field name check
+  if (fieldAffectsData && field.name.includes('.')) {
+    throw new InvalidFieldName(field, field.name)
+  }
+
+  // Auto-label
+  if (
+    'name' in field &&
+    field.name &&
+    typeof field.label !== 'object' &&
+    typeof field.label !== 'string' &&
+    typeof field.label !== 'function' &&
+    field.label !== false
+  ) {
+    field.label = toWords(field.name)
+  }
+
+  // Checkbox default
+  if (
+    field.type === 'checkbox' &&
+    typeof field.defaultValue === 'undefined' &&
+    field.required === true
+  ) {
+    field.defaultValue = false
+  }
+
+  // Join field sanitization
+  if (field.type === 'join') {
+    sanitizeJoinField({
+      config,
+      field,
+      joinPath,
+      joins,
+      parentIsLocalized,
+      polymorphicJoins,
+    })
+  }
+
+  // Relationship/upload validation
+  if (field.type === 'relationship' || field.type === 'upload') {
+    if (Array.isArray(field.relationTo) && field.relationTo.length === 0) {
+      throw new Error(
+        `Field "${field.name}" of type "${field.type}" has an empty relationTo array. At least one collection must be specified.`,
+      )
+    }
+
+    if (validRelationships) {
+      const relationships = Array.isArray(field.relationTo) ? field.relationTo : [field.relationTo]
+
+      relationships.forEach((relationship: string) => {
+        if (!validRelationships.includes(relationship)) {
+          throw new InvalidFieldRelationship(field, relationship)
+        }
+      })
+    }
+
+    if (field.min && !field.minRows) {
+      console.warn(
+        `(payload): The "min" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "minRows" instead.`,
+      )
+      field.minRows = field.min
+    }
+
+    if (field.max && !field.maxRows) {
+      console.warn(
+        `(payload): The "max" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "maxRows" instead.`,
+      )
+      field.maxRows = field.max
+    }
+  }
+
+  // Upload isSortable default
+  if (field.type === 'upload') {
+    if (!field.admin || !('isSortable' in field.admin)) {
+      field.admin = {
+        isSortable: true,
+        ...field.admin,
+      }
+    }
+  }
+
+  // Array ID field
+  if (field.type === 'array' && field.fields) {
+    const hasCustomID = field.fields.some((f) => 'name' in f && f.name === 'id')
+    if (!hasCustomID) {
+      field.fields.push(baseIDField)
+    }
+  }
+
+  // Blocks/array labels
+  if ((field.type === 'blocks' || field.type === 'array') && field.label) {
+    field.labels = field.labels || formatLabels(field.name)
+  }
+
+  if (fieldAffectsData) {
+    if (existingFieldNames.has(field.name)) {
+      throw new DuplicateFieldName(field.name)
+    } else if (!['blockName', 'id'].includes(field.name)) {
+      existingFieldNames.add(field.name)
+    }
+
+    if (typeof field.localized !== 'undefined') {
+      let shouldDisableLocalized = !config.localization
+
+      if (
+        process.env.NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized !== 'true' &&
+        parentIsLocalized &&
+        // @todo PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY=true will be the default in 4.0
+        process.env.PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY !== 'true'
+      ) {
+        shouldDisableLocalized = true
+      }
+
+      if (shouldDisableLocalized) {
+        delete field.localized
+      }
+    }
+
+    if (typeof field.validate === 'undefined') {
+      if ('virtual' in field && field.virtual) {
+        field.validate = (): true => true
+      } else {
+        const defaultValidate = validations[field.type as keyof typeof validations]
+        if (defaultValidate) {
+          field.validate = (val: any, options: any) =>
+            defaultValidate(val, { ...field, ...options })
+        } else {
+          field.validate = (): true => true
+        }
+      }
+    }
+
+    if (!field.hooks) {
+      field.hooks = {}
+    }
+
+    if (!field.access) {
+      field.access = {}
+    }
+
+    setDefaultBeforeDuplicate(field, parentIsLocalized)
+  }
+
+  if (!field.admin) {
+    field.admin = {}
+  }
+
+  // Make sure that the richText field has an editor
+  if (field.type === 'richText') {
+    const sanitizeRichText = async (_config: SanitizedConfig) => {
+      if (!field.editor) {
+        if (_config.editor && !requireFieldLevelRichTextEditor) {
+          // config.editor should be sanitized at this point
+          field.editor = _config.editor
+        } else {
+          throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
+        }
+      }
+
+      if (typeof field.editor === 'function') {
+        field.editor = await field.editor({
+          config: _config,
+          isRoot: requireFieldLevelRichTextEditor,
+          parentIsLocalized: (parentIsLocalized || field.localized)!,
+        })
+      }
+
+      if (field.editor.i18n && Object.keys(field.editor.i18n).length >= 0) {
+        config.i18n!.translations = deepMergeSimple(config.i18n!.translations!, field.editor.i18n)
+      }
+    }
+    if (richTextSanitizationPromises) {
+      richTextSanitizationPromises.push(sanitizeRichText)
+    } else {
+      await sanitizeRichText(config as unknown as SanitizedConfig)
+    }
+  }
+
+  if (field.type === 'blocks' && field.blocks) {
+    if (field.blockReferences && field.blocks?.length) {
+      throw new Error('You cannot have both blockReferences and blocks in the same blocks field')
+    }
+
+    const blockSlugs: string[] = []
+
+    for (const block of field.blockReferences ?? field.blocks) {
+      const blockSlug = typeof block === 'string' ? block : block.slug
+
+      if (blockSlugs.includes(blockSlug)) {
+        throw new DuplicateFieldName(blockSlug)
+      }
+
+      blockSlugs.push(blockSlug)
+
+      if (typeof block === 'string') {
+        continue
+      }
+
+      if (block._sanitized === true) {
+        continue
+      }
+
+      block._sanitized = true
+      block.fields = block.fields.concat(baseBlockFields)
+      block.labels = !block.labels ? formatLabels(block.slug) : block.labels
+
+      block.fields = await sanitizeFields({
+        collectionConfig,
+        config,
+        existingFieldNames: new Set(),
+        fields: block.fields,
+        isTopLevelField: false,
+        parentIndexPath: '',
+        parentIsLocalized: (parentIsLocalized || field.localized)!,
+        parentSchemaPath: schemaPath + '.' + block.slug,
+        requireFieldLevelRichTextEditor,
+        richTextSanitizationPromises,
+        validRelationships,
+      })
+    }
+  }
+
+  if ('fields' in field && field.fields) {
+    field.fields = await sanitizeFields({
+      collectionConfig,
+      config,
+      existingFieldNames: fieldAffectsData ? new Set() : existingFieldNames,
+      fields: field.fields,
+      isTopLevelField: isTopLevelField && !fieldAffectsData,
+      joinPath: fieldAffectsData ? `${joinPath ? joinPath + '.' : ''}${field.name}` : joinPath,
+      joins,
+      parentIndexPath: fieldAffectsData ? '' : indexPath,
+      parentIsLocalized: parentIsLocalized || fieldIsLocalized(field),
+      parentSchemaPath: schemaPath,
+      polymorphicJoins,
+      requireFieldLevelRichTextEditor,
+      richTextSanitizationPromises,
+      validRelationships,
+    })
+  }
+
+  if (field.type === 'tabs') {
+    for (let j = 0; j < field.tabs.length; j++) {
+      const tab = field.tabs[j]!
+
+      const isNamedTab = tabHasName(tab)
+
+      if (isNamedTab && typeof tab.label === 'undefined') {
+        tab.label = toWords(tab.name)
+      }
+
+      const { indexPath: tabIndexPath, schemaPath: tabSchemaPath } = getFieldPaths({
+        field: tab,
+        index: j,
+        parentIndexPath: indexPath,
+        parentSchemaPath: schemaPath,
+      })
+
+      if (
+        'admin' in tab &&
+        tab.admin?.condition &&
+        typeof tab.admin.condition === 'function' &&
+        !tab.id
+      ) {
+        tab.id = tabSchemaPath
+      }
+
+      tab.fields = await sanitizeFields({
+        collectionConfig,
+        config,
+        existingFieldNames: isNamedTab ? new Set() : existingFieldNames,
+        fields: tab.fields,
+        isTopLevelField: isTopLevelField && !isNamedTab,
+        joinPath: isNamedTab ? `${joinPath ? joinPath + '.' : ''}${tab.name}` : joinPath,
+        joins,
+        parentIndexPath: isNamedTab ? '' : tabIndexPath,
+        parentIsLocalized: parentIsLocalized || (isNamedTab && tab.localized)!,
+        parentSchemaPath: tabSchemaPath,
+        polymorphicJoins,
+        requireFieldLevelRichTextEditor,
+        richTextSanitizationPromises,
+        validRelationships,
+      })
+
+      field.tabs[j] = tab
+    }
+  }
+
+  if (field.type === 'ui' && typeof field.admin.disableBulkEdit === 'undefined') {
+    field.admin.disableBulkEdit = true
+  }
+
+  // Timezone field insertion
+  if (field.type === 'date' && field.timezone) {
+    const name = field.name + '_tz'
+
+    let defaultTimezone =
+      field.timezone && typeof field.timezone === 'object'
+        ? field.timezone.defaultTimezone
+        : config.admin?.timezones?.defaultTimezone
+
+    const required =
+      field.required ||
+      (field.timezone && typeof field.timezone === 'object' && field.timezone.required)
+
+    const supportedTimezones =
+      field.timezone && typeof field.timezone === 'object' && field.timezone.supportedTimezones
+        ? field.timezone.supportedTimezones
+        : config.admin?.timezones?.supportedTimezones
+
+    const options =
+      typeof supportedTimezones === 'function'
+        ? supportedTimezones({ defaultTimezones })
+        : supportedTimezones
+
+    validateTimezones({
+      source: `field "${field.name}" timezone.supportedTimezones`,
+      timezones: options,
+    })
+
+    if (options && options.length === 1 && options[0]?.value) {
+      defaultTimezone = options[0].value
+    }
+
+    // Generate label for timezone field
+    const timezoneLabel = typeof field.label === 'string' ? `${field.label} Tz` : toWords(name)
+
+    const baseField = baseTimezoneField({
+      name,
+      defaultValue: defaultTimezone,
+      label: timezoneLabel,
+      options,
+      required,
+    })
+
+    // Apply override if provided
+    const timezoneField =
+      typeof field.timezone === 'object' && typeof field.timezone.override === 'function'
+        ? field.timezone.override({ baseField })
+        : baseField
+
+    result.fieldsToInsert = [timezoneField]
+  }
+
+  // Virtual field handling
+  if ('virtual' in field && typeof field.virtual === 'string') {
+    const virtualField = field
+    const configFields = (collectionConfig || globalConfig)?.fields
+    if (configFields) {
+      let flattenFields = flattenAllFields({ fields: configFields })
+      const paths = field.virtual.split('.')
+      let isHasMany = false
+
+      for (const [idx, segment] of paths.entries()) {
+        const foundField = flattenFields.find((e) => e.name === segment)
+        if (!foundField) {
+          break
+        }
+
+        if (
+          foundField.type === 'group' ||
+          foundField.type === 'tab' ||
+          foundField.type === 'array'
+        ) {
+          flattenFields = foundField.flattenedFields
+        } else if (
+          (foundField.type === 'relationship' || foundField.type === 'upload') &&
+          idx !== paths.length - 1 &&
+          typeof foundField.relationTo === 'string'
+        ) {
+          if (
+            foundField.hasMany &&
+            (virtualField.type === 'text' ||
+              virtualField.type === 'number' ||
+              virtualField.type === 'select')
+          ) {
+            if (isHasMany) {
+              throw new InvalidConfiguration(
+                `Virtual field ${virtualField.name} in ${globalConfig ? `global ${globalConfig.slug}` : `collection ${collectionConfig?.slug}`} references 2 or more hasMany relationships on the path ${virtualField.virtual} which is not allowed.`,
+              )
+            }
+
+            isHasMany = true
+            virtualField.hasMany = true
+          }
+          const relatedCollection = config.collections?.find(
+            (e) => e.slug === foundField.relationTo,
+          )
+          if (relatedCollection) {
+            flattenFields = flattenAllFields({ fields: relatedCollection.fields })
+          }
+        }
+      }
+    }
+  }
+
+  return result
+}
+
 export const sanitizeFields = async ({
   collectionConfig,
   config,
@@ -102,7 +613,7 @@ export const sanitizeFields = async ({
   requireFieldLevelRichTextEditor = false,
   richTextSanitizationPromises,
   validRelationships,
-}: Args): Promise<Field[]> => {
+}: SanitizeFieldsArgs): Promise<Field[]> => {
   if (!fields) {
     return []
   }
@@ -110,440 +621,30 @@ export const sanitizeFields = async ({
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i]!
 
-    if ('_sanitized' in field && field._sanitized === true) {
-      continue
-    }
-
-    if ('_sanitized' in field) {
-      field._sanitized = true
-    }
-
-    if (!field.type) {
-      throw new MissingFieldType(field)
-    }
-
-    const fieldAffectsData = _fieldAffectsData(field)
-
-    const { indexPath, schemaPath } = getFieldPaths({
+    const result = await sanitizeField({
+      collectionConfig,
+      config,
+      existingFieldNames,
       field,
+      globalConfig,
       index: i,
+      isTopLevelField,
+      joinPath,
+      joins,
       parentIndexPath,
+      parentIsLocalized,
       parentSchemaPath,
+      polymorphicJoins,
+      requireFieldLevelRichTextEditor,
+      richTextSanitizationPromises,
+      validRelationships,
     })
-
-    if (isTopLevelField && fieldAffectsData && field.name) {
-      if (collectionConfig && collectionConfig.upload) {
-        if (reservedBaseUploadFieldNames.includes(field.name)) {
-          throw new ReservedFieldName(field, field.name)
-        }
-      }
-
-      if (
-        collectionConfig &&
-        collectionConfig.auth &&
-        typeof collectionConfig.auth === 'object' &&
-        !collectionConfig.auth.disableLocalStrategy
-      ) {
-        if (reservedBaseAuthFieldNames.includes(field.name)) {
-          throw new ReservedFieldName(field, field.name)
-        }
-
-        if (collectionConfig.auth.verify) {
-          // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
-          if (reservedAPIKeyFieldNames.includes(field.name)) {
-            throw new ReservedFieldName(field, field.name)
-          }
-
-          // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
-          if (reservedVerifyFieldNames.includes(field.name)) {
-            throw new ReservedFieldName(field, field.name)
-          }
-        }
-      }
-    }
-
-    // assert that field names do not contain forbidden characters
-    if (fieldAffectsData && field.name.includes('.')) {
-      throw new InvalidFieldName(field, field.name)
-    }
-
-    // Auto-label
-    if (
-      'name' in field &&
-      field.name &&
-      typeof field.label !== 'object' &&
-      typeof field.label !== 'string' &&
-      typeof field.label !== 'function' &&
-      field.label !== false
-    ) {
-      field.label = toWords(field.name)
-    }
-
-    if (
-      field.type === 'checkbox' &&
-      typeof field.defaultValue === 'undefined' &&
-      field.required === true
-    ) {
-      field.defaultValue = false
-    }
-
-    if (field.type === 'join') {
-      sanitizeJoinField({ config, field, joinPath, joins, parentIsLocalized, polymorphicJoins })
-    }
-
-    if (field.type === 'relationship' || field.type === 'upload') {
-      // Validate that relationTo is not empty
-      if (Array.isArray(field.relationTo) && field.relationTo.length === 0) {
-        throw new Error(
-          `Field "${field.name}" of type "${field.type}" has an empty relationTo array. At least one collection must be specified.`,
-        )
-      }
-
-      if (validRelationships) {
-        const relationships = Array.isArray(field.relationTo)
-          ? field.relationTo
-          : [field.relationTo]
-
-        relationships.forEach((relationship: string) => {
-          if (!validRelationships.includes(relationship)) {
-            throw new InvalidFieldRelationship(field, relationship)
-          }
-        })
-      }
-
-      if (field.min && !field.minRows) {
-        console.warn(
-          `(payload): The "min" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "minRows" instead.`,
-        )
-        field.minRows = field.min
-      }
-
-      if (field.max && !field.maxRows) {
-        console.warn(
-          `(payload): The "max" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "maxRows" instead.`,
-        )
-        field.maxRows = field.max
-      }
-    }
-
-    if (field.type === 'upload') {
-      if (!field.admin || !('isSortable' in field.admin)) {
-        field.admin = {
-          isSortable: true,
-          ...field.admin,
-        }
-      }
-    }
-
-    if (field.type === 'array' && field.fields) {
-      const hasCustomID = field.fields.some((f) => 'name' in f && f.name === 'id')
-      if (!hasCustomID) {
-        field.fields.push(baseIDField)
-      }
-    }
-
-    if ((field.type === 'blocks' || field.type === 'array') && field.label) {
-      field.labels = field.labels || formatLabels(field.name)
-    }
-
-    if (fieldAffectsData) {
-      if (existingFieldNames.has(field.name)) {
-        throw new DuplicateFieldName(field.name)
-      } else if (!['blockName', 'id'].includes(field.name)) {
-        existingFieldNames.add(field.name)
-      }
-
-      if (typeof field.localized !== 'undefined') {
-        let shouldDisableLocalized = !config.localization
-
-        if (
-          process.env.NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized !== 'true' &&
-          parentIsLocalized &&
-          // @todo PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY=true will be the default in 4.0
-          process.env.PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY !== 'true'
-        ) {
-          shouldDisableLocalized = true
-        }
-
-        if (shouldDisableLocalized) {
-          delete field.localized
-        }
-      }
-
-      if (typeof field.validate === 'undefined') {
-        if ('virtual' in field && field.virtual) {
-          field.validate = (): true => true
-        } else {
-          const defaultValidate = validations[field.type as keyof typeof validations]
-          if (defaultValidate) {
-            field.validate = (val: any, options: any) =>
-              defaultValidate(val, { ...field, ...options })
-          } else {
-            field.validate = (): true => true
-          }
-        }
-      }
-
-      if (!field.hooks) {
-        field.hooks = {}
-      }
-
-      if (!field.access) {
-        field.access = {}
-      }
-
-      setDefaultBeforeDuplicate(field, parentIsLocalized)
-    }
-
-    if (!field.admin) {
-      field.admin = {}
-    }
-
-    // Make sure that the richText field has an editor
-    if (field.type === 'richText') {
-      const sanitizeRichText = async (_config: SanitizedConfig) => {
-        if (!field.editor) {
-          if (_config.editor && !requireFieldLevelRichTextEditor) {
-            // config.editor should be sanitized at this point
-            field.editor = _config.editor
-          } else {
-            throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
-          }
-        }
-
-        if (typeof field.editor === 'function') {
-          field.editor = await field.editor({
-            config: _config,
-            isRoot: requireFieldLevelRichTextEditor,
-            parentIsLocalized: (parentIsLocalized || field.localized)!,
-          })
-        }
-
-        if (field.editor.i18n && Object.keys(field.editor.i18n).length >= 0) {
-          config.i18n!.translations = deepMergeSimple(config.i18n!.translations!, field.editor.i18n)
-        }
-      }
-      if (richTextSanitizationPromises) {
-        richTextSanitizationPromises.push(sanitizeRichText)
-      } else {
-        await sanitizeRichText(config as unknown as SanitizedConfig)
-      }
-    }
-
-    if (field.type === 'blocks' && field.blocks) {
-      if (field.blockReferences && field.blocks?.length) {
-        throw new Error('You cannot have both blockReferences and blocks in the same blocks field')
-      }
-
-      const blockSlugs: string[] = []
-
-      for (const block of field.blockReferences ?? field.blocks) {
-        const blockSlug = typeof block === 'string' ? block : block.slug
-
-        if (blockSlugs.includes(blockSlug)) {
-          throw new DuplicateFieldName(blockSlug)
-        }
-
-        blockSlugs.push(blockSlug)
-
-        if (typeof block === 'string') {
-          continue
-        }
-
-        if (block._sanitized === true) {
-          continue
-        }
-
-        block._sanitized = true
-        block.fields = block.fields.concat(baseBlockFields)
-        block.labels = !block.labels ? formatLabels(block.slug) : block.labels
-
-        block.fields = await sanitizeFields({
-          collectionConfig,
-          config,
-          existingFieldNames: new Set(),
-          fields: block.fields,
-          isTopLevelField: false,
-          parentIndexPath: '',
-          parentIsLocalized: (parentIsLocalized || field.localized)!,
-          parentSchemaPath: schemaPath + '.' + block.slug,
-          requireFieldLevelRichTextEditor,
-          richTextSanitizationPromises,
-          validRelationships,
-        })
-      }
-    }
-
-    if ('fields' in field && field.fields) {
-      field.fields = await sanitizeFields({
-        collectionConfig,
-        config,
-        existingFieldNames: fieldAffectsData ? new Set() : existingFieldNames,
-        fields: field.fields,
-        isTopLevelField: isTopLevelField && !fieldAffectsData,
-        joinPath: fieldAffectsData ? `${joinPath ? joinPath + '.' : ''}${field.name}` : joinPath,
-        joins,
-        parentIndexPath: fieldAffectsData ? '' : indexPath,
-        parentIsLocalized: parentIsLocalized || fieldIsLocalized(field),
-        parentSchemaPath: schemaPath,
-        polymorphicJoins,
-        requireFieldLevelRichTextEditor,
-        richTextSanitizationPromises,
-        validRelationships,
-      })
-    }
-
-    if (field.type === 'tabs') {
-      for (let j = 0; j < field.tabs.length; j++) {
-        const tab = field.tabs[j]!
-
-        const isNamedTab = tabHasName(tab)
-
-        if (isNamedTab && typeof tab.label === 'undefined') {
-          tab.label = toWords(tab.name)
-        }
-
-        const { indexPath: tabIndexPath, schemaPath: tabSchemaPath } = getFieldPaths({
-          field: tab,
-          index: j,
-          parentIndexPath: indexPath,
-          parentSchemaPath: schemaPath,
-        })
-
-        if (
-          'admin' in tab &&
-          tab.admin?.condition &&
-          typeof tab.admin.condition === 'function' &&
-          !tab.id
-        ) {
-          tab.id = tabSchemaPath
-        }
-
-        tab.fields = await sanitizeFields({
-          collectionConfig,
-          config,
-          existingFieldNames: isNamedTab ? new Set() : existingFieldNames,
-          fields: tab.fields,
-          isTopLevelField: isTopLevelField && !isNamedTab,
-          joinPath: isNamedTab ? `${joinPath ? joinPath + '.' : ''}${tab.name}` : joinPath,
-          joins,
-          parentIndexPath: isNamedTab ? '' : tabIndexPath,
-          parentIsLocalized: parentIsLocalized || (isNamedTab && tab.localized)!,
-          parentSchemaPath: tabSchemaPath,
-          polymorphicJoins,
-          requireFieldLevelRichTextEditor,
-          richTextSanitizationPromises,
-          validRelationships,
-        })
-
-        field.tabs[j] = tab
-      }
-    }
-
-    if (field.type === 'ui' && typeof field.admin.disableBulkEdit === 'undefined') {
-      field.admin.disableBulkEdit = true
-    }
 
     fields[i] = field
 
-    // Insert our field after assignment
-    if (field.type === 'date' && field.timezone) {
-      const name = field.name + '_tz'
-
-      let defaultTimezone =
-        field.timezone && typeof field.timezone === 'object'
-          ? field.timezone.defaultTimezone
-          : config.admin?.timezones?.defaultTimezone
-
-      const required =
-        field.required ||
-        (field.timezone && typeof field.timezone === 'object' && field.timezone.required)
-
-      const supportedTimezones =
-        field.timezone && typeof field.timezone === 'object' && field.timezone.supportedTimezones
-          ? field.timezone.supportedTimezones
-          : config.admin?.timezones?.supportedTimezones
-
-      const options =
-        typeof supportedTimezones === 'function'
-          ? supportedTimezones({ defaultTimezones })
-          : supportedTimezones
-
-      validateTimezones({
-        source: `field "${field.name}" timezone.supportedTimezones`,
-        timezones: options,
-      })
-
-      if (options && options.length === 1 && options[0]?.value) {
-        defaultTimezone = options[0].value
-      }
-
-      // Generate label for timezone field
-      // Use parent field's label + ' Tz' if it's a simple string, otherwise fallback to name
-      const timezoneLabel = typeof field.label === 'string' ? `${field.label} Tz` : toWords(name)
-
-      // Need to set the options here manually so that any database enums are generated correctly
-      // The UI component will import the options from the config
-      const baseField = baseTimezoneField({
-        name,
-        defaultValue: defaultTimezone,
-        label: timezoneLabel,
-        options,
-        required,
-      })
-
-      // Apply override if provided
-      const timezoneField =
-        typeof field.timezone === 'object' && typeof field.timezone.override === 'function'
-          ? field.timezone.override({ baseField })
-          : baseField
-
-      fields.splice(++i, 0, timezoneField)
-    }
-
-    if ('virtual' in field && typeof field.virtual === 'string') {
-      const virtualField = field
-      const fields = (collectionConfig || globalConfig)?.fields
-      if (fields) {
-        let flattenFields = flattenAllFields({ fields })
-        const paths = field.virtual.split('.')
-        let isHasMany = false
-
-        for (const [i, segment] of paths.entries()) {
-          const field = flattenFields.find((e) => e.name === segment)
-          if (!field) {
-            break
-          }
-
-          if (field.type === 'group' || field.type === 'tab' || field.type === 'array') {
-            flattenFields = field.flattenedFields
-          } else if (
-            (field.type === 'relationship' || field.type === 'upload') &&
-            i !== paths.length - 1 &&
-            typeof field.relationTo === 'string'
-          ) {
-            if (
-              field.hasMany &&
-              (virtualField.type === 'text' ||
-                virtualField.type === 'number' ||
-                virtualField.type === 'select')
-            ) {
-              if (isHasMany) {
-                throw new InvalidConfiguration(
-                  `Virtual field ${virtualField.name} in ${globalConfig ? `global ${globalConfig.slug}` : `collection ${collectionConfig?.slug}`} references 2 or more hasMany relationships on the path ${virtualField.virtual} which is not allowed.`,
-                )
-              }
-
-              isHasMany = true
-              virtualField.hasMany = true
-            }
-            const relatedCollection = config.collections?.find((e) => e.slug === field.relationTo)
-            if (relatedCollection) {
-              flattenFields = flattenAllFields({ fields: relatedCollection.fields })
-            }
-          }
-        }
-      }
+    if (result.fieldsToInsert?.length) {
+      fields.splice(i + 1, 0, ...result.fieldsToInsert)
+      i += result.fieldsToInsert.length
     }
   }
 

--- a/packages/payload/src/fields/config/sanitizeJoinField.ts
+++ b/packages/payload/src/fields/config/sanitizeJoinField.ts
@@ -3,6 +3,19 @@ import type { Config } from '../../config/types.js'
 import type { FlattenedJoinField, JoinField } from './types.js'
 
 import { APIError } from '../../errors/index.js'
+
+/**
+ * Info about an orderable join field, collected during sanitization
+ * and processed after all collections are sanitized.
+ */
+export type OrderableJoinInfo = {
+  /** The `on` path of the join field */
+  joinFieldOn: string
+  /** The name of the order field to add (e.g., `_posts_myJoin_order`) */
+  orderFieldName: string
+  /** The collection that will receive the order field */
+  targetCollectionSlug: string
+}
 import { InvalidFieldJoin } from '../../errors/InvalidFieldJoin.js'
 import { flattenAllFields } from '../../utilities/flattenAllFields.js'
 import { getFieldByPath } from '../../utilities/getFieldByPath.js'
@@ -12,6 +25,7 @@ export const sanitizeJoinField = ({
   field,
   joinPath,
   joins,
+  orderableJoins,
   parentIsLocalized,
   polymorphicJoins,
   validateOnly,
@@ -20,6 +34,8 @@ export const sanitizeJoinField = ({
   field: FlattenedJoinField | JoinField
   joinPath?: string
   joins?: SanitizedJoins
+  /** Tracker for orderable join fields - populated during sanitization */
+  orderableJoins?: OrderableJoinInfo[]
   parentIsLocalized: boolean
   polymorphicJoins?: SanitizedJoin[]
   validateOnly?: boolean
@@ -37,6 +53,11 @@ export const sanitizeJoinField = ({
     parentIsLocalized,
     // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
     targetField: undefined,
+  }
+
+  // Orderable joins must target a single collection
+  if (field.orderable && Array.isArray(field.collection)) {
+    throw new APIError('Orderable joins must target a single collection')
   }
 
   if (Array.isArray(field.collection)) {
@@ -95,6 +116,21 @@ export const sanitizeJoinField = ({
 
   if (validateOnly) {
     return
+  }
+
+  // Track orderable joins for post-sanitization processing
+  if (field.orderable && orderableJoins) {
+    const prefix = joinPath ? joinPath.replace(/\./g, '_') + '_' : ''
+    const orderFieldName = `_${field.collection}_${prefix}${field.name}_order`
+
+    // Set defaultSort on the join field
+    field.defaultSort = field.defaultSort ?? orderFieldName
+
+    orderableJoins.push({
+      joinFieldOn: field.on,
+      orderFieldName,
+      targetCollectionSlug: field.collection,
+    })
   }
 
   join.targetField = relationshipField.field

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1535,7 +1535,8 @@ export interface GlobalCustom extends Record<string, any> {}
 
 export interface GlobalAdminCustom extends Record<string, any> {}
 
-export { sanitizeFields } from './fields/config/sanitize.js'
+export { sanitizeField, sanitizeFields } from './fields/config/sanitize.js'
+export type { SanitizeFieldArgs } from './fields/config/sanitize.js'
 
 export type {
   AdminClient,


### PR DESCRIPTION
Extracts per-field sanitization logic into a standalone `sanitizeField` function that can be called independently. The `sanitizeFields` function now delegates to `sanitizeField` in a loop, maintaining identical behavior while exposing the core logic.

This enables sanitizing individual fields after initial config sanitization, which is needed for the orderable optimization in the follow-up PR.

Exports `sanitizeField` and `SanitizeFieldArgs` from the payload package.