### PR TITLE
ci: update actions to resolve Node.js 20 deprecation warnings

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -67,7 +67,7 @@ runs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
         version: ${{ env.PNPM_VERSION }}
         run_install: false
@@ -93,7 +93,7 @@ runs:
 
     - name: Restore pnpm install cache
       if: ${{ inputs.pnpm-restore-cache == 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ env.PNPM_INSTALL_CACHE_KEY }}

--- a/.github/workflows/label-on-change.yml
+++ b/.github/workflows/label-on-change.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.action == 'labeled' && startsWith(github.event.label.name, 'status:')
     steps:
       - name: Ensure only one status label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -55,7 +55,7 @@ jobs:
     if: github.event.action == 'closed'
     steps:
       - name: Remove all labels on issue close
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Lock issues
-        uses: dessant/lock-threads@v5
+        uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
         with:
           process-only: 'issues'
           issue-inactive-days: '7'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -88,7 +88,7 @@ jobs:
           DO_NOT_TRACK: 1 # Disable Turbopack telemetry
 
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
@@ -108,7 +108,7 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
@@ -134,7 +134,7 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
@@ -203,7 +203,7 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
@@ -271,7 +271,7 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
@@ -281,7 +281,7 @@ jobs:
         run: pnpm prepare-run-test-against-prod:ci
 
       - name: Cache prepared test environment
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             test/packed
@@ -312,14 +312,14 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Restore prepared test environment
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             test/packed
@@ -348,7 +348,7 @@ jobs:
 
       - name: Cache Playwright Browsers for Playwright's Version
         id: cache-playwright-browsers
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
@@ -394,7 +394,7 @@ jobs:
           PLAYWRIGHT_JSON_OUTPUT_NAME: results_${{ matrix.suite }}_${{ matrix.shard }}.json
           NEXT_TELEMETRY_DISABLED: 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results-${{ matrix.suite }}_${{ matrix.shard }}${{ matrix.cacheComponents && '_cc' || '' }}
@@ -452,7 +452,7 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
@@ -482,7 +482,7 @@ jobs:
 
       - name: Cache Playwright Browsers for Playwright's Version
         id: cache-playwright-browsers
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
@@ -527,7 +527,7 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}
@@ -590,7 +590,7 @@ jobs:
           cache-propagation-delay: 120 # https://github.com/actions/cache/issues/1710
 
       - name: Restore build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./*
           key: ${{ github.sha }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -93,7 +93,7 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -114,7 +114,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         id: stale
         with:
           debug-only: ${{ inputs.dry-run || false }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: View context attributes
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: console.log({ context })
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Tag with 'created-by'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

- Update all GitHub Actions flagged with Node.js 20 deprecation warnings to their latest major versions
- Pin all updated actions to full 40-character commit SHAs (per [GitHub security best practices](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)) to prevent supply-chain attacks via tag mutation and SHA-1 collision vulnerabilities

### Actions updated

| Action | Old | New | Files |
|--------|-----|-----|-------|
| `actions/cache` | `v4` | `v5.0.5` | setup/action.yml, main.yml |
| `actions/cache/save` | `v4` | `v5.0.5` | main.yml |
| `actions/cache/restore` | `v4` | `v5.0.5` | main.yml |
| `pnpm/action-setup` | `v4` | `v5.0.0` | setup/action.yml |
| `actions/upload-artifact` | `v4` | `v7.0.1` | main.yml |
| `dorny/paths-filter` | `v3` | `v4.0.1` | main.yml |
| `actions/stale` | `v9` | `v10.2.0` | stale.yml |
| `marocchino/sticky-pull-request-comment` | `v2` | `v3.0.4` | pr-title.yml |
| `actions/github-script` | `v7` | `v9.0.0` | triage.yml, label-on-change.yml |
| `dessant/lock-threads` | `v5` | `v6.0.0` | lock-issues.yml |

### Not updated (not flagged / no newer major)

- `actions/checkout@v5`, `actions/setup-node@v6`, `peter-evans/create-pull-request@v7`, `peter-evans/repository-dispatch@v3`, `amannn/action-semantic-pull-request@v6`, `slackapi/slack-github-action@v2.1.1`, `supabase/setup-cli@v1`, `exoego/esbuild-bundle-analyzer@v1` — not flagged in CI warnings (already Node 22+ compatible)
- `actions-ecosystem/action-add-labels@v1`, `actions-ecosystem/action-remove-labels@v1` — no newer major available; only used conditionally
- `SethCohen/github-releases-to-discord@v1.19.0` — only minor bump available (v1.20.0)
- `.github/actions/release-commenter/action.yml` — local action using `node20` runtime; requires a separate code change to update to `node22`

### Context

GitHub is deprecating Node.js 20 for Actions runners. Actions will be forced to Node.js 24 starting June 2, 2026, and Node.js 20 will be removed September 16, 2026.