### PR TITLE
fix: correct slugifyTitle hook example in documentation

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -292,7 +292,7 @@ const slugifyTitle: PostTitleHook = ({
       .replace(/[^\w\s-]/g, '')
       .replace(/\s+/g, '-')
 
-    return value
+    return slug
   }
 
   return value


### PR DESCRIPTION
## What?

Fixed incorrect return statement in the `slugifyTitle` field hook example in the official documentation.

The example was generating a properly formatted slug but then incorrectly returning the original `value` instead of the slugified result.

## Why?

This was a bug in the documentation that could mislead developers implementing automatic slug generation. The hook appeared to work, but in reality did nothing useful.

## How?

- Changed `return value` to `return slug` in the example

## Before/After

**Before:**
```ts
const slug = value.toLowerCase()... 
return value // ← bug

**Aftere:**
```ts
const slug = value.toLowerCase()... 
return slug