### PR TITLE
fix(ui): resolve globals correctly in copyDataFromLocale

### DIFF
--- a/packages/ui/src/utilities/copyDataFromLocale.ts
+++ b/packages/ui/src/utilities/copyDataFromLocale.ts
@@ -1,5 +1,6 @@
 import ObjectIdImport from 'bson-objectid'
 import {
+  APIError,
   canAccessAdmin,
   type CollectionSlug,
   type Data,
@@ -235,7 +236,7 @@ export const copyDataFromLocale = async (args: CopyDataFromLocaleArgs) => {
     overrideData = false,
     req: {
       payload,
-      payload: { collections, globals },
+      payload: { collections },
       user,
     },
     req,
@@ -297,9 +298,20 @@ export const copyDataFromLocale = async (args: CopyDataFromLocaleArgs) => {
     throw new Error(`Error fetching data from locale "${toLocale}"`)
   }
 
-  const fields = globalSlug
-    ? globals[globalSlug].config.fields
-    : collections[collectionSlug].config.fields
+  let fields: Field[]
+  if (globalSlug) {
+    const globalConfig = payload.globals.config.find((c) => c.slug === globalSlug)
+    if (!globalConfig) {
+      throw new APIError(`The global with slug ${String(globalSlug)} can't be found.`, 404)
+    }
+    fields = globalConfig.fields
+  } else {
+    const collection = collections[collectionSlug]
+    if (!collection) {
+      throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`, 404)
+    }
+    fields = collection.config.fields
+  }
 
   const fromLocaleDataWithoutID = fromLocaleData.value
   const toLocaleDataWithoutID = toLocaleData.value

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -463,6 +463,17 @@ export default buildConfigWithDefaults({
         },
       },
     },
+    {
+      slug: 'localized-global-for-copy',
+      fields: [
+        { name: 'title', type: 'text', localized: true },
+        {
+          name: 'group',
+          type: 'group',
+          fields: [{ name: 'subtitle', type: 'text', localized: true }],
+        },
+      ],
+    },
   ],
   localization: {
     filterAvailableLocales: ({ locales }) => {

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -3315,6 +3315,52 @@ describe('Localization', () => {
 
         expect(enPublishedAfter.title).toBe('Published EN')
       })
+
+      describe('copyDataFromLocale - globals', () => {
+        it('copies undefined fields from a source locale to a target locale on a global', async () => {
+          await payload.updateGlobal({
+            slug: 'localized-global-for-copy',
+            data: { title: 'Hello', group: { subtitle: 'World' } },
+            locale: 'en',
+          })
+
+          await payload.updateGlobal({
+            slug: 'localized-global-for-copy',
+            data: { title: null, group: { subtitle: null } },
+            locale: 'es',
+          })
+
+          const req = await createLocalReq({ user }, payload)
+          await copyDataFromLocaleHandler({
+            fromLocale: 'en',
+            globalSlug: 'localized-global-for-copy',
+            overrideData: false,
+            req,
+            toLocale: 'es',
+          })
+
+          const result = await payload.findGlobal({
+            slug: 'localized-global-for-copy',
+            locale: 'es',
+            draft: true,
+          })
+          expect(result.title).toBe('Hello')
+          expect(result.group?.subtitle).toBe('World')
+        })
+
+        it('throws a clear error when the global slug does not exist', async () => {
+          const req = await createLocalReq({ user }, payload)
+          await expect(
+            copyDataFromLocaleHandler({
+              fromLocale: 'en',
+              globalSlug: 'does-not-exist' as never,
+              overrideData: false,
+              req,
+              toLocale: 'es',
+            }),
+          ).rejects.toThrow(/can't be found/)
+        })
+      })
     })
 
     describe('Multiple fallback locales', () => {

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -138,11 +138,15 @@ export interface Config {
     'global-array': GlobalArray;
     'global-text': GlobalText;
     'global-drafts': GlobalDraft;
+    'localized-global-for-copy': LocalizedGlobalForCopy;
   };
   globalsSelect: {
     'global-array': GlobalArraySelect<false> | GlobalArraySelect<true>;
     'global-text': GlobalTextSelect<false> | GlobalTextSelect<true>;
     'global-drafts': GlobalDraftsSelect<false> | GlobalDraftsSelect<true>;
+    'localized-global-for-copy':
+      | LocalizedGlobalForCopySelect<false>
+      | LocalizedGlobalForCopySelect<true>;
   };
   locale: 'xx' | 'en' | 'es' | 'pt' | 'ar' | 'hu';
   widgets: {
@@ -1793,6 +1797,19 @@ export interface GlobalDraft {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-global-for-copy".
+ */
+export interface LocalizedGlobalForCopy {
+  id: string;
+  title?: string | null;
+  group?: {
+    subtitle?: string | null;
+  };
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "global-array_select".
  */
 export interface GlobalArraySelect<T extends boolean = true> {
@@ -1823,6 +1840,21 @@ export interface GlobalTextSelect<T extends boolean = true> {
 export interface GlobalDraftsSelect<T extends boolean = true> {
   text?: T;
   _status?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-global-for-copy_select".
+ */
+export interface LocalizedGlobalForCopySelect<T extends boolean = true> {
+  title?: T;
+  group?:
+    | T
+    | {
+        subtitle?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;


### PR DESCRIPTION
## The bug

Calling the server function `copyDataFromLocaleHandler` with a `globalSlug` (triggered by the admin UI's "Copy to locale" button on any Global) crashes with:

    TypeError: Cannot read properties of undefined (reading 'config')
        at copyDataFromLocale (packages/ui/src/utilities/copyDataFromLocale.ts:208)

The same button works fine for Collections. For Globals it is 100% broken. Reproducible on current `main` and released versions up to at least `v3.83.0`.

### Repro steps
1. In any config with `localization` enabled and ≥ 2 locales, define a Global (e.g. `{ slug: 'homescreen-layout', fields: [...] }`).
2. Edit the Global in one locale, save.
3. Switch to another locale, open the "Copy to locale" menu, pick the source locale, click "Copy".
4. Observe the error above in server logs; the admin toast shows "Cannot read properties of undefined (reading 'config')".

## Root cause

`copyDataFromLocale` destructured `globals` off `req.payload` and then looked up `globals[globalSlug].config.fields`, assuming `payload.globals` is a slug-keyed map the way `payload.collections` is. It isn't. Per `packages/payload/src/index.ts`, `payload.globals` always has shape `{ config: SanitizedGlobalConfig[] }`. Every other place in the codebase (e.g. `packages/payload/src/globals/operations/local/findOne.ts`, `update.ts`, `restoreVersion.ts`, `findVersions.ts`, `findVersionByID.ts`, `countVersions.ts`, `utilities/handleEndpoints.ts`, `utilities/getRequestEntity.ts`) resolves a global via `payload.globals.config.find((c) => c.slug === globalSlug)`. `copyDataFromLocale` was the only offender, so `globals[globalSlug]` was always `undefined` for a real slug and `.config` threw.

## The fix

- Look up the global via `payload.globals.config.find((c) => c.slug === globalSlug)`, matching the rest of Payload.
- Throw `APIError("The global with slug X can't be found.", 404)` if the slug is missing (mirrored the same guard on the collection branch so a bad `collectionSlug` no longer crashes on `undefined.config.fields` either).
- Removed the unused `globals` destructure.

Public signatures of `copyDataFromLocale` / `copyDataFromLocaleHandler` are unchanged.

## Tests

Added under `test/localization/int.spec.ts`, inside the existing `Copying To Locale` block:

- `copies undefined fields from a source locale to a target locale on a global` — seeds `en`, clears `es`, calls `copyDataFromLocaleHandler` with `globalSlug`, asserts `title` and `group.subtitle` are copied on the `es` draft. This would have failed on `main` with the original `TypeError`.
- `throws a clear error when the global slug does not exist` — asserts the new `APIError` path.

Introduced a minimal `localized-global-for-copy` global in `test/localization/config.ts` for the round-trip.

Run locally with:

    pnpm test:int --filter localization