### PR TITLE
fix(templates): prevent stale priceInUSD display when USD pricing is disabled (#16160)

### DIFF
--- a/templates/ecommerce/src/app/(app)/shop/page.tsx
+++ b/templates/ecommerce/src/app/(app)/shop/page.tsx
@@ -29,6 +29,7 @@ export default async function ShopPage({ searchParams }: Props) {
       gallery: true,
       categories: true,
       priceInUSD: true,
+      priceInUSDEnabled: true,
     },
     ...(sort ? { sort } : { sort: 'title' }),
     ...(searchValue || category
@@ -73,6 +74,12 @@ export default async function ShopPage({ searchParams }: Props) {
       : {}),
   })
 
+  // Filter out disabled USD prices to prevent stale prices from displaying
+  const cleanProducts = products.docs.map((product) => ({
+    ...product,
+    priceInUSD: product.priceInUSDEnabled ? product.priceInUSD : undefined,
+  }))
+
   const resultsText = products.docs.length > 1 ? 'results' : 'result'
 
   return (
@@ -90,9 +97,9 @@ export default async function ShopPage({ searchParams }: Props) {
         <p className="mb-4">No products found. Please try different filters.</p>
       )}
 
-      {products?.docs.length > 0 ? (
+      {cleanProducts.length > 0 ? (
         <Grid className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {products.docs.map((product) => {
+          {cleanProducts.map((product) => {
             return <ProductGridItem key={product.id} product={product} />
           })}
         </Grid>


### PR DESCRIPTION
Fixes #16160 - Ecommerce template displays stale priceInUSD when USD pricing is disabled

Problem: When USD pricing is disabled, products still show stale USD prices

Solution: Added priceInUSDEnabled check to filter out disabled prices before rendering