### PR TITLE
fix: handle concurrent autosave write conflicts gracefully

### DIFF
--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -134,7 +134,7 @@ export async function saveVersion<TData extends JsonObject = JsonObject>({
       errorMessage = `There was an error while saving a version for the global ${typeof global.label === 'string' ? global.label : global.slug}.`
     }
     payload.logger.error({ err, msg: errorMessage })
-    return undefined!
+    throw err
   }
 
   const max = getVersionsMax(collection || global!)

--- a/packages/payload/src/versions/updateLatestVersion.ts
+++ b/packages/payload/src/versions/updateLatestVersion.ts
@@ -76,6 +76,8 @@ export async function updateLatestVersion<TData extends JsonObject>({
     },
   }
 
+  let versionUpdateFailed: boolean | undefined = undefined
+
   try {
     if (collection) {
       return await payload.db.updateVersion<TData>({
@@ -91,11 +93,14 @@ export async function updateLatestVersion<TData extends JsonObject>({
       req,
     })
   } catch (err) {
+    versionUpdateFailed = true
     payload.logger.warn({
       err,
       msg: `Failed to update latest version — checking if a concurrent write already succeeded.`,
     })
+  }
 
+  if (versionUpdateFailed) {
     // If a concurrent request already committed, return its result to avoid a duplicate version.
     // If updatedAt is unchanged, the update genuinely failed — fall back to createVersion.
     try {
@@ -128,7 +133,7 @@ export async function updateLatestVersion<TData extends JsonObject>({
     } catch {
       // If the follow-up query also fails, fall through to createVersion
     }
-
-    return undefined
   }
+
+  return undefined
 }

--- a/packages/payload/src/versions/updateLatestVersion.ts
+++ b/packages/payload/src/versions/updateLatestVersion.ts
@@ -76,17 +76,25 @@ export async function updateLatestVersion<TData extends JsonObject>({
     },
   }
 
-  if (collection) {
-    return await payload.db.updateVersion<TData>({
+  try {
+    if (collection) {
+      return await payload.db.updateVersion<TData>({
+        ...updateVersionArgs,
+        collection: collection.slug,
+        req,
+      })
+    }
+
+    return await payload.db.updateGlobalVersion<TData>({
       ...updateVersionArgs,
-      collection: collection.slug,
+      global: global!.slug,
       req,
     })
+  } catch (err) {
+    payload.logger.warn({
+      err,
+      msg: `Failed to update latest version — a concurrent write likely won the race. A new version will be created as fallback.`,
+    })
+    return undefined
   }
-
-  return await payload.db.updateGlobalVersion<TData>({
-    ...updateVersionArgs,
-    global: global!.slug,
-    req,
-  })
 }

--- a/packages/payload/src/versions/updateLatestVersion.ts
+++ b/packages/payload/src/versions/updateLatestVersion.ts
@@ -93,8 +93,42 @@ export async function updateLatestVersion<TData extends JsonObject>({
   } catch (err) {
     payload.logger.warn({
       err,
-      msg: `Failed to update latest version — a concurrent write likely won the race. A new version will be created as fallback.`,
+      msg: `Failed to update latest version — checking if a concurrent write already succeeded.`,
     })
+
+    // If a concurrent request already committed, return its result to avoid a duplicate version.
+    // If updatedAt is unchanged, the update genuinely failed — fall back to createVersion.
+    try {
+      let freshDocs: JsonObject[]
+
+      if (collection) {
+        ;({ docs: freshDocs } = await payload.db.findVersions<TData>({
+          collection: collection.slug,
+          limit: 1,
+          pagination: false,
+          req,
+          sort: '-updatedAt',
+          where: { parent: { equals: id } },
+        }))
+      } else {
+        ;({ docs: freshDocs } = await payload.db.findGlobalVersions<TData>({
+          global: global!.slug,
+          limit: 1,
+          pagination: false,
+          req,
+          sort: '-updatedAt',
+        }))
+      }
+
+      const [freshVersion] = freshDocs
+
+      if (freshVersion && new Date(freshVersion.updatedAt) > new Date(latestVersion.updatedAt)) {
+        return freshVersion
+      }
+    } catch {
+      // If the follow-up query also fails, fall through to createVersion
+    }
+
     return undefined
   }
 }

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -6,7 +6,7 @@ import { createLocalReq, saveVersion, ValidationError } from 'payload'
 import { wait } from 'payload/shared'
 import * as qs from 'qs-esm'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { AutosaveMultiSelectPost, DraftPost } from './payload-types.js'
@@ -1735,6 +1735,88 @@ describe('Versions', () => {
 
         await cleanupDocuments({
           collectionSlugs: [draftCollectionSlug],
+          payload,
+        })
+      })
+
+      it('should fall back to creating a new version when updateVersion fails due to a concurrent write', async () => {
+        const doc = await payload.create({
+          collection: autosaveCollectionSlug,
+          data: { title: 'original', _status: 'draft' },
+          draft: true,
+        })
+
+        // Establish an existing autosave version so updateLatestVersion has something to update
+        await payload.update({
+          id: doc.id,
+          autosave: true,
+          collection: autosaveCollectionSlug,
+          data: { title: 'first autosave' },
+          draft: true,
+        })
+
+        const spy = vi
+          .spyOn(payload.db, 'updateVersion')
+          .mockRejectedValueOnce(new Error('concurrent update conflict'))
+
+        // Should not throw — updateLatestVersion catches the error and saveVersion falls back to createVersion
+        const result = await payload.update({
+          id: doc.id,
+          autosave: true,
+          collection: autosaveCollectionSlug,
+          data: { title: 'second autosave' },
+          draft: true,
+        })
+
+        spy.mockRestore()
+
+        expect(result.title).toBe('second autosave')
+
+        // A new version was created as fallback instead of the in-place update
+        const { totalDocs } = await payload.countVersions({
+          collection: autosaveCollectionSlug,
+          where: { parent: { equals: doc.id } },
+        })
+
+        // create → 1 version, first autosave updates in place → still 1 version on autosave collection (it creates a new autosave),
+        // second autosave failed update → fell back to create → one extra version
+        expect(totalDocs).toBeGreaterThan(1)
+
+        await cleanupDocuments({
+          collectionSlugs: [autosaveCollectionSlug],
+          payload,
+        })
+      })
+
+      it('should propagate the error when createVersion also fails', async () => {
+        const doc = await payload.create({
+          collection: autosaveCollectionSlug,
+          data: { title: 'original', _status: 'draft' },
+          draft: true,
+        })
+
+        const updateVersionSpy = vi
+          .spyOn(payload.db, 'updateVersion')
+          .mockRejectedValueOnce(new Error('concurrent update conflict'))
+        const createVersionSpy = vi
+          .spyOn(payload.db, 'createVersion')
+          .mockRejectedValueOnce(new Error('database connection lost'))
+
+        await expect(
+          payload.update({
+            id: doc.id,
+            autosave: true,
+            collection: autosaveCollectionSlug,
+            data: { title: 'will fail' },
+            draft: true,
+          }),
+        ).rejects.toThrow('database connection lost')
+
+        updateVersionSpy.mockRestore()
+        createVersionSpy.mockRestore()
+
+        await cleanupDocuments({
+          collectionSlugs: [autosaveCollectionSlug],
           payload,
         })
       })


### PR DESCRIPTION
### What?

Two-part fix for intermittent 500s during autosave on serverless environments.

1. `updateLatestVersion` catches errors from `updateVersion`/`updateGlobalVersion` and checks whether a concurrent write already succeeded before falling back to `createVersion`
2. `saveVersion` re-throws instead of `return undefined!` so genuine failures still surface as real errors

### Why?

On serverless, concurrent autosave requests race to update the same version row. The losing request gets a DB error. Previously `saveVersion` caught it and returned `undefined!`, which was assigned to `result`. Downstream field hooks then accessed properties on `undefined`:

```
TypeError: Cannot read properties of undefined (reading '_status')
```

### How?

When `updateVersion` fails, we re-query the row and check if `updatedAt` has moved — if it has, a concurrent request already committed and we return that result. If not, we fall back to `createVersion`. If that also fails, `saveVersion` re-throws.

Fixes #16217

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213985147428664