### PR TITLE
fix(drizzle, db-mongodb): handle ['null'] array when filtering hasMany relationship field by None

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -210,7 +210,7 @@ export const sanitizeQueryValue = ({
   }
 
   if (['relationship', 'upload'].includes(field.type)) {
-    if (val === 'null') {
+    if (val === 'null' || (Array.isArray(val) && val.length === 1 && val[0] === 'null')) {
       formattedValue = null
     }
 

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -141,7 +141,7 @@ export const sanitizeQueryValue = ({
   }
 
   if (field.type === 'relationship' || field.type === 'upload') {
-    if (val === 'null') {
+    if (val === 'null' || (Array.isArray(val) && val.length === 1 && val[0] === 'null')) {
       formattedValue = null
     } else if (!(formattedValue === null || typeof formattedValue === 'boolean')) {
       // convert the value to the idType of the relationship

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -706,6 +706,9 @@ describe('Relationships', () => {
         })
 
         it('should query using "equals: null" on a hasMany relationship field', async () => {
+          await payload.delete({ collection: 'directors', where: {} })
+          await payload.delete({ collection: 'movies', where: {} })
+
           const movie = await payload.create({
             collection: 'movies',
             data: { name: 'Some Movie' },

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -704,6 +704,55 @@ describe('Relationships', () => {
           expect(query.docs[0].text).toEqual('Tree 3')
           expect(query.docs[1].text).toEqual('Tree 4')
         })
+
+        it('should query using "equals: null" on a hasMany relationship field', async () => {
+          const movie = await payload.create({
+            collection: 'movies',
+            data: { name: 'Some Movie' },
+          })
+
+          const directorWithMovies = await payload.create({
+            collection: 'directors',
+            data: {
+              name: 'Director With Movies',
+              movies: [movie.id],
+            },
+          })
+
+          const directorWithoutMovies = await payload.create({
+            collection: 'directors',
+            data: {
+              name: 'Director Without Movies',
+            },
+          })
+
+          // Test programmatic API with null
+          const programmaticResult = await payload.find({
+            collection: 'directors',
+            depth: 0,
+            where: {
+              movies: { equals: null },
+            },
+          })
+
+          expect(programmaticResult.totalDocs).toBe(1)
+          expect(programmaticResult.docs[0]?.id).toBe(directorWithoutMovies.id)
+
+          // Test REST API with ['null'] — the form the admin UI sends for "None"
+          const restResult = await restClient
+            .GET(`/directors`, {
+              query: {
+                where: {
+                  movies: { equals: ['null'] },
+                },
+                depth: 0,
+              },
+            })
+            .then((res) => res.json())
+
+          expect(restResult.totalDocs).toBe(1)
+          expect(restResult.docs[0]?.id).toBe(directorWithoutMovies.id)
+        })
       })
 
       describe('sorting by relationships', () => {

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -711,7 +711,7 @@ describe('Relationships', () => {
             data: { name: 'Some Movie' },
           })
 
-          const directorWithMovies = await payload.create({
+          await payload.create({
             collection: 'directors',
             data: {
               name: 'Director With Movies',
@@ -748,7 +748,7 @@ describe('Relationships', () => {
                 depth: 0,
               },
             })
-            .then((res) => res.json())
+            .then((res) => res.json() as Promise<{ docs: Director[]; totalDocs: number }>)
 
           expect(restResult.totalDocs).toBe(1)
           expect(restResult.docs[0]?.id).toBe(directorWithoutMovies.id)


### PR DESCRIPTION
### What?

When filtering a `hasMany` relationship field by **None** in the Payload admin panel list view, no results are returned — even when documents with no related entries exist.

### Why?

The issue exists in both `packages/drizzle/src/queries/sanitizeQueryValue.ts` and `packages/db-mongodb/src/queries/sanitizeQueryValue.ts`, inside the `relationship`/`upload` type block.

When the admin UI sends a "None" filter for a `hasMany` relationship field, the value arrives as `['null']` — an array containing the string `'null'`. The current null check in both adapters only handles the plain string form:

```ts
if (val === 'null') {
  formattedValue = null
}
```

Since `['null'] !== 'null'`, the check is bypassed. In the drizzle adapter, the `['null']` value then reaches the array-handling branch which converts `operator: 'equals'` to `operator: 'in'` with `value: ['null']`, generating:

```sql
WHERE types_id IN ('null')
```

In the MongoDB adapter, the unconverted `['null']` value causes a query error, returning `{ errors: [...] }` instead of results.

Both cases result in the filter producing no valid output.

### How?

Extended the null check in both adapters to also handle the `['null']` array form that `hasMany` relationship fields produce:

```ts
// before
if (val === 'null') {
  formattedValue = null
}

// after
if (val === 'null' || (Array.isArray(val) && val.length === 1 && val[0] === 'null')) {
  formattedValue = null
}
```

Fixes #16292