### PR TITLE
fix: polymorphic relationship returns null when target is trashed

### DIFF
--- a/examples/draft-preview/src/components/CMSLink/index.tsx
+++ b/examples/draft-preview/src/components/CMSLink/index.tsx
@@ -30,7 +30,10 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   url,
 }) => {
   const href =
-    type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
+    type === 'reference' &&
+    reference?.value &&
+    typeof reference.value === 'object' &&
+    reference.value.slug
       ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
           reference.value.slug
         }`

--- a/examples/live-preview/src/app/(app)/_components/CMSLink/index.tsx
+++ b/examples/live-preview/src/app/(app)/_components/CMSLink/index.tsx
@@ -30,7 +30,10 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   url,
 }) => {
   const href =
-    type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
+    type === 'reference' &&
+    reference?.value &&
+    typeof reference.value === 'object' &&
+    reference.value.slug
       ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
           reference.value.slug
         }`

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -120,12 +120,20 @@ const populate = async ({
           dataToUpdate[field.name].docs[index ?? key!].value = relationshipValue
         }
       } else if (Array.isArray(field.relationTo)) {
-        dataToUpdate[field.name][index ?? key!].value = relationshipValue
+        if (relationshipValue === null) {
+          dataToUpdate[field.name][index ?? key!] = null
+        } else {
+          dataToUpdate[field.name][index ?? key!].value = relationshipValue
+        }
       } else {
         dataToUpdate[field.name][index ?? key!] = relationshipValue
       }
     } else if (field.type !== 'join' && Array.isArray(field.relationTo)) {
-      dataToUpdate[field.name].value = relationshipValue
+      if (relationshipValue === null) {
+        dataToUpdate[field.name] = null
+      } else {
+        dataToUpdate[field.name].value = relationshipValue
+      }
     } else {
       if (field.type === 'join' && Array.isArray(field.collection)) {
         dataToUpdate[field.name].value = relationshipValue

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -320,6 +320,23 @@ export function withNullableJSONSchemaType(
   return fieldTypes
 }
 
+/**
+ * Single relationships whose target collection has `trash: true` can be
+ * silently nulled at read time when the target document is trashed (see
+ * `relationshipPopulationPromise`). The generated type must reflect that
+ * even when the field is `required`.
+ */
+function isAnyRelationTargetTrashable(
+  relationTo: string | string[],
+  collections?: SanitizedCollectionConfig[],
+): boolean {
+  if (!collections) {
+    return false
+  }
+  const targets = Array.isArray(relationTo) ? relationTo : [relationTo]
+  return targets.some((slug) => collections.find((c) => c.slug === slug)?.trash === true)
+}
+
 function entityOrFieldToJsDocs({
   entity,
   i18n,
@@ -669,11 +686,13 @@ export function fieldsToJSONSchema(
                   },
                 }
               } else {
+                const isRequiredAndStable =
+                  isRequired && !isAnyRelationTargetTrashable(field.relationTo, config?.collections)
                 fieldSchema = {
                   ...baseFieldSchema,
                   oneOf: field.relationTo.map((relation) => {
                     return {
-                      type: withNullableJSONSchemaType('object', isRequired),
+                      type: withNullableJSONSchemaType('object', isRequiredAndStable),
                       additionalProperties: false,
                       properties: {
                         relationTo: {
@@ -711,13 +730,15 @@ export function fieldsToJSONSchema(
                 },
               }
             } else {
+              const isRequiredAndStable =
+                isRequired && !isAnyRelationTargetTrashable(field.relationTo, config?.collections)
               fieldSchema = {
                 ...baseFieldSchema,
                 oneOf: [
                   {
                     type: withNullableJSONSchemaType(
                       collectionIDFieldTypes[field.relationTo]!,
-                      isRequired,
+                      isRequiredAndStable,
                     ),
                   },
                   { $ref: `#/definitions/${field.relationTo}` },

--- a/templates/ecommerce/src/components/Link/index.tsx
+++ b/templates/ecommerce/src/components/Link/index.tsx
@@ -34,7 +34,10 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
   } = props
 
   const href =
-    type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
+    type === 'reference' &&
+    reference?.value &&
+    typeof reference.value === 'object' &&
+    reference.value.slug
       ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
           reference.value.slug
         }`

--- a/templates/website/src/components/Link/index.tsx
+++ b/templates/website/src/components/Link/index.tsx
@@ -34,7 +34,10 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
   } = props
 
   const href =
-    type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
+    type === 'reference' &&
+    reference?.value &&
+    typeof reference.value === 'object' &&
+    reference.value.slug
       ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
           reference.value.slug
         }`

--- a/templates/with-vercel-website/src/components/Link/index.tsx
+++ b/templates/with-vercel-website/src/components/Link/index.tsx
@@ -34,7 +34,10 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
   } = props
 
   const href =
-    type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
+    type === 'reference' &&
+    reference?.value &&
+    typeof reference.value === 'object' &&
+    reference.value.slug
       ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
           reference.value.slug
         }`

--- a/test/trash/collections/Pages/index.ts
+++ b/test/trash/collections/Pages/index.ts
@@ -26,6 +26,23 @@ export const Pages: CollectionConfig = {
       type: 'relationship',
       relationTo: postsSlug,
     },
+    {
+      name: 'featuredItem',
+      type: 'relationship',
+      relationTo: [postsSlug, pagesSlug],
+    },
+    {
+      name: 'relatedItems',
+      type: 'relationship',
+      relationTo: [postsSlug, pagesSlug],
+      hasMany: true,
+    },
+    {
+      name: 'localizedFeaturedItem',
+      type: 'relationship',
+      relationTo: [postsSlug, pagesSlug],
+      localized: true,
+    },
   ],
   versions: {
     drafts: true,

--- a/test/trash/int.spec.ts
+++ b/test/trash/int.spec.ts
@@ -2315,5 +2315,117 @@ describe('trash', () => {
       expect(Array.isArray(relatedPosts)).toBe(true)
       expect(relatedPosts).toHaveLength(2)
     })
+
+    it('should return null for a trashed document in a single polymorphic relationship', async () => {
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with featured item',
+          featuredItem: { relationTo: postsSlug, value: postsDocTwo.id },
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 1,
+      })
+
+      expect(result.featuredItem).toBeNull()
+    })
+
+    it('should populate a non-trashed document in a single polymorphic relationship', async () => {
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with featured item',
+          featuredItem: { relationTo: postsSlug, value: postsDocOne.id },
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 1,
+      })
+
+      expect(result.featuredItem).toMatchObject({
+        relationTo: postsSlug,
+        value: { id: postsDocOne.id },
+      })
+    })
+
+    it('should not include trashed entries in hasMany polymorphic relationship', async () => {
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with related items',
+          relatedItems: [
+            { relationTo: postsSlug, value: postsDocOne.id },
+            { relationTo: postsSlug, value: postsDocTwo.id },
+          ],
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 1,
+      })
+
+      expect(result.relatedItems).toHaveLength(1)
+      const [remaining] = result.relatedItems as {
+        relationTo: string
+        value: { id: number | string }
+      }[]
+      expect(remaining?.value?.id).toBe(postsDocOne.id)
+    })
+
+    it('should preserve trashed polymorphic IDs at depth=0', async () => {
+      const page = await payload.create({
+        collection: pagesSlug,
+        data: {
+          title: 'Page with featured item depth 0',
+          featuredItem: { relationTo: postsSlug, value: postsDocTwo.id },
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        depth: 0,
+      })
+
+      expect(result.featuredItem).toEqual({
+        relationTo: postsSlug,
+        value: postsDocTwo.id,
+      })
+    })
+
+    it('should return null per-locale for a trashed document in a localized single polymorphic relationship', async () => {
+      const page = await payload.create({
+        collection: pagesSlug,
+        locale: 'en',
+        data: {
+          title: 'Page with localized featured item',
+          localizedFeaturedItem: { relationTo: postsSlug, value: postsDocTwo.id },
+        },
+      })
+      createdPageIDs.push(page.id)
+
+      const result = await payload.findByID({
+        collection: pagesSlug,
+        id: page.id,
+        locale: 'all',
+        depth: 1,
+      })
+
+      const localized = result.localizedFeaturedItem as Record<string, unknown>
+      expect(localized?.en).toBeNull()
+    })
   })
 })

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -132,6 +132,36 @@ export interface Page {
   title?: string | null;
   relatedPosts?: (string | Post)[] | null;
   featuredPost?: (string | null) | Post;
+  featuredItem?:
+    | ({
+        relationTo: 'posts';
+        value: string | Post;
+      } | null)
+    | ({
+        relationTo: 'pages';
+        value: string | Page;
+      } | null);
+  relatedItems?:
+    | (
+        | {
+            relationTo: 'posts';
+            value: string | Post;
+          }
+        | {
+            relationTo: 'pages';
+            value: string | Page;
+          }
+      )[]
+    | null;
+  localizedFeaturedItem?:
+    | ({
+        relationTo: 'posts';
+        value: string | Post;
+      } | null)
+    | ({
+        relationTo: 'pages';
+        value: string | Page;
+      } | null);
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -249,7 +279,7 @@ export interface PayloadLockedDocument {
   user: {
     relationTo: 'users';
     value: string | User;
-  };
+  } | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -262,7 +292,7 @@ export interface PayloadPreference {
   user: {
     relationTo: 'users';
     value: string | User;
-  };
+  } | null;
   key?: string | null;
   value?:
     | {
@@ -295,6 +325,9 @@ export interface PagesSelect<T extends boolean = true> {
   title?: T;
   relatedPosts?: T;
   featuredPost?: T;
+  featuredItem?: T;
+  relatedItems?: T;
+  localizedFeaturedItem?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;


### PR DESCRIPTION
### What?

  Polymorphic single relationships to a trashed document return `null` instead of `{ relationTo, value: null }`. Single relationships to a `trash: true` collection are also nullable in generated types regardless of
  `required`.

  ### Why?

  The runtime emitted a shape the types said was impossible. `typeof reference.value === 'object' && reference.value.slug` typechecked but crashed on trashed targets — `typeof null === 'object'`.

  #16102 set "for single relationships, the field is set to null" but implemented it for non-polymorphic only. Polymorphic single (and localized polymorphic single) were missed. The schema widening covers `required:
   true` rels to trashable collections, where the runtime nulls the field but the type used to forbid it.

  ### How?

  - **Runtime** (`relationshipPopulationPromise.ts`): null the whole wrapper, not just `wrapper.value`, when the populated value is `null`. Covers single polymorphic and localized polymorphic single. Polymorphic
  hasMany was already filtered.
  - **Schema** (`configToJSONSchema.ts`): widen single rels to `trash: true` targets to `T | null` regardless of `required`. `payload-locked-documents.user` and `payload-preferences.user` widen automatically.
  - **Templates / examples**: truthy guard on `reference.value` in `CMSLink` (3 templates, 2 examples).
  - **Tests**: three polymorphic fields on `Pages`; five integration tests; `payload-types.ts` regenerated.