### PR TITLE
docs: fix typo in Collection Config docs (collection → collections)

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -12,7 +12,7 @@ Collections are also used to achieve [Authentication](../authentication/overview
 
 Collections are the primary way to structure recurring data in your application, such as users, products, pages, posts, and other types of content that you might want to manage. Each Collection can have its own unique [Access Control](../access-control/overview), [Hooks](../hooks/overview), [Admin Options](#admin-options), and more.
 
-To define a Collection Config, use the `collection` property in your [Payload Config](./overview):
+To define a Collection Config, use the `collections` property in your [Payload Config](./overview):
 
 ```ts
 import { buildConfig } from 'payload'


### PR DESCRIPTION
### What?

Fix incorrect property name in documentation for defining a Collection Config.

### Why?

The documentation incorrectly referenced `collection` instead of the correct `collections` property in the Payload Config. This could mislead users and cause configuration errors.

### How?

Updated the documentation to replace `collection` with `collections` in the relevant section.

### Before

```ts
collection: [...]
```

### After

```ts
collections: [...]
```

Fixes # (N/A)
