### PR TITLE
chore: pass --browser chromium to playwright MCP

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -8,7 +8,9 @@
         "@playwright/mcp@latest",
         "--caps=vision,verify,tracing,devtools",
         "--isolated",
-        "--headless"
+        "--headless",
+        "--browser",
+        "chromium"
       ]
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,9 @@
         "@playwright/mcp@latest",
         "--caps=vision,verify,tracing,devtools",
         "--isolated",
-        "--headless"
+        "--headless",
+        "--browser",
+        "chromium"
       ]
     }
   }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,7 +8,9 @@
         "@playwright/mcp@latest",
         "--caps=vision,verify,tracing,devtools",
         "--isolated",
-        "--headless"
+        "--headless",
+        "--browser",
+        "chromium"
       ]
     }
   }


### PR DESCRIPTION
@playwright/mcp defaults to the `chrome` channel, which on Linux looks for `/opt/google/chrome/chrome` - Google doesn't ship branded Chrome for Linux arm64, so the MCP fails to start in devcontainers running on Apple Silicon hosts.

`--browser chromium` switches to chromium instead, which has an arm64 build and works on both x64 and arm64 hosts.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214456571439649