### PR TITLE
fix(next): use correct config key for disabling turbo server fast refresh

### DIFF
--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -72,7 +72,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
     experimental: {
       ...(nextConfig.experimental || {}),
       // Server fast refresh breaks HMR
-      ...(hasServerFastRefreshConfigOption ? { enableServerFastRefresh: false } : {}),
+      ...(hasServerFastRefreshConfigOption ? { turbopackServerFastRefresh: false } : {}),
     },
     sassOptions: {
       ...(nextConfig.sassOptions || {}),


### PR DESCRIPTION
The previous PR set `enableServerFastRefresh: false` which was not the correct config key - it should be `turbopackServerFastRefresh: false`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213983836266026