### PR TITLE
fix(ui): bulk edit ignores fields in named tabs and shows incorrect labels for unlabeled containers

### DIFF
--- a/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
+++ b/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
@@ -83,11 +83,14 @@ export const reduceFieldOptions = ({
     }
 
     if (!(field.type === 'array' || field.type === 'blocks') && fieldHasSubFields(field)) {
+      const fieldHasLabel = 'label' in field && field.label
       return [
         ...fieldsToUse,
         ...reduceFieldOptions({
           fields: field.fields,
-          labelPrefix: combineFieldLabel({ CustomLabel, field, prefix: labelPrefix }),
+          labelPrefix: fieldHasLabel
+            ? combineFieldLabel({ CustomLabel, field, prefix: labelPrefix })
+            : labelPrefix,
           parentPath: path,
           path: createNestedClientFieldPath(path, field),
           permissions: fieldPermissions,
@@ -107,7 +110,7 @@ export const reduceFieldOptions = ({
                 fields: tab.fields,
                 labelPrefix,
                 parentPath: path,
-                path: isNamedTab ? createNestedClientFieldPath(path, field) : path,
+                path: isNamedTab ? createNestedClientFieldPath(path, tab as ClientField) : path,
                 permissions: fieldPermissions,
               }),
             ]

--- a/test/bulk-edit/collections/Tabs/index.ts
+++ b/test/bulk-edit/collections/Tabs/index.ts
@@ -25,6 +25,10 @@ export const TabsCollection: CollectionConfig = {
                   name: 'tabTab',
                   fields: [
                     {
+                      name: 'tabText',
+                      type: 'text',
+                    },
+                    {
                       name: 'tabTabArray',
                       type: 'array',
                       fields: [
@@ -33,6 +37,24 @@ export const TabsCollection: CollectionConfig = {
                           type: 'text',
                         },
                       ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'noLabelGroup',
+              type: 'group',
+              label: false,
+              fields: [
+                {
+                  type: 'row',
+                  fields: [
+                    {
+                      name: 'rowText',
+                      type: 'text',
+                      label: 'Row Text',
+                      admin: { width: '50%' },
                     },
                   ],
                 },

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -745,6 +745,102 @@ test.describe('Bulk Edit', () => {
       .toEqual('nestedText')
   })
 
+  test('should bulk edit a field inside a named tab', async () => {
+    const originalDoc = await payload.create({
+      collection: tabsSlug,
+      data: {
+        title: 'Tab Doc',
+        tabTab: {
+          tabText: 'original value',
+        },
+      },
+    })
+
+    await page.goto(tabsUrl.list)
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    await addListFilter({
+      page,
+      fieldLabel: 'ID',
+      operatorLabel: 'equals',
+      value: originalDoc.id,
+    })
+
+    await page.locator('table tbody tr.row-1 input[type="checkbox"]').check()
+    await page
+      .locator('.list-selection__actions .btn', {
+        hasText: 'Edit',
+      })
+      .click()
+
+    const bulkEditForm = page.locator('form.edit-many__form')
+    await expect(bulkEditForm).toBeVisible()
+
+    await selectInput({
+      selectLocator: bulkEditForm.locator('.react-select'),
+      options: ['Tab Text'],
+      multiSelect: true,
+    })
+
+    await bulkEditForm.getByLabel('Tab Text').fill('updated value')
+    await bulkEditForm.locator('button[type="submit"]').click()
+
+    await expect(bulkEditForm).toBeHidden()
+
+    const updatedDocQuery = await payload.find({
+      collection: tabsSlug,
+      where: {
+        id: {
+          equals: originalDoc.id,
+        },
+      },
+    })
+    const updatedDoc = updatedDocQuery.docs[0]
+
+    await expect
+      .poll(() => updatedDoc?.tabTab?.tabText, { timeout: POLL_TOPASS_TIMEOUT })
+      .toEqual('updated value')
+
+    await payload.delete({ collection: tabsSlug, id: originalDoc.id })
+  })
+
+  test('should show clean labels for fields inside label-false groups and rows', async () => {
+    const doc = await payload.create({
+      collection: tabsSlug,
+      data: { title: 'Label Test Doc' },
+    })
+
+    await page.goto(tabsUrl.list)
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    await addListFilter({
+      page,
+      fieldLabel: 'ID',
+      operatorLabel: 'equals',
+      value: doc.id,
+    })
+
+    await page.locator('table tbody tr.row-1 input[type="checkbox"]').check()
+    await page
+      .locator('.list-selection__actions .btn', {
+        hasText: 'Edit',
+      })
+      .click()
+
+    const bulkEditForm = page.locator('form.edit-many__form')
+    await expect(bulkEditForm).toBeVisible()
+
+    await bulkEditForm.locator('.field-select .rs__control').click()
+
+    // The option must match exactly — no spurious "> >" prefix
+    const option = bulkEditForm.locator('.field-select .rs__option', {
+      hasText: exactText('Row Text'),
+    })
+    await expect(option).toBeVisible()
+
+    await payload.delete({ collection: tabsSlug, id: doc.id })
+  })
+
   test('should preserve beforeInput components when selecting multiple fields', async () => {
     await deleteAllPosts()
     await createPost({ title: 'Post 1' })

--- a/test/bulk-edit/payload-types.ts
+++ b/test/bulk-edit/payload-types.ts
@@ -92,6 +92,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -168,12 +171,16 @@ export interface Tab {
   id: string;
   title?: string | null;
   tabTab?: {
+    tabText?: string | null;
     tabTabArray?:
       | {
           tabTabArrayText?: string | null;
           id?: string | null;
         }[]
       | null;
+  };
+  noLabelGroup?: {
+    rowText?: string | null;
   };
   updatedAt: string;
   createdAt: string;
@@ -338,12 +345,18 @@ export interface TabsSelect<T extends boolean = true> {
   tabTab?:
     | T
     | {
+        tabText?: T;
         tabTabArray?:
           | T
           | {
               tabTabArrayText?: T;
               id?: T;
             };
+      };
+  noLabelGroup?:
+    | T
+    | {
+        rowText?: T;
       };
   updatedAt?: T;
   createdAt?: T;
@@ -409,6 +422,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
## Overview

Fixes two bugs in `reduceFieldOptions` affecting the bulk edit field selector.

### Key Changes

Fields inside named tabs were not updating on bulk edit - the tab namespace was being stripped from the field path, so the API received `{ status: "draft" }` instead of `{ myTab: { status: "draft" } }` and silently skipped the update.

Fields nested inside unlabeled containers (`row`, groups with `label: false`) were showing spurious `> >` prefixes in the dropdown.

Fixes #15995 