### PR TITLE
fix(translations): fix lock translation for polish language

### DIFF
--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -359,7 +359,7 @@ export const plTranslations: DefaultTranslationsObject = {
     loading: 'Ładowanie',
     locale: 'Ustawienia regionalne',
     locales: 'Ustawienia regionalne',
-    lock: 'Zamek',
+    lock: 'Zablokuj',
     menu: 'Menu',
     moreOptions: 'Więcej opcji',
     move: 'Przesuń',


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?

Lock word translation fix for the polish language.

### Why?

The current word "zamek" doesn't make sense in the context of eg. slug locking, as it's noun instead of verb.
It was probably automatically translated, that's why this issue appears.