### PR TITLE
fix(fields): set readOnly on virtual fields in admin UI

### DIFF
--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -356,6 +356,12 @@ export const sanitizeField = async ({
     field.admin = {}
   }
 
+  // Virtual fields (virtual: true) are computed server-side and never persisted,
+  // so they must be read-only in the admin UI.
+  if ('virtual' in field && field.virtual === true && !field.admin.readOnly) {
+    field.admin.readOnly = true
+  }
+
   // Make sure that the richText field has an editor
   if (field.type === 'richText') {
     const sanitizeRichText = async (_config: SanitizedConfig) => {


### PR DESCRIPTION
## Problem

Virtual fields (`virtual: true`) are computed server-side and never persisted to the database. Despite this, the admin UI renders them as standard editable inputs — users can type values into them, but those values are silently discarded on save.

## Fix

During field sanitization in `sanitizeField`, after `field.admin` is guaranteed to exist, set `readOnly: true` on any field where `virtual === true`:

```typescript
if ('virtual' in field && field.virtual === true && !field.admin.readOnly) {
  field.admin.readOnly = true
}
```

The guard (`!field.admin.readOnly`) preserves explicit `readOnly: false` overrides in case a developer has a reason to display a virtual field differently.

## Scope

1 file, 6-line addition in `packages/payload/src/fields/config/sanitize.ts`. No behavior change for non-virtual fields.

Fixes #16013