### PR TITLE
fix: enforce mimeTypes restriction when useTempFiles is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,7 +348,7 @@ test/azurestoragedata/
 /media-without-delete-access
 /media-documents
 /media-with-always-insert-fields
-
+/tmp
 
 
 licenses.csv

--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -114,10 +114,17 @@ export const checkFileRestrictions = async ({
 
   // Secondary mimetype check to assess file type from buffer
   if (configMimeTypes.length > 0) {
-    let detected =
-      isTempFile && tempFilePath
-        ? await fileTypeFromFile(tempFilePath)
-        : await fileTypeFromBuffer(file.data)
+    let detected
+    try {
+      detected =
+        isTempFile && tempFilePath
+          ? await fileTypeFromFile(tempFilePath)
+          : await fileTypeFromBuffer(file.data)
+    } catch {
+      throw new ValidationError({
+        errors: [{ message: 'Could not read uploaded file for type detection.', path: 'file' }],
+      })
+    }
     const typeFromExtension = file.name.split('.').pop() || ''
 
     // Handle SVG files that are detected as XML due to <?xml declarations

--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -53,7 +53,6 @@ export const checkFileRestrictions = async ({
 }: checkFileRestrictionsParams): Promise<void> => {
   const errors: string[] = []
   const { upload: uploadConfig } = collection
-  const useTempFiles = req?.payload?.config?.upload?.useTempFiles ?? false
   const configMimeTypes =
     uploadConfig &&
     typeof uploadConfig === 'object' &&
@@ -105,7 +104,7 @@ export const checkFileRestrictions = async ({
       }
     }
 
-    if (!detected && !useTempFiles) {
+    if (!detected) {
       const mimeTypeFromExtension = getFileTypeFallback(file.name).mime
       const extIsValid = validateMimeType(mimeTypeFromExtension, configMimeTypes)
 

--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -87,12 +87,16 @@ export const checkFileRestrictions = async ({
     return
   }
 
-  // When useTempFiles is enabled, file.data is an empty buffer because the content
-  // is stored on disk at tempFilePath instead. Read the actual content so all
-  // content-based validation (MIME detection, SVG safety, PDF integrity) still works.
+  // file.data is empty when the content is on disk (tempFilePath). Read it so content validation works.
   let fileData = file.data
   if ((!fileData || fileData.length === 0) && file.tempFilePath) {
-    fileData = await fs.readFile(file.tempFilePath)
+    try {
+      fileData = await fs.readFile(file.tempFilePath)
+    } catch {
+      throw new ValidationError({
+        errors: [{ message: 'Could not read uploaded file for validation.', path: 'file' }],
+      })
+    }
   }
 
   // Secondary mimetype check to assess file type from buffer

--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -1,4 +1,4 @@
-import { fileTypeFromBuffer } from 'file-type'
+import { fileTypeFromBuffer, fileTypeFromFile } from 'file-type'
 import fs from 'fs/promises'
 
 import type { checkFileRestrictionsParams, FileAllowList } from './types.js'
@@ -87,11 +87,24 @@ export const checkFileRestrictions = async ({
     return
   }
 
-  // file.data is empty when the content is on disk (tempFilePath). Read it so content validation works.
-  let fileData = file.data
-  if ((!fileData || fileData.length === 0) && file.tempFilePath) {
+  // For temp files, use fileTypeFromFile so large files (e.g. video) are never loaded into memory
+  // just for detection. For content validation (SVG safety, PDF integrity), the full buffer is
+  // loaded lazily and only when the file type actually requires it.
+  const { tempFilePath } = file
+  const isTempFile = !!tempFilePath && (!file.data || file.data.length === 0)
+
+  // Lazily reads the full file — only reached for small text-based types (SVG, PDF).
+  let _fileBuffer: Buffer | undefined
+  const getFileBuffer = async (): Promise<Buffer> => {
+    if (_fileBuffer) {
+      return _fileBuffer
+    }
+    if (!isTempFile || !tempFilePath) {
+      return (_fileBuffer = file.data)
+    }
     try {
-      fileData = await fs.readFile(file.tempFilePath)
+      _fileBuffer = await fs.readFile(tempFilePath)
+      return _fileBuffer
     } catch {
       throw new ValidationError({
         errors: [{ message: 'Could not read uploaded file for validation.', path: 'file' }],
@@ -101,7 +114,10 @@ export const checkFileRestrictions = async ({
 
   // Secondary mimetype check to assess file type from buffer
   if (configMimeTypes.length > 0) {
-    let detected = await fileTypeFromBuffer(fileData)
+    let detected =
+      isTempFile && tempFilePath
+        ? await fileTypeFromFile(tempFilePath)
+        : await fileTypeFromBuffer(file.data)
     const typeFromExtension = file.name.split('.').pop() || ''
 
     // Handle SVG files that are detected as XML due to <?xml declarations
@@ -111,9 +127,9 @@ export const checkFileRestrictions = async ({
         (type) => type.includes('image/') && (type.includes('svg') || type === 'image/*'),
       )
     ) {
-      const isSvg = detectSvgFromXml(fileData)
+      const isSvg = detectSvgFromXml(await getFileBuffer())
       if (isSvg) {
-        detected = { ext: 'svg' as any, mime: 'image/svg+xml' as any }
+        detected = { ext: 'svg', mime: 'image/svg+xml' }
       }
     }
 
@@ -128,7 +144,7 @@ export const checkFileRestrictions = async ({
       } else {
         // SVG security check (text-based files not detectable by buffer)
         if (typeFromExtension.toLowerCase() === 'svg') {
-          const isSafeSvg = validateSvg(fileData)
+          const isSafeSvg = validateSvg(await getFileBuffer())
           if (!isSafeSvg) {
             errors.push('SVG file contains potentially harmful content.')
           }
@@ -136,7 +152,7 @@ export const checkFileRestrictions = async ({
 
         // PDF validation
         if (mimeTypeFromExtension === 'application/pdf') {
-          const isValidPDF = validatePDF(fileData)
+          const isValidPDF = validatePDF(await getFileBuffer())
           if (!isValidPDF) {
             errors.push('Invalid or corrupted PDF file.')
           }
@@ -153,7 +169,7 @@ export const checkFileRestrictions = async ({
     const passesMimeTypeCheck = detected?.mime && validateMimeType(detected.mime, configMimeTypes)
 
     if (passesMimeTypeCheck && detected?.mime === 'application/pdf') {
-      const isValidPDF = validatePDF(fileData)
+      const isValidPDF = validatePDF(await getFileBuffer())
       if (!isValidPDF) {
         errors.push('Invalid PDF file.')
       }

--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -1,4 +1,5 @@
 import { fileTypeFromBuffer } from 'file-type'
+import fs from 'fs/promises'
 
 import type { checkFileRestrictionsParams, FileAllowList } from './types.js'
 
@@ -86,9 +87,17 @@ export const checkFileRestrictions = async ({
     return
   }
 
+  // When useTempFiles is enabled, file.data is an empty buffer because the content
+  // is stored on disk at tempFilePath instead. Read the actual content so all
+  // content-based validation (MIME detection, SVG safety, PDF integrity) still works.
+  let fileData = file.data
+  if ((!fileData || fileData.length === 0) && file.tempFilePath) {
+    fileData = await fs.readFile(file.tempFilePath)
+  }
+
   // Secondary mimetype check to assess file type from buffer
   if (configMimeTypes.length > 0) {
-    let detected = await fileTypeFromBuffer(file.data)
+    let detected = await fileTypeFromBuffer(fileData)
     const typeFromExtension = file.name.split('.').pop() || ''
 
     // Handle SVG files that are detected as XML due to <?xml declarations
@@ -98,7 +107,7 @@ export const checkFileRestrictions = async ({
         (type) => type.includes('image/') && (type.includes('svg') || type === 'image/*'),
       )
     ) {
-      const isSvg = detectSvgFromXml(file.data)
+      const isSvg = detectSvgFromXml(fileData)
       if (isSvg) {
         detected = { ext: 'svg' as any, mime: 'image/svg+xml' as any }
       }
@@ -115,7 +124,7 @@ export const checkFileRestrictions = async ({
       } else {
         // SVG security check (text-based files not detectable by buffer)
         if (typeFromExtension.toLowerCase() === 'svg') {
-          const isSafeSvg = validateSvg(file.data)
+          const isSafeSvg = validateSvg(fileData)
           if (!isSafeSvg) {
             errors.push('SVG file contains potentially harmful content.')
           }
@@ -123,7 +132,7 @@ export const checkFileRestrictions = async ({
 
         // PDF validation
         if (mimeTypeFromExtension === 'application/pdf') {
-          const isValidPDF = validatePDF(file.data)
+          const isValidPDF = validatePDF(fileData)
           if (!isValidPDF) {
             errors.push('Invalid or corrupted PDF file.')
           }
@@ -140,7 +149,7 @@ export const checkFileRestrictions = async ({
     const passesMimeTypeCheck = detected?.mime && validateMimeType(detected.mime, configMimeTypes)
 
     if (passesMimeTypeCheck && detected?.mime === 'application/pdf') {
-      const isValidPDF = validatePDF(file?.data)
+      const isValidPDF = validatePDF(fileData)
       if (!isValidPDF) {
         errors.push('Invalid PDF file.')
       }

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -316,7 +316,7 @@ export type UploadConfig = {
 }
 export type checkFileRestrictionsParams = {
   collection: CollectionConfig
-  file: File
+  file: { tempFilePath?: string } & File
   req: PayloadRequest
 }
 

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -316,7 +316,7 @@ export type UploadConfig = {
 }
 export type checkFileRestrictionsParams = {
   collection: CollectionConfig
-  file: { tempFilePath?: string } & File
+  file: File
   req: PayloadRequest
 }
 
@@ -341,6 +341,10 @@ export type File = {
    * The size of the file in bytes.
    */
   size: number
+  /**
+   * Path to the temp file on disk when useTempFiles is enabled. In this case file.data will be an empty buffer.
+   */
+  tempFilePath?: string
 }
 
 export type FileToSave = {

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -1120,6 +1120,13 @@ describe('Collections - Uploads', () => {
       describe('useTempFiles MIME type bypass', () => {
         const createdTmpFiles: string[] = []
 
+        const mockReq = {
+          payload: {
+            config: { upload: { useTempFiles: true } },
+            logger: { warn: () => {}, error: () => {} },
+          },
+        } as unknown as PayloadRequest
+
         afterEach(async () => {
           for (const tmpFile of createdTmpFiles) {
             try {
@@ -1136,13 +1143,6 @@ describe('Collections - Uploads', () => {
           const tmpFile = path.join(os.tmpdir(), `payload-test-${randomUUID()}.html`)
           createdTmpFiles.push(tmpFile)
           await fs.promises.writeFile(tmpFile, htmlContent)
-
-          const mockReq = {
-            payload: {
-              config: { upload: { useTempFiles: true } },
-              logger: { warn: () => {}, error: () => {} },
-            },
-          } as unknown as PayloadRequest
 
           await expect(
             checkFileRestrictions({
@@ -1170,13 +1170,6 @@ describe('Collections - Uploads', () => {
           createdTmpFiles.push(tmpFile)
           await fs.promises.writeFile(tmpFile, svgContent)
 
-          const mockReq = {
-            payload: {
-              config: { upload: { useTempFiles: true } },
-              logger: { warn: () => {}, error: () => {} },
-            },
-          } as unknown as PayloadRequest
-
           await expect(
             checkFileRestrictions({
               collection: {
@@ -1201,13 +1194,6 @@ describe('Collections - Uploads', () => {
           createdTmpFiles.push(tmpFile)
           await fs.promises.writeFile(tmpFile, pngData)
 
-          const mockReq = {
-            payload: {
-              config: { upload: { useTempFiles: true } },
-              logger: { warn: () => {}, error: () => {} },
-            },
-          } as unknown as PayloadRequest
-
           await expect(
             checkFileRestrictions({
               collection: {
@@ -1227,13 +1213,6 @@ describe('Collections - Uploads', () => {
         })
 
         it('should throw ValidationError when tempFilePath is missing and file.data is empty', async () => {
-          const mockReq = {
-            payload: {
-              config: { upload: { useTempFiles: true } },
-              logger: { warn: () => {}, error: () => {} },
-            },
-          } as unknown as PayloadRequest
-
           // No tempFilePath — falls through to extension-based check, which should still reject
           await expect(
             checkFileRestrictions({

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -1230,6 +1230,30 @@ describe('Collections - Uploads', () => {
             }),
           ).rejects.toMatchObject({ name: 'ValidationError' })
         })
+
+        it('should reject an invalid PDF when useTempFiles is enabled', async () => {
+          const invalidPdfContent = Buffer.from('not a pdf')
+          const tmpFile = path.join(os.tmpdir(), `payload-test-${randomUUID()}.pdf`)
+          createdTmpFiles.push(tmpFile)
+          await fs.promises.writeFile(tmpFile, invalidPdfContent)
+
+          await expect(
+            checkFileRestrictions({
+              collection: {
+                slug: 'test',
+                upload: { mimeTypes: ['application/pdf'], staticDir: '/tmp' },
+              } as any,
+              file: {
+                data: Buffer.alloc(0),
+                mimetype: 'application/pdf',
+                name: 'invalid.pdf',
+                size: invalidPdfContent.length,
+                tempFilePath: tmpFile,
+              },
+              req: mockReq,
+            }),
+          ).rejects.toMatchObject({ name: 'ValidationError' })
+        })
       })
     })
   })

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -4,6 +4,7 @@ import type { CollectionSlug, Payload, PayloadRequest } from 'payload'
 import { randomUUID } from 'crypto'
 import fs from 'fs'
 import { createServer } from 'http'
+import os from 'os'
 import path from 'path'
 import { _internal_safeFetchGlobal, createPayloadRequest, getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
@@ -13,6 +14,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vitest } from 'vi
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Enlarge, Media } from './payload-types.js'
 
+// eslint-disable-next-line payload/no-relative-monorepo-imports
+import { checkFileRestrictions } from '../../packages/payload/src/uploads/checkFileRestrictions.js'
 // eslint-disable-next-line payload/no-relative-monorepo-imports
 import { getExternalFile } from '../../packages/payload/src/uploads/getExternalFile.js'
 // eslint-disable-next-line payload/no-relative-monorepo-imports
@@ -502,13 +505,13 @@ describe('Collections - Uploads', () => {
       it('should serve files with hash characters in filename', async () => {
         const filePath = path.resolve(dirname, './image.png')
         const file = await getFileByPath(filePath)
-        file!.name = "file #hash.png"
+        file!.name = 'file #hash.png'
 
-        const mediaDoc = (await payload.create({
+        const mediaDoc = await payload.create({
           collection: mediaSlug,
           data: {},
           file,
-        }))
+        })
 
         expect(mediaDoc.url).toContain('%23')
         expect(mediaDoc.url).not.toContain('#')
@@ -1112,6 +1115,85 @@ describe('Collections - Uploads', () => {
             file,
           }),
         ).resolves.not.toThrow()
+      })
+
+      describe('useTempFiles MIME type bypass', () => {
+        const createdTmpFiles: string[] = []
+
+        afterEach(async () => {
+          for (const tmpFile of createdTmpFiles) {
+            try {
+              await fs.promises.unlink(tmpFile)
+            } catch {
+              // ignore cleanup errors
+            }
+          }
+          createdTmpFiles.length = 0
+        })
+
+        it('should not bypass mimeTypes restriction when useTempFiles is enabled and file is HTML', async () => {
+          const htmlContent = Buffer.from('<html><script>alert("xss")</script></html>')
+          const tmpFile = path.join(os.tmpdir(), `payload-test-${randomUUID()}.html`)
+          createdTmpFiles.push(tmpFile)
+          await fs.promises.writeFile(tmpFile, htmlContent)
+
+          const mockReq = {
+            payload: {
+              config: { upload: { useTempFiles: true } },
+              logger: { warn: () => {}, error: () => {} },
+            },
+          } as unknown as PayloadRequest
+
+          await expect(
+            checkFileRestrictions({
+              collection: {
+                slug: 'test',
+                upload: { mimeTypes: ['image/*'], staticDir: '/tmp' },
+              } as any,
+              file: {
+                data: Buffer.alloc(0),
+                mimetype: 'text/html',
+                name: 'malicious.html',
+                size: htmlContent.length,
+                tempFilePath: tmpFile,
+              },
+              req: mockReq,
+            }),
+          ).rejects.toMatchObject({ name: 'ValidationError' })
+        })
+
+        it('should not bypass SVG content validation when useTempFiles is enabled', async () => {
+          const svgContent = Buffer.from(
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert("xss")</script></svg>',
+          )
+          const tmpFile = path.join(os.tmpdir(), `payload-test-${randomUUID()}.svg`)
+          createdTmpFiles.push(tmpFile)
+          await fs.promises.writeFile(tmpFile, svgContent)
+
+          const mockReq = {
+            payload: {
+              config: { upload: { useTempFiles: true } },
+              logger: { warn: () => {}, error: () => {} },
+            },
+          } as unknown as PayloadRequest
+
+          await expect(
+            checkFileRestrictions({
+              collection: {
+                slug: 'test',
+                upload: { mimeTypes: ['image/svg+xml', 'image/*'], staticDir: '/tmp' },
+              } as any,
+              file: {
+                data: Buffer.alloc(0),
+                mimetype: 'image/svg+xml',
+                name: 'malicious.svg',
+                size: svgContent.length,
+                tempFilePath: tmpFile,
+              },
+              req: mockReq,
+            }),
+          ).rejects.toMatchObject({ name: 'ValidationError' })
+        })
       })
     })
   })

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -1194,6 +1194,63 @@ describe('Collections - Uploads', () => {
             }),
           ).rejects.toMatchObject({ name: 'ValidationError' })
         })
+
+        it('should allow a valid image file when useTempFiles is enabled', async () => {
+          const pngData = await fs.promises.readFile(path.resolve(dirname, './image.png'))
+          const tmpFile = path.join(os.tmpdir(), `payload-test-${randomUUID()}.png`)
+          createdTmpFiles.push(tmpFile)
+          await fs.promises.writeFile(tmpFile, pngData)
+
+          const mockReq = {
+            payload: {
+              config: { upload: { useTempFiles: true } },
+              logger: { warn: () => {}, error: () => {} },
+            },
+          } as unknown as PayloadRequest
+
+          await expect(
+            checkFileRestrictions({
+              collection: {
+                slug: 'test',
+                upload: { mimeTypes: ['image/*'], staticDir: '/tmp' },
+              } as any,
+              file: {
+                data: Buffer.alloc(0),
+                mimetype: 'image/png',
+                name: 'valid.png',
+                size: pngData.length,
+                tempFilePath: tmpFile,
+              },
+              req: mockReq,
+            }),
+          ).resolves.not.toThrow()
+        })
+
+        it('should throw ValidationError when tempFilePath is missing and file.data is empty', async () => {
+          const mockReq = {
+            payload: {
+              config: { upload: { useTempFiles: true } },
+              logger: { warn: () => {}, error: () => {} },
+            },
+          } as unknown as PayloadRequest
+
+          // No tempFilePath — falls through to extension-based check, which should still reject
+          await expect(
+            checkFileRestrictions({
+              collection: {
+                slug: 'test',
+                upload: { mimeTypes: ['image/*'], staticDir: '/tmp' },
+              } as any,
+              file: {
+                data: Buffer.alloc(0),
+                mimetype: 'text/html',
+                name: 'malicious.html',
+                size: 0,
+              },
+              req: mockReq,
+            }),
+          ).rejects.toMatchObject({ name: 'ValidationError' })
+        })
       })
     })
   })


### PR DESCRIPTION
This replaces #16236 which was auto-closed when the fork was deleted.

# Overview

Fixes MIME type validation being skipped on upload collections when `upload.useTempFiles: true` is set globally.

## Key Changes

- Use `fileTypeFromFile` for temp files instead of loading the full buffer — avoids reading large files (e.g. 2GB video) into memory just for MIME detection
- Removed the `!useTempFiles` gate that was causing the entire fallback validation block to be skipped
- Added `tempFilePath` to the `File` type directly instead of intersecting it at the call site
- Full file content is loaded lazily via `getFileBuffer()` and only when needed for SVG/PDF content validation

## Design Decisions

The original code used the `useTempFiles` config flag to decide whether to run fallback validation, but checking `tempFilePath` directly is more accurate, files uploaded via the local API always have `file.data` populated even when `useTempFiles` is enabled.

Simply removing the gate (as originally suggested) would've fixed the extension check but left `validateSvg` broken, since it would still run on an empty buffer and always return safe.

Fixes #16233. 