### PR TITLE
fix(plugin-multi-tenant): tenant field unselectable in bulk upload "Edit all"

### DIFF
--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -34,7 +34,9 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
   const { isValid: isFormValid, setModified } = useForm()
   const { id: docID, collectionSlug } = useDocumentInfo()
   const { isModalOpen, openModal } = useModal()
-  const isEditManyModalOpen = collectionSlug ? isModalOpen(`edit-${collectionSlug}`) : false
+  const isEditManyModalOpen = collectionSlug
+    ? isModalOpen(`edit-${collectionSlug}`) || isModalOpen(`edit-${collectionSlug}-bulk-uploads`)
+    : false
   const isConfirmingRef = React.useRef<boolean>(false)
   const prevModified = React.useRef(modified)
   const prevValue = React.useRef<typeof value>(value)

--- a/test/plugin-multi-tenant/collections/Media.ts
+++ b/test/plugin-multi-tenant/collections/Media.ts
@@ -1,0 +1,17 @@
+import type { CollectionConfig } from 'payload'
+
+import { mediaSlug } from '../shared.js'
+
+export const Media: CollectionConfig = {
+  slug: mediaSlug,
+  admin: {
+    useAsTitle: 'filename',
+  },
+  fields: [
+    {
+      name: 'alt',
+      type: 'text',
+    },
+  ],
+  upload: true,
+}

--- a/test/plugin-multi-tenant/config.base.ts
+++ b/test/plugin-multi-tenant/config.base.ts
@@ -10,6 +10,7 @@ const dirname = path.dirname(filename)
 import type { Config as ConfigType } from './payload-types.js'
 
 import { AutosaveGlobal } from './collections/AutosaveGlobal.js'
+import { Media } from './collections/Media.js'
 import { Menu } from './collections/Menu.js'
 import { MenuItems } from './collections/MenuItems.js'
 import { MultiTenantPosts } from './collections/MultiTenantPosts.js'
@@ -19,6 +20,7 @@ import { Users } from './collections/Users/index.js'
 import { seed } from './seed/index.js'
 import {
   autosaveGlobalSlug,
+  mediaSlug,
   menuItemsSlug,
   menuSlug,
   multiTenantPostsSlug,
@@ -34,6 +36,7 @@ export const baseConfig: Partial<Config> = {
     AutosaveGlobal,
     Relationships,
     MultiTenantPosts,
+    Media,
     {
       slug: notTenantedSlug,
       admin: {
@@ -110,6 +113,7 @@ export const baseConfig: Partial<Config> = {
             hasMany: true,
           },
         },
+        [mediaSlug]: {},
       },
       i18n: {
         translations: {

--- a/test/plugin-multi-tenant/e2e.spec.ts
+++ b/test/plugin-multi-tenant/e2e.spec.ts
@@ -30,7 +30,14 @@ import { reInitializeDB } from '../__helpers/shared/clearAndSeed/reInitializeDB.
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { credentials } from './credentials.js'
-import { autosaveGlobalSlug, menuItemsSlug, menuSlug, tenantsSlug, usersSlug } from './shared.js'
+import {
+  autosaveGlobalSlug,
+  mediaSlug,
+  menuItemsSlug,
+  menuSlug,
+  tenantsSlug,
+  usersSlug,
+} from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -40,6 +47,7 @@ test.describe('Multi Tenant', () => {
   let serverURL: string
   let globalMenuURL: AdminUrlUtil
   let autosaveGlobalURL: AdminUrlUtil
+  let mediaURL: AdminUrlUtil
   let menuItemsURL: AdminUrlUtil
   let usersURL: AdminUrlUtil
   let tenantsURL: AdminUrlUtil
@@ -53,6 +61,7 @@ test.describe('Multi Tenant', () => {
       await initPayloadE2ENoConfig<Config>({ dirname })
     serverURL = serverFromInit
     globalMenuURL = new AdminUrlUtil(serverURL, menuSlug)
+    mediaURL = new AdminUrlUtil(serverURL, mediaSlug)
     menuItemsURL = new AdminUrlUtil(serverURL, menuItemsSlug)
     usersURL = new AdminUrlUtil(serverURL, usersSlug)
     tenantsURL = new AdminUrlUtil(serverURL, tenantsSlug)
@@ -458,6 +467,64 @@ test.describe('Multi Tenant', () => {
       await expect(page.getByText('Steel Cat Menu')).toBeHidden()
       await expect(page.getByText('Anchor Bar Menu')).toBeHidden()
       await expect(page.locator('.rs__menu')).toHaveCount(1)
+    })
+  })
+
+  test.describe('Bulk Upload', () => {
+    test('should render the tenant field inline in the Edit all drawer for bulk uploads', async () => {
+      await loginClientSide({
+        data: credentials.admin,
+        page,
+        serverURL,
+      })
+
+      await page.goto(mediaURL.list)
+      await clearTenantFilter({ page })
+
+      await page.locator('.list-header__title-actions button', { hasText: 'Bulk Upload' }).click()
+
+      await page
+        .locator('.dropzone input[type="file"]')
+        .setInputFiles([
+          path.resolve(dirname, '../uploads/image.png'),
+          path.resolve(dirname, '../uploads/test-image.png'),
+        ])
+
+      // The per-file form opens an AssignTenantFieldModal automatically; cancel it
+      // so we can drive the bulk-edit flow ourselves.
+      const perFileAssignModal = page
+        .locator('dialog#assign-tenant-field-modal')
+        .filter({ hasText: 'Assign' })
+      await expect(perFileAssignModal).toBeVisible()
+      await perFileAssignModal.locator('button', { hasText: 'Cancel' }).click()
+      await expect(perFileAssignModal).toBeHidden()
+
+      // Open the bulk-upload "Edit all" drawer and pick the Site (tenant) field.
+      await page.locator('.edit-many-bulk-uploads__toggle').click()
+      const editManyDrawer = page.locator('dialog#edit-media-bulk-uploads')
+      await expect(editManyDrawer).toBeVisible()
+
+      await selectInput({
+        multiSelect: true,
+        options: ['Site'],
+        selectLocator: editManyDrawer.locator('.edit-many-bulk-uploads__form .react-select'),
+      })
+
+      // The Site field should render inline inside the bulk-edit drawer (like Alt does).
+      // The bug: TenantField doesn't recognize 'edit-${slug}-bulk-uploads' as an
+      // edit-many context, so it wraps itself in a non-interactive AssignTenantFieldModal.
+      const inlineTenantField = editManyDrawer.locator('.tenantField .field-type.relationship')
+      await expect(inlineTenantField).toBeVisible()
+
+      await selectInput({
+        multiSelect: false,
+        option: 'Blue Dog',
+        selectLocator: inlineTenantField,
+        selectType: 'relationship',
+      })
+      await expect(
+        inlineTenantField.locator('.relationship--single-value__text', { hasText: 'Blue Dog' }),
+      ).toBeVisible()
     })
   })
 

--- a/test/plugin-multi-tenant/shared.ts
+++ b/test/plugin-multi-tenant/shared.ts
@@ -13,3 +13,5 @@ export const relationshipsSlug = 'relationships'
 export const notTenantedSlug = 'notTenanted'
 
 export const multiTenantPostsSlug = 'multi-tenant-posts'
+
+export const mediaSlug = 'media'


### PR DESCRIPTION
In a multi-tenant collection that has uploads enabled, picking the tenant field ("Site" in our test) inside the bulk-upload "Edit all" drawer leaves you with an unresponsive dropdown - clicks land on it but the menu never opens, so there's no way to bulk-assign a tenant to the files you're uploading.

`TenantField` decides whether to render inline or wrap itself in `AssignTenantFieldModal` by checking if the `edit-${slug}` modal is open. The bulk-upload edit-many drawer uses `edit-${slug}-bulk-uploads` instead, so the check misses, the field re-wraps itself in a nested `AssignTenantFieldModal`. Widening the check to match both slugs makes the tenant relationship render inline in the bulk-edit drawer, the same way every other field does, and you can pick a tenant normally.

## Before

[before-fix.webm](https://github.com/user-attachments/assets/ba7eda87-b849-4cd9-9a37-f76c84a0b124)

## After

[after-fix.webm](https://github.com/user-attachments/assets/21e96f6c-ef3a-4330-8eef-f618d28a40d9)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214434612753281