### PR TITLE
fix(collections): validate virtual fields in useAsTitle for auth collections (#16142)

### DIFF
--- a/packages/payload/src/collections/config/useAsTitle.ts
+++ b/packages/payload/src/collections/config/useAsTitle.ts
@@ -23,26 +23,22 @@ export const validateUseAsTitle = (config: CollectionConfig) => {
       return false
     })
 
-    // If auth is enabled then we don't need to
-    if (config.auth) {
-      if (config.admin.useAsTitle !== 'email') {
-        if (!useAsTitleField) {
-          throw new InvalidConfiguration(
-            `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" does not exist in the collection "${config.slug}"`,
-          )
-        }
-      }
-    } else {
-      if (useAsTitleField && 'virtual' in useAsTitleField && useAsTitleField.virtual === true) {
-        throw new InvalidConfiguration(
-          `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" in the collection "${config.slug}" is virtual. A virtual field can be used as the title only when linked to a relationship field.`,
-        )
-      }
-      if (!useAsTitleField) {
-        throw new InvalidConfiguration(
-          `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" does not exist in the collection "${config.slug}"`,
-        )
-      }
+    // For auth collections, 'email' is a special allowed value
+    const isEmailField = config.auth && config.admin.useAsTitle === 'email'
+
+    // Check if field exists (skip for 'email' on auth collections)
+    if (!useAsTitleField && !isEmailField) {
+      throw new InvalidConfiguration(
+        `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" does not exist in the collection "${config.slug}"`,
+      )
+    }
+
+    // Virtual field validation applies to all collections (including auth-enabled)
+    // Skip for 'email' on auth collections since it's not a real field
+    if (useAsTitleField && 'virtual' in useAsTitleField && useAsTitleField.virtual === true) {
+      throw new InvalidConfiguration(
+        `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" in the collection "${config.slug}" is virtual. A virtual field can be used as the title only when linked to a relationship field.`,
+      )
     }
   }
 }


### PR DESCRIPTION
Fixes #16142 - useAsTitle virtual field validation is skipped if collection has auth enabled

Problem: Virtual field validation was being skipped for auth-enabled collections, allowing virtual fields to be used as title which breaks relationship searching

Solution: Moved virtual field validation outside the auth check so it applies to all collections