### PR TITLE
fix: process bulk update/delete sequentially to prevent silent data loss

### DIFF
--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -136,7 +136,7 @@ export const deleteOperation = async <
 
     const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
 
-    const promises = docs.map(async (doc) => {
+    const processDoc = async (doc: (typeof docs)[number]) => {
       let result
 
       const { id } = doc
@@ -307,18 +307,12 @@ export const deleteOperation = async <
         })
       }
       return null
-    })
+    }
 
-    // Process sequentially when using single transaction mode to avoid shared state issues
-    // Process in parallel when using one transaction for better performance
-    let awaitedDocs
-    if (req.payload.db.bulkOperationsSingleTransaction) {
-      awaitedDocs = []
-      for (const promise of promises) {
-        awaitedDocs.push(await promise)
-      }
-    } else {
-      awaitedDocs = await Promise.all(promises)
+    // Process sequentially to avoid interleaving queries on a shared transaction connection
+    const awaitedDocs: (DataFromCollectionSlug<TSlug> | null)[] = []
+    for (const doc of docs) {
+      awaitedDocs.push(await processDoc(doc))
     }
 
     // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -231,7 +231,7 @@ export const updateOperation = async <
 
     const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
 
-    const promises = docs.map(async (docWithLocales) => {
+    const processDoc = async (docWithLocales: (typeof docs)[number]) => {
       const { id } = docWithLocales
 
       try {
@@ -300,25 +300,21 @@ export const updateOperation = async <
         })
       }
       return null
-    })
+    }
 
+    // Process sequentially to avoid interleaving queries on a shared transaction connection
+    const awaitedDocs: (DataFromCollectionSlug<TSlug> | null)[] = []
+    for (const doc of docs) {
+      awaitedDocs.push(await processDoc(doc))
+    }
+
+    // Unlink temp files after processing — each `processDoc` reads from `filesToUpload`,
+    // and now that processing is sequential the files must remain on disk until done
     await unlinkTempFiles({
       collectionConfig,
       config,
       req,
     })
-
-    // Process sequentially when using single transaction mode to avoid shared state issues
-    // Process in parallel when using one transaction for better performance
-    let awaitedDocs: (DataFromCollectionSlug<TSlug> | null)[]
-    if (req.payload.db.bulkOperationsSingleTransaction) {
-      awaitedDocs = []
-      for (const promise of promises) {
-        awaitedDocs.push(await promise)
-      }
-    } else {
-      awaitedDocs = await Promise.all(promises)
-    }
 
     let result = {
       docs: awaitedDocs.filter(Boolean),

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -1,4 +1,9 @@
-import type { Config, TextField } from 'payload'
+import type {
+  CollectionBeforeChangeHook,
+  CollectionBeforeDeleteHook,
+  Config,
+  TextField,
+} from 'payload'
 
 import { randomUUID } from 'crypto'
 import { fileURLToPath } from 'node:url'
@@ -24,6 +29,32 @@ const defaultValueField: TextField = {
   name: 'defaultValue',
   type: 'text',
   defaultValue: 'default value from database',
+}
+
+// Test-only assertion used by the `bulk-ops-sequential` collection. Throws if
+// invoked while another invocation on the same request is in flight, with a
+// 10ms hold to widen the overlap window. Detects regressions of the bulk
+// update/delete sequential processing fix from #16075.
+const assertBulkInFlight = (req: { context: Record<string, unknown> }) => {
+  if (req.context.bulkInFlight) {
+    throw new Error('bulk hook ran while another was in flight')
+  }
+  req.context.bulkInFlight = true
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      req.context.bulkInFlight = false
+      resolve()
+    }, 10)
+  })
+}
+
+const assertSequentialBeforeChange: CollectionBeforeChangeHook = async ({ data, req }) => {
+  await assertBulkInFlight(req)
+  return data
+}
+
+const assertSequentialBeforeDelete: CollectionBeforeDeleteHook = async ({ req }) => {
+  await assertBulkInFlight(req)
 }
 
 const filename = fileURLToPath(import.meta.url)
@@ -106,6 +137,19 @@ export const getConfig: () => Partial<Config> = () => ({
           name: 'number',
         },
       ],
+    },
+    {
+      slug: 'bulk-ops-sequential',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+      ],
+      hooks: {
+        beforeChange: [assertSequentialBeforeChange],
+        beforeDelete: [assertSequentialBeforeDelete],
+      },
     },
     {
       slug: 'simple-localized',

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2448,6 +2448,105 @@ describe('database', () => {
       }
     })
 
+    describe('bulk operations sequential processing', () => {
+      const createdIDs: (number | string)[] = []
+
+      afterEach(async () => {
+        // Single-doc deletes so cleanup is not affected by the bulk path under test.
+        // Errors are swallowed because the bulk delete test removes the docs itself.
+        for (const id of createdIDs) {
+          try {
+            await payload.delete({ id, collection: 'bulk-ops-sequential' })
+          } catch {
+            /* best-effort cleanup */
+          }
+        }
+        createdIDs.length = 0
+      })
+
+      const seedDocs = async () => {
+        const docs = await Promise.all(
+          Array.from({ length: 5 }, (_, index) =>
+            payload.create({
+              collection: 'bulk-ops-sequential',
+              data: { text: `bulk-${index}` },
+            }),
+          ),
+        )
+        const ids = docs.map((doc) => doc.id)
+        createdIDs.push(...ids)
+        return ids
+      }
+
+      describe('default mode', () => {
+        let originalValue: boolean
+
+        beforeEach(() => {
+          originalValue = payload.db.bulkOperationsSingleTransaction
+          payload.db.bulkOperationsSingleTransaction = false
+        })
+
+        afterEach(() => {
+          payload.db.bulkOperationsSingleTransaction = originalValue
+        })
+
+        it('should run bulk update hook pipelines sequentially', async () => {
+          const ids = await seedDocs()
+          const result = await payload.update({
+            collection: 'bulk-ops-sequential',
+            data: { text: 'updated' },
+            where: { id: { in: ids } },
+          })
+          expect(result.docs).toHaveLength(5)
+          expect(result.errors).toHaveLength(0)
+        })
+
+        it('should run bulk delete hook pipelines sequentially', async () => {
+          const ids = await seedDocs()
+          const result = await payload.delete({
+            collection: 'bulk-ops-sequential',
+            where: { id: { in: ids } },
+          })
+          expect(result.docs).toHaveLength(5)
+          expect(result.errors).toHaveLength(0)
+        })
+      })
+
+      describe('bulkOperationsSingleTransaction enabled', () => {
+        let originalValue: boolean
+
+        beforeEach(() => {
+          originalValue = payload.db.bulkOperationsSingleTransaction
+          payload.db.bulkOperationsSingleTransaction = true
+        })
+
+        afterEach(() => {
+          payload.db.bulkOperationsSingleTransaction = originalValue
+        })
+
+        it('should run bulk update hook pipelines sequentially', async () => {
+          const ids = await seedDocs()
+          const result = await payload.update({
+            collection: 'bulk-ops-sequential',
+            data: { text: 'updated' },
+            where: { id: { in: ids } },
+          })
+          expect(result.docs).toHaveLength(5)
+          expect(result.errors).toHaveLength(0)
+        })
+
+        it('should run bulk delete hook pipelines sequentially', async () => {
+          const ids = await seedDocs()
+          const result = await payload.delete({
+            collection: 'bulk-ops-sequential',
+            where: { id: { in: ids } },
+          })
+          expect(result.docs).toHaveLength(5)
+          expect(result.errors).toHaveLength(0)
+        })
+      })
+    })
+
     it('should CRUD point field', async () => {
       const result = await payload.create({
         collection: 'default-values',


### PR DESCRIPTION
## Summary

Fixes a race condition in bulk update/delete that causes silent data loss. Built on top of #16076 by @razmenaia (his PR fixes `delete.ts`); this PR adds the same fix to `update.ts` and adds deterministic tests for both files in both `bulkOperationsSingleTransaction` modes.

I do not want to take credit for @razmenaia's work — happy for someone to copy these `update.ts` changes into #16076 and close this PR. I just want the issue resolved.

Closes #16075.

## The bug

`docs.map(async ...)` in both `update.ts` and `delete.ts` eagerly starts every per-doc callback at once. The subsequent `for...of await` only controls the order results are *collected*, not when they execute. Every per-doc operation runs concurrently on the shared transaction connection, interleaving queries and silently dropping writes.

This affects **both** modes:
- **Default mode** (`bulkOperationsSingleTransaction: false`): all per-doc operations share the outer transaction's connection — verified by the new tests.
- **`bulkOperationsSingleTransaction: true`**: each doc nominally gets its own transaction, but the antipattern still starts all callbacks concurrently — also verified by the new tests.

## The fix

Extract the per-doc body into a named `processDoc` function, iterate sequentially:

```ts
const processDoc = async (doc) => { /* existing body */ }

const awaitedDocs: (DataFromCollectionSlug<TSlug> | null)[] = []
for (const doc of docs) {
  awaitedDocs.push(await processDoc(doc))
}
```

Same pattern in both files. The per-doc transaction handling for `bulkOperationsSingleTransaction` inside `processDoc` is preserved unchanged.

### `unlinkTempFiles` reorder in `update.ts`

The previous code awaited `unlinkTempFiles` between defining the promise array and consuming it. Because `.map(async ...)` started the promises eagerly, any consumer reading `req.file.tempFilePath` had usually opened it already. With sequential `for...of`, the unlink happens *before* any `processDoc` runs, leaving consumers with deleted paths. Moved the unlink to after the per-doc loop. This matches the order already used by `updateByID.ts:235` and `create.ts:443`.

### Performance trade-off

Bulk operations are now strictly sequential rather than `Promise.all`-parallel. This is the only correct fix: the bug exists in both modes because all per-doc operations share the outer transaction's connection regardless of `bulkOperationsSingleTransaction`. There is no safe parallel path while sharing a connection. The verified-failing tests in both modes confirm the conditional `Promise.all` branch was never safe to begin with.

## Tests

Razmenaia's #16076 ships a stress test (25 docs × 10 iterations) that does not reliably reproduce the bug on a fast local Postgres — operations can naturally serialize even when started concurrently.

This PR adds a **deterministic** test instead. A dedicated test-only collection `bulk-ops-sequential` has `beforeChange`/`beforeDelete` hooks that throw if invoked while another invocation on the same request is in flight, with a 10ms hold to widen the overlap window. Four tests cover the matrix:

| | bulk update | bulk delete |
|---|---|---|
| **default mode** | ✓ | ✓ |
| **`bulkOperationsSingleTransaction: true`** | ✓ | ✓ |

Verified locally:
- Reverting `update.ts` and `delete.ts` to `main`: **all 4 tests fail** with `bulk hook ran while another was in flight`.
- With the fix in place: all 171 database integration tests pass on Postgres.
- 0 new lint errors introduced.