### PR TITLE
fix(ui): skip admin.condition checks in bulk edit

### DIFF
--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -168,6 +168,11 @@ export type BuildFormStateArgs = {
    * @experimental This property is experimental and may change in the future. Use at your own risk.
    */
   skipClientConfigAuth?: boolean
+  /**
+   * If true, skips checking each field's admin.condition when building form state.
+   * Useful for bulk edit where sibling data is not document-backed.
+   */
+  skipConditionChecks?: boolean
   skipValidation?: boolean
   updateLastEdited?: boolean
 } & (

--- a/packages/ui/src/elements/BulkUpload/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/BulkUpload/EditMany/DrawerContent.tsx
@@ -75,6 +75,7 @@ export const EditManyBulkUploadsDrawerContent: React.FC<
         schemaPath: collection.slug,
         select,
         signal: controller.signal,
+        skipConditionChecks: true,
         skipValidation: !submitted,
       })
 
@@ -126,6 +127,7 @@ export const EditManyBulkUploadsDrawerContent: React.FC<
             return acc
           }, {} as SelectType),
         ),
+        skipConditionChecks: true,
         skipValidation: true,
       })
 

--- a/packages/ui/src/elements/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/EditMany/DrawerContent.tsx
@@ -204,6 +204,7 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
         schemaPath: collection.slug,
         select,
         signal: controller.signal,
+        skipConditionChecks: true,
         skipValidation: !submitted,
       })
 
@@ -303,6 +304,7 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
             return acc
           }, {} as SelectType),
         ),
+        skipConditionChecks: true,
         skipValidation: true,
       })
 

--- a/packages/ui/src/forms/fieldSchemasToFormState/index.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/index.tsx
@@ -77,6 +77,7 @@ type Args = {
   schemaPath: string
   select?: SelectType
   selectMode?: SelectMode
+  skipConditionChecks?: boolean
   skipValidation?: boolean
 }
 
@@ -101,6 +102,7 @@ export const fieldSchemasToFormState = async ({
   schemaPath,
   select,
   selectMode,
+  skipConditionChecks,
   skipValidation,
 }: Args): Promise<FormState> => {
   if (!clientFieldSchemaMap && renderFieldFn) {
@@ -160,6 +162,7 @@ export const fieldSchemasToFormState = async ({
       req,
       select,
       selectMode,
+      skipConditionChecks,
       skipValidation,
       state,
     })

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -118,6 +118,7 @@ export const buildFormState = async (
     schemaPath = collectionSlug || globalSlug || widgetSlug,
     select,
     skipClientConfigAuth,
+    skipConditionChecks,
     skipValidation,
     updateLastEdited,
   } = args
@@ -228,6 +229,7 @@ export const buildFormState = async (
     schemaPath,
     select,
     selectMode,
+    skipConditionChecks,
     skipValidation,
   })
 

--- a/test/bulk-edit/collections/Posts/index.ts
+++ b/test/bulk-edit/collections/Posts/index.ts
@@ -25,6 +25,28 @@ export const PostsCollection: CollectionConfig = {
       type: 'textarea',
     },
     {
+      name: 'conditionController',
+      type: 'select',
+      options: [
+        {
+          label: 'Show',
+          value: 'show',
+        },
+        {
+          label: 'Hide',
+          value: 'hide',
+        },
+      ],
+    },
+    {
+      name: 'conditionalBulkEditField',
+      type: 'text',
+      label: 'Conditional Bulk Edit Field',
+      admin: {
+        condition: (_, siblingData) => siblingData?.conditionController === 'show',
+      },
+    },
+    {
       name: 'fieldWithBeforeInputA1',
       type: 'text',
       label: 'Field With Before Input A1',

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -875,6 +875,47 @@ test.describe('Bulk Edit', () => {
     await expect(beforeInputB).toHaveCount(1)
     await expect(beforeInputB).toBeVisible()
   })
+
+  test('should render selected field even when admin.condition depends on unselected sibling data', async () => {
+    await deleteAllPosts()
+
+    const updatedValue = 'Updated conditional bulk field'
+    const { id } = await createPost({ title: 'Conditional Post' })
+
+    await page.goto(postsUrl.list)
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    const { modal } = await selectAllAndEditMany(page)
+
+    await selectInput({
+      selectLocator: modal.locator('.field-select'),
+      options: ['Conditional Bulk Edit Field'],
+      multiSelect: true,
+    })
+
+    const conditionalField = modal.locator('#field-conditionalBulkEditField')
+    await expect(conditionalField).toBeVisible()
+
+    await conditionalField.fill(updatedValue)
+    await modal.locator('.form-submit button[type="submit"].edit-many__publish').click()
+
+    await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+      'Updated 1 Post successfully.',
+    )
+
+    const updatedDocQuery = await payload.find({
+      collection: postsSlug,
+      where: {
+        id: {
+          equals: id,
+        },
+      },
+      depth: 0,
+    })
+    const updatedDoc = updatedDocQuery.docs[0]
+
+    expect((updatedDoc as any)?.conditionalBulkEditField).toBe(updatedValue)
+  })
 })
 
 async function selectFieldToEdit(


### PR DESCRIPTION
Closes #16336

## Summary
This PR fixes an issue where fields with `admin.condition` appear in the bulk edit field selector but are silently hidden after selection.

## Problem
In the bulk edit flow, selected fields can be rendered without meaningful sibling document state. Because of that, `admin.condition` may evaluate to `false`, which hides fields that the user explicitly selected for bulk editing.

## Fix
- Skip `admin.condition` checks in the bulk edit flow
- Preserve normal `admin.condition` behavior outside bulk edit
- Ensure explicitly selected bulk edit fields render as expected

## Testing
- Reproduced the issue using the scenario described in #16336
- Verified that selected fields now render in bulk edit
- Verified standard conditional field behavior remains unchanged outside bulk edit