### PR TITLE
fix: await CLI startup

### DIFF
--- a/packages/payload/bin.js
+++ b/packages/payload/bin.js
@@ -15,7 +15,7 @@ if (disableTranspile) {
     await bin()
   }
 
-  void start()
+  await start()
 } else {
   const filename = fileURLToPath(import.meta.url)
   const dirname = path.dirname(filename)
@@ -30,7 +30,7 @@ if (disableTranspile) {
       await bin()
     }
 
-    void start()
+    await start()
   } else if (useSwc) {
     const { register } = await import('node:module')
     // Remove --use-swc from arguments
@@ -49,6 +49,6 @@ if (disableTranspile) {
       await bin()
     }
 
-    void start()
+    await start()
   }
 }


### PR DESCRIPTION
### What?
Ensures Payload writes a file before exiting the process.

### Why?
Relevant explanation is in https://github.com/payloadcms/payload/issues/16381

### How?
Alternative to #16382. This adds top-level await. I didn't know if that is already allowed in the Payload codebase.

Fixes #16381 

