### PR TITLE
fix(ui): fix drawer scroll on iOS Safari

### DIFF
--- a/packages/ui/src/elements/Drawer/index.scss
+++ b/packages/ui/src/elements/Drawer/index.scss
@@ -36,8 +36,11 @@ $transTime: 200;
     &__content-children {
       position: relative;
       z-index: 1;
-      overflow: auto;
+      overflow-y: auto;
       height: 100%;
+      // Fix scroll on iOS Safari — single-finger swipe does not scroll without these
+      -webkit-overflow-scrolling: touch;
+      touch-action: pan-y;
     }
 
     &--is-open {


### PR DESCRIPTION
## What?

Fixes #14866

On real iPhone Safari, the admin drawer content cannot be scrolled with one finger — it appears frozen.

## Why?

iOS Safari requires explicit opt-in for touch scrolling on scrollable containers. Without `-webkit-overflow-scrolling: touch` and `touch-action: pan-y`, single-finger swipe gestures are not recognized as scroll events inside the drawer.

## How?

Added the two required CSS properties to `.drawer__content-children`, which is the scrollable container inside the drawer:

```scss
-webkit-overflow-scrolling: touch;
touch-action: pan-y;
```

Also changed `overflow: auto` to `overflow-y: auto` to be more explicit about the scroll axis.