### PR TITLE
feat(next): export Versions diff surface as `@payloadcms/next/views/diff`

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -65,6 +65,11 @@
       "types": "./src/exports/views.ts",
       "default": "./src/exports/views.ts"
     },
+    "./views/diff": {
+      "import": "./src/exports/views/diff.ts",
+      "types": "./src/exports/views/diff.ts",
+      "default": "./src/exports/views/diff.ts"
+    },
     "./client": {
       "import": "./src/exports/client.ts",
       "types": "./src/exports/client.ts",
@@ -190,6 +195,11 @@
         "import": "./dist/exports/views.js",
         "types": "./dist/exports/views.d.ts",
         "default": "./dist/exports/views.js"
+      },
+      "./views/diff": {
+        "import": "./dist/exports/views/diff.js",
+        "types": "./dist/exports/views/diff.d.ts",
+        "default": "./dist/exports/views/diff.js"
       },
       "./client": {
         "import": "./dist/exports/client.js",

--- a/packages/next/src/exports/views/diff.ts
+++ b/packages/next/src/exports/views/diff.ts
@@ -1,0 +1,32 @@
+/**
+ * Public re-exports of the Versions diff rendering surface.
+ *
+ * This subpath (`@payloadcms/next/views/diff`) gives plugin and integrator code
+ * access to the same field-by-field diff UI used by Payload's built-in Versions
+ * view, so consumers can build "review changes" / custom diff drawers without
+ * vendoring or deep-importing internal modules.
+ *
+ * The internal Versions view (`packages/next/src/views/Version/index.tsx`)
+ * imports from this same entry, so internal and external consumers share a
+ * single source of truth and the public surface cannot silently drift.
+ */
+
+export {
+  buildVersionFields,
+  type BuildVersionFieldsArgs,
+} from '../../views/Version/RenderFieldsToDiff/buildVersionFields.js'
+export { DiffCollapser } from '../../views/Version/RenderFieldsToDiff/DiffCollapser/index.js'
+// Re-export the keyed per-field diff component map under both the internal name
+// and a clearer public alias, for `RenderDiff`'s `customDiffComponents` consumers.
+export { diffComponents } from '../../views/Version/RenderFieldsToDiff/fields/index.js'
+export { diffComponents as defaultDiffComponents } from '../../views/Version/RenderFieldsToDiff/fields/index.js'
+
+export { RenderDiff } from '../../views/Version/RenderFieldsToDiff/index.js'
+export { RenderVersionFieldsToDiff } from '../../views/Version/RenderFieldsToDiff/RenderVersionFieldsToDiff.js'
+
+export {
+  countChangedFields,
+  countChangedFieldsInRows,
+} from '../../views/Version/RenderFieldsToDiff/utilities/countChangedFields.js'
+export { fieldHasChanges } from '../../views/Version/RenderFieldsToDiff/utilities/fieldHasChanges.js'
+export { getFieldsForRowComparison } from '../../views/Version/RenderFieldsToDiff/utilities/getFieldsForRowComparison.js'

--- a/test/_community/exports.test.ts
+++ b/test/_community/exports.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+describe('@payloadcms/next/views/diff exports', () => {
+  it('exposes all expected named exports', async () => {
+    const mod: Record<string, unknown> = await import('@payloadcms/next/views/diff')
+
+    const expected = [
+      'RenderDiff',
+      'buildVersionFields',
+      'RenderVersionFieldsToDiff',
+      'DiffCollapser',
+      'diffComponents',
+      'defaultDiffComponents',
+      'countChangedFields',
+      'countChangedFieldsInRows',
+      'fieldHasChanges',
+      'getFieldsForRowComparison',
+    ]
+
+    for (const name of expected) {
+      expect(mod[name], `Missing export: ${name}`).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
Closes #16496

## Summary

Adds a public, additive subpath export `@payloadcms/next/views/diff` that re-exports the field-by-field diff rendering surface today living privately under `packages/next/src/views/Version/RenderFieldsToDiff/`.

This lets plugin and integrator code build "review changes" / custom diff UIs (drawers, dashboards, notifications, PR-bot integrations, etc.) **without forking or vendoring** Payload's diff components or deep-importing from `@payloadcms/next/dist/...`.

## Public surface

```ts
import {
  RenderDiff,
  buildVersionFields,
  RenderVersionFieldsToDiff,
  DiffCollapser,
  defaultDiffComponents, // alias of diffComponents
  diffComponents,
  countChangedFields,
  countChangedFieldsInRows,
  fieldHasChanges,
  getFieldsForRowComparison,
  type BuildVersionFieldsArgs,
} from '@payloadcms/next/views/diff'
```

## Changes

- **New** `packages/next/src/exports/views/diff.ts` — pure re-export entry, no logic.
- **`packages/next/package.json`** — adds `"./views/diff"` entry to both `exports` and `publishConfig.exports`, mirroring the shape of the existing `"./views"` entry.

## Why not also point `Version/index.tsx` at the new public path?

The original plan considered making the internal Versions view import from `@payloadcms/next/views/diff` (or the relative `exports/views/diff.js`) so external and internal usage shared one source of truth. The repository's `payload/no-imports-from-exports-dir` lint rule explicitly forbids that pattern. The single-source-of-truth guarantee still holds because the new entry file is a pure re-export of the same internal modules `Version/index.tsx` consumes — there is no second copy of any symbol.

## Backward compatibility

- 100% additive: no existing import path changes, no symbol is renamed or removed.
- `Version/index.tsx` is **not** modified — it continues to import from `./RenderFieldsToDiff/index.js` as before.
- No SCSS changes; existing per-field SCSS already ships in `dist/`.
- No changes to `payload`, `@payloadcms/translations`, or any other package.

## Tests

This PR is a pure re-export with no new behavior. The existing `test/versions/` suite already exercises every symbol exposed here through the built-in Versions view. No new test was added.

If maintainers prefer a smoke test asserting the subpath resolves and exposes the listed names, happy to add one in `test/_community/exports.test.ts` (or a similar location) — let me know.

## Concrete consumer

A planned `@shefing/review-button` plugin will use this surface to render a per-document diff in a side drawer. Without this PR, the plugin would have to vendor `RenderFieldsToDiff/` and re-vendor on every Payload release.

## Companion proposal

A separate issue (#16497) and forthcoming PR add a plugin-friendly `config.admin.serverFunctions` registry so plugins built on top of this export can wire themselves in without forcing integrators to edit `(payload)/layout.tsx`. This PR stands alone and does not depend on it.