### PR TITLE
fix: apply EXIF rotation in crop pipeline and add regression tests

### DIFF
--- a/packages/payload/src/uploads/cropImage.spec.ts
+++ b/packages/payload/src/uploads/cropImage.spec.ts
@@ -1,0 +1,51 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+import type { PayloadRequest } from '../types/index.js'
+
+import { cropImage } from './cropImage.js'
+
+describe('cropImage', () => {
+  it('should crop EXIF-oriented images using rotated dimensions', async () => {
+    // @ts-expect-error sharp default export depends on tsconfig interop settings
+    const sharp = (await import('sharp')).default as typeof import('sharp')
+
+    const baseImageSVG = Buffer.from(
+      '<svg width="1200" height="800" xmlns="http://www.w3.org/2000/svg"><rect width="1200" height="800" fill="#00ffff"/></svg>',
+    )
+
+    const exifOrientedJpeg = await sharp(baseImageSVG)
+      .jpeg()
+      .withMetadata({ orientation: 6 })
+      .toBuffer()
+
+    const result = await cropImage({
+      cropData: {
+        height: 100,
+        unit: '%',
+        width: 100,
+        x: 0,
+        y: 0,
+      },
+      dimensions: {
+        height: 1200,
+        width: 800,
+      },
+      file: {
+        data: exifOrientedJpeg,
+        mimetype: 'image/jpeg',
+        name: 'oriented.jpg',
+        size: exifOrientedJpeg.length,
+      },
+      heightInPixels: 1199,
+      req: {} as PayloadRequest,
+      sharp,
+      widthInPixels: 799,
+      withMetadata: false,
+    })
+
+    expect(result.info.width).toEqual(799)
+    expect(result.info.height).toEqual(1199)
+  })
+})

--- a/packages/payload/src/uploads/cropImage.ts
+++ b/packages/payload/src/uploads/cropImage.ts
@@ -53,10 +53,9 @@ export async function cropImage({
       let adjustedHeight = originalHeight
 
       if (fileIsAnimatedType) {
-        const animatedMetadata = await sharp(
-          file.tempFilePath || file.data,
-          sharpOptions,
-        ).metadata()
+        const animatedMetadata = await sharp(file.tempFilePath || file.data, sharpOptions)
+          .rotate() // pass rotate() to auto-rotate based on EXIF data.
+          .metadata()
         adjustedHeight = animatedMetadata.pages ? animatedMetadata.height! : originalHeight
       }
 
@@ -77,7 +76,9 @@ export async function cropImage({
       width: Number(widthInPixels),
     }
 
-    let cropped = sharp(file.tempFilePath || file.data, sharpOptions).extract(formattedCropData)
+    let cropped = sharp(file.tempFilePath || file.data, sharpOptions)
+      .rotate() // pass rotate() to auto-rotate based on EXIF data.
+      .extract(formattedCropData)
 
     cropped = await optionallyAppendMetadata({
       req: req!,


### PR DESCRIPTION
### What?
This PR fixes EXIF-orientation handling in the upload crop pipeline.
Specifically:
- apply `sharp().rotate()` before `.extract(...)` in `cropImage` so crop coordinates are applied in the same oriented coordinate space as other upload transforms
- apply `.rotate()` in the animated metadata read path used by the no-op crop branch to keep dimension handling consistent
- add regression tests in `cropImage.spec.ts` for:
  - EXIF-oriented crop behavior
### Why?
Cropping images with EXIF orientation > 1 could behave incorrectly because crop extraction was not using the same EXIF-normalized orientation path as the rest of upload processing.
This could lead to:
- wrong crop orientation / flipped output
- in some cases, crop failures (e.g. bad extract area) due to coordinate mismatch
Related issue: [#16347](https://github.com/payloadcms/payload/issues/16347)
### How?
- Updated `packages/payload/src/uploads/cropImage.ts`:
  - added `.rotate()` before metadata read in the animated branch
  - added `.rotate()` before crop `.extract(...)`
- Added `packages/payload/src/uploads/cropImage.spec.ts` with targeted regression coverage
- Verified test run:
  - `pnpm vitest packages/payload/src/uploads/cropImage.spec.ts`
Fixes #16347