### PR TITLE
fix(drizzle): use aliasTable for transitive joins with hasMany (#16109)

### DIFF
--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -395,7 +395,7 @@ export const getTableColumnFromPath = ({
             addJoinTable({
               condition: and(
                 eq(
-                  adapter.tables[rootTableName].id,
+                  (aliasTable || adapter.tables[rootTableName]).id,
                   aliasRelationshipTable[
                     `${(relationshipField.field as RelationshipField).relationTo as string}ID`
                   ],


### PR DESCRIPTION
Fixes #16109 - Query error when transitive join field has hasMany: true

Problem: When querying collections with transitive joins (quest -> lesson -> course) where the join field has hasMany: true, the query fails with DrizzleQueryError: no such column: lesson.id

Root Cause: The join condition incorrectly used adapter.tables[rootTableName].id instead of considering that in transitive joins, the table may have been aliased.

Solution: Changed the join condition to use (aliasTable || adapter.tables[rootTableName]).id to correctly reference the aliased table when one exists.

Changes: packages/drizzle/src/queries/getTableColumnFromPath.ts