### PR TITLE
fix(plugin-cloud-storage): pass req to find in getFilePrefix for transaction support

### DIFF
--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -45,6 +45,7 @@ export async function getFilePrefix({
     draft: true,
     limit: 1,
     pagination: false,
+    req,
     where: {
       or: [
         {


### PR DESCRIPTION
## What
Fixes #15989 - `getFilePrefix` returns empty prefix during create transaction, causing crop/save flow to fail with `Failed to persist upload data`.

## Root Cause
In `packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts`, the `req.payload.find()` call on line 42 does **not** pass `req`. During a create operation, the document is being created within a transaction. Without `req`, the find query runs outside the transaction context and cannot see the uncommitted document, so it returns no results and the prefix resolves to an empty string `''`.

## Symptoms (as reported)
- `Failed to persist upload data for collection ...` (warning in afterChange)
- `GET /api/media/file/<filename>` returns 404
- Crop/edit flow fails during initial upload when using S3 storage with a non-empty prefix

## Fix
Added `req` to the `find()` call so the query participates in the same transaction and can see the just-created document:

```diff
 const files = await req.payload.find({
   collection: collection.slug,
   depth: 0,
   draft: true,
   limit: 1,
   pagination: false,
+  req,
   where: {
```