### PR TITLE
feat(ui): update Group field styles to match v4 design

### DIFF
--- a/packages/ui/src/fields/FieldDescription/index.css
+++ b/packages/ui/src/fields/FieldDescription/index.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   .field-description {
     display: flex;
-    color: var(--text-tertiary);
+    color: var(--text-secondary);
   }
 
   .field-description--margin-bottom {

--- a/packages/ui/src/fields/Group/index.css
+++ b/packages/ui/src/fields/Group/index.css
@@ -9,7 +9,7 @@
     &::before {
       content: '';
       position: absolute;
-      top: calc(var(--spacer-5) / 2);
+      top: calc(var(--spacer-5) / -2);
       left: calc(var(--gutter-h) * -1);
       right: calc(var(--gutter-h) * -1);
       height: 0;
@@ -88,14 +88,14 @@
   .group-field__header {
     margin-bottom: var(--spacer-2-5);
     display: flex;
+    flex-direction: column;
+    gap: var(--spacer-1);
+  }
+
+  .group-field__title-row {
+    display: flex;
     align-items: center;
     gap: var(--spacer-2);
-
-    > header {
-      display: flex;
-      flex-direction: column;
-      gap: var(--spacer-1);
-    }
   }
 
   .group-field__title {

--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -82,20 +82,22 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
           {Boolean(Label || Description || label || fieldHasErrors) && (
             <div className={`${baseClass}__header`}>
               <div className={`${baseClass}__title-row`}>
-                <RenderCustomComponent
-                  CustomComponent={Label}
-                  Fallback={
-                    <h3 className={`${baseClass}__title`}>
-                      <FieldLabel
-                        as="span"
-                        label={getTranslation(label, i18n)}
-                        localized={false}
-                        path={path}
-                        required={false}
-                      />
-                    </h3>
-                  }
-                />
+                {Boolean(Label || Description || label) && (
+                  <RenderCustomComponent
+                    CustomComponent={Label}
+                    Fallback={
+                      <h3 className={`${baseClass}__title`}>
+                        <FieldLabel
+                          as="span"
+                          label={getTranslation(label, i18n)}
+                          localized={false}
+                          path={path}
+                          required={false}
+                        />
+                      </h3>
+                    }
+                  />
+                )}
                 {fieldHasErrors && <ErrorPill count={errorCount} i18n={i18n} withMessage />}
               </div>
               <RenderCustomComponent

--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -81,29 +81,27 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
         <div className={`${baseClass}__wrap`}>
           {Boolean(Label || Description || label || fieldHasErrors) && (
             <div className={`${baseClass}__header`}>
-              {Boolean(Label || Description || label) && (
-                <header>
-                  <RenderCustomComponent
-                    CustomComponent={Label}
-                    Fallback={
-                      <h3 className={`${baseClass}__title`}>
-                        <FieldLabel
-                          as="span"
-                          label={getTranslation(label, i18n)}
-                          localized={false}
-                          path={path}
-                          required={false}
-                        />
-                      </h3>
-                    }
-                  />
-                  <RenderCustomComponent
-                    CustomComponent={Description}
-                    Fallback={<FieldDescription description={description} path={path} />}
-                  />
-                </header>
-              )}
-              {fieldHasErrors && <ErrorPill count={errorCount} i18n={i18n} withMessage />}
+              <div className={`${baseClass}__title-row`}>
+                <RenderCustomComponent
+                  CustomComponent={Label}
+                  Fallback={
+                    <h3 className={`${baseClass}__title`}>
+                      <FieldLabel
+                        as="span"
+                        label={getTranslation(label, i18n)}
+                        localized={false}
+                        path={path}
+                        required={false}
+                      />
+                    </h3>
+                  }
+                />
+                {fieldHasErrors && <ErrorPill count={errorCount} i18n={i18n} withMessage />}
+              </div>
+              <RenderCustomComponent
+                CustomComponent={Description}
+                Fallback={<FieldDescription description={description} path={path} />}
+              />
             </div>
           )}
           {BeforeInput}

--- a/test/v4/collections/Group/index.ts
+++ b/test/v4/collections/Group/index.ts
@@ -62,6 +62,19 @@ const GroupFields: CollectionConfig = {
         },
       ],
     },
+    {
+      type: 'group',
+      name: 'unnamedGroup',
+      label: '',
+      fields: [
+        {
+          name: 'unnamedGroupField',
+          type: 'text',
+          label: 'Field in Unnamed Group',
+          required: true,
+        },
+      ],
+    },
   ],
 }
 

--- a/test/v4/collections/Group/index.ts
+++ b/test/v4/collections/Group/index.ts
@@ -9,6 +9,9 @@ const GroupFields: CollectionConfig = {
       name: 'shippingInfo',
       type: 'group',
       label: 'Shipping Info',
+      admin: {
+        description: 'Enter the shipping address details',
+      },
       fields: [
         {
           name: 'name',
@@ -34,6 +37,28 @@ const GroupFields: CollectionConfig = {
           admin: {
             description: 'The primary contact email for this account',
           },
+        },
+      ],
+    },
+    {
+      name: 'requiredInfo',
+      type: 'group',
+      label: 'Required Info',
+      admin: {
+        description: 'This group has required fields to test error state',
+      },
+      fields: [
+        {
+          name: 'requiredField',
+          type: 'text',
+          label: 'Required Field',
+          required: true,
+        },
+        {
+          name: 'anotherRequired',
+          type: 'text',
+          label: 'Another Required',
+          required: true,
         },
       ],
     },


### PR DESCRIPTION
## Summary

Updates the Group field component styles to match the v4 design.

## Changes

- **Separator line position**: Changed from top border to bottom border - each group now owns its bottom separator instead of top
- **Description color**: Updated FieldDescription color from `--text-tertiary` to `--text-secondary`
- **ErrorPill positioning**: Restructured header to place ErrorPill inline with the title (instead of after description)
- **Test collection**: Added test variants for required fields with validation errors

## References

https://app.asana.com/1/10497086658021/project/1213409914712008/task/1214061555627424?focus=true