### PR TITLE
fix: pass data to update access in bulk update operation

### DIFF
--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -130,7 +130,10 @@ export const updateOperation = async <
 
     let accessResult: AccessResult
     if (!overrideAccess) {
-      accessResult = await executeAccess({ req }, collectionConfig.access.update)
+      accessResult = await executeAccess(
+        { data: bulkUpdateData, req },
+        collectionConfig.access.update,
+      )
     }
 
     await validateQueryPaths({


### PR DESCRIPTION
### What?

  Pass `bulkUpdateData` to `executeAccess` for the update access check in the bulk `updateOperation`, matching the existing behavior of `updateByIDOperation`.

### Why?

The bulk `updateOperation` does not pass `data` to the update access function, while `updateByIDOperation` does. This means access functions cannot inspect the incoming update payload during bulk operations, for example, to detect a trash (soft-delete) attempt by checking `data.deletedAt`.

This is inconsistent: the delete access check in the same function already passes `data: bulkUpdateData` (line 160), but the update access check (line 133) omits it.

In practice, this breaks collections that set `update` access based on `data` — e.g., a form submissions collection that blocks regular edits (`update: () => false` via plugin defaults) but needs to allow trash operations by checking `data.deletedAt`.

### How?

One-line change in `packages/payload/src/collections/operations/update.ts`:

```diff
-      accessResult = await executeAccess({ req }, collectionConfig.access.update)
+      accessResult = await executeAccess({ data: bulkUpdateData, req }, collectionConfig.access.update)
```

This matches updateByIDOperation (line 120 in `updateByID.ts`):

```ts
await executeAccess({ id, data, req }, collectionConfig.access.update)
```
