### PR TITLE
chore: allow e2e port to be defined by env vars

### DIFF
--- a/test/__helpers/shared/initPayloadE2ENoConfig.ts
+++ b/test/__helpers/shared/initPayloadE2ENoConfig.ts
@@ -26,7 +26,10 @@ export async function initPayloadE2ENoConfig<T extends GeneratedTypes<T>>({
 }: Args): Promise<Result<T>> {
   const testSuiteName = path.basename(dirname)
 
-  const port = 3000
+  // Default to 3000 if PORT is not set, but allow it to be overridden by the environment variable
+  const defaultPort = 3000
+
+  const port = process.env.PORT ? Number(process.env.PORT) : defaultPort
   process.env.PORT = String(port)
   process.env.PAYLOAD_CI_DEPENDENCY_CHECKER = 'true'
 
@@ -51,7 +54,7 @@ export async function initPayloadE2ENoConfig<T extends GeneratedTypes<T>>({
         if (code === 0) {
           res()
         }
-        rej()
+        rej(new Error('closed with code ' + code))
       })
     })
   }


### PR DESCRIPTION
Port number is currently hardcoded to 3000, this makes it so it defaults back to 3000 but you can override it via env vars. Helps when running lots of e2es in parallel with various agents by providing predictability.