### PR TITLE
fix(ui): add min-height and padding to textarea field

### DIFF
--- a/packages/ui/src/fields/Textarea/index.css
+++ b/packages/ui/src/fields/Textarea/index.css
@@ -18,6 +18,7 @@
       height: auto;
       display: flex;
       field-sizing: content;
+      padding: var(--spacer-2);
 
       &:hover:not(:focus):not(:disabled) {
         border-color: var(--border-default-default);
@@ -26,10 +27,6 @@
       &:focus {
         border-color: var(--border-selected);
       }
-    }
-
-    textarea:not(:empty) {
-      min-height: calc(var(--rows) * var(--base) + 1rem + 0.125rem);
     }
 
     &.read-only {


### PR DESCRIPTION
Fixes textarea field shrinking below a minimum height when content is typed and adds proper padding.

### Changes
- Adds `padding: var(--spacer-2)` to textarea for consistent 8px padding (matching Figma design)
- Removes the `:not(:empty)` selector that was overriding min-height with a rows-based calculation that could be smaller than the base min-height or invalid when `--rows` wasn't set

### Before
Textarea would shrink to content size as you typed, potentially becoming very small.

### After
Textarea maintains a minimum height of `3.75rem` and grows with content via `field-sizing: content`.