### PR TITLE
feat: wire AdminAdapter into Payload lifecycle

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -37,6 +37,7 @@ import {
   verifyEmailLocal,
   type Options as VerifyEmailOptions,
 } from './auth/operations/local/verifyEmail.js'
+import type { BaseAdminAdapter } from './admin/adapter/types.js'
 export { createAdminAdapter } from './admin/adapter/index.js'
 export type {
   AdminAdapterResult,
@@ -395,6 +396,8 @@ let checkedDependencies = false
  * @description Payload
  */
 export class BasePayload {
+  adminAdapter?: BaseAdminAdapter
+
   /**
    * @description Authorization and Authentication using headers and cookies to run auth user strategies
    * @returns permissions: Permissions
@@ -469,6 +472,10 @@ export class BasePayload {
 
     if (this.db?.destroy && typeof this.db.destroy === 'function') {
       await this.db.destroy()
+    }
+
+    if (this.adminAdapter?.destroy && typeof this.adminAdapter.destroy === 'function') {
+      await this.adminAdapter.destroy()
     }
   }
 
@@ -888,6 +895,11 @@ export class BasePayload {
 
     this.db = this.config.db.init({ payload: this })
     this.db.payload = this
+
+    if (this.config.admin?.adapter) {
+      this.adminAdapter = this.config.admin.adapter.init({ payload: this })
+      this.adminAdapter.payload = this
+    }
 
     this.kv = this.config.kv.init({ payload: this })
 


### PR DESCRIPTION
## Summary
- Add `adminAdapter?: BaseAdminAdapter` property to `BasePayload`
- Initialize adapter after `db.init` in `Payload.init()`, mirroring the db/kv pattern
- Call `adminAdapter.destroy()` in `Payload.destroy()` for cleanup

**3/8** in the AdminAdapter stack.

## Stack (AdminAdapter Pattern)
| # | PR | Branch |
|---|---|---|
| 1 | feat: define AdminAdapter types | `gj/admin-adapter-types` |
| 2 | feat: add createAdminAdapter and exports | `gj/create-admin-adapter` |
| **3** | **feat: wire AdminAdapter lifecycle** | **`gj/wire-admin-adapter-lifecycle`** |
| 4 | feat(ui): RouterProvider context | `gj/router-provider-context` |
| 5 | refactor(ui): replace next/navigation | `gj/replace-next-navigation-imports` |
| 6 | refactor: decouple core from Next.js | `gj/decouple-core-from-next` |
| 7 | refactor: split views | `gj/split-views-server-render` |
| 8 | feat(next): implement AdminAdapter | `gj/next-adapter-implementation` |