### PR TITLE
fix(ui): enable trash confirmation for folder document deletes

### DIFF
--- a/packages/ui/src/views/CollectionFolder/ListSelection/index.tsx
+++ b/packages/ui/src/views/CollectionFolder/ListSelection/index.tsx
@@ -81,6 +81,7 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
         return collection.slug === Object.keys(groupedSelections)[0]
       })
     : null
+  const hasTrashPermission = Boolean(collectionConfig?.trash) && singleNonFolderCollectionSelected
 
   if (count === 0) {
     return null
@@ -181,8 +182,10 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
               clearSelections()
             }}
             hasDeletePermission={true}
+            hasTrashPermission={hasTrashPermission}
             key="bulk-delete"
             selections={groupedSelections}
+            trash={hasTrashPermission}
           />
         ),
       ].filter(Boolean)}

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -199,6 +199,35 @@ test.describe('Folders', () => {
       await expect(secondDoc).toContainText('Document 1')
     })
 
+    test('should show trash-aware bulk delete confirmation for folder documents in trash-enabled collections', async () => {
+      await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))
+      await createFolder({ folderName: 'Folder With Trashed Post', page })
+      await createPostWithExistingFolder('Post In Folder', 'Folder With Trashed Post')
+
+      await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))
+      await clickFolderCard({ folderName: 'Folder With Trashed Post', page, doubleClick: true })
+
+      const postCard = page
+        .locator('div[role="button"].draggable-with-click')
+        .filter({
+          has: page.locator('.folder-file-card__name', { hasText: 'Post In Folder' }),
+        })
+        .first()
+
+      await postCard.click()
+
+      const deleteButton = page.locator('.list-selection__actions button', {
+        hasText: 'Delete',
+      })
+      await deleteButton.click()
+
+      await expect(page.locator('#confirm-delete-many-docs')).toBeVisible()
+      await expect(
+        page.locator('#confirm-delete-many-docs .confirmation-modal__content'),
+      ).toContainText('You are about to move 1 Post to the trash')
+      await expect(page.locator('#delete-forever')).toBeVisible()
+    })
+
     test('should move folder', async () => {
       await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))
       await createFolder({ folderName: 'Move Into This Folder', page })


### PR DESCRIPTION
### What?

  Fix folder-view bulk delete so documents from trash-enabled collections use the same Trash-aware confirmation modal as the normal collection list view.

  This updates the folder selection delete action to forward Trash support when the current selection is from a single non-folder collection with `trash: true`.

  It also adds a regression test to the folders E2E suite.

  ### Why?

  In folder view, deleting documents from a collection like `posts` that has both `folders: true` and `trash: true` opened the standard delete confirmation modal instead of the Trash-
  enabled version.

  Because of that:
  - the modal copy was incorrect
  - the `Skip trash and delete permanently` checkbox was missing

  This made folder-based document deletes behave differently from the normal collection list, even though they target the same collection and delete flow.

  ### How?

  - update `CollectionFolder/ListSelection` to compute whether Trash should be enabled for the current grouped selection
  - pass `hasTrashPermission` and `trash` to `DeleteMany_v4` when the selection is from a single non-folder collection with `trash: true`
  - add an E2E regression test covering folder-view bulk delete for a trash-enabled collection

  Manual verification:
  - ran the `folders` test app locally
  - created a folder with `Posts`
  - created a post inside the folder
  - selected the post from folder view and clicked `Delete`
  - confirmed the modal now says the document will be moved to trash and shows the `Skip trash and delete permanently` checkbox

  Fixes #16327