### PR TITLE
fix(plugin-multi-tenant): serialize transaction dataloader finds

### DIFF
--- a/packages/payload/src/collections/dataloader.spec.ts
+++ b/packages/payload/src/collections/dataloader.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDataLoader } from './dataloader.js'
+
+const createDeferred = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+describe('getDataLoader', () => {
+  it('should serialize find calls while a transaction is active', async () => {
+    const calls: string[] = []
+    const firstStarted = createDeferred()
+    const releaseFirst = createDeferred()
+    let activeFinds = 0
+    let maxActiveFinds = 0
+
+    const req = {
+      transactionID: 'transaction-id',
+      payload: {
+        find: async (args: { where: { id: { equals: string } } }) => {
+          const id = args.where.id.equals
+
+          calls.push(`start:${id}`)
+          activeFinds += 1
+          maxActiveFinds = Math.max(maxActiveFinds, activeFinds)
+
+          if (id === 'first') {
+            firstStarted.resolve()
+            await releaseFirst.promise
+          }
+
+          calls.push(`finish:${id}`)
+          activeFinds -= 1
+
+          return { docs: [] }
+        },
+      },
+    }
+
+    const dataLoader = getDataLoader(req as never)
+    const firstFind = dataLoader.find({
+      collection: 'items',
+      req,
+      where: { id: { equals: 'first' } },
+    } as never)
+
+    await firstStarted.promise
+
+    const secondFind = dataLoader.find({
+      collection: 'items',
+      req,
+      where: { id: { equals: 'second' } },
+    } as never)
+
+    await Promise.resolve()
+
+    expect(maxActiveFinds).toBe(1)
+
+    releaseFirst.resolve()
+    await Promise.all([firstFind, secondFind])
+
+    expect(calls).toEqual(['start:first', 'finish:first', 'start:second', 'finish:second'])
+  })
+
+  it('should not serialize find calls outside a transaction', async () => {
+    const calls: string[] = []
+    const firstStarted = createDeferred()
+    const releaseFirst = createDeferred()
+    let activeFinds = 0
+    let maxActiveFinds = 0
+
+    const req = {
+      payload: {
+        find: async (args: { where: { id: { equals: string } } }) => {
+          const id = args.where.id.equals
+
+          calls.push(`start:${id}`)
+          activeFinds += 1
+          maxActiveFinds = Math.max(maxActiveFinds, activeFinds)
+
+          if (id === 'first') {
+            firstStarted.resolve()
+            await releaseFirst.promise
+          }
+
+          calls.push(`finish:${id}`)
+          activeFinds -= 1
+
+          return { docs: [] }
+        },
+      },
+    }
+
+    const dataLoader = getDataLoader(req as never)
+    const firstFind = dataLoader.find({
+      collection: 'items',
+      req,
+      where: { id: { equals: 'first' } },
+    } as never)
+
+    await firstStarted.promise
+
+    const secondFind = dataLoader.find({
+      collection: 'items',
+      req,
+      where: { id: { equals: 'second' } },
+    } as never)
+
+    await secondFind
+
+    expect(maxActiveFinds).toBe(2)
+    expect(calls).toEqual(['start:first', 'start:second', 'finish:second'])
+
+    releaseFirst.resolve()
+    await firstFind
+
+    expect(calls).toEqual(['start:first', 'start:second', 'finish:second', 'finish:first'])
+  })
+})

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -166,6 +166,7 @@ const batchAndLoadDocs =
 export const getDataLoader = (req: PayloadRequest) => {
   const findQueries = new Map()
   const dataLoader = new DataLoader(batchAndLoadDocs(req)) as PayloadRequest['payloadDataLoader']
+  let findQueue: Promise<unknown> = Promise.resolve()
 
   dataLoader.find = ((args: FindArgs) => {
     const key = createFindDataloaderCacheKey(args)
@@ -173,7 +174,17 @@ export const getDataLoader = (req: PayloadRequest) => {
     if (cached) {
       return cached
     }
-    const request = req.payload.find(args)
+
+    const hasTransaction = Boolean(args.req?.transactionID || req.transactionID)
+    // MongoDB sessions cannot run multiple operations concurrently in the same transaction.
+    const request = hasTransaction
+      ? findQueue.then(() => req.payload.find(args))
+      : req.payload.find(args)
+
+    if (hasTransaction) {
+      findQueue = request.catch(() => undefined)
+    }
+
     findQueries.set(key, request)
     return request
   }) as Payload['find']

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -9,7 +9,14 @@ import type { Relationship } from './payload-types.js'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
-import { multiTenantPostsSlug, relationshipsSlug, tenantsSlug, usersSlug } from './shared.js'
+import {
+  menuItemsSlug,
+  menuSlug,
+  multiTenantPostsSlug,
+  relationshipsSlug,
+  tenantsSlug,
+  usersSlug,
+} from './shared.js'
 
 let payload: Payload
 let restClient: NextRESTClient
@@ -99,6 +106,51 @@ describe('@payloadcms/plugin-multi-tenant', () => {
 
         // @ts-expect-error unsafe access okay in test
         expect(newRelationship.relationship?.title).toBe('Owned by bar with no ac')
+      })
+
+      it('should create an array of same-tenant relationships without transaction races', async () => {
+        const rowCount = 8
+        const tenant = await payload.create({
+          collection: tenantsSlug,
+          data: {
+            domain: 'relationship-race.test',
+            name: 'Relationship Race Tenant',
+          },
+        })
+        const menuItems = await Promise.all(
+          Array.from({ length: rowCount }, (_, index) =>
+            payload.create({
+              collection: menuItemsSlug,
+              data: {
+                name: `Relationship Race Item ${index}`,
+                tenant: tenant.id,
+              },
+            }),
+          ),
+        )
+
+        const menu = await payload.create({
+          collection: menuSlug,
+          data: {
+            menuItems: menuItems.map((menuItem) => ({
+              active: true,
+              menuItem: menuItem.id,
+            })),
+            tenant: tenant.id,
+            title: 'Relationship Race Menu',
+          },
+          req: {
+            headers: new Headers([['cookie', `payload-tenant=${tenant.id}`]]),
+          },
+        })
+
+        expect(menu.menuItems).toHaveLength(rowCount)
+
+        await payload.delete({ collection: menuSlug, id: menu.id })
+        for (const menuItem of menuItems) {
+          await payload.delete({ collection: menuItemsSlug, id: menuItem.id })
+        }
+        await payload.delete({ collection: tenantsSlug, id: tenant.id })
       })
 
       it('ensure relationship document with relationship to different tenant cannot be created if tenant header passed', async () => {


### PR DESCRIPTION
### What?

Serialize `payloadDataLoader.find` calls only while a request is running inside a transaction. This prevents multiple relationship/filterOptions validators from issuing concurrent MongoDB operations on the same transaction session.

### Why?

The multi-tenant plugin auto-injects relationship `filterOptions`. Array rows are validated in parallel, so creating a tenant-scoped document with several relationship rows can trigger concurrent `payload.find` calls in the same MongoDB transaction and surface false `invalid relationship` validation errors.

### How?

- Add a per-request find queue in `getDataLoader` for transactional finds.
- Leave non-transactional finds concurrent.
- Add unit coverage for transactional serialization and non-transactional concurrency.
- Add a multi-tenant integration regression covering array relationship creation with same-tenant items.

Fixes #16462

### Verification

- `pnpm exec vitest run --project unit packages/payload/src/collections/dataloader.spec.ts`
- `pnpm exec vitest run --project int test/plugin-multi-tenant/int.spec.ts -t 'should create an array of same-tenant relationships without transaction races' --no-cache`
- `pnpm exec vitest run --project int test/plugin-multi-tenant/int.spec.ts --no-cache`
- `pnpm exec prettier --check packages/payload/src/collections/dataloader.ts packages/payload/src/collections/dataloader.spec.ts test/plugin-multi-tenant/int.spec.ts`
- `pnpm exec eslint --flag v10_config_lookup_from_file packages/payload/src/collections/dataloader.ts`
- `pnpm exec eslint --flag v10_config_lookup_from_file --no-warn-ignored packages/payload/src/collections/dataloader.spec.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm exec eslint --flag v10_config_lookup_from_file --cache --cache-strategy content --no-error-on-unmatched-pattern test/plugin-multi-tenant/int.spec.ts` (passes with existing warnings for `token` and `blueDogTenantID`)
- `pnpm --filter payload build:swc`
- `git diff --check`

Note: a combined ESLint run over both changed non-spec files hit local Node heap/timeout limits, so I verified the files separately.