### PR TITLE
chore: update deprecated VS code rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,8 +27,8 @@
   "stylelint.validate": ["css", "scss"],
   "css.validate": false,
   "scss.validate": false,
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   // Load .git-blame-ignore-revs file
   "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"],
   // Essentially disables bun test buttons

--- a/docs/typescript/ts-plugin.mdx
+++ b/docs/typescript/ts-plugin.mdx
@@ -47,8 +47,8 @@ For teams, add the following to `.vscode/settings.json` so everyone is prompted 
 
 ```json
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true
 }
 ```
 

--- a/templates/_template/.vscode/settings.json
+++ b/templates/_template/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/_template/.vscode/settings.json
+++ b/templates/_template/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/blank/.vscode/settings.json
+++ b/templates/blank/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/blank/.vscode/settings.json
+++ b/templates/blank/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/ecommerce/.vscode/settings.json
+++ b/templates/ecommerce/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit",
     "source.organizeImports": "explicit",

--- a/templates/plugin/.vscode/settings.json
+++ b/templates/plugin/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/plugin/.vscode/settings.json
+++ b/templates/plugin/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/website/.vscode/settings.json
+++ b/templates/website/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/website/.vscode/settings.json
+++ b/templates/website/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-cloudflare-d1/.vscode/settings.json
+++ b/templates/with-cloudflare-d1/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-cloudflare-d1/.vscode/settings.json
+++ b/templates/with-cloudflare-d1/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-postgres/.vscode/settings.json
+++ b/templates/with-postgres/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-postgres/.vscode/settings.json
+++ b/templates/with-postgres/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-vercel-mongodb/.vscode/settings.json
+++ b/templates/with-vercel-mongodb/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-vercel-mongodb/.vscode/settings.json
+++ b/templates/with-vercel-mongodb/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-vercel-postgres/.vscode/settings.json
+++ b/templates/with-vercel-postgres/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-vercel-postgres/.vscode/settings.json
+++ b/templates/with-vercel-postgres/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-vercel-website/.vscode/settings.json
+++ b/templates/with-vercel-website/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSaveMode": "file",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/templates/with-vercel-website/.vscode/settings.json
+++ b/templates/with-vercel-website/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[javascript][typescript][typescriptreact]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"


### PR DESCRIPTION
Replacing depricated rules in all `.vscode/settings.json`

```json
{
  "typescript.tsdk": "node_modules/typescript/lib",
  "typescript.enablePromptUseWorkspaceTsdk": true
}
```

with proper 

```json
{
  "js/ts.tsdk.path": "node_modules/typescript/lib",
  "js/ts.tsdk.promptToUseWorkspaceVersion": true
}
```