### PR TITLE
feat(plugin-mcp): allow external plugins to extend mcp plugin

### DIFF
--- a/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
+++ b/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
@@ -1,16 +1,16 @@
 import type { CollectionConfig, CollectionSlug } from 'payload'
 
-import type { PluginMCPServerConfig } from '../types.js'
+import type { MCPPluginConfig } from '../types.js'
 
 import { toCamelCase } from '../utils/camelCase.js'
 import { createApiKeyFields } from '../utils/createApiKeyFields.js'
 
 export const createAPIKeysCollection = (
-  collections: PluginMCPServerConfig['collections'],
-  globals: PluginMCPServerConfig['globals'],
+  collections: MCPPluginConfig['collections'],
+  globals: MCPPluginConfig['globals'],
   customTools: Array<{ description: string; name: string }> = [],
-  experimentalTools: NonNullable<PluginMCPServerConfig['experimental']>['tools'] = {},
-  pluginOptions: PluginMCPServerConfig,
+  experimentalTools: NonNullable<MCPPluginConfig['experimental']>['tools'] = {},
+  pluginOptions: MCPPluginConfig,
 ): CollectionConfig => {
   const customToolsFields = customTools.map((tool) => {
     const camelCasedName = toCamelCase(tool.name)

--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -1,12 +1,12 @@
 import crypto from 'crypto'
 import { type PayloadHandler, type TypedUser, UnauthorizedError, type Where } from 'payload'
 
-import type { MCPAccessSettings, PluginMCPServerConfig } from '../types.js'
+import type { MCPAccessSettings, MCPPluginConfig } from '../types.js'
 
 import { createRequestFromPayloadRequest } from '../mcp/createRequest.js'
 import { getMCPHandler } from '../mcp/getMcpHandler.js'
 
-export const initializeMCPHandler = (pluginOptions: PluginMCPServerConfig) => {
+export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
   const mcpHandler: PayloadHandler = async (req) => {
     const { payload } = req
     const MCPOptions = pluginOptions.mcp || {}

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -1,4 +1,4 @@
-import type { Config, Plugin } from 'payload'
+import { definePlugin } from 'payload'
 
 import type { MCPAccessSettings, MCPPluginConfig } from './types.js'
 
@@ -9,18 +9,24 @@ declare module 'payload' {
   export interface PayloadRequest {
     payloadAPI: 'GraphQL' | 'local' | 'MCP' | 'REST'
   }
+  interface RegisteredPlugins {
+    '@payloadcms/plugin-mcp': MCPPluginConfig
+  }
 }
 
 import { defaults } from './defaults.js'
 
 export type { MCPAccessSettings, MCPPluginConfig }
+
 /**
  * The MCP Plugin for Payload. This plugin allows you to add MCP capabilities to your Payload project.
  *
  * @param pluginOptions - The options for the MCP plugin.
  */
-export const mcpPlugin = (pluginOptions: MCPPluginConfig): Plugin => {
-  const plugin: Plugin = (config: Config): Config => {
+export const mcpPlugin = definePlugin<MCPPluginConfig>({
+  slug: '@payloadcms/plugin-mcp',
+  order: 10,
+  plugin: ({ config, plugins: _plugins, ...pluginOptions }) => {
     if (!config.collections) {
       config.collections = []
     }
@@ -103,11 +109,5 @@ export const mcpPlugin = (pluginOptions: MCPPluginConfig): Plugin => {
     })
 
     return config
-  }
-
-  plugin.slug = '@payloadcms/plugin-mcp'
-  plugin.options = pluginOptions
-  plugin.priority = 10
-
-  return plugin
-}
+  },
+})

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -1,6 +1,6 @@
 import type { Config, Plugin } from 'payload'
 
-import type { MCPAccessSettings, PluginMCPServerConfig } from './types.js'
+import type { MCPAccessSettings, MCPPluginConfig } from './types.js'
 
 import { createAPIKeysCollection } from './collections/createApiKeysCollection.js'
 import { initializeMCPHandler } from './endpoints/mcp.js'
@@ -13,13 +13,13 @@ declare module 'payload' {
 
 import { defaults } from './defaults.js'
 
-export type { MCPAccessSettings, PluginMCPServerConfig }
+export type { MCPAccessSettings, MCPPluginConfig }
 /**
  * The MCP Plugin for Payload. This plugin allows you to add MCP capabilities to your Payload project.
  *
  * @param pluginOptions - The options for the MCP plugin.
  */
-export const mcpPlugin = (pluginOptions: PluginMCPServerConfig): Plugin => {
+export const mcpPlugin = (pluginOptions: MCPPluginConfig): Plugin => {
   const plugin: Plugin = (config: Config): Config => {
     if (!config.collections) {
       config.collections = []

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'payload'
+import type { Config, Plugin } from 'payload'
 
 import type { MCPAccessSettings, PluginMCPServerConfig } from './types.js'
 
@@ -13,15 +13,14 @@ declare module 'payload' {
 
 import { defaults } from './defaults.js'
 
-export type { MCPAccessSettings }
+export type { MCPAccessSettings, PluginMCPServerConfig }
 /**
  * The MCP Plugin for Payload. This plugin allows you to add MCP capabilities to your Payload project.
  *
  * @param pluginOptions - The options for the MCP plugin.
  */
-export const mcpPlugin =
-  (pluginOptions: PluginMCPServerConfig) =>
-  (config: Config): Config => {
+export const mcpPlugin = (pluginOptions: PluginMCPServerConfig): Plugin => {
+  const plugin: Plugin = (config: Config): Config => {
     if (!config.collections) {
       config.collections = []
     }
@@ -105,3 +104,10 @@ export const mcpPlugin =
 
     return config
   }
+
+  plugin.slug = '@payloadcms/plugin-mcp'
+  plugin.options = pluginOptions
+  plugin.priority = 10
+
+  return plugin
+}

--- a/packages/plugin-mcp/src/mcp/getMcpHandler.ts
+++ b/packages/plugin-mcp/src/mcp/getMcpHandler.ts
@@ -4,7 +4,7 @@ import { createMcpHandler } from 'mcp-handler'
 import { join } from 'path'
 import { APIError, configToJSONSchema, type PayloadRequest, type TypedUser } from 'payload'
 
-import type { MCPAccessSettings, PluginMCPServerConfig } from '../types.js'
+import type { MCPAccessSettings, MCPPluginConfig } from '../types.js'
 
 import { toCamelCase } from '../utils/camelCase.js'
 import { getEnabledSlugs } from '../utils/getEnabledSlugs.js'
@@ -44,7 +44,7 @@ import { runJobTool } from './tools/job/run.js'
 import { updateJobTool } from './tools/job/update.js'
 
 export const getMCPHandler = (
-  pluginOptions: PluginMCPServerConfig,
+  pluginOptions: MCPPluginConfig,
   mcpAccessSettings: MCPAccessSettings,
   req: PayloadRequest,
 ) => {
@@ -63,15 +63,15 @@ export const getMCPHandler = (
   }
 
   const payloadToolHandler = (
-    handler: NonNullable<NonNullable<PluginMCPServerConfig['mcp']>['tools']>[number]['handler'],
+    handler: NonNullable<NonNullable<MCPPluginConfig['mcp']>['tools']>[number]['handler'],
   ) => wrapHandler(handler)
 
   const payloadPromptHandler = (
-    handler: NonNullable<NonNullable<PluginMCPServerConfig['mcp']>['prompts']>[number]['handler'],
+    handler: NonNullable<NonNullable<MCPPluginConfig['mcp']>['prompts']>[number]['handler'],
   ) => wrapHandler(handler)
 
   const payloadResourceHandler = (
-    handler: NonNullable<NonNullable<PluginMCPServerConfig['mcp']>['resources']>[number]['handler'],
+    handler: NonNullable<NonNullable<MCPPluginConfig['mcp']>['resources']>[number]['handler'],
   ) => wrapHandler(handler)
 
   // User
@@ -88,7 +88,7 @@ export const getMCPHandler = (
 
   // Experimental MCP Tool Requirements
   const isDevelopment = process.env.NODE_ENV === 'development'
-  const experimentalTools: NonNullable<PluginMCPServerConfig['experimental']>['tools'] =
+  const experimentalTools: NonNullable<MCPPluginConfig['experimental']>['tools'] =
     pluginOptions?.experimental?.tools || {}
   const collectionsPluginConfig = pluginOptions.collections || {}
   const globalsPluginConfig = pluginOptions.globals || {}

--- a/packages/plugin-mcp/src/mcp/tools/global/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/global/find.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { PayloadRequest, SelectType, TypedUser } from 'payload'
 
-import type { PluginMCPServerConfig } from '../../../types.js'
+import type { MCPPluginConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import { toolSchemas } from '../schemas.js'
@@ -12,7 +12,7 @@ export const findGlobalTool = (
   user: TypedUser,
   verboseLogs: boolean,
   globalSlug: string,
-  globals: PluginMCPServerConfig['globals'],
+  globals: MCPPluginConfig['globals'],
 ) => {
   const tool = async (
     depth: number = 0,

--- a/packages/plugin-mcp/src/mcp/tools/global/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/global/update.ts
@@ -4,7 +4,7 @@ import type { PayloadRequest, SelectType, TypedUser } from 'payload'
 
 import { z } from 'zod'
 
-import type { PluginMCPServerConfig } from '../../../types.js'
+import type { MCPPluginConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import {
@@ -20,7 +20,7 @@ export const updateGlobalTool = (
   user: TypedUser,
   verboseLogs: boolean,
   globalSlug: string,
-  globals: PluginMCPServerConfig['globals'],
+  globals: MCPPluginConfig['globals'],
   schema: JSONSchema4,
 ) => {
   const tool = async (

--- a/packages/plugin-mcp/src/mcp/tools/resource/create.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/create.ts
@@ -4,7 +4,7 @@ import type { PayloadRequest, SelectType, TypedUser } from 'payload'
 
 import { z } from 'zod'
 
-import type { PluginMCPServerConfig } from '../../../types.js'
+import type { MCPPluginConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import {
@@ -20,7 +20,7 @@ export const createResourceTool = (
   user: TypedUser,
   verboseLogs: boolean,
   collectionSlug: string,
-  collections: PluginMCPServerConfig['collections'],
+  collections: MCPPluginConfig['collections'],
   schema: JSONSchema4,
 ) => {
   const tool = async (

--- a/packages/plugin-mcp/src/mcp/tools/resource/delete.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/delete.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { PayloadRequest, TypedUser } from 'payload'
 
-import type { PluginMCPServerConfig } from '../../../types.js'
+import type { MCPPluginConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import { toolSchemas } from '../schemas.js'
@@ -12,7 +12,7 @@ export const deleteResourceTool = (
   user: TypedUser,
   verboseLogs: boolean,
   collectionSlug: string,
-  collections: PluginMCPServerConfig['collections'],
+  collections: MCPPluginConfig['collections'],
 ) => {
   const tool = async (
     id?: number | string,

--- a/packages/plugin-mcp/src/mcp/tools/resource/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/find.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { PayloadRequest, SelectType, TypedUser } from 'payload'
 
-import type { PluginMCPServerConfig } from '../../../types.js'
+import type { MCPPluginConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import { toolSchemas } from '../schemas.js'
@@ -12,7 +12,7 @@ export const findResourceTool = (
   user: TypedUser,
   verboseLogs: boolean,
   collectionSlug: string,
-  collections: PluginMCPServerConfig['collections'],
+  collections: MCPPluginConfig['collections'],
 ) => {
   const tool = async (
     id?: number | string,

--- a/packages/plugin-mcp/src/mcp/tools/resource/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/update.ts
@@ -4,7 +4,7 @@ import type { PayloadRequest, SelectType, TypedUser } from 'payload'
 
 import { z } from 'zod'
 
-import type { PluginMCPServerConfig } from '../../../types.js'
+import type { MCPPluginConfig } from '../../../types.js'
 
 import { toCamelCase } from '../../../utils/camelCase.js'
 import {
@@ -20,7 +20,7 @@ export const updateResourceTool = (
   user: TypedUser,
   verboseLogs: boolean,
   collectionSlug: string,
-  collections: PluginMCPServerConfig['collections'],
+  collections: MCPPluginConfig['collections'],
   schema: JSONSchema4,
 ) => {
   const tool = async (

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -9,7 +9,7 @@ import type { z } from 'zod'
 
 import { type ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-export type PluginMCPServerConfig = {
+export type MCPPluginConfig = {
   /**
    * Set the collections that should be available as resources via MCP.
    */
@@ -425,7 +425,7 @@ export type MCPAccessSettings = {
   user: TypedUser
 } & Record<string, unknown>
 
-export type EntityConfig = PluginMCPServerConfig['collections'] | PluginMCPServerConfig['globals']
+export type EntityConfig = MCPPluginConfig['collections'] | MCPPluginConfig['globals']
 
 export type FieldDefinition = {
   description?: string

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -1,5 +1,5 @@
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { mcpPlugin, type MCPPluginConfig } from '@payloadcms/plugin-mcp'
+import { mcpPlugin } from '@payloadcms/plugin-mcp'
 import path from 'path'
 import { definePlugin } from 'payload'
 import { fileURLToPath } from 'url'
@@ -72,10 +72,10 @@ export default buildConfigWithDefaults({
     definePlugin({
       order: 1,
       slug: 'before-mcp',
-      plugin: ({ config }) => {
-        const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
+      plugin: ({ config, plugins }) => {
+        const mcp = plugins['@payloadcms/plugin-mcp']
         if (mcp?.options) {
-          const opts = mcp.options as unknown as MCPPluginConfig
+          const opts = mcp.options
           opts.mcp ??= {}
           opts.mcp.tools ??= []
           opts.mcp.tools.push({
@@ -409,10 +409,10 @@ export default buildConfigWithDefaults({
     definePlugin({
       order: 1,
       slug: 'after-mcp',
-      plugin: ({ config }) => {
-        const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
+      plugin: ({ config, plugins }) => {
+        const mcp = plugins['@payloadcms/plugin-mcp']
         if (mcp?.options) {
-          const opts = mcp.options as unknown as MCPPluginConfig
+          const opts = mcp.options
           opts.mcp ??= {}
           opts.mcp.tools ??= []
           opts.mcp.tools.push({

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'payload'
 
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { mcpPlugin, type PluginMCPServerConfig } from '@payloadcms/plugin-mcp'
+import { mcpPlugin, type MCPPluginConfig } from '@payloadcms/plugin-mcp'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { z } from 'zod'
@@ -74,7 +74,7 @@ export default buildConfigWithDefaults({
       const plugin: Plugin = (config) => {
         const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
         if (mcp?.options) {
-          const opts = mcp.options as unknown as PluginMCPServerConfig
+          const opts = mcp.options as unknown as MCPPluginConfig
           opts.mcp ??= {}
           opts.mcp.tools ??= []
           opts.mcp.tools.push({
@@ -411,7 +411,7 @@ export default buildConfigWithDefaults({
       const plugin: Plugin = (config) => {
         const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
         if (mcp?.options) {
-          const opts = mcp.options as unknown as PluginMCPServerConfig
+          const opts = mcp.options as unknown as MCPPluginConfig
           opts.mcp ??= {}
           opts.mcp.tools ??= []
           opts.mcp.tools.push({

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -1,8 +1,7 @@
-import type { Plugin } from 'payload'
-
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { mcpPlugin, type MCPPluginConfig } from '@payloadcms/plugin-mcp'
 import path from 'path'
+import { definePlugin } from 'payload'
 import { fileURLToPath } from 'url'
 import { z } from 'zod'
 
@@ -70,8 +69,10 @@ export default buildConfigWithDefaults({
   onInit: seed,
   plugins: [
     // Plugin listed BEFORE mcp in the array — injects a tool via slug + options
-    (() => {
-      const plugin: Plugin = (config) => {
+    definePlugin({
+      order: 1,
+      slug: 'before-mcp',
+      plugin: ({ config }) => {
         const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
         if (mcp?.options) {
           const opts = mcp.options as unknown as MCPPluginConfig
@@ -87,11 +88,9 @@ export default buildConfigWithDefaults({
           })
         }
         return config
-      }
-      plugin.slug = 'before-mcp'
-      plugin.priority = 1
-      return plugin
+      },
     })(),
+
     mcpPlugin({
       /**
        * Override the authentication method.
@@ -407,8 +406,10 @@ export default buildConfigWithDefaults({
       },
     }),
     // Plugin listed AFTER mcp in the array — also injects a tool via slug + options
-    (() => {
-      const plugin: Plugin = (config) => {
+    definePlugin({
+      order: 1,
+      slug: 'after-mcp',
+      plugin: ({ config }) => {
         const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
         if (mcp?.options) {
           const opts = mcp.options as unknown as MCPPluginConfig
@@ -424,10 +425,7 @@ export default buildConfigWithDefaults({
           })
         }
         return config
-      }
-      plugin.slug = 'after-mcp'
-      plugin.priority = 1
-      return plugin
+      },
     })(),
   ],
   typescript: {

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -1,5 +1,7 @@
+import type { Plugin } from 'payload'
+
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { type MCPAccessSettings, mcpPlugin } from '@payloadcms/plugin-mcp'
+import { mcpPlugin, type PluginMCPServerConfig } from '@payloadcms/plugin-mcp'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { z } from 'zod'
@@ -67,6 +69,29 @@ export default buildConfigWithDefaults({
   globals: [SiteSettings],
   onInit: seed,
   plugins: [
+    // Plugin listed BEFORE mcp in the array — injects a tool via slug + options
+    (() => {
+      const plugin: Plugin = (config) => {
+        const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
+        if (mcp?.options) {
+          const opts = mcp.options as unknown as PluginMCPServerConfig
+          opts.mcp ??= {}
+          opts.mcp.tools ??= []
+          opts.mcp.tools.push({
+            name: 'injectedBefore',
+            description: 'Tool injected by a plugin listed before mcp',
+            handler: () => ({
+              content: [{ type: 'text' as const, text: 'injected-before' }],
+            }),
+            parameters: {},
+          })
+        }
+        return config
+      }
+      plugin.slug = 'before-mcp'
+      plugin.priority = 1
+      return plugin
+    })(),
     mcpPlugin({
       /**
        * Override the authentication method.
@@ -381,6 +406,29 @@ export default buildConfigWithDefaults({
         },
       },
     }),
+    // Plugin listed AFTER mcp in the array — also injects a tool via slug + options
+    (() => {
+      const plugin: Plugin = (config) => {
+        const mcp = config.plugins?.find((p) => p.slug === '@payloadcms/plugin-mcp')
+        if (mcp?.options) {
+          const opts = mcp.options as unknown as PluginMCPServerConfig
+          opts.mcp ??= {}
+          opts.mcp.tools ??= []
+          opts.mcp.tools.push({
+            name: 'injectedAfter',
+            description: 'Tool injected by a plugin listed after mcp',
+            handler: () => ({
+              content: [{ type: 'text' as const, text: 'injected-after' }],
+            }),
+            parameters: {},
+          })
+        }
+        return config
+      }
+      plugin.slug = 'after-mcp'
+      plugin.priority = 1
+      return plugin
+    })(),
   ],
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -298,7 +298,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.jsonrpc).toBe('2.0')
       expect(json.result).toBeDefined()
       expect(json.result.tools).toBeDefined()
-      expect(json.result.tools).toHaveLength(4)
+      expect(json.result.tools).toHaveLength(6)
       expect(json.result.tools[0].name).toBe('findProducts')
       expect(json.result.tools[0].description).toContain(
         'Find documents in a collection by ID or where clause using Find or FindByID.',
@@ -496,6 +496,31 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.result.tools[3].inputSchema.properties.sides.description).toContain(
         'Number of sides on the dice (default: 6)',
       )
+    })
+
+    it('should list tools injected by other plugins via slug and options', async () => {
+      const apiKey = await getApiKey()
+      const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          params: {},
+        }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await parseStreamResponse(response)
+      const toolNames = json.result.tools.map((t: { name: string }) => t.name)
+
+      // Both plugins inject tools into mcp's options via slug discovery,
+      // regardless of whether they are listed before or after mcp in the plugins array
+      expect(toolNames).toContain('injectedBefore')
+      expect(toolNames).toContain('injectedAfter')
     })
 
     it('should list resources', async () => {


### PR DESCRIPTION
Plugins can now extend plugin-mcp (e.g. inject custom MCP tools). A plugin finds plugin-mcp by slug via `config.plugins`, accesses its options, and pushes tools directly into `options.mcp.tools`. Because plugin-mcp uses a high priority (runs last), the injected tools are available when it builds the MCP server.

Also exports `MCPPluginConfig` type so external plugins can type the options object when injecting tools. Since it wasn't exported before, I took the opportunity to rename `PluginMCPServerConfig` => `MCPPluginConfig`. This is simpler and more consistent with type from our other plugins

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214013522421643