### PR TITLE
refactor: decouple core package from Next.js

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -99,7 +99,6 @@
     "pretest": "pnpm build"
   },
   "dependencies": {
-    "@next/env": "^15.1.5",
     "@payloadcms/translations": "workspace:*",
     "@types/busboy": "1.5.4",
     "ajv": "8.17.1",
@@ -110,6 +109,8 @@
     "croner": "9.1.0",
     "dataloader": "2.2.3",
     "deepmerge": "4.3.1",
+    "dotenv": "16.4.7",
+    "dotenv-expand": "12.0.1",
     "file-type": "19.3.0",
     "get-tsconfig": "4.8.1",
     "http-status": "2.1.0",

--- a/packages/payload/src/bin/loadEnv.ts
+++ b/packages/payload/src/bin/loadEnv.ts
@@ -1,27 +1,63 @@
-import nextEnvImport from '@next/env'
+import dotenvImport from 'dotenv'
+import dotenvExpandImport from 'dotenv-expand'
+import fs from 'fs'
+import path from 'path'
 
 import { findUpSync } from '../utilities/findUp.js'
-const { loadEnvConfig } = nextEnvImport
+
+const dotenvConfig =
+  'config' in dotenvImport ? dotenvImport.config : (dotenvImport as any).default.config
+const dotenvExpand =
+  'expand' in dotenvExpandImport
+    ? dotenvExpandImport.expand
+    : (dotenvExpandImport as any).default.expand
+
+function getEnvFilenames(dev: boolean): string[] {
+  if (dev) {
+    return ['.env.development.local', '.env.local', '.env.development', '.env']
+  }
+  return ['.env.production.local', '.env.local', '.env.production', '.env']
+}
+
+function loadEnvFromDir(dir: string, dev: boolean): boolean {
+  const filenames = getEnvFilenames(dev)
+  let loaded = false
+
+  for (const filename of filenames) {
+    const filePath = path.resolve(dir, filename)
+    try {
+      fs.accessSync(filePath)
+    } catch {
+      continue
+    }
+    const env = dotenvConfig({ path: filePath })
+    if (env.parsed) {
+      dotenvExpand(env)
+      loaded = true
+    }
+  }
+
+  return loaded
+}
 
 /**
- * Try to find user's env files and load it. Uses the same algorithm next.js uses to parse env files, meaning this also supports .env.local, .env.development, .env.production, etc.
+ * Try to find user's env files and load them. Supports .env, .env.local,
+ * .env.development, .env.production (same priority as Next.js).
  */
-export function loadEnv(path?: string) {
-  if (path?.length) {
-    loadEnvConfig(path, true)
+export function loadEnv(envPath?: string) {
+  if (envPath?.length) {
+    loadEnvFromDir(envPath, true)
     return
   }
 
   const dev = process.env.NODE_ENV !== 'production'
-  const { loadedEnvFiles } = loadEnvConfig(process.cwd(), dev)
+  const loaded = loadEnvFromDir(process.cwd(), dev)
 
-  if (!loadedEnvFiles?.length) {
-    // use findUp to find the env file. So, run loadEnvConfig for every directory upwards
+  if (!loaded) {
     findUpSync({
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       condition: (dir) => {
-        const { loadedEnvFiles } = loadEnvConfig(dir, true)
-        if (loadedEnvFiles?.length) {
+        if (loadEnvFromDir(dir, true)) {
           return true
         }
       },

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -10,7 +10,6 @@ import type { BusboyConfig } from 'busboy'
 import type GraphQL from 'graphql'
 import type { GraphQLFormattedError } from 'graphql'
 import type { JSONSchema4 } from 'json-schema'
-import type { Metadata } from 'next'
 import type { DestinationStream, Level, LoggerOptions } from 'pino'
 import type React from 'react'
 import type { default as sharp } from 'sharp'
@@ -208,6 +207,37 @@ export type OGImageConfig = {
  */
 type DeepClone<T> = T extends object ? { [K in keyof T]: DeepClone<T[K]> } : T
 
+/** Subset of Next.js Metadata that Payload actually consumes. */
+export type PayloadMetadata = {
+  description?: null | string
+  icons?:
+    | {
+        apple?: PayloadMetadataIcon[]
+        icon?: PayloadMetadataIcon[]
+        shortcut?: PayloadMetadataIcon[]
+      }
+    | null
+    | PayloadMetadataIcon[]
+  keywords?: null | string | string[]
+  metadataBase?: null | URL
+  openGraph?: {
+    description?: string
+    images?: OGImageConfig[]
+    siteName?: string
+    title?: string
+  } | null
+  robots?: { follow?: boolean; index?: boolean } | null | string
+  title?: null | string
+}
+
+type PayloadMetadataIcon = {
+  media?: string
+  rel?: string
+  sizes?: string
+  type?: string
+  url: string
+}
+
 export type MetaConfig = {
   /**
    * When `static`, a pre-made image will be used for all pages.
@@ -221,7 +251,7 @@ export type MetaConfig = {
    * @example `" - Custom CMS"`
    */
   titleSuffix?: string
-} & DeepClone<Metadata>
+} & DeepClone<PayloadMetadata>
 
 export type ServerOnlyLivePreviewProperties = keyof Pick<RootLivePreviewConfig, 'url'>
 

--- a/packages/payload/src/utilities/getRequestLanguage.ts
+++ b/packages/payload/src/utilities/getRequestLanguage.ts
@@ -1,5 +1,4 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
-import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies.js'
 
 import { extractHeaderLanguage } from '@payloadcms/translations'
 
@@ -7,7 +6,7 @@ import type { SanitizedConfig } from '../config/types.js'
 
 type GetRequestLanguageArgs = {
   config: SanitizedConfig
-  cookies: Map<string, string> | ReadonlyRequestCookies
+  cookies: Map<string, string>
   defaultLanguage?: AcceptedLanguages
   headers: Request['headers']
 }
@@ -18,10 +17,8 @@ export const getRequestLanguage = ({
   headers,
 }: GetRequestLanguageArgs): AcceptedLanguages => {
   const supportedLanguageKeys = Object.keys(config.i18n.supportedLanguages) as AcceptedLanguages[]
-  const langCookie = cookies.get(`${config.cookiePrefix || 'payload'}-lng`)
-
-  const languageFromCookie: AcceptedLanguages = (
-    typeof langCookie === 'string' ? langCookie : langCookie?.value
+  const languageFromCookie = cookies.get(
+    `${config.cookiePrefix || 'payload'}-lng`,
   ) as AcceptedLanguages
 
   if (languageFromCookie && supportedLanguageKeys.includes(languageFromCookie)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -873,9 +873,6 @@ importers:
 
   packages/payload:
     dependencies:
-      '@next/env':
-        specifier: ^15.1.5
-        version: 15.5.14
       '@payloadcms/translations':
         specifier: workspace:*
         version: link:../translations
@@ -906,6 +903,12 @@ importers:
       deepmerge:
         specifier: 4.3.1
         version: 4.3.1
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      dotenv-expand:
+        specifier: 12.0.1
+        version: 12.0.1
       file-type:
         specifier: 19.3.0
         version: 19.3.0
@@ -1876,7 +1879,7 @@ importers:
         version: 16.8.1
       next:
         specifier: 16.2.1
-        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
+        version: 16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
       payload:
         specifier: workspace:*
         version: link:../../packages/payload
@@ -1913,7 +1916,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.1
-        version: 16.2.1(@typescript-eslint/parser@8.57.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3)
+        version: 16.2.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3)
       jsdom:
         specifier: 28.0.0
         version: 28.0.0(@noble/hashes@1.8.0)
@@ -2208,7 +2211,7 @@ importers:
         version: 16.4.7
       geist:
         specifier: ^1.3.0
-        version: 1.7.0(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))
+        version: 1.7.0(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -2217,10 +2220,10 @@ importers:
         version: 0.563.0(react@19.2.4)
       next:
         specifier: 16.2.1
-        version: 16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
+        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))
+        version: 4.2.3(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))
       payload:
         specifier: workspace:*
         version: link:../../packages/payload
@@ -2281,7 +2284,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.1
-        version: 16.2.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3)
+        version: 16.2.1(@typescript-eslint/parser@8.57.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3)
       jsdom:
         specifier: 28.0.0
         version: 28.0.0(@noble/hashes@1.8.0)
@@ -5589,9 +5592,6 @@ packages:
 
   '@next/env@13.5.11':
     resolution: {integrity: sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==}
-
-  '@next/env@15.5.14':
-    resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
 
   '@next/env@16.2.1':
     resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
@@ -9620,6 +9620,10 @@ packages:
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
     engines: {node: '>=18'}
+
+  dotenv-expand@12.0.1:
+    resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
+    engines: {node: '>=12'}
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
@@ -18454,8 +18458,6 @@ snapshots:
 
   '@next/env@13.5.11': {}
 
-  '@next/env@15.5.14': {}
-
   '@next/env@16.2.1': {}
 
   '@next/eslint-plugin-next@15.5.14':
@@ -23125,6 +23127,10 @@ snapshots:
     dependencies:
       type-fest: 4.41.0
 
+  dotenv-expand@12.0.1:
+    dependencies:
+      dotenv: 16.4.7
+
   dotenv@16.4.7: {}
 
   drizzle-kit@0.31.7:
@@ -24547,6 +24553,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  geist@1.7.0(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)):
+    dependencies:
+      next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
 
   geist@1.7.0(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)):
     dependencies:
@@ -26146,13 +26156,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next-sitemap@4.2.3(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)):
+  next-sitemap@4.2.3(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
+      next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
 
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
- Replace `@next/env` with `dotenv` + `dotenv-expand` in `loadEnv.ts`, preserving Next-compatible `.env` file resolution priority
- Replace `Metadata` type import from `next` with `PayloadMetadata` subset type
- Remove `ReadonlyRequestCookies` from `getRequestLanguage` (now uses `Map<string, string>` only)
- Update `package.json`: remove `@next/env`, add `dotenv`/`dotenv-expand`

After this PR, `packages/payload` has zero Next.js imports.

**6/8** in the AdminAdapter stack.

## Stack (AdminAdapter Pattern)
| # | PR | Branch |
|---|---|---|
| 1 | feat: define AdminAdapter types | `gj/admin-adapter-types` |
| 2 | feat: add createAdminAdapter and exports | `gj/create-admin-adapter` |
| 3 | feat: wire AdminAdapter lifecycle | `gj/wire-admin-adapter-lifecycle` |
| 4 | feat(ui): RouterProvider context | `gj/router-provider-context` |
| 5 | refactor(ui): replace next/navigation | `gj/replace-next-navigation-imports` |
| **6** | **refactor: decouple core from Next.js** | **`gj/decouple-core-from-next`** |
| 7 | refactor: split views | `gj/split-views-server-render` |
| 8 | feat(next): implement AdminAdapter | `gj/next-adapter-implementation` |