### PR TITLE
feat(richtext-lexical): publicly export INSERT_UPLOAD_WITH_DRAWER_COMMAND

### DIFF
--- a/packages/richtext-lexical/src/exports/client/index.ts
+++ b/packages/richtext-lexical/src/exports/client/index.ts
@@ -47,6 +47,7 @@ export { TableFeatureClient } from '../../features/experimental_table/client/ind
 
 export { ToolbarDropdown } from '../../features/toolbars/shared/ToolbarDropdown/index.js'
 export { UploadFeatureClient } from '../../features/upload/client/index.js'
+export { INSERT_UPLOAD_WITH_DRAWER_COMMAND } from '../../features/upload/client/drawer/commands.js'
 
 export { RichTextField } from '../../field/index.js'
 export {


### PR DESCRIPTION
Per #16262, `INSERT_UPLOAD_WITH_DRAWER_COMMAND` is defined in the upload feature's client drawer module but is not re-exported from the package's public client entry. Userland code that wants to extend upload-drawer behavior currently has to import from `@payloadcms/richtext-lexical/dist/...`, which is brittle and couples app code to internal layout.

Re-export it alongside `UploadFeatureClient` from `@payloadcms/richtext-lexical/client`, matching the pattern already used for `INSERT_BLOCK_COMMAND` / `INSERT_INLINE_BLOCK_COMMAND`.

Closes #16262