### PR TITLE
fix: regression bug when multiple routes share parent paths

### DIFF
--- a/packages/next/src/views/Root/getCustomCollectionViewByRoute.spec.ts
+++ b/packages/next/src/views/Root/getCustomCollectionViewByRoute.spec.ts
@@ -196,4 +196,90 @@ describe('getCustomCollectionViewByRoute', () => {
       expect(mapResult.viewKey).toBe('map')
     })
   })
+
+  describe('shadowing regression — sibling paths without exact', () => {
+    const siblingViews: Views = {
+      ordersIndex: {
+        Component: '/components/views/ListView/index.js#ListView',
+        path: '/orders',
+      },
+      orderDetail: {
+        Component: '/components/views/DetailView/index.js#DetailView',
+        path: '/orders/:orderNumber',
+      },
+    }
+
+    it('should resolve /orders to the index view', () => {
+      const result = getCustomCollectionViewByRoute({
+        adminRoute: '/admin',
+        baseRoute: '/collections/my-collection',
+        currentRoute: '/admin/collections/my-collection/orders',
+        views: siblingViews,
+      })
+
+      expect(result.viewKey).toBe('ordersIndex')
+    })
+
+    it('should resolve /orders/123 to the detail view, not the index view', () => {
+      const result = getCustomCollectionViewByRoute({
+        adminRoute: '/admin',
+        baseRoute: '/collections/my-collection',
+        currentRoute: '/admin/collections/my-collection/orders/123',
+        views: siblingViews,
+      })
+
+      expect(result.viewKey).toBe('orderDetail')
+    })
+
+    it('should resolve to the same views regardless of registration order', () => {
+      const reversedViews: Views = {
+        orderDetail: siblingViews.orderDetail,
+        ordersIndex: siblingViews.ordersIndex,
+      }
+
+      const indexResult = getCustomCollectionViewByRoute({
+        adminRoute: '/admin',
+        baseRoute: '/collections/my-collection',
+        currentRoute: '/admin/collections/my-collection/orders',
+        views: reversedViews,
+      })
+
+      const detailResult = getCustomCollectionViewByRoute({
+        adminRoute: '/admin',
+        baseRoute: '/collections/my-collection',
+        currentRoute: '/admin/collections/my-collection/orders/123',
+        views: reversedViews,
+      })
+
+      expect(indexResult.viewKey).toBe('ordersIndex')
+      expect(detailResult.viewKey).toBe('orderDetail')
+    })
+
+    it('should prefer an exact sibling over prefix matches at the same URL', () => {
+      const viewsWithExactSibling: Views = {
+        ordersIndex: {
+          Component: '/components/views/ListView/index.js#ListView',
+          path: '/orders',
+        },
+        orderDetail: {
+          Component: '/components/views/DetailView/index.js#DetailView',
+          path: '/orders/:orderNumber',
+        },
+        ordersBulk: {
+          Component: '/components/views/BulkView/index.js#BulkView',
+          exact: true,
+          path: '/orders/bulk',
+        },
+      }
+
+      const result = getCustomCollectionViewByRoute({
+        adminRoute: '/admin',
+        baseRoute: '/collections/my-collection',
+        currentRoute: '/admin/collections/my-collection/orders/bulk',
+        views: viewsWithExactSibling,
+      })
+
+      expect(result.viewKey).toBe('ordersBulk')
+    })
+  })
 })

--- a/packages/next/src/views/Root/getCustomCollectionViewByRoute.ts
+++ b/packages/next/src/views/Root/getCustomCollectionViewByRoute.ts
@@ -9,6 +9,12 @@ import type { ViewFromConfig } from './getRouteData.js'
 
 import { isPathMatchingRoute } from './isPathMatchingRoute.js'
 
+type ViewScore = {
+  dynamicSegmentCount: number
+  exact: boolean
+  matchedLength: number
+}
+
 export const getCustomCollectionViewByRoute = ({
   adminRoute,
   baseRoute,
@@ -30,11 +36,15 @@ export const getCustomCollectionViewByRoute = ({
         ? currentRouteWithAdmin.slice(adminRoute.length)
         : currentRouteWithAdmin
 
+  let bestKey: null | string = null
+  let bestView: AdminViewConfig | null = null
+  let bestScore: null | ViewScore = null
+
   if (views && typeof views === 'object') {
-    const foundEntry = Object.entries(views).find(([key, view]) => {
+    for (const [key, view] of Object.entries(views)) {
       // Skip the known collection view types: edit and list
       if (key === 'edit' || key === 'list') {
-        return false
+        continue
       }
 
       // Type guard: custom views should be AdminViewConfig with path and Component
@@ -45,31 +55,45 @@ export const getCustomCollectionViewByRoute = ({
         'Component' in view &&
         typeof view.path === 'string'
 
-      if (isAdminViewConfig) {
-        const adminView = view as AdminViewConfig
-        const viewPath = `${baseRoute}${adminView.path}`
-
-        return isPathMatchingRoute({
-          currentRoute,
-          exact: adminView.exact,
-          path: viewPath,
-          sensitive: adminView.sensitive,
-          strict: adminView.strict,
-        })
+      if (!isAdminViewConfig) {
+        continue
       }
 
-      return false
-    })
+      const adminView = view as AdminViewConfig
+      const viewPath = `${baseRoute}${adminView.path}`
 
-    if (foundEntry) {
-      const [viewKey, foundViewConfig] = foundEntry
-      const adminView = foundViewConfig as AdminViewConfig
-      return {
-        view: {
-          payloadComponent: adminView.Component as PayloadComponent<AdminViewServerProps>,
-        },
-        viewKey,
+      const match = isPathMatchingRoute({
+        currentRoute,
+        exact: adminView.exact,
+        path: viewPath,
+        sensitive: adminView.sensitive,
+        strict: adminView.strict,
+      })
+
+      if (!match) {
+        continue
       }
+
+      const candidateScore: ViewScore = {
+        dynamicSegmentCount: match.dynamicSegmentCount,
+        exact: Boolean(adminView.exact),
+        matchedLength: match.matchedLength,
+      }
+
+      if (isMoreSpecific(candidateScore, bestScore)) {
+        bestKey = key
+        bestView = adminView
+        bestScore = candidateScore
+      }
+    }
+  }
+
+  if (bestView) {
+    return {
+      view: {
+        payloadComponent: bestView.Component as PayloadComponent<AdminViewServerProps>,
+      },
+      viewKey: bestKey,
     }
   }
 
@@ -79,4 +103,24 @@ export const getCustomCollectionViewByRoute = ({
     },
     viewKey: null,
   }
+}
+
+const isMoreSpecific = (candidate: ViewScore, best: null | ViewScore): boolean => {
+  if (!best) {
+    return true
+  }
+
+  if (candidate.matchedLength !== best.matchedLength) {
+    return candidate.matchedLength > best.matchedLength
+  }
+
+  if (candidate.exact !== best.exact) {
+    return candidate.exact
+  }
+
+  if (candidate.dynamicSegmentCount !== best.dynamicSegmentCount) {
+    return candidate.dynamicSegmentCount < best.dynamicSegmentCount
+  }
+
+  return false
 }

--- a/packages/next/src/views/Root/getCustomViewByRoute.spec.ts
+++ b/packages/next/src/views/Root/getCustomViewByRoute.spec.ts
@@ -1,0 +1,153 @@
+import type { SanitizedConfig } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { getCustomViewByRoute } from './getCustomViewByRoute.js'
+
+type Views = SanitizedConfig['admin']['components']['views']
+
+const buildConfig = (views: Views, adminRoute = '/admin'): SanitizedConfig =>
+  ({
+    admin: {
+      components: {
+        views,
+      },
+    },
+    routes: {
+      admin: adminRoute,
+    },
+  }) as unknown as SanitizedConfig
+
+describe('getCustomViewByRoute', () => {
+  describe('route matching', () => {
+    it('should match an exact custom view', () => {
+      const config = buildConfig({
+        dashboard: {
+          Component: '/components/views/Dashboard/index.js#Dashboard',
+          exact: true,
+          path: '/dashboard',
+        },
+      })
+
+      const result = getCustomViewByRoute({
+        config,
+        currentRoute: '/admin/dashboard',
+      })
+
+      expect(result.viewKey).toBe('dashboard')
+    })
+
+    it('should match when adminRoute is /', () => {
+      const config = buildConfig(
+        {
+          dashboard: {
+            Component: '/components/views/Dashboard/index.js#Dashboard',
+            exact: true,
+            path: '/dashboard',
+          },
+        },
+        '/',
+      )
+
+      const result = getCustomViewByRoute({
+        config,
+        currentRoute: '/dashboard',
+      })
+
+      expect(result.viewKey).toBe('dashboard')
+    })
+
+    it('should not match when the route does not correspond to any custom view', () => {
+      const config = buildConfig({
+        dashboard: {
+          Component: '/components/views/Dashboard/index.js#Dashboard',
+          exact: true,
+          path: '/dashboard',
+        },
+      })
+
+      const result = getCustomViewByRoute({
+        config,
+        currentRoute: '/admin/other',
+      })
+
+      expect(result.viewKey).toBeNull()
+    })
+  })
+
+  describe('shadowing regression — sibling paths without exact', () => {
+    const siblingViews: Views = {
+      regressionList: {
+        Component: '/components/views/RegressionList/index.js#RegressionList',
+        path: '/regression-repro',
+      },
+      regressionDetail: {
+        Component: '/components/views/RegressionDetail/index.js#RegressionDetail',
+        path: '/regression-repro/:id',
+      },
+    }
+
+    it('should resolve /regression-repro to the list view', () => {
+      const result = getCustomViewByRoute({
+        config: buildConfig(siblingViews),
+        currentRoute: '/admin/regression-repro',
+      })
+
+      expect(result.viewKey).toBe('regressionList')
+    })
+
+    it('should resolve /regression-repro/123 to the detail view, not the list view', () => {
+      const result = getCustomViewByRoute({
+        config: buildConfig(siblingViews),
+        currentRoute: '/admin/regression-repro/123',
+      })
+
+      expect(result.viewKey).toBe('regressionDetail')
+    })
+
+    it('should resolve to the same views regardless of registration order', () => {
+      const reversedViews: Views = {
+        regressionDetail: siblingViews.regressionDetail,
+        regressionList: siblingViews.regressionList,
+      }
+
+      const listResult = getCustomViewByRoute({
+        config: buildConfig(reversedViews),
+        currentRoute: '/admin/regression-repro',
+      })
+
+      const detailResult = getCustomViewByRoute({
+        config: buildConfig(reversedViews),
+        currentRoute: '/admin/regression-repro/123',
+      })
+
+      expect(listResult.viewKey).toBe('regressionList')
+      expect(detailResult.viewKey).toBe('regressionDetail')
+    })
+
+    it('should prefer an exact sibling over prefix matches at the same URL', () => {
+      const viewsWithExactSibling: Views = {
+        regressionList: {
+          Component: '/components/views/RegressionList/index.js#RegressionList',
+          path: '/regression-repro',
+        },
+        regressionDetail: {
+          Component: '/components/views/RegressionDetail/index.js#RegressionDetail',
+          path: '/regression-repro/:id',
+        },
+        regressionBulk: {
+          Component: '/components/views/RegressionBulk/index.js#RegressionBulk',
+          exact: true,
+          path: '/regression-repro/bulk',
+        },
+      }
+
+      const result = getCustomViewByRoute({
+        config: buildConfig(viewsWithExactSibling),
+        currentRoute: '/admin/regression-repro/bulk',
+      })
+
+      expect(result.viewKey).toBe('regressionBulk')
+    })
+  })
+})

--- a/packages/next/src/views/Root/getCustomViewByRoute.ts
+++ b/packages/next/src/views/Root/getCustomViewByRoute.ts
@@ -1,4 +1,9 @@
-import type { AdminViewConfig, SanitizedConfig } from 'payload'
+import type {
+  AdminViewConfig,
+  AdminViewServerProps,
+  PayloadComponent,
+  SanitizedConfig,
+} from 'payload'
 
 import type { ViewFromConfig } from './getRouteData.js'
 
@@ -22,32 +27,46 @@ export const getCustomViewByRoute = ({
     routes: { admin: adminRoute },
   } = config
 
-  let viewKey: string
-
   const currentRoute =
     adminRoute === '/' ? currentRouteWithAdmin : currentRouteWithAdmin.replace(adminRoute, '')
 
-  const foundViewConfig =
-    (views &&
-      typeof views === 'object' &&
-      Object.entries(views).find(([key, view]) => {
-        const isMatching = isPathMatchingRoute({
-          currentRoute,
-          exact: view.exact,
-          path: view.path,
-          sensitive: view.sensitive,
-          strict: view.strict,
-        })
+  let bestKey: null | string = null
+  let bestConfig: AdminViewConfig | null = null
+  let bestScore: {
+    dynamicSegmentCount: number
+    exact: boolean
+    matchedLength: number
+  } | null = null
 
-        if (isMatching) {
-          viewKey = key
-        }
+  if (views && typeof views === 'object') {
+    for (const [key, view] of Object.entries(views)) {
+      const match = isPathMatchingRoute({
+        currentRoute,
+        exact: view.exact,
+        path: view.path,
+        sensitive: view.sensitive,
+        strict: view.strict,
+      })
 
-        return isMatching
-      })?.[1]) ||
-    undefined
+      if (!match) {
+        continue
+      }
 
-  if (!foundViewConfig) {
+      const candidateScore = {
+        dynamicSegmentCount: match.dynamicSegmentCount,
+        exact: Boolean(view.exact),
+        matchedLength: match.matchedLength,
+      }
+
+      if (isMoreSpecific(candidateScore, bestScore)) {
+        bestKey = key
+        bestConfig = view
+        bestScore = candidateScore
+      }
+    }
+  }
+
+  if (!bestConfig) {
     return {
       view: {
         Component: null,
@@ -59,9 +78,32 @@ export const getCustomViewByRoute = ({
 
   return {
     view: {
-      payloadComponent: foundViewConfig.Component,
+      payloadComponent: bestConfig.Component as PayloadComponent<AdminViewServerProps>,
     },
-    viewConfig: foundViewConfig,
-    viewKey,
+    viewConfig: bestConfig,
+    viewKey: bestKey,
   }
+}
+
+const isMoreSpecific = (
+  candidate: { dynamicSegmentCount: number; exact: boolean; matchedLength: number },
+  best: { dynamicSegmentCount: number; exact: boolean; matchedLength: number } | null,
+): boolean => {
+  if (!best) {
+    return true
+  }
+
+  if (candidate.matchedLength !== best.matchedLength) {
+    return candidate.matchedLength > best.matchedLength
+  }
+
+  if (candidate.exact !== best.exact) {
+    return candidate.exact
+  }
+
+  if (candidate.dynamicSegmentCount !== best.dynamicSegmentCount) {
+    return candidate.dynamicSegmentCount < best.dynamicSegmentCount
+  }
+
+  return false
 }

--- a/packages/next/src/views/Root/isPathMatchingRoute.spec.ts
+++ b/packages/next/src/views/Root/isPathMatchingRoute.spec.ts
@@ -5,11 +5,11 @@ import { isPathMatchingRoute } from './isPathMatchingRoute.js'
 describe('isPathMatchingRoute', () => {
   describe('no path defined', () => {
     it('should return false when path is undefined', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/anything', path: undefined })).toBe(false)
+      expect(isPathMatchingRoute({ currentRoute: '/anything', path: undefined })).toBeFalsy()
     })
 
     it('should return false when path is empty string', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/anything', path: '' })).toBe(false)
+      expect(isPathMatchingRoute({ currentRoute: '/anything', path: '' })).toBeFalsy()
     })
   })
 
@@ -17,13 +17,13 @@ describe('isPathMatchingRoute', () => {
     it('should match when currentRoute exactly equals the static path', () => {
       expect(
         isPathMatchingRoute({ currentRoute: '/dashboard', exact: true, path: '/dashboard' }),
-      ).toBe(true)
+      ).toBeTruthy()
     })
 
     it('should not match when currentRoute differs from the path', () => {
       expect(
         isPathMatchingRoute({ currentRoute: '/settings', exact: true, path: '/dashboard' }),
-      ).toBe(false)
+      ).toBeFalsy()
     })
 
     it('should not match a sub-path when exact is true', () => {
@@ -33,7 +33,7 @@ describe('isPathMatchingRoute', () => {
           exact: true,
           path: '/dashboard',
         }),
-      ).toBe(false)
+      ).toBeFalsy()
     })
 
     it('should match a parameterized path exactly', () => {
@@ -43,7 +43,7 @@ describe('isPathMatchingRoute', () => {
           exact: true,
           path: '/custom/:id',
         }),
-      ).toBe(true)
+      ).toBeTruthy()
     })
 
     it('should not match a parameterized path with extra segments', () => {
@@ -53,27 +53,27 @@ describe('isPathMatchingRoute', () => {
           exact: true,
           path: '/custom/:id',
         }),
-      ).toBe(false)
+      ).toBeFalsy()
     })
 
     it('should match root path exactly', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/', exact: true, path: '/' })).toBe(true)
+      expect(isPathMatchingRoute({ currentRoute: '/', exact: true, path: '/' })).toBeTruthy()
     })
 
     it('should not match root path against other routes when exact', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/login', exact: true, path: '/' })).toBe(false)
+      expect(isPathMatchingRoute({ currentRoute: '/login', exact: true, path: '/' })).toBeFalsy()
     })
   })
 
   describe('non-exact (prefix) matching', () => {
     it('should match when currentRoute equals the path', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/dashboard', path: '/dashboard' })).toBe(true)
+      expect(isPathMatchingRoute({ currentRoute: '/dashboard', path: '/dashboard' })).toBeTruthy()
     })
 
     it('should match a sub-path at a segment boundary', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/dashboard/settings', path: '/dashboard' })).toBe(
-        true,
-      )
+      expect(
+        isPathMatchingRoute({ currentRoute: '/dashboard/settings', path: '/dashboard' }),
+      ).toBeTruthy()
     })
 
     it('should match deeply nested sub-paths', () => {
@@ -82,17 +82,17 @@ describe('isPathMatchingRoute', () => {
           currentRoute: '/dashboard/settings/advanced/debug',
           path: '/dashboard',
         }),
-      ).toBe(true)
+      ).toBeTruthy()
     })
 
     it('should not match when route shares a prefix but not at a segment boundary', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/dashboard-extra', path: '/dashboard' })).toBe(
-        false,
-      )
+      expect(
+        isPathMatchingRoute({ currentRoute: '/dashboard-extra', path: '/dashboard' }),
+      ).toBeFalsy()
     })
 
     it('should not match a completely different route', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/settings', path: '/dashboard' })).toBe(false)
+      expect(isPathMatchingRoute({ currentRoute: '/settings', path: '/dashboard' })).toBeFalsy()
     })
 
     it('should match a parameterized path with a sub-path', () => {
@@ -101,7 +101,7 @@ describe('isPathMatchingRoute', () => {
           currentRoute: '/custom/123/edit',
           path: '/custom/:id',
         }),
-      ).toBe(false)
+      ).toBeFalsy()
       // pathToRegexp is end-anchored by default, so /custom/:id does not match /custom/123/edit.
       // The literal fallback '/custom/:id' also won't startsWith-match.
       // Parameterized views should use exact: true or include all segments in the pattern.
@@ -113,26 +113,26 @@ describe('isPathMatchingRoute', () => {
           currentRoute: '/custom/123extra',
           path: '/custom/:id',
         }),
-      ).toBe(true)
+      ).toBeTruthy()
       // :id captures everything up to the next / — '123extra' is a valid :id value
     })
   })
 
   describe('root path / without exact — regression for route shadowing bug', () => {
     it('should match root path against itself', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/', path: '/' })).toBe(true)
+      expect(isPathMatchingRoute({ currentRoute: '/', path: '/' })).toBeTruthy()
     })
 
     it('should not match root path against /login', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/login', path: '/' })).toBe(false)
+      expect(isPathMatchingRoute({ currentRoute: '/login', path: '/' })).toBeFalsy()
     })
 
     it('should not match root path against /collections/posts', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/collections/posts', path: '/' })).toBe(false)
+      expect(isPathMatchingRoute({ currentRoute: '/collections/posts', path: '/' })).toBeFalsy()
     })
 
     it('should not match root path against /collections/posts/123', () => {
-      expect(isPathMatchingRoute({ currentRoute: '/collections/posts/123', path: '/' })).toBe(false)
+      expect(isPathMatchingRoute({ currentRoute: '/collections/posts/123', path: '/' })).toBeFalsy()
     })
   })
 
@@ -144,7 +144,7 @@ describe('isPathMatchingRoute', () => {
           exact: true,
           path: '/dashboard',
         }),
-      ).toBe(true)
+      ).toBeTruthy()
     })
 
     it('should not match different cases when sensitive is true', () => {
@@ -155,7 +155,7 @@ describe('isPathMatchingRoute', () => {
           path: '/dashboard',
           sensitive: true,
         }),
-      ).toBe(false)
+      ).toBeFalsy()
     })
   })
 
@@ -167,7 +167,7 @@ describe('isPathMatchingRoute', () => {
           exact: true,
           path: '/dashboard',
         }),
-      ).toBe(true)
+      ).toBeTruthy()
     })
 
     it('should not match trailing slash mismatch when strict is true', () => {
@@ -178,7 +178,62 @@ describe('isPathMatchingRoute', () => {
           path: '/dashboard',
           strict: true,
         }),
-      ).toBe(false)
+      ).toBeFalsy()
+    })
+  })
+
+  describe('match strength — enables best-match resolution in consumers', () => {
+    it('should expose matchedLength reflecting the regex-matched portion of currentRoute for parameterized paths', () => {
+      const result = isPathMatchingRoute({
+        currentRoute: '/orders/123',
+        path: '/orders/:id',
+      })
+
+      expect(result).not.toBe(false)
+      expect(result).toMatchObject({
+        matchedLength: '/orders/123'.length,
+        dynamicSegmentCount: 1,
+      })
+    })
+
+    it('should expose matchedLength reflecting the literal path for prefix matches', () => {
+      const result = isPathMatchingRoute({
+        currentRoute: '/orders/123',
+        path: '/orders',
+      })
+
+      expect(result).not.toBe(false)
+      expect(result).toMatchObject({
+        matchedLength: '/orders'.length,
+        dynamicSegmentCount: 0,
+      })
+    })
+
+    it('should rank a more specific parameterized path above a less specific literal prefix at the same URL', () => {
+      const specific = isPathMatchingRoute({
+        currentRoute: '/orders/123',
+        path: '/orders/:id',
+      })
+
+      const generic = isPathMatchingRoute({
+        currentRoute: '/orders/123',
+        path: '/orders',
+      })
+
+      expect(specific).not.toBe(false)
+      expect(generic).not.toBe(false)
+      expect((specific as { matchedLength: number }).matchedLength).toBeGreaterThan(
+        (generic as { matchedLength: number }).matchedLength,
+      )
+    })
+
+    it('should return false for a non-matching path (not a zero-length match)', () => {
+      expect(
+        isPathMatchingRoute({
+          currentRoute: '/orders',
+          path: '/products',
+        }),
+      ).toBeFalsy()
     })
   })
 })

--- a/packages/next/src/views/Root/isPathMatchingRoute.ts
+++ b/packages/next/src/views/Root/isPathMatchingRoute.ts
@@ -1,5 +1,10 @@
 import { pathToRegexp } from 'path-to-regexp'
 
+export type PathMatch = {
+  dynamicSegmentCount: number
+  matchedLength: number
+}
+
 export const isPathMatchingRoute = ({
   currentRoute,
   exact,
@@ -12,7 +17,7 @@ export const isPathMatchingRoute = ({
   path?: string
   sensitive?: boolean
   strict?: boolean
-}) => {
+}): false | PathMatch => {
   // if no path is defined, we cannot match it so return false early
   if (!viewPath) {
     return false
@@ -29,18 +34,24 @@ export const isPathMatchingRoute = ({
 
   const match = regex.exec(currentRoute)
   const viewRoute = match?.[0] || viewPath
+  const dynamicSegmentCount = keys.length
 
   if (exact) {
-    return currentRoute === viewRoute
-  }
-
-  if (!exact) {
-    if (!currentRoute.startsWith(viewRoute)) {
-      return false
+    if (currentRoute === viewRoute) {
+      return { dynamicSegmentCount, matchedLength: viewRoute.length }
     }
-
-    const remainingPath = currentRoute.slice(viewRoute.length)
-
-    return remainingPath === '' || remainingPath.startsWith('/')
+    return false
   }
+
+  if (!currentRoute.startsWith(viewRoute)) {
+    return false
+  }
+
+  const remainingPath = currentRoute.slice(viewRoute.length)
+
+  if (remainingPath === '' || remainingPath.startsWith('/')) {
+    return { dynamicSegmentCount, matchedLength: viewRoute.length }
+  }
+
+  return false
 }

--- a/test/admin/components/views/SiblingChildView/index.tsx
+++ b/test/admin/components/views/SiblingChildView/index.tsx
@@ -1,0 +1,15 @@
+import type { AdminViewServerProps } from 'payload'
+
+import { MinimalTemplate } from '@payloadcms/next/templates'
+import React from 'react'
+
+export function SiblingChildView({ params }: AdminViewServerProps) {
+  const id = params?.segments?.[1]
+
+  return (
+    <MinimalTemplate>
+      <h1 id="sibling-child-view-title">Sibling Child View</h1>
+      <p id="sibling-child-view-id">{id}</p>
+    </MinimalTemplate>
+  )
+}

--- a/test/admin/components/views/SiblingRootView/index.tsx
+++ b/test/admin/components/views/SiblingRootView/index.tsx
@@ -1,0 +1,12 @@
+import type { AdminViewServerProps } from 'payload'
+
+import { MinimalTemplate } from '@payloadcms/next/templates'
+import React from 'react'
+
+export function SiblingRootView(_: AdminViewServerProps) {
+  return (
+    <MinimalTemplate>
+      <h1 id="sibling-root-view-title">Sibling Root View</h1>
+    </MinimalTemplate>
+  )
+}

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -56,6 +56,8 @@ import {
   customViewPath,
   protectedCustomNestedViewPath,
   publicCustomViewPath,
+  siblingChildViewPath,
+  siblingRootViewPath,
 } from './shared.js'
 import { editMenuItemsSlug, reorderTabsSlug } from './slugs.js'
 process.env.NEXT_BASE_PATH = BASE_PATH
@@ -138,6 +140,14 @@ export default buildConfigWithDefaults({
         ButtonShowcase: {
           Component: '/components/views/ButtonStyles/index.js#ButtonStyles',
           path: '/button-styles',
+        },
+        SiblingRootView: {
+          Component: '/components/views/SiblingRootView/index.js#SiblingRootView',
+          path: siblingRootViewPath,
+        },
+        SiblingChildView: {
+          Component: '/components/views/SiblingChildView/index.js#SiblingChildView',
+          path: siblingChildViewPath,
         },
       },
     },

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -30,6 +30,9 @@ import {
   customViewTitle,
   protectedCustomNestedViewPath,
   publicCustomViewPath,
+  siblingChildViewTitle,
+  siblingRootViewPath,
+  siblingRootViewTitle,
   slugPluralLabel,
 } from '../../shared.js'
 import {
@@ -767,6 +770,29 @@ describe('General', () => {
         }),
       )
       await expect(page.locator('h1#custom-view-title')).toContainText(customNestedViewTitle)
+    })
+
+    test('should render sibling root view at the parent path', async () => {
+      await page.goto(
+        formatAdminURL({
+          adminRoute,
+          path: siblingRootViewPath,
+          serverURL,
+        }),
+      )
+      await expect(page.locator('h1#sibling-root-view-title')).toContainText(siblingRootViewTitle)
+    })
+
+    test('should render sibling child view at the nested path, not the sibling root view', async () => {
+      await page.goto(
+        formatAdminURL({
+          adminRoute,
+          path: `${siblingRootViewPath}/123`,
+          serverURL,
+        }),
+      )
+      await expect(page.locator('h1#sibling-child-view-title')).toContainText(siblingChildViewTitle)
+      await expect(page.locator('#sibling-child-view-id')).toContainText('123')
     })
   })
 

--- a/test/admin/shared.ts
+++ b/test/admin/shared.ts
@@ -16,6 +16,14 @@ export const customParamViewPathBase = '/custom-param'
 
 export const customParamViewPath = `${customParamViewPathBase}/:id`
 
+export const siblingRootViewPath = '/sibling-root'
+
+export const siblingChildViewPath = `${siblingRootViewPath}/:id`
+
+export const siblingRootViewTitle = 'Sibling Root View'
+
+export const siblingChildViewTitle = 'Sibling Child View'
+
 export const customViewTitle = 'Custom View'
 
 export const customCollectionViewTitle = 'Custom Collection View'


### PR DESCRIPTION
## What & why

Fixes a regression where two custom admin views sharing a parent path could resolve incorrectly depending on the order they were registered in the views object.

For example, given:

```ts
views: {
  ordersIndex:  { path: '/orders' },
  orderDetail:  { path: '/orders/:id' },
}
```


Navigating to `/orders/123` previously resolved to `ordersIndex` (the prefix match registered first) instead of the more specific `orderDetail`. Reversing registration order changed the result, making behavior non-deterministic from a user perspective.

The custom-view resolver used `Object.entries(views).find(...)`, which returns the first match. This change replaces the early-exit lookup with a full scan that ranks all matching views by specificity and picks the best one.

## Specificity ranking

When more than one custom view matches the current URL, the winner is chosen by:

1. Longest matched portion of the URL wins (`/orders/:id` → 11 chars vs `/orders` → 7 chars for `/orders/123`)
2. If equal, `exact: true` wins over a prefix match
3. If still equal, fewer dynamic segments wins (literals beat params)

## Changes

- `isPathMatchingRoute` now returns `false | { matchedLength, dynamicSegmentCount }` instead of `boolean`. Existing call sites that only use truthy/falsy semantics are unaffected.
- `getCustomViewByRoute` (Root) and `getCustomCollectionViewByRoute` now scan all matches and pick by specificity.
- Added unit specs for both resolvers including registration-order-independence tests.
- Added match-strength tests to `isPathMatchingRoute.spec.ts`.
- Added e2e coverage in `test/admin` with new `SiblingRootView` and `SiblingChildView` fixtures verifying the rendering at `/sibling-root` and `/sibling-root/:id`.
