### PR TITLE
fix: stop workflows retrying forever when no retries are configured

### DIFF
--- a/packages/payload/src/queues/errors/handleWorkflowError.ts
+++ b/packages/payload/src/queues/errors/handleWorkflowError.ts
@@ -44,10 +44,16 @@ export async function handleWorkflowError({
     stack: error.stack,
   }
 
-  const { hasFinalError, maxWorkflowRetries, waitUntil } = getWorkflowRetryBehavior({
-    job,
-    retriesConfig: workflowConfig.retries!,
-  })
+  // No retries configured => permanently fail.
+  const hasNoRetriesConfigured =
+    workflowConfig.retries === undefined || workflowConfig.retries === null
+
+  const { hasFinalError, maxWorkflowRetries, waitUntil } = hasNoRetriesConfigured
+    ? { hasFinalError: true as const, maxWorkflowRetries: undefined, waitUntil: undefined }
+    : getWorkflowRetryBehavior({
+        job,
+        retriesConfig: workflowConfig.retries,
+      })
 
   if (!hasFinalError) {
     if (job.waitUntil) {

--- a/packages/payload/src/queues/errors/handleWorkflowError.ts
+++ b/packages/payload/src/queues/errors/handleWorkflowError.ts
@@ -44,7 +44,9 @@ export async function handleWorkflowError({
     stack: error.stack,
   }
 
-  // No retries configured => permanently fail.
+  // No retries configured => permanently fail. Errors reaching this handler are
+  // workflow-level (task errors are routed to handleTaskError first), so there's
+  // nothing else to bound them.
   const hasNoRetriesConfigured =
     workflowConfig.retries === undefined || workflowConfig.retries === null
 

--- a/packages/payload/src/queues/errors/handleWorkflowError.ts
+++ b/packages/payload/src/queues/errors/handleWorkflowError.ts
@@ -51,7 +51,7 @@ export async function handleWorkflowError({
     workflowConfig.retries === undefined || workflowConfig.retries === null
 
   const { hasFinalError, maxWorkflowRetries, waitUntil } = hasNoRetriesConfigured
-    ? { hasFinalError: true as const, maxWorkflowRetries: undefined, waitUntil: undefined }
+    ? { hasFinalError: true, maxWorkflowRetries: undefined, waitUntil: undefined }
     : getWorkflowRetryBehavior({
         job,
         retriesConfig: workflowConfig.retries,

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -330,23 +330,46 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
     }
     const jobReq = isolateObjectProperty(req, 'transactionID')
 
-    const workflowConfig: WorkflowConfig =
-      job.workflowSlug && jobsConfig.workflows?.length
-        ? jobsConfig.workflows.find(({ slug }) => slug === job.workflowSlug)!
-        : {
-            slug: 'singleTask',
-            handler: async ({ job, tasks }) => {
-              await tasks[job.taskSlug as string]!('1', {
-                input: job.input,
-              })
-            },
-          }
+    let workflowConfig: undefined | WorkflowConfig = undefined
+
+    if (job.workflowSlug && jobsConfig.workflows?.length) {
+      workflowConfig = jobsConfig.workflows.find(({ slug }) => slug === job.workflowSlug)
+    } else if (job.taskSlug && jobsConfig.tasks?.length) {
+      const taskExists = jobsConfig.tasks.some(({ slug }) => slug === job.taskSlug)
+      if (taskExists) {
+        workflowConfig = {
+          slug: 'singleTask',
+          handler: async ({ job, tasks }) => {
+            await tasks[job.taskSlug as string]!('1', {
+              input: job.input,
+            })
+          },
+        }
+      }
+    }
 
     if (!workflowConfig) {
+      const slugLabel = job.taskSlug ? `task '${job.taskSlug}'` : `workflow '${job.workflowSlug}'`
+      const errorMessage = `Job references ${slugLabel}, which is not registered in payload.config.jobs. The slug may have been removed from config after the job was queued.`
+
+      if (!silent || (typeof silent === 'object' && !silent.error)) {
+        payload.logger.error({
+          msg: `Error running job ${job.workflowSlug || `Task: ${job.taskSlug}`} id: ${job.id} - ${errorMessage}`,
+        })
+      }
+
+      const updateJob = getUpdateJobFunction(job, jobReq)
+      await updateJob({
+        error: { message: errorMessage },
+        hasError: true,
+        processing: false,
+        totalTried: (job.totalTried ?? 0) + 1,
+      })
+
       return {
         id: job.id,
         result: {
-          status: 'error',
+          status: 'error-reached-max-retries',
         },
       } // Skip jobs with no workflow configuration
     }

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -349,7 +349,8 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
     }
 
     if (!workflowConfig) {
-      // Permanently fail jobs that reference a workflow or task that is no longer registered in config, as they can never be completed successfully. No point in retrying them
+      // Permanently fail jobs whose task/workflow slug is no longer registered in config — they can never complete.
+      const errorMessage = `${job.taskSlug ? `Task '${job.taskSlug}'` : `Workflow '${job.workflowSlug}'`} is not registered in payload.config.jobs.`
 
       if (!silent || (typeof silent === 'object' && !silent.error)) {
         payload.logger.error({

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -349,8 +349,7 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
     }
 
     if (!workflowConfig) {
-      const slugLabel = job.taskSlug ? `task '${job.taskSlug}'` : `workflow '${job.workflowSlug}'`
-      const errorMessage = `Job references ${slugLabel}, which is not registered in payload.config.jobs. The slug may have been removed from config after the job was queued.`
+      // Permanently fail jobs that reference a workflow or task that is no longer registered in config, as they can never be completed successfully. No point in retrying them
 
       if (!silent || (typeof silent === 'object' && !silent.error)) {
         payload.logger.error({
@@ -371,7 +370,7 @@ export const runJobs = async (args: RunJobsArgs): Promise<RunJobsResult> => {
         result: {
           status: 'error-reached-max-retries',
         },
-      } // Skip jobs with no workflow configuration
+      }
     }
 
     try {

--- a/test/queues/getConfig.ts
+++ b/test/queues/getConfig.ts
@@ -38,6 +38,8 @@ import { selfCancelWorkflow } from './workflows/selfCancel.js'
 import { subTaskWorkflow } from './workflows/subTask.js'
 import { subTaskFailsWorkflow } from './workflows/subTaskFails.js'
 import { supersedesConcurrencyWorkflow } from './workflows/supersedesConcurrency.js'
+import { throwsInHandlerNoRetriesWorkflow } from './workflows/throwsInHandlerNoRetries.js'
+import { throwsInHandlerRetries1Workflow } from './workflows/throwsInHandlerRetries1.js'
 import { updatePostWorkflow } from './workflows/updatePost.js'
 import { updatePostJSONWorkflow } from './workflows/updatePostJSON.js'
 import { workflowAndTasksRetriesUndefinedWorkflow } from './workflows/workflowAndTasksRetriesUndefined.js'
@@ -179,6 +181,8 @@ export const getConfig: () => Partial<Config> = () => ({
       noConcurrencyWorkflow,
       queueSpecificConcurrencyWorkflow,
       supersedesConcurrencyWorkflow,
+      throwsInHandlerNoRetriesWorkflow,
+      throwsInHandlerRetries1Workflow,
     ],
   },
   editor: lexicalEditor(),

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -938,6 +938,43 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[0]?.title).toBe('from single task')
   })
 
+  describe('when a queued task slug is no longer registered in config', () => {
+    let originalTasks: typeof payload.config.jobs.tasks
+
+    beforeEach(() => {
+      originalTasks = payload.config.jobs.tasks
+    })
+
+    afterEach(() => {
+      payload.config.jobs.tasks = originalTasks
+    })
+
+    it('should permanently fail the job after one attempt instead of retrying forever', async () => {
+      payload.config.jobs.deleteJobOnComplete = false
+
+      const job = await payload.jobs.queue({
+        task: 'CreateSimple',
+        input: {
+          message: 'queued before task removal',
+        },
+      })
+
+      // Simulate a deploy that removed the 'CreateSimple' task from config
+      payload.config.jobs.tasks = originalTasks!.filter((t) => t.slug !== 'CreateSimple')
+
+      await payload.jobs.run({ silent: true })
+
+      const jobAfterRun = await payload.findByID({
+        collection: 'payload-jobs',
+        id: job.id,
+      })
+
+      expect(jobAfterRun.hasError).toBe(true)
+      expect(jobAfterRun.processing).toBe(false)
+      expect(jobAfterRun.totalTried).toBe(1)
+    })
+  })
+
   it('can queue and run via the endpoint single tasks without workflows', async () => {
     const workflowsRef = payload.config.jobs.workflows
     delete payload.config.jobs.workflows

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -973,6 +973,78 @@ describe('Queues - Payload', () => {
       expect(jobAfterRun.processing).toBe(false)
       expect(jobAfterRun.totalTried).toBe(1)
     })
+
+    it('should permanently fail when a workflow handler calls a task that has been removed', async () => {
+      payload.config.jobs.deleteJobOnComplete = false
+
+      const job = await payload.jobs.queue({
+        workflow: 'workflowNoRetriesSet',
+        input: {
+          message: 'queued before referenced task removal',
+        },
+      })
+
+      payload.config.jobs.tasks = originalTasks!.filter((t) => t.slug !== 'CreateSimple')
+
+      await payload.jobs.run({ silent: true })
+
+      const jobAfterRun = await payload.findByID({
+        collection: 'payload-jobs',
+        id: job.id,
+      })
+
+      expect(jobAfterRun.hasError).toBe(true)
+      expect(jobAfterRun.processing).toBe(false)
+      expect(jobAfterRun.totalTried).toBe(1)
+    })
+  })
+
+  it('should not retry a workflow with no retries configured when its handler throws', async () => {
+    payload.config.jobs.deleteJobOnComplete = false
+
+    const job = await payload.jobs.queue({
+      workflow: 'throwsInHandlerNoRetries',
+      input: {},
+    })
+
+    await payload.jobs.run({ silent: true })
+
+    const jobAfterRun = await payload.findByID({
+      collection: 'payload-jobs',
+      id: job.id,
+    })
+
+    expect(jobAfterRun.hasError).toBe(true)
+    expect(jobAfterRun.processing).toBe(false)
+    expect(jobAfterRun.totalTried).toBe(1)
+  })
+
+  it('should retry a workflow with retries=1 exactly once when its handler throws', async () => {
+    payload.config.jobs.deleteJobOnComplete = false
+
+    const job = await payload.jobs.queue({
+      workflow: 'throwsInHandlerRetries1',
+      input: {},
+    })
+
+    let hasJobsRemaining = true
+    while (hasJobsRemaining) {
+      const response = await payload.jobs.run({ silent: true })
+      if (response.noJobsRemaining) {
+        hasJobsRemaining = false
+      }
+    }
+
+    const jobAfterRun = await payload.findByID({
+      collection: 'payload-jobs',
+      id: job.id,
+    })
+
+    // Initial attempt + 1 retry = 2. Once hasError is true the queue stops picking it up,
+    // so the loop naturally bounds at exactly 2 attempts.
+    expect(jobAfterRun.totalTried).toBe(2)
+    expect(jobAfterRun.hasError).toBe(true)
+    expect(jobAfterRun.processing).toBe(false)
   })
 
   it('can queue and run via the endpoint single tasks without workflows', async () => {

--- a/test/queues/payload-types.ts
+++ b/test/queues/payload-types.ts
@@ -94,6 +94,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: {
@@ -140,6 +143,8 @@ export interface Config {
       noConcurrency: WorkflowNoConcurrency;
       queueSpecificConcurrency: WorkflowQueueSpecificConcurrency;
       supersedesConcurrency: WorkflowSupersedesConcurrency;
+      throwsInHandlerNoRetries: WorkflowThrowsInHandlerNoRetries;
+      throwsInHandlerRetries1: WorkflowThrowsInHandlerRetries1;
     };
   };
 }
@@ -365,6 +370,8 @@ export interface PayloadJob {
         | 'noConcurrency'
         | 'queueSpecificConcurrency'
         | 'supersedesConcurrency'
+        | 'throwsInHandlerNoRetries'
+        | 'throwsInHandlerRetries1'
       )
     | null;
   taskSlug?:
@@ -570,6 +577,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -931,6 +948,20 @@ export interface WorkflowSupersedesConcurrency {
     resourceId: string;
     delayMs?: number | null;
   };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "WorkflowThrowsInHandlerNoRetries".
+ */
+export interface WorkflowThrowsInHandlerNoRetries {
+  input?: unknown;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "WorkflowThrowsInHandlerRetries1".
+ */
+export interface WorkflowThrowsInHandlerRetries1 {
+  input?: unknown;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/queues/workflows/throwsInHandlerNoRetries.ts
+++ b/test/queues/workflows/throwsInHandlerNoRetries.ts
@@ -1,0 +1,10 @@
+import type { WorkflowConfig } from 'payload'
+
+export const throwsInHandlerNoRetriesWorkflow: WorkflowConfig<'throwsInHandlerNoRetries'> = {
+  slug: 'throwsInHandlerNoRetries',
+  inputSchema: [],
+  // Intentionally no `retries` set — exercises the default no-retries-on-workflow-error behavior
+  handler: () => {
+    throw new Error('This workflow throws in its handler')
+  },
+}

--- a/test/queues/workflows/throwsInHandlerRetries1.ts
+++ b/test/queues/workflows/throwsInHandlerRetries1.ts
@@ -1,0 +1,10 @@
+import type { WorkflowConfig } from 'payload'
+
+export const throwsInHandlerRetries1Workflow: WorkflowConfig<'throwsInHandlerRetries1'> = {
+  slug: 'throwsInHandlerRetries1',
+  inputSchema: [],
+  retries: 1,
+  handler: () => {
+    throw new Error('This workflow throws in its handler')
+  },
+}


### PR DESCRIPTION
Jobs with a workflow that had no `retries` configured would retry forever with no backoff if the workflow handler threw an error. We hit this when a task slug was removed from config in a deploy after the job was queued - the inline single-task workflow would throw a `TypeError` calling the missing task.

Why the bug existed: when a *task* throws, `handleTaskError` runs first and uses the task's own `retries` value to cap retries, so a workflow with no `retries` is fine - the task's retry limit is what stops the loop. But when the workflow *handler itself* throws, the error skips `handleTaskError` and goes straight to `handleWorkflowError`. The existing default there for "no workflow retries set" was "retry indefinitely, the task's limit will stop it" - except no task was ever involved, so nothing stopped the loop.

`handleWorkflowError` now permanently fails the job when the workflow has no retries set. The task case is unchanged on purpose: a workflow without retries that calls a task with `retries: 3` still retries the task up to 3 times like before.

There's also a smaller fix for jobs whose `workflowSlug` is no longer in config - those previously returned early without calling `updateJob`, leaving them stuck in `processing: true` indefinitely.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214434612753285