### PR TITLE
fix: flush busboy and await completion in multipart parser

### DIFF
--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.spec.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { processMultipartFormdata } from './index.js'
+
+function createMultipartRequest(chunks: Uint8Array[], boundary: string): Request {
+  let index = 0
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index])
+        index++
+      } else {
+        controller.close()
+      }
+    },
+  })
+
+  return new Request('http://localhost/', {
+    method: 'POST',
+    headers: {
+      'content-type': `multipart/form-data; boundary=${boundary}`,
+      'transfer-encoding': 'chunked',
+    },
+    body: stream,
+    // @ts-expect-error duplex is required for streaming bodies
+    duplex: 'half',
+  })
+}
+
+describe('processMultipart', () => {
+  it('runs parseNested post-processing before resolving', async () => {
+    const boundary = '----test-boundary-nested'
+    const body = new TextEncoder().encode(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="user[name]"\r\n` +
+        `\r\n` +
+        `Alice\r\n` +
+        `--${boundary}--\r\n`,
+    )
+
+    const request = createMultipartRequest([body], boundary)
+    const result = await processMultipartFormdata({
+      request,
+      options: { parseNested: true },
+    })
+
+    expect(result.fields?.user).toEqual({ name: 'Alice' })
+  })
+})

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -180,22 +180,26 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
 
   const busboyComplete = new Promise<void>((resolve, reject) => {
     busboy.on('finish', async () => {
-      debugLog(options, `Busboy finished parsing request.`)
-      if (options.parseNested) {
-        result.fields = processNested(result.fields)
-        result.files = processNested(result.files)
-      }
-
-      if (request[waitFlushProperty]) {
-        try {
-          await Promise.all(request[waitFlushProperty])
-          delete request[waitFlushProperty]
-        } catch (err) {
-          debugLog(options, `Error waiting for file write promises: ${err}`)
+      try {
+        debugLog(options, `Busboy finished parsing request.`)
+        if (options.parseNested) {
+          result.fields = processNested(result.fields)
+          result.files = processNested(result.files)
         }
-      }
 
-      resolve()
+        if (request[waitFlushProperty]) {
+          try {
+            await Promise.all(request[waitFlushProperty])
+            delete request[waitFlushProperty]
+          } catch (err) {
+            debugLog(options, `Error waiting for file write promises: ${err}`)
+          }
+        }
+
+        resolve()
+      } catch (err) {
+        reject(err as Error)
+      }
     })
 
     busboy.on('error', (err: Error) => {

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -178,33 +178,31 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
     uploadTimer.set()
   })
 
-  busboy.on('finish', async () => {
-    debugLog(options, `Busboy finished parsing request.`)
-    if (options.parseNested) {
-      result.fields = processNested(result.fields)
-      result.files = processNested(result.files)
-    }
-
-    if (request[waitFlushProperty]) {
-      try {
-        await Promise.all(request[waitFlushProperty]).then(() => {
-          delete request[waitFlushProperty]
-        })
-      } catch (err) {
-        debugLog(options, `Error waiting for file write promises: ${err}`)
+  const busboyComplete = new Promise<void>((resolve, reject) => {
+    busboy.on('finish', async () => {
+      debugLog(options, `Busboy finished parsing request.`)
+      if (options.parseNested) {
+        result.fields = processNested(result.fields)
+        result.files = processNested(result.files)
       }
-    }
 
-    return result
-  })
+      if (request[waitFlushProperty]) {
+        try {
+          await Promise.all(request[waitFlushProperty])
+          delete request[waitFlushProperty]
+        } catch (err) {
+          debugLog(options, `Error waiting for file write promises: ${err}`)
+        }
+      }
 
-  busboy.on(
-    'error',
-    (err = new APIError('Busboy error parsing multipart request', httpStatus.BAD_REQUEST)) => {
+      resolve()
+    })
+
+    busboy.on('error', (err: Error) => {
       debugLog(options, `Busboy error`)
-      throw err
-    },
-  )
+      reject(err ?? new APIError('Busboy error parsing multipart request', httpStatus.BAD_REQUEST))
+    })
+  })
 
   while (parsingRequest) {
     const { done, value } = await reader!.read()
@@ -218,11 +216,17 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
     }
   }
 
+  // Flush Busboy's internal buffer so trailing bytes at a chunk boundary
+  // (e.g. the closing multipart boundary) don't stall the parse.
+  busboy.end()
+
   if (fileCount !== 0) {
     await allFilesComplete.catch((e) => {
       throw e
     })
   }
+
+  await busboyComplete
 
   return result
 }


### PR DESCRIPTION
### What?

`processMultipart` now calls `busboy.end()` after draining the request body and awaits the Busboy `finish` handler before returning. Busboy errors reject the returned promise instead of throwing inside an event listener.

### Why?

Busboy is a Transform stream and can hold the closing multipart boundary in its internal buffer until `end()` is called. The parser drained the request body in a `while` loop but never called `end()`. Locally and on staging the 1-2KB body lands as a single chunk and it didn't matter, but on Vercel serverless the stream is chunked by the CDN and the final `field` event for `_payload` sometimes never fired. `result.fields` stayed `undefined`, `addDataAndFileToRequest` skipped `req.data = JSON.parse(fields._payload)`, and `updateDocument` crashed:

```
TypeError: Cannot read properties of undefined (reading '_status')
```

While in there, the `busboy.on('finish', ...)` handler also runs `parseNested` and awaits queued file-write promises via `waitFlushProperty`, but nothing awaited it. `processMultipart` could return before that work completed, making `parseNested` results timing-dependent and leaking file-flush errors.

### How?

- Call `busboy.end()` after the read loop.
- Wrap the `finish` and `error` handlers in a `busboyComplete` promise that `processMultipart` awaits before returning, so `parseNested` and file-write flushes always complete before the caller sees the result. A try/catch inside the `finish` handler rejects the promise instead of hanging if `processNested` throws.
- Convert the Busboy `error` listener from `throw err` to `reject(err)`. A throw inside an event listener was either crashing the process as `uncaughtException` or being swallowed depending on the code path
- Add a unit test with `parseNested: true` that exercises the `finish` code path. Fails without the fix, passes with it.