### PR TITLE
fix(next): use namespace import for @next/env to fix Node 24 ESM compat

### DIFF
--- a/packages/payload/src/bin/loadEnv.ts
+++ b/packages/payload/src/bin/loadEnv.ts
@@ -1,7 +1,11 @@
-import nextEnvImport from '@next/env'
+import * as nextEnvImport from '@next/env'
 
 import { findUpSync } from '../utilities/findUp.js'
-const { loadEnvConfig } = nextEnvImport
+
+// @next/env is CJS-only with no default export. Node 24 strictly follows the
+// __esModule flag and returns undefined for default imports of such packages.
+// Namespace import + fallback handles both Node 24 and older Node versions.
+const loadEnvConfig = nextEnvImport.loadEnvConfig ?? (nextEnvImport as any).default?.loadEnvConfig
 
 /**
  * Try to find user's env files and load it. Uses the same algorithm next.js uses to parse env files, meaning this also supports .env.local, .env.development, .env.production, etc.


### PR DESCRIPTION
## What

  Fixes `payload run` crashing immediately on Node.js 24 with:

      TypeError: Cannot destructure property 'loadEnvConfig' of 'import_env.default' as it is undefined.

  ## Why

  `@next/env` is a CJS-only bundle that sets `__esModule: true` on `module.exports` but has no `.default` property. Node 24
  strictly follows the `__esModule` flag and returns `undefined` for default imports. Older Node versions (18/20) fall back to
  the whole `module.exports` object, which is why this only surfaces on Node 24.

  Named imports also fail — the CJS bundle is not statically analyzable so Node 24 cannot detect its named exports. The namespace
   import (`import * as`) is the only form that works across all Node versions.

  ## How

  ```diff
  - import nextEnvImport from '@next/env'
  - const { loadEnvConfig } = nextEnvImport
  + import * as nextEnvImport from '@next/env'
  + const loadEnvConfig = nextEnvImport.loadEnvConfig ?? (nextEnvImport as any).default?.loadEnvConfig

  Closes #16341
  ```