### PR TITLE
templates: fix tailwind typography config so that it works better with shadcn CLI

### DIFF
--- a/templates/ecommerce/tailwind.config.mjs
+++ b/templates/ecommerce/tailwind.config.mjs
@@ -85,7 +85,7 @@ export default {
         error: 'hsl(var(--error))',
         warning: 'hsl(var(--warning))',
       },
-      typography: ({ theme }) => ({
+      typography: {
         DEFAULT: {
           css: {
             '--tw-prose-body': 'var(--text)',
@@ -100,7 +100,7 @@ export default {
             },
           },
         },
-      }),
+      },
       fontFamily: {
         mono: ['var(--font-geist-mono)'],
         sans: ['var(--font-geist-sans)'],

--- a/templates/website/tailwind.config.mjs
+++ b/templates/website/tailwind.config.mjs
@@ -2,7 +2,7 @@
 const config = {
   theme: {
     extend: {
-      typography: () => ({
+      typography: {
         DEFAULT: {
           css: [
             {
@@ -40,7 +40,7 @@ const config = {
             },
           ],
         },
-      }),
+      },
     },
   },
 }

--- a/templates/with-vercel-website/tailwind.config.mjs
+++ b/templates/with-vercel-website/tailwind.config.mjs
@@ -2,7 +2,7 @@
 const config = {
   theme: {
     extend: {
-      typography: () => ({
+      typography: {
         DEFAULT: {
           css: [
             {
@@ -40,7 +40,7 @@ const config = {
             },
           ],
         },
-      }),
+      },
     },
   },
 }


### PR DESCRIPTION
Typography config as a function can cause issues with automatic merging from the shadcn CLI so this just changes it to a static object since we didn't use the function arguments themselves.