### PR TITLE
feat(ui): restyle textarea field to match v4 design

### DIFF
--- a/packages/ui/src/fields/Textarea/index.css
+++ b/packages/ui/src/fields/Textarea/index.css
@@ -24,7 +24,7 @@
       }
 
       &:focus {
-        border-color: var(--border-selected-strong);
+        border-color: var(--border-selected);
       }
     }
 

--- a/packages/ui/src/fields/Textarea/index.css
+++ b/packages/ui/src/fields/Textarea/index.css
@@ -5,6 +5,12 @@
     flex-direction: column;
     gap: var(--spacer-2);
 
+    .field-type__wrap {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacer-2);
+    }
+
     textarea {
       overflow-y: auto;
       resize: vertical;
@@ -12,6 +18,14 @@
       height: auto;
       display: flex;
       field-sizing: content;
+
+      &:hover:not(:focus):not(:disabled) {
+        border-color: var(--border-default-default);
+      }
+
+      &:focus {
+        border-color: var(--border-selected-strong);
+      }
     }
 
     textarea:not(:empty) {
@@ -19,9 +33,10 @@
     }
 
     &.read-only {
-      .textarea-outer {
-        background: var(--bg-disabled-default);
-        color: var(--text-disabled-default);
+      textarea {
+        background: var(--bg-default-default);
+        border-color: var(--border-default-default);
+        color: var(--text-default);
       }
     }
 

--- a/test/v4/collections/Textarea/index.ts
+++ b/test/v4/collections/Textarea/index.ts
@@ -16,19 +16,32 @@ const TextareaFields: CollectionConfig = {
     {
       name: 'contentRequired',
       type: 'textarea',
-      label: 'Content',
+      label: 'Content Required',
       required: true,
       admin: {
-        description: 'The main body content for this entry',
+        description: 'This field is required',
+      },
+    },
+    {
+      name: 'contentReadOnly',
+      type: 'textarea',
+      label: 'Content Read Only',
+      defaultValue:
+        'Payload is the open-source, fullstack Next.js framework, giving you instant backend superpowers.',
+      admin: {
+        readOnly: true,
+        description: 'This field is read-only',
       },
     },
     {
       name: 'contentDisabled',
       type: 'textarea',
-      label: 'Content',
+      label: 'Content Disabled',
+      defaultValue:
+        'Payload is the open-source, fullstack Next.js framework, giving you instant backend superpowers.',
       admin: {
-        readOnly: true,
-        description: 'The main body content for this entry',
+        disabled: true,
+        description: 'This field is disabled',
       },
     },
   ],


### PR DESCRIPTION
## Summary
Restyles the Textarea field component to match the v4 design.

## Changes
- Updated `packages/ui/src/fields/Textarea/index.css`:
  - Added hover state: border becomes visible on hover
  - Updated focus state: blue border (`--border-selected-strong`)
  - Fixed read-only styling: white background + gray border (was using disabled colors)
  - Added flex + gap to `.field-type__wrap` for proper spacing between input and description
  
- Updated `test/v4/collections/Textarea/index.ts`:
  - Added proper field variants for testing: default, required, readOnly, disabled
  - Added defaultValues to readOnly/disabled fields so content is visible for testing
  
## Reference
https://app.asana.com/1/10497086658021/project/1213409914712008/task/1214061555627404?focus=true