### PR TITLE
fix(ui): resolve SSR hydration mismatch in DraggableSortable (aria-describedby)

### DIFF
--- a/packages/ui/src/elements/DraggableSortable/index.tsx
+++ b/packages/ui/src/elements/DraggableSortable/index.tsx
@@ -12,7 +12,7 @@ import {
   useSensors,
 } from '@dnd-kit/core'
 import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
-import React, { useCallback, useId } from 'react'
+import React, { useCallback, useId, useState } from 'react'
 
 import type { Props } from './types.js'
 
@@ -21,8 +21,16 @@ export { Props }
 export const DraggableSortable: React.FC<Props> = (props) => {
   const { children, className, ids, onDragEnd, onDragStart } = props
 
-  const dndContextID = useId()
-  const sortableContextID = useId()
+  // useId() can produce different values between server and client when the
+  // component is rendered inside a subtree that is not part of the initial
+  // SSR output (e.g. inside a hidden portal or lazily-mounted panel).
+  // @dnd-kit derives aria-describedby from the DndContext id, so a mismatch
+  // triggers a React hydration warning. Using useState ensures the id is only
+  // ever generated on the client, keeping SSR and client in sync.
+  // See: https://github.com/clauderic/dnd-kit/issues/926
+  const reactId = useId()
+  const [dndContextID] = useState(reactId)
+  const [sortableContextID] = useState(reactId + '-sortable')
 
   const { setNodeRef } = useDroppable({
     id: dndContextID,
@@ -84,17 +92,12 @@ export const DraggableSortable: React.FC<Props> = (props) => {
   return (
     <DndContext
       collisionDetection={closestCenter}
-      // Provide stable ID to fix hydration issues: https://github.com/clauderic/dnd-kit/issues/926
       id={dndContextID}
       onDragEnd={handleDragEnd}
       onDragStart={handleDragStart}
       sensors={sensors}
     >
-      <SortableContext
-        // Provide stable ID to fix hydration issues: https://github.com/clauderic/dnd-kit/issues/926
-        id={sortableContextID}
-        items={ids}
-      >
+      <SortableContext id={sortableContextID} items={ids}>
         <div className={className} ref={setNodeRef}>
           {children}
         </div>


### PR DESCRIPTION
## Problem

When `DraggableSortable` is mounted inside a subtree that was **not part of the initial SSR output** (e.g. the hidden column-picker panel in collection list views), `useId()` produces different values between the server render and the client hydration pass.

`@dnd-kit` derives `aria-describedby` on every sortable item from the `DndContext` id. Because the id differs, React emits a hydration mismatch warning for **every draggable pill** in the selector:

```
+ aria-describedby="_R_2qjakuatpesneb6jd5rlb_"
- aria-describedby="_R_badajpbn5ritpcqdl5rlb_"
```

This affects all collection list views that use the column picker (Videos, Offers, Reviews, etc.).

## Root cause

`useId()` is deterministic only when the component tree rendered on the server matches the tree hydrated on the client. When a component is conditionally mounted (hidden `div`, portal, lazy panel), the hook's counter is incremented differently on each side, producing mismatched ids.

## Fix

Initialise both `dndContextID` and `sortableContextID` through `useState` instead of using the `useId()` value directly. `useState` initialises only on the client, so the id is never included in SSR output and there is nothing to mismatch.

```tsx
const reactId = useId()
const [dndContextID] = useState(reactId)
const [sortableContextID] = useState(reactId + '-sortable')
```

The values remain stable across re-renders (empty deps in `useState`), so drag-and-drop behaviour is unaffected.

## References

- [dnd-kit/dnd-kit#926](https://github.com/clauderic/dnd-kit/issues/926)
- [nextjs.org/docs/messages/react-hydration-error](https://nextjs.org/docs/messages/react-hydration-error)