### PR TITLE
feat(next): implement AdminAdapter interface

### DIFF
--- a/packages/next/src/adapter/RouterProvider.tsx
+++ b/packages/next/src/adapter/RouterProvider.tsx
@@ -1,0 +1,45 @@
+'use client'
+import type { RouterContextType, LinkProps as RouterLinkProps } from '@payloadcms/ui'
+
+import { RouterProvider as BaseRouterProvider } from '@payloadcms/ui'
+import NextLinkImport from 'next/link.js'
+import {
+  useParams as useNextParams,
+  usePathname as useNextPathname,
+  useRouter as useNextRouter,
+  useSearchParams as useNextSearchParams,
+} from 'next/navigation.js'
+import React from 'react'
+
+const NextLink = 'default' in NextLinkImport ? NextLinkImport.default : NextLinkImport
+
+const AdapterLink: React.FC<RouterLinkProps> = ({ children, ...rest }) => {
+  return <NextLink {...rest}>{children}</NextLink>
+}
+
+export const NextRouterProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const nextRouter = useNextRouter()
+  const pathname = useNextPathname()
+  const searchParams = useNextSearchParams()
+  const params = useNextParams()
+
+  const router: RouterContextType = React.useMemo(
+    () => ({
+      Link: AdapterLink,
+      params,
+      pathname,
+      router: {
+        back: nextRouter.back,
+        forward: nextRouter.forward,
+        prefetch: nextRouter.prefetch,
+        push: nextRouter.push,
+        refresh: nextRouter.refresh,
+        replace: nextRouter.replace,
+      },
+      searchParams,
+    }),
+    [nextRouter, pathname, searchParams, params],
+  )
+
+  return <BaseRouterProvider router={router}>{children}</BaseRouterProvider>
+}

--- a/packages/next/src/adapter/index.ts
+++ b/packages/next/src/adapter/index.ts
@@ -1,0 +1,47 @@
+import type { AdminAdapterResult, BaseAdminAdapter, CookieOptions } from 'payload'
+
+import { notFound, redirect } from 'next/navigation.js'
+import { createAdminAdapter } from 'payload'
+
+import { handleServerFunctions } from '../utilities/handleServerFunctions.js'
+import { initReq as nextInitReq } from '../utilities/initReq.js'
+import { NextRouterProvider } from './RouterProvider.js'
+
+export function nextAdapter(): AdminAdapterResult {
+  return {
+    name: 'next',
+    init: ({ payload }) => {
+      return createAdminAdapter({
+        name: 'next',
+        createRouteHandlers: () => {
+          // Route handlers in the Next.js adapter are set up via the file-system routing
+          // convention (app/api/[...slug]/route.ts) rather than being created dynamically.
+          // This is a no-op for the Next.js adapter.
+          return {}
+        },
+        deleteCookie: async (name: string) => {
+          const { cookies } = await import('next/headers.js')
+          const cookieStore = await cookies()
+          cookieStore.delete(name)
+        },
+        getCookie: async (name: string) => {
+          const { cookies } = await import('next/headers.js')
+          const cookieStore = await cookies()
+          return cookieStore.get(name)?.value
+        },
+        handleServerFunctions,
+        initReq: ({ config, importMap }) =>
+          nextInitReq({ configPromise: config, importMap, key: 'adapter' }),
+        notFound: () => notFound(),
+        payload,
+        redirect: (url: string) => redirect(url),
+        RouterProvider: NextRouterProvider,
+        setCookie: async (name: string, value: string, options?: CookieOptions) => {
+          const { cookies } = await import('next/headers.js')
+          const cookieStore = await cookies()
+          cookieStore.set(name, value, options)
+        },
+      } satisfies BaseAdminAdapter)
+    },
+  }
+}

--- a/packages/next/src/index.js
+++ b/packages/next/src/index.js
@@ -1,1 +1,2 @@
+export { nextAdapter } from './adapter/index.js'
 export { default as withPayload } from './withPayload/withPayload.js'

--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -8,6 +8,7 @@ import { cookies as nextCookies } from 'next/headers.js'
 import { applyLocaleFiltering } from 'payload/shared'
 import React, { Suspense } from 'react'
 
+import { NextRouterProvider } from '../../adapter/RouterProvider.js'
 import { getNavPrefs } from '../../elements/Nav/getNavPrefs.js'
 import { getRequestTheme } from '../../utilities/getRequestTheme.js'
 import { initReq } from '../../utilities/initReq.js'
@@ -130,40 +131,42 @@ const RootLayoutContent = async ({
         <style>{`@layer payload-default, payload;`}</style>
       </head>
       <body>
-        <RootProvider
-          config={clientConfig}
-          dateFNSKey={req.i18n.dateFNSKey}
-          fallbackLang={config.i18n.fallbackLanguage}
-          isNavOpen={navPrefs?.open ?? true}
-          languageCode={languageCode}
-          languageOptions={languageOptions}
-          locale={req.locale}
-          permissions={req.user ? permissions : null}
-          serverFunction={serverFunction}
-          switchLanguageServerAction={switchLanguageServerAction}
-          theme={theme}
-          translations={req.i18n.translations}
-          user={req.user}
-        >
-          <ProgressBar />
-          {Array.isArray(config.admin?.components?.providers) &&
-          config.admin?.components?.providers.length > 0 ? (
-            <NestProviders
-              importMap={req.payload.importMap}
-              providers={config.admin?.components?.providers}
-              serverProps={{
-                i18n: req.i18n,
-                payload: req.payload,
-                permissions,
-                user: req.user,
-              }}
-            >
-              {children}
-            </NestProviders>
-          ) : (
-            children
-          )}
-        </RootProvider>
+        <NextRouterProvider>
+          <RootProvider
+            config={clientConfig}
+            dateFNSKey={req.i18n.dateFNSKey}
+            fallbackLang={config.i18n.fallbackLanguage}
+            isNavOpen={navPrefs?.open ?? true}
+            languageCode={languageCode}
+            languageOptions={languageOptions}
+            locale={req.locale}
+            permissions={req.user ? permissions : null}
+            serverFunction={serverFunction}
+            switchLanguageServerAction={switchLanguageServerAction}
+            theme={theme}
+            translations={req.i18n.translations}
+            user={req.user}
+          >
+            <ProgressBar />
+            {Array.isArray(config.admin?.components?.providers) &&
+            config.admin?.components?.providers.length > 0 ? (
+              <NestProviders
+                importMap={req.payload.importMap}
+                providers={config.admin?.components?.providers}
+                serverProps={{
+                  i18n: req.i18n,
+                  payload: req.payload,
+                  permissions,
+                  user: req.user,
+                }}
+              >
+                {children}
+              </NestProviders>
+            ) : (
+              children
+            )}
+          </RootProvider>
+        </NextRouterProvider>
         <div id="portal" />
       </body>
     </html>

--- a/packages/next/src/utilities/getNextRequestI18n.ts
+++ b/packages/next/src/utilities/getNextRequestI18n.ts
@@ -27,6 +27,10 @@ export const getNextRequestI18n = async <
   return (await initI18n({
     config: config.i18n,
     context: 'client',
-    language: getRequestLanguage({ config, cookies: await cookies(), headers: await headers() }),
+    language: getRequestLanguage({
+      config,
+      cookies: new Map((await cookies()).getAll().map((c) => [c.name, c.value])),
+      headers: await headers(),
+    }),
   })) as any
 }


### PR DESCRIPTION
## Summary
- Create `nextAdapter()` factory implementing `BaseAdminAdapter` for Next.js
- Async cookie methods via dynamic `import('next/headers')`
- `initReq` delegates to existing Next.js request initialization
- `notFound`/`redirect` wrappers around `next/navigation`
- `NextRouterProvider` bridging `next/navigation` hooks to the framework-agnostic `RouterProvider` context
- Wire `NextRouterProvider` into the Root layout

**8/8** — final PR in the AdminAdapter stack.

## Stack (AdminAdapter Pattern)
| # | PR | Branch |
|---|---|---|
| 1 | feat: define AdminAdapter types | `gj/admin-adapter-types` |
| 2 | feat: add createAdminAdapter and exports | `gj/create-admin-adapter` |
| 3 | feat: wire AdminAdapter lifecycle | `gj/wire-admin-adapter-lifecycle` |
| 4 | feat(ui): RouterProvider context | `gj/router-provider-context` |
| 5 | refactor(ui): replace next/navigation | `gj/replace-next-navigation-imports` |
| 6 | refactor: decouple core from Next.js | `gj/decouple-core-from-next` |
| 7 | refactor: split views | `gj/split-views-server-render` |
| **8** | **feat(next): implement AdminAdapter** | **`gj/next-adapter-implementation`** |