### PR TITLE
fix(richtext-lexical): internal links export as [text](undefined) in markdown transformer

### DIFF
--- a/packages/richtext-lexical/src/features/link/markdownTransformer.spec.ts
+++ b/packages/richtext-lexical/src/features/link/markdownTransformer.spec.ts
@@ -37,6 +37,7 @@ describe('createLinkMarkdownTransformer', () => {
     })
 
     it('should export a custom link that opens in a new tab', () => {
+      // newTab is a Payload field — markdown has no equivalent, so it is intentionally dropped
       const markdown = toMarkdown(() => {
         const link = $createLinkNode({
           fields: { linkType: 'custom', url: 'https://payloadcms.com', newTab: true, doc: null },
@@ -46,6 +47,27 @@ describe('createLinkMarkdownTransformer', () => {
       })
 
       expect(markdown).toBe('[Payload](https://payloadcms.com)')
+    })
+
+    it('should produce an empty href when url is null or undefined', () => {
+      const markdownNull = toMarkdown(() => {
+        const link = $createLinkNode({
+          fields: { linkType: 'custom', url: null as unknown as string, newTab: false, doc: null },
+        })
+        link.append($createTextNode('Broken'))
+        $getRoot().append($createParagraphNode().append(link))
+      })
+
+      const markdownUndefined = toMarkdown(() => {
+        const link = $createLinkNode({
+          fields: { linkType: 'custom', newTab: false, doc: null },
+        })
+        link.append($createTextNode('Broken'))
+        $getRoot().append($createParagraphNode().append(link))
+      })
+
+      expect(markdownNull).toBe('[Broken]()')
+      expect(markdownUndefined).toBe('[Broken]()')
     })
   })
 

--- a/packages/richtext-lexical/src/features/link/markdownTransformer.spec.ts
+++ b/packages/richtext-lexical/src/features/link/markdownTransformer.spec.ts
@@ -1,0 +1,142 @@
+import { createHeadlessEditor } from '@lexical/headless'
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical'
+import { describe, expect, it } from 'vitest'
+
+import { $convertToMarkdownString } from '../../packages/@lexical/markdown/index.js'
+import { AutoLinkNode } from './nodes/AutoLinkNode.js'
+import { $createLinkNode, LinkNode } from './nodes/LinkNode.js'
+import type { SerializedLinkNode } from './nodes/types.js'
+import { LinkMarkdownTransformer, createLinkMarkdownTransformer } from './markdownTransformer.js'
+
+function createEditor() {
+  return createHeadlessEditor({ nodes: [LinkNode, AutoLinkNode] })
+}
+
+function toMarkdown(setupFn: () => void, transformer = LinkMarkdownTransformer): string {
+  const editor = createEditor()
+  editor.update(setupFn, { discrete: true })
+  let markdown = ''
+  editor.getEditorState().read(() => {
+    markdown = $convertToMarkdownString([transformer])
+  })
+  return markdown
+}
+
+describe('createLinkMarkdownTransformer', () => {
+  describe('custom links', () => {
+    it('should export a custom link with its url', () => {
+      const markdown = toMarkdown(() => {
+        const link = $createLinkNode({
+          fields: { linkType: 'custom', url: 'https://payloadcms.com', newTab: false, doc: null },
+        })
+        link.append($createTextNode('Payload'))
+        $getRoot().append($createParagraphNode().append(link))
+      })
+
+      expect(markdown).toBe('[Payload](https://payloadcms.com)')
+    })
+
+    it('should export a custom link that opens in a new tab', () => {
+      const markdown = toMarkdown(() => {
+        const link = $createLinkNode({
+          fields: { linkType: 'custom', url: 'https://payloadcms.com', newTab: true, doc: null },
+        })
+        link.append($createTextNode('Payload'))
+        $getRoot().append($createParagraphNode().append(link))
+      })
+
+      expect(markdown).toBe('[Payload](https://payloadcms.com)')
+    })
+  })
+
+  describe('internal links', () => {
+    it('should export an empty href when no internalDocToHref is provided', () => {
+      const markdown = toMarkdown(() => {
+        const link = $createLinkNode({
+          fields: {
+            linkType: 'internal',
+            doc: { relationTo: 'pages', value: { id: '1', slug: 'about' } },
+            newTab: false,
+          },
+        })
+        link.append($createTextNode('About'))
+        $getRoot().append($createParagraphNode().append(link))
+      })
+
+      expect(markdown).toBe('[About]()')
+    })
+
+    it('should call internalDocToHref and use the returned url', () => {
+      const transformer = createLinkMarkdownTransformer({
+        internalDocToHref: ({ linkNode }) => {
+          const value = linkNode.fields.doc?.value
+          if (value && typeof value === 'object' && 'slug' in value) {
+            return `/${value.slug}`
+          }
+          return '/'
+        },
+      })
+
+      const markdown = toMarkdown(() => {
+        const link = $createLinkNode({
+          fields: {
+            linkType: 'internal',
+            doc: { relationTo: 'pages', value: { id: '1', slug: 'about' } },
+            newTab: false,
+          },
+        })
+        link.append($createTextNode('About'))
+        $getRoot().append($createParagraphNode().append(link))
+      }, transformer)
+
+      expect(markdown).toBe('[About](/about)')
+    })
+
+    it('should pass the full serialized link node to internalDocToHref', () => {
+      let capturedLinkNode: SerializedLinkNode | null = null
+
+      const transformer = createLinkMarkdownTransformer({
+        internalDocToHref: ({ linkNode }) => {
+          capturedLinkNode = linkNode
+          return '/captured'
+        },
+      })
+
+      toMarkdown(() => {
+        const link = $createLinkNode({
+          fields: {
+            linkType: 'internal',
+            doc: { relationTo: 'pages', value: { id: '42', title: 'Home' } },
+            newTab: true,
+          },
+        })
+        link.append($createTextNode('Home'))
+        $getRoot().append($createParagraphNode().append(link))
+      }, transformer)
+
+      expect(capturedLinkNode).not.toBeNull()
+      expect(capturedLinkNode!.fields.linkType).toBe('internal')
+      expect(capturedLinkNode!.fields.doc?.relationTo).toBe('pages')
+      expect(capturedLinkNode!.fields.doc?.value).toMatchObject({ id: '42', title: 'Home' })
+      expect(capturedLinkNode!.fields.newTab).toBe(true)
+    })
+  })
+
+  describe('LinkMarkdownTransformer (static export)', () => {
+    it('should behave identically to createLinkMarkdownTransformer() with no args', () => {
+      const setup = () => {
+        const link = $createLinkNode({
+          fields: { linkType: 'custom', url: 'https://example.com', newTab: false, doc: null },
+        })
+        link.append($createTextNode('Example'))
+        $getRoot().append($createParagraphNode().append(link))
+      }
+
+      const fromStatic = toMarkdown(setup, LinkMarkdownTransformer)
+      const fromFactory = toMarkdown(setup, createLinkMarkdownTransformer())
+
+      expect(fromStatic).toBe(fromFactory)
+      expect(fromStatic).toBe('[Example](https://example.com)')
+    })
+  })
+})

--- a/packages/richtext-lexical/src/features/link/markdownTransformer.ts
+++ b/packages/richtext-lexical/src/features/link/markdownTransformer.ts
@@ -9,11 +9,44 @@
 import { $createTextNode, $isTextNode } from 'lexical'
 
 import type { TextMatchTransformer } from '../../packages/@lexical/markdown/MarkdownTransformers.js'
+import type { SerializedLinkNode } from './nodes/types.js'
 
 import { $createLinkNode, $isLinkNode, LinkNode } from './nodes/LinkNode.js'
 
 // - then longer tags match (e.g. ** or __ should go before * or _)
-export const LinkMarkdownTransformer: TextMatchTransformer = {
+
+export type CreateLinkMarkdownTransformerArgs = {
+  /**
+   * A function that receives a serialized internal link node and returns the URL string.
+   * Required for internal links (linkType === 'internal') to be exported correctly, since
+   * internal links store a doc reference rather than a URL.
+   *
+   * Without this, internal links will export as `[text]()` with an empty href.
+   */
+  internalDocToHref?: (args: { linkNode: SerializedLinkNode }) => string
+}
+
+const replaceTransformer: TextMatchTransformer['replace'] = (textNode, match) => {
+  const [, linkText, linkUrl] = match
+  const linkNode = $createLinkNode({
+    fields: {
+      doc: null,
+      linkType: 'custom',
+      newTab: false,
+      url: linkUrl,
+    },
+  })
+  const linkTextNode = $createTextNode(linkText)
+  linkTextNode.setFormat(textNode.getFormat())
+  linkNode.append(linkTextNode)
+  textNode.replace(linkNode)
+
+  return linkTextNode
+}
+
+export const createLinkMarkdownTransformer = (
+  args?: CreateLinkMarkdownTransformerArgs,
+): TextMatchTransformer => ({
   type: 'text-match',
   dependencies: [LinkNode],
   export: (_node, exportChildren) => {
@@ -21,32 +54,27 @@ export const LinkMarkdownTransformer: TextMatchTransformer = {
       return null
     }
     const node: LinkNode = _node
-    const { url } = node.getFields()
+    const fields = node.getFields()
+
+    let url: string
+
+    if (fields.linkType === 'internal') {
+      if (args?.internalDocToHref) {
+        url = args.internalDocToHref({ linkNode: node.exportJSON() })
+      } else {
+        url = ''
+      }
+    } else {
+      url = fields.url ?? ''
+    }
 
     const textContent = exportChildren(node)
-
-    const linkContent = `[${textContent}](${url})`
-
-    return linkContent
+    return `[${textContent}](${url})`
   },
   importRegExp: /(?<!!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)/,
   regExp: /(?<!!)\[([^[]+)\]\(([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\)$/,
-  replace: (textNode, match) => {
-    const [, linkText, linkUrl] = match
-    const linkNode = $createLinkNode({
-      fields: {
-        doc: null,
-        linkType: 'custom',
-        newTab: false,
-        url: linkUrl,
-      },
-    })
-    const linkTextNode = $createTextNode(linkText)
-    linkTextNode.setFormat(textNode.getFormat())
-    linkNode.append(linkTextNode)
-    textNode.replace(linkNode)
-
-    return linkTextNode
-  },
+  replace: replaceTransformer,
   trigger: ')',
-}
+})
+
+export const LinkMarkdownTransformer: TextMatchTransformer = createLinkMarkdownTransformer()

--- a/packages/richtext-lexical/src/features/link/markdownTransformer.ts
+++ b/packages/richtext-lexical/src/features/link/markdownTransformer.ts
@@ -11,6 +11,7 @@ import { $createTextNode, $isTextNode } from 'lexical'
 import type { TextMatchTransformer } from '../../packages/@lexical/markdown/MarkdownTransformers.js'
 import type { SerializedLinkNode } from './nodes/types.js'
 
+import { sanitizeUrl } from '../../lexical/utils/url.js'
 import { $createLinkNode, $isLinkNode, LinkNode } from './nodes/LinkNode.js'
 
 // - then longer tags match (e.g. ** or __ should go before * or _)
@@ -60,12 +61,16 @@ export const createLinkMarkdownTransformer = (
 
     if (fields.linkType === 'internal') {
       if (args?.internalDocToHref) {
-        url = args.internalDocToHref({ linkNode: node.exportJSON() })
+        url = sanitizeUrl(args.internalDocToHref({ linkNode: node.exportJSON() }))
       } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Lexical → Markdown converter: found internal link but internalDocToHref is not provided — link will have an empty href',
+        )
         url = ''
       }
     } else {
-      url = fields.url ?? ''
+      url = sanitizeUrl(fields.url ?? '')
     }
 
     const textContent = exportChildren(node)

--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -12,11 +12,12 @@ import { sanitizeFields } from 'payload'
 
 import type { NodeWithHooks } from '../../typesServer.js'
 import type { ClientProps } from '../client/index.js'
+import type { SerializedLinkNode } from '../nodes/types.js'
 
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/lexicalToHtml_deprecated/converter/index.js'
 import { createNode } from '../../typeUtilities.js'
-import { LinkMarkdownTransformer } from '../markdownTransformer.js'
+import { createLinkMarkdownTransformer } from '../markdownTransformer.js'
 import { AutoLinkNode } from '../nodes/AutoLinkNode.js'
 import { LinkNode } from '../nodes/LinkNode.js'
 import { linkPopulationPromiseHOC } from './graphQLPopulationPromise.js'
@@ -73,6 +74,12 @@ export type LinkFeatureServerProps = {
    *
    * {@link https://payloadcms.com/docs/getting-started/concepts#field-level-max-depth}
    */
+  /**
+   * Resolves an internal link node to a URL string for use in the markdown converter.
+   * Internal links store a doc reference rather than a URL, so without this the markdown
+   * output will have an empty href: `[link text]()`.
+   */
+  internalDocToHref?: (args: { linkNode: SerializedLinkNode }) => string
   maxDepth?: number
 } & ExclusiveLinkCollectionsProps
 
@@ -158,7 +165,9 @@ export const LinkFeature = createServerFeature<
         return schemaMap
       },
       i18n,
-      markdownTransformers: [LinkMarkdownTransformer],
+      markdownTransformers: [
+        createLinkMarkdownTransformer({ internalDocToHref: props.internalDocToHref }),
+      ],
       nodes: [
         props?.disableAutoLinks === true
           ? null

--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -69,17 +69,17 @@ export type LinkFeatureServerProps = {
       }) => (Field | FieldAffectingData)[])
     | Field[]
   /**
-   * Sets a maximum population depth for the internal doc default field of link, regardless of the remaining depth when the field is reached.
-   * This behaves exactly like the maxDepth properties of relationship and upload fields.
-   *
-   * {@link https://payloadcms.com/docs/getting-started/concepts#field-level-max-depth}
-   */
-  /**
    * Resolves an internal link node to a URL string for use in the markdown converter.
    * Internal links store a doc reference rather than a URL, so without this the markdown
    * output will have an empty href: `[link text]()`.
    */
   internalDocToHref?: (args: { linkNode: SerializedLinkNode }) => string
+  /**
+   * Sets a maximum population depth for the internal doc default field of link, regardless of the remaining depth when the field is reached.
+   * This behaves exactly like the maxDepth properties of relationship and upload fields.
+   *
+   * {@link https://payloadcms.com/docs/getting-started/concepts#field-level-max-depth}
+   */
   maxDepth?: number
 } & ExclusiveLinkCollectionsProps
 


### PR DESCRIPTION
## Overview

Payload has two types of links: custom (you type a URL) and internal (you pick a page). For internal links, Payload never stores a URL, only a reference to the page (`doc`). Whatever renders the link is responsible for resolving that reference to a URL at render time.

The HTML converters handled this with an `internalDocToHref` callback. The markdown transformer didn't, so it produced `[text](undefined)` for every internal link.

## Key Changes

The transformer is now a `createLinkMarkdownTransformer(args?)` factory that accepts an optional `internalDocToHref` callback. Pass it to `LinkFeature` and it gets threaded through to the transformer. Without it, internal links fall back to `[text]()` instead of `[text](undefined)`.

`LinkMarkdownTransformer` remains as a static backwards-compatible export.

## Design Decisions

The callback is synchronous unlike the HTML converter variant, because `doc.value` is already populated by the time markdown export runs.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213983113414606