### PR TITLE
fix(drizzle): allow unicode JSON query values

### DIFF
--- a/packages/drizzle/src/utilities/escapeSQLValue.spec.ts
+++ b/packages/drizzle/src/utilities/escapeSQLValue.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { escapeSQLValue } from './escapeSQLValue.js'
+
+describe('escapeSQLValue', () => {
+  it('should allow Unicode letters and numbers in JSON query values', () => {
+    expect(escapeSQLValue('你好世界')).toBe('你好世界')
+    expect(escapeSQLValue('café naïve Größe')).toBe('café naïve Größe')
+    expect(escapeSQLValue('item １２３ @.+-:_')).toBe('item １２３ @.+-:_')
+  })
+
+  it('should reject SQL metacharacters in string values', () => {
+    expect(() => escapeSQLValue("value' OR 1=1")).toThrow('is not allowed as a JSON query value')
+    expect(() => escapeSQLValue('value; DROP TABLE users')).toThrow(
+      'is not allowed as a JSON query value',
+    )
+    expect(() => escapeSQLValue('value/path')).toThrow('is not allowed as a JSON query value')
+  })
+})

--- a/packages/drizzle/src/utilities/escapeSQLValue.ts
+++ b/packages/drizzle/src/utilities/escapeSQLValue.ts
@@ -1,6 +1,6 @@
 import { APIError } from 'payload'
 
-export const SAFE_STRING_REGEX = /^[\w @.\-+:]*$/
+export const SAFE_STRING_REGEX = /^[\p{L}\p{N}_ @.\-+:]*$/u
 
 export const escapeSQLValue = (value: unknown): boolean | null | number | string => {
   if (value === null) {


### PR DESCRIPTION
### What?

Allow Unicode letters and numbers in `@payloadcms/drizzle` JSON query values and add regression coverage for the escape helper.

### Why?

JSON field queries with values like CJK text, accented Latin text, or full-width digits currently throw `is not allowed as a JSON query value`, which breaks internationalized JSON data queries.

Fixes #16401

### How?

The safe string regex now uses Unicode letter/number character classes while preserving the existing punctuation allowlist. The new unit test verifies Unicode values pass while quote, semicolon, and slash metacharacters still fail.

### Testing

- `pnpm exec vitest run --project unit packages/drizzle/src/utilities/escapeSQLValue.spec.ts packages/drizzle/src/utilities/isValidStringID.spec.ts`
- `pnpm exec eslint --flag v10_config_lookup_from_file --no-warn-ignored packages/drizzle/src/utilities/escapeSQLValue.ts packages/drizzle/src/utilities/escapeSQLValue.spec.ts`
- `pnpm exec prettier --check packages/drizzle/src/utilities/escapeSQLValue.ts packages/drizzle/src/utilities/escapeSQLValue.spec.ts`
- `git diff --check HEAD~1..HEAD`
- `pnpm --filter @payloadcms/drizzle build:swc`
