### PR TITLE
ci: add missing e2e test suite to CI

### DIFF
--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -73,6 +73,7 @@ export default createE2EConfig([
   { file: 'lexical__collections__LexicalViewsProvider', shards: 1, parallel: false },
   { file: 'lexical__collections__LexicalViewsProviderDefault', shards: 1, parallel: false },
   { file: 'lexical__collections__LexicalViewsNested', shards: 1, parallel: false },
+  { file: 'lexical__collections__LexicalAutosaveBlock', shards: 1, parallel: false },
 
   { file: 'lexical__collections__OnDemandForm', shards: 1 },
   { file: 'lexical__collections__Lexical__e2e__main', shards: 2 },


### PR DESCRIPTION
Adds the new `lexical__collections__LexicalAutosaveBlock` suite add by https://github.com/payloadcms/payload/pull/16478 to run in CI.