### PR TITLE
fix(plugin-ecommerce): remove invalid deletedAt query when trash is disabled

### DIFF
--- a/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
+++ b/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
@@ -29,7 +29,6 @@ export const validateOptions: (props?: Props) => Validate =
       joins: {
         variants: {
           where: {
-            deletedAt: { exists: false },
             ...(data.id && {
               id: {
                 not_equals: data.id, // exclude the current variant from the search


### PR DESCRIPTION
### What?

Removes the `deletedAt` filter from the variants join query in the validateOptions hook.

### Why?

The current implementation assumes the presence of a `deletedAt` field. When trash is disabled on the Variants collection (trash: false), this field does not exist, causing a QueryError:

"The following path cannot be queried: deletedAt"

This breaks variant creation and updates.

### How?

Removed the `deletedAt` clause from the join query. Payload already excludes soft-deleted documents by default unless explicitly requested, making this filter redundant.

### Notes

Fixes #16367