### PR TITLE
ci: temporarily disable template builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -374,7 +374,9 @@ jobs:
   build-and-test-templates:
     runs-on: ubuntu-24.04
     needs: [changes, build]
-    if: needs.changes.outputs.needs_build == 'true'
+    # Temporarily disabled: template builds require a published beta of workspace packages.
+    # Re-enable once the next 4.x beta is published on npm.
+    if: false
     name: build-template-${{ matrix.template }}-${{ matrix.database }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Overview

Template build CI jobs fail on `main` after the version bump to `4.0.0-beta.0` because `tools/scripts/src/build-template-with-local-pkgs.ts` hardcodes a stale placeholder version (`3.42.0`) when rewriting `workspace:*` deps, and the 4.x beta isn't published on npm yet. Disable the jobs until the next 4.x beta ships.

Example failure: https://github.com/payloadcms/payload/actions/runs/24848623266/job/72743812553

## Key Changes

- **Skip `build-and-test-templates` in `main.yml`**
  - Set the job's `if:` to `false` with a comment noting it's temporary and should be re-enabled after the next 4.x beta publishes.
  - Skipped jobs report `skipped`, so the `all-green` gate (which only fails on `failure`/`cancelled`) still passes.

## Design Decisions

Chose to gate at the workflow level rather than patch the template build script. The underlying fix (reading the real workspace version instead of the hardcoded `3.42.0`) belongs in a follow-up once we can validate against a published beta; short-circuiting the job here unblocks `main` without masking the problem in the script itself.