### PR TITLE
fix: file extension restriction doesn't check for dot

### DIFF
--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -187,7 +187,7 @@ export const checkFileRestrictions = async ({
     }
   } else {
     const isRestricted = RESTRICTED_FILE_EXT_AND_TYPES.some((type) => {
-      const hasRestrictedExt = type.extensions.some((ext) => file.name.toLowerCase().endsWith(ext))
+      const hasRestrictedExt = type.extensions.some((ext) => file.name.toLowerCase().endsWith("." + ext))
       const hasRestrictedMime = type.mimeType === file.mimetype
       return hasRestrictedExt || hasRestrictedMime
     })


### PR DESCRIPTION
### What?

Add a dot `.` in front of the checked extension before validating.

### Why?

The current file restriction checker checks for extensions by checking the end of the filename.
```js
file.name.toLowerCase().endsWith(ext)
```
It does not check if a dot is present, which gives problems with files that have no extension at all.
I uploaded a file with the name `0a621d9d1aa24f8ca3a5fbd523f6a24174061deb` (a md5 hash). This file triggered the `deb` restriction because it ended in `deb`.

### How?

Before:
```js
const hasRestrictedExt = type.extensions.some((ext) => file.name.toLowerCase().endsWith(ext))
```
After:
```js
const hasRestrictedExt = type.extensions.some((ext) => file.name.toLowerCase().endsWith("." + ext))
```