### PR TITLE
feat: add afterPlugins config property for cross-plugin discovery

### DIFF
--- a/docs/plugins/build-your-own.mdx
+++ b/docs/plugins/build-your-own.mdx
@@ -49,10 +49,11 @@ export default config;
 The initialization process goes in the following order:
 
 1. Incoming config is validated
-2. Plugins execute
-3. Default options are integrated
-4. Sanitization cleans and validates data
-5. Final config gets initialized
+2. Plugins execute (pass 1)
+3. `afterPlugins` callbacks execute (pass 2)
+4. Default options are integrated
+5. Sanitization cleans and validates data
+6. Final config gets initialized
 
 ## Plugin Template
 
@@ -255,6 +256,74 @@ config.onInit = async payload => {
   onInitExtension(pluginOptions, payload)
 }
 ```
+
+### Cross-plugin discovery with afterPlugins
+
+When a plugin needs to read or react to config contributed by _other_ plugins, the standard single-pass approach doesn't work because plugin execution order is unpredictable. The `afterPlugins` config property solves this by giving plugins a second pass that runs after every plugin has executed.
+
+During its first pass, a plugin registers an `afterPlugins` callback. Payload calls these callbacks once all plugins have finished, passing the fully-assembled config so each callback can inspect it.
+
+A common pattern is for plugins to accept options both from their own arguments _and_ from `config.custom`. This lets other plugins inject configuration into your plugin without needing to know the execution order - they simply write to `config.custom.myPlugin`, and your `afterPlugins` callback picks it up.
+
+```ts
+import type { Config, Plugin } from 'payload'
+
+type MyPluginOptions = {
+  tools: Array<{ name: string; description: string }>
+}
+
+export const myPlugin =
+  (pluginOptions: MyPluginOptions): Plugin =>
+  (incomingConfig) => {
+    return {
+      ...incomingConfig,
+
+      // Pass 1: register collections, fields, etc.
+      collections: [...(incomingConfig.collections || []), myCollection],
+
+      // Pass 2: discover tools contributed by other plugins via config.custom
+      afterPlugins: [
+        ...(incomingConfig.afterPlugins || []),
+        (finalConfig) => {
+          // Merge tools from plugin args with tools other plugins added to config.custom
+          const externalTools = (finalConfig.custom?.myPlugin?.tools ??
+            []) as MyPluginOptions['tools']
+          const allTools = [...pluginOptions.tools, ...externalTools]
+
+          // Use allTools to add fields, endpoints, etc.
+
+          return finalConfig
+        },
+      ],
+    }
+  }
+```
+
+Any other plugin can contribute to `myPlugin` without importing it - just write to `config.custom`:
+
+```ts
+// anotherPlugin.ts
+export const anotherPlugin: Plugin = (incomingConfig) => {
+  return {
+    ...incomingConfig,
+    custom: {
+      ...(incomingConfig.custom || {}),
+      myPlugin: {
+        tools: [
+          ...(incomingConfig.custom?.myPlugin?.tools ?? []),
+          { name: 'search', description: 'Full-text search tool' },
+        ],
+      },
+    },
+  }
+}
+```
+
+**When to use `afterPlugins`:**
+
+- Reading values that other plugins contribute during pass 1 (e.g. `config.custom`)
+- Discovering collections, globals, or fields registered by other plugins
+- Any cross-plugin coordination where execution order would otherwise matter
 
 ## Types
 

--- a/packages/payload/src/config/build.ts
+++ b/packages/payload/src/config/build.ts
@@ -9,19 +9,14 @@ import { sanitizeConfig } from './sanitize.js'
  */
 export async function buildConfig(config: Config): Promise<SanitizedConfig> {
   if (Array.isArray(config.plugins)) {
-    let configAfterPlugins = config
     for (const plugin of config.plugins) {
-      configAfterPlugins = await plugin(configAfterPlugins)
+      config = await plugin(config)
     }
-    config = configAfterPlugins
   }
 
-  // Pass 2: run afterPlugins callbacks for cross-plugin discovery.
-  // Plugins can push callbacks to config.afterPlugins during pass 1 to defer
-  // work that depends on the fully-assembled config from all plugins.
   if (Array.isArray(config.afterPlugins)) {
-    for (const callback of config.afterPlugins) {
-      config = await callback(config)
+    for (const afterPlugin of config.afterPlugins) {
+      config = await afterPlugin(config)
     }
   }
 

--- a/packages/payload/src/config/build.ts
+++ b/packages/payload/src/config/build.ts
@@ -13,7 +13,16 @@ export async function buildConfig(config: Config): Promise<SanitizedConfig> {
     for (const plugin of config.plugins) {
       configAfterPlugins = await plugin(configAfterPlugins)
     }
-    return await sanitizeConfig(configAfterPlugins)
+    config = configAfterPlugins
+  }
+
+  // Pass 2: run afterPlugins callbacks for cross-plugin discovery.
+  // Plugins can push callbacks to config.afterPlugins during pass 1 to defer
+  // work that depends on the fully-assembled config from all plugins.
+  if (Array.isArray(config.afterPlugins)) {
+    for (const callback of config.afterPlugins) {
+      config = await callback(config)
+    }
   }
 
   return await sanitizeConfig(config)

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1093,6 +1093,17 @@ export type Config = {
   }
 
   /**
+   * Callbacks that run after all plugins have been applied (second pass).
+   *
+   * Plugins can push callbacks here during their initial execution to defer work
+   * that depends on the fully-assembled config - for example, discovering tools or
+   * collections registered by other plugins.
+   *
+   * These callbacks receive the config after every plugin has run and return a
+   * modified config. They execute in the order they were pushed.
+   */
+  afterPlugins?: Array<(config: Config) => Config | Promise<Config>>
+  /**
    * Configure authentication-related Payload-wide settings.
    */
   auth?: {

--- a/test/plugins/config.ts
+++ b/test/plugins/config.ts
@@ -7,6 +7,7 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export const pagesSlug = 'pages'
+export const afterPluginSlug = 'after-plugin-pages'
 
 export default buildConfigWithDefaults({
   admin: {
@@ -22,21 +23,50 @@ export default buildConfigWithDefaults({
     },
   ],
   plugins: [
-    (config) => ({
-      ...config,
-      collections: [
-        ...(config.collections || []),
-        {
-          slug: pagesSlug,
-          fields: [
-            {
-              name: 'title',
-              type: 'text',
-            },
-          ],
-        },
-      ],
-    }),
+    (config) => {
+      return {
+        ...config,
+        afterPlugins: [
+          ...(config.afterPlugins || []),
+          (finalConfig) => {
+            const hasPages = finalConfig.collections?.some((c) => c.slug === pagesSlug)
+
+            return {
+              ...finalConfig,
+              collections: [
+                ...(finalConfig.collections || []),
+                {
+                  slug: afterPluginSlug,
+                  fields: [
+                    {
+                      name: 'title',
+                      type: 'text' as const,
+                    },
+                    {
+                      name: 'discoveredPages',
+                      type: 'checkbox' as const,
+                      defaultValue: hasPages,
+                    },
+                  ],
+                },
+              ],
+            }
+          },
+        ],
+        collections: [
+          ...(config.collections || []),
+          {
+            slug: pagesSlug,
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+              },
+            ],
+          },
+        ],
+      }
+    },
   ],
   onInit: async (payload) => {
     await payload.create({

--- a/test/plugins/int.spec.ts
+++ b/test/plugins/int.spec.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { pagesSlug } from './config.js'
+import { afterPluginSlug, pagesSlug } from './config.js'
 
 let payload: Payload
 
@@ -30,5 +30,34 @@ describe('Collections - Plugins', () => {
     })
 
     expect(id).toBeDefined()
+
+    await payload.delete({ collection: pagesSlug, id })
+  })
+
+  describe('afterPlugins', () => {
+    it('should create collection registered by afterPlugins callback', async () => {
+      const { id } = await payload.create({
+        collection: afterPluginSlug,
+        data: {
+          title: 'After Plugin Page',
+        },
+      })
+
+      expect(id).toBeDefined()
+
+      await payload.delete({ collection: afterPluginSlug, id })
+    })
+
+    it('should have access to the fully-assembled config from all plugins', () => {
+      // The afterPlugins callback checks whether the pages collection exists
+      // and sets discoveredPages accordingly
+      const collection = payload.config.collections.find((c) => c.slug === afterPluginSlug)
+      const discoveredField = collection?.fields.find(
+        (f) => 'name' in f && f.name === 'discoveredPages',
+      )
+
+      expect(discoveredField).toBeDefined()
+      expect('defaultValue' in discoveredField! && discoveredField.defaultValue).toBe(true)
+    })
   })
 })

--- a/test/plugins/payload-types.ts
+++ b/test/plugins/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     users: User;
     pages: Page;
+    'after-plugin-pages': AfterPluginPage;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -78,6 +79,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     pages: PagesSelect<false> | PagesSelect<true>;
+    'after-plugin-pages': AfterPluginPagesSelect<false> | AfterPluginPagesSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -90,6 +92,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -151,6 +156,17 @@ export interface Page {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "after-plugin-pages".
+ */
+export interface AfterPluginPage {
+  id: string;
+  title?: string | null;
+  discoveredPages?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -180,6 +196,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'pages';
         value: string | Page;
+      } | null)
+    | ({
+        relationTo: 'after-plugin-pages';
+        value: string | AfterPluginPage;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -256,6 +276,16 @@ export interface PagesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "after-plugin-pages_select".
+ */
+export interface AfterPluginPagesSelect<T extends boolean = true> {
+  title?: T;
+  discoveredPages?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -293,6 +323,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Adds a new `afterPlugins` config property that gives plugins a second pass after all plugins have executed. Plugins register callbacks during their initial pass, and Payload calls them once every plugin has run, passing the fully-assembled config. 

This is a prerequisite for enabling cross-plugin integration patterns - for example, allowing third-party plugins to inject their own MCP tools into `plugin-mcp` without worrying about plugin execution order.

Currently, this would not be possible - plugin-mcp would not register injected tools if it runs before the 3rd-party plugin.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214013522421639