### PR TITLE
chore: refactor email generation types to use TypedUser

### DIFF
--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -142,28 +142,28 @@ export type ClientUser = {
 } & BaseUser
 
 export type UserSession = { createdAt: Date | string; expiresAt: Date | string; id: string }
-type GenerateVerifyEmailHTML<TUser = any> = (args: {
+type GenerateVerifyEmailHTML<TUser = TypedUser> = (args: {
   req: PayloadRequest
   token: string
   user: TUser
 }) => Promise<string> | string
 
-type GenerateVerifyEmailSubject<TUser = any> = (args: {
+type GenerateVerifyEmailSubject<TUser = TypedUser> = (args: {
   req: PayloadRequest
   token: string
   user: TUser
 }) => Promise<string> | string
 
-type GenerateForgotPasswordEmailHTML<TUser = any> = (args?: {
-  req?: PayloadRequest
-  token?: string
-  user?: TUser
+type GenerateForgotPasswordEmailHTML<TUser = TypedUser> = (args?: {
+  req: PayloadRequest
+  token: string
+  user: TUser
 }) => Promise<string> | string
 
-type GenerateForgotPasswordEmailSubject<TUser = any> = (args?: {
-  req?: PayloadRequest
-  token?: string
-  user?: TUser
+type GenerateForgotPasswordEmailSubject<TUser = TypedUser> = (args?: {
+  req: PayloadRequest
+  token: string
+  user: TUser
 }) => Promise<string> | string
 
 export type AuthStrategyFunctionArgs = {


### PR DESCRIPTION
This will improve the types of the auth mail methods (forgot password & verify). Currently the types are nullable for forgot password, and the user is typed as `any` for both. This will update these types to use the `TypedUser`, which should help a lot.

I came across this while implementing a custom email, since I had to do a lot of unneeded `null` checks.