### PR TITLE
fix: guard against NaN when searching versioned collections by ID

### DIFF
--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -230,9 +230,14 @@ export const sanitizeQueryValue = ({
         })
       } else {
         if (idType === 'number') {
-          formattedValue = Number(val)
-        }
-        if (idType === 'text') {
+          const numericVal = Number(val)
+
+          if (Number.isNaN(numericVal)) {
+            return null
+          }
+
+          formattedValue = numericVal
+        } else if (idType === 'text') {
           formattedValue = String(val)
         }
       }


### PR DESCRIPTION
## Description

When list search merges an `id` condition and drafts are enabled, `appendVersionToQueryKey` rewrites `id` to `parent`. For numeric collection IDs, `sanitizeQueryValue` coerced the search string with `Number()` without rejecting non-numeric input, producing `NaN` as a bound parameter against `parent_id` (integer). Postgres then failed with `invalid input syntax for type integer: "NaN"`.

This change returns `null` from `sanitizeQueryValue` when the coerced relationship ID is `NaN`, so `parseParams` skips adding that constraint (same pattern as polymorphic relationship handling). Other searchable fields in the same OR continue to work.

Fixes #15648

Made with [Cursor](https://cursor.com)