### PR TITLE
fix(plugin-ecommerce): prevent crash when variant.options is undefined

### DIFF
--- a/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
+++ b/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
@@ -58,11 +58,16 @@ export const validateOptions: (props?: Props) => Validate =
       const existingOptions: (number | string)[][] = []
 
       variants.forEach((variant: any) => {
-        existingOptions.push(variant.options)
+        if (Array.isArray(variant?.options)) {
+          existingOptions.push(variant.options)
+        }
       })
 
       const exists = existingOptions.some(
-        (combo) => combo.length === values.length && combo.every((val) => values.includes(val)),
+        (combo) =>
+          Array.isArray(combo) &&
+          combo.length === values.length &&
+          combo.every((val) => values.includes(val)),
       )
 
       if (exists) {


### PR DESCRIPTION
### What?

Fixes a runtime crash in the validateOptions hook of the ecommerce plugin when a variant has `options` set to `undefined` or `null`.

### Why?

The current implementation assumes that every variant has `options` as an array. In real-world scenarios, this is not always true due to:
- Legacy data (before the options field existed)
- Partially migrated data
- Direct database inserts bypassing validation

When such a variant is encountered, the code attempts to access `.length` on a non-array value, resulting in a TypeError and blocking all variant creation/updates for that product.

### How?

Added defensive checks using `Array.isArray()`:
- While collecting existing variant options, only valid arrays are considered
- During duplicate comparison, an additional guard ensures safety

This approach:
- Prevents crashes
- Maintains correct duplicate detection logic
- Safely ignores invalid/legacy data without mutating it

Fixes #16368