### PR TITLE
fix: handle multipart uploads without content-length

### DIFF
--- a/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.spec.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { isEligibleRequest } from './isEligibleRequest.js'
+
+describe('isEligibleRequest', () => {
+  it('should accept multipart POST requests with a body stream when content-length is absent', () => {
+    const formData = new FormData()
+    formData.append('file', new Blob(['hello world'], { type: 'text/plain' }), 'hello.txt')
+
+    const request = new Request('http://localhost/api/upload', {
+      body: formData,
+      method: 'POST',
+    })
+
+    expect(request.headers.get('content-length')).toBeNull()
+    expect(isEligibleRequest(request)).toBe(true)
+  })
+
+  it('should reject multipart POST requests when no body is present', () => {
+    const request = new Request('http://localhost/api/upload', {
+      headers: {
+        'content-type': 'multipart/form-data; boundary=----test-boundary',
+      },
+      method: 'POST',
+    })
+
+    expect(isEligibleRequest(request)).toBe(false)
+  })
+})

--- a/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.ts
@@ -3,9 +3,10 @@ const ACCEPTABLE_CONTENT_TYPE = /multipart\/['"()+-_]+(?:; ?['"()+-_]*)+$/i
 const UNACCEPTABLE_METHODS = new Set(['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'TRACE'])
 
 const hasBody = (req: Request): boolean => {
+  const contentLength = req.headers.get('content-length')
+
   return Boolean(
-    req.headers.get('transfer-encoding') ||
-      (req.headers.get('content-length') && req.headers.get('content-length') !== '0'),
+    req.body || req.headers.get('transfer-encoding') || (contentLength && contentLength !== '0'),
   )
 }
 

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -33,10 +33,17 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
   let filesCompleted = 0
   let allFilesHaveResolved: (value?: unknown) => void
   let failedResolvingFiles: (err: Error) => void
+  let busboyFinishedResolve: () => void
+  let busboyFinishedReject: (err: Error) => void
 
   const allFilesComplete = new Promise((res, rej) => {
     allFilesHaveResolved = res
     failedResolvingFiles = rej
+  })
+
+  const busboyFinished = new Promise<void>((resolve, reject) => {
+    busboyFinishedResolve = resolve
+    busboyFinishedReject = reject
   })
 
   const result: FetchAPIFileUploadResponse = {
@@ -195,14 +202,14 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
       }
     }
 
-    return result
+    busboyFinishedResolve()
   })
 
   busboy.on(
     'error',
     (err = new APIError('Busboy error parsing multipart request', httpStatus.BAD_REQUEST)) => {
       debugLog(options, `Busboy error`)
-      throw err
+      busboyFinishedReject(err)
     },
   )
 
@@ -211,6 +218,7 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
 
     if (done) {
       parsingRequest = false
+      busboy.end()
     }
 
     if (value && !shouldAbortProccessing) {
@@ -223,6 +231,8 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
       throw e
     })
   }
+
+  await busboyFinished
 
   return result
 }

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -209,7 +209,12 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
     'error',
     (err = new APIError('Busboy error parsing multipart request', httpStatus.BAD_REQUEST)) => {
       debugLog(options, `Busboy error`)
-      busboyFinishedReject(err)
+      const busboyError =
+        err instanceof Error
+          ? err
+          : new APIError('Busboy error parsing multipart request', httpStatus.BAD_REQUEST)
+
+      busboyFinishedReject(busboyError)
     },
   )
 

--- a/packages/payload/src/utilities/addDataAndFileToRequest.spec.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.spec.ts
@@ -1,0 +1,49 @@
+import type { PayloadRequest } from '../types/index.js'
+
+import { describe, expect, it } from 'vitest'
+
+import { addDataAndFileToRequest } from './addDataAndFileToRequest.js'
+
+type MinimalReq = Pick<PayloadRequest, 'body' | 'headers' | 'method' | 'payload'> & {
+  file?: PayloadRequest['file']
+}
+
+const createReqWithMultipartBody = (): MinimalReq => {
+  const formData = new FormData()
+  formData.append('file', new Blob(['hello world'], { type: 'text/plain' }), 'hello.txt')
+
+  const request = new Request('http://localhost/api/upload', {
+    body: formData,
+    method: 'POST',
+  })
+
+  return {
+    body: request.body,
+    headers: request.headers,
+    method: request.method,
+    payload: {
+      collections: {},
+      config: {
+        bodyParser: {},
+        upload: {},
+      },
+      logger: {
+        error: () => {},
+      },
+    } as unknown as PayloadRequest['payload'],
+  }
+}
+
+describe('addDataAndFileToRequest', () => {
+  it('should parse multipart form-data even when content-length is absent', async () => {
+    const req = createReqWithMultipartBody()
+
+    expect(req.headers.get('content-length')).toBeNull()
+
+    await addDataAndFileToRequest(req as PayloadRequest)
+
+    expect(req.file).toBeDefined()
+    expect(req.file?.name).toBe('hello.txt')
+    expect(req.file?.mimetype).toBe('text/plain')
+  })
+})

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -14,6 +14,7 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
   if (method && ['PATCH', 'POST', 'PUT'].includes(method.toUpperCase()) && body) {
     const [contentType] = (headers.get('Content-Type') || '').split(';', 1)
     const bodyByteSize = parseInt(req.headers.get('Content-Length') || '0', 10)
+    const hasBodyStream = req.body !== null
 
     if (contentType === 'application/json') {
       try {
@@ -29,7 +30,7 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
         req.payload.logger.error(error)
         throw error
       }
-    } else if (bodyByteSize && contentType?.includes('multipart/')) {
+    } else if ((bodyByteSize || hasBodyStream) && contentType?.includes('multipart/')) {
       const { error, fields, files } = await processMultipartFormdata({
         options: {
           ...(payload.config.bodyParser || {}),

--- a/test/__helpers/shared/NextRESTClient.ts
+++ b/test/__helpers/shared/NextRESTClient.ts
@@ -12,7 +12,6 @@ import {
 import * as qs from 'qs-esm'
 
 import { devUser } from '../../credentials.js'
-import { getFormDataSize } from './getFormDataSize.js'
 
 type ValidPath = `/${string}`
 type RequestOptions = {
@@ -106,10 +105,6 @@ export class NextRESTClient {
 
     if (options?.file) {
       headers.set('Content-Length', options.file.size.toString())
-    }
-
-    if (isFormData) {
-      headers.set('Content-Length', getFormDataSize(options.body as FormData).toString())
     }
 
     if (!isFormData && !headers.has('Content-Type')) {


### PR DESCRIPTION
## Summary
- accept multipart requests when a body stream is present even if `Content-Length` is missing
- add base-case coverage for multipart eligibility and request parsing without `Content-Length`
- wait for multipart parser completion before returning parsed files to avoid temp-file race/empty-file reads
- stop forcing manual FormData `Content-Length` in the test REST client helper

## What This Fixes
The Azure streaming upload MIME test intermittently failed because multipart FormData requests could be skipped or race file reads in certain no-`Content-Length` paths, producing empty-file upload behavior.

This test would fail:
```ts
TypeError: Cannot read properties of undefined (reading 'url')
 ❯ test/storage-azure/streamingUploads.int.spec.ts:61:56
   59|       })
   60|     ).json()
   61|     const response = await restClient.GET(newMedia.doc.url.replace(/^\…
     |                                                        ^
   62|     expect(response.headers.get('content-type')).toEqual('image/png')
   63|   })
```

## Validation
- `pnpm exec vitest run packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.spec.ts packages/payload/src/utilities/addDataAndFileToRequest.spec.ts`
- `pnpm exec vitest run --project int test/storage-azure/streamingUploads.int.spec.ts -t "preserves mime type when uploaded via rest endpoint"` (5 consecutive passes)
