### PR TITLE
feat(next): add config.admin.serverFunctions registry for plugins

### DIFF
--- a/packages/next/src/utilities/handleServerFunctions.ts
+++ b/packages/next/src/utilities/handleServerFunctions.ts
@@ -53,7 +53,13 @@ export const handleServerFunctions: ServerFunctionHandler = async (args) => {
     req,
   }
 
-  const fn = extraServerFunctions?.[fnKey] || baseServerFunctions[fnKey]
+  // Lookup order:
+  //   1. integrator-supplied `serverFunctions` prop on <RootLayout /> (highest priority — back-compat)
+  //   2. `config.admin.serverFunctions` registry (populated by plugins via payload.config.ts)
+  //   3. built-in baseServerFunctions
+  const adminServerFunctions = req.payload.config.admin?.serverFunctions
+  const fn =
+    extraServerFunctions?.[fnKey] || adminServerFunctions?.[fnKey] || baseServerFunctions[fnKey]
 
   if (!fn) {
     throw new Error(`Unknown Server Function: ${fnKey}`)

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -32,6 +32,7 @@ export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
       reset: '/reset',
       unauthorized: '/unauthorized',
     },
+    serverFunctions: {},
     theme: 'all',
   },
   auth: {
@@ -110,6 +111,9 @@ export const addDefaultsToConfig = (config: Config): Config => {
       reset: '/reset',
       unauthorized: '/unauthorized',
       ...(config?.admin?.routes || {}),
+    },
+    serverFunctions: {
+      ...(config?.admin?.serverFunctions || {}),
     },
   }
 

--- a/packages/payload/src/config/sanitize.serverFunctions.spec.ts
+++ b/packages/payload/src/config/sanitize.serverFunctions.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Config } from './types.js'
+
+import { sanitizeConfig } from './sanitize.js'
+
+/**
+ * Tests for the `admin.serverFunctions` registry added to the Config surface.
+ *
+ * The lookup-order behavior in `handleServerFunctions` is intentionally NOT tested
+ * here because that handler depends on the full Next.js / payload runtime stack
+ * (`initReq`, `getPayload`, request headers). Those code paths are exercised by
+ * the e2e suite in `test/server-functions/`. This file only covers the new
+ * sanitize-time validation and defaulting that lives in `sanitizeAdminConfig`.
+ */
+describe('admin.serverFunctions registry — sanitize', () => {
+  const minimalConfig = (): Config =>
+    // Cast: a fully-typed Config requires fields we don't care about for these tests.
+    ({
+      collections: [],
+    }) as unknown as Config
+
+  it('defaults `admin.serverFunctions` to an empty object when not provided', async () => {
+    const sanitized = await sanitizeConfig(minimalConfig())
+
+    expect(sanitized.admin?.serverFunctions).toBeDefined()
+    expect(sanitized.admin?.serverFunctions).toEqual({})
+  })
+
+  it('preserves user-supplied server functions on the sanitized config', async () => {
+    const handler = async () => 'ok'
+    const config = minimalConfig()
+    config.admin = {
+      serverFunctions: {
+        '@my-plugin/foo': handler,
+      },
+    }
+
+    const sanitized = await sanitizeConfig(config)
+
+    expect(sanitized.admin?.serverFunctions?.['@my-plugin/foo']).toBe(handler)
+  })
+
+  it('throws when a server function value is not a function', async () => {
+    const config = minimalConfig()
+    config.admin = {
+      // @ts-expect-error — intentionally invalid
+      serverFunctions: { 'bad/key': 'not a function' },
+    }
+
+    await expect(sanitizeConfig(config)).rejects.toThrow(/admin\.serverFunctions\["bad\/key"\]/)
+  })
+
+  it('throws when a server function key is an empty string', async () => {
+    const config = minimalConfig()
+    config.admin = {
+      serverFunctions: {
+        '': async () => 'ok',
+      },
+    }
+
+    await expect(sanitizeConfig(config)).rejects.toThrow(
+      /admin\.serverFunctions: keys must be non-empty strings/,
+    )
+  })
+})

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -110,6 +110,29 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
     timezones: sanitizedConfig.admin!.timezones.supportedTimezones as Timezone[],
   })
 
+  // Validate `admin.serverFunctions` registry. This is intentionally lightweight:
+  // - Keys must be non-empty strings (`Object.entries` already gives us strings, so
+  //   we only need to reject the empty-string case which would silently break lookup).
+  // - Values must be functions; anything else means the plugin/integrator wired it up
+  //   incorrectly and would otherwise fail with an opaque error at call time.
+  // We do not warn on cross-plugin key collisions here because plugins mutate the
+  // config one-by-one before `sanitizeConfig` runs — by the time we see the merged
+  // map the colliding entry is already overwritten. Plugins are expected to
+  // namespace their keys (e.g. `'@my-plugin/foo'`).
+  const serverFunctions = sanitizedConfig.admin?.serverFunctions
+  if (serverFunctions) {
+    for (const [key, value] of Object.entries(serverFunctions)) {
+      if (!key) {
+        throw new InvalidConfiguration(`admin.serverFunctions: keys must be non-empty strings.`)
+      }
+      if (typeof value !== 'function') {
+        throw new InvalidConfiguration(
+          `admin.serverFunctions["${key}"]: value must be a function, received ${typeof value}.`,
+        )
+      }
+    }
+  }
+
   return sanitizedConfig as unknown as Partial<SanitizedConfig>
 }
 

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -16,6 +16,7 @@ import type React from 'react'
 import type { default as sharp } from 'sharp'
 import type { DeepRequired } from 'ts-essentials'
 
+import type { ServerFunction } from '../admin/functions/index.js'
 import type { RichTextAdapterProvider } from '../admin/RichText.js'
 import type {
   CustomStatus,
@@ -1084,6 +1085,23 @@ export type Config = {
        */
       unauthorized?: `/${string}`
     }
+    /**
+     * Register custom server functions callable from the admin via
+     * `useServerFunctions().serverFunction({ name, args })`.
+     *
+     * This registry is intended for plugins that need to ship a server function
+     * without forcing every integrator to import and pass it into the
+     * `serverFunctions` prop on `<RootLayout />` in `(payload)/layout.tsx`.
+     *
+     * Plugins should namespace their keys to avoid collisions
+     * (e.g. `'@my-plugin/render-foo'`).
+     *
+     * Lookup order in `handleServerFunctions`:
+     *   1. integrator-supplied `serverFunctions` prop on `<RootLayout />` (highest priority — back-compat)
+     *   2. `config.admin.serverFunctions`
+     *   3. built-in payload server functions
+     */
+    serverFunctions?: Record<string, ServerFunction>
     /**
      * Suppresses React hydration mismatch warnings during the hydration of the root <html> tag.
      * Useful in scenarios where the server-rendered HTML might intentionally differ from the client-rendered DOM.


### PR DESCRIPTION
Closes #16497

## Summary

Adds an optional `serverFunctions?: Record<string, ServerFunction>` field on `Config['admin']` so that **plugins** can register custom server functions through `payload.config.ts` instead of asking every integrator to wire them into the `serverFunctions` prop of `<RootLayout />` in `(payload)/layout.tsx`.

## Motivation

Today, the only way a plugin can ship a server function is to ask the integrator to:
1. Import the plugin's server function in `app/(payload)/layout.tsx`.
2. Add it to the `serverFunctions={{ ... }}` prop on `<RootLayout />`.

This is hostile to "single-line install" plugin UX — the plugin's `payload.config.ts` factory can wire collections, globals, fields, components, endpoints, and admin routes, but it cannot wire a server function. A concrete consumer is a planned `@shefing/review-button` plugin (companion: #16496) that needs a `'render-review-diff'` server function on the server side.

## Changes

- **`packages/payload/src/config/types.ts`**
  - Add `serverFunctions?: Record<string, ServerFunction>` to the `admin` block of `Config`, with a JSDoc that documents the lookup order and recommends namespaced keys (e.g. `'@my-plugin/foo'`).
  - `SanitizedConfig.admin.serverFunctions` is automatically inherited via `DeepRequired<Config['admin']>`.
- **`packages/payload/src/config/defaults.ts`**
  - Default `admin.serverFunctions` to `{}` in both the static `defaults` object and `addDefaultsToConfig` so callers can always do `config.admin.serverFunctions[key]` without a guard.
- **`packages/payload/src/config/sanitize.ts`**
  - Inside `sanitizeAdminConfig`, validate keys are non-empty strings and values are functions. Throw `InvalidConfiguration` on misuse so plugin/integrator wiring errors fail fast at config build time.
- **`packages/next/src/utilities/handleServerFunctions.ts`**
  - New lookup order:
    ```ts
    const adminServerFunctions = req.payload.config.admin?.serverFunctions
    const fn =
      extraServerFunctions?.[fnKey] ||
      adminServerFunctions?.[fnKey] ||
      baseServerFunctions[fnKey]
    ```
  - The integrator-supplied `serverFunctions` prop continues to win on key conflicts, preserving back-compat.
- **`packages/payload/src/config/sanitize.serverFunctions.spec.ts`** *(new — 4 unit tests)*
  - Defaults `admin.serverFunctions` to `{}` when absent.
  - Preserves user-supplied entries through sanitize.
  - Rejects non-function values.
  - Rejects empty-string keys.

All 1329 existing unit tests still pass alongside the 4 new ones.

## Lookup order

```
1. integrator-supplied `serverFunctions` prop on <RootLayout />   ← highest priority (back-compat)
2. config.admin.serverFunctions                                    ← the new registry
3. baseServerFunctions (built-ins)                                 ← lowest priority
```

> The lookup-order behavior in `handleServerFunctions` itself is intentionally not unit-tested in this PR because that handler depends on the full Next/payload runtime stack (`initReq`, `getPayload`, request headers). It is exercised end-to-end by the existing `test/server-functions/` suite.

## Backward compatibility

- Fully additive: no field is removed or renamed.
- Existing wiring on `<RootLayout serverFunctions={...} />` continues to win on key collisions.
- Built-in server functions still resolve when nothing else is registered with the same key.
- No runtime cost beyond a single object lookup per server-function call.

## Cross-plugin key collisions

Plugins are expected to namespace their keys (e.g. `'@my-plugin/foo'`). I considered emitting a `console.warn` at sanitize time when two plugins register the same key, but plugins mutate `Config` one-by-one before `sanitizeConfig` runs, so by the time sanitize sees the merged map the colliding entry has already been overwritten — the warning can't be reliably produced from the central pipeline. Happy to add a per-plugin merge helper if the team prefers that direction.

## Concrete consumer

A planned `@shefing/review-button` plugin will use this registry to ship a `'shefing/review-button:render-diff'` server function without forcing every integrator to edit `(payload)/layout.tsx`.

## Companion proposal

Companion PR #16498 (issue #16496) exposes the Versions diff surface as `@payloadcms/next/views/diff`. The two PRs are independent and can be reviewed/merged separately.