### PR TITLE
fix(plugin-nested-docs): detect circular parent references

### DIFF
--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig, Document, PayloadRequest } from 'payload'
 
+import { APIError } from 'payload'
+
 import type { NestedDocsPluginConfig } from '../types.js'
 
 export const getParents = async (
@@ -14,6 +16,15 @@ export const getParents = async (
   let retrievedParent: null | Record<string, unknown> = null
 
   if (parent) {
+    const parentID = typeof parent === 'object' ? (parent as Record<string, unknown>).id : parent
+
+    // Detect circular parent references to prevent infinite recursion
+    if (docs.some((d) => d.id === parentID)) {
+      throw new APIError(
+        'Circular parent reference detected. A document cannot be its own ancestor.',
+      )
+    }
+
     // If not auto-populated, and we have an ID
     if (typeof parent === 'string' || typeof parent === 'number') {
       retrievedParent = await req.payload.findByID({

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -192,6 +192,84 @@ describe('@payloadcms/plugin-nested-docs', () => {
     })
   })
 
+  describe('circular references', () => {
+    const createdPageIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of [...createdPageIDs].reverse()) {
+        await payload.delete({ collection: 'pages', id })
+      }
+      createdPageIDs.length = 0
+    })
+
+    it('should throw an error when setting a page as its own parent', async () => {
+      const page = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Self Parent',
+          slug: 'self-parent',
+        },
+      })
+
+      createdPageIDs.push(page.id)
+
+      await expect(
+        payload.update({
+          collection: 'pages',
+          id: page.id,
+          data: {
+            parent: page.id,
+          },
+        }),
+      ).rejects.toThrow(/[Cc]ircular/)
+    })
+
+    it('should throw an error when creating a circular parent chain', async () => {
+      const pageA = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Circle A',
+          slug: 'circle-a',
+        },
+      })
+
+      createdPageIDs.push(pageA.id)
+
+      const pageB = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Circle B',
+          slug: 'circle-b',
+          parent: pageA.id,
+        },
+      })
+
+      createdPageIDs.push(pageB.id)
+
+      const pageC = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Circle C',
+          slug: 'circle-c',
+          parent: pageB.id,
+        },
+      })
+
+      createdPageIDs.push(pageC.id)
+
+      // Setting A's parent to C creates a cycle: A -> C -> B -> A
+      await expect(
+        payload.update({
+          collection: 'pages',
+          id: pageA.id,
+          data: {
+            parent: pageC.id,
+          },
+        }),
+      ).rejects.toThrow(/[Cc]ircular/)
+    })
+  })
+
   describe('versions', () => {
     const createdPageIDs: (number | string)[] = []
 


### PR DESCRIPTION
### What?

Adds circular reference detection to the `getParents` utility in the nested-docs plugin.

### Why?

Setting a document's parent to one of its own descendants causes `getParents` to recurse infinitely, hanging the server. For example, if you have pages A → B → C and set A's parent to C, the breadcrumb generation enters an infinite loop.

The parent field already has a `filterOptions` guard that prevents selecting descendants in the UI, but it relies on breadcrumbs being up-to-date in the database. If breadcrumbs are stale for any reason, the filter won't catch the circular reference, and the server hangs on save. This also doesn't protect against circular references created via the API directly.

### How?

Before each recursive call in `getParents`, check if the parent ID already exists in the collected ancestor chain. If a cycle is detected, throw an `APIError` instead of recursing.

Two integration tests added:

- Setting a page as its own parent
- Creating a circular chain (A → B → C → A)
