### PR TITLE
fix(ui): json and richText fields expose unsupported operators in WhereBuilder

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/field-types.tsx
+++ b/packages/ui/src/elements/WhereBuilder/field-types.tsx
@@ -108,7 +108,7 @@ export const fieldTypeConditions: {
   },
   json: {
     component: 'Text',
-    operators: [...base, like, contains, notLike, within, intersects],
+    operators: [exists],
   },
   number: {
     component: 'Number',
@@ -128,7 +128,7 @@ export const fieldTypeConditions: {
   },
   richText: {
     component: 'Text',
-    operators: [...base, like, notLike, contains],
+    operators: [exists],
   },
   select: {
     component: 'Select',

--- a/test/fields/collections/JSON/e2e.spec.ts
+++ b/test/fields/collections/JSON/e2e.spec.ts
@@ -8,14 +8,15 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../../../__helpers/shared/sdk/index.js'
 import type { Config } from '../../payload-types.js'
 
+import { openListFilters } from '../../../__helpers/e2e/filters/openListFilters.js'
 import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
   saveDocAndAssert,
 } from '../../../__helpers/e2e/helpers.js'
 import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
-import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../../../__helpers/shared/rest.js'
 import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 import { jsonFieldsSlug } from '../../slugs.js'
@@ -218,6 +219,32 @@ describe('JSON', () => {
     await expect(() => {
       expect(newHeight).toBeGreaterThan(originalHeight)
     }).toPass()
+  })
+
+  describe('WhereBuilder', () => {
+    test('should only expose exists operator for json field', async () => {
+      await page.goto(url.list)
+
+      await openListFilters(page, {})
+
+      const whereBuilder = page.locator('.where-builder')
+      await whereBuilder.locator('.where-builder__add-first-filter').click()
+
+      const condition = whereBuilder.locator('.where-builder__or-filters > li').first()
+
+      // Select the 'json' field
+      await condition.locator('.condition__field .rs__control').click()
+      await page
+        .locator('.rs__option', { hasText: /^json$/i })
+        .first()
+        .click()
+
+      // Open the operator dropdown and collect all available options
+      await condition.locator('.condition__operator .rs__control').click()
+      const operatorOptions = page.locator('.rs__option')
+      await expect(operatorOptions).toHaveCount(1)
+      await expect(operatorOptions.first()).toHaveText('exists')
+    })
   })
 
   describe('A11y', () => {

--- a/test/lexical/collections/RichText/e2e.spec.ts
+++ b/test/lexical/collections/RichText/e2e.spec.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 
+import { openListFilters } from '../../../__helpers/e2e/filters/openListFilters.js'
 import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
@@ -16,6 +17,7 @@ import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
 import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+import { richTextFieldsSlug } from '../../slugs.js'
 
 const filename = fileURLToPath(import.meta.url)
 const currentFolder = path.dirname(filename)
@@ -427,6 +429,33 @@ describe('Rich Text', () => {
       await expect(richTextField).toBeVisible()
       const richTextValue = await richTextField.innerText()
       expect(richTextValue).toContain('Rich text')
+    })
+  })
+
+  describe('WhereBuilder', () => {
+    test('should only expose exists operator for richText field', async () => {
+      const url = new AdminUrlUtil(serverURL, richTextFieldsSlug)
+      await page.goto(url.list)
+
+      await openListFilters(page, {})
+
+      const whereBuilder = page.locator('.where-builder')
+      await whereBuilder.locator('.where-builder__add-first-filter').click()
+
+      const condition = whereBuilder.locator('.where-builder__or-filters > li').first()
+
+      // Select the 'richText' field
+      await condition.locator('.condition__field .rs__control').click()
+      await page
+        .locator('.rs__option', { hasText: /^Rich Text$/ })
+        .first()
+        .click()
+
+      // Open the operator dropdown and collect all available options
+      await condition.locator('.condition__operator .rs__control').click()
+      const operatorOptions = page.locator('.rs__option')
+      await expect(operatorOptions).toHaveCount(1)
+      await expect(operatorOptions.first()).toHaveText('exists')
     })
   })
 })

--- a/test/lexical/payload-types.ts
+++ b/test/lexical/payload-types.ts
@@ -159,7 +159,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es' | 'he') | ('en' | 'es' | 'he')[];
   globals: {
@@ -221,7 +221,7 @@ export interface BlockWithBlockRef {
  * via the `definition` "lexical-benchmark".
  */
 export interface LexicalBenchmark {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -245,7 +245,7 @@ export interface LexicalBenchmark {
  * via the `definition` "lexical-fully-featured".
  */
 export interface LexicalFullyFeatured {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -269,7 +269,7 @@ export interface LexicalFullyFeatured {
  * via the `definition` "lexical-autosave".
  */
 export interface LexicalAutosave {
-  id: number;
+  id: string;
   title?: string | null;
   cta?:
     | {
@@ -300,7 +300,7 @@ export interface LexicalAutosave {
  * via the `definition` "lexical-link-feature".
  */
 export interface LexicalLinkFeature {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -324,7 +324,7 @@ export interface LexicalLinkFeature {
  * via the `definition` "lexical-lists-features".
  */
 export interface LexicalListsFeature {
-  id: number;
+  id: string;
   onlyOrderedList?: {
     root: {
       type: string;
@@ -348,7 +348,7 @@ export interface LexicalListsFeature {
  * via the `definition` "lexical-heading-feature".
  */
 export interface LexicalHeadingFeature {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -372,7 +372,7 @@ export interface LexicalHeadingFeature {
  * via the `definition` "lexical-jsx-converter".
  */
 export interface LexicalJsxConverter {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -396,7 +396,7 @@ export interface LexicalJsxConverter {
  * via the `definition` "lexical-fields".
  */
 export interface LexicalField {
-  id: number;
+  id: string;
   title: string;
   lexicalRootEditor?: {
     root: {
@@ -458,7 +458,7 @@ export interface LexicalField {
  * via the `definition` "lexical-views".
  */
 export interface LexicalView {
-  id: number;
+  id: string;
   customDefaultView?: {
     root: {
       type: string;
@@ -497,7 +497,7 @@ export interface LexicalView {
  * via the `definition` "lexical-views-frontend".
  */
 export interface LexicalViewsFrontend {
-  id: number;
+  id: string;
   customFrontendViews?: {
     root: {
       type: string;
@@ -521,7 +521,7 @@ export interface LexicalViewsFrontend {
  * via the `definition` "lexical-views-provider".
  */
 export interface LexicalViewsProvider {
-  id: number;
+  id: string;
   viewProviderWrapper?: {
     richTextField?: {
       root: {
@@ -547,7 +547,7 @@ export interface LexicalViewsProvider {
  * via the `definition` "lexical-views-provider-default".
  */
 export interface LexicalViewsProviderDefault {
-  id: number;
+  id: string;
   defaultViewWrapper?: {
     richTextField?: {
       root: {
@@ -573,7 +573,7 @@ export interface LexicalViewsProviderDefault {
  * via the `definition` "lexical-views-provider-fallback".
  */
 export interface LexicalViewsProviderFallback {
-  id: number;
+  id: string;
   fallbackViewWrapper?: {
     richTextField?: {
       root: {
@@ -599,7 +599,7 @@ export interface LexicalViewsProviderFallback {
  * via the `definition` "lexical-views-nested".
  */
 export interface LexicalViewsNested {
-  id: number;
+  id: string;
   parentRichText?: {
     root: {
       type: string;
@@ -623,7 +623,7 @@ export interface LexicalViewsNested {
  * via the `definition` "lexical-migrate-fields".
  */
 export interface LexicalMigrateField {
-  id: number;
+  id: string;
   title: string;
   lexicalWithLexicalPluginData?: {
     root: {
@@ -718,7 +718,7 @@ export interface LexicalMigrateField {
  * via the `definition` "lexical-localized-fields".
  */
 export interface LexicalLocalizedField {
-  id: number;
+  id: string;
   title: string;
   /**
    * Non-localized field with localized block subfields
@@ -764,7 +764,7 @@ export interface LexicalLocalizedField {
  * via the `definition` "lexicalObjectReferenceBug".
  */
 export interface LexicalObjectReferenceBug {
-  id: number;
+  id: string;
   lexicalDefault?: {
     root: {
       type: string;
@@ -803,7 +803,7 @@ export interface LexicalObjectReferenceBug {
  * via the `definition` "LexicalInBlock".
  */
 export interface LexicalInBlock {
-  id: number;
+  id: string;
   content?: {
     root: {
       type: string;
@@ -849,7 +849,7 @@ export interface LexicalInBlock {
  * via the `definition` "lexical-access-control".
  */
 export interface LexicalAccessControl {
-  id: number;
+  id: string;
   title?: string | null;
   richText?: {
     root: {
@@ -874,7 +874,7 @@ export interface LexicalAccessControl {
  * via the `definition` "lexical-relationship-fields".
  */
 export interface LexicalRelationshipField {
-  id: number;
+  id: string;
   richText?: {
     root: {
       type: string;
@@ -944,7 +944,7 @@ export interface LexicalRelationshipField {
  * via the `definition` "lexical-nested-blocks".
  */
 export interface LexicalNestedBlock {
-  id: number;
+  id: string;
   title: string;
   richText?: {
     root: {
@@ -969,7 +969,7 @@ export interface LexicalNestedBlock {
  * via the `definition` "rich-text-fields".
  */
 export interface RichTextField {
-  id: number;
+  id: string;
   title: string;
   lexicalCustomFields: {
     root: {
@@ -1050,7 +1050,7 @@ export interface RichTextField {
  * via the `definition` "text-fields".
  */
 export interface TextField {
-  id: number;
+  id: string;
   text: string;
   hiddenTextField?: string | null;
   /**
@@ -1102,9 +1102,9 @@ export interface TextField {
  * via the `definition` "uploads".
  */
 export interface Upload {
-  id: number;
+  id: string;
   text?: string | null;
-  media?: (number | null) | Upload;
+  media?: (string | null) | Upload;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1122,9 +1122,9 @@ export interface Upload {
  * via the `definition` "uploads2".
  */
 export interface Uploads2 {
-  id: number;
+  id: string;
   text?: string | null;
-  media?: (number | null) | Upload;
+  media?: (string | null) | Upload;
   altText?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1143,7 +1143,7 @@ export interface Uploads2 {
  * via the `definition` "array-fields".
  */
 export interface ArrayField {
-  id: number;
+  id: string;
   title?: string | null;
   items: {
     text: string;
@@ -1241,7 +1241,7 @@ export interface ArrayField {
  * via the `definition` "OnDemandForm".
  */
 export interface OnDemandForm {
-  id: number;
+  id: string;
   json?:
     | {
         [k: string]: unknown;
@@ -1259,7 +1259,7 @@ export interface OnDemandForm {
  * via the `definition` "OnDemandOutsideForm".
  */
 export interface OnDemandOutsideForm {
-  id: number;
+  id: string;
   json?:
     | {
         [k: string]: unknown;
@@ -1292,7 +1292,7 @@ export interface OnDemandOutsideForm {
  * via the `definition` "lexical-custom-cell".
  */
 export interface LexicalCustomCell {
-  id: number;
+  id: string;
   title: string;
   richTextField?: {
     root: {
@@ -1317,7 +1317,7 @@ export interface LexicalCustomCell {
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
-  id: number;
+  id: string;
   key: string;
   data:
     | {
@@ -1334,7 +1334,7 @@ export interface PayloadKv {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -1359,132 +1359,132 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'lexical-benchmark';
-        value: number | LexicalBenchmark;
+        value: string | LexicalBenchmark;
       } | null)
     | ({
         relationTo: 'lexical-fully-featured';
-        value: number | LexicalFullyFeatured;
+        value: string | LexicalFullyFeatured;
       } | null)
     | ({
         relationTo: 'lexical-autosave';
-        value: number | LexicalAutosave;
+        value: string | LexicalAutosave;
       } | null)
     | ({
         relationTo: 'lexical-link-feature';
-        value: number | LexicalLinkFeature;
+        value: string | LexicalLinkFeature;
       } | null)
     | ({
         relationTo: 'lexical-lists-features';
-        value: number | LexicalListsFeature;
+        value: string | LexicalListsFeature;
       } | null)
     | ({
         relationTo: 'lexical-heading-feature';
-        value: number | LexicalHeadingFeature;
+        value: string | LexicalHeadingFeature;
       } | null)
     | ({
         relationTo: 'lexical-jsx-converter';
-        value: number | LexicalJsxConverter;
+        value: string | LexicalJsxConverter;
       } | null)
     | ({
         relationTo: 'lexical-fields';
-        value: number | LexicalField;
+        value: string | LexicalField;
       } | null)
     | ({
         relationTo: 'lexical-views';
-        value: number | LexicalView;
+        value: string | LexicalView;
       } | null)
     | ({
         relationTo: 'lexical-views-frontend';
-        value: number | LexicalViewsFrontend;
+        value: string | LexicalViewsFrontend;
       } | null)
     | ({
         relationTo: 'lexical-views-provider';
-        value: number | LexicalViewsProvider;
+        value: string | LexicalViewsProvider;
       } | null)
     | ({
         relationTo: 'lexical-views-provider-default';
-        value: number | LexicalViewsProviderDefault;
+        value: string | LexicalViewsProviderDefault;
       } | null)
     | ({
         relationTo: 'lexical-views-provider-fallback';
-        value: number | LexicalViewsProviderFallback;
+        value: string | LexicalViewsProviderFallback;
       } | null)
     | ({
         relationTo: 'lexical-views-nested';
-        value: number | LexicalViewsNested;
+        value: string | LexicalViewsNested;
       } | null)
     | ({
         relationTo: 'lexical-migrate-fields';
-        value: number | LexicalMigrateField;
+        value: string | LexicalMigrateField;
       } | null)
     | ({
         relationTo: 'lexical-localized-fields';
-        value: number | LexicalLocalizedField;
+        value: string | LexicalLocalizedField;
       } | null)
     | ({
         relationTo: 'lexicalObjectReferenceBug';
-        value: number | LexicalObjectReferenceBug;
+        value: string | LexicalObjectReferenceBug;
       } | null)
     | ({
         relationTo: 'LexicalInBlock';
-        value: number | LexicalInBlock;
+        value: string | LexicalInBlock;
       } | null)
     | ({
         relationTo: 'lexical-access-control';
-        value: number | LexicalAccessControl;
+        value: string | LexicalAccessControl;
       } | null)
     | ({
         relationTo: 'lexical-relationship-fields';
-        value: number | LexicalRelationshipField;
+        value: string | LexicalRelationshipField;
       } | null)
     | ({
         relationTo: 'lexical-nested-blocks';
-        value: number | LexicalNestedBlock;
+        value: string | LexicalNestedBlock;
       } | null)
     | ({
         relationTo: 'rich-text-fields';
-        value: number | RichTextField;
+        value: string | RichTextField;
       } | null)
     | ({
         relationTo: 'text-fields';
-        value: number | TextField;
+        value: string | TextField;
       } | null)
     | ({
         relationTo: 'uploads';
-        value: number | Upload;
+        value: string | Upload;
       } | null)
     | ({
         relationTo: 'uploads2';
-        value: number | Uploads2;
+        value: string | Uploads2;
       } | null)
     | ({
         relationTo: 'array-fields';
-        value: number | ArrayField;
+        value: string | ArrayField;
       } | null)
     | ({
         relationTo: 'OnDemandForm';
-        value: number | OnDemandForm;
+        value: string | OnDemandForm;
       } | null)
     | ({
         relationTo: 'OnDemandOutsideForm';
-        value: number | OnDemandOutsideForm;
+        value: string | OnDemandOutsideForm;
       } | null)
     | ({
         relationTo: 'lexical-custom-cell';
-        value: number | LexicalCustomCell;
+        value: string | LexicalCustomCell;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -1494,10 +1494,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -1517,7 +1517,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -2087,7 +2087,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "tabsWithRichText".
  */
 export interface TabsWithRichText {
-  id: number;
+  id: string;
   tab1?: {
     rt1?: {
       root: {
@@ -2181,7 +2181,7 @@ export interface LexicalBlocksRadioButtonsBlock {
 export interface AvatarGroupBlock {
   avatars?:
     | {
-        image?: (number | null) | Upload;
+        image?: (string | null) | Upload;
         id?: string | null;
       }[]
     | null;


### PR DESCRIPTION
# Overview

Fixes broken operators exposed in the WhereBuilder for `json` and `richText` fields. Both field types are stored as JSONB in Postgres, so string operators like `contains`, `like`, and `not_like` throw `operator does not exist: jsonb ~~* text`. In MongoDB, `$regex` on a BSON document field silently returns 0 results. The `within`/`intersects` operators on `json` were also wrong since those are geo operators.

## Key Changes

Reduced the WhereBuilder operator list for both `json` and `richText` to `[exists]` only, and added e2e tests asserting only `exists` is available in the dropdown for both field types.

## Design Decisions

`exists` is the only operator that works and makes sense for these fields in the UI. Programmatic queries via the API with `equals`/`in` still work if you pass the exact JSON document, this only affects what the WhereBuilder exposes.