### PR TITLE
templates: bump plugin template to latest payload version

### DIFF
--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -46,13 +46,13 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
-    "@payloadcms/db-mongodb": "3.37.0",
-    "@payloadcms/db-postgres": "3.37.0",
-    "@payloadcms/db-sqlite": "3.37.0",
-    "@payloadcms/eslint-config": "3.9.0",
-    "@payloadcms/next": "3.37.0",
-    "@payloadcms/richtext-lexical": "3.37.0",
-    "@payloadcms/ui": "3.37.0",
+    "@payloadcms/db-mongodb": "3.82.1",
+    "@payloadcms/db-postgres": "3.82.1",
+    "@payloadcms/db-sqlite": "3.82.1",
+    "@payloadcms/eslint-config": "3.28.0",
+    "@payloadcms/next": "3.82.1",
+    "@payloadcms/richtext-lexical": "3.82.1",
+    "@payloadcms/ui": "3.82.1",
     "@playwright/test": "1.58.2",
     "@swc-node/register": "1.10.9",
     "@swc/cli": "0.6.0",
@@ -67,7 +67,7 @@
     "mongodb-memory-server": "10.1.4",
     "next": "16.2.3",
     "open": "^10.1.0",
-    "payload": "3.37.0",
+    "payload": "3.82.1",
     "prettier": "^3.4.2",
     "qs-esm": "8.0.1",
     "react": "19.2.4",
@@ -80,7 +80,7 @@
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "payload": "^3.37.0"
+    "payload": "^3.82.1"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",

--- a/tools/scripts/src/generate-template-variations.ts
+++ b/tools/scripts/src/generate-template-variations.ts
@@ -211,13 +211,17 @@ async function main() {
     },
   ]
 
-  // If template is set, only generate that template
-  if (template) {
+  // If template is set, only generate that template. The plugin template is not a
+  // standard variation (see `bumpPluginTemplate` below), so allow it through without
+  // matching a variation entry.
+  if (template && template !== 'plugin') {
     const variation = variations.find((v) => v.dirname === template)
     if (!variation) {
       throw new Error(`Variation not found: ${template}`)
     }
     variations = [variation]
+  } else if (template === 'plugin') {
+    variations = []
   }
 
   for (const variation of variations) {
@@ -373,6 +377,11 @@ async function main() {
 
     log(`Done configuring payload config for ${destDir}/src/payload.config.ts`)
   }
+
+  if (!template || template === 'plugin') {
+    await bumpPluginTemplate()
+  }
+
   log('Running prettier on generated files...')
   execSyncSafe(`pnpm prettier --write templates "*.{js,jsx,ts,tsx}"`, { cwd: PROJECT_ROOT })
 
@@ -542,11 +551,43 @@ async function bumpPackageJson({
     }
   }
 
+  // Peer deps use a caret range so consumers can install patch/minor updates.
+  const peerDependencies = packageJson.peerDependencies
+  if (peerDependencies) {
+    for (const packageName of Object.keys(peerDependencies)) {
+      if (
+        (packageName === 'payload' || packageName.startsWith('@payloadcms')) &&
+        !DO_NOT_BUMP.includes(packageName)
+      ) {
+        peerDependencies[packageName] = `^${latestVersion}`
+      }
+    }
+  }
+
   // write it out
   await fs.writeFile(
     path.resolve(templateDir, 'package.json'),
     JSON.stringify(packageJson, null, 2),
   )
+}
+
+/**
+ * The plugin template is not a standard app-template variation (no payload.config.ts,
+ * no migrations, no importmap) but its pinned Payload versions still need to be bumped
+ * on each release. Unlike `blank`/`website`/`ecommerce`, it is not part of the pnpm
+ * workspace, so its versions drift unless we bump them explicitly.
+ */
+async function bumpPluginTemplate() {
+  header('Bumping plugin template...')
+  const pluginDir = path.join(TEMPLATES_DIR, 'plugin')
+  const payloadVersion = await getLatestPackageVersion({ packageName: 'payload' })
+  if (!payloadVersion) {
+    throw new Error('Could not resolve latest payload version')
+  }
+  await bumpPackageJson({
+    templateDir: pluginDir,
+    latestVersion: payloadVersion,
+  })
 }
 
 /**


### PR DESCRIPTION
### What?
Bump the plugin template's pinned Payload package versions from `3.37.0` to `3.82.1` and add it to `generate-template-variations.ts` so future releases bump it automatically.

### Why?
Audit against the current Payload version (`3.82.1`):

| Template | Payload version | Status |
|---|---|---|
| `blank`, `ecommerce`, `website` | `workspace:*` | ✅ auto-bumped |
| `with-cloudflare-d1`, `with-postgres`, `with-vercel-*` | `3.82.1` | ✅ bumped via release workflow / manual PRs |
| `plugin` | `3.37.0` | ❌ stale (~45 patches behind) |

The plugin template is not a standard app-template variation, so `generate-template-variations.ts` skipped it entirely. The post-release workflow therefore never touched it, and the recent manual bump PRs (#16212, #16229) only covered app templates.

### How?
1. `templates/plugin/package.json` — bump `payload` + `@payloadcms/*` devDeps from `3.37.0` → `3.82.1`, bump `@payloadcms/eslint-config` from `3.9.0` → `3.28.0`, bump `peerDependencies.payload` from `^3.37.0` → `^3.82.1`.
2. `tools/scripts/src/generate-template-variations.ts`:
   - Allow `--template plugin` through the filter (plugin isn't a variation entry).
   - After the main loop, call a new `bumpPluginTemplate()` helper which resolves the latest `payload` version from npm and reuses `bumpPackageJson`.
   - Extend `bumpPackageJson` to also bump `peerDependencies` entries, writing `^<version>` so plugin consumers can install compatible patch/minor updates (exact pins would be too strict for a peer dep).

Verified locally with `pnpm script:gen-templates --template plugin` — picked up the latest npm version (`3.83.0`), bumped devDeps, wrote `^3.83.0` to peer deps, and preserved `@payloadcms/eslint-config` via the existing `DO_NOT_BUMP` list.