### PR TITLE
feat: define AdminAdapter types

### DIFF
--- a/packages/payload/src/admin/adapter/types.ts
+++ b/packages/payload/src/admin/adapter/types.ts
@@ -1,0 +1,62 @@
+import type React from 'react'
+
+import type { ImportMap } from '../../bin/generateImportMap/index.js'
+import type { SanitizedConfig } from '../../config/types.js'
+import type { Payload } from '../../types/index.js'
+import type { InitReqResult, ServerFunctionHandler } from '../functions/index.js'
+
+export type CookieOptions = {
+  domain?: string
+  expires?: Date
+  httpOnly?: boolean
+  maxAge?: number
+  path?: string
+  sameSite?: 'lax' | 'none' | 'strict'
+  secure?: boolean
+}
+
+export type RouteHandler = (request: Request) => Promise<Response> | Response
+
+export type RouteHandlers = {
+  DELETE?: RouteHandler
+  GET?: RouteHandler
+  PATCH?: RouteHandler
+  POST?: RouteHandler
+  PUT?: RouteHandler
+}
+
+export type BaseAdminAdapter = {
+  /** Create route handlers for REST + GraphQL endpoints */
+  createRouteHandlers: (config: SanitizedConfig) => RouteHandlers
+  /** Delete a cookie */
+  deleteCookie: (name: string) => void
+  /** Destroy the adapter (cleanup) */
+  destroy?: () => Promise<void> | void
+  /** Generate metadata for the admin panel */
+  generateMetadata?: (args: { config: SanitizedConfig }) => Promise<Record<string, unknown>>
+  /** Get a cookie value by name */
+  getCookie: (name: string) => string | undefined
+  /** Handle server function dispatching */
+  handleServerFunctions: ServerFunctionHandler
+  /** Initialize the request context, returning a PayloadRequest and related data */
+  initReq: (args: { config: SanitizedConfig; importMap: ImportMap }) => Promise<InitReqResult>
+  /** Adapter name for identification */
+  name: string
+  /** Server-side not found navigation — throws framework-specific error */
+  notFound: () => never
+  /** The Payload instance, set after init */
+  payload: Payload
+  /** Server-side redirect navigation — throws framework-specific error */
+  redirect: (url: string) => never
+  /** Client-side router provider wrapping framework navigation hooks */
+  RouterProvider: React.ComponentType<{ children: React.ReactNode }>
+  /** Set a cookie */
+  setCookie: (name: string, value: string, options?: CookieOptions) => void
+}
+
+export type AdminAdapterResult<T extends BaseAdminAdapter = BaseAdminAdapter> = {
+  /** Initialize the adapter, binding it to the Payload instance */
+  init: (args: { payload: Payload }) => T
+  /** Adapter name for identification */
+  name: string
+}

--- a/packages/payload/src/admin/adapter/types.ts
+++ b/packages/payload/src/admin/adapter/types.ts
@@ -25,17 +25,17 @@ export type RouteHandlers = {
   PUT?: RouteHandler
 }
 
-export type BaseAdminAdapter = {
+export interface BaseAdminAdapter {
   /** Create route handlers for REST + GraphQL endpoints */
   createRouteHandlers: (config: SanitizedConfig) => RouteHandlers
   /** Delete a cookie */
-  deleteCookie: (name: string) => void
+  deleteCookie: (name: string) => Promise<void> | void
   /** Destroy the adapter (cleanup) */
   destroy?: () => Promise<void> | void
   /** Generate metadata for the admin panel */
   generateMetadata?: (args: { config: SanitizedConfig }) => Promise<Record<string, unknown>>
   /** Get a cookie value by name */
-  getCookie: (name: string) => string | undefined
+  getCookie: (name: string) => Promise<string | undefined> | string | undefined
   /** Handle server function dispatching */
   handleServerFunctions: ServerFunctionHandler
   /** Initialize the request context, returning a PayloadRequest and related data */
@@ -51,7 +51,7 @@ export type BaseAdminAdapter = {
   /** Client-side router provider wrapping framework navigation hooks */
   RouterProvider: React.ComponentType<{ children: React.ReactNode }>
   /** Set a cookie */
-  setCookie: (name: string, value: string, options?: CookieOptions) => void
+  setCookie: (name: string, value: string, options?: CookieOptions) => Promise<void> | void
 }
 
 export type AdminAdapterResult<T extends BaseAdminAdapter = BaseAdminAdapter> = {


### PR DESCRIPTION
## Summary
- Define `BaseAdminAdapter` interface and supporting types (`CookieOptions`, `RouteHandler`, `RouteHandlers`, `AdminAdapterResult`)
- Framework-agnostic contract for admin panel integration: HTTP routing, cookies, server functions, navigation, and client-side router
- Async cookie methods (`Promise<void> | void`) to support frameworks like Next.js with dynamic `cookies()`

**1/8** in the AdminAdapter stack.

## Stack (AdminAdapter Pattern)
| # | PR | Branch |
|---|---|---|
| 1 | feat: define AdminAdapter types | `gj/admin-adapter-types` |
| 2 | feat: add createAdminAdapter and exports | `gj/create-admin-adapter` |
| 3 | feat: wire AdminAdapter lifecycle | `gj/wire-admin-adapter-lifecycle` |
| 4 | feat(ui): RouterProvider context | `gj/router-provider-context` |
| 5 | refactor(ui): replace next/navigation | `gj/replace-next-navigation-imports` |
| 6 | refactor: decouple core from Next.js | `gj/decouple-core-from-next` |
| 7 | refactor: split views | `gj/split-views-server-render` |
| 8 | feat(next): implement AdminAdapter | `gj/next-adapter-implementation` |