### PR TITLE
feat(ui): add RouterProvider context and navigation hooks

### DIFF
--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -326,6 +326,8 @@ export {
   RouteTransitionProvider,
   useRouteTransition,
 } from '../../providers/RouteTransition/index.js'
+export { RouterProvider, usePathname, useRouter } from '../../providers/Router/index.js'
+export type { LinkProps, RouterContextType, RouterInstance } from '../../providers/Router/types.js'
 export { ConfigProvider, PageConfigProvider, useConfig } from '../../providers/Config/index.js'
 export { DocumentEventsProvider, useDocumentEvents } from '../../providers/DocumentEvents/index.js'
 export { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentInfo/index.js'

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -327,7 +327,12 @@ export {
   useRouteTransition,
 } from '../../providers/RouteTransition/index.js'
 export { RouterProvider, usePathname, useRouter } from '../../providers/Router/index.js'
-export type { LinkProps, RouterContextType, RouterInstance } from '../../providers/Router/types.js'
+export type {
+  LinkProps,
+  NavigateOptions,
+  RouterContextType,
+  RouterInstance,
+} from '../../providers/Router/types.js'
 export { ConfigProvider, PageConfigProvider, useConfig } from '../../providers/Config/index.js'
 export { DocumentEventsProvider, useDocumentEvents } from '../../providers/DocumentEvents/index.js'
 export { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentInfo/index.js'

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -14,6 +14,7 @@ import { ModalContainer, ModalProvider } from '@faceless-ui/modal'
 import { ScrollInfoProvider } from '@faceless-ui/scroll-info'
 import React from 'react'
 
+import type { RouterContextType } from '../Router/types.js'
 import type { Theme } from '../Theme/index.js'
 
 import { CloseModalOnRouteChange } from '../../elements/CloseModalOnRouteChange/index.js'
@@ -31,6 +32,7 @@ import { LocaleProvider } from '../Locale/index.js'
 import { ParamsProvider } from '../Params/index.js'
 import { PreferencesProvider } from '../Preferences/index.js'
 import { RouteCache } from '../RouteCache/index.js'
+import { RouterProvider } from '../Router/index.js'
 import { RouteTransitionProvider } from '../RouteTransition/index.js'
 import { SearchParamsProvider } from '../SearchParams/index.js'
 import { ServerFunctionsProvider } from '../ServerFunctions/index.js'
@@ -49,6 +51,7 @@ type Props = {
   readonly languageOptions: LanguageOptions
   readonly locale?: Locale['code']
   readonly permissions: SanitizedPermissions
+  readonly router?: RouterContextType
   readonly serverFunction: ServerFunctionClient
   readonly switchLanguageServerAction?: (lang: string) => Promise<void>
   readonly theme: Theme
@@ -66,6 +69,7 @@ export const RootProvider: React.FC<Props> = ({
   languageOptions,
   locale,
   permissions,
+  router,
   serverFunction,
   switchLanguageServerAction,
   theme,
@@ -74,7 +78,7 @@ export const RootProvider: React.FC<Props> = ({
 }) => {
   const dndContextID = React.useId()
 
-  return (
+  const content = (
     <ClickOutsideProvider>
       <ServerFunctionsProvider serverFunction={serverFunction}>
         <RouteTransitionProvider>
@@ -145,4 +149,10 @@ export const RootProvider: React.FC<Props> = ({
       <ToastContainer config={config} />
     </ClickOutsideProvider>
   )
+
+  if (router) {
+    return <RouterProvider router={router}>{content}</RouterProvider>
+  }
+
+  return content
 }

--- a/packages/ui/src/providers/Router/index.tsx
+++ b/packages/ui/src/providers/Router/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+import React, { createContext, use } from 'react'
+
+import type { LinkProps, RouterContextType, RouterInstance } from './types.js'
+
+export type { LinkProps, RouterContextType, RouterInstance }
+
+const RouterContext = createContext<null | RouterContextType>(null)
+
+export const RouterProvider: React.FC<{
+  children: React.ReactNode
+  router: RouterContextType
+}> = ({ children, router }) => {
+  return <RouterContext value={router}>{children}</RouterContext>
+}
+
+function useRouterContext(): RouterContextType {
+  const ctx = use(RouterContext)
+  if (!ctx) {
+    throw new Error('RouterProvider is not in the tree. Make sure your admin adapter provides one.')
+  }
+  return ctx
+}
+
+export const useRouter = (): RouterInstance => useRouterContext().router
+
+export const usePathname = (): string => useRouterContext().pathname
+
+export const useSearchParams = (): URLSearchParams => useRouterContext().searchParams
+
+export const useParams = (): Record<string, string | string[]> => useRouterContext().params
+
+export const Link: React.FC<LinkProps> = (props) => {
+  const { Link: AdapterLink } = useRouterContext()
+  return <AdapterLink {...props} />
+}

--- a/packages/ui/src/providers/Router/types.ts
+++ b/packages/ui/src/providers/Router/types.ts
@@ -9,13 +9,17 @@ export type LinkProps = {
   scroll?: boolean
 } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'onClick'>
 
+export type NavigateOptions = {
+  scroll?: boolean
+}
+
 export type RouterInstance = {
   back: () => void
   forward: () => void
   prefetch: (url: string) => void
-  push: (url: string) => void
+  push: (url: string, options?: NavigateOptions) => void
   refresh: () => void
-  replace: (url: string) => void
+  replace: (url: string, options?: NavigateOptions) => void
 }
 
 /**

--- a/packages/ui/src/providers/Router/types.ts
+++ b/packages/ui/src/providers/Router/types.ts
@@ -1,0 +1,32 @@
+import type React from 'react'
+
+export type LinkProps = {
+  children?: React.ReactNode
+  href: string
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>
+  prefetch?: boolean
+  replace?: boolean
+  scroll?: boolean
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'onClick'>
+
+export type RouterInstance = {
+  back: () => void
+  forward: () => void
+  prefetch: (url: string) => void
+  push: (url: string) => void
+  refresh: () => void
+  replace: (url: string) => void
+}
+
+/**
+ * Values provided by a RouterProvider. The adapter creates a component that
+ * calls framework-specific hooks and places the results here, so that
+ * `packages/ui` never imports from any framework directly.
+ */
+export type RouterContextType = {
+  Link: React.ComponentType<LinkProps>
+  params: Record<string, string | string[]>
+  pathname: string
+  router: RouterInstance
+  searchParams: URLSearchParams
+}


### PR DESCRIPTION
## Summary
- Add `RouterProvider` with value-based context (`params`, `pathname`, `router`, `searchParams`, `Link`) — avoids dynamic hook calls that the React Compiler rejects
- Add `useRouter`, `usePathname`, `useSearchParams`, `useParams` hook wrappers reading from context
- Add `NavigateOptions` type for scroll support in `push`/`replace`
- Integrate `RouterProvider` into `RootProvider` via optional `router` prop

**4/8** in the AdminAdapter stack.

## Stack (AdminAdapter Pattern)
| # | PR | Branch |
|---|---|---|
| 1 | feat: define AdminAdapter types | `gj/admin-adapter-types` |
| 2 | feat: add createAdminAdapter and exports | `gj/create-admin-adapter` |
| 3 | feat: wire AdminAdapter lifecycle | `gj/wire-admin-adapter-lifecycle` |
| **4** | **feat(ui): RouterProvider context** | **`gj/router-provider-context`** |
| 5 | refactor(ui): replace next/navigation | `gj/replace-next-navigation-imports` |
| 6 | refactor: decouple core from Next.js | `gj/decouple-core-from-next` |
| 7 | refactor: split views | `gj/split-views-server-render` |
| 8 | feat(next): implement AdminAdapter | `gj/next-adapter-implementation` |