### PR TITLE
ci: update issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
@@ -1,7 +1,12 @@
-name: Functionality Bug
-description: '[REPRODUCTION REQUIRED] - Create a bug report'
-labels: ['status: needs-triage', 'validate-reproduction']
+name: Functionality Bug (v3)
+description: '[REPRODUCTION REQUIRED] - Report a bug in Payload v3'
+labels: ['status: needs-triage', 'validate-reproduction', 'v3']
 body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Payload v3 is in maintenance mode.** Only bug fixes are being accepted against v3 — new features are not. If you want to propose a new feature, please open a discussion targeting Payload v4 instead: https://github.com/payloadcms/payload/discussions
+
   - type: textarea
     attributes:
       label: Describe the Bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature Request
+  - name: Feature Request (v4 only)
     url: https://github.com/payloadcms/payload/discussions
-    about: Suggest an idea to improve Payload in our GitHub Discussions
+    about: Suggest an idea for Payload v4 in GitHub Discussions. Payload v3 is in maintenance mode — new features are not being accepted against v3.
   - name: Question about Payload
     url: https://github.com/payloadcms/payload/discussions
     about: Please ask Payload-related questions in our GitHub Discussions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,11 @@ Thank you for the PR! Please go through the checklist below and make sure you've
 
 Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.
 
+## Which branch should this PR target?
+
+- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
+- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.
+
 The following items will ensure that your PR is handled as smoothly as possible:
 
 - PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.


### PR DESCRIPTION
# Overview

Update issue and PR templates to signal that Payload v3 is in maintenance mode (bug fixes only) and direct new-feature contributions at v4 on `main`.

Companion to the v4 multi-branch publishing rollout: `main` = v4 development, `3.x` = v3 maintenance. These templates live on the default branch and are served for all issues/PRs regardless of target branch.

## Key Changes

- **Issue template config** (`.github/ISSUE_TEMPLATE/config.yml`)
  - Rename "Feature Request" contact link to "Feature Request (v4 only)" and note v3 is not accepting new features.

- **v3 bug report** (`.github/ISSUE_TEMPLATE/1.bug_report_v3.yml`)
  - Rename to "Functionality Bug (v3)".
  - Add top-of-form callout: v3 is maintenance-only; feature proposals go to discussions against v4.
  - Add `v3` label.

- **Pull request template** (`.github/PULL_REQUEST_TEMPLATE.md`)
  - Add branch-targeting guidance: `main` for v4 work, `3.x` for v3 bug fixes only (no new features).

## Design Decisions

- Templates stay on `main` (the default branch) only; GitHub serves them from the default branch for all issues/PRs, so no duplication onto `3.x` is needed. `3.x` already has its issue templates deleted (commit `e37a90a`).
- v3 bug reports remain accepted — only new features are redirected — since v3 stays in maintenance, not end-of-life.