### PR TITLE
fix(richtext-lexical): cursor kicked out of nested richtext while typing in a block

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
@@ -24,7 +24,7 @@ import {
   useTranslation,
 } from '@payloadcms/ui'
 import { abortAndIgnore } from '@payloadcms/ui/shared'
-import { $getNodeByKey } from 'lexical'
+import { $getNodeByKey, SKIP_DOM_SELECTION_TAG } from 'lexical'
 import {
   type BlocksFieldClient,
   type ClientBlock,
@@ -269,15 +269,20 @@ export const BlockComponent: React.FC<BlockComponentProps> = (props) => {
         ) as BlockFields
 
         // Things like default values may come back from the server => update the node with the new data
-        editor.update(() => {
-          const node = $getNodeByKey(nodeKey)
-          if (node && $isBlockNode(node)) {
-            const newData = newFormStateData
-            newData.blockType = blockType
+        editor.update(
+          () => {
+            const node = $getNodeByKey(nodeKey)
+            if (node && $isBlockNode(node)) {
+              const newData = newFormStateData
+              newData.blockType = blockType
 
-            node.setFields(newData, true)
-          }
-        })
+              node.setFields(newData, true)
+            }
+          },
+          // Without this, the outer editor's reconciler resets DOM selection
+          // back into its own root, kicking focus out of any nested richText.
+          { tag: SKIP_DOM_SELECTION_TAG },
+        )
 
         setInitialState(state)
         if (!CustomLabelFromProps) {
@@ -377,14 +382,19 @@ export const BlockComponent: React.FC<BlockComponentProps> = (props) => {
       ) as BlockFields
 
       setTimeout(() => {
-        editor.update(() => {
-          const node = $getNodeByKey(nodeKey)
-          if (node && $isBlockNode(node)) {
-            const newData = newFormStateData
-            newData.blockType = blockType
-            node.setFields(newData, true)
-          }
-        })
+        editor.update(
+          () => {
+            const node = $getNodeByKey(nodeKey)
+            if (node && $isBlockNode(node)) {
+              const newData = newFormStateData
+              newData.blockType = blockType
+              node.setFields(newData, true)
+            }
+          },
+          // Without this, the outer editor's reconciler resets DOM selection
+          // back into its own root, kicking focus out of any nested richText.
+          { tag: SKIP_DOM_SELECTION_TAG },
+        )
       }, 0)
 
       if (submit) {
@@ -677,12 +687,17 @@ export const BlockComponent: React.FC<BlockComponentProps> = (props) => {
           onSubmit={(formState, newData) => {
             // This is only called when form is submitted from drawer - usually only the case if the block has a custom Block component
             newData.blockType = blockType
-            editor.update(() => {
-              const node = $getNodeByKey(nodeKey)
-              if (node && $isBlockNode(node)) {
-                node.setFields(newData as BlockFields, true)
-              }
-            })
+            editor.update(
+              () => {
+                const node = $getNodeByKey(nodeKey)
+                if (node && $isBlockNode(node)) {
+                  node.setFields(newData as BlockFields, true)
+                }
+              },
+              // Without this, the outer editor's reconciler resets DOM selection
+              // back into its own root, kicking focus out of any nested richText.
+              { tag: SKIP_DOM_SELECTION_TAG },
+            )
             toggleDrawer()
           }}
           submitted={submitted}

--- a/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
@@ -22,7 +22,7 @@ import {
   useTranslation,
 } from '@payloadcms/ui'
 import { abortAndIgnore } from '@payloadcms/ui/shared'
-import { $getNodeByKey } from 'lexical'
+import { $getNodeByKey, SKIP_DOM_SELECTION_TAG } from 'lexical'
 
 import './index.scss'
 
@@ -264,15 +264,20 @@ export const InlineBlockComponent: React.FC<InlineBlockComponentProps<InlineBloc
         ) as InlineBlockFields
 
         // Things like default values may come back from the server => update the node with the new data
-        editor.update(() => {
-          const node = $getNodeByKey(nodeKey)
-          if (node && $isInlineBlockNode(node)) {
-            const newData = newFormStateData
-            newData.blockType = formData.blockType
+        editor.update(
+          () => {
+            const node = $getNodeByKey(nodeKey)
+            if (node && $isInlineBlockNode(node)) {
+              const newData = newFormStateData
+              newData.blockType = formData.blockType
 
-            node.setFields(newData, true)
-          }
-        })
+              node.setFields(newData, true)
+            }
+          },
+          // Without this, the outer editor's reconciler resets DOM selection
+          // back into its own root, kicking focus out of any nested richText.
+          { tag: SKIP_DOM_SELECTION_TAG },
+        )
 
         setInitialState(state)
         if (!CustomLabelFromProps) {
@@ -392,12 +397,17 @@ export const InlineBlockComponent: React.FC<InlineBlockComponentProps<InlineBloc
     (formState: FormState, newData: Data) => {
       newData.blockType = formData.blockType
 
-      editor.update(() => {
-        const node = $getNodeByKey(nodeKey)
-        if (node && $isInlineBlockNode(node)) {
-          node.setFields(newData as InlineBlockFields, true)
-        }
-      })
+      editor.update(
+        () => {
+          const node = $getNodeByKey(nodeKey)
+          if (node && $isInlineBlockNode(node)) {
+            node.setFields(newData as InlineBlockFields, true)
+          }
+        },
+        // Without this, the outer editor's reconciler resets DOM selection
+        // back into its own root, kicking focus out of any nested richText.
+        { tag: SKIP_DOM_SELECTION_TAG },
+      )
     },
     [editor, nodeKey, formData],
   )

--- a/test/lexical/baseConfig.ts
+++ b/test/lexical/baseConfig.ts
@@ -14,6 +14,7 @@ import {
 } from './collections/Lexical/index.js'
 import { LexicalAccessControl } from './collections/LexicalAccessControl/index.js'
 import { LexicalAutosave } from './collections/LexicalAutosave/index.js'
+import { LexicalAutosaveBlock } from './collections/LexicalAutosaveBlock/index.js'
 import { LexicalBenchmark } from './collections/LexicalBenchmark/index.js'
 import { LexicalCustomCell } from './collections/LexicalCustomCell/index.js'
 import { LexicalHeadingFeature } from './collections/LexicalHeadingFeature/index.js'
@@ -71,6 +72,7 @@ export const baseConfig: Partial<Config> = {
     LexicalLocalizedFields,
     LexicalObjectReferenceBugCollection,
     LexicalInBlock,
+    LexicalAutosaveBlock,
     LexicalAccessControl,
     LexicalRelationshipsFields,
     LexicalSlugFieldNameCollision,

--- a/test/lexical/collections/LexicalAutosaveBlock/e2e.spec.ts
+++ b/test/lexical/collections/LexicalAutosaveBlock/e2e.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import type { PayloadTestSDK } from '../../../__helpers/shared/sdk/index.js'
+import type { Config } from '../../payload-types.js'
+
+import { ensureCompilationIsDone } from '../../../__helpers/e2e/helpers.js'
+import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
+import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+import { lexicalAutosaveBlockSlug } from '../../slugs.js'
+import { LexicalHelpers } from '../utils.js'
+
+const filename = fileURLToPath(import.meta.url)
+const currentFolder = path.dirname(filename)
+const dirname = path.resolve(currentFolder, '../../')
+
+let payload: PayloadTestSDK<Config>
+let serverURL: string
+
+const { beforeAll, beforeEach, describe } = test
+
+// Repro: when the parent collection has autosave enabled, every autosave
+// re-renders the outer richText, which unmounts/remounts the block decorator
+// containing the nested richText. The nested editor loses focus and any
+// characters typed after the autosave fires are dropped on the floor.
+describe('Lexical: nested richText loses focus on parent autosave', () => {
+  let lexical: LexicalHelpers
+
+  beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(TEST_TIMEOUT_LONG)
+    process.env.SEED_IN_CONFIG_ONINIT = 'false'
+    ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
+
+    const page = await browser.newPage()
+    await ensureCompilationIsDone({ page, serverURL })
+    await page.close()
+  })
+
+  beforeEach(async ({ page }) => {
+    const url = new AdminUrlUtil(serverURL, lexicalAutosaveBlockSlug)
+    lexical = new LexicalHelpers(page)
+    await page.goto(url.create)
+    await lexical.editor.first().focus()
+  })
+
+  test('typing in a nested richText keeps focus and retains characters across autosaves', async ({
+    page,
+  }) => {
+    await lexical.slashCommand('blockwithrichtext', true, 'Block With Rich Text')
+
+    await expect(lexical.editor).toHaveCount(2)
+
+    const nestedEditor = lexical.editor.nth(1)
+    await nestedEditor.click()
+
+    // Per-key delay > autosave interval (100ms) so autosave is guaranteed to
+    // fire between keystrokes. That is the timing that triggers the bug.
+    const typed = 'abcdefghij'
+    await page.keyboard.type(typed, { delay: 300 })
+
+    // Allow any in-flight autosave to settle so the focus state has converged.
+    await page.waitForTimeout(500)
+
+    await expect(nestedEditor).toHaveText(typed)
+
+    const isNestedFocused = await page.evaluate(() => {
+      const editors = document.querySelectorAll('[data-lexical-editor="true"]')
+      return document.activeElement === editors[1]
+    })
+    expect(isNestedFocused).toBe(true)
+  })
+})

--- a/test/lexical/collections/LexicalAutosaveBlock/index.ts
+++ b/test/lexical/collections/LexicalAutosaveBlock/index.ts
@@ -1,0 +1,40 @@
+import type { CollectionConfig } from 'payload'
+
+import { BlocksFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
+
+import { lexicalAutosaveBlockSlug } from '../../slugs.js'
+
+export const LexicalAutosaveBlock: CollectionConfig = {
+  slug: lexicalAutosaveBlockSlug,
+  versions: {
+    drafts: {
+      autosave: {
+        interval: 100,
+      },
+    },
+  },
+  fields: [
+    {
+      name: 'content',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: [
+          BlocksFeature({
+            blocks: [
+              {
+                slug: 'blockWithRichText',
+                fields: [
+                  {
+                    name: 'nestedRichText',
+                    type: 'richText',
+                    editor: lexicalEditor(),
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    },
+  ],
+}

--- a/test/lexical/payload-types.ts
+++ b/test/lexical/payload-types.ts
@@ -103,6 +103,7 @@ export interface Config {
     'lexical-localized-fields': LexicalLocalizedField;
     lexicalObjectReferenceBug: LexicalObjectReferenceBug;
     LexicalInBlock: LexicalInBlock;
+    'lexical-autosave-block': LexicalAutosaveBlock;
     'lexical-access-control': LexicalAccessControl;
     'lexical-relationship-fields': LexicalRelationshipField;
     collision: Collision;
@@ -140,6 +141,7 @@ export interface Config {
     'lexical-localized-fields': LexicalLocalizedFieldsSelect<false> | LexicalLocalizedFieldsSelect<true>;
     lexicalObjectReferenceBug: LexicalObjectReferenceBugSelect<false> | LexicalObjectReferenceBugSelect<true>;
     LexicalInBlock: LexicalInBlockSelect<false> | LexicalInBlockSelect<true>;
+    'lexical-autosave-block': LexicalAutosaveBlockSelect<false> | LexicalAutosaveBlockSelect<true>;
     'lexical-access-control': LexicalAccessControlSelect<false> | LexicalAccessControlSelect<true>;
     'lexical-relationship-fields': LexicalRelationshipFieldsSelect<false> | LexicalRelationshipFieldsSelect<true>;
     collision: CollisionSelect<false> | CollisionSelect<true>;
@@ -159,7 +161,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es' | 'he') | ('en' | 'es' | 'he')[];
   globals: {
@@ -221,7 +223,7 @@ export interface BlockWithBlockRef {
  * via the `definition` "lexical-benchmark".
  */
 export interface LexicalBenchmark {
-  id: string;
+  id: number;
   richText?: {
     root: {
       type: string;
@@ -245,7 +247,7 @@ export interface LexicalBenchmark {
  * via the `definition` "lexical-fully-featured".
  */
 export interface LexicalFullyFeatured {
-  id: string;
+  id: number;
   richText?: {
     root: {
       type: string;
@@ -269,7 +271,7 @@ export interface LexicalFullyFeatured {
  * via the `definition` "lexical-autosave".
  */
 export interface LexicalAutosave {
-  id: string;
+  id: number;
   title?: string | null;
   cta?:
     | {
@@ -300,7 +302,7 @@ export interface LexicalAutosave {
  * via the `definition` "lexical-link-feature".
  */
 export interface LexicalLinkFeature {
-  id: string;
+  id: number;
   richText?: {
     root: {
       type: string;
@@ -324,7 +326,7 @@ export interface LexicalLinkFeature {
  * via the `definition` "lexical-lists-features".
  */
 export interface LexicalListsFeature {
-  id: string;
+  id: number;
   onlyOrderedList?: {
     root: {
       type: string;
@@ -348,7 +350,7 @@ export interface LexicalListsFeature {
  * via the `definition` "lexical-heading-feature".
  */
 export interface LexicalHeadingFeature {
-  id: string;
+  id: number;
   richText?: {
     root: {
       type: string;
@@ -372,7 +374,7 @@ export interface LexicalHeadingFeature {
  * via the `definition` "lexical-jsx-converter".
  */
 export interface LexicalJsxConverter {
-  id: string;
+  id: number;
   richText?: {
     root: {
       type: string;
@@ -396,7 +398,7 @@ export interface LexicalJsxConverter {
  * via the `definition` "lexical-fields".
  */
 export interface LexicalField {
-  id: string;
+  id: number;
   title: string;
   lexicalRootEditor?: {
     root: {
@@ -458,7 +460,7 @@ export interface LexicalField {
  * via the `definition` "lexical-views".
  */
 export interface LexicalView {
-  id: string;
+  id: number;
   customDefaultView?: {
     root: {
       type: string;
@@ -497,7 +499,7 @@ export interface LexicalView {
  * via the `definition` "lexical-views-frontend".
  */
 export interface LexicalViewsFrontend {
-  id: string;
+  id: number;
   customFrontendViews?: {
     root: {
       type: string;
@@ -521,7 +523,7 @@ export interface LexicalViewsFrontend {
  * via the `definition` "lexical-views-provider".
  */
 export interface LexicalViewsProvider {
-  id: string;
+  id: number;
   viewProviderWrapper?: {
     richTextField?: {
       root: {
@@ -547,7 +549,7 @@ export interface LexicalViewsProvider {
  * via the `definition` "lexical-views-provider-default".
  */
 export interface LexicalViewsProviderDefault {
-  id: string;
+  id: number;
   defaultViewWrapper?: {
     richTextField?: {
       root: {
@@ -573,7 +575,7 @@ export interface LexicalViewsProviderDefault {
  * via the `definition` "lexical-views-provider-fallback".
  */
 export interface LexicalViewsProviderFallback {
-  id: string;
+  id: number;
   fallbackViewWrapper?: {
     richTextField?: {
       root: {
@@ -599,7 +601,7 @@ export interface LexicalViewsProviderFallback {
  * via the `definition` "lexical-views-nested".
  */
 export interface LexicalViewsNested {
-  id: string;
+  id: number;
   parentRichText?: {
     root: {
       type: string;
@@ -623,7 +625,7 @@ export interface LexicalViewsNested {
  * via the `definition` "lexical-localized-fields".
  */
 export interface LexicalLocalizedField {
-  id: string;
+  id: number;
   title: string;
   /**
    * Non-localized field with localized block subfields
@@ -669,7 +671,7 @@ export interface LexicalLocalizedField {
  * via the `definition` "lexicalObjectReferenceBug".
  */
 export interface LexicalObjectReferenceBug {
-  id: string;
+  id: number;
   lexicalDefault?: {
     root: {
       type: string;
@@ -708,7 +710,7 @@ export interface LexicalObjectReferenceBug {
  * via the `definition` "LexicalInBlock".
  */
 export interface LexicalInBlock {
-  id: string;
+  id: number;
   content?: {
     root: {
       type: string;
@@ -751,10 +753,35 @@ export interface LexicalInBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "lexical-autosave-block".
+ */
+export interface LexicalAutosaveBlock {
+  id: number;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "lexical-access-control".
  */
 export interface LexicalAccessControl {
-  id: string;
+  id: number;
   title?: string | null;
   richText?: {
     root: {
@@ -779,7 +806,7 @@ export interface LexicalAccessControl {
  * via the `definition` "lexical-relationship-fields".
  */
 export interface LexicalRelationshipField {
-  id: string;
+  id: number;
   richText?: {
     root: {
       type: string;
@@ -849,7 +876,7 @@ export interface LexicalRelationshipField {
  * via the `definition` "collision".
  */
 export interface Collision {
-  id: string;
+  id: number;
   collision?: {
     root: {
       type: string;
@@ -873,7 +900,7 @@ export interface Collision {
  * via the `definition` "lexical-nested-blocks".
  */
 export interface LexicalNestedBlock {
-  id: string;
+  id: number;
   title: string;
   richText?: {
     root: {
@@ -898,7 +925,7 @@ export interface LexicalNestedBlock {
  * via the `definition` "rich-text-fields".
  */
 export interface RichTextField {
-  id: string;
+  id: number;
   title: string;
   lexicalCustomFields: {
     root: {
@@ -954,7 +981,7 @@ export interface RichTextField {
  * via the `definition` "text-fields".
  */
 export interface TextField {
-  id: string;
+  id: number;
   text: string;
   hiddenTextField?: string | null;
   /**
@@ -1006,9 +1033,9 @@ export interface TextField {
  * via the `definition` "uploads".
  */
 export interface Upload {
-  id: string;
+  id: number;
   text?: string | null;
-  media?: (string | null) | Upload;
+  media?: (number | null) | Upload;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -1026,9 +1053,9 @@ export interface Upload {
  * via the `definition` "uploads2".
  */
 export interface Uploads2 {
-  id: string;
+  id: number;
   text?: string | null;
-  media?: (string | null) | Upload;
+  media?: (number | null) | Upload;
   altText?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1047,7 +1074,7 @@ export interface Uploads2 {
  * via the `definition` "array-fields".
  */
 export interface ArrayField {
-  id: string;
+  id: number;
   title?: string | null;
   items: {
     text: string;
@@ -1145,7 +1172,7 @@ export interface ArrayField {
  * via the `definition` "OnDemandForm".
  */
 export interface OnDemandForm {
-  id: string;
+  id: number;
   json?:
     | {
         [k: string]: unknown;
@@ -1163,7 +1190,7 @@ export interface OnDemandForm {
  * via the `definition` "OnDemandOutsideForm".
  */
 export interface OnDemandOutsideForm {
-  id: string;
+  id: number;
   json?:
     | {
         [k: string]: unknown;
@@ -1196,7 +1223,7 @@ export interface OnDemandOutsideForm {
  * via the `definition` "lexical-custom-cell".
  */
 export interface LexicalCustomCell {
-  id: string;
+  id: number;
   title: string;
   richTextField?: {
     root: {
@@ -1221,7 +1248,7 @@ export interface LexicalCustomCell {
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
-  id: string;
+  id: number;
   key: string;
   data:
     | {
@@ -1238,7 +1265,7 @@ export interface PayloadKv {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -1263,132 +1290,136 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'lexical-benchmark';
-        value: string | LexicalBenchmark;
+        value: number | LexicalBenchmark;
       } | null)
     | ({
         relationTo: 'lexical-fully-featured';
-        value: string | LexicalFullyFeatured;
+        value: number | LexicalFullyFeatured;
       } | null)
     | ({
         relationTo: 'lexical-autosave';
-        value: string | LexicalAutosave;
+        value: number | LexicalAutosave;
       } | null)
     | ({
         relationTo: 'lexical-link-feature';
-        value: string | LexicalLinkFeature;
+        value: number | LexicalLinkFeature;
       } | null)
     | ({
         relationTo: 'lexical-lists-features';
-        value: string | LexicalListsFeature;
+        value: number | LexicalListsFeature;
       } | null)
     | ({
         relationTo: 'lexical-heading-feature';
-        value: string | LexicalHeadingFeature;
+        value: number | LexicalHeadingFeature;
       } | null)
     | ({
         relationTo: 'lexical-jsx-converter';
-        value: string | LexicalJsxConverter;
+        value: number | LexicalJsxConverter;
       } | null)
     | ({
         relationTo: 'lexical-fields';
-        value: string | LexicalField;
+        value: number | LexicalField;
       } | null)
     | ({
         relationTo: 'lexical-views';
-        value: string | LexicalView;
+        value: number | LexicalView;
       } | null)
     | ({
         relationTo: 'lexical-views-frontend';
-        value: string | LexicalViewsFrontend;
+        value: number | LexicalViewsFrontend;
       } | null)
     | ({
         relationTo: 'lexical-views-provider';
-        value: string | LexicalViewsProvider;
+        value: number | LexicalViewsProvider;
       } | null)
     | ({
         relationTo: 'lexical-views-provider-default';
-        value: string | LexicalViewsProviderDefault;
+        value: number | LexicalViewsProviderDefault;
       } | null)
     | ({
         relationTo: 'lexical-views-provider-fallback';
-        value: string | LexicalViewsProviderFallback;
+        value: number | LexicalViewsProviderFallback;
       } | null)
     | ({
         relationTo: 'lexical-views-nested';
-        value: string | LexicalViewsNested;
+        value: number | LexicalViewsNested;
       } | null)
     | ({
         relationTo: 'lexical-localized-fields';
-        value: string | LexicalLocalizedField;
+        value: number | LexicalLocalizedField;
       } | null)
     | ({
         relationTo: 'lexicalObjectReferenceBug';
-        value: string | LexicalObjectReferenceBug;
+        value: number | LexicalObjectReferenceBug;
       } | null)
     | ({
         relationTo: 'LexicalInBlock';
-        value: string | LexicalInBlock;
+        value: number | LexicalInBlock;
+      } | null)
+    | ({
+        relationTo: 'lexical-autosave-block';
+        value: number | LexicalAutosaveBlock;
       } | null)
     | ({
         relationTo: 'lexical-access-control';
-        value: string | LexicalAccessControl;
+        value: number | LexicalAccessControl;
       } | null)
     | ({
         relationTo: 'lexical-relationship-fields';
-        value: string | LexicalRelationshipField;
+        value: number | LexicalRelationshipField;
       } | null)
     | ({
         relationTo: 'collision';
-        value: string | Collision;
+        value: number | Collision;
       } | null)
     | ({
         relationTo: 'lexical-nested-blocks';
-        value: string | LexicalNestedBlock;
+        value: number | LexicalNestedBlock;
       } | null)
     | ({
         relationTo: 'rich-text-fields';
-        value: string | RichTextField;
+        value: number | RichTextField;
       } | null)
     | ({
         relationTo: 'text-fields';
-        value: string | TextField;
+        value: number | TextField;
       } | null)
     | ({
         relationTo: 'uploads';
-        value: string | Upload;
+        value: number | Upload;
       } | null)
     | ({
         relationTo: 'uploads2';
-        value: string | Uploads2;
+        value: number | Uploads2;
       } | null)
     | ({
         relationTo: 'array-fields';
-        value: string | ArrayField;
+        value: number | ArrayField;
       } | null)
     | ({
         relationTo: 'OnDemandForm';
-        value: string | OnDemandForm;
+        value: number | OnDemandForm;
       } | null)
     | ({
         relationTo: 'OnDemandOutsideForm';
-        value: string | OnDemandOutsideForm;
+        value: number | OnDemandOutsideForm;
       } | null)
     | ({
         relationTo: 'lexical-custom-cell';
-        value: string | LexicalCustomCell;
+        value: number | LexicalCustomCell;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -1398,10 +1429,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -1421,7 +1452,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -1617,6 +1648,16 @@ export interface LexicalInBlockSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "lexical-autosave-block_select".
+ */
+export interface LexicalAutosaveBlockSelect<T extends boolean = true> {
+  content?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1964,7 +2005,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "tabsWithRichText".
  */
 export interface TabsWithRichText {
-  id: string;
+  id: number;
   tab1?: {
     rt1?: {
       root: {
@@ -2058,7 +2099,7 @@ export interface LexicalBlocksRadioButtonsBlock {
 export interface AvatarGroupBlock {
   avatars?:
     | {
-        image?: (string | null) | Upload;
+        image?: (number | null) | Upload;
         id?: string | null;
       }[]
     | null;

--- a/test/lexical/slugs.ts
+++ b/test/lexical/slugs.ts
@@ -16,6 +16,7 @@ export const lexicalLocalizedFieldsSlug = 'lexical-localized-fields'
 export const lexicalRelationshipFieldsSlug = 'lexical-relationship-fields'
 export const lexicalAccessControlSlug = 'lexical-access-control'
 export const lexicalAutosaveSlug = 'lexical-autosave'
+export const lexicalAutosaveBlockSlug = 'lexical-autosave-block'
 export const richTextFieldsSlug = 'rich-text-fields'
 export const lexicalSlugFieldNameCollisionSlug = 'collision'
 


### PR DESCRIPTION
With autosave enabled, typing into a richtext field nested inside a Lexical block randomly kicks the cursor out of the nested editor and silently drops any characters typed after the jump.

The block keeps its data in sync with the outer lexical editor by calling `editor.update(() => node.setFields(...))` whenever the inner block form's onChange fires. That update runs Lexical's `updateDOMSelection`, sees the active element sitting inside a nested contenteditable rather than the outer editor's own selection, and forcibly resets DOM selection back into the outer root.

The fix passes `SKIP_DOM_SELECTION_TAG` to the data-sync `editor.update` calls in both block components so the reconciler leaves DOM selection alone during these syncs.

## Before

https://github.com/user-attachments/assets/dbbacd93-2c1f-4f2b-9bfa-ecac300d3917

## After

https://github.com/user-attachments/assets/b74aae33-0559-44b0-bf51-49b9063bc7ca

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214500030269826