### PR TITLE
ci: do not block PRs on broken Next.js canary publishes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
   # is consumed by `tests-int` (to skip canary variants) and by
   # `notify-next-canary-broken` (to post a sticky PR comment).
   probe-next-canary:
-    name: Probe Next.js canary
+    name: probe-next-canary
     runs-on: ubuntu-24.04
     needs: changes
     if: needs.changes.outputs.needs_tests == 'true'
@@ -74,16 +74,37 @@ jobs:
     steps:
       - name: Probe registry for complete canary publish
         id: probe
+        # Each `npm view` is retried with backoff to ride out transient
+        # registry hiccups; only after both peer lookups consistently fail
+        # do we report `healthy=false` and trigger the canary skip.
         run: |
-          NEXT_VERSION="$(npm view next@canary version 2>/dev/null || true)"
+          retry_npm_view() {
+            local spec="$1"
+            for attempt in 1 2 3; do
+              if npm view "$spec" version >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep $((attempt * 2))
+            done
+            return 1
+          }
+
+          NEXT_VERSION=""
+          for attempt in 1 2 3; do
+            NEXT_VERSION="$(npm view next@canary version 2>/dev/null || true)"
+            if [ -n "$NEXT_VERSION" ]; then
+              break
+            fi
+            sleep $((attempt * 2))
+          done
           echo "Resolved next@canary version: ${NEXT_VERSION:-<empty>}"
           echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
           if [ -z "$NEXT_VERSION" ]; then
             echo "healthy=unknown" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if npm view "@next/env@${NEXT_VERSION}" version >/dev/null 2>&1 \
-            && npm view "@next/eslint-plugin-next@${NEXT_VERSION}" version >/dev/null 2>&1; then
+          if retry_npm_view "@next/env@${NEXT_VERSION}" \
+            && retry_npm_view "@next/eslint-plugin-next@${NEXT_VERSION}"; then
             echo "healthy=true" >> "$GITHUB_OUTPUT"
           else
             echo "healthy=false" >> "$GITHUB_OUTPUT"
@@ -669,10 +690,10 @@ jobs:
   # Intentionally NOT included in `all-green` so that an upstream Next.js
   # breakage cannot block a Payload PR from merging.
   notify-next-canary-broken:
-    name: Notify Next.js canary breakage
+    name: notify-next-canary-broken
     runs-on: ubuntu-24.04
-    needs: probe-next-canary
-    if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+    needs: [changes, probe-next-canary]
+    if: ${{ always() && needs.changes.outputs.needs_tests == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
     permissions:
       pull-requests: write
     steps:
@@ -686,7 +707,7 @@ jobs:
 
             CI detected that the current `next@canary` (`${{ needs.probe-next-canary.outputs.next_version }}`) is missing one of its peer packages (`@next/env` or `@next/eslint-plugin-next`) for the same version on the npm registry, so `pnpm create next-app@canary` would fail with `ERR_PNPM_NO_MATCHING_VERSION`. This is unrelated to this PR.
 
-            **This will not block your PR.** The `Canary` variants of `test/create-payload-app/int.spec.ts` were skipped for this run via Vitest's `-t` filter; the rest of the suite still ran normally and this comment is purely informational.
+            **This will not block your PR.** The `Canary` variants of `test/create-payload-app/int.spec.ts` are being skipped for this run via Vitest's `-t` filter; the rest of the suite still runs normally and this comment is purely informational.
 
             Please open an issue in [vercel/next.js](https://github.com/vercel/next.js/issues/new/choose) as soon as possible so the upstream team can republish a complete canary, then re-run CI on this PR once a new canary is out to confirm the fix.
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -673,37 +673,6 @@ jobs:
         if: failure()
         run: docker logs content-api || true
 
-  # Sticky PR comment about upstream Next.js canary breakage. Intentionally
-  # not part of `all-green` so it cannot block a Payload PR from merging.
-  notify-next-canary-broken:
-    name: notify-next-canary-broken
-    runs-on: ubuntu-24.04
-    needs: [changes, probe-next-canary]
-    if: ${{ always() && needs.changes.outputs.needs_tests == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Post sticky PR comment about Next.js canary breakage
-        if: needs.probe-next-canary.outputs.healthy == 'false'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          header: next-canary-broken
-          message: |
-            ## Heads-up: Next.js canary publish is incomplete on npm
-
-            CI detected that the current `next@canary` (`${{ needs.probe-next-canary.outputs.next_version }}`) is missing one of its peer packages (`@next/env` or `@next/eslint-plugin-next`) for the same version on the npm registry, so `pnpm create next-app@canary` would fail with `ERR_PNPM_NO_MATCHING_VERSION`. This is unrelated to this PR.
-
-            **This will not block your PR.** The `Canary` variants of `test/create-payload-app/int.spec.ts` are being skipped for this run via Vitest's `-t` filter; the rest of the suite still runs normally and this comment is purely informational.
-
-            Please open an issue in [vercel/next.js](https://github.com/vercel/next.js/issues/new/choose) as soon as possible so the upstream team can republish a complete canary, then re-run CI on this PR once a new canary is out to confirm the fix.
-
-      - name: Remove sticky PR comment when canary is healthy again
-        if: needs.probe-next-canary.outputs.healthy == 'true'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          header: next-canary-broken
-          delete: true
-
   all-green:
     name: All Green
     if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,13 +56,9 @@ jobs:
           echo "needs_tests: ${{ steps.filter.outputs.needs_tests }}"
           echo "templates: ${{ steps.filter.outputs.templates }}"
 
-  # Probes the npm registry for a complete `next@canary` publish before any
-  # integration test runs `pnpm create next-app@canary`. When Vercel publishes
-  # `next@<canary>` but its peers (`@next/env`, `@next/eslint-plugin-next`)
-  # are missing for the same version, the canary install fails with
-  # `ERR_PNPM_NO_MATCHING_VERSION`, which is unrelated to the PR. The output
-  # is consumed by `tests-int` (to skip canary variants) and by
-  # `notify-next-canary-broken` (to post a sticky PR comment).
+  # Detects upstream Next.js canary publishes that are missing `@next/env` or
+  # `@next/eslint-plugin-next` for the same version (would break
+  # `pnpm create next-app@canary` with `ERR_PNPM_NO_MATCHING_VERSION`).
   probe-next-canary:
     name: probe-next-canary
     runs-on: ubuntu-24.04
@@ -74,9 +70,6 @@ jobs:
     steps:
       - name: Probe registry for complete canary publish
         id: probe
-        # Each `npm view` is retried with backoff to ride out transient
-        # registry hiccups; only after both peer lookups consistently fail
-        # do we report `healthy=false` and trigger the canary skip.
         run: |
           retry_npm_view() {
             local spec="$1"
@@ -246,11 +239,6 @@ jobs:
         with:
           database: ${{ matrix.database }}
 
-      # When `probe-next-canary` reports that the current `next@canary` has an
-      # incomplete publish on npm, skip the `Canary` variants in
-      # `test/create-payload-app/int.spec.ts` via Vitest's test name pattern so
-      # an upstream Next.js issue cannot block this PR. The latest variants
-      # still run and remain strict.
       - name: Integration Tests
         env:
           NODE_OPTIONS: --max-old-space-size=8096
@@ -685,10 +673,8 @@ jobs:
         if: failure()
         run: docker logs content-api || true
 
-  # Posts a sticky PR comment when `probe-next-canary` reported an incomplete
-  # `next@canary` publish on npm and `Canary` tests were skipped as a result.
-  # Intentionally NOT included in `all-green` so that an upstream Next.js
-  # breakage cannot block a Payload PR from merging.
+  # Sticky PR comment about upstream Next.js canary breakage. Intentionally
+  # not part of `all-green` so it cannot block a Payload PR from merging.
   notify-next-canary-broken:
     name: notify-next-canary-broken
     runs-on: ubuntu-24.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,39 @@ jobs:
           echo "needs_tests: ${{ steps.filter.outputs.needs_tests }}"
           echo "templates: ${{ steps.filter.outputs.templates }}"
 
+  # Probes the npm registry for a complete `next@canary` publish before any
+  # integration test runs `pnpm create next-app@canary`. When Vercel publishes
+  # `next@<canary>` but its peers (`@next/env`, `@next/eslint-plugin-next`)
+  # are missing for the same version, the canary install fails with
+  # `ERR_PNPM_NO_MATCHING_VERSION`, which is unrelated to the PR. The output
+  # is consumed by `tests-int` (to skip canary variants) and by
+  # `notify-next-canary-broken` (to post a sticky PR comment).
+  probe-next-canary:
+    name: Probe Next.js canary
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.needs_tests == 'true'
+    outputs:
+      healthy: ${{ steps.probe.outputs.healthy }}
+      next_version: ${{ steps.probe.outputs.next_version }}
+    steps:
+      - name: Probe registry for complete canary publish
+        id: probe
+        run: |
+          NEXT_VERSION="$(npm view next@canary version 2>/dev/null || true)"
+          echo "Resolved next@canary version: ${NEXT_VERSION:-<empty>}"
+          echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ -z "$NEXT_VERSION" ]; then
+            echo "healthy=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if npm view "@next/env@${NEXT_VERSION}" version >/dev/null 2>&1 \
+            && npm view "@next/eslint-plugin-next@${NEXT_VERSION}" version >/dev/null 2>&1; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     runs-on: ubuntu-24.04
     steps:
@@ -152,7 +185,7 @@ jobs:
 
   tests-int:
     runs-on: ubuntu-24.04
-    needs: [changes, build, int-matrix]
+    needs: [changes, build, int-matrix, probe-next-canary]
     if: needs.changes.outputs.needs_tests == 'true'
     name: int-${{ matrix.database }}${{ matrix.total-shards > 1 && format(' ({0}/{1})', matrix.shard, matrix.total-shards) || '' }}
     timeout-minutes: 45
@@ -192,14 +225,25 @@ jobs:
         with:
           database: ${{ matrix.database }}
 
+      # When `probe-next-canary` reports that the current `next@canary` has an
+      # incomplete publish on npm, skip the `Canary` variants in
+      # `test/create-payload-app/int.spec.ts` via Vitest's test name pattern so
+      # an upstream Next.js issue cannot block this PR. The latest variants
+      # still run and remain strict.
       - name: Integration Tests
-        run: pnpm test:int --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
         env:
           NODE_OPTIONS: --max-old-space-size=8096
           PAYLOAD_DATABASE: ${{ matrix.database }}
           POSTGRES_URL: ${{ steps.db.outputs.POSTGRES_URL }}
           MONGODB_URL: ${{ steps.db.outputs.MONGODB_URL }}
           MONGODB_ATLAS_URL: ${{ steps.db.outputs.MONGODB_ATLAS_URL }}
+        run: |
+          if [ "${{ needs.probe-next-canary.outputs.healthy }}" = "false" ]; then
+            echo "::warning::Next.js canary publish is incomplete on npm (next@${{ needs.probe-next-canary.outputs.next_version }}); skipping Canary tests for this run."
+            pnpm test:int --shard=${{ matrix.shard }}/${{ matrix.total-shards }} -t '^(?!.*Canary).*$'
+          else
+            pnpm test:int --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
+          fi
 
   # Generate the E2E test matrix from TypeScript config
   e2e-matrix:
@@ -619,6 +663,39 @@ jobs:
       - name: Dump Content API logs on failure
         if: failure()
         run: docker logs content-api || true
+
+  # Posts a sticky PR comment when `probe-next-canary` reported an incomplete
+  # `next@canary` publish on npm and `Canary` tests were skipped as a result.
+  # Intentionally NOT included in `all-green` so that an upstream Next.js
+  # breakage cannot block a Payload PR from merging.
+  notify-next-canary-broken:
+    name: Notify Next.js canary breakage
+    runs-on: ubuntu-24.04
+    needs: probe-next-canary
+    if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post sticky PR comment about Next.js canary breakage
+        if: needs.probe-next-canary.outputs.healthy == 'false'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: next-canary-broken
+          message: |
+            ## Heads-up: Next.js canary publish is incomplete on npm
+
+            CI detected that the current `next@canary` (`${{ needs.probe-next-canary.outputs.next_version }}`) is missing one of its peer packages (`@next/env` or `@next/eslint-plugin-next`) for the same version on the npm registry, so `pnpm create next-app@canary` would fail with `ERR_PNPM_NO_MATCHING_VERSION`. This is unrelated to this PR.
+
+            **This will not block your PR.** The `Canary` variants of `test/create-payload-app/int.spec.ts` were skipped for this run via Vitest's `-t` filter; the rest of the suite still ran normally and this comment is purely informational.
+
+            Please open an issue in [vercel/next.js](https://github.com/vercel/next.js/issues/new/choose) as soon as possible so the upstream team can republish a complete canary, then re-run CI on this PR once a new canary is out to confirm the fix.
+
+      - name: Remove sticky PR comment when canary is healthy again
+        if: needs.probe-next-canary.outputs.healthy == 'true'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: next-canary-broken
+          delete: true
 
   all-green:
     name: All Green

--- a/.github/workflows/notify-next-canary.yml
+++ b/.github/workflows/notify-next-canary.yml
@@ -1,0 +1,85 @@
+name: notify-next-canary
+
+# Runs on `pull_request_target` so the sticky comment also works on PRs from
+# forks (regular `pull_request` workflows have a read-only GITHUB_TOKEN on
+# fork PRs and cannot post comments). This is safe because the probe only
+# calls `npm view` and never checks out or executes PR code.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Detects upstream Next.js canary publishes that are missing `@next/env` or
+  # `@next/eslint-plugin-next` for the same version (would break
+  # `pnpm create next-app@canary` with `ERR_PNPM_NO_MATCHING_VERSION`).
+  probe:
+    runs-on: ubuntu-24.04
+    outputs:
+      healthy: ${{ steps.probe.outputs.healthy }}
+      next_version: ${{ steps.probe.outputs.next_version }}
+    steps:
+      - name: Probe registry for complete canary publish
+        id: probe
+        run: |
+          retry_npm_view() {
+            local spec="$1"
+            for attempt in 1 2 3; do
+              if npm view "$spec" version >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep $((attempt * 2))
+            done
+            return 1
+          }
+
+          NEXT_VERSION=""
+          for attempt in 1 2 3; do
+            NEXT_VERSION="$(npm view next@canary version 2>/dev/null || true)"
+            if [ -n "$NEXT_VERSION" ]; then
+              break
+            fi
+            sleep $((attempt * 2))
+          done
+          echo "Resolved next@canary version: ${NEXT_VERSION:-<empty>}"
+          echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ -z "$NEXT_VERSION" ]; then
+            echo "healthy=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if retry_npm_view "@next/env@${NEXT_VERSION}" \
+            && retry_npm_view "@next/eslint-plugin-next@${NEXT_VERSION}"; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  notify:
+    runs-on: ubuntu-24.04
+    needs: probe
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post sticky PR comment about Next.js canary breakage
+        if: needs.probe.outputs.healthy == 'false'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: next-canary-broken
+          message: |
+            ## Heads-up: Next.js canary publish is incomplete on npm
+
+            CI detected that the current `next@canary` (`${{ needs.probe.outputs.next_version }}`) is missing one of its peer packages (`@next/env` or `@next/eslint-plugin-next`) for the same version on the npm registry, so `pnpm create next-app@canary` would fail with `ERR_PNPM_NO_MATCHING_VERSION`. This is unrelated to this PR.
+
+            **This will not block your PR.** The `Canary` variants of `test/create-payload-app/int.spec.ts` are being skipped for this run via Vitest's `-t` filter; the rest of the suite still runs normally and this comment is purely informational.
+
+            Please open an issue in [vercel/next.js](https://github.com/vercel/next.js/issues/new/choose) as soon as possible so the upstream team can republish a complete canary, then re-run CI on this PR once a new canary is out to confirm the fix.
+
+      - name: Remove sticky PR comment when canary is healthy again
+        if: needs.probe.outputs.healthy == 'true'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: next-canary-broken
+          delete: true


### PR DESCRIPTION
When Vercel publishes `next@<canary>` to npm but its peer packages (`@next/env`, `@next/eslint-plugin-next`) are missing for the same version, `pnpm create next-app@canary` fails with `ERR_PNPM_NO_MATCHING_VERSION`, which used to fail every `int-* (1/3)` shard on every PR for reasons unrelated to the PR.

A new `probe-next-canary` job checks the registry up front:
- If the canary is incomplete, `tests-int` skips the `Canary` variants in `test/create-payload-app/int.spec.ts` via Vitest's `-t` filter (`^(?!.*Canary).*$`). The latest variants still run and remain strict.
- A new `notify-next-canary-broken` job posts a sticky PR comment via `marocchino/sticky-pull-request-comment` explaining the upstream issue, making clear it does not block the PR, and asking the author to open an issue at vercel/next.js. The comment is removed automatically once a healthy canary lands on npm. The job is intentionally not part of `all-green` so an upstream Next.js breakage cannot block a Payload PR.

Implementation is YAML-only; the test file is unchanged.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
