### PR TITLE
feat(plugin-ecommerce): add support for payment hooks

### DIFF
--- a/docs/ecommerce/payments.mdx
+++ b/docs/ecommerce/payments.mdx
@@ -191,6 +191,7 @@ You can make your own payment adapter by implementing the `PaymentAdapter` inter
 | `confirmOrder`    | `(args: ConfirmOrderArgs) => Promise<void>`                     | The function that is called via the `/api/payments/{provider_name}/confirm-order` endpoint to confirm an order after a payment has been made. [More](#confirmOrder)                            |
 | `endpoints`       | `Endpoint[]`                                                    | (Optional) An array of endpoints to be bootstrapped to Payload's API in order to support the payment method. All API paths are relative to `/api/payments/{provider_name}`                     |
 | `group`           | `GroupField`                                                    | A group field config to be used in transactions to track the necessary data for the payment processor, eg. PaymentIntentID for Stripe. See [Payment Fields](#payment-fields) for more details. |
+| `hooks`           | `PaymentHooks`                                                  | (Optional) Hooks that run only for this adapter. See [Adapter hooks](#adapter-hooks) for details.                                                                                              |
 
 The arguments can be extended but should always include the `PaymentAdapterArgs` type which has the following types:
 
@@ -399,6 +400,74 @@ export const confirmOrder: NonNullable<PaymentAdapter>['confirmOrder'] =
     }
   }
 ```
+
+#### Adapter hooks
+
+In addition to [plugin-level hooks](./plugin#payment-hooks) that run for every payment method, a `PaymentAdapter` can define its own hooks that run only for that specific adapter. Adapter-level hooks execute **after** the plugin-level hooks, so they can see adjustments already contributed by the plugin-level pipeline.
+
+The same three hook points are available on `paymentMethod.hooks`:
+
+| Hook                    | Description                                                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `beforeInitiatePayment` | Runs before this adapter's `initiatePayment`. Return `Adjustment[]` to add adjustments specific to this adapter. |
+| `beforeConfirmOrder`    | Runs before this adapter's `confirmOrder`. Throwing aborts confirmation for this adapter only.                   |
+| `afterConfirmOrder`     | Runs after this adapter successfully confirms an order. Errors are logged but do not fail the response.          |
+
+##### Simple example
+
+```ts
+import type { PaymentAdapter } from '@payloadcms/plugin-ecommerce/types'
+
+const myAdapter: PaymentAdapter = {
+  name: 'my-provider',
+  // ...required properties (initiatePayment, confirmOrder, group)
+  hooks: {
+    afterConfirmOrder: [
+      async ({ orderID, req }) => {
+        req.payload.logger.info(`Order ${orderID} confirmed via my-provider`)
+      },
+    ],
+  },
+}
+```
+
+##### When to use adapter-level hooks
+
+Use adapter-level hooks when the logic is specific to one payment provider:
+
+- Provider-specific fees (e.g. a surcharge that only applies when using a particular processor).
+- Adjustments computed by an integration service tied to that adapter (e.g. Stripe Tax).
+- Side effects that should only fire for a specific provider after confirmation.
+
+For logic that should apply to every payment method (taxes, shipping, discount codes), prefer [plugin-level hooks](./plugin#payment-hooks) so you do not have to copy them to each adapter.
+
+```ts
+import type { PaymentAdapter } from '@payloadcms/plugin-ecommerce/types'
+
+const stripeAdapter: PaymentAdapter = {
+  // ...required properties
+  hooks: {
+    beforeInitiatePayment: [
+      async ({ subtotal, adjustments }) => {
+        // Stripe-specific: apply a 2.9% + 30¢ surcharge only when paying via Stripe
+        const taxableAmount =
+          subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
+        const surcharge = Math.round(taxableAmount * 0.029) + 30
+
+        return [
+          {
+            type: 'custom',
+            label: 'Processing Fee',
+            amount: surcharge,
+          },
+        ]
+      },
+    ],
+  },
+}
+```
+
+See [plugin.mdx#Payment hooks](./plugin#payment-hooks) for the full `Adjustment` shape and the list of arguments passed to each hook.
 
 #### Payment Fields
 

--- a/docs/ecommerce/payments.mdx
+++ b/docs/ecommerce/payments.mdx
@@ -403,15 +403,15 @@ export const confirmOrder: NonNullable<PaymentAdapter>['confirmOrder'] =
 
 #### Adapter hooks
 
-In addition to [plugin-level hooks](./plugin#payment-hooks) that run for every payment method, a `PaymentAdapter` can define its own hooks that run only for that specific adapter. Adapter-level hooks execute **after** the plugin-level hooks, so they can see adjustments already contributed by the plugin-level pipeline.
+In addition to [plugin-level hooks](./plugin#payment-hooks) that run for every payment method, a `PaymentAdapter` can define its own hooks that run only for that specific adapter. Adapter-level hooks execute **after** the plugin-level hooks, so they receive the `summary` already updated by the plugin-level pipeline.
 
 The same three hook points are available on `paymentMethod.hooks`:
 
-| Hook                    | Description                                                                                                      |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `beforeInitiatePayment` | Runs before this adapter's `initiatePayment`. Return `Adjustment[]` to add adjustments specific to this adapter. |
-| `beforeConfirmOrder`    | Runs before this adapter's `confirmOrder`. Throwing aborts confirmation for this adapter only.                   |
-| `afterConfirmOrder`     | Runs after this adapter successfully confirms an order. Errors are logged but do not fail the response.          |
+| Hook                    | Description                                                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `beforeInitiatePayment` | Runs before this adapter's `initiatePayment`. Receives and returns a `Summary` — append lines specific to this adapter. |
+| `beforeConfirmOrder`    | Runs before this adapter's `confirmOrder`. Throwing aborts confirmation for this adapter only.                          |
+| `afterConfirmOrder`     | Runs after this adapter successfully confirms an order. Errors are logged but do not fail the response.                 |
 
 ##### Simple example
 
@@ -448,26 +448,32 @@ const stripeAdapter: PaymentAdapter = {
   // ...required properties
   hooks: {
     beforeInitiatePayment: [
-      async ({ subtotal, adjustments }) => {
-        // Stripe-specific: apply a 2.9% + 30¢ surcharge only when paying via Stripe
-        const taxableAmount =
-          subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
-        const surcharge = Math.round(taxableAmount * 0.029) + 30
+      async ({ summary }) => {
+        // Stripe-specific: apply a 2.9% + 30¢ surcharge on the running total
+        const currentTotal = summary.lines.reduce(
+          (sum, line) => sum + line.amount,
+          0,
+        )
+        const surcharge = Math.round(currentTotal * 0.029) + 30
 
-        return [
-          {
-            type: 'custom',
-            label: 'Processing Fee',
-            amount: surcharge,
-          },
-        ]
+        return {
+          ...summary,
+          lines: [
+            ...summary.lines,
+            {
+              type: 'custom',
+              label: 'Processing Fee',
+              amount: surcharge,
+            },
+          ],
+        }
       },
     ],
   },
 }
 ```
 
-See [plugin.mdx#Payment hooks](./plugin#payment-hooks) for the full `Adjustment` shape and the list of arguments passed to each hook.
+See [plugin.mdx#Payment hooks](./plugin#payment-hooks) for the full `Summary` / `Line` shapes and the list of arguments passed to each hook.
 
 #### Payment Fields
 

--- a/docs/ecommerce/plugin.mdx
+++ b/docs/ecommerce/plugin.mdx
@@ -753,27 +753,46 @@ Hooks can be defined at two levels:
 - **Plugin-level** hooks (`payments.hooks`) run for every payment method configured in the plugin.
 - **Adapter-level** hooks (`paymentMethod.hooks`) run only for the specific adapter they belong to. See [Adapter hooks](./payments#adapter-hooks) for details.
 
-Plugin-level hooks run first, then adapter-level hooks. Within each tier hooks run sequentially, so later hooks receive the cumulative adjustments from earlier ones.
+Plugin-level hooks run first, then adapter-level hooks. Within each tier, hooks run sequentially — each hook receives the `summary` updated by every earlier hook.
 
-| Hook                    | Signature                                         | Description                                                                                                                                |
-| ----------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `beforeInitiatePayment` | `(args) => Adjustment[] \| Promise<Adjustment[]>` | Runs after cart and product validation, before the adapter's `initiatePayment`. Return adjustments to apply to the total. Throwing aborts. |
-| `beforeConfirmOrder`    | `(args) => void \| Promise<void>`                 | Runs before the adapter's `confirmOrder`. Use for pre-confirmation checks (e.g. re-validating a gift card). Throwing aborts.               |
-| `afterConfirmOrder`     | `(args) => void \| Promise<void>`                 | Runs after a successful order. Use for side effects like emails or redeeming gift cards. Errors are logged but do not fail the response.   |
+| Hook                    | Signature                               | Description                                                                                                                              |
+| ----------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `beforeInitiatePayment` | `(args) => Summary \| Promise<Summary>` | Runs after cart and product validation, before the adapter's `initiatePayment`. Return an updated `Summary`. Throwing aborts.            |
+| `beforeConfirmOrder`    | `(args) => void \| Promise<void>`       | Runs before the adapter's `confirmOrder`. Use for pre-confirmation checks (e.g. re-validating a gift card). Throwing aborts.             |
+| `afterConfirmOrder`     | `(args) => void \| Promise<void>`       | Runs after a successful order. Use for side effects like emails or redeeming gift cards. Errors are logged but do not fail the response. |
 
-#### Adjustments
+#### The Summary object
 
-An `Adjustment` represents a monetary modification to the payment total:
+The summary is a running breakdown of what the customer will be charged. The plugin builds an initial summary from the cart subtotal and pipes it through every `beforeInitiatePayment` hook. The final summary is passed to the payment adapter, returned in the API response, and stored on the transaction and order records.
 
-| Property   | Type                                                           | Description                                                                                                           |
-| ---------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `type`     | `'tax' \| 'shipping' \| 'discount' \| 'gift_card' \| 'custom'` | The type of adjustment.                                                                                               |
-| `label`    | `string`                                                       | Human-readable label for display (e.g. "CA Sales Tax", "Standard Shipping").                                          |
-| `amount`   | `number`                                                       | The amount in the smallest currency unit (e.g. cents). Positive values increase the total, negative values reduce it. |
-| `id`       | `string`                                                       | (Optional) Unique identifier, useful for idempotency.                                                                 |
-| `metadata` | `object`                                                       | (Optional) Arbitrary metadata — useful for storing provider transaction IDs or audit data.                            |
+```ts
+type Summary = {
+  total: number // recomputed by the plugin after each hook
+  currency: string // locked — cannot be changed inside a hook
+  lines: Line[] // lines[0] is always the cart subtotal
+}
 
-The final amount charged to the customer is `cart.subtotal + sum(adjustments)`.
+type Line = {
+  type: 'subtotal' | 'tax' | 'shipping' | 'discount' | 'gift_card' | 'custom'
+  label: string
+  amount: number // signed; negative reduces the total (discounts, gift cards)
+  metadata?: Record<string, unknown>
+}
+```
+
+When `hooks` are configured the plugin adds a read-only `summary` group field to the default transactions and orders collections, so the breakdown is queryable alongside the existing `amount` field — useful for receipts, refunds, and tax reporting. If you aren't using hooks, these fields are not added to your collections.
+
+<Banner type="info">
+  You never need to recalculate `summary.total` yourself. The plugin recomputes
+  it from `sum(lines[].amount)` after every hook runs. Just return the summary
+  with your line appended (or an existing line modified) — the plugin handles
+  the math.
+</Banner>
+
+**Invariants enforced after each hook:**
+
+- `lines[0]` must remain the subtotal line with the original cart subtotal. Removing it or changing its amount throws.
+- `currency` cannot change.
 
 #### Simple example
 
@@ -792,15 +811,17 @@ export default buildConfig({
         ],
         hooks: {
           beforeInitiatePayment: [
-            () => {
-              return [
+            ({ summary }) => ({
+              ...summary,
+              lines: [
+                ...summary.lines,
                 {
                   type: 'custom',
                   label: 'Handling Fee',
                   amount: 500, // $5.00
                 },
-              ]
-            },
+              ],
+            }),
           ],
         },
       },
@@ -811,7 +832,7 @@ export default buildConfig({
 
 #### How to add taxes and shipping calculations
 
-This is the canonical use case — you compute taxes and shipping on the server, attach them as adjustments, and the sum is what the payment provider charges. Because hooks run sequentially, you can calculate tax on `subtotal + shipping` by reading the cumulative `adjustments` argument:
+This is the canonical use case — you compute taxes and shipping on the server and append them to `summary.lines`. Because hooks run sequentially, the tax hook can read the shipping line out of `summary.lines` and tax it when the region requires:
 
 ```ts
 import { ecommercePlugin } from '@payloadcms/plugin-ecommerce'
@@ -827,9 +848,9 @@ export default buildConfig({
         hooks: {
           beforeInitiatePayment: [
             // 1. Add shipping cost based on the shipping address
-            async ({ cart, shippingAddress }) => {
+            async ({ summary, cart, shippingAddress }) => {
               if (!shippingAddress) {
-                return []
+                return summary
               }
 
               const shippingCost = await calculateShippingCost({
@@ -837,33 +858,47 @@ export default buildConfig({
                 address: shippingAddress,
               })
 
-              return [
-                {
-                  type: 'shipping',
-                  label: 'Standard Shipping',
-                  amount: shippingCost,
-                },
-              ]
+              return {
+                ...summary,
+                lines: [
+                  ...summary.lines,
+                  {
+                    type: 'shipping',
+                    label: 'Standard Shipping',
+                    amount: shippingCost,
+                  },
+                ],
+              }
             },
-            // 2. Calculate tax on subtotal + shipping (runs after shipping hook)
-            async ({ adjustments, shippingAddress, subtotal }) => {
+            // 2. Calculate tax — taxes shipping only where the jurisdiction requires
+            async ({ summary, shippingAddress }) => {
               if (!shippingAddress) {
-                return []
+                return summary
               }
 
-              const taxableAmount =
-                subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
+              const shippingIsTaxable = isShippingTaxableIn(shippingAddress)
+              const taxableAmount = summary.lines
+                .filter(
+                  (line) =>
+                    line.type === 'subtotal' ||
+                    (line.type === 'shipping' && shippingIsTaxable),
+                )
+                .reduce((sum, line) => sum + line.amount, 0)
 
               const taxRate = await fetchTaxRate(shippingAddress)
               const taxAmount = Math.round(taxableAmount * taxRate)
 
-              return [
-                {
-                  type: 'tax',
-                  label: `Sales Tax (${(taxRate * 100).toFixed(2)}%)`,
-                  amount: taxAmount,
-                },
-              ]
+              return {
+                ...summary,
+                lines: [
+                  ...summary.lines,
+                  {
+                    type: 'tax',
+                    label: `Sales Tax (${(taxRate * 100).toFixed(2)}%)`,
+                    amount: taxAmount,
+                  },
+                ],
+              }
             },
           ],
         },
@@ -873,24 +908,46 @@ export default buildConfig({
 })
 ```
 
-Each hook receives the following arguments:
+Each `beforeInitiatePayment` hook receives:
 
-| Property           | Type                   | Description                                                      |
-| ------------------ | ---------------------- | ---------------------------------------------------------------- |
-| `cart`             | `Cart`                 | The validated cart with items and subtotal.                      |
-| `subtotal`         | `number`               | The computed subtotal from cart items (smallest currency unit).  |
-| `adjustments`      | `Adjustment[]`         | Cumulative adjustments from hooks that ran earlier in the chain. |
-| `currency`         | `string`               | The resolved currency code.                                      |
-| `currenciesConfig` | `CurrenciesConfig`     | The full currencies configuration.                               |
-| `customerEmail`    | `string`               | Customer email address.                                          |
-| `billingAddress`   | `Address \| undefined` | The billing address if provided.                                 |
-| `shippingAddress`  | `Address \| undefined` | The shipping address if provided.                                |
-| `req`              | `PayloadRequest`       | The Payload request — use `req.payload` for database access.     |
+| Property           | Type                   | Description                                                                                            |
+| ------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `summary`          | `Summary`              | The running summary — lines from the cart plus anything earlier hooks appended. Return an updated one. |
+| `cart`             | `Cart`                 | The validated cart with items.                                                                         |
+| `currency`         | `string`               | The resolved currency code.                                                                            |
+| `currenciesConfig` | `CurrenciesConfig`     | The full currencies configuration.                                                                     |
+| `customerEmail`    | `string`               | Customer email address.                                                                                |
+| `billingAddress`   | `Address \| undefined` | The billing address if provided.                                                                       |
+| `shippingAddress`  | `Address \| undefined` | The shipping address if provided.                                                                      |
+| `req`              | `PayloadRequest`       | The Payload request — use `req.payload` for database access.                                           |
+
+#### Response shape
+
+Once all `beforeInitiatePayment` hooks have run, the `/payments/{provider}/initiate` endpoint returns the final summary alongside the adapter's response:
+
+```json
+{
+  "message": "Payment initiated successfully",
+  "clientSecret": "pi_...",
+  "paymentIntentID": "pi_...",
+  "summary": {
+    "total": 22000,
+    "currency": "USD",
+    "lines": [
+      { "type": "subtotal", "label": "Subtotal", "amount": 20000 },
+      { "type": "shipping", "label": "Standard", "amount": 500 },
+      { "type": "tax", "label": "Sales Tax", "amount": 1500 }
+    ]
+  }
+}
+```
+
+Frontends can render the breakdown directly from `summary.lines` without having to re-run the calculation logic.
 
 <Banner type="warning">
   Always compute prices on the server. Never read tax or shipping costs from
-  client-supplied values — the payment amount is whatever your hooks return plus
-  the validated cart subtotal.
+  client-supplied values — the payment amount is whatever your hooks produce on
+  top of the validated cart subtotal.
 </Banner>
 
 ## Products

--- a/docs/ecommerce/plugin.mdx
+++ b/docs/ecommerce/plugin.mdx
@@ -624,9 +624,10 @@ For now it's quite rudimentary tracking with no integrations to 3rd party servic
 
 The `payments` option is used to configure payments and supported payment methods.
 
-| Option           | Type    | Description                                                                                       |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `paymentMethods` | `array` | An array of payment method adapters. Currently, only Stripe is supported. [More](#stripe-adapter) |
+| Option           | Type     | Description                                                                                                                           |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `paymentMethods` | `array`  | An array of payment method adapters. Currently, only Stripe is supported. [More](#stripe-adapter)                                     |
+| `hooks`          | `object` | Hooks that run for all payment methods. Use these to add adjustments like tax and shipping to the final total. [More](#payment-hooks) |
 
 ### Payment adapters
 
@@ -742,6 +743,155 @@ import { stripeAdapterClient } from '@payloadcms/plugin-ecommerce/payments/strip
   {children}
 </EcommerceProvider>
 ```
+
+### Payment hooks
+
+Payment hooks let you inject logic into the payment flow without modifying payment adapters. They are the recommended way to apply taxes, shipping costs, discount codes, gift cards, or any other monetary adjustment on top of the cart subtotal.
+
+Hooks can be defined at two levels:
+
+- **Plugin-level** hooks (`payments.hooks`) run for every payment method configured in the plugin.
+- **Adapter-level** hooks (`paymentMethod.hooks`) run only for the specific adapter they belong to. See [Adapter hooks](./payments#adapter-hooks) for details.
+
+Plugin-level hooks run first, then adapter-level hooks. Within each tier hooks run sequentially, so later hooks receive the cumulative adjustments from earlier ones.
+
+| Hook                    | Signature                                         | Description                                                                                                                                |
+| ----------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `beforeInitiatePayment` | `(args) => Adjustment[] \| Promise<Adjustment[]>` | Runs after cart and product validation, before the adapter's `initiatePayment`. Return adjustments to apply to the total. Throwing aborts. |
+| `beforeConfirmOrder`    | `(args) => void \| Promise<void>`                 | Runs before the adapter's `confirmOrder`. Use for pre-confirmation checks (e.g. re-validating a gift card). Throwing aborts.               |
+| `afterConfirmOrder`     | `(args) => void \| Promise<void>`                 | Runs after a successful order. Use for side effects like emails or redeeming gift cards. Errors are logged but do not fail the response.   |
+
+#### Adjustments
+
+An `Adjustment` represents a monetary modification to the payment total:
+
+| Property   | Type                                                           | Description                                                                                                           |
+| ---------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `type`     | `'tax' \| 'shipping' \| 'discount' \| 'gift_card' \| 'custom'` | The type of adjustment.                                                                                               |
+| `label`    | `string`                                                       | Human-readable label for display (e.g. "CA Sales Tax", "Standard Shipping").                                          |
+| `amount`   | `number`                                                       | The amount in the smallest currency unit (e.g. cents). Positive values increase the total, negative values reduce it. |
+| `id`       | `string`                                                       | (Optional) Unique identifier, useful for idempotency.                                                                 |
+| `metadata` | `object`                                                       | (Optional) Arbitrary metadata — useful for storing provider transaction IDs or audit data.                            |
+
+The final amount charged to the customer is `cart.subtotal + sum(adjustments)`.
+
+#### Simple example
+
+A minimal hook that adds a $5 flat handling fee to every payment:
+
+```ts
+import { ecommercePlugin } from '@payloadcms/plugin-ecommerce'
+
+export default buildConfig({
+  plugins: [
+    ecommercePlugin({
+      // rest of config...
+      payments: {
+        paymentMethods: [
+          /* your payment adapters */
+        ],
+        hooks: {
+          beforeInitiatePayment: [
+            () => {
+              return [
+                {
+                  type: 'custom',
+                  label: 'Handling Fee',
+                  amount: 500, // $5.00
+                },
+              ]
+            },
+          ],
+        },
+      },
+    }),
+  ],
+})
+```
+
+#### How to add taxes and shipping calculations
+
+This is the canonical use case — you compute taxes and shipping on the server, attach them as adjustments, and the sum is what the payment provider charges. Because hooks run sequentially, you can calculate tax on `subtotal + shipping` by reading the cumulative `adjustments` argument:
+
+```ts
+import { ecommercePlugin } from '@payloadcms/plugin-ecommerce'
+
+export default buildConfig({
+  plugins: [
+    ecommercePlugin({
+      // rest of config...
+      payments: {
+        paymentMethods: [
+          /* your payment adapters */
+        ],
+        hooks: {
+          beforeInitiatePayment: [
+            // 1. Add shipping cost based on the shipping address
+            async ({ cart, shippingAddress }) => {
+              if (!shippingAddress) {
+                return []
+              }
+
+              const shippingCost = await calculateShippingCost({
+                items: cart.items,
+                address: shippingAddress,
+              })
+
+              return [
+                {
+                  type: 'shipping',
+                  label: 'Standard Shipping',
+                  amount: shippingCost,
+                },
+              ]
+            },
+            // 2. Calculate tax on subtotal + shipping (runs after shipping hook)
+            async ({ adjustments, shippingAddress, subtotal }) => {
+              if (!shippingAddress) {
+                return []
+              }
+
+              const taxableAmount =
+                subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
+
+              const taxRate = await fetchTaxRate(shippingAddress)
+              const taxAmount = Math.round(taxableAmount * taxRate)
+
+              return [
+                {
+                  type: 'tax',
+                  label: `Sales Tax (${(taxRate * 100).toFixed(2)}%)`,
+                  amount: taxAmount,
+                },
+              ]
+            },
+          ],
+        },
+      },
+    }),
+  ],
+})
+```
+
+Each hook receives the following arguments:
+
+| Property           | Type                   | Description                                                      |
+| ------------------ | ---------------------- | ---------------------------------------------------------------- |
+| `cart`             | `Cart`                 | The validated cart with items and subtotal.                      |
+| `subtotal`         | `number`               | The computed subtotal from cart items (smallest currency unit).  |
+| `adjustments`      | `Adjustment[]`         | Cumulative adjustments from hooks that ran earlier in the chain. |
+| `currency`         | `string`               | The resolved currency code.                                      |
+| `currenciesConfig` | `CurrenciesConfig`     | The full currencies configuration.                               |
+| `customerEmail`    | `string`               | Customer email address.                                          |
+| `billingAddress`   | `Address \| undefined` | The billing address if provided.                                 |
+| `shippingAddress`  | `Address \| undefined` | The shipping address if provided.                                |
+| `req`              | `PayloadRequest`       | The Payload request — use `req.payload` for database access.     |
+
+<Banner type="warning">
+  Always compute prices on the server. Never read tax or shipping costs from
+  client-supplied values — the payment amount is whatever your hooks return plus
+  the validated cart subtotal.
+</Banner>
 
 ## Products
 

--- a/packages/plugin-ecommerce/src/collections/orders/createOrdersCollection.ts
+++ b/packages/plugin-ecommerce/src/collections/orders/createOrdersCollection.ts
@@ -5,6 +5,7 @@ import type { AccessConfig, CurrenciesConfig } from '../../types/index.js'
 import { amountField } from '../../fields/amountField.js'
 import { cartItemsField } from '../../fields/cartItemsField.js'
 import { currencyField } from '../../fields/currencyField.js'
+import { summaryField } from '../../fields/summaryField.js'
 import { accessOR } from '../../utilities/accessComposition.js'
 
 type Props = {
@@ -19,6 +20,12 @@ type Props = {
    */
   customersSlug?: string
   enableVariants?: boolean
+  /**
+   * Whether payment hooks are configured. When true, a `summary` group field is
+   * added to the collection to record the breakdown (subtotal, tax, shipping, etc.)
+   * produced by the payment hook pipeline.
+   */
+  hasHooks?: boolean
   /**
    * Slug of the products collection, defaults to 'products'.
    */
@@ -40,6 +47,7 @@ export const createOrdersCollection: (props: Props) => CollectionConfig = (props
     currenciesConfig,
     customersSlug = 'users',
     enableVariants = false,
+    hasHooks = false,
     productsSlug = 'products',
     transactionsSlug = 'transactions',
     variantsSlug = 'variants',
@@ -187,6 +195,7 @@ export const createOrdersCollection: (props: Props) => CollectionConfig = (props
           } as Field,
         ]
       : []),
+    ...(hasHooks && currenciesConfig ? [summaryField({ currenciesConfig })] : []),
   ]
 
   const baseConfig: CollectionConfig = {

--- a/packages/plugin-ecommerce/src/collections/transactions/createTransactionsCollection.ts
+++ b/packages/plugin-ecommerce/src/collections/transactions/createTransactionsCollection.ts
@@ -6,6 +6,7 @@ import { amountField } from '../../fields/amountField.js'
 import { cartItemsField } from '../../fields/cartItemsField.js'
 import { currencyField } from '../../fields/currencyField.js'
 import { statusField } from '../../fields/statusField.js'
+import { summaryField } from '../../fields/summaryField.js'
 
 type Props = {
   access: Pick<AccessConfig, 'isAdmin'>
@@ -26,6 +27,12 @@ type Props = {
    * Enable variants in the transactions collection.
    */
   enableVariants?: boolean
+  /**
+   * Whether payment hooks are configured. When true, a `summary` group field is
+   * added to the collection to record the breakdown (subtotal, tax, shipping, etc.)
+   * produced by the payment hook pipeline.
+   */
+  hasHooks?: boolean
   /**
    * Slug of the orders collection, defaults to 'orders'.
    */
@@ -49,6 +56,7 @@ export const createTransactionsCollection: (props: Props) => CollectionConfig = 
     currenciesConfig,
     customersSlug = 'users',
     enableVariants = false,
+    hasHooks = false,
     ordersSlug = 'orders',
     paymentMethods,
     productsSlug = 'products',
@@ -187,6 +195,7 @@ export const createTransactionsCollection: (props: Props) => CollectionConfig = 
           } as Field,
         ]
       : []),
+    ...(hasHooks && currenciesConfig ? [summaryField({ currenciesConfig })] : []),
   ]
 
   const baseConfig: CollectionConfig = {

--- a/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
@@ -1,6 +1,16 @@
 import { addDataAndFileToRequest, type DefaultDocumentIDType, type Endpoint } from 'payload'
 
-import type { CurrenciesConfig, PaymentAdapter, ProductsValidation } from '../types/index.js'
+import type {
+  CurrenciesConfig,
+  PaymentAdapter,
+  PaymentHooks,
+  ProductsValidation,
+} from '../types/index.js'
+
+import {
+  runAfterConfirmOrderHooks,
+  runBeforeConfirmOrderHooks,
+} from '../utilities/runPaymentHooks.js'
 
 type Args = {
   /**
@@ -16,6 +26,10 @@ type Args = {
    * The slug of the orders collection, defaults to 'orders'.
    */
   ordersSlug?: string
+  /**
+   * Plugin-level payment hooks that run for all payment methods.
+   */
+  paymentHooks?: PaymentHooks
   paymentMethod: PaymentAdapter
   /**
    * The slug of the products collection, defaults to 'products'.
@@ -47,6 +61,7 @@ export const confirmOrderHandler: ConfirmOrderHandler =
     currenciesConfig,
     customersSlug = 'users',
     ordersSlug = 'orders',
+    paymentHooks,
     paymentMethod,
     productsSlug = 'products',
     productsValidation,
@@ -155,6 +170,32 @@ export const confirmOrderHandler: ConfirmOrderHandler =
       )
     }
 
+    // Run beforeConfirmOrder hooks (plugin-level then adapter-level)
+    const pluginBeforeHooks = paymentHooks?.beforeConfirmOrder ?? []
+    const adapterBeforeHooks = paymentMethod.hooks?.beforeConfirmOrder ?? []
+    const allBeforeConfirmHooks = [...pluginBeforeHooks, ...adapterBeforeHooks]
+
+    if (allBeforeConfirmHooks.length > 0) {
+      try {
+        await runBeforeConfirmOrderHooks(allBeforeConfirmHooks, {
+          customerEmail,
+          data: data as Record<string, unknown>,
+          req,
+        })
+      } catch (error) {
+        payload.logger.error(error, 'Error in beforeConfirmOrder hook.')
+
+        return Response.json(
+          {
+            message: error instanceof Error ? error.message : 'Error in beforeConfirmOrder hook.',
+          },
+          {
+            status: 400,
+          },
+        )
+      }
+    }
+
     try {
       const paymentResponse = await paymentMethod.confirmOrder({
         cartsSlug,
@@ -207,6 +248,26 @@ export const confirmOrderHandler: ConfirmOrderHandler =
               })
             }
           }
+        }
+      }
+
+      // Run afterConfirmOrder hooks (plugin-level then adapter-level)
+      // Errors are logged but do not fail the response
+      if (paymentResponse.orderID && paymentResponse.transactionID) {
+        const pluginAfterHooks = paymentHooks?.afterConfirmOrder ?? []
+        const adapterAfterHooks = paymentMethod.hooks?.afterConfirmOrder ?? []
+        const allAfterConfirmHooks = [...pluginAfterHooks, ...adapterAfterHooks]
+
+        if (allAfterConfirmHooks.length > 0) {
+          await runAfterConfirmOrderHooks(
+            allAfterConfirmHooks,
+            {
+              orderID: paymentResponse.orderID,
+              req,
+              transactionID: paymentResponse.transactionID,
+            },
+            payload.logger,
+          )
         }
       }
 

--- a/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
@@ -23,6 +23,12 @@ type Args = {
    */
   customersSlug?: string
   /**
+   * Whether the transactions/orders collections have the `summary` field.
+   * When true, the handler copies the summary from the transaction onto the
+   * created order and includes it in the response.
+   */
+  hasHooks?: boolean
+  /**
    * The slug of the orders collection, defaults to 'orders'.
    */
   ordersSlug?: string
@@ -60,6 +66,7 @@ export const confirmOrderHandler: ConfirmOrderHandler =
     cartsSlug = 'carts',
     currenciesConfig,
     customersSlug = 'users',
+    hasHooks = false,
     ordersSlug = 'orders',
     paymentHooks,
     paymentMethod,
@@ -209,6 +216,8 @@ export const confirmOrderHandler: ConfirmOrderHandler =
         transactionsSlug,
       })
 
+      let persistedSummary: unknown
+
       if (paymentResponse.transactionID) {
         const transaction = await payload.findByID({
           id: paymentResponse.transactionID,
@@ -217,8 +226,13 @@ export const confirmOrderHandler: ConfirmOrderHandler =
           select: {
             id: true,
             items: true,
+            ...(hasHooks ? { summary: true } : {}),
           },
         })
+
+        if (hasHooks && transaction && 'summary' in transaction) {
+          persistedSummary = (transaction as { summary?: unknown }).summary
+        }
 
         if (transaction && Array.isArray(transaction.items) && transaction.items.length > 0) {
           for (const item of transaction.items) {
@@ -251,6 +265,23 @@ export const confirmOrderHandler: ConfirmOrderHandler =
         }
       }
 
+      // Copy the summary from the transaction onto the order so the breakdown
+      // is available on both records. Errors are logged, not thrown — the order
+      // has already been successfully created by the adapter.
+      if (hasHooks && paymentResponse.orderID && persistedSummary) {
+        try {
+          await payload.update({
+            id: paymentResponse.orderID,
+            collection: ordersSlug,
+            data: { summary: persistedSummary },
+            overrideAccess: true,
+            req,
+          })
+        } catch (error) {
+          payload.logger.error(error, 'Failed to copy summary onto order.')
+        }
+      }
+
       // Run afterConfirmOrder hooks (plugin-level then adapter-level)
       // Errors are logged but do not fail the response
       if (paymentResponse.orderID && paymentResponse.transactionID) {
@@ -273,6 +304,10 @@ export const confirmOrderHandler: ConfirmOrderHandler =
 
       if ('paymentResponse.transactionID' in paymentResponse && paymentResponse.transactionID) {
         delete (paymentResponse as Partial<typeof paymentResponse>).transactionID
+      }
+
+      if (hasHooks && persistedSummary) {
+        return Response.json({ ...paymentResponse, summary: persistedSummary })
       }
 
       return Response.json(paymentResponse)

--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -1,12 +1,12 @@
 import { addDataAndFileToRequest, type DefaultDocumentIDType, type Endpoint } from 'payload'
 
 import type {
-  Adjustment,
   CurrenciesConfig,
   PaymentAdapter,
   PaymentHooks,
   ProductsValidation,
   SanitizedEcommercePluginConfig,
+  Summary,
 } from '../types/index.js'
 
 import { defaultProductsValidation } from '../utilities/defaultProductsValidation.js'
@@ -22,6 +22,12 @@ type Args = {
    * The slug of the customers collection, defaults to 'users'.
    */
   customersSlug?: string
+  /**
+   * Whether the transactions collection has the `summary` field. When true,
+   * the handler will persist the computed summary onto the transaction record
+   * after the adapter returns.
+   */
+  hasHooks?: boolean
   /**
    * Track inventory stock for the products and variants.
    * Accepts an object to override the default field name.
@@ -61,6 +67,7 @@ export const initiatePaymentHandler: InitiatePayment =
     cartsSlug = 'carts',
     currenciesConfig,
     customersSlug = 'users',
+    hasHooks = false,
     paymentHooks,
     paymentMethod,
     productsSlug = 'products',
@@ -319,18 +326,22 @@ export const initiatePaymentHandler: InitiatePayment =
       }
     }
 
-    // Run payment hooks to compute adjustments (tax, shipping, discounts, etc.)
+    // Build the initial payment summary from the cart subtotal, then run hooks
+    // (plugin-level then adapter-level) to append tax, shipping, discounts, etc.
+    const cartSubtotal = cart.subtotal ?? 0
+    let summary: Summary = {
+      currency,
+      lines: [{ type: 'subtotal', amount: cartSubtotal, label: 'Subtotal' }],
+      total: cartSubtotal,
+    }
+
     const pluginHooks = paymentHooks?.beforeInitiatePayment ?? []
     const adapterHooks = paymentMethod.hooks?.beforeInitiatePayment ?? []
     const allBeforeInitiateHooks = [...pluginHooks, ...adapterHooks]
 
-    let adjustments: Adjustment[] = []
-    let total = cart.subtotal ?? 0
-
     if (allBeforeInitiateHooks.length > 0) {
       try {
-        const hookContext = {
-          adjustments: [],
+        summary = await runBeforeInitiatePaymentHooks(allBeforeInitiateHooks, {
           billingAddress,
           cart,
           currenciesConfig,
@@ -338,12 +349,8 @@ export const initiatePaymentHandler: InitiatePayment =
           customerEmail,
           req,
           shippingAddress,
-          subtotal: cart.subtotal ?? 0,
-        }
-
-        adjustments = await runBeforeInitiatePaymentHooks(allBeforeInitiateHooks, hookContext)
-        total =
-          (cart.subtotal ?? 0) + adjustments.reduce((sum, adjustment) => sum + adjustment.amount, 0)
+          summary,
+        })
       } catch (error) {
         payload.logger.error(error, 'Error in beforeInitiatePayment hook.')
 
@@ -357,36 +364,52 @@ export const initiatePaymentHandler: InitiatePayment =
           },
         )
       }
+    }
 
-      if (total <= 0) {
-        return Response.json(
-          {
-            message: 'Total after adjustments must be greater than zero.',
-          },
-          {
-            status: 400,
-          },
-        )
-      }
+    if (summary.total <= 0) {
+      return Response.json(
+        {
+          message: 'Total after adjustments must be greater than zero.',
+        },
+        {
+          status: 400,
+        },
+      )
     }
 
     try {
       const paymentResponse = await paymentMethod.initiatePayment({
         customersSlug,
         data: {
-          adjustments,
           billingAddress,
           cart,
           currency,
           customerEmail,
           shippingAddress,
-          total,
+          summary,
         },
         req,
         transactionsSlug,
       })
 
-      return Response.json(paymentResponse)
+      // Persist the summary onto the transaction so the breakdown is queryable
+      // later (receipts, refunds, reporting). The adapter returns the transactionID
+      // when it has created a record; if not, persistence is skipped gracefully.
+      if (hasHooks && paymentResponse.transactionID) {
+        try {
+          await payload.update({
+            id: paymentResponse.transactionID,
+            collection: transactionsSlug,
+            data: { summary },
+            overrideAccess: true,
+            req,
+          })
+        } catch (error) {
+          payload.logger.error(error, 'Failed to persist summary onto transaction.')
+        }
+      }
+
+      return Response.json({ ...paymentResponse, summary })
     } catch (error) {
       payload.logger.error(error, 'Error initiating payment.')
 

--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -1,13 +1,16 @@
 import { addDataAndFileToRequest, type DefaultDocumentIDType, type Endpoint } from 'payload'
 
 import type {
+  Adjustment,
   CurrenciesConfig,
   PaymentAdapter,
+  PaymentHooks,
   ProductsValidation,
   SanitizedEcommercePluginConfig,
 } from '../types/index.js'
 
 import { defaultProductsValidation } from '../utilities/defaultProductsValidation.js'
+import { runBeforeInitiatePaymentHooks } from '../utilities/runPaymentHooks.js'
 
 type Args = {
   /**
@@ -24,6 +27,10 @@ type Args = {
    * Accepts an object to override the default field name.
    */
   inventory?: SanitizedEcommercePluginConfig['inventory']
+  /**
+   * Plugin-level payment hooks that run for all payment methods.
+   */
+  paymentHooks?: PaymentHooks
   paymentMethod: PaymentAdapter
   /**
    * The slug of the products collection, defaults to 'products'.
@@ -54,6 +61,7 @@ export const initiatePaymentHandler: InitiatePayment =
     cartsSlug = 'carts',
     currenciesConfig,
     customersSlug = 'users',
+    paymentHooks,
     paymentMethod,
     productsSlug = 'products',
     productsValidation,
@@ -311,15 +319,68 @@ export const initiatePaymentHandler: InitiatePayment =
       }
     }
 
+    // Run payment hooks to compute adjustments (tax, shipping, discounts, etc.)
+    const pluginHooks = paymentHooks?.beforeInitiatePayment ?? []
+    const adapterHooks = paymentMethod.hooks?.beforeInitiatePayment ?? []
+    const allBeforeInitiateHooks = [...pluginHooks, ...adapterHooks]
+
+    let adjustments: Adjustment[] = []
+    let total = cart.subtotal ?? 0
+
+    if (allBeforeInitiateHooks.length > 0) {
+      try {
+        const hookContext = {
+          adjustments: [],
+          billingAddress,
+          cart,
+          currenciesConfig,
+          currency,
+          customerEmail,
+          req,
+          shippingAddress,
+          subtotal: cart.subtotal ?? 0,
+        }
+
+        adjustments = await runBeforeInitiatePaymentHooks(allBeforeInitiateHooks, hookContext)
+        total =
+          (cart.subtotal ?? 0) + adjustments.reduce((sum, adjustment) => sum + adjustment.amount, 0)
+      } catch (error) {
+        payload.logger.error(error, 'Error in beforeInitiatePayment hook.')
+
+        return Response.json(
+          {
+            message:
+              error instanceof Error ? error.message : 'Error in beforeInitiatePayment hook.',
+          },
+          {
+            status: 400,
+          },
+        )
+      }
+
+      if (total <= 0) {
+        return Response.json(
+          {
+            message: 'Total after adjustments must be greater than zero.',
+          },
+          {
+            status: 400,
+          },
+        )
+      }
+    }
+
     try {
       const paymentResponse = await paymentMethod.initiatePayment({
         customersSlug,
         data: {
+          adjustments,
           billingAddress,
           cart,
           currency,
           customerEmail,
           shippingAddress,
+          total,
         },
         req,
         transactionsSlug,

--- a/packages/plugin-ecommerce/src/exports/types.ts
+++ b/packages/plugin-ecommerce/src/exports/types.ts
@@ -1,6 +1,4 @@
 export type {
-  Adjustment,
-  AdjustmentType,
   AfterConfirmOrderHook,
   BeforeConfirmOrderHook,
   BeforeInitiatePaymentHook,
@@ -14,6 +12,8 @@ export type {
   EcommerceConfig,
   EcommerceContextType,
   EcommercePluginConfig,
+  Line,
+  LineType,
   PaymentAdapter,
   PaymentAdapterArgs,
   PaymentAdapterClient,
@@ -21,6 +21,7 @@ export type {
   PaymentHooks,
   ProductsValidation,
   SanitizedEcommercePluginConfig,
+  Summary,
 } from '../types/index.js'
 
 export type { TypedEcommerce } from '../types/utilities.js'

--- a/packages/plugin-ecommerce/src/exports/types.ts
+++ b/packages/plugin-ecommerce/src/exports/types.ts
@@ -1,4 +1,9 @@
 export type {
+  Adjustment,
+  AdjustmentType,
+  AfterConfirmOrderHook,
+  BeforeConfirmOrderHook,
+  BeforeInitiatePaymentHook,
   CollectionOverride,
   CollectionSlugMap,
   ContextProps,
@@ -13,6 +18,7 @@ export type {
   PaymentAdapterArgs,
   PaymentAdapterClient,
   PaymentAdapterClientArgs,
+  PaymentHooks,
   ProductsValidation,
   SanitizedEcommercePluginConfig,
 } from '../types/index.js'

--- a/packages/plugin-ecommerce/src/fields/summaryField.ts
+++ b/packages/plugin-ecommerce/src/fields/summaryField.ts
@@ -1,0 +1,70 @@
+import type { Field, GroupField } from 'payload'
+
+import type { CurrenciesConfig } from '../types/index.js'
+
+import { amountField } from './amountField.js'
+import { currencyField } from './currencyField.js'
+
+type Props = {
+  currenciesConfig: CurrenciesConfig
+  overrides?: Partial<GroupField>
+}
+
+/**
+ * A read-only group field that records the computed payment summary for a
+ * transaction or order — total, currency, and the ordered list of lines
+ * (subtotal, tax, shipping, discount, etc.) produced by the payment hook pipeline.
+ */
+export const summaryField: (props: Props) => GroupField = ({ currenciesConfig, overrides }) => {
+  const lineFields: Field[] = [
+    {
+      name: 'type',
+      type: 'select',
+      options: [
+        { label: 'Subtotal', value: 'subtotal' },
+        { label: 'Tax', value: 'tax' },
+        { label: 'Shipping', value: 'shipping' },
+        { label: 'Discount', value: 'discount' },
+        { label: 'Gift Card', value: 'gift_card' },
+        { label: 'Custom', value: 'custom' },
+      ],
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'text',
+      required: true,
+    },
+    amountField({
+      currenciesConfig,
+      overrides: { required: true },
+    }),
+    {
+      name: 'metadata',
+      type: 'json',
+    },
+  ]
+
+  const field: GroupField = {
+    name: 'summary',
+    type: 'group',
+    admin: {
+      readOnly: true,
+    },
+    fields: [
+      amountField({
+        currenciesConfig,
+        overrides: { name: 'total' },
+      }),
+      currencyField({ currenciesConfig }),
+      {
+        name: 'lines',
+        type: 'array',
+        fields: lineFields,
+      },
+    ],
+    ...overrides,
+  }
+
+  return field
+}

--- a/packages/plugin-ecommerce/src/index.ts
+++ b/packages/plugin-ecommerce/src/index.ts
@@ -32,6 +32,13 @@ export const ecommercePlugin =
 
     const accessConfig = sanitizedPluginConfig.access
 
+    // Payment hooks are opt-in. When any hook is configured (either plugin-level
+    // or on an adapter), the default transactions and orders collections gain a
+    // `summary` field that records the breakdown produced by the hook pipeline.
+    const hasHooks =
+      Boolean(sanitizedPluginConfig.payments.hooks) ||
+      (sanitizedPluginConfig.payments.paymentMethods ?? []).some((pm) => Boolean(pm.hooks))
+
     // Ensure collections exists
     if (!incomingConfig.collections) {
       incomingConfig.collections = []
@@ -196,6 +203,7 @@ export const ecommercePlugin =
         currenciesConfig,
         customersSlug: collectionSlugMap.customers,
         enableVariants,
+        hasHooks,
         productsSlug: collectionSlugMap.products,
         variantsSlug: collectionSlugMap.variants ?? 'variants',
       })
@@ -235,6 +243,7 @@ export const ecommercePlugin =
           const initiatePayment: Endpoint = {
             handler: initiatePaymentHandler({
               currenciesConfig,
+              hasHooks,
               inventory: sanitizedPluginConfig.inventory,
               paymentHooks,
               paymentMethod,
@@ -251,6 +260,7 @@ export const ecommercePlugin =
             handler: confirmOrderHandler({
               cartsSlug: collectionSlugMap.carts,
               currenciesConfig,
+              hasHooks,
               ordersSlug: collectionSlugMap.orders,
               paymentHooks,
               paymentMethod,
@@ -292,6 +302,7 @@ export const ecommercePlugin =
         currenciesConfig,
         customersSlug: collectionSlugMap.customers,
         enableVariants,
+        hasHooks,
         ordersSlug: collectionSlugMap.orders,
         paymentMethods,
         productsSlug: collectionSlugMap.products,

--- a/packages/plugin-ecommerce/src/index.ts
+++ b/packages/plugin-ecommerce/src/index.ts
@@ -226,6 +226,8 @@ export const ecommercePlugin =
             sanitizedPluginConfig.products.validation) ||
           undefined
 
+        const paymentHooks = sanitizedPluginConfig.payments.hooks
+
         paymentMethods.forEach((paymentMethod) => {
           const methodPath = `/payments/${paymentMethod.name}`
           const endpoints: Endpoint[] = []
@@ -234,6 +236,7 @@ export const ecommercePlugin =
             handler: initiatePaymentHandler({
               currenciesConfig,
               inventory: sanitizedPluginConfig.inventory,
+              paymentHooks,
               paymentMethod,
               productsSlug: collectionSlugMap.products,
               productsValidation,
@@ -249,6 +252,7 @@ export const ecommercePlugin =
               cartsSlug: collectionSlugMap.carts,
               currenciesConfig,
               ordersSlug: collectionSlugMap.orders,
+              paymentHooks,
               paymentMethod,
               productsSlug: collectionSlugMap.products,
               productsValidation,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/index.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/index.ts
@@ -1,4 +1,4 @@
-import type { Field, GroupField, PayloadRequest } from 'payload'
+import type { DefaultDocumentIDType, Field, GroupField, PayloadRequest } from 'payload'
 import type { Stripe } from 'stripe'
 
 import type {
@@ -132,4 +132,5 @@ export type InitiatePaymentReturnType = {
   clientSecret: string
   message: string
   paymentIntentID: string
+  transactionID: DefaultDocumentIDType
 }

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -18,7 +18,8 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
     const customerEmail = data.customerEmail
     const currency = data.currency
     const cart = data.cart
-    const amount = cart.subtotal
+    const amount = data.total ?? cart.subtotal
+    const adjustments = data.adjustments
     const billingAddressFromData = data.billingAddress
     const shippingAddressFromData = data.shippingAddress
 
@@ -96,6 +97,9 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
         currency,
         customer: customer.id,
         metadata: {
+          ...(adjustments && adjustments.length > 0
+            ? { adjustments: JSON.stringify(adjustments) }
+            : {}),
           cartID: cart.id,
           cartItemsSnapshot: JSON.stringify(flattenedCart),
           shippingAddress: shippingAddressAsString,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -18,8 +18,8 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
     const customerEmail = data.customerEmail
     const currency = data.currency
     const cart = data.cart
-    const amount = data.total ?? cart.subtotal
-    const adjustments = data.adjustments
+    const summary = data.summary
+    const amount = summary.total
     const billingAddressFromData = data.billingAddress
     const shippingAddressFromData = data.shippingAddress
 
@@ -97,12 +97,10 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
         currency,
         customer: customer.id,
         metadata: {
-          ...(adjustments && adjustments.length > 0
-            ? { adjustments: JSON.stringify(adjustments) }
-            : {}),
           cartID: cart.id,
           cartItemsSnapshot: JSON.stringify(flattenedCart),
           shippingAddress: shippingAddressAsString,
+          summary: JSON.stringify(summary),
         },
       })
 
@@ -130,6 +128,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
         clientSecret: paymentIntent.client_secret || '',
         message: 'Payment initiated successfully',
         paymentIntentID: paymentIntent.id,
+        transactionID: transaction.id,
       }
 
       return returnData

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -45,31 +45,58 @@ type DefaultCartType = {
 
 export type Cart = DefaultCartType
 
-export type AdjustmentType = 'custom' | 'discount' | 'gift_card' | 'shipping' | 'tax'
+export type LineType = 'custom' | 'discount' | 'gift_card' | 'shipping' | 'subtotal' | 'tax'
 
-export type Adjustment = {
+/**
+ * A single line item making up a payment summary — items, tax, shipping, discount, etc.
+ */
+export type Line = {
   /**
-   * The amount of the adjustment in the smallest currency unit (e.g. cents for USD).
+   * The signed amount of the line in the smallest currency unit (e.g. cents for USD).
    * Positive values increase the total (tax, shipping).
    * Negative values decrease the total (discount, gift card).
    */
   amount: number
   /**
-   * Optional unique identifier for this adjustment, useful for idempotency.
-   */
-  id?: string
-  /**
    * Human-readable label for display (e.g., "CA Sales Tax", "Standard Shipping").
    */
   label: string
   /**
-   * Optional metadata for adapter-specific or user-specific data.
+   * Optional metadata for adapter-specific or user-specific data. A common pattern
+   * is to stash a `taxable` flag here so later hooks know whether to include this line,
+   * or an external identifier for idempotency with a tax/shipping provider.
    */
   metadata?: Record<string, unknown>
   /**
-   * The type of adjustment.
+   * The type of line.
    */
-  type: AdjustmentType
+  type: LineType
+}
+
+/**
+ * Full breakdown of the payment amount. Passed through the beforeInitiatePayment hook
+ * pipeline and returned in the `/payments/{provider}/initiate` response.
+ *
+ * The plugin recomputes `total` from `lines` after every hook, so you never need to
+ * update `total` yourself inside a hook — just return the updated `lines`. The first
+ * line is always the cart subtotal and is managed by the plugin; removing it or changing
+ * its amount will throw.
+ */
+export type Summary = {
+  /**
+   * The ISO currency code used for all line amounts.
+   */
+  currency: string
+  /**
+   * Ordered list of line items contributing to the total.
+   * `lines[0]` is always the cart subtotal and is managed by the plugin.
+   */
+  lines: Line[]
+  /**
+   * The final amount charged. Always equal to `sum(lines[].amount)`. This value is
+   * recomputed by the plugin after each hook — any value a hook sets is ignored.
+   */
+  total: number
 }
 
 /**
@@ -108,21 +135,31 @@ export type PaymentHookContext = {
 
 /**
  * Hook that runs before payment initiation, after validation.
- * Returns an array of adjustments to apply to the payment total.
+ *
+ * Receives the current `Summary` (total, currency, lines) and must return an updated
+ * `Summary`. Typically you'll spread the incoming summary and append your line:
+ *
+ * ```ts
+ * return {
+ *   ...summary,
+ *   lines: [...summary.lines, { type: 'tax', label: 'Sales Tax', amount: 1500 }],
+ * }
+ * ```
+ *
+ * The plugin recomputes `summary.total` from `summary.lines` after this hook runs,
+ * so you never need to update `total` yourself.
+ *
  * Throwing an error aborts the payment.
  */
 export type BeforeInitiatePaymentHook = (
   args: {
     /**
-     * Adjustments from previously-run hooks in the chain.
+     * The running summary — the cart subtotal plus any lines contributed by prior hooks.
+     * Return a new summary with your line appended (or existing lines modified).
      */
-    adjustments: Adjustment[]
-    /**
-     * The computed subtotal from cart items.
-     */
-    subtotal: number
+    summary: Summary
   } & PaymentHookContext,
-) => Adjustment[] | Promise<Adjustment[]>
+) => Promise<Summary> | Summary
 
 /**
  * Hook that runs before order confirmation.
@@ -180,6 +217,13 @@ type InitiatePaymentReturnType = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
   message: string
+  /**
+   * Optional ID of the transaction record created during initiation. When returned,
+   * the plugin will write the computed `summary` onto this transaction — so the
+   * breakdown (subtotal, tax, shipping, etc.) is available on the record alongside
+   * the total.
+   */
+  transactionID?: DefaultDocumentIDType
 }
 
 type InitiatePayment = (args: {
@@ -188,10 +232,6 @@ type InitiatePayment = (args: {
    */
   customersSlug?: string
   data: {
-    /**
-     * Adjustments computed by payment hooks. Empty array when no hooks are configured.
-     */
-    adjustments?: Adjustment[]
     /**
      * Billing address for the payment.
      */
@@ -210,9 +250,11 @@ type InitiatePayment = (args: {
      */
     shippingAddress?: TypedCollection['addresses']
     /**
-     * The final total (subtotal + sum of adjustments). Equals subtotal when no adjustments are present.
+     * The final payment summary after all beforeInitiatePayment hooks have run.
+     * Use `summary.total` as the amount to charge and store `summary.lines` if you
+     * need to persist the breakdown (e.g. in provider metadata).
      */
-    total?: number
+    summary: Summary
   }
   req: PayloadRequest
   /**

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -45,6 +45,134 @@ type DefaultCartType = {
 
 export type Cart = DefaultCartType
 
+export type AdjustmentType = 'custom' | 'discount' | 'gift_card' | 'shipping' | 'tax'
+
+export type Adjustment = {
+  /**
+   * The amount of the adjustment in the smallest currency unit (e.g. cents for USD).
+   * Positive values increase the total (tax, shipping).
+   * Negative values decrease the total (discount, gift card).
+   */
+  amount: number
+  /**
+   * Optional unique identifier for this adjustment, useful for idempotency.
+   */
+  id?: string
+  /**
+   * Human-readable label for display (e.g., "CA Sales Tax", "Standard Shipping").
+   */
+  label: string
+  /**
+   * Optional metadata for adapter-specific or user-specific data.
+   */
+  metadata?: Record<string, unknown>
+  /**
+   * The type of adjustment.
+   */
+  type: AdjustmentType
+}
+
+/**
+ * Context provided to payment hooks during the initiate payment flow.
+ */
+export type PaymentHookContext = {
+  /**
+   * Billing address, if provided.
+   */
+  billingAddress?: TypedCollection['addresses']
+  /**
+   * The validated cart with items.
+   */
+  cart: Cart
+  /**
+   * The currencies configuration.
+   */
+  currenciesConfig: CurrenciesConfig
+  /**
+   * The resolved currency code.
+   */
+  currency: string
+  /**
+   * Customer email address.
+   */
+  customerEmail: string
+  /**
+   * The Payload request object.
+   */
+  req: PayloadRequest
+  /**
+   * Shipping address, if provided.
+   */
+  shippingAddress?: TypedCollection['addresses']
+}
+
+/**
+ * Hook that runs before payment initiation, after validation.
+ * Returns an array of adjustments to apply to the payment total.
+ * Throwing an error aborts the payment.
+ */
+export type BeforeInitiatePaymentHook = (
+  args: {
+    /**
+     * Adjustments from previously-run hooks in the chain.
+     */
+    adjustments: Adjustment[]
+    /**
+     * The computed subtotal from cart items.
+     */
+    subtotal: number
+  } & PaymentHookContext,
+) => Adjustment[] | Promise<Adjustment[]>
+
+/**
+ * Hook that runs before order confirmation.
+ * Can inspect data before the adapter confirms. Throwing an error aborts the confirmation.
+ */
+export type BeforeConfirmOrderHook = (args: {
+  /**
+   * Customer email.
+   */
+  customerEmail: string
+  /**
+   * All data passed to the confirm-order endpoint.
+   */
+  data: Record<string, unknown>
+  /**
+   * The Payload request object.
+   */
+  req: PayloadRequest
+}) => Promise<void> | void
+
+/**
+ * Hook that runs after order confirmation succeeds.
+ * For side effects only (sending emails, updating external systems, redeeming gift cards).
+ * Return value is ignored. Errors are logged but do not fail the response.
+ */
+export type AfterConfirmOrderHook = (args: {
+  /**
+   * The created order ID.
+   */
+  orderID: DefaultDocumentIDType
+  /**
+   * The Payload request object.
+   */
+  req: PayloadRequest
+  /**
+   * The transaction ID.
+   */
+  transactionID: DefaultDocumentIDType
+}) => Promise<void> | void
+
+/**
+ * Hook configuration for the payment flow. Used at both the plugin level
+ * (runs for all payment methods) and the adapter level (runs for that adapter only).
+ */
+export type PaymentHooks = {
+  afterConfirmOrder?: AfterConfirmOrderHook[]
+  beforeConfirmOrder?: BeforeConfirmOrderHook[]
+  beforeInitiatePayment?: BeforeInitiatePaymentHook[]
+}
+
 type InitiatePaymentReturnType = {
   /**
    * Allows for additional data to be returned, such as payment method specific data
@@ -60,6 +188,10 @@ type InitiatePayment = (args: {
    */
   customersSlug?: string
   data: {
+    /**
+     * Adjustments computed by payment hooks. Empty array when no hooks are configured.
+     */
+    adjustments?: Adjustment[]
     /**
      * Billing address for the payment.
      */
@@ -77,6 +209,10 @@ type InitiatePayment = (args: {
      * Shipping address for the payment.
      */
     shippingAddress?: TypedCollection['addresses']
+    /**
+     * The final total (subtotal + sum of adjustments). Equals subtotal when no adjustments are present.
+     */
+    total?: number
   }
   req: PayloadRequest
   /**
@@ -193,6 +329,21 @@ export type PaymentAdapter = {
    * ```
    */
   group: GroupField
+  /**
+   * Hooks specific to this payment adapter. These run after plugin-level hooks.
+   *
+   * @example
+   * ```ts
+   * hooks: {
+   *   beforeInitiatePayment: [
+   *     async ({ subtotal }) => {
+   *       return [{ type: 'tax', label: 'Stripe Tax', amount: calculatedTax }]
+   *     },
+   *   ],
+   * }
+   * ```
+   */
+  hooks?: PaymentHooks
   /**
    * The function that is called via the `/api/payments/{provider_name}/initiate` endpoint to initiate a payment for an order.
    *
@@ -441,6 +592,22 @@ export type CustomQuery = {
 }
 
 export type PaymentsConfig = {
+  /**
+   * Hooks that run for all payment methods. Plugin-level hooks execute before adapter-level hooks.
+   *
+   * @example
+   * ```ts
+   * hooks: {
+   *   beforeInitiatePayment: [
+   *     async ({ subtotal, shippingAddress }) => {
+   *       const taxRate = await fetchTaxRate(shippingAddress)
+   *       return [{ type: 'tax', label: 'Sales Tax', amount: Math.round(subtotal * taxRate) }]
+   *     },
+   *   ],
+   * }
+   * ```
+   */
+  hooks?: PaymentHooks
   paymentMethods?: PaymentAdapter[]
   productsQuery?: CustomQuery
   variantsQuery?: CustomQuery
@@ -783,6 +950,7 @@ export type SanitizedEcommercePluginConfig = {
   currencies: Required<CurrenciesConfig>
   inventory?: InventoryConfig
   payments: {
+    hooks?: PaymentHooks
     paymentMethods: [] | PaymentAdapter[]
   }
 } & Omit<

--- a/packages/plugin-ecommerce/src/utilities/runPaymentHooks.spec.ts
+++ b/packages/plugin-ecommerce/src/utilities/runPaymentHooks.spec.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  AfterConfirmOrderHook,
+  Adjustment,
+  BeforeConfirmOrderHook,
+  BeforeInitiatePaymentHook,
+} from '../types/index.js'
+
+import {
+  runAfterConfirmOrderHooks,
+  runBeforeConfirmOrderHooks,
+  runBeforeInitiatePaymentHooks,
+} from './runPaymentHooks.js'
+
+const createMockInitiateContext = (overrides = {}) => ({
+  adjustments: [] as Adjustment[],
+  cart: {
+    id: 'cart-1',
+    items: [{ id: 'item-1', product: 'prod-1', quantity: 1 }],
+    subtotal: 1000,
+  },
+  currency: 'USD',
+  currenciesConfig: {
+    defaultCurrency: 'USD',
+    supportedCurrencies: [{ code: 'USD', decimals: 2, label: 'US Dollar', symbol: '$' }],
+  },
+  customerEmail: 'test@example.com',
+  req: {} as any,
+  subtotal: 1000,
+  ...overrides,
+})
+
+describe('runBeforeInitiatePaymentHooks', () => {
+  it('should return empty array when no hooks are provided', async () => {
+    const context = createMockInitiateContext()
+    const result = await runBeforeInitiatePaymentHooks([], context)
+    expect(result).toEqual([])
+  })
+
+  it('should accumulate adjustments from a single hook', async () => {
+    const taxHook: BeforeInitiatePaymentHook = () => [
+      { amount: 100, label: 'Sales Tax', type: 'tax' },
+    ]
+
+    const context = createMockInitiateContext()
+    const result = await runBeforeInitiatePaymentHooks([taxHook], context)
+
+    expect(result).toEqual([{ amount: 100, label: 'Sales Tax', type: 'tax' }])
+  })
+
+  it('should accumulate adjustments from multiple hooks', async () => {
+    const taxHook: BeforeInitiatePaymentHook = () => [
+      { amount: 100, label: 'Sales Tax', type: 'tax' },
+    ]
+
+    const shippingHook: BeforeInitiatePaymentHook = () => [
+      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
+    ]
+
+    const context = createMockInitiateContext()
+    const result = await runBeforeInitiatePaymentHooks([taxHook, shippingHook], context)
+
+    expect(result).toEqual([
+      { amount: 100, label: 'Sales Tax', type: 'tax' },
+      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
+    ])
+  })
+
+  it('should pass cumulative adjustments to subsequent hooks', async () => {
+    const shippingHook: BeforeInitiatePaymentHook = () => [
+      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
+    ]
+
+    const taxOnTotalHook: BeforeInitiatePaymentHook = ({ adjustments, subtotal }) => {
+      const currentTotal = subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
+      return [{ amount: Math.round(currentTotal * 0.1), label: 'Tax on total', type: 'tax' }]
+    }
+
+    const context = createMockInitiateContext({ subtotal: 1000 })
+    const result = await runBeforeInitiatePaymentHooks([shippingHook, taxOnTotalHook], context)
+
+    expect(result).toEqual([
+      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
+      { amount: 150, label: 'Tax on total', type: 'tax' },
+    ])
+  })
+
+  it('should handle async hooks', async () => {
+    const asyncHook: BeforeInitiatePaymentHook = async () => {
+      return [{ amount: 200, label: 'Async Tax', type: 'tax' }]
+    }
+
+    const context = createMockInitiateContext()
+    const result = await runBeforeInitiatePaymentHooks([asyncHook], context)
+
+    expect(result).toEqual([{ amount: 200, label: 'Async Tax', type: 'tax' }])
+  })
+
+  it('should throw when a hook throws, aborting payment', async () => {
+    const failingHook: BeforeInitiatePaymentHook = () => {
+      throw new Error('Tax service unavailable')
+    }
+
+    const neverReachedHook: BeforeInitiatePaymentHook = vi.fn(() => [])
+
+    const context = createMockInitiateContext()
+
+    await expect(
+      runBeforeInitiatePaymentHooks([failingHook, neverReachedHook], context),
+    ).rejects.toThrow('Tax service unavailable')
+
+    expect(neverReachedHook).not.toHaveBeenCalled()
+  })
+
+  it('should handle hooks that return an empty array', async () => {
+    const emptyHook: BeforeInitiatePaymentHook = () => []
+    const taxHook: BeforeInitiatePaymentHook = () => [{ amount: 100, label: 'Tax', type: 'tax' }]
+
+    const context = createMockInitiateContext()
+    const result = await runBeforeInitiatePaymentHooks([emptyHook, taxHook], context)
+
+    expect(result).toEqual([{ amount: 100, label: 'Tax', type: 'tax' }])
+  })
+
+  it('should preserve existing adjustments passed in context', async () => {
+    const existingAdjustments: Adjustment[] = [{ amount: 50, label: 'Existing', type: 'custom' }]
+
+    const taxHook: BeforeInitiatePaymentHook = () => [{ amount: 100, label: 'Tax', type: 'tax' }]
+
+    const context = createMockInitiateContext({ adjustments: existingAdjustments })
+    const result = await runBeforeInitiatePaymentHooks([taxHook], context)
+
+    expect(result).toEqual([
+      { amount: 50, label: 'Existing', type: 'custom' },
+      { amount: 100, label: 'Tax', type: 'tax' },
+    ])
+  })
+})
+
+describe('runBeforeConfirmOrderHooks', () => {
+  const createMockConfirmContext = () => ({
+    customerEmail: 'test@example.com',
+    data: { paymentIntentID: 'pi_123' } as Record<string, unknown>,
+    req: {} as any,
+  })
+
+  it('should execute hooks sequentially', async () => {
+    const executionOrder: number[] = []
+
+    const hookOne: BeforeConfirmOrderHook = async () => {
+      executionOrder.push(1)
+    }
+
+    const hookTwo: BeforeConfirmOrderHook = async () => {
+      executionOrder.push(2)
+    }
+
+    const context = createMockConfirmContext()
+    await runBeforeConfirmOrderHooks([hookOne, hookTwo], context)
+
+    expect(executionOrder).toEqual([1, 2])
+  })
+
+  it('should throw when a hook throws', async () => {
+    const failingHook: BeforeConfirmOrderHook = () => {
+      throw new Error('Confirmation check failed')
+    }
+
+    const context = createMockConfirmContext()
+
+    await expect(runBeforeConfirmOrderHooks([failingHook], context)).rejects.toThrow(
+      'Confirmation check failed',
+    )
+  })
+
+  it('should not execute subsequent hooks after a failure', async () => {
+    const failingHook: BeforeConfirmOrderHook = () => {
+      throw new Error('Failed')
+    }
+
+    const neverReachedHook: BeforeConfirmOrderHook = vi.fn()
+
+    const context = createMockConfirmContext()
+
+    await expect(
+      runBeforeConfirmOrderHooks([failingHook, neverReachedHook], context),
+    ).rejects.toThrow('Failed')
+
+    expect(neverReachedHook).not.toHaveBeenCalled()
+  })
+
+  it('should handle empty hooks array', async () => {
+    const context = createMockConfirmContext()
+    await expect(runBeforeConfirmOrderHooks([], context)).resolves.toBeUndefined()
+  })
+})
+
+describe('runAfterConfirmOrderHooks', () => {
+  const createMockAfterContext = () => ({
+    orderID: 'order-1' as any,
+    req: {} as any,
+    transactionID: 'txn-1' as any,
+  })
+
+  const mockLogger = {
+    error: vi.fn(),
+  }
+
+  it('should not throw when a hook throws', async () => {
+    const failingHook: AfterConfirmOrderHook = () => {
+      throw new Error('Email service down')
+    }
+
+    const context = createMockAfterContext()
+    mockLogger.error.mockClear()
+
+    await expect(
+      runAfterConfirmOrderHooks([failingHook], context, mockLogger),
+    ).resolves.toBeUndefined()
+
+    expect(mockLogger.error).toHaveBeenCalled()
+  })
+
+  it('should execute all hooks even if one fails', async () => {
+    const executionOrder: number[] = []
+
+    const failingHook: AfterConfirmOrderHook = () => {
+      executionOrder.push(1)
+      throw new Error('Hook 1 failed')
+    }
+
+    const successHook: AfterConfirmOrderHook = async () => {
+      executionOrder.push(2)
+    }
+
+    const context = createMockAfterContext()
+    mockLogger.error.mockClear()
+
+    await runAfterConfirmOrderHooks([failingHook, successHook], context, mockLogger)
+
+    expect(executionOrder).toEqual([1, 2])
+    expect(mockLogger.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle empty hooks array', async () => {
+    const context = createMockAfterContext()
+    await expect(runAfterConfirmOrderHooks([], context, mockLogger)).resolves.toBeUndefined()
+  })
+
+  it('should pass correct context to hooks', async () => {
+    const receivedArgs: any[] = []
+
+    const captureHook: AfterConfirmOrderHook = (args) => {
+      receivedArgs.push(args)
+    }
+
+    const context = createMockAfterContext()
+    await runAfterConfirmOrderHooks([captureHook], context, mockLogger)
+
+    expect(receivedArgs[0]).toEqual({
+      orderID: 'order-1',
+      req: {},
+      transactionID: 'txn-1',
+    })
+  })
+})

--- a/packages/plugin-ecommerce/src/utilities/runPaymentHooks.spec.ts
+++ b/packages/plugin-ecommerce/src/utilities/runPaymentHooks.spec.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type {
   AfterConfirmOrderHook,
-  Adjustment,
   BeforeConfirmOrderHook,
   BeforeInitiatePaymentHook,
+  Summary,
 } from '../types/index.js'
 
 import {
@@ -13,96 +13,109 @@ import {
   runBeforeInitiatePaymentHooks,
 } from './runPaymentHooks.js'
 
-const createMockInitiateContext = (overrides = {}) => ({
-  adjustments: [] as Adjustment[],
+const createSummary = (subtotal = 1000): Summary => ({
+  currency: 'USD',
+  lines: [{ amount: subtotal, label: 'Subtotal', type: 'subtotal' }],
+  total: subtotal,
+})
+
+const createMockInitiateContext = (overrides: Record<string, unknown> = {}) => ({
+  billingAddress: undefined as any,
   cart: {
     id: 'cart-1',
     items: [{ id: 'item-1', product: 'prod-1', quantity: 1 }],
     subtotal: 1000,
   },
-  currency: 'USD',
   currenciesConfig: {
     defaultCurrency: 'USD',
     supportedCurrencies: [{ code: 'USD', decimals: 2, label: 'US Dollar', symbol: '$' }],
   },
+  currency: 'USD',
   customerEmail: 'test@example.com',
   req: {} as any,
-  subtotal: 1000,
+  shippingAddress: undefined as any,
+  summary: createSummary(),
   ...overrides,
 })
 
 describe('runBeforeInitiatePaymentHooks', () => {
-  it('should return empty array when no hooks are provided', async () => {
+  it('should return the incoming summary unchanged when no hooks are provided', async () => {
     const context = createMockInitiateContext()
     const result = await runBeforeInitiatePaymentHooks([], context)
-    expect(result).toEqual([])
+
+    expect(result.total).toBe(1000)
+    expect(result.lines).toHaveLength(1)
+    expect(result.lines[0]?.type).toBe('subtotal')
   })
 
-  it('should accumulate adjustments from a single hook', async () => {
-    const taxHook: BeforeInitiatePaymentHook = () => [
-      { amount: 100, label: 'Sales Tax', type: 'tax' },
-    ]
+  it('should append a single line and recompute total', async () => {
+    const taxHook: BeforeInitiatePaymentHook = ({ summary }) => ({
+      ...summary,
+      lines: [...summary.lines, { amount: 100, label: 'Sales Tax', type: 'tax' }],
+    })
 
     const context = createMockInitiateContext()
     const result = await runBeforeInitiatePaymentHooks([taxHook], context)
 
-    expect(result).toEqual([{ amount: 100, label: 'Sales Tax', type: 'tax' }])
+    expect(result.lines).toHaveLength(2)
+    expect(result.total).toBe(1100)
   })
 
-  it('should accumulate adjustments from multiple hooks', async () => {
-    const taxHook: BeforeInitiatePaymentHook = () => [
-      { amount: 100, label: 'Sales Tax', type: 'tax' },
-    ]
+  it('should pipe summary through multiple hooks and recompute total after each', async () => {
+    const shippingHook: BeforeInitiatePaymentHook = ({ summary }) => ({
+      ...summary,
+      lines: [...summary.lines, { amount: 500, label: 'Standard Shipping', type: 'shipping' }],
+    })
 
-    const shippingHook: BeforeInitiatePaymentHook = () => [
-      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
-    ]
+    const taxOnAllHook: BeforeInitiatePaymentHook = ({ summary }) => {
+      const taxable = summary.lines.reduce((sum, l) => sum + l.amount, 0)
+      return {
+        ...summary,
+        lines: [
+          ...summary.lines,
+          { amount: Math.round(taxable * 0.1), label: 'Tax (10%)', type: 'tax' },
+        ],
+      }
+    }
 
     const context = createMockInitiateContext()
-    const result = await runBeforeInitiatePaymentHooks([taxHook, shippingHook], context)
+    const result = await runBeforeInitiatePaymentHooks([shippingHook, taxOnAllHook], context)
 
-    expect(result).toEqual([
-      { amount: 100, label: 'Sales Tax', type: 'tax' },
-      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
-    ])
+    expect(result.lines).toHaveLength(3)
+    expect(result.total).toBe(1000 + 500 + Math.round(1500 * 0.1))
   })
 
-  it('should pass cumulative adjustments to subsequent hooks', async () => {
-    const shippingHook: BeforeInitiatePaymentHook = () => [
-      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
-    ]
+  it('should ignore any total a hook tries to set and recompute from lines', async () => {
+    const badHook: BeforeInitiatePaymentHook = ({ summary }) => ({
+      ...summary,
+      lines: [...summary.lines, { amount: 200, label: 'Tax', type: 'tax' }],
+      total: 999999,
+    })
 
-    const taxOnTotalHook: BeforeInitiatePaymentHook = ({ adjustments, subtotal }) => {
-      const currentTotal = subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
-      return [{ amount: Math.round(currentTotal * 0.1), label: 'Tax on total', type: 'tax' }]
-    }
+    const context = createMockInitiateContext()
+    const result = await runBeforeInitiatePaymentHooks([badHook], context)
 
-    const context = createMockInitiateContext({ subtotal: 1000 })
-    const result = await runBeforeInitiatePaymentHooks([shippingHook, taxOnTotalHook], context)
-
-    expect(result).toEqual([
-      { amount: 500, label: 'Standard Shipping', type: 'shipping' },
-      { amount: 150, label: 'Tax on total', type: 'tax' },
-    ])
+    expect(result.total).toBe(1200)
   })
 
-  it('should handle async hooks', async () => {
-    const asyncHook: BeforeInitiatePaymentHook = async () => {
-      return [{ amount: 200, label: 'Async Tax', type: 'tax' }]
-    }
+  it('should support async hooks', async () => {
+    const asyncHook: BeforeInitiatePaymentHook = async ({ summary }) => ({
+      ...summary,
+      lines: [...summary.lines, { amount: 200, label: 'Async Tax', type: 'tax' }],
+    })
 
     const context = createMockInitiateContext()
     const result = await runBeforeInitiatePaymentHooks([asyncHook], context)
 
-    expect(result).toEqual([{ amount: 200, label: 'Async Tax', type: 'tax' }])
+    expect(result.total).toBe(1200)
   })
 
-  it('should throw when a hook throws, aborting payment', async () => {
+  it('should throw when a hook throws, aborting the pipeline', async () => {
     const failingHook: BeforeInitiatePaymentHook = () => {
       throw new Error('Tax service unavailable')
     }
 
-    const neverReachedHook: BeforeInitiatePaymentHook = vi.fn(() => [])
+    const neverReachedHook: BeforeInitiatePaymentHook = vi.fn(({ summary }) => summary)
 
     const context = createMockInitiateContext()
 
@@ -113,28 +126,51 @@ describe('runBeforeInitiatePaymentHooks', () => {
     expect(neverReachedHook).not.toHaveBeenCalled()
   })
 
-  it('should handle hooks that return an empty array', async () => {
-    const emptyHook: BeforeInitiatePaymentHook = () => []
-    const taxHook: BeforeInitiatePaymentHook = () => [{ amount: 100, label: 'Tax', type: 'tax' }]
+  it('should throw when a hook removes the subtotal line', async () => {
+    const badHook: BeforeInitiatePaymentHook = ({ summary }) => ({
+      ...summary,
+      lines: summary.lines.filter((l) => l.type !== 'subtotal'),
+    })
 
     const context = createMockInitiateContext()
-    const result = await runBeforeInitiatePaymentHooks([emptyHook, taxHook], context)
 
-    expect(result).toEqual([{ amount: 100, label: 'Tax', type: 'tax' }])
+    await expect(runBeforeInitiatePaymentHooks([badHook], context)).rejects.toThrow(/subtotal line/)
   })
 
-  it('should preserve existing adjustments passed in context', async () => {
-    const existingAdjustments: Adjustment[] = [{ amount: 50, label: 'Existing', type: 'custom' }]
+  it('should throw when a hook modifies the subtotal amount', async () => {
+    const badHook: BeforeInitiatePaymentHook = ({ summary }) => ({
+      ...summary,
+      lines: [{ ...summary.lines[0]!, amount: 1 }, ...summary.lines.slice(1)],
+    })
 
-    const taxHook: BeforeInitiatePaymentHook = () => [{ amount: 100, label: 'Tax', type: 'tax' }]
+    const context = createMockInitiateContext()
 
-    const context = createMockInitiateContext({ adjustments: existingAdjustments })
-    const result = await runBeforeInitiatePaymentHooks([taxHook], context)
+    await expect(runBeforeInitiatePaymentHooks([badHook], context)).rejects.toThrow(
+      /subtotal amount/i,
+    )
+  })
 
-    expect(result).toEqual([
-      { amount: 50, label: 'Existing', type: 'custom' },
-      { amount: 100, label: 'Tax', type: 'tax' },
-    ])
+  it('should throw when a hook changes currency', async () => {
+    const badHook: BeforeInitiatePaymentHook = ({ summary }) => ({
+      ...summary,
+      currency: 'EUR',
+    })
+
+    const context = createMockInitiateContext()
+
+    await expect(runBeforeInitiatePaymentHooks([badHook], context)).rejects.toThrow(/currency/i)
+  })
+
+  it('should allow negative line amounts (discounts) and reflect them in total', async () => {
+    const discountHook: BeforeInitiatePaymentHook = ({ summary }) => ({
+      ...summary,
+      lines: [...summary.lines, { amount: -200, label: 'Discount: SAVE20', type: 'discount' }],
+    })
+
+    const context = createMockInitiateContext()
+    const result = await runBeforeInitiatePaymentHooks([discountHook], context)
+
+    expect(result.total).toBe(800)
   })
 })
 

--- a/packages/plugin-ecommerce/src/utilities/runPaymentHooks.ts
+++ b/packages/plugin-ecommerce/src/utilities/runPaymentHooks.ts
@@ -1,30 +1,77 @@
 import type {
-  Adjustment,
   AfterConfirmOrderHook,
   BeforeConfirmOrderHook,
   BeforeInitiatePaymentHook,
+  Summary,
 } from '../types/index.js'
 
+const recomputeTotal = (summary: Summary): Summary => ({
+  ...summary,
+  total: summary.lines.reduce((sum, line) => sum + line.amount, 0),
+})
+
+const assertSummaryInvariants = (
+  summary: Summary,
+  expected: { currency: string; subtotal: number },
+  hookIndex: number,
+): void => {
+  if (!summary || !Array.isArray(summary.lines)) {
+    throw new Error(
+      `beforeInitiatePayment hook ${hookIndex} returned an invalid summary (missing lines).`,
+    )
+  }
+
+  const subtotalLine = summary.lines[0]
+
+  if (!subtotalLine || subtotalLine.type !== 'subtotal') {
+    throw new Error(
+      `beforeInitiatePayment hook ${hookIndex} removed or reordered the subtotal line. lines[0] must always be the cart subtotal.`,
+    )
+  }
+
+  if (subtotalLine.amount !== expected.subtotal) {
+    throw new Error(
+      `beforeInitiatePayment hook ${hookIndex} changed the subtotal amount from ${expected.subtotal} to ${subtotalLine.amount}. Subtotal is managed by the plugin and must not be mutated.`,
+    )
+  }
+
+  if (summary.currency !== expected.currency) {
+    throw new Error(
+      `beforeInitiatePayment hook ${hookIndex} changed summary.currency — currency must remain "${expected.currency}".`,
+    )
+  }
+}
+
 /**
- * Runs beforeInitiatePayment hooks sequentially, accumulating adjustments.
- * Each hook receives the cumulative adjustments from prior hooks.
- * Throws if any hook throws, aborting the payment.
+ * Runs beforeInitiatePayment hooks sequentially, piping the Summary through each.
+ *
+ * After every hook, the plugin:
+ * 1. Recomputes `total` from `sum(lines[].amount)` — any total the hook sets is ignored.
+ * 2. Validates `lines[0]` is still the subtotal line with the original cart subtotal.
+ * 3. Validates `currency` has not changed.
+ *
+ * Throws (aborting the payment) if a hook throws or breaks an invariant.
  */
 export async function runBeforeInitiatePaymentHooks(
   hooks: BeforeInitiatePaymentHook[],
-  context: Parameters<BeforeInitiatePaymentHook>[0],
-): Promise<Adjustment[]> {
-  let adjustments = [...context.adjustments]
+  context: { summary: Summary } & Omit<Parameters<BeforeInitiatePaymentHook>[0], 'summary'>,
+): Promise<Summary> {
+  let summary: Summary = recomputeTotal(context.summary)
 
-  for (const hook of hooks) {
-    const newAdjustments = await hook({ ...context, adjustments })
-
-    if (Array.isArray(newAdjustments)) {
-      adjustments = [...adjustments, ...newAdjustments]
-    }
+  const expected = {
+    currency: summary.currency,
+    subtotal: summary.lines[0]?.amount ?? 0,
   }
 
-  return adjustments
+  for (let i = 0; i < hooks.length; i++) {
+    const hook = hooks[i]!
+    const next = await hook({ ...context, summary })
+
+    assertSummaryInvariants(next, expected, i)
+    summary = recomputeTotal(next)
+  }
+
+  return summary
 }
 
 /**

--- a/packages/plugin-ecommerce/src/utilities/runPaymentHooks.ts
+++ b/packages/plugin-ecommerce/src/utilities/runPaymentHooks.ts
@@ -1,0 +1,60 @@
+import type {
+  Adjustment,
+  AfterConfirmOrderHook,
+  BeforeConfirmOrderHook,
+  BeforeInitiatePaymentHook,
+} from '../types/index.js'
+
+/**
+ * Runs beforeInitiatePayment hooks sequentially, accumulating adjustments.
+ * Each hook receives the cumulative adjustments from prior hooks.
+ * Throws if any hook throws, aborting the payment.
+ */
+export async function runBeforeInitiatePaymentHooks(
+  hooks: BeforeInitiatePaymentHook[],
+  context: Parameters<BeforeInitiatePaymentHook>[0],
+): Promise<Adjustment[]> {
+  let adjustments = [...context.adjustments]
+
+  for (const hook of hooks) {
+    const newAdjustments = await hook({ ...context, adjustments })
+
+    if (Array.isArray(newAdjustments)) {
+      adjustments = [...adjustments, ...newAdjustments]
+    }
+  }
+
+  return adjustments
+}
+
+/**
+ * Runs beforeConfirmOrder hooks sequentially.
+ * Throws if any hook throws, aborting the confirmation.
+ */
+export async function runBeforeConfirmOrderHooks(
+  hooks: BeforeConfirmOrderHook[],
+  context: Parameters<BeforeConfirmOrderHook>[0],
+): Promise<void> {
+  for (const hook of hooks) {
+    await hook(context)
+  }
+}
+
+/**
+ * Runs afterConfirmOrder hooks sequentially.
+ * Errors are caught and logged but do not fail the response.
+ * All hooks execute even if some fail.
+ */
+export async function runAfterConfirmOrderHooks(
+  hooks: AfterConfirmOrderHook[],
+  context: Parameters<AfterConfirmOrderHook>[0],
+  logger: { error: (...args: unknown[]) => void },
+): Promise<void> {
+  for (const hook of hooks) {
+    try {
+      await hook(context)
+    } catch (error) {
+      logger.error(error, 'Error in afterConfirmOrder hook.')
+    }
+  }
+}

--- a/packages/plugin-ecommerce/src/utilities/sanitizePluginConfig.spec.ts
+++ b/packages/plugin-ecommerce/src/utilities/sanitizePluginConfig.spec.ts
@@ -342,6 +342,35 @@ describe('sanitizePluginConfig', () => {
 
       expect(result.payments.paymentMethods).toEqual([mockAdapter])
     })
+
+    it('should preserve hooks when provided', () => {
+      const beforeInitiateHook = vitest.fn()
+      const afterConfirmHook = vitest.fn()
+
+      const config: EcommercePluginConfig = {
+        ...minimalConfig,
+        payments: {
+          hooks: {
+            afterConfirmOrder: [afterConfirmHook],
+            beforeInitiatePayment: [beforeInitiateHook],
+          },
+          paymentMethods: [],
+        },
+      }
+
+      const result = sanitizePluginConfig({ pluginConfig: config })
+
+      expect(result.payments.hooks).toEqual({
+        afterConfirmOrder: [afterConfirmHook],
+        beforeInitiatePayment: [beforeInitiateHook],
+      })
+    })
+
+    it('should default hooks to undefined when not provided', () => {
+      const result = sanitizePluginConfig({ pluginConfig: minimalConfig })
+
+      expect(result.payments.hooks).toBeUndefined()
+    })
   })
 
   describe('products', () => {

--- a/test/plugin-ecommerce/config.ts
+++ b/test/plugin-ecommerce/config.ts
@@ -12,6 +12,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { Media } from './collections/Media.js'
 import { Users } from './collections/Users.js'
+import { mockPaymentAdapter, mockPluginHooks } from './mockPaymentAdapter.js'
 import { seed } from './seed/index.js'
 
 export const currenciesConfig: NonNullable<EcommercePluginConfig['currencies']> = {
@@ -90,7 +91,9 @@ export default buildConfigWithDefaults({
         variants: true,
       },
       payments: {
+        hooks: mockPluginHooks,
         paymentMethods: [
+          mockPaymentAdapter,
           stripeAdapter({
             secretKey: process.env.STRIPE_SECRET_KEY!,
             publishableKey: process.env.STRIPE_PUBLISHABLE_KEY!,

--- a/test/plugin-ecommerce/int.spec.ts
+++ b/test/plugin-ecommerce/int.spec.ts
@@ -1295,15 +1295,15 @@ describe('ecommerce', () => {
 
       expect(mockState.pluginBeforeInitiatePayment).toHaveLength(1)
       expect(mockState.adapterBeforeInitiatePayment).toHaveLength(1)
-      expect(mockState.pluginBeforeInitiatePayment[0]?.subtotal).toBe(1999)
-      expect(mockState.adapterBeforeInitiatePayment[0]?.subtotal).toBe(1999)
+      expect(mockState.pluginBeforeInitiatePayment[0]?.summary.lines[0]?.amount).toBe(1999)
+      expect(mockState.adapterBeforeInitiatePayment[0]?.summary.lines[0]?.amount).toBe(1999)
     })
 
-    it('should include adjustments in the total passed to the adapter', async () => {
+    it('should include hook-appended lines in the summary passed to the adapter', async () => {
       const { cartId, cartSecret } = await createCartAndAddProduct()
 
       setMockAdapterOptions({
-        injectAdjustments: [
+        appendLines: [
           { amount: 500, label: 'Shipping', type: 'shipping' },
           { amount: 200, label: 'Tax', type: 'tax' },
         ],
@@ -1321,16 +1321,18 @@ describe('ecommerce', () => {
         .then((res) => res.json())
 
       expect(mockState.initiateCalls).toHaveLength(1)
-      expect(mockState.initiateCalls[0]?.subtotal).toBe(1999)
-      expect(mockState.initiateCalls[0]?.total).toBe(1999 + 500 + 200)
-      expect(mockState.initiateCalls[0]?.adjustments).toHaveLength(2)
+      const summary = mockState.initiateCalls[0]?.summary
+      expect(summary?.lines).toHaveLength(3)
+      expect(summary?.lines[0]?.type).toBe('subtotal')
+      expect(summary?.lines[0]?.amount).toBe(1999)
+      expect(summary?.total).toBe(1999 + 500 + 200)
     })
 
-    it('should pass cumulative adjustments between hooks in order (plugin then adapter)', async () => {
+    it('should pass cumulative lines between hooks in order (plugin then adapter)', async () => {
       const { cartId, cartSecret } = await createCartAndAddProduct()
 
       setMockAdapterOptions({
-        injectAdjustments: [{ amount: 300, label: 'Adapter adj', type: 'custom' }],
+        appendLines: [{ amount: 300, label: 'Adapter line', type: 'custom' }],
       })
 
       await restClient
@@ -1344,10 +1346,10 @@ describe('ecommerce', () => {
         })
         .then((res) => res.json())
 
-      expect(mockState.pluginBeforeInitiatePayment[0]?.adjustments).toHaveLength(0)
-      expect(mockState.adapterBeforeInitiatePayment[0]?.adjustments).toHaveLength(0)
-      expect(mockState.initiateCalls[0]?.adjustments).toHaveLength(1)
-      expect(mockState.initiateCalls[0]?.total).toBe(1999 + 300)
+      expect(mockState.pluginBeforeInitiatePayment[0]?.summary.lines).toHaveLength(1)
+      expect(mockState.adapterBeforeInitiatePayment[0]?.summary.lines).toHaveLength(1)
+      expect(mockState.initiateCalls[0]?.summary.lines).toHaveLength(2)
+      expect(mockState.initiateCalls[0]?.summary.total).toBe(1999 + 300)
     })
 
     it('should abort payment when a beforeInitiatePayment hook throws', async () => {
@@ -1499,22 +1501,40 @@ describe('ecommerce', () => {
         .then((res) => res.json())
 
       expect(mockState.initiateCalls).toHaveLength(1)
-      expect(mockState.initiateCalls[0]?.subtotal).toBe(expectedSubtotal)
-      expect(mockState.initiateCalls[0]?.total).toBe(expectedTotal)
-      expect(mockState.initiateCalls[0]?.adjustments).toHaveLength(1)
-      expect(mockState.initiateCalls[0]?.adjustments?.[0]?.amount).toBe(expectedTax)
-      expect(mockState.initiateCalls[0]?.adjustments?.[0]?.type).toBe('tax')
+      const summary = mockState.initiateCalls[0]?.summary
+      expect(summary?.lines[0]?.type).toBe('subtotal')
+      expect(summary?.lines[0]?.amount).toBe(expectedSubtotal)
+      expect(summary?.total).toBe(expectedTotal)
+      expect(summary?.lines).toHaveLength(2)
+      expect(summary?.lines[1]?.type).toBe('tax')
+      expect(summary?.lines[1]?.amount).toBe(expectedTax)
+
+      expect(initiateResponse.summary).toBeDefined()
+      expect(initiateResponse.summary.total).toBe(expectedTotal)
+      expect(initiateResponse.summary.lines).toHaveLength(2)
+      expect(initiateResponse.summary.lines[0].type).toBe('subtotal')
+      expect(initiateResponse.summary.lines[1].type).toBe('tax')
 
       const transactions = await payload.find({
         collection: 'transactions',
         depth: 0,
+        overrideAccess: true,
         where: {
           'mock.mockPaymentID': { equals: initiateResponse.mockPaymentID },
         },
       })
-      expect(transactions.docs[0]?.amount).toBe(expectedTotal)
-      if (transactions.docs[0]?.id) {
-        createdTransactionIds.push(transactions.docs[0].id)
+      const transactionDoc = transactions.docs[0] as { id: string; summary?: any } | undefined
+      expect(transactionDoc?.amount).toBe(expectedTotal)
+      expect(transactionDoc?.summary).toBeDefined()
+      expect(transactionDoc?.summary?.total).toBe(expectedTotal)
+      expect(transactionDoc?.summary?.currency).toBe('USD')
+      expect(transactionDoc?.summary?.lines).toHaveLength(2)
+      expect(transactionDoc?.summary?.lines[0]?.type).toBe('subtotal')
+      expect(transactionDoc?.summary?.lines[0]?.amount).toBe(expectedSubtotal)
+      expect(transactionDoc?.summary?.lines[1]?.type).toBe('tax')
+      expect(transactionDoc?.summary?.lines[1]?.amount).toBe(expectedTax)
+      if (transactionDoc?.id) {
+        createdTransactionIds.push(transactionDoc.id)
       }
 
       const confirmResponse = await restClient
@@ -1532,15 +1552,26 @@ describe('ecommerce', () => {
       expect(confirmResponse.orderID).toBeTruthy()
       createdOrderIds.push(confirmResponse.orderID)
 
-      const order = await payload.findByID({
+      expect(confirmResponse.summary).toBeDefined()
+      expect(confirmResponse.summary.total).toBe(expectedTotal)
+      expect(confirmResponse.summary.lines).toHaveLength(2)
+      expect(confirmResponse.summary.lines[0].type).toBe('subtotal')
+      expect(confirmResponse.summary.lines[1].type).toBe('tax')
+
+      const order = (await payload.findByID({
         id: confirmResponse.orderID,
         collection: 'orders',
         overrideAccess: true,
-      })
+      })) as { amount: number; currency: string; summary?: any }
 
       expect(order.amount).toBe(expectedTotal)
       expect(order.amount).not.toBe(expectedSubtotal)
       expect(order.currency).toBe('USD')
+      expect(order.summary).toBeDefined()
+      expect(order.summary?.total).toBe(expectedTotal)
+      expect(order.summary?.lines).toHaveLength(2)
+      expect(order.summary?.lines[0]?.type).toBe('subtotal')
+      expect(order.summary?.lines[1]?.type).toBe('tax')
 
       await payload.delete({ id: cleanProductId, collection: 'products' }).catch(() => null)
     })

--- a/test/plugin-ecommerce/int.spec.ts
+++ b/test/plugin-ecommerce/int.spec.ts
@@ -1,11 +1,17 @@
 import path from 'path'
 import { type Payload } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import {
+  mockState,
+  resetMockAdapterOptions,
+  resetMockState,
+  setMockAdapterOptions,
+} from './mockPaymentAdapter.js'
 
 let payload: Payload
 let restClient: NextRESTClient
@@ -1217,6 +1223,362 @@ describe('ecommerce', () => {
 
       expect(userCartResponse.id).toBe(guestCartId)
       expect(userCartResponse.items).toHaveLength(1)
+    })
+  })
+
+  describe('payment hooks', () => {
+    let productId: string
+    const createdCartIds: string[] = []
+    const createdOrderIds: string[] = []
+    const createdTransactionIds: string[] = []
+
+    beforeAll(async () => {
+      const product = await payload.create({
+        collection: 'products',
+        data: {
+          name: 'Hook Test Product',
+          inventory: 100,
+          priceInUSDEnabled: true,
+          priceInUSD: 1999,
+        },
+      })
+      productId = product.id
+    })
+
+    afterAll(async () => {
+      await payload.delete({ id: productId, collection: 'products' }).catch(() => null)
+    })
+
+    afterEach(async () => {
+      resetMockState()
+      resetMockAdapterOptions()
+
+      for (const id of createdTransactionIds) {
+        await payload.delete({ id, collection: 'transactions' }).catch(() => null)
+      }
+      createdTransactionIds.length = 0
+
+      for (const id of createdOrderIds) {
+        await payload.delete({ id, collection: 'orders' }).catch(() => null)
+      }
+      createdOrderIds.length = 0
+
+      for (const id of createdCartIds) {
+        await payload.delete({ id, collection: 'carts' }).catch(() => null)
+      }
+      createdCartIds.length = 0
+    })
+
+    const createCartAndAddProduct = async () => {
+      const { cartId, cartSecret } = await createGuestCartWithItems(restClient, productId)
+      createdCartIds.push(cartId)
+      return { cartId, cartSecret }
+    }
+
+    it('should call both plugin-level and adapter-level beforeInitiatePayment hooks', async () => {
+      const { cartId, cartSecret } = await createCartAndAddProduct()
+
+      const response = await restClient
+        .POST('/payments/mock/initiate', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      if (response.transactionID) {
+        createdTransactionIds.push(response.transactionID)
+      }
+
+      expect(mockState.pluginBeforeInitiatePayment).toHaveLength(1)
+      expect(mockState.adapterBeforeInitiatePayment).toHaveLength(1)
+      expect(mockState.pluginBeforeInitiatePayment[0]?.subtotal).toBe(1999)
+      expect(mockState.adapterBeforeInitiatePayment[0]?.subtotal).toBe(1999)
+    })
+
+    it('should include adjustments in the total passed to the adapter', async () => {
+      const { cartId, cartSecret } = await createCartAndAddProduct()
+
+      setMockAdapterOptions({
+        injectAdjustments: [
+          { amount: 500, label: 'Shipping', type: 'shipping' },
+          { amount: 200, label: 'Tax', type: 'tax' },
+        ],
+      })
+
+      await restClient
+        .POST('/payments/mock/initiate', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      expect(mockState.initiateCalls).toHaveLength(1)
+      expect(mockState.initiateCalls[0]?.subtotal).toBe(1999)
+      expect(mockState.initiateCalls[0]?.total).toBe(1999 + 500 + 200)
+      expect(mockState.initiateCalls[0]?.adjustments).toHaveLength(2)
+    })
+
+    it('should pass cumulative adjustments between hooks in order (plugin then adapter)', async () => {
+      const { cartId, cartSecret } = await createCartAndAddProduct()
+
+      setMockAdapterOptions({
+        injectAdjustments: [{ amount: 300, label: 'Adapter adj', type: 'custom' }],
+      })
+
+      await restClient
+        .POST('/payments/mock/initiate', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      expect(mockState.pluginBeforeInitiatePayment[0]?.adjustments).toHaveLength(0)
+      expect(mockState.adapterBeforeInitiatePayment[0]?.adjustments).toHaveLength(0)
+      expect(mockState.initiateCalls[0]?.adjustments).toHaveLength(1)
+      expect(mockState.initiateCalls[0]?.total).toBe(1999 + 300)
+    })
+
+    it('should abort payment when a beforeInitiatePayment hook throws', async () => {
+      const { cartId, cartSecret } = await createCartAndAddProduct()
+
+      setMockAdapterOptions({ throwInBeforeInitiatePayment: true })
+
+      const response = await restClient.POST('/payments/mock/initiate', {
+        auth: false,
+        body: JSON.stringify({
+          cartID: cartId,
+          customerEmail: 'hooks-test@example.com',
+          secret: cartSecret,
+        }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(mockState.initiateCalls).toHaveLength(0)
+    })
+
+    it('should call beforeConfirmOrder and afterConfirmOrder hooks', async () => {
+      const { cartId, cartSecret } = await createCartAndAddProduct()
+
+      const initiateResponse = await restClient
+        .POST('/payments/mock/initiate', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      const confirmResponse = await restClient
+        .POST('/payments/mock/confirm-order', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            mockPaymentID: initiateResponse.mockPaymentID,
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      if (confirmResponse.orderID) {
+        createdOrderIds.push(confirmResponse.orderID)
+      }
+
+      expect(mockState.pluginBeforeConfirmOrder).toHaveLength(1)
+      expect(mockState.adapterBeforeConfirmOrder).toHaveLength(1)
+      expect(mockState.pluginAfterConfirmOrder).toHaveLength(1)
+      expect(mockState.adapterAfterConfirmOrder).toHaveLength(1)
+      expect(mockState.pluginAfterConfirmOrder[0]?.orderID).toBe(confirmResponse.orderID)
+    })
+
+    it('should abort confirmation when a beforeConfirmOrder hook throws', async () => {
+      const { cartId, cartSecret } = await createCartAndAddProduct()
+
+      const initiateResponse = await restClient
+        .POST('/payments/mock/initiate', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      setMockAdapterOptions({ throwInBeforeConfirmOrder: true })
+
+      const confirmResponse = await restClient.POST('/payments/mock/confirm-order', {
+        auth: false,
+        body: JSON.stringify({
+          cartID: cartId,
+          customerEmail: 'hooks-test@example.com',
+          mockPaymentID: initiateResponse.mockPaymentID,
+          secret: cartSecret,
+        }),
+      })
+
+      expect(confirmResponse.status).toBe(400)
+      expect(mockState.confirmOrderCalls).toHaveLength(0)
+      expect(mockState.pluginAfterConfirmOrder).toHaveLength(0)
+    })
+
+    it('should charge subtotal plus 10% adjustment end-to-end and persist the final amount on the order', async () => {
+      const cleanProduct = await payload.create({
+        collection: 'products',
+        data: {
+          name: 'Clean Price Product',
+          inventory: 100,
+          priceInUSDEnabled: true,
+          priceInUSD: 10000,
+        },
+      })
+      const cleanProductId = cleanProduct.id
+
+      const quantity = 2
+      const expectedSubtotal = 10000 * quantity
+      const expectedTax = Math.round(expectedSubtotal * 0.1)
+      const expectedTotal = expectedSubtotal + expectedTax
+
+      const createCartResponse = await restClient
+        .POST('/carts', {
+          auth: false,
+          body: JSON.stringify({
+            currency: 'USD',
+            items: [],
+          }),
+        })
+        .then((res) => res.json())
+
+      const cartId = createCartResponse.doc.id as string
+      const cartSecret = createCartResponse.doc.secret as string
+      createdCartIds.push(cartId)
+
+      await restClient
+        .POST(`/carts/${cartId}/add-item`, {
+          auth: false,
+          body: JSON.stringify({
+            item: { product: cleanProductId },
+            quantity,
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      const cartAfterAdd = await payload.findByID({
+        id: cartId,
+        collection: 'carts',
+        overrideAccess: true,
+      })
+      expect(cartAfterAdd.subtotal).toBe(expectedSubtotal)
+
+      setMockAdapterOptions({ addTenPercentTax: true })
+
+      const initiateResponse = await restClient
+        .POST('/payments/mock/initiate', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'e2e-test@example.com',
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      expect(mockState.initiateCalls).toHaveLength(1)
+      expect(mockState.initiateCalls[0]?.subtotal).toBe(expectedSubtotal)
+      expect(mockState.initiateCalls[0]?.total).toBe(expectedTotal)
+      expect(mockState.initiateCalls[0]?.adjustments).toHaveLength(1)
+      expect(mockState.initiateCalls[0]?.adjustments?.[0]?.amount).toBe(expectedTax)
+      expect(mockState.initiateCalls[0]?.adjustments?.[0]?.type).toBe('tax')
+
+      const transactions = await payload.find({
+        collection: 'transactions',
+        depth: 0,
+        where: {
+          'mock.mockPaymentID': { equals: initiateResponse.mockPaymentID },
+        },
+      })
+      expect(transactions.docs[0]?.amount).toBe(expectedTotal)
+      if (transactions.docs[0]?.id) {
+        createdTransactionIds.push(transactions.docs[0].id)
+      }
+
+      const confirmResponse = await restClient
+        .POST('/payments/mock/confirm-order', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'e2e-test@example.com',
+            mockPaymentID: initiateResponse.mockPaymentID,
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      expect(confirmResponse.orderID).toBeTruthy()
+      createdOrderIds.push(confirmResponse.orderID)
+
+      const order = await payload.findByID({
+        id: confirmResponse.orderID,
+        collection: 'orders',
+        overrideAccess: true,
+      })
+
+      expect(order.amount).toBe(expectedTotal)
+      expect(order.amount).not.toBe(expectedSubtotal)
+      expect(order.currency).toBe('USD')
+
+      await payload.delete({ id: cleanProductId, collection: 'products' }).catch(() => null)
+    })
+
+    it('should not fail order when an afterConfirmOrder hook throws', async () => {
+      const { cartId, cartSecret } = await createCartAndAddProduct()
+
+      const initiateResponse = await restClient
+        .POST('/payments/mock/initiate', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      setMockAdapterOptions({ throwInAfterConfirmOrder: true })
+
+      const confirmResponse = await restClient
+        .POST('/payments/mock/confirm-order', {
+          auth: false,
+          body: JSON.stringify({
+            cartID: cartId,
+            customerEmail: 'hooks-test@example.com',
+            mockPaymentID: initiateResponse.mockPaymentID,
+            secret: cartSecret,
+          }),
+        })
+        .then((res) => res.json())
+
+      if (confirmResponse.orderID) {
+        createdOrderIds.push(confirmResponse.orderID)
+      }
+
+      expect(confirmResponse.orderID).toBeTruthy()
+      expect(mockState.adapterAfterConfirmOrder).toHaveLength(1)
     })
   })
 })

--- a/test/plugin-ecommerce/mockPaymentAdapter.ts
+++ b/test/plugin-ecommerce/mockPaymentAdapter.ts
@@ -1,0 +1,225 @@
+import type {
+  Adjustment,
+  AfterConfirmOrderHook,
+  BeforeConfirmOrderHook,
+  BeforeInitiatePaymentHook,
+  PaymentAdapter,
+} from '@payloadcms/plugin-ecommerce/types'
+
+type MockState = {
+  adapterAfterConfirmOrder: Array<{ orderID: unknown; transactionID: unknown }>
+  adapterBeforeConfirmOrder: Array<{ data: unknown }>
+  adapterBeforeInitiatePayment: Array<{ adjustments: Adjustment[]; subtotal: number }>
+  confirmOrderCalls: Array<{ data: unknown }>
+  initiateCalls: Array<{ adjustments?: Adjustment[]; subtotal: number; total?: number }>
+  pluginAfterConfirmOrder: Array<{ orderID: unknown; transactionID: unknown }>
+  pluginBeforeConfirmOrder: Array<{ data: unknown }>
+  pluginBeforeInitiatePayment: Array<{ adjustments: Adjustment[]; subtotal: number }>
+}
+
+export const mockState: MockState = {
+  adapterAfterConfirmOrder: [],
+  adapterBeforeConfirmOrder: [],
+  adapterBeforeInitiatePayment: [],
+  confirmOrderCalls: [],
+  initiateCalls: [],
+  pluginAfterConfirmOrder: [],
+  pluginBeforeConfirmOrder: [],
+  pluginBeforeInitiatePayment: [],
+}
+
+export const resetMockState = () => {
+  mockState.adapterAfterConfirmOrder = []
+  mockState.adapterBeforeConfirmOrder = []
+  mockState.adapterBeforeInitiatePayment = []
+  mockState.confirmOrderCalls = []
+  mockState.initiateCalls = []
+  mockState.pluginAfterConfirmOrder = []
+  mockState.pluginBeforeConfirmOrder = []
+  mockState.pluginBeforeInitiatePayment = []
+}
+
+export const mockPluginHooks: {
+  afterConfirmOrder: AfterConfirmOrderHook[]
+  beforeConfirmOrder: BeforeConfirmOrderHook[]
+  beforeInitiatePayment: BeforeInitiatePaymentHook[]
+} = {
+  afterConfirmOrder: [
+    ({ orderID, transactionID }) => {
+      mockState.pluginAfterConfirmOrder.push({ orderID, transactionID })
+    },
+  ],
+  beforeConfirmOrder: [
+    ({ data }) => {
+      mockState.pluginBeforeConfirmOrder.push({ data })
+    },
+  ],
+  beforeInitiatePayment: [
+    ({ adjustments, subtotal }) => {
+      mockState.pluginBeforeInitiatePayment.push({ adjustments: [...adjustments], subtotal })
+      return []
+    },
+  ],
+}
+
+type MockAdapterOptions = {
+  addTenPercentTax?: boolean
+  failConfirmOrder?: boolean
+  injectAdjustments?: Adjustment[]
+  throwInAfterConfirmOrder?: boolean
+  throwInBeforeConfirmOrder?: boolean
+  throwInBeforeInitiatePayment?: boolean
+}
+
+let currentOptions: MockAdapterOptions = {}
+
+export const setMockAdapterOptions = (options: MockAdapterOptions) => {
+  currentOptions = options
+}
+
+export const resetMockAdapterOptions = () => {
+  currentOptions = {}
+}
+
+export const mockPaymentAdapter: PaymentAdapter = {
+  name: 'mock',
+  confirmOrder: async ({ data, ordersSlug, req, transactionsSlug }) => {
+    mockState.confirmOrderCalls.push({ data })
+
+    const payload = req.payload
+
+    const transactions = await payload.find({
+      collection: transactionsSlug ?? 'transactions',
+      depth: 0,
+      where: {
+        'mock.mockPaymentID': {
+          equals: (data as { mockPaymentID: string }).mockPaymentID,
+        },
+      },
+    })
+
+    const transaction = transactions.docs[0]
+
+    if (!transaction) {
+      throw new Error('Mock transaction not found')
+    }
+
+    const order = await payload.create({
+      collection: ordersSlug ?? 'orders',
+      data: {
+        amount: transaction.amount,
+        currency: transaction.currency,
+        customerEmail: transaction.customerEmail,
+        items: transaction.items,
+        status: 'processing',
+        transactions: [transaction.id],
+      },
+      req,
+    })
+
+    await payload.update({
+      id: transaction.id,
+      collection: transactionsSlug ?? 'transactions',
+      data: {
+        order: order.id,
+        status: 'succeeded',
+      },
+      req,
+    })
+
+    return {
+      message: 'Mock order confirmed',
+      orderID: order.id,
+      transactionID: transaction.id,
+    }
+  },
+  group: {
+    name: 'mock',
+    type: 'group',
+    admin: {
+      condition: (data) => data?.paymentMethod === 'mock',
+    },
+    fields: [
+      {
+        name: 'mockPaymentID',
+        type: 'text',
+      },
+    ],
+  },
+  hooks: {
+    afterConfirmOrder: [
+      ({ orderID, transactionID }) => {
+        mockState.adapterAfterConfirmOrder.push({ orderID, transactionID })
+        if (currentOptions.throwInAfterConfirmOrder) {
+          throw new Error('Adapter afterConfirmOrder failure')
+        }
+      },
+    ],
+    beforeConfirmOrder: [
+      ({ data }) => {
+        mockState.adapterBeforeConfirmOrder.push({ data })
+        if (currentOptions.throwInBeforeConfirmOrder) {
+          throw new Error('Adapter beforeConfirmOrder failure')
+        }
+      },
+    ],
+    beforeInitiatePayment: [
+      ({ adjustments, subtotal }) => {
+        mockState.adapterBeforeInitiatePayment.push({ adjustments: [...adjustments], subtotal })
+        if (currentOptions.throwInBeforeInitiatePayment) {
+          throw new Error('Adapter beforeInitiatePayment failure')
+        }
+        if (currentOptions.addTenPercentTax) {
+          const taxableAmount = subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
+          return [
+            {
+              amount: Math.round(taxableAmount * 0.1),
+              label: 'Tax (10%)',
+              type: 'tax',
+            },
+          ]
+        }
+        return currentOptions.injectAdjustments ?? []
+      },
+    ],
+  },
+  initiatePayment: async ({ data, req, transactionsSlug }) => {
+    const payload = req.payload
+    const mockPaymentID = `mock_${Date.now()}_${Math.random().toString(36).slice(2)}`
+
+    mockState.initiateCalls.push({
+      adjustments: data.adjustments,
+      subtotal: data.cart.subtotal ?? 0,
+      total: data.total,
+    })
+
+    const flattenedCart = data.cart.items.map((item) => ({
+      product: typeof item.product === 'object' ? item.product.id : item.product,
+      quantity: item.quantity,
+      ...(item.variant
+        ? { variant: typeof item.variant === 'object' ? item.variant.id : item.variant }
+        : {}),
+    }))
+
+    await payload.create({
+      collection: transactionsSlug,
+      data: {
+        ...(req.user ? { customer: req.user.id } : { customerEmail: data.customerEmail }),
+        amount: data.total ?? data.cart.subtotal,
+        currency: data.currency,
+        items: flattenedCart,
+        mock: { mockPaymentID },
+        paymentMethod: 'mock',
+        status: 'pending',
+      },
+      req,
+    })
+
+    return {
+      adjustments: data.adjustments,
+      message: 'Mock payment initiated',
+      mockPaymentID,
+      total: data.total,
+    }
+  },
+}

--- a/test/plugin-ecommerce/mockPaymentAdapter.ts
+++ b/test/plugin-ecommerce/mockPaymentAdapter.ts
@@ -1,20 +1,21 @@
 import type {
-  Adjustment,
   AfterConfirmOrderHook,
   BeforeConfirmOrderHook,
   BeforeInitiatePaymentHook,
+  Line,
   PaymentAdapter,
+  Summary,
 } from '@payloadcms/plugin-ecommerce/types'
 
 type MockState = {
   adapterAfterConfirmOrder: Array<{ orderID: unknown; transactionID: unknown }>
   adapterBeforeConfirmOrder: Array<{ data: unknown }>
-  adapterBeforeInitiatePayment: Array<{ adjustments: Adjustment[]; subtotal: number }>
+  adapterBeforeInitiatePayment: Array<{ summary: Summary }>
   confirmOrderCalls: Array<{ data: unknown }>
-  initiateCalls: Array<{ adjustments?: Adjustment[]; subtotal: number; total?: number }>
+  initiateCalls: Array<{ summary: Summary }>
   pluginAfterConfirmOrder: Array<{ orderID: unknown; transactionID: unknown }>
   pluginBeforeConfirmOrder: Array<{ data: unknown }>
-  pluginBeforeInitiatePayment: Array<{ adjustments: Adjustment[]; subtotal: number }>
+  pluginBeforeInitiatePayment: Array<{ summary: Summary }>
 }
 
 export const mockState: MockState = {
@@ -39,6 +40,12 @@ export const resetMockState = () => {
   mockState.pluginBeforeInitiatePayment = []
 }
 
+const cloneSummary = (summary: Summary): Summary => ({
+  currency: summary.currency,
+  lines: summary.lines.map((line) => ({ ...line })),
+  total: summary.total,
+})
+
 export const mockPluginHooks: {
   afterConfirmOrder: AfterConfirmOrderHook[]
   beforeConfirmOrder: BeforeConfirmOrderHook[]
@@ -55,17 +62,17 @@ export const mockPluginHooks: {
     },
   ],
   beforeInitiatePayment: [
-    ({ adjustments, subtotal }) => {
-      mockState.pluginBeforeInitiatePayment.push({ adjustments: [...adjustments], subtotal })
-      return []
+    ({ summary }) => {
+      mockState.pluginBeforeInitiatePayment.push({ summary: cloneSummary(summary) })
+      return summary
     },
   ],
 }
 
 type MockAdapterOptions = {
   addTenPercentTax?: boolean
+  appendLines?: Line[]
   failConfirmOrder?: boolean
-  injectAdjustments?: Adjustment[]
   throwInAfterConfirmOrder?: boolean
   throwInBeforeConfirmOrder?: boolean
   throwInBeforeInitiatePayment?: boolean
@@ -164,22 +171,36 @@ export const mockPaymentAdapter: PaymentAdapter = {
       },
     ],
     beforeInitiatePayment: [
-      ({ adjustments, subtotal }) => {
-        mockState.adapterBeforeInitiatePayment.push({ adjustments: [...adjustments], subtotal })
+      ({ summary }) => {
+        mockState.adapterBeforeInitiatePayment.push({ summary: cloneSummary(summary) })
+
         if (currentOptions.throwInBeforeInitiatePayment) {
           throw new Error('Adapter beforeInitiatePayment failure')
         }
+
         if (currentOptions.addTenPercentTax) {
-          const taxableAmount = subtotal + adjustments.reduce((sum, adj) => sum + adj.amount, 0)
-          return [
-            {
-              amount: Math.round(taxableAmount * 0.1),
-              label: 'Tax (10%)',
-              type: 'tax',
-            },
-          ]
+          const taxableAmount = summary.lines.reduce((sum, line) => sum + line.amount, 0)
+          return {
+            ...summary,
+            lines: [
+              ...summary.lines,
+              {
+                amount: Math.round(taxableAmount * 0.1),
+                label: 'Tax (10%)',
+                type: 'tax',
+              },
+            ],
+          }
         }
-        return currentOptions.injectAdjustments ?? []
+
+        if (currentOptions.appendLines && currentOptions.appendLines.length > 0) {
+          return {
+            ...summary,
+            lines: [...summary.lines, ...currentOptions.appendLines],
+          }
+        }
+
+        return summary
       },
     ],
   },
@@ -187,11 +208,7 @@ export const mockPaymentAdapter: PaymentAdapter = {
     const payload = req.payload
     const mockPaymentID = `mock_${Date.now()}_${Math.random().toString(36).slice(2)}`
 
-    mockState.initiateCalls.push({
-      adjustments: data.adjustments,
-      subtotal: data.cart.subtotal ?? 0,
-      total: data.total,
-    })
+    mockState.initiateCalls.push({ summary: cloneSummary(data.summary) })
 
     const flattenedCart = data.cart.items.map((item) => ({
       product: typeof item.product === 'object' ? item.product.id : item.product,
@@ -201,11 +218,11 @@ export const mockPaymentAdapter: PaymentAdapter = {
         : {}),
     }))
 
-    await payload.create({
+    const transaction = await payload.create({
       collection: transactionsSlug,
       data: {
         ...(req.user ? { customer: req.user.id } : { customerEmail: data.customerEmail }),
-        amount: data.total ?? data.cart.subtotal,
+        amount: data.summary.total,
         currency: data.currency,
         items: flattenedCart,
         mock: { mockPaymentID },
@@ -216,10 +233,9 @@ export const mockPaymentAdapter: PaymentAdapter = {
     })
 
     return {
-      adjustments: data.adjustments,
       message: 'Mock payment initiated',
       mockPaymentID,
-      total: data.total,
+      transactionID: transaction.id,
     }
   },
 }


### PR DESCRIPTION
Adds a hook system to the payment flow so applications can compute taxes, shipping, discounts, gift cards, and any other monetary adjustment on top of the cart subtotal — without forking or wrapping payment adapters.

## Why

Today the cart subtotal flows straight from `items × quantity × price` into the payment provider. There's no way to insert the adjustments that real-world commerce requires. Adapters are linear and closed.

## What

A three-hook pipeline, an opt-in persistence model, and a typed summary returned from the API.

## Hooks

| Hook                    | Purpose                                                                                   |
| ----------------------- | ----------------------------------------------------------------------------------------- |
| `beforeInitiatePayment` | Append lines (tax, shipping, discount) to the running `Summary`. Throwing aborts payment. |
| `beforeConfirmOrder`    | Pre-confirmation checks (e.g. re-validate a gift card). Throwing aborts.                  |
| `afterConfirmOrder`     | Side effects (emails, external systems). Errors logged, do not fail the response.         |

Hooks are defined at two levels. Plugin-level hooks (`payments.hooks`) run for all payment methods; adapter-level hooks (`paymentMethod.hooks`) run only for that adapter. Plugin-level runs first.

## The Summary model

```ts
type Summary = {
  total: number // always recomputed by the plugin — never trust what a hook sets
  currency: string // locked — cannot be changed inside a hook
  lines: Line[] // lines[0] is always the cart subtotal, managed by the plugin
}

type Line = {
  type: 'subtotal' | 'tax' | 'shipping' | 'discount' | 'gift_card' | 'custom'
  label: string
  amount: number // signed; negative reduces the total
  metadata?: Record<string, unknown>
}
```

Hooks receive and return the full `Summary`. The plugin recomputes `total = sum(lines.amount)` after each hook runs — hook authors just append (or modify) lines.

## Example — taxes and shipping

```ts
ecommercePlugin({
  payments: {
    paymentMethods: [stripeAdapter({ ... })],
    hooks: {
      beforeInitiatePayment: [
        async ({ summary, cart, shippingAddress }) => {
          if (!shippingAddress) return summary
          const cost = await calculateShippingCost({ items: cart.items, address: shippingAddress })
          return {
            ...summary,
            lines: [...summary.lines, { type: 'shipping', label: 'Standard', amount: cost }],
          }
        },
        async ({ summary, shippingAddress }) => {
          if (!shippingAddress) return summary
          const shippingTaxable = isShippingTaxableIn(shippingAddress)
          const taxable = summary.lines
            .filter((l) => l.type === 'subtotal' || (l.type === 'shipping' && shippingTaxable))
            .reduce((sum, l) => sum + l.amount, 0)
          const rate = await fetchTaxRate(shippingAddress)
          return {
            ...summary,
            lines: [...summary.lines, { type: 'tax', label: 'Sales Tax', amount: Math.round(taxable * rate) }],
          }
        },
      ],
    },
  },
})
```

## Invariants enforced between hooks

The plugin validates after every hook:

- `lines[0]` stays the subtotal line with the original cart subtotal (throws if removed or mutated).
- `currency` cannot change.
- `total` is recomputed automatically — you don't set it.

## API response

`/payments/{provider}/initiate` and `/payments/{provider}/confirm-order` now include `summary` alongside existing fields. Purely additive — existing fields untouched.

```json
{
  "message": "Payment initiated successfully",
  "clientSecret": "pi_...",
  "paymentIntentID": "pi_...",
  "transactionID": "...",
  "summary": {
    "total": 22000,
    "currency": "USD",
    "lines": [
      { "type": "subtotal", "label": "Subtotal", "amount": 20000 },
      { "type": "shipping", "label": "Standard", "amount": 500 },
      { "type": "tax", "label": "Sales Tax", "amount": 1500 },
    ],
  },
}
```

## Persistence

When `payments.hooks` or any `paymentMethod.hooks` is configured, the plugin adds a read-only `summary` group field to the default `transactions` and `orders` collections. The breakdown is persisted alongside the `amount` total, so it's queryable for receipts, refunds, and reporting.

```ts
await payload.find({
  collection: 'orders',
  where: { 'summary.lines.type': { equals: 'tax' } },
})
```

**Opt-in:** the field is only added when hooks are configured. Existing users not adopting hooks see zero schema change.

## Breaking changes

All new config is optional. The `InitiatePayment` data shape on the `PaymentAdapter` interface replaced `adjustments`/`total` with `summary` — but the only adapter (Stripe) is updated in this PR, and the prior shape was added in the same development cycle as this change (not on any released version).
