### PR TITLE
ci: add evals and skills scopes [skip ci]

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -49,6 +49,7 @@ jobs:
             email-nodemailer
             email-resend
             eslint
+            evals
             graphql
             kv
             kv-redis
@@ -73,6 +74,7 @@ jobs:
             richtext-\*
             richtext-lexical
             sdk
+            skills
             storage-\*
             storage-azure
             storage-gcs


### PR DESCRIPTION
Add `evals` and `skills` as valid PR title scopes