### PR TITLE
test: azure stream tests flake

### DIFF
--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -224,5 +224,13 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
     })
   }
 
+  // Ensure temp files are fully flushed to disk before returning.
+  // allFilesComplete resolves when all file streams end, but writeStream.end()
+  // is non-blocking — the temp file may not be fully written yet.
+  if (request[waitFlushProperty]) {
+    await Promise.all(request[waitFlushProperty])
+    delete request[waitFlushProperty]
+  }
+
   return result
 }

--- a/test/storage-azure/int.spec.ts
+++ b/test/storage-azure/int.spec.ts
@@ -48,12 +48,16 @@ describe('@payloadcms/storage-azure', () => {
 
     const data = new FormData()
     data.append('file', new Blob([fileBuffer], { type: 'image/png' }), 'image2.png')
-    const newMedia: { doc: { url: string } } = await (
+    const newMedia: { doc?: { url: string }; errors?: unknown; message?: string } = await (
       await restClient.POST('/media', {
         body: data,
       })
     ).json()
-    const response = await restClient.GET(newMedia.doc.url.replace(/^\/api/, '') as `/${string}`)
+    expect(
+      newMedia.doc,
+      `Upload failed: ${JSON.stringify(newMedia.errors || newMedia.message)}`,
+    ).toBeDefined()
+    const response = await restClient.GET(newMedia.doc?.url.replace(/^\/api/, '') as `/${string}`)
     expect(response.headers.get('content-type')).toEqual('image/png')
   })
 

--- a/test/storage-azure/streamingUploads.int.spec.ts
+++ b/test/storage-azure/streamingUploads.int.spec.ts
@@ -53,12 +53,16 @@ describe('@payloadcms/storage-azure streamingUploads', () => {
 
     const data = new FormData()
     data.append('file', new Blob([fileBuffer], { type: 'image/png' }), 'image1.png')
-    const newMedia: { doc: { url: string } } = await (
+    const newMedia: { doc?: { url: string }; errors?: unknown; message?: string } = await (
       await restClient.POST('/media', {
         body: data,
       })
     ).json()
-    const response = await restClient.GET(newMedia.doc.url.replace(/^\/api/, '') as `/${string}`)
+    expect(
+      newMedia.doc,
+      `Upload failed: ${JSON.stringify(newMedia.errors || newMedia.message)}`,
+    ).toBeDefined()
+    const response = await restClient.GET(newMedia.doc?.url.replace(/^\/api/, '') as `/${string}`)
     expect(response.headers.get('content-type')).toEqual('image/png')
   })
 


### PR DESCRIPTION
# Overview

Fixes a race condition in `processMultipart` that causes flaky "Empty file" errors when `useTempFiles` is enabled. The temp file write stream could still be flushing to disk when `generateFileData` tried to read it.

Observed as a CI flake in `test/storage-azure/streamingUploads.int.spec.ts` on the `int-mongodb-atlas` job.

## Key Changes

- **Await temp file write promises before returning from `processMultipart`**
  - `allFilesComplete` resolves when all file streams end, but `writeStream.end()` is non-blocking. The temp file may not be fully written yet. Now we await the existing `waitFlushProperty` promises in the main return path, not just in the `busboy.on('finish')` callback (whose return value was discarded).

- **Add upload response validation in storage-azure tests**
  - Both `int.spec.ts` and `streamingUploads.int.spec.ts` accessed `newMedia.doc.url` without checking whether the upload succeeded. If the upload fails, this produced a confusing `TypeError` instead of the actual error. Now the tests assert `doc` is defined with a message that includes the server error.

## Design Decisions

The race condition has existed since `processMultipart.ts` was introduced in Jan 2025 (`686e48d17`). It only surfaces under disk I/O pressure because `writeStream.end()` usually completes fast enough. Rather than restructuring the async flow (making `complete()` return a Promise, changing the Handler type contract), this fix reuses the `waitFlushProperty` promises that were already being tracked and awaits them in the right place.

## Overall Flow

```mermaid
sequenceDiagram
    participant C as Client
    participant PM as processMultipart
    participant B as Busboy
    participant WS as WriteStream
    participant GFD as generateFileData

    C->>PM: POST /media (FormData)
    PM->>B: Parse multipart body
    B->>WS: Stream file data to temp file
    B-->>PM: file 'end' event (allFilesComplete resolves)
    Note over PM: writeStream.end() called but<br/>flush may still be in progress
    PM->>WS: await waitFlushProperty (NEW)
    WS-->>PM: flush complete
    PM-->>GFD: return result with tempFilePath
    GFD->>WS: read temp file (now guaranteed complete)
```