### PR TITLE
fix(auth): allow cross-site navigation to preserve authentication (#16031)

### DIFF
--- a/packages/payload/src/auth/extractJWT.ts
+++ b/packages/payload/src/auth/extractJWT.ts
@@ -42,9 +42,15 @@ const extractionMethods: Record<string, ExtractionMethod> = {
 
     // No Origin with csrf configured — fall back to Sec-Fetch-Site
     const secFetchSite = headers.get('Sec-Fetch-Site')
+    const secFetchMode = headers.get('Sec-Fetch-Mode')
 
-    // Allow same-origin, same-site, and direct navigations (none)
-    if (secFetchSite === 'same-origin' || secFetchSite === 'same-site' || secFetchSite === 'none') {
+    // Allow same-origin, same-site, direct navigations (none), and cross-site navigation (e.g., email links)
+    if (
+      secFetchSite === 'same-origin' ||
+      secFetchSite === 'same-site' ||
+      secFetchSite === 'none' ||
+      secFetchMode === 'navigate'
+    ) {
       return cookieToken
     }
 


### PR DESCRIPTION
## Description

Fixes #16031 - Cross-site navigation (e.g. email links) logs out authenticated users in 3.79.1

### Problem
Since 3.79.1, clicking a link to a Payload-authenticated route from an external source (such as email client or another site) causes login state to be lost on the first load.

### Root Cause
The CSRF protection introduced in #15751 didn't handle secFetchSite === 'navigate' which is sent when users click links from external sources like email clients.

### Solution
Added secFetchMode === 'navigate' check to allow cross-site navigation requests while maintaining CSRF protection for API calls.

### Changes
- packages/payload/src/auth/extractJWT.ts: Check for secFetchMode === 'navigate' in addition to existing secFetchSite checks

### Testing
- Verified that email links now preserve authentication
- Verified that CSRF protection still blocks malicious cross-site API requests