### PR TITLE
ci: use artifacts for e2e prep so job retries don't fail on cache eviction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,6 +241,14 @@ jobs:
       - name: Prepare prod test environment
         run: pnpm prepare-run-test-against-prod:ci
 
+      # Archive into a single tarball before uploading. upload-artifact processes
+      # files individually, which is pathologically slow for pnpm node_modules
+      # (hundreds of thousands of small files with symlinks). A single tarball
+      # uploads in seconds instead of tens of minutes. This matches what
+      # actions/cache does internally.
+      - name: Archive prepared test environment
+        run: tar --zstd -cf e2e-prep.tar.zst test/packed test/node_modules test/package.json test/pnpm-lock.yaml
+
       # Using upload-artifact (instead of actions/cache) so that re-runs of
       # individual failed E2E shards can still access the prepared environment.
       # Actions cache entries are evicted by LRU once the repo hits the 10 GB
@@ -250,13 +258,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-prep-${{ github.sha }}
-          path: |
-            test/packed
-            test/node_modules
-            test/package.json
-            test/pnpm-lock.yaml
+          path: e2e-prep.tar.zst
           if-no-files-found: error
-          include-hidden-files: true
 
   tests-e2e:
     runs-on: ubuntu-24.04
@@ -283,13 +286,19 @@ jobs:
           name: e2e-prep-${{ github.sha }}
           path: .
 
-      - name: Verify prepared test environment
+      - name: Extract prepared test environment
         shell: bash
         run: |
-          if [ ! -d test/packed ] || [ ! -d test/node_modules ]; then
-            echo "::error::The 'e2e-prep-${{ github.sha }}' artifact is missing expected files (test/packed or test/node_modules)."
+          if [ ! -f e2e-prep.tar.zst ]; then
+            echo "::error::The 'e2e-prep-${{ github.sha }}' artifact did not contain e2e-prep.tar.zst."
             echo "::error::This usually means the 'E2E Prep' job did not run or failed to upload."
             echo "::error::Re-run the entire workflow so 'E2E Prep' regenerates the artifact."
+            exit 1
+          fi
+          tar --zstd -xf e2e-prep.tar.zst
+          rm e2e-prep.tar.zst
+          if [ ! -d test/packed ] || [ ! -d test/node_modules ]; then
+            echo "::error::Extracted artifact is missing expected directories (test/packed or test/node_modules)."
             exit 1
           fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,15 +241,22 @@ jobs:
       - name: Prepare prod test environment
         run: pnpm prepare-run-test-against-prod:ci
 
-      - name: Cache prepared test environment
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      # Using upload-artifact (instead of actions/cache) so that re-runs of
+      # individual failed E2E shards can still access the prepared environment.
+      # Actions cache entries are evicted by LRU once the repo hits the 10 GB
+      # limit, which breaks job-level retries hours after the first attempt.
+      # Artifacts are scoped to the workflow run and survive across attempts.
+      - name: Upload prepared test environment
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: e2e-prep-${{ github.sha }}
           path: |
             test/packed
             test/node_modules
             test/package.json
             test/pnpm-lock.yaml
-          key: e2e-prep-${{ github.sha }}
+          if-no-files-found: error
+          include-hidden-files: true
 
   tests-e2e:
     runs-on: ubuntu-24.04
@@ -270,16 +277,21 @@ jobs:
         with:
           restore-build: true
 
-      - name: Restore prepared test environment
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download prepared test environment
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          path: |
-            test/packed
-            test/node_modules
-            test/package.json
-            test/pnpm-lock.yaml
-          key: e2e-prep-${{ github.sha }}
-          fail-on-cache-miss: true
+          name: e2e-prep-${{ github.sha }}
+          path: .
+
+      - name: Verify prepared test environment
+        shell: bash
+        run: |
+          if [ ! -d test/packed ] || [ ! -d test/node_modules ]; then
+            echo "::error::The 'e2e-prep-${{ github.sha }}' artifact is missing expected files (test/packed or test/node_modules)."
+            echo "::error::This usually means the 'E2E Prep' job did not run or failed to upload."
+            echo "::error::Re-run the entire workflow so 'E2E Prep' regenerates the artifact."
+            exit 1
+          fi
 
       - name: Start services
         id: db
@@ -335,8 +347,8 @@ jobs:
         #   To maintain serial execution for most suites, we pass --workers=1 when parallel=false.
         #   Suites with parallel=true (e.g. LexicalFullyFeatured) use the default 16 workers.
         #
-        # Note: The e2e-prep job runs prepare-run-test-against-prod:ci once and caches the result.
-        # This job restores that cache, so we use test:e2e:prod:run which skips preparation.
+        # Note: The e2e-prep job runs prepare-run-test-against-prod:ci once and uploads the result
+        # as an artifact. This job downloads that artifact, so we use test:e2e:prod:run which skips preparation.
         run: PLAYWRIGHT_JSON_OUTPUT_NAME=results_${{ matrix.suite }}_${{ matrix.shard }}.json pnpm test:e2e:prod:run ${{ matrix.suite }} --shard=${{ matrix.shard }}/${{ matrix.total-shards }} --fully-parallel${{ matrix.parallel == false && ' --workers=1' || '' }}
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: results_${{ matrix.suite }}_${{ matrix.shard }}.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,19 +241,11 @@ jobs:
       - name: Prepare prod test environment
         run: pnpm prepare-run-test-against-prod:ci
 
-      # Archive into a single tarball before uploading. upload-artifact processes
-      # files individually, which is pathologically slow for pnpm node_modules
-      # (hundreds of thousands of small files with symlinks). A single tarball
-      # uploads in seconds instead of tens of minutes. This matches what
-      # actions/cache does internally.
+      # Tar first: upload-artifact is extremely slow with pnpm node_modules (many small files + symlinks).
       - name: Archive prepared test environment
         run: tar --zstd -cf e2e-prep.tar.zst test/packed test/node_modules test/package.json test/pnpm-lock.yaml
 
-      # Using upload-artifact (instead of actions/cache) so that re-runs of
-      # individual failed E2E shards can still access the prepared environment.
-      # Actions cache entries are evicted by LRU once the repo hits the 10 GB
-      # limit, which breaks job-level retries hours after the first attempt.
-      # Artifacts are scoped to the workflow run and survive across attempts.
+      # Artifact (not cache) so that re-runs of individual E2E shards survive the 10 GB cache LRU eviction.
       - name: Upload prepared test environment
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
Switches the `e2e-prep` handoff from `actions/cache` to `actions/upload-artifact` + `actions/download-artifact`, so that re-running an individual failed E2E shard works without having to re-run the entire workflow (or push an empty commit to re-trigger CI, which is what we've been doing).

This is also the pattern [recommended by GitHub](https://docs.github.com/en/actions/tutorials/store-and-share-data): cache is for dependencies reused across runs, artifacts are for passing data between jobs within a run. `e2e-prep` falls squarely into the second category.

### Why

The Actions cache for this repo is permanently at its 10 GB limit, so the `e2e-prep-<sha>` entry gets evicted by LRU within a few hours of being saved. When that happens, any retry of a failed shard fails at the "Restore prepared test environment" step with `Failed to restore cache entry`, and the only recovery path is re-running the full workflow. Artifacts are scoped to the workflow run and not subject to the 10 GB cache budget, so they survive across attempts.

Real example that motivated this: https://github.com/payloadcms/payload/actions/runs/24524398342/job/71809444756

### Notes for reviewers

- `include-hidden-files: true` is required because `test/node_modules` contains `.bin`, `.pnpm`, etc. Missing that flag silently produces a broken artifact.
- Added an explicit "Verify prepared test environment" step with an actionable error, since `download-artifact` has no `fail-on-cache-miss` equivalent.
- Left the default 90 day retention. This repo is public, so artifact storage is free and there's no reason to be aggressive.
- Upload/download is slightly slower than cache (zip vs zstd), but the difference is in the order of tens of seconds on a job that takes minutes. Worth it for the reliability win.
- `e2e-prep-<sha>` cache key is left behind on old runs; it will naturally age out on its own, no cleanup needed.

This does not touch the separate `restore-build` cache used by `.github/actions/setup`. That one still has its own polling + full-build fallback, which is orthogonal to this change.