### PR TITLE
fix(ui): resolve mobile navbar overlap in dashboard step nav

### DIFF
--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/DashboardStepNav.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/DashboardStepNav.tsx
@@ -12,6 +12,36 @@ import {
 } from '@payloadcms/ui'
 import { useEffect, useId } from 'react'
 
+type DashboardEditActionsProps = {
+  onCancel: () => void
+  onSaveChanges: () => void
+  widgetsDrawerSlug: string
+}
+
+function DashboardEditActions({
+  onCancel,
+  onSaveChanges,
+  widgetsDrawerSlug,
+}: DashboardEditActionsProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="dashboard-breadcrumb-dropdown__actions">
+      <DrawerToggler className="drawer-toggler--unstyled" slug={widgetsDrawerSlug}>
+        <Button buttonStyle="pill" el="span" size="small">
+          {t('dashboard:addButton')}
+        </Button>
+      </DrawerToggler>
+      <Button buttonStyle="pill" onClick={onSaveChanges} size="small">
+        {t('fields:saveChanges')}
+      </Button>
+      <Button buttonStyle="pill" onClick={onCancel} size="small">
+        {t('general:cancel')}
+      </Button>
+    </div>
+  )
+}
+
 export function DashboardStepNav({
   addWidget,
   cancel,
@@ -54,6 +84,15 @@ export function DashboardStepNav({
   return (
     <>
       {isEditing && (
+        <div className="dashboard-mobile-edit-actions">
+          <DashboardEditActions
+            onCancel={cancel}
+            onSaveChanges={saveLayout}
+            widgetsDrawerSlug={drawerSlug}
+          />
+        </div>
+      )}
+      {isEditing && (
         <ItemsDrawer
           drawerSlug={drawerSlug}
           items={widgets}
@@ -82,19 +121,11 @@ export function DashboardBreadcrumbDropdown(props: {
     return (
       <div className="dashboard-breadcrumb-dropdown__editing">
         <span>{t('dashboard:editingDashboard')}</span>
-        <div className="dashboard-breadcrumb-dropdown__actions">
-          <DrawerToggler className="drawer-toggler--unstyled" slug={widgetsDrawerSlug}>
-            <Button buttonStyle="pill" el="span" size="small">
-              {t('dashboard:addButton')}
-            </Button>
-          </DrawerToggler>
-          <Button buttonStyle="pill" onClick={onSaveChanges} size="small">
-            {t('fields:saveChanges')}
-          </Button>
-          <Button buttonStyle="pill" onClick={onCancel} size="small">
-            {t('general:cancel')}
-          </Button>
-        </div>
+        <DashboardEditActions
+          onCancel={onCancel}
+          onSaveChanges={onSaveChanges}
+          widgetsDrawerSlug={widgetsDrawerSlug}
+        />
       </div>
     )
   }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.client.tsx
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.client.tsx
@@ -86,6 +86,15 @@ export function ModularDashboardClient({
 
   return (
     <div>
+      <DashboardStepNav
+        addWidget={addWidget}
+        cancel={cancel}
+        isEditing={isEditing}
+        resetLayout={resetLayout}
+        saveLayout={saveLayout}
+        setIsEditing={setIsEditing}
+        widgets={widgets}
+      />
       <DndContext
         autoScroll={{
           enabled: true,
@@ -226,15 +235,6 @@ export function ModularDashboardClient({
           </DragOverlay>
         </div>
       </DndContext>
-      <DashboardStepNav
-        addWidget={addWidget}
-        cancel={cancel}
-        isEditing={isEditing}
-        resetLayout={resetLayout}
-        saveLayout={saveLayout}
-        setIsEditing={setIsEditing}
-        widgets={widgets}
-      />
       {cancelModal}
     </div>
   )

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.scss
@@ -239,11 +239,21 @@
         align-items: center;
         display: flex !important;
         gap: 12px;
+
+        @media (max-width: 450px) {
+          gap: 4px;
+          min-width: 0;
+          // No overflow: hidden — would clip the dropdown popup
+        }
       }
 
       &__actions {
         display: flex !important;
         gap: 8px;
+
+        @media (max-width: 450px) {
+          display: none !important;
+        }
       }
     }
 
@@ -312,6 +322,52 @@
       &:hover,
       &:focus {
         background: transparent;
+      }
+    }
+
+  }
+
+  .dashboard-mobile-edit-actions {
+    display: none;
+    margin: 0 6px 10px;
+
+    @media (max-width: 450px) {
+      display: block;
+    }
+
+    .dashboard-breadcrumb-dropdown__actions {
+      display: grid !important;
+      gap: 8px;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      width: 100%;
+
+      > * {
+        min-width: 0;
+      }
+
+      .drawer-toggler--unstyled {
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+        margin: 0;
+        min-height: 0;
+        outline: none;
+        padding: 0;
+        width: 100%;
+
+        &:hover,
+        &:focus {
+          background: transparent;
+        }
+      }
+
+      .btn {
+        align-items: center;
+        display: inline-flex;
+        justify-content: center;
+        min-width: 0;
+        white-space: nowrap;
+        width: 100%;
       }
     }
   }

--- a/packages/ui/src/elements/AppHeader/index.scss
+++ b/packages/ui/src/elements/AppHeader/index.scss
@@ -27,7 +27,6 @@
 
     &__localizer-spacing {
       visibility: hidden;
-      // flex-shrink: 0;
     }
 
     &__bg {
@@ -51,7 +50,6 @@
       padding: 0 var(--gutter-h);
       position: relative;
       flex-grow: 1;
-      // min-width: 0;
     }
 
     &__wrapper {
@@ -62,7 +60,6 @@
       flex-grow: 1;
       justify-content: space-between;
       width: 100%;
-      // min-width: 0;
     }
 
     &__account {
@@ -100,11 +97,8 @@
 
     &__step-nav-wrapper {
       flex-grow: 0;
-      // flex-shrink: 1;
-      // min-width: 0;
       display: flex;
       width: 100%;
-      // No overflow: hidden here — it clips dropdowns/popups
 
       &::-webkit-scrollbar {
         display: none;
@@ -176,7 +170,6 @@
       &__mobile-nav-toggler {
         display: flex;
         align-items: center;
-        // flex-shrink: 0;
 
         &.nav-toggler--is-open {
           opacity: 0.5;
@@ -196,26 +189,6 @@
         max-width: 150px;
         margin-right: 0;
       }
-
-      // &__step-nav-wrapper {
-      //   min-width: 0;
-      //   flex-shrink: 1;
-      //   // overflow: hidden removed — was clipping dropdown popups
-      // }
-
-      // &__controls-wrapper {
-      //   min-width: 0;
-      //   flex-shrink: 1;
-      //   // overflow: hidden removed — was clipping dropdown popups
-      // }
-
-      // &__localizer-spacing {
-      //   flex-shrink: 0;
-      // }
-
-      // &__account {
-      //   flex-shrink: 0;
-      // }
     }
   }
 }

--- a/packages/ui/src/elements/AppHeader/index.scss
+++ b/packages/ui/src/elements/AppHeader/index.scss
@@ -27,6 +27,7 @@
 
     &__localizer-spacing {
       visibility: hidden;
+      // flex-shrink: 0;
     }
 
     &__bg {
@@ -50,6 +51,7 @@
       padding: 0 var(--gutter-h);
       position: relative;
       flex-grow: 1;
+      // min-width: 0;
     }
 
     &__wrapper {
@@ -60,6 +62,7 @@
       flex-grow: 1;
       justify-content: space-between;
       width: 100%;
+      // min-width: 0;
     }
 
     &__account {
@@ -97,8 +100,11 @@
 
     &__step-nav-wrapper {
       flex-grow: 0;
+      // flex-shrink: 1;
+      // min-width: 0;
       display: flex;
       width: 100%;
+      // No overflow: hidden here — it clips dropdowns/popups
 
       &::-webkit-scrollbar {
         display: none;
@@ -158,7 +164,7 @@
 
     @include small-break {
       &__localizer.localizer {
-        right: base(2);
+        right: calc(base(2) + var(--base));
       }
 
       &--nav-open {
@@ -170,6 +176,7 @@
       &__mobile-nav-toggler {
         display: flex;
         align-items: center;
+        // flex-shrink: 0;
 
         &.nav-toggler--is-open {
           opacity: 0.5;
@@ -189,6 +196,26 @@
         max-width: 150px;
         margin-right: 0;
       }
+
+      // &__step-nav-wrapper {
+      //   min-width: 0;
+      //   flex-shrink: 1;
+      //   // overflow: hidden removed — was clipping dropdown popups
+      // }
+
+      // &__controls-wrapper {
+      //   min-width: 0;
+      //   flex-shrink: 1;
+      //   // overflow: hidden removed — was clipping dropdown popups
+      // }
+
+      // &__localizer-spacing {
+      //   flex-shrink: 0;
+      // }
+
+      // &__account {
+      //   flex-shrink: 0;
+      // }
     }
   }
 }


### PR DESCRIPTION
## Fix: Mobile navbar overlap in dashboard step nav

### Problem

On smaller screens, action buttons (Add, Save, Cancel) overlap with the content below (e.g., "Collections"), leading to layout breakage and poor usability.

### Solution

* Updated the layout of `.dashboard-breadcrumb-dropdown` for mobile view
* Moved action buttons to a separate row below the breadcrumb
* Improved flex behavior to prevent overflow and overlapping
* Added minor component restructuring in `DashboardStepNav` to support better layout handling

### Changes

* `DashboardStepNav.tsx`
* `index.client.tsx`
* `modular-dashboard/index.scss`
* `AppHeader/index.scss`

### Visual Comparison (Mobile View)

**Before:**
![Before](https://github.com/user-attachments/assets/8b07e172-30ab-47fd-a409-4a32194c66fc)

**After:**
![After](https://github.com/user-attachments/assets/7568c5c0-27f7-43c4-a3ee-55fb840379f6)

### Testing

* Verified on mobile viewport
* No additional test failures introduced
* Existing functionality remains unchanged

### Note

This change is scoped to fix a layout issue without affecting core functionality.
Open to feedback if this approach aligns with the intended design system.
