### PR TITLE
fix(examples/localization): correct tailwind config path in globals.css

### DIFF
--- a/examples/localization/src/app/(frontend)/[locale]/globals.css
+++ b/examples/localization/src/app/(frontend)/[locale]/globals.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
-@config '../../../tailwind.config.mjs';
+@config '../../../../tailwind.config.mjs';
 
 @custom-variant dark (&:is([data-theme='dark'] *));
 @custom-variant sm (@media (width >= theme(--breakpoint-sm)));


### PR DESCRIPTION
### What?
Updated the `@config` path in `src/app/(frontend)/[locale]/globals.css`.

### Why?
The previous path was incorrect, causing the Tailwind configuration to be missed within the nested locale route.

### How?
Adjusted the relative path from `../../../tailwind.config.mjs to ../../../../tailwind.config.mjs`.

