### PR TITLE
fix: add PDF upload MIME fallback

### DIFF
--- a/packages/payload/src/uploads/getFileTypeFallback.spec.ts
+++ b/packages/payload/src/uploads/getFileTypeFallback.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFileTypeFallback } from './getFileTypeFallback.js'
+
+describe('getFileTypeFallback', () => {
+  it('should map PDF filenames to application/pdf', () => {
+    expect(getFileTypeFallback('document.pdf')).toStrictEqual({
+      ext: 'pdf',
+      mime: 'application/pdf',
+    })
+  })
+})

--- a/packages/payload/src/uploads/getFileTypeFallback.ts
+++ b/packages/payload/src/uploads/getFileTypeFallback.ts
@@ -13,6 +13,7 @@ const extensionMap: {
   js: 'application/javascript',
   json: 'application/json',
   md: 'text/markdown',
+  pdf: 'application/pdf',
   svg: 'image/svg+xml',
   xml: 'application/xml',
   yml: 'application/x-yaml',


### PR DESCRIPTION
## Summary
- Add `.pdf` to the upload MIME fallback map as `application/pdf`
- Add a focused unit regression test for PDF fallback detection

## Testing
- `pnpm exec vitest run --project unit packages/payload/src/uploads/getFileTypeFallback.spec.ts`
- `pnpm exec vitest run --project unit packages/payload/src/uploads`
- `pnpm exec prettier --check packages/payload/src/uploads/getFileTypeFallback.ts packages/payload/src/uploads/getFileTypeFallback.spec.ts`
- `pnpm exec eslint --flag v10_config_lookup_from_file --cache --cache-strategy content packages/payload/src/uploads/getFileTypeFallback.ts`
- `pnpm exec eslint --flag v10_config_lookup_from_file --cache --cache-strategy content --no-warn-ignored packages/payload/src/uploads/getFileTypeFallback.spec.ts`
- `pnpm --filter payload build:swc`
- `git diff --check`

Fixes #16485
