### PR TITLE
feat: add createAdminAdapter helper and exports

### DIFF
--- a/packages/payload/src/admin/adapter/createAdminAdapter.ts
+++ b/packages/payload/src/admin/adapter/createAdminAdapter.ts
@@ -1,0 +1,5 @@
+import type { BaseAdminAdapter } from './types.js'
+
+export function createAdminAdapter<T extends BaseAdminAdapter>(args: T): T {
+  return args
+}

--- a/packages/payload/src/admin/adapter/index.ts
+++ b/packages/payload/src/admin/adapter/index.ts
@@ -1,0 +1,8 @@
+export { createAdminAdapter } from './createAdminAdapter.js'
+export type {
+  AdminAdapterResult,
+  BaseAdminAdapter,
+  CookieOptions,
+  RouteHandler,
+  RouteHandlers,
+} from './types.js'

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -16,6 +16,7 @@ import type React from 'react'
 import type { default as sharp } from 'sharp'
 import type { DeepRequired } from 'ts-essentials'
 
+import type { AdminAdapterResult } from '../admin/adapter/types.js'
 import type { RichTextAdapterProvider } from '../admin/RichText.js'
 import type {
   DocumentSubViewTypes,
@@ -818,6 +819,19 @@ export type SanitizedDashboardConfig = {
 export type Config = {
   /** Configure admin dashboard */
   admin?: {
+    /**
+     * The admin adapter to use for framework-specific concerns (request handling, routing, cookies).
+     * Defaults to auto-detecting @payloadcms/next if installed.
+     *
+     * @example
+     * ```ts
+     * import { nextAdapter } from '@payloadcms/next'
+     * admin: {
+     *   adapter: nextAdapter(),
+     * }
+     * ```
+     */
+    adapter?: AdminAdapterResult
     /** Automatically log in as a user */
     autoLogin?:
       | {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -37,6 +37,14 @@ import {
   verifyEmailLocal,
   type Options as VerifyEmailOptions,
 } from './auth/operations/local/verifyEmail.js'
+export { createAdminAdapter } from './admin/adapter/index.js'
+export type {
+  AdminAdapterResult,
+  BaseAdminAdapter,
+  CookieOptions,
+  RouteHandler,
+  RouteHandlers,
+} from './admin/adapter/types.js'
 export type { FieldState } from './admin/forms/Form.js'
 import type { InitOptions, SanitizedConfig } from './config/types.js'
 import type { BaseDatabaseAdapter, PaginatedDistinctDocs, PaginatedDocs } from './database/types.js'


### PR DESCRIPTION
## Summary
- Add `createAdminAdapter` factory function (mirrors `createDatabaseAdapter` pattern)
- Add `admin.adapter` field to `Config` type with JSDoc and usage example
- Export `createAdminAdapter` and all adapter types from `packages/payload`

**2/8** in the AdminAdapter stack.

## Stack (AdminAdapter Pattern)
| # | PR | Branch |
|---|---|---|
| 1 | feat: define AdminAdapter types | `gj/admin-adapter-types` |
| **2** | **feat: add createAdminAdapter and exports** | **`gj/create-admin-adapter`** |
| 3 | feat: wire AdminAdapter lifecycle | `gj/wire-admin-adapter-lifecycle` |
| 4 | feat(ui): RouterProvider context | `gj/router-provider-context` |
| 5 | refactor(ui): replace next/navigation | `gj/replace-next-navigation-imports` |
| 6 | refactor: decouple core from Next.js | `gj/decouple-core-from-next` |
| 7 | refactor: split views | `gj/split-views-server-render` |
| 8 | feat(next): implement AdminAdapter | `gj/next-adapter-implementation` |