### PR TITLE
feat: add support for `cascade` behavior in SQL relationships

### DIFF
--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -963,7 +963,7 @@ export const traverseFields = ({
             type: colType,
             reference: {
               name: 'id',
-              onDelete: 'set null',
+              onDelete: field.cascade === 'delete' ? 'cascade' : 'set null',
               table: tableName,
             },
           }

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1214,6 +1214,12 @@ export type SelectFieldClient = {
   Pick<SelectField, 'hasMany' | 'interfaceName' | 'options' | 'type'>
 
 type SharedRelationshipProperties = {
+  /**
+   * Defines the behavior when the referenced document is deleted.
+   * Only applied in SQL databases (Postgres, SQLite). No-op on MongoDB.
+   * @default 'set-null'
+   */
+  cascade?: 'delete' | 'set-null'
   filterOptions?: FilterOptions
   /**
    * Sets a maximum population depth for this field, regardless of the remaining depth when this field is reached.

--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -239,6 +239,18 @@ export default buildConfigWithDefaults({
           name: 'director',
           type: 'relationship',
           relationTo: 'directors',
+          cascade: 'delete',
+        },
+        {
+          name: 'directorSetNull',
+          type: 'relationship',
+          relationTo: 'directors',
+          cascade: 'set-null',
+        },
+        {
+          name: 'directorNoCascade',
+          type: 'relationship',
+          relationTo: 'directors',
         },
         {
           type: 'array',

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -2114,6 +2114,23 @@ describe('Relationships', () => {
   })
 })
 
+describe.skipIf(mongooseList.includes(process.env.PAYLOAD_DATABASE || ''))('Cascade Delete', () => {
+  it('should set onDelete cascade in schema for cascade: delete', () => {
+    const db = payload.db as import('@payloadcms/drizzle').DrizzleAdapter
+    expect(db.rawTables['movies'].columns['director'].reference?.onDelete).toBe('cascade')
+  })
+
+  it('should set onDelete set null in schema for cascade: set-null', () => {
+    const db = payload.db as import('@payloadcms/drizzle').DrizzleAdapter
+    expect(db.rawTables['movies'].columns['directorSetNull'].reference?.onDelete).toBe('set null')
+  })
+
+  it('should set onDelete set null in schema when cascade is undefined', () => {
+    const db = payload.db as import('@payloadcms/drizzle').DrizzleAdapter
+    expect(db.rawTables['movies'].columns['directorNoCascade'].reference?.onDelete).toBe('set null')
+  })
+})
+
 async function createPost(overrides?: Partial<Post>) {
   return payload.create({ collection: slug, data: { title: 'title', ...overrides } })
 }


### PR DESCRIPTION

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

-->
### What?
- Introduced `cascade` option for relationship fields to define behavior on referenced document deletion (`delete` or `set-null`).
- Updated schema traversal logic to handle cascade types.
- Added integration tests to verify cascade behaviors in SQL databases.

### Why?

Avoid N+1 SQL queries on delete.
Already handled by drizzle, just expose the option to the Collection.


Fixes 

https://github.com/payloadcms/payload/discussions/655


