### PR TITLE
feat: add createAdminAdapter helper and exports

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -852,6 +852,14 @@ export type Config = {
     /**
      * The admin adapter to use for framework-specific concerns (request handling, routing, cookies).
      * Defaults to auto-detecting @payloadcms/next if installed.
+     *
+     * @example
+     * ```ts
+     * import { nextAdapter } from '@payloadcms/next'
+     * admin: {
+     *   adapter: nextAdapter(),
+     * }
+     * ```
      */
     adapter?: AdminAdapterResult
     /** Automatically log in as a user */

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1405,6 +1405,14 @@ export { defaults } from './config/defaults.js'
 export { type OrderableEndpointBody } from './config/orderable/index.js'
 export { sanitizeConfig } from './config/sanitize.js'
 export type * from './config/types.js'
+export { createAdminAdapter } from './admin/adapter/createAdminAdapter.js'
+export type {
+  AdminAdapterResult,
+  BaseAdminAdapter,
+  CookieOptions,
+  RouteHandler,
+  RouteHandlers,
+} from './admin/adapter/types.js'
 export { combineQueries } from './database/combineQueries.js'
 export { createDatabaseAdapter } from './database/createDatabaseAdapter.js'
 export { defaultBeginTransaction } from './database/defaultBeginTransaction.js'


### PR DESCRIPTION
## Summary
- Adds `createAdminAdapter` factory function in `packages/payload/src/admin/adapter/`
- Adds `adapter?: AdminAdapterResult` to the `admin` config block in `packages/payload/src/config/types.ts` with JSDoc and usage example
- Exports `createAdminAdapter` and adapter types from `packages/payload/src/index.ts`

## Stack (AdminAdapter Pattern)
| # | Branch | Status |
|---|---|---|
| **1** | `create-admin-adapter` | **← you are here** |
| 2 | `wire-admin-adapter-lifecycle` | |
| 3 | `router-provider-context` | |
| 4 | `replace-next-navigation-imports` | |
| 5 | `decouple-core-from-next` | |
| 6 | `split-views-server-render` | |
| 7 | `next-adapter-implementation` | |

## Test plan
- [ ] Verify `createAdminAdapter` is importable from `payload`
- [ ] Verify `adapter` config option accepts an `AdminAdapterResult`
- [ ] Existing tests pass without regression