### PR TITLE
feat: add internal plugin priority and slug api for cross-plugin discovery

### DIFF
--- a/packages/payload/src/config/build.ts
+++ b/packages/payload/src/config/build.ts
@@ -9,11 +9,11 @@ import { sanitizeConfig } from './sanitize.js'
  */
 export async function buildConfig(config: Config): Promise<SanitizedConfig> {
   if (Array.isArray(config.plugins)) {
-    let configAfterPlugins = config
-    for (const plugin of config.plugins) {
-      configAfterPlugins = await plugin(configAfterPlugins)
+    const sorted = [...config.plugins].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+
+    for (const plugin of sorted) {
+      config = await plugin(config)
     }
-    return await sanitizeConfig(configAfterPlugins)
   }
 
   return await sanitizeConfig(config)

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -143,7 +143,14 @@ type Prettify<T> = {
   [K in keyof T]: T[K]
 } & NonNullable<unknown>
 
-export type Plugin = (config: Config) => Config | Promise<Config>
+export type Plugin = ((config: Config) => Config | Promise<Config>) & {
+  /** @internal Plugin options exposed for cross-plugin mutation. */
+  options?: Record<string, unknown>
+  /** @internal Execution order - lower values run first. Defaults to 0. */
+  priority?: number
+  /** @internal Unique identifier for cross-plugin discovery via `config.plugins`. */
+  slug?: string
+}
 
 export type LivePreviewURLType = null | string | undefined
 

--- a/test/plugins/config.ts
+++ b/test/plugins/config.ts
@@ -1,7 +1,7 @@
+import type { Config, Plugin } from 'payload'
+
 import { fileURLToPath } from 'node:url'
 import path from 'path'
-
-import type { Plugin } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -9,6 +9,58 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export const pagesSlug = 'pages'
+
+type ReaderPluginOptions = {
+  items: Array<{ name: string }>
+}
+
+/**
+ * High-priority plugin that reads both its own options and config.custom.
+ * Other plugins can inject additional items into its options via slug discovery.
+ */
+const readerPlugin = (pluginOptions: ReaderPluginOptions): Plugin => {
+  const plugin: Plugin = (config: Config): Config => ({
+    ...config,
+    custom: {
+      ...(config.custom || {}),
+      readerSawValue: (config.custom?.writerValue as string) ?? null,
+      readerItems: pluginOptions.items.map((i) => i.name),
+    },
+  })
+
+  plugin.slug = 'priority-reader'
+  plugin.priority = 10
+  plugin.options = pluginOptions
+
+  return plugin
+}
+
+/**
+ * Low-priority plugin that writes to config.custom and injects items
+ * into the reader plugin's options via slug discovery.
+ */
+const writerPlugin = (): Plugin => {
+  const plugin: Plugin = (config: Config): Config => {
+    const reader = config.plugins?.find((p) => p.slug === 'priority-reader')
+    if (reader?.options) {
+      const opts = reader.options as unknown as ReaderPluginOptions
+      opts.items.push({ name: 'injected-by-writer' })
+    }
+
+    return {
+      ...config,
+      custom: {
+        ...(config.custom || {}),
+        writerValue: 'written-by-low-priority',
+      },
+    }
+  }
+
+  plugin.priority = 1
+  plugin.slug = 'priority-writer'
+
+  return plugin
+}
 
 export default buildConfigWithDefaults({
   admin: {
@@ -39,33 +91,9 @@ export default buildConfigWithDefaults({
         },
       ],
     }),
-    // High-priority plugin runs last — reads config.custom written by the low-priority plugin.
-    // Intentionally listed BEFORE the writer in the array to verify priority sorting works.
-    (() => {
-      const reader: Plugin = (config) => ({
-        ...config,
-        custom: {
-          ...(config.custom || {}),
-          readerSawValue: (config.custom?.writerValue as string) ?? null,
-        },
-      })
-      reader.slug = 'priority-reader'
-      reader.priority = 10
-      return reader
-    })(),
-    // Low-priority plugin runs first — writes to config.custom
-    (() => {
-      const writer: Plugin = (config) => ({
-        ...config,
-        custom: {
-          ...(config.custom || {}),
-          writerValue: 'written-by-low-priority',
-        },
-      })
-      writer.slug = 'priority-writer'
-      writer.priority = 1
-      return writer
-    })(),
+    // Intentionally listed BEFORE the writer to verify priority sorting works
+    readerPlugin({ items: [{ name: 'user-provided' }] }),
+    writerPlugin(),
   ],
   onInit: async (payload) => {
     await payload.create({

--- a/test/plugins/config.ts
+++ b/test/plugins/config.ts
@@ -1,6 +1,8 @@
 import { fileURLToPath } from 'node:url'
 import path from 'path'
 
+import type { Plugin } from 'payload'
+
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 const filename = fileURLToPath(import.meta.url)
@@ -37,6 +39,33 @@ export default buildConfigWithDefaults({
         },
       ],
     }),
+    // High-priority plugin runs last — reads config.custom written by the low-priority plugin.
+    // Intentionally listed BEFORE the writer in the array to verify priority sorting works.
+    (() => {
+      const reader: Plugin = (config) => ({
+        ...config,
+        custom: {
+          ...(config.custom || {}),
+          readerSawValue: (config.custom?.writerValue as string) ?? null,
+        },
+      })
+      reader.slug = 'priority-reader'
+      reader.priority = 10
+      return reader
+    })(),
+    // Low-priority plugin runs first — writes to config.custom
+    (() => {
+      const writer: Plugin = (config) => ({
+        ...config,
+        custom: {
+          ...(config.custom || {}),
+          writerValue: 'written-by-low-priority',
+        },
+      })
+      writer.slug = 'priority-writer'
+      writer.priority = 1
+      return writer
+    })(),
   ],
   onInit: async (payload) => {
     await payload.create({

--- a/test/plugins/int.spec.ts
+++ b/test/plugins/int.spec.ts
@@ -32,12 +32,28 @@ describe('Collections - Plugins', () => {
     expect(id).toBeDefined()
   })
 
-  describe('plugin priority', () => {
+  describe('plugin priority, slug, and options', () => {
     it('should execute plugins sorted by priority regardless of array order', () => {
-      // The reader plugin (priority 10) is listed BEFORE the writer (priority 1) in the
-      // plugins array, but priority sorting ensures the writer runs first.
-      // If sorting didn't work, the reader would see null instead of the writer's value.
+      // The reader (priority 10) is listed BEFORE the writer (priority 1) in the array,
+      // but priority sorting ensures the writer runs first.
       expect(payload.config.custom?.readerSawValue).toBe('written-by-low-priority')
+    })
+
+    it('should allow plugins to find each other by slug', () => {
+      const reader = payload.config.plugins?.find((p) => p.slug === 'priority-reader')
+      const writer = payload.config.plugins?.find((p) => p.slug === 'priority-writer')
+
+      expect(reader).toBeDefined()
+      expect(writer).toBeDefined()
+    })
+
+    it('should allow a plugin to mutate another plugin options via slug', () => {
+      // The writer (runs first) finds the reader by slug and pushes into its options.items.
+      // The reader (runs second) sees both the user-provided and injected items.
+      const items = payload.config.custom?.readerItems as string[]
+
+      expect(items).toContain('user-provided')
+      expect(items).toContain('injected-by-writer')
     })
   })
 })

--- a/test/plugins/int.spec.ts
+++ b/test/plugins/int.spec.ts
@@ -31,4 +31,13 @@ describe('Collections - Plugins', () => {
 
     expect(id).toBeDefined()
   })
+
+  describe('plugin priority', () => {
+    it('should execute plugins sorted by priority regardless of array order', () => {
+      // The reader plugin (priority 10) is listed BEFORE the writer (priority 1) in the
+      // plugins array, but priority sorting ensures the writer runs first.
+      // If sorting didn't work, the reader would see null instead of the writer's value.
+      expect(payload.config.custom?.readerSawValue).toBe('written-by-low-priority')
+    })
+  })
 })


### PR DESCRIPTION
Adds a temporary, internal API for plugin execution ordering and cross-plugin discovery. Plugins can now attach three optional properties to their function:

- `priority` - controls execution order (ascending, default 0), so a high-priority plugin is guaranteed to see config changes from all lower-priority plugins
- `slug` - unique identifier so plugins can find each other in `config.plugins` without importing each other. Useful for checking within plugin A whether plugin B is installed
- `options` - exposes the plugin's closure args, allowing other plugins to mutate them before the plugin executes (e.g. injecting tools into plugin-mcp's options)

Marked as `@internal` so we can start using this across our own plugins without committing to a public API yet.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214027832433527