### PR TITLE
fix(drizzle): sort by `join` field on versioned collection with custom text id

### DIFF
--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -393,10 +393,14 @@ export const getTableColumnFromPath = ({
           }
 
           if (!existingTable) {
+            const rootIDColumn =
+              adapter.versionsSuffix && rootTableName.endsWith(adapter.versionsSuffix)
+                ? adapter.tables[rootTableName].parent
+                : adapter.tables[rootTableName].id
             addJoinTable({
               condition: and(
                 eq(
-                  adapter.tables[rootTableName].id,
+                  rootIDColumn,
                   aliasRelationshipTable[
                     `${(relationshipField.field as RelationshipField).relationTo as string}ID`
                   ],
@@ -490,18 +494,20 @@ export const getTableColumnFromPath = ({
               ? adapter.tableNameMap.get(`${newTableName}_${toSnakeCase(onSegments[0])}`)
               : undefined
 
+          const sourceIDColumn = aliasTable
+            ? aliasTable.id
+            : adapter.versionsSuffix && tableName.endsWith(adapter.versionsSuffix)
+              ? adapter.tables[tableName].parent
+              : adapter.tables[tableName].id
+
           if (arrayTableName) {
-            // join from main table to array table
             const { newAliasTable: arrayAliasTable } = getTableAlias({
               adapter,
               tableName: arrayTableName,
             })
 
             joins.push({
-              condition: eq(
-                arrayAliasTable[onSegments.slice(1).join('_')],
-                aliasTable ? aliasTable.id : adapter.tables[tableName].id,
-              ),
+              condition: eq(arrayAliasTable[onSegments.slice(1).join('_')], sourceIDColumn),
               queryPath: `${constraintPath}${field.name}._array`,
               table: arrayAliasTable,
             })
@@ -516,10 +522,7 @@ export const getTableColumnFromPath = ({
             })
           } else {
             joins.push({
-              condition: eq(
-                newAliasTable[field.on.replaceAll('.', '_')],
-                aliasTable ? aliasTable.id : adapter.tables[tableName].id,
-              ),
+              condition: eq(newAliasTable[field.on.replaceAll('.', '_')], sourceIDColumn),
               queryPath: `${constraintPath}${field.name}`,
               table: newAliasTable,
             })

--- a/test/joins/config.ts
+++ b/test/joins/config.ts
@@ -21,6 +21,8 @@ import {
   postsSlug,
   restrictedCategoriesSlug,
   restrictedPostsSlug,
+  textIdCategoriesVersionsSlug,
+  textIdPostsSlug,
 } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -340,6 +342,44 @@ export default buildConfigWithDefaults({
     },
     FolderPoly1,
     FolderPoly2,
+    {
+      slug: textIdCategoriesVersionsSlug,
+      versions: { drafts: true },
+      fields: [
+        { name: 'id', type: 'text' },
+        { name: 'name', type: 'text' },
+        {
+          name: 'relatedSingle',
+          type: 'join',
+          collection: textIdPostsSlug,
+          on: 'category',
+        },
+        {
+          name: 'relatedMany',
+          type: 'join',
+          collection: textIdPostsSlug,
+          on: 'categories',
+        },
+      ],
+    },
+    {
+      slug: textIdPostsSlug,
+      fields: [
+        { name: 'id', type: 'text' },
+        { name: 'title', type: 'text' },
+        {
+          name: 'category',
+          type: 'relationship',
+          relationTo: textIdCategoriesVersionsSlug,
+        },
+        {
+          name: 'categories',
+          type: 'relationship',
+          relationTo: textIdCategoriesVersionsSlug,
+          hasMany: true,
+        },
+      ],
+    },
   ],
   localization: {
     locales: [

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -866,6 +866,40 @@ describe('Joins Field', () => {
 
       expect(res.docs[0].relatedVersionsMany.docs[0].id).toBe(version.id)
     })
+
+    it('should not crash when sorting drafts by a join field on a versioned collection with custom text id', async () => {
+      const category = await payload.create({
+        collection: 'text-id-categories-versions' as never,
+        data: { id: 'cat-text-1', name: 'cat-1' } as never,
+      })
+
+      await payload.create({
+        collection: 'text-id-posts' as never,
+        data: {
+          id: 'post-text-1',
+          title: 'post-1',
+          category: (category as { id: string }).id,
+          categories: [(category as { id: string }).id],
+        } as never,
+      })
+
+      const single = await payload.find({
+        collection: 'text-id-categories-versions' as never,
+        draft: true,
+        sort: 'relatedSingle',
+      })
+      expect(single.docs).toHaveLength(1)
+
+      const many = await payload.find({
+        collection: 'text-id-categories-versions' as never,
+        draft: true,
+        sort: 'relatedMany',
+      })
+      expect(many.docs).toHaveLength(1)
+
+      await payload.delete({ collection: 'text-id-posts' as never, where: {} })
+      await payload.delete({ collection: 'text-id-categories-versions' as never, where: {} })
+    })
   })
 
   describe('REST', () => {

--- a/test/joins/shared.ts
+++ b/test/joins/shared.ts
@@ -24,6 +24,10 @@ export const categoriesVersionsSlug = 'categories-versions'
 
 export const versionsSlug = 'versions'
 
+export const textIdCategoriesVersionsSlug = 'text-id-categories-versions'
+
+export const textIdPostsSlug = 'text-id-posts'
+
 export const collectionSlugs = [
   categoriesSlug,
   categoriesVersionsSlug,


### PR DESCRIPTION
### What?

Fix a Postgres crash when sorting the admin list view by a `join` field on a collection that has both `versions: { drafts: true }` enabled **and** a custom text id (e.g. nanoid).

### Why?

In that combination the query fails with `operator does not exist: integer = character varying`, the broken sort is persisted into `payload_preferences`, and the user cannot recover from the admin UI — the only fix today is to manually edit the database.

### How?

In `getTableColumnFromPath.ts`, both branches of `case 'join'` built the join condition off `adapter.tables[*].id`. On a versions table (`*_v`) `id` is the version-row PK (integer), not the parent document id — but the joined column actually references the parent document id, which is `varchar` for custom text ids.

Use the versions table's `parent` column (mapped from `parent_id`) as the join key whenever the source table is a versions table. Both branches need the same fix; otherwise only some shapes of `on` are repaired.

Regression test added under `test/joins`, exercising both code paths.

Fixes #16390

Made with [Cursor](https://cursor.com)