### PR TITLE
chore(templates): fix link to one-click deployment

### DIFF
--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -287,7 +287,7 @@ export default buildConfig({
   // ...
 ```
 
-There is also a simplified [one click deploy](https://github.com/payloadcms/payload/tree/templates/with-vercel-postgres) to Vercel should you need it.
+There is also a simplified [one click deploy](https://github.com/payloadcms/payload/tree/main/templates/with-vercel-postgres) to Vercel should you need it.
 
 ### Self-hosting
 


### PR DESCRIPTION
Fixes a broken one-click deployment link from the website template, which wrongfully omits the branch name from the URL.