### PR TITLE
fix: add type declarations for css export (TypeScript 6 compat)

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -23,6 +23,7 @@
   "type": "module",
   "exports": {
     "./css": {
+      "types": "./src/exports/css.ts",
       "import": "./src/dummy.css",
       "default": "./src/dummy.css"
     },
@@ -153,6 +154,7 @@
   "publishConfig": {
     "exports": {
       "./css": {
+        "types": "./dist/exports/css.d.ts",
         "import": "./dist/prod/styles.css",
         "default": "./dist/prod/styles.css"
       },

--- a/packages/next/src/exports/css.ts
+++ b/packages/next/src/exports/css.ts
@@ -1,0 +1,2 @@
+const styles: void = undefined
+export default styles


### PR DESCRIPTION
### What?

Add TypeScript type declarations for the `./css` package export in `@payloadcms/next`.

### Why?

TypeScript 6 enables [`noUncheckedSideEffectImports`](https://www.typescriptlang.org/tsconfig/noUncheckedSideEffectImports.html) by default. This causes `import '@payloadcms/next/css'` — present in all three files generated by `create-payload-app` — to fail with:

error TS2882: Cannot find module or type declarations for side-effect import of '@payloadcms/next/css'.

The published `./css` export currently has no `types` field:

  ```json
  "./css": {
    "import": "./dist/prod/styles.css",
    "default": "./dist/prod/styles.css"
  }
```

### How?

Add src/exports/css.ts as a regular TypeScript source file (consistent with all other exports so the existing build pipeline produces dist/exports/css.d.ts. Then wire the types field into both dev and publishConfig exports.

**Testing:**
Tested locally by copying the new files
`cp ../../payload/packages/next/dist/exports/css.* node_modules/@payloadcms/next/dist/exports`
and pacthing the package.json manually:
```
--- original-package.json       2026-04-22 10:43:26
+++ package.json        2026-04-22 10:43:57
@@ -24,6 +24,7 @@
   "exports": {
     "./css": {
       "import": "./dist/prod/styles.css",
+      "types": "./dist/exports/css.d.ts",
       "default": "./dist/prod/styles.css"
     },
     "./withPayload": {
```
after that my test project builds fine with typescript 6.0.3

Fixes #16346