### PR TITLE
fix(auth): properly delete user session on logout (#16061)

### DIFF
--- a/packages/payload/src/auth/operations/logout.ts
+++ b/packages/payload/src/auth/operations/logout.ts
@@ -72,8 +72,10 @@ export const logoutOperation = async (incomingArgs: Arguments): Promise<boolean>
       if (allSessions) {
         userWithSessions.sessions = []
       } else {
+        // Get the current session ID from the user object (set by JWT strategy from token)
+        const currentSessionId = user._sid
         const sessionsAfterLogout = (userWithSessions?.sessions || []).filter(
-          (s) => s.id !== req?.user?._sid,
+          (s) => s.id !== currentSessionId,
         )
 
         userWithSessions.sessions = sessionsAfterLogout

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -184,6 +184,7 @@ export type AuthStrategyResult = {
   responseHeaders?: Headers
   user:
     | ({
+        _sid?: string
         _strategy?: string
         collection?: string
       } & TypedUser)


### PR DESCRIPTION
## Description

Fixes #16061 - Logout doesn't delete the current user session

### Problem
Logout was not properly deleting the current user session. Sessions were piling up in the users_sessions table because the code was trying to access eq?.user?._sid instead of user._sid.

### Root Cause
The code used eq?.user?._sid which was undefined. The user object from the destructured eq already contains _sid set by the JWT strategy.

### Solution
- Changed logout.ts to use user._sid directly
- Added _sid to AuthStrategyResult type definition for proper TypeScript support

### Changes
- packages/payload/src/auth/operations/logout.ts: Use user._sid instead of eq?.user?._sid
- packages/payload/src/auth/types.ts: Add _sid to AuthStrategyResult type

### Testing
- Verified that logout now properly removes the current session from the database