### PR TITLE
fix(payload): validate virtual useAstitle when auth is enabled

### DIFF
--- a/packages/payload/src/collections/config/useAsTitle.spec.ts
+++ b/packages/payload/src/collections/config/useAsTitle.spec.ts
@@ -201,5 +201,32 @@ describe('sanitize - collections -', () => {
         )
       }).rejects.toThrow(InvalidConfiguration)
     })
+
+    it('should throw when useAsTitle is a virtual field (boolean) and auth is enabled', async () => {
+      const collectionConfig: CollectionConfig = {
+        ...defaultCollection,
+        auth: true,
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+            virtual: true,
+          },
+        ],
+        admin: {
+          useAsTitle: 'name',
+        },
+      }
+      await expect(async () => {
+        await sanitizeCollection(
+          // @ts-expect-error
+          {
+            ...config,
+            collections: [collectionConfig],
+          },
+          collectionConfig,
+        )
+      }).rejects.toThrow(InvalidConfiguration)
+    })
   })
 })

--- a/packages/payload/src/collections/config/useAsTitle.ts
+++ b/packages/payload/src/collections/config/useAsTitle.ts
@@ -23,26 +23,20 @@ export const validateUseAsTitle = (config: CollectionConfig) => {
       return false
     })
 
-    // If auth is enabled then we don't need to
-    if (config.auth) {
-      if (config.admin.useAsTitle !== 'email') {
-        if (!useAsTitleField) {
-          throw new InvalidConfiguration(
-            `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" does not exist in the collection "${config.slug}"`,
-          )
-        }
-      }
-    } else {
-      if (useAsTitleField && 'virtual' in useAsTitleField && useAsTitleField.virtual === true) {
-        throw new InvalidConfiguration(
-          `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" in the collection "${config.slug}" is virtual. A virtual field can be used as the title only when linked to a relationship field.`,
-        )
-      }
-      if (!useAsTitleField) {
-        throw new InvalidConfiguration(
-          `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" does not exist in the collection "${config.slug}"`,
-        )
-      }
+    if (config.auth && config.admin.useAsTitle === 'email') {
+      return
+    }
+
+    if (!useAsTitleField) {
+      throw new InvalidConfiguration(
+        `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" does not exist in the collection "${config.slug}"`,
+      )
+    }
+
+    if ('virtual' in useAsTitleField && useAsTitleField.virtual === true) {
+      throw new InvalidConfiguration(
+        `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" in the collection "${config.slug}" is virtual. A virtual field can be used as the title only when linked to a relationship field.`,
+      )
     }
   }
 }


### PR DESCRIPTION
### what?
- Run the same useAsTitle + virtual checks for auth collections as for non-auth (still special-case email).

### Why?

- Virtual useAsTitle was only validated when auth was off.

### How?
- Single path: return early only for email; then existence + virtual === true check.

Fixes : #16142