### PR TITLE
fix(ui): remove conflicting width property in sort-row__icon styles

### DIFF
--- a/packages/ui/src/elements/SortRow/index.scss
+++ b/packages/ui/src/elements/SortRow/index.scss
@@ -16,7 +16,6 @@
       margin-left: -2px;
       margin-top: -2px;
       display: block;
-      width: min-content;
     }
   }
 }


### PR DESCRIPTION
The .sort-row__icon had conflicting width properties: 'width: 22px' was overridden by 'width: min-content', causing potential table header misalignment when orderable: true. Removed the conflicting min-content rule to ensure consistent column sizing.

Fixes #16251

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Removed the conflicting `width: min-content` CSS property from `.sort-row__icon` in `packages/ui/src/elements/SortRow/index.scss` that was overriding the `width: 22px` property.

### Why?
The conflicting width property was causing potential table header misalignment when `orderable: true` is enabled. The second `width: min-content` was overriding the intended `width: 22px`, preventing consistent column sizing between table headers and body rows.

### How?
- Removed the conflicting `width: min-content` line from the `.sort-row__icon` CSS rule
- Verified all 37 sort/orderable integration tests pass
- Tested table rendering on localhost:3000/admin/collections/orderable

Fixes #16251

-->
