### PR TITLE
fix(ui): unpublish button missing for globals and version count incorrectly incrementing after unpublish

### DIFF
--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -160,15 +160,17 @@ export const DocumentControls: React.FC<{
     ? docHasTrashPermission || docHasDeletePermission
     : collectionDeletePermission
 
-  const showDotMenu = Boolean(
-    collectionConfig && id && !disableActions && (hasCreatePermission || hasDeletePermission),
-  )
-
   const unsavedDraftWithValidations =
     !id && collectionConfig?.versions?.drafts && collectionConfig.versions?.drafts.validate
 
   const globalHasDraftsEnabled = hasDraftsEnabled(globalConfig)
   const collectionHasDraftsEnabled = hasDraftsEnabled(collectionConfig)
+
+  const showDotMenu = Boolean(
+    !disableActions &&
+      ((collectionConfig && id && (hasCreatePermission || hasDeletePermission)) ||
+        (globalConfig && globalHasDraftsEnabled)),
+  )
   const collectionAutosaveEnabled = hasAutosaveEnabled(collectionConfig)
   const globalAutosaveEnabled = hasAutosaveEnabled(globalConfig)
   const autosaveEnabled = collectionAutosaveEnabled || globalAutosaveEnabled

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -133,7 +133,6 @@ export const DocumentControls: React.FC<{
     admin: { dateFormat },
     localization,
     routes: { admin: adminRoute },
-    serverURL,
   } = config
 
   // Settings these in state to avoid hydration issues if there is a mismatch between the server and client
@@ -169,7 +168,7 @@ export const DocumentControls: React.FC<{
   const showDotMenu = Boolean(
     !disableActions &&
       ((collectionConfig && id && (hasCreatePermission || hasDeletePermission)) ||
-        (globalConfig && globalHasDraftsEnabled)),
+        (globalConfig && (globalHasDraftsEnabled || localization))),
   )
   const collectionAutosaveEnabled = hasAutosaveEnabled(collectionConfig)
   const globalAutosaveEnabled = hasAutosaveEnabled(globalConfig)

--- a/packages/ui/src/elements/UnpublishButton/index.tsx
+++ b/packages/ui/src/elements/UnpublishButton/index.tsx
@@ -110,7 +110,9 @@ export function UnpublishButton({
             })
 
             toast.success(t('version:unpublishedSuccessfully'))
-            incrementVersionCount()
+            if (!unpublishAll) {
+              incrementVersionCount()
+            }
             setUnpublishedVersionCount(1)
             setMostRecentVersionIsAutosaved(false)
             setHasPublishedDoc(false)

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -611,6 +611,19 @@ describe('Localization', () => {
         'English block text content',
       )
     })
+
+    test('should show copy to locale in dot menu for globals without drafts', async () => {
+      const globalURL = new AdminUrlUtil(serverURL, 'global-text')
+      await page.goto(globalURL.global('global-text'))
+
+      await openDocControls(page)
+
+      await expect(page.locator('#copy-locale-data__button')).toBeVisible()
+      await expect(page.locator('#action-create')).not.toBeAttached()
+      await expect(page.locator('#action-delete')).not.toBeAttached()
+      await expect(page.locator('#action-duplicate')).not.toBeAttached()
+      await expect(page.locator('#action-unpublish')).not.toBeAttached()
+    })
   })
 
   describe('locale change', () => {

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -31,6 +31,7 @@ import DraftUnlimitedGlobal from './globals/DraftUnlimited.js'
 import DraftWithMaxGlobal from './globals/DraftWithMax.js'
 import LocalizedGlobal from './globals/LocalizedGlobal.js'
 import { MaxVersions } from './globals/MaxVersions.js'
+import SimpleDraftGlobal from './globals/SimpleDraft.js'
 import { seed } from './seed.js'
 import { BASE_PATH } from './shared.js'
 process.env.NEXT_BASE_PATH = BASE_PATH
@@ -73,6 +74,7 @@ export default buildConfigWithDefaults({
     LocalizedGlobal,
     MaxVersions,
     DraftUnlimitedGlobal,
+    SimpleDraftGlobal,
   ],
   indexSortableFields: true,
   localization: {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -79,6 +79,7 @@ import {
   localizedCollectionSlug,
   localizedGlobalSlug,
   postCollectionSlug,
+  simpleDraftGlobalSlug,
   textCollectionSlug,
   versionCollectionSlug,
 } from './slugs.js'
@@ -858,6 +859,35 @@ describe('Versions', () => {
       })
     })
 
+    test('collections — should not increment version count when unpublishing', async () => {
+      const publishedDoc = await payload.create({
+        collection: draftCollectionSlug,
+        data: {
+          _status: 'published',
+          title: 'unpublish version count test',
+          description: 'description',
+        },
+      })
+
+      await page.goto(url.edit(publishedDoc.id))
+
+      const versionsCountSelector = `.doc-tabs__tabs .pill-version-count`
+      await page.locator(versionsCountSelector).waitFor({ state: 'visible' })
+      const countBefore = await page.locator(versionsCountSelector).textContent()
+
+      await openDocControls(page)
+      await page.locator('#action-unpublish').click()
+      await page.locator('[id^="confirm-un-publish-"] #confirm-action').click()
+      await expect(page.locator('.payload-toast-item')).toBeVisible()
+
+      await expect.poll(() => page.locator(versionsCountSelector).textContent()).toBe(countBefore)
+
+      await payload.delete({
+        collection: draftCollectionSlug,
+        id: publishedDoc.id,
+      })
+    })
+
     test('should show documents title in relationship even if draft document', async () => {
       await payload.create({
         collection: autosaveCollectionSlug,
@@ -1219,15 +1249,65 @@ describe('Versions', () => {
       await expect(page.locator('#action-save')).not.toBeAttached()
     })
 
+    test('globals — should show unpublish button after publishing', async () => {
+      await payload.updateGlobal({
+        slug: simpleDraftGlobalSlug,
+        data: { title: 'published global', _status: 'published' },
+      })
+
+      const globalURL = new AdminUrlUtil(serverURL, simpleDraftGlobalSlug)
+      await page.goto(globalURL.global(simpleDraftGlobalSlug))
+
+      await openDocControls(page)
+      await expect(page.locator('#action-unpublish')).toBeVisible()
+    })
+
+    test('globals — dot menu should only contain unpublish and copy to locale options', async () => {
+      await payload.updateGlobal({
+        slug: simpleDraftGlobalSlug,
+        data: { title: 'published global', _status: 'published' },
+      })
+
+      const globalURL = new AdminUrlUtil(serverURL, simpleDraftGlobalSlug)
+      await page.goto(globalURL.global(simpleDraftGlobalSlug))
+
+      await openDocControls(page)
+
+      await expect(page.locator('#action-unpublish')).toBeVisible()
+      await expect(page.locator('#copy-locale-data__button')).toBeVisible()
+      await expect(page.locator('#action-create')).not.toBeAttached()
+      await expect(page.locator('#action-delete')).not.toBeAttached()
+      await expect(page.locator('#action-duplicate')).not.toBeAttached()
+    })
+
+    test('globals — should not increment version count when unpublishing', async () => {
+      await payload.updateGlobal({
+        slug: simpleDraftGlobalSlug,
+        data: { title: 'unpublish version count test', _status: 'published' },
+      })
+
+      const globalURL = new AdminUrlUtil(serverURL, simpleDraftGlobalSlug)
+      await page.goto(globalURL.global(simpleDraftGlobalSlug))
+
+      const versionsCountPill = page.locator(`.doc-tabs__tabs .pill-version-count`)
+      await versionsCountPill.waitFor({ state: 'visible' })
+      const countBefore = await versionsCountPill.textContent()
+
+      await openDocControls(page)
+      await page.locator('#action-unpublish').click()
+      await page.locator('[id^="confirm-un-publish-"] #confirm-action').click()
+      await expect(page.locator('.payload-toast-item')).toBeVisible()
+
+      await expect.poll(() => versionsCountPill.textContent()).toBe(countBefore)
+    })
+
     test('globals — should hide unpublish button when access control prevents update', async () => {
-      // Then publish it with override access to create a published version
       await payload.updateGlobal({
         slug: disablePublishGlobalSlug,
         data: {
           _status: 'published',
           title: 'published global',
         },
-        overrideAccess: true,
       })
 
       const url = new AdminUrlUtil(serverURL, disablePublishGlobalSlug)

--- a/test/versions/globals/SimpleDraft.ts
+++ b/test/versions/globals/SimpleDraft.ts
@@ -1,0 +1,20 @@
+import type { GlobalConfig } from 'payload'
+
+import { simpleDraftGlobalSlug } from '../slugs.js'
+
+const SimpleDraftGlobal: GlobalConfig = {
+  slug: simpleDraftGlobalSlug,
+  label: 'Simple Draft Global',
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+  ],
+}
+
+export default SimpleDraftGlobal

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -136,6 +136,7 @@ export interface Config {
     'localized-global': LocalizedGlobal;
     'max-versions': MaxVersion;
     'draft-unlimited-global': DraftUnlimitedGlobal;
+    'simple-draft-global': SimpleDraftGlobal;
   };
   globalsSelect: {
     'autosave-global': AutosaveGlobalSelect<false> | AutosaveGlobalSelect<true>;
@@ -146,6 +147,7 @@ export interface Config {
     'localized-global': LocalizedGlobalSelect<false> | LocalizedGlobalSelect<true>;
     'max-versions': MaxVersionsSelect<false> | MaxVersionsSelect<true>;
     'draft-unlimited-global': DraftUnlimitedGlobalSelect<false> | DraftUnlimitedGlobalSelect<true>;
+    'simple-draft-global': SimpleDraftGlobalSelect<false> | SimpleDraftGlobalSelect<true>;
   };
   locale: 'en' | 'es' | 'de';
   widgets: {
@@ -1504,6 +1506,17 @@ export interface DraftUnlimitedGlobal {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "simple-draft-global".
+ */
+export interface SimpleDraftGlobal {
+  id: string;
+  title: string;
+  _status?: ('draft' | 'published') | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "autosave-global_select".
  */
 export interface AutosaveGlobalSelect<T extends boolean = true> {
@@ -1585,6 +1598,17 @@ export interface MaxVersionsSelect<T extends boolean = true> {
  * via the `definition` "draft-unlimited-global_select".
  */
 export interface DraftUnlimitedGlobalSelect<T extends boolean = true> {
+  title?: T;
+  _status?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "simple-draft-global_select".
+ */
+export interface SimpleDraftGlobalSelect<T extends boolean = true> {
   title?: T;
   _status?: T;
   updatedAt?: T;

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -50,11 +50,19 @@ export const autosaveWithDraftButtonGlobal = 'autosave-with-draft-button-global'
 
 export const draftGlobalSlug = 'draft-global'
 
+export const simpleDraftGlobalSlug = 'simple-draft-global'
+
 export const draftUnlimitedGlobalSlug = 'draft-unlimited-global'
 
 export const draftWithMaxGlobalSlug = 'draft-with-max-global'
 
-export const globalSlugs = [autoSaveGlobalSlug, draftGlobalSlug]
+export const globalSlugs = [
+  autoSaveGlobalSlug,
+  draftGlobalSlug,
+  simpleDraftGlobalSlug,
+  draftUnlimitedGlobalSlug,
+  draftWithMaxGlobalSlug,
+]
 
 export const localizedCollectionSlug = 'localized-posts'
 


### PR DESCRIPTION
# Overview

Fixes the unpublish button not appearing for globals, and fixes the version count tab incorrectly incrementing after unpublishing.

## Key Changes

- Extended `showDotMenu` in `DocumentControls` to render for globals with drafts enabled
- Fixed `incrementVersionCount` being called unconditionally on unpublish — it should only fire when unpublishing a specific locale, not all locales

## Design Decisions

Collection-only dot menu actions (create, duplicate, delete) self-guard via permissions that are always false for globals, so no extra conditions were needed.

#### Before
<img width="1221" height="402" alt="Screenshot 2026-04-07 at 3 44 28 PM" src="https://github.com/user-attachments/assets/e60984f9-6abd-4110-9374-d5d22027a608" />

#### After
<img width="1217" height="434" alt="Screenshot 2026-04-07 at 3 40 53 PM" src="https://github.com/user-attachments/assets/94e38404-0d70-47dd-b28a-f8e76a52d275" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213980133285459