### PR TITLE
test: disable tests for content api

### DIFF
--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -616,7 +616,7 @@ describe('collections-graphql', () => {
         const [lat, lng] = point
 
         it('should return a document near a point', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const nearQuery = `
@@ -644,7 +644,7 @@ describe('collections-graphql', () => {
         })
 
         it('should not return a point far away', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const nearQuery = `
@@ -672,7 +672,7 @@ describe('collections-graphql', () => {
         })
 
         it('should sort find results by nearest distance', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           // creating twice as many records as we are querying to get a random sample
@@ -731,7 +731,7 @@ describe('collections-graphql', () => {
         ]
 
         it('should return a document with the point inside the polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const query = `
@@ -762,7 +762,7 @@ describe('collections-graphql', () => {
         })
 
         it('should not return a document with the point outside the polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const reducedPolygon = polygon.map((vertex) => vertex.map((coord) => coord * 0.1))
@@ -804,7 +804,7 @@ describe('collections-graphql', () => {
         ]
 
         it('should return a document with the point intersecting the polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const query = `
@@ -835,7 +835,7 @@ describe('collections-graphql', () => {
         })
 
         it('should not return a document with the point not intersecting a smaller polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const reducedPolygon = polygon.map((vertex) => vertex.map((coord) => coord * 0.1))

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -616,7 +616,7 @@ describe('collections-graphql', () => {
         const [lat, lng] = point
 
         it('should return a document near a point', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const nearQuery = `
@@ -644,7 +644,7 @@ describe('collections-graphql', () => {
         })
 
         it('should not return a point far away', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const nearQuery = `
@@ -672,7 +672,7 @@ describe('collections-graphql', () => {
         })
 
         it('should sort find results by nearest distance', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           // creating twice as many records as we are querying to get a random sample
@@ -731,7 +731,7 @@ describe('collections-graphql', () => {
         ]
 
         it('should return a document with the point inside the polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const query = `
@@ -762,7 +762,7 @@ describe('collections-graphql', () => {
         })
 
         it('should not return a document with the point outside the polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const reducedPolygon = polygon.map((vertex) => vertex.map((coord) => coord * 0.1))
@@ -804,7 +804,7 @@ describe('collections-graphql', () => {
         ]
 
         it('should return a document with the point intersecting the polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const query = `
@@ -835,7 +835,7 @@ describe('collections-graphql', () => {
         })
 
         it('should not return a document with the point not intersecting a smaller polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const reducedPolygon = polygon.map((vertex) => vertex.map((coord) => coord * 0.1))

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -1149,7 +1149,7 @@ describe('collections-rest', () => {
         const point = [10, 20]
         const [lat, lng] = point
         it('should return a document near a point', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
 
@@ -1184,7 +1184,7 @@ describe('collections-rest', () => {
         })
 
         it('should omit maxDistance and return a document from minDistance', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
 
@@ -1205,7 +1205,7 @@ describe('collections-rest', () => {
         })
 
         it('should omit maxDistance and not return a document because exceeds minDistance', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
 
@@ -1227,7 +1227,7 @@ describe('collections-rest', () => {
 
         // https://github.com/payloadcms/payload/issues/14471 - ensure geospatial queries use true geodetic meters, not the distorted meters of EPSG:3857
         it('should use true geodetic meters at high latitudes', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
 
@@ -1269,7 +1269,7 @@ describe('collections-rest', () => {
         })
 
         it('should not return a point far away', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
 
@@ -1290,7 +1290,7 @@ describe('collections-rest', () => {
         })
 
         it('should sort find results by nearest distance', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
 
@@ -1345,7 +1345,7 @@ describe('collections-rest', () => {
           [9.0, 19.0], // back to starting point to close the polygon
         ]
         it('should return a document with the point inside the polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           // There should be 1 total points document populated by default with the point [10, 20]
@@ -1368,7 +1368,7 @@ describe('collections-rest', () => {
         })
 
         it('should not return a document with the point outside a smaller polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const response = await restClient.GET(`/${pointSlug}`, {
@@ -1401,7 +1401,7 @@ describe('collections-rest', () => {
         ]
 
         it('should return a document with the point intersecting the polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           // There should be 1 total points document populated by default with the point [10, 20]
@@ -1424,7 +1424,7 @@ describe('collections-rest', () => {
         })
 
         it('should not return a document with the point not intersecting a smaller polygon', async () => {
-          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
             return
           }
           const response = await restClient.GET(`/${pointSlug}`, {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -1149,7 +1149,7 @@ describe('collections-rest', () => {
         const point = [10, 20]
         const [lat, lng] = point
         it('should return a document near a point', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
 
@@ -1184,7 +1184,7 @@ describe('collections-rest', () => {
         })
 
         it('should omit maxDistance and return a document from minDistance', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
 
@@ -1205,7 +1205,7 @@ describe('collections-rest', () => {
         })
 
         it('should omit maxDistance and not return a document because exceeds minDistance', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
 
@@ -1227,7 +1227,7 @@ describe('collections-rest', () => {
 
         // https://github.com/payloadcms/payload/issues/14471 - ensure geospatial queries use true geodetic meters, not the distorted meters of EPSG:3857
         it('should use true geodetic meters at high latitudes', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
 
@@ -1269,7 +1269,7 @@ describe('collections-rest', () => {
         })
 
         it('should not return a point far away', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
 
@@ -1290,7 +1290,7 @@ describe('collections-rest', () => {
         })
 
         it('should sort find results by nearest distance', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
 
@@ -1345,7 +1345,7 @@ describe('collections-rest', () => {
           [9.0, 19.0], // back to starting point to close the polygon
         ]
         it('should return a document with the point inside the polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           // There should be 1 total points document populated by default with the point [10, 20]
@@ -1368,7 +1368,7 @@ describe('collections-rest', () => {
         })
 
         it('should not return a document with the point outside a smaller polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const response = await restClient.GET(`/${pointSlug}`, {
@@ -1401,7 +1401,7 @@ describe('collections-rest', () => {
         ]
 
         it('should return a document with the point intersecting the polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           // There should be 1 total points document populated by default with the point [10, 20]
@@ -1424,7 +1424,7 @@ describe('collections-rest', () => {
         })
 
         it('should not return a document with the point not intersecting a smaller polygon', async () => {
-          if (payload.db.name === 'sqlite') {
+          if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
             return
           }
           const response = await restClient.GET(`/${pointSlug}`, {

--- a/test/custom-graphql/int.spec.ts
+++ b/test/custom-graphql/int.spec.ts
@@ -24,7 +24,9 @@ describe('Custom GraphQL', () => {
   })
 
   if (
-    !['cosmosdb', 'firestore', 'sqlite', 'sqlite-uuid'].includes(process.env.PAYLOAD_DATABASE || '')
+    !['content-api', 'cosmosdb', 'firestore', 'sqlite', 'sqlite-uuid'].includes(
+      process.env.PAYLOAD_DATABASE || '',
+    )
   ) {
     describe('Isolated Transaction ID', () => {
       it('should isolate transaction IDs between queries in the same request', async () => {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1688,6 +1688,9 @@ describe('database', () => {
     })
 
     it('should run migrate', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       await payload.db.migrate()
       const { docs } = await payload.find({
         collection: 'payload-migrations',
@@ -1698,6 +1701,9 @@ describe('database', () => {
     })
 
     it('should run migrate:status', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       let error
       try {
         await payload.db.migrateStatus()
@@ -1708,6 +1714,9 @@ describe('database', () => {
     })
 
     it('should run migrate:fresh', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       await payload.db.migrateFresh({ forceAcceptWarning: true })
       const { docs } = await payload.find({
         collection: 'payload-migrations',
@@ -1894,6 +1903,9 @@ describe('database', () => {
 
   describe('schema', () => {
     it('should use custom dbNames', () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       expect(payload.db).toBeDefined()
 
       if (payload.db.name === 'mongoose') {
@@ -2021,7 +2033,9 @@ describe('database', () => {
     describe('local api', () => {
       // sqlite cannot handle concurrent write transactions
       if (
-        !['cosmosdb', 'firestore', 'sqlite', 'sqlite-uuid'].includes(process.env.PAYLOAD_DATABASE)
+        !['content-api', 'cosmosdb', 'firestore', 'sqlite', 'sqlite-uuid'].includes(
+          process.env.PAYLOAD_DATABASE,
+        )
       ) {
         it('should commit multiple operations in isolation', async () => {
           const req = {
@@ -3120,7 +3134,7 @@ describe('database', () => {
     })
 
     it('should extend the existing table with extra column and modify the existing column with enforcing DB level length', async () => {
-      if (payload.db.name === 'mongoose') {
+      if (payload.db.name === 'mongoose' || payload.db.name === 'content_api') {
         return
       }
 
@@ -3185,7 +3199,7 @@ describe('database', () => {
     })
 
     it('should extend the existing table with composite unique and throw ValidationError on it', async () => {
-      if (payload.db.name === 'mongoose') {
+      if (payload.db.name === 'mongoose' || payload.db.name === 'content_api') {
         return
       }
 

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3869,6 +3869,10 @@ describe('database', () => {
   })
 
   it('should not allow document creation with relationship data to an invalid document ID', async () => {
+    if (payload.db.name === 'content-api') {
+      return
+    }
+
     let invalidDoc
 
     // mongo requires ObjectId, postgres UUID and content-api number (wrong type for text ID)

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1688,7 +1688,7 @@ describe('database', () => {
     })
 
     it('should run migrate', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       await payload.db.migrate()
@@ -1701,7 +1701,7 @@ describe('database', () => {
     })
 
     it('should run migrate:status', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       let error
@@ -1714,7 +1714,7 @@ describe('database', () => {
     })
 
     it('should run migrate:fresh', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       await payload.db.migrateFresh({ forceAcceptWarning: true })
@@ -1903,7 +1903,7 @@ describe('database', () => {
 
   describe('schema', () => {
     it('should use custom dbNames', () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       expect(payload.db).toBeDefined()
@@ -3134,7 +3134,7 @@ describe('database', () => {
     })
 
     it('should extend the existing table with extra column and modify the existing column with enforcing DB level length', async () => {
-      if (payload.db.name === 'mongoose' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'mongoose' || payload.db.name === 'content-api') {
         return
       }
 
@@ -3199,7 +3199,7 @@ describe('database', () => {
     })
 
     it('should extend the existing table with composite unique and throw ValidationError on it', async () => {
-      if (payload.db.name === 'mongoose' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'mongoose' || payload.db.name === 'content-api') {
         return
       }
 
@@ -3872,7 +3872,7 @@ describe('database', () => {
     let invalidDoc
 
     // mongo requires ObjectId, postgres UUID and content-api number (wrong type for text ID)
-    const invalidId = payload.db.name === 'content_api' ? 1 : 'not-real-id'
+    const invalidId = payload.db.name === 'content-api' ? 1 : 'not-real-id'
 
     try {
       invalidDoc = await payload.create({

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -683,7 +683,7 @@ describe('Fields', () => {
     })
 
     it('should query relationship inside array', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const result = await payload.find({
@@ -1517,14 +1517,14 @@ describe('Fields', () => {
       })
 
       it('should have 2dsphere indexes on point fields', () => {
-        if (payload.db.name === 'content_api') {
+        if (payload.db.name === 'content-api') {
           return
         }
         expect(definitions.point).toEqual('2dsphere')
       })
 
       it('should have 2dsphere indexes on point fields in groups', () => {
-        if (payload.db.name === 'content_api') {
+        if (payload.db.name === 'content-api') {
           return
         }
         expect(definitions['group.point']).toEqual('2dsphere')
@@ -1587,7 +1587,7 @@ describe('Fields', () => {
     })
 
     it('should read', async () => {
-      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
         return
       }
       const find = await payload.find({
@@ -1603,7 +1603,7 @@ describe('Fields', () => {
     })
 
     it('should create', async () => {
-      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
         return
       }
       doc = await payload.create({
@@ -1621,7 +1621,7 @@ describe('Fields', () => {
     })
 
     it('should not create duplicate point when unique', async () => {
-      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
         return
       }
       // Use unique values for this test to avoid collisions with other tests
@@ -1666,7 +1666,7 @@ describe('Fields', () => {
     })
 
     it('should throw validation error when "required" field is set to null', async () => {
-      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
         return
       }
       // Use unique values to avoid collisions
@@ -1695,7 +1695,7 @@ describe('Fields', () => {
     })
 
     it('should not throw validation error when non-"required" field is set to null', async () => {
-      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
         return
       }
       // Use unique values to avoid collisions
@@ -1726,7 +1726,7 @@ describe('Fields', () => {
     })
 
     it('should not error with camel case name point field', async () => {
-      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content-api') {
         return
       }
 
@@ -2995,7 +2995,7 @@ describe('Fields', () => {
     })
 
     it('should hot module reload and still be able to create', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const testDoc1 = await payload.findByID({

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -683,6 +683,9 @@ describe('Fields', () => {
     })
 
     it('should query relationship inside array', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const result = await payload.find({
         collection: relationshipFieldsSlug,
         where: {
@@ -1514,10 +1517,16 @@ describe('Fields', () => {
       })
 
       it('should have 2dsphere indexes on point fields', () => {
+        if (payload.db.name === 'content_api') {
+          return
+        }
         expect(definitions.point).toEqual('2dsphere')
       })
 
       it('should have 2dsphere indexes on point fields in groups', () => {
+        if (payload.db.name === 'content_api') {
+          return
+        }
         expect(definitions['group.point']).toEqual('2dsphere')
       })
 
@@ -1578,7 +1587,7 @@ describe('Fields', () => {
     })
 
     it('should read', async () => {
-      if (payload.db.name === 'sqlite') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
         return
       }
       const find = await payload.find({
@@ -1594,7 +1603,7 @@ describe('Fields', () => {
     })
 
     it('should create', async () => {
-      if (payload.db.name === 'sqlite') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
         return
       }
       doc = await payload.create({
@@ -1612,7 +1621,7 @@ describe('Fields', () => {
     })
 
     it('should not create duplicate point when unique', async () => {
-      if (payload.db.name === 'sqlite') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
         return
       }
       // Use unique values for this test to avoid collisions with other tests
@@ -1657,7 +1666,7 @@ describe('Fields', () => {
     })
 
     it('should throw validation error when "required" field is set to null', async () => {
-      if (payload.db.name === 'sqlite') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
         return
       }
       // Use unique values to avoid collisions
@@ -1686,7 +1695,7 @@ describe('Fields', () => {
     })
 
     it('should not throw validation error when non-"required" field is set to null', async () => {
-      if (payload.db.name === 'sqlite') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
         return
       }
       // Use unique values to avoid collisions
@@ -1717,7 +1726,7 @@ describe('Fields', () => {
     })
 
     it('should not error with camel case name point field', async () => {
-      if (payload.db.name === 'sqlite') {
+      if (payload.db.name === 'sqlite' || payload.db.name === 'content_api') {
         return
       }
 
@@ -2986,6 +2995,9 @@ describe('Fields', () => {
     })
 
     it('should hot module reload and still be able to create', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const testDoc1 = await payload.findByID({
         id: document.id,
         collection: tabsFieldsSlug,

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -217,6 +217,9 @@ describe('Joins Field', () => {
   })
 
   it('should count hasMany relationship joins', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const res = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -252,6 +255,9 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins with array relationships', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -262,6 +268,9 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins with array hasMany relationships', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -272,6 +281,9 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins with localized array relationships', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -301,6 +313,9 @@ describe('Joins Field', () => {
   })
 
   it('should join on polymorphic relationships', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const categoryWithPosts = await payload.findByID({
       collection: categoriesSlug,
       id: category.id,
@@ -370,6 +385,9 @@ describe('Joins Field', () => {
   })
 
   it('should allow join where query on hasMany select fields', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const folderDoc = await payload.create({
       collection: 'payload-folders',
       data: {
@@ -420,6 +438,9 @@ describe('Joins Field', () => {
   })
 
   it('should query where with exists for hasMany select fields', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     await payload.delete({ collection: 'payload-folders', where: {} })
     const folderDoc = await payload.create({
       collection: 'payload-folders',
@@ -541,6 +562,9 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins using find with hasMany relationships', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const result = await payload.find({
       collection: categoriesSlug,
       where: {
@@ -566,6 +590,9 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins using find with hasMany localized relationships', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const post_1 = await createPost(
       {
         title: `test es localized 1`,
@@ -781,6 +808,9 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins when versions on both sides draft false', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -794,6 +824,9 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany relationships when versions on both sides draft false', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -807,6 +840,9 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany relationships when versions on both sides draft true payload.db.queryDrafts', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -823,6 +859,9 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany when on both sides documents are in draft', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const category = await payload.create({
         collection: 'categories-versions',
         data: { _status: 'draft' },
@@ -852,6 +891,9 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins when versions on both sides draft true payload.db.queryDrafts', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -1276,6 +1318,9 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany when on both sides documents are in draft', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const category = await payload.create({
         collection: 'categories-versions',
         data: { _status: 'draft' },
@@ -1491,6 +1536,9 @@ describe('Joins Field', () => {
   })
 
   it('local API should not populate individual join by providing schemaPath=false', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const {
       docs: [res],
     } = await payload.find({
@@ -1513,6 +1561,9 @@ describe('Joins Field', () => {
   })
 
   it('rEST API should not populate individual join by providing schemaPath=false', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const {
       docs: [res],
     } = await restClient
@@ -1836,6 +1887,9 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with hasMany relationship', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1851,6 +1905,9 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with relationship nested to a group', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1866,6 +1923,9 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with relationship nested to an array', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const category = await payload.create({ collection: 'categories', data: {} })
     const post = await payload.create({
       collection: 'posts',
@@ -1884,6 +1944,9 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field multiple times', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1912,6 +1975,9 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with hasMany relationship multiple times', async () => {
+    if (payload.db.name === 'content_api') {
+      return
+    }
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -217,7 +217,7 @@ describe('Joins Field', () => {
   })
 
   it('should count hasMany relationship joins', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const res = await payload.findByID({
@@ -255,7 +255,7 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins with array relationships', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const categoryWithPosts = await payload.findByID({
@@ -268,7 +268,7 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins with array hasMany relationships', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const categoryWithPosts = await payload.findByID({
@@ -281,7 +281,7 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins with localized array relationships', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const categoryWithPosts = await payload.findByID({
@@ -313,7 +313,7 @@ describe('Joins Field', () => {
   })
 
   it('should join on polymorphic relationships', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const categoryWithPosts = await payload.findByID({
@@ -385,7 +385,7 @@ describe('Joins Field', () => {
   })
 
   it('should allow join where query on hasMany select fields', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const folderDoc = await payload.create({
@@ -438,7 +438,7 @@ describe('Joins Field', () => {
   })
 
   it('should query where with exists for hasMany select fields', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     await payload.delete({ collection: 'payload-folders', where: {} })
@@ -562,7 +562,7 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins using find with hasMany relationships', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const result = await payload.find({
@@ -590,7 +590,7 @@ describe('Joins Field', () => {
   })
 
   it('should populate joins using find with hasMany localized relationships', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const post_1 = await createPost(
@@ -808,7 +808,7 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins when versions on both sides draft false', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
@@ -824,7 +824,7 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany relationships when versions on both sides draft false', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
@@ -840,7 +840,7 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany relationships when versions on both sides draft true payload.db.queryDrafts', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
@@ -859,7 +859,7 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany when on both sides documents are in draft', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const category = await payload.create({
@@ -891,7 +891,7 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins when versions on both sides draft true payload.db.queryDrafts', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const category = await payload.create({ collection: 'categories-versions', data: {} })
@@ -1318,7 +1318,7 @@ describe('Joins Field', () => {
     })
 
     it('should populate joins with hasMany when on both sides documents are in draft', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const category = await payload.create({
@@ -1536,7 +1536,7 @@ describe('Joins Field', () => {
   })
 
   it('local API should not populate individual join by providing schemaPath=false', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const {
@@ -1561,7 +1561,7 @@ describe('Joins Field', () => {
   })
 
   it('rEST API should not populate individual join by providing schemaPath=false', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const {
@@ -1887,7 +1887,7 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with hasMany relationship', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const category = await payload.create({ collection: 'categories', data: {} })
@@ -1905,7 +1905,7 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with relationship nested to a group', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const category = await payload.create({ collection: 'categories', data: {} })
@@ -1923,7 +1923,7 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with relationship nested to an array', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const category = await payload.create({ collection: 'categories', data: {} })
@@ -1944,7 +1944,7 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field multiple times', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const category = await payload.create({ collection: 'categories', data: {} })
@@ -1975,7 +1975,7 @@ describe('Joins Field', () => {
   })
 
   it('should support where querying by a join field with hasMany relationship multiple times', async () => {
-    if (payload.db.name === 'content_api') {
+    if (payload.db.name === 'content-api') {
       return
     }
     const category = await payload.create({ collection: 'categories', data: {} })

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -4612,6 +4612,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       it('should handle errors in batch processing and continue', async () => {
+        if (payload.db.name === 'content-api') {
+          return
+        }
+
         const csvContent = `title,excerpt,relationship
 "Valid Doc 1","Excerpt 1",""
 "Valid Doc 2","Excerpt 2","invalid-id"

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -432,7 +432,7 @@ describe('Relationships', () => {
       })
 
       it('should allow query hasMany select in relationship', async () => {
-        if (payload.db.name === 'content_api') {
+        if (payload.db.name === 'content-api') {
           return
         }
         const movie = await payload.create({ collection: 'movies', data: { select: ['a', 'b'] } })
@@ -711,7 +711,7 @@ describe('Relationships', () => {
 
       describe('sorting by relationships', () => {
         it('should sort by a property of a relationship', async () => {
-          if (payload.db.name === 'content_api') {
+          if (payload.db.name === 'content-api') {
             return
           }
           await payload.delete({ collection: 'directors', where: {} })
@@ -800,7 +800,7 @@ describe('Relationships', () => {
         })
 
         it('should sort by a property of a nested relationship', async () => {
-          if (payload.db.name === 'content_api') {
+          if (payload.db.name === 'content-api') {
             return
           }
           await payload.delete({ collection: 'directors', where: {} })
@@ -842,7 +842,7 @@ describe('Relationships', () => {
         })
 
         it('should sort by multiple properties of a relationship', async () => {
-          if (payload.db.name === 'content_api') {
+          if (payload.db.name === 'content-api') {
             return
           }
           await payload.delete({ collection: 'directors', where: {} })
@@ -886,7 +886,7 @@ describe('Relationships', () => {
         })
 
         it('should sort by a property of a hasMany relationship', async () => {
-          if (payload.db.name === 'content_api') {
+          if (payload.db.name === 'content-api') {
             return
           }
           const movie1 = await payload.create({
@@ -1274,7 +1274,7 @@ describe('Relationships', () => {
       })
 
       it('should allow querying within array nesting', async () => {
-        if (payload.db.name === 'content_api') {
+        if (payload.db.name === 'content-api') {
           return
         }
         const page = await payload.create({
@@ -1309,7 +1309,7 @@ describe('Relationships', () => {
     })
 
     it('should allow querying within block nesting', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const director = await payload.create({
@@ -1360,7 +1360,7 @@ describe('Relationships', () => {
     })
 
     it('should allow querying hasMany in array', async () => {
-      if (payload.db.name === 'content_api') {
+      if (payload.db.name === 'content-api') {
         return
       }
       const director = await payload.create({

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -432,6 +432,9 @@ describe('Relationships', () => {
       })
 
       it('should allow query hasMany select in relationship', async () => {
+        if (payload.db.name === 'content_api') {
+          return
+        }
         const movie = await payload.create({ collection: 'movies', data: { select: ['a', 'b'] } })
         const doc = await payload.create({
           collection: 'directors',
@@ -708,6 +711,9 @@ describe('Relationships', () => {
 
       describe('sorting by relationships', () => {
         it('should sort by a property of a relationship', async () => {
+          if (payload.db.name === 'content_api') {
+            return
+          }
           await payload.delete({ collection: 'directors', where: {} })
           await payload.delete({ collection: 'movies', where: {} })
 
@@ -794,6 +800,9 @@ describe('Relationships', () => {
         })
 
         it('should sort by a property of a nested relationship', async () => {
+          if (payload.db.name === 'content_api') {
+            return
+          }
           await payload.delete({ collection: 'directors', where: {} })
           await payload.delete({ collection: 'movies', where: {} })
 
@@ -833,6 +842,9 @@ describe('Relationships', () => {
         })
 
         it('should sort by multiple properties of a relationship', async () => {
+          if (payload.db.name === 'content_api') {
+            return
+          }
           await payload.delete({ collection: 'directors', where: {} })
           await payload.delete({ collection: 'movies', where: {} })
 
@@ -874,6 +886,9 @@ describe('Relationships', () => {
         })
 
         it('should sort by a property of a hasMany relationship', async () => {
+          if (payload.db.name === 'content_api') {
+            return
+          }
           const movie1 = await payload.create({
             collection: 'movies',
             data: {
@@ -1259,6 +1274,9 @@ describe('Relationships', () => {
       })
 
       it('should allow querying within array nesting', async () => {
+        if (payload.db.name === 'content_api') {
+          return
+        }
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1291,6 +1309,9 @@ describe('Relationships', () => {
     })
 
     it('should allow querying within block nesting', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const director = await payload.create({
         collection: 'directors',
         data: { name: 'Test Director' },
@@ -1339,6 +1360,9 @@ describe('Relationships', () => {
     })
 
     it('should allow querying hasMany in array', async () => {
+      if (payload.db.name === 'content_api') {
+        return
+      }
       const director = await payload.create({
         collection: 'directors',
         data: { name: 'Test Director1337' },

--- a/test/runTestsWithSummary.ts
+++ b/test/runTestsWithSummary.ts
@@ -76,7 +76,7 @@ interface SuiteResult {
 }
 
 const isContentAPIMode = process.env.PAYLOAD_DATABASE === 'content-api'
-const contentAPISuiteTimeout = 15000
+const contentAPISuiteTimeout = 90000
 const vitestBinary = './node_modules/.bin/vitest'
 
 function getVitestEnv(options?: { unsetPayloadDatabase?: boolean }): NodeJS.ProcessEnv {


### PR DESCRIPTION
### What?
Disables unit tests described in this doc for the content api:
https://docs.google.com/document/d/120xmnUUCii_d7Tc4kvqItWV0D3td5RVCzM5JeWQ48Gk/edit?tab=t.0
### Why?
The content api isn't going to support the above features/complex query patterns, though that may (will) change in the future.
### How?
Early returns from tests if the db is the content-api
Fixes #

Reran test:int:summary, saw the following output:
Ran with the following commits:
Figma: 03d0e73d2b8f52c360c82f0a359d07397ad1d666
Enterprise-Plugins: 759a79b282f14f1e9815cf423cd84374f7414b0a
📈 Overall Results:
   Suites: 33/48 passed
   Tests:  1766/1871 passed
   Time:   8m 13s

❌ Failed or partially failed suites:
   ⚠️ collections-rest (109/112)
   ⚠️ database (127/158)
   ⚠️ folders (11/14)
   ⚠️ joins (71/75)
   ⚠️ kv (2/3)
   ⚠️ localization (111/115)
   ⚠️ plugin-import-export (178/188)
   ⚠️ plugin-mcp (66/67)
   ⚠️ relationships (51/57)
   ⚠️ sdk (35/38)
   ⚠️ select (113/114)
   ⚠️ sort (33/37)
   ⚠️ uploads (91/93)
   ⚠️ versions (70/93)
   ⚠️ fields (148/157)

