### PR TITLE
fix(plugin-ecommerce): extract id from cart items, so that a new transaction ca…

### DIFF
--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -76,7 +76,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
 
         // Preserve any additional custom properties (e.g., deliveryOption, customizations)
         // that may have been added via cartItemMatcher
-        const { product: _product, variant: _variant, ...customProperties } = item
+        const { id: _id, product: _product, variant: _variant, ...customProperties } = item
 
         return {
           ...customProperties,


### PR DESCRIPTION
# Description
Fixes #16453 . This fix extracts the id field on deconstruction in the intiatePayment handler for the stripe payment adapter. This way new cart items with new Ids can be created when a customer initiates a payment twice without cleaning up the cart.

