### PR TITLE
feat(storage-vercel-blob): add allowOverwrite option (re-open of #16078)

### DIFF
--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -12,6 +12,7 @@ import { uploadFile } from './uploadFile.js'
 interface CreateVercelBlobAdapterArgs {
   access: 'public'
   addRandomSuffix?: boolean
+  allowOverwrite?: boolean
   baseUrl: string
   cacheControlMaxAge: number
   clientUploads?: ClientUploadsConfig
@@ -22,6 +23,7 @@ interface CreateVercelBlobAdapterArgs {
 export function createVercelBlobAdapter({
   access,
   addRandomSuffix,
+  allowOverwrite,
   baseUrl,
   cacheControlMaxAge,
   clientUploads,
@@ -55,6 +57,7 @@ export function createVercelBlobAdapter({
       const result = await uploadFile({
         access,
         addRandomSuffix,
+        allowOverwrite,
         buffer,
         cacheControlMaxAge,
         collectionPrefix: prefix,

--- a/packages/storage-vercel-blob/src/client/VercelBlobClientUploadHandler.ts
+++ b/packages/storage-vercel-blob/src/client/VercelBlobClientUploadHandler.ts
@@ -6,6 +6,7 @@ import { formatAdminURL } from 'payload/shared'
 
 export type VercelBlobClientUploadHandlerExtra = {
   addRandomSuffix: boolean
+  allowOverwrite: boolean
   useCompositePrefixes: boolean
 }
 
@@ -22,7 +23,7 @@ export const VercelBlobClientUploadHandler =
       apiRoute,
       collectionSlug,
       docPrefix,
-      extra: { addRandomSuffix, useCompositePrefixes = false },
+      extra: { addRandomSuffix, allowOverwrite, useCompositePrefixes = false },
       file,
       prefix,
       serverHandlerPath,

--- a/packages/storage-vercel-blob/src/getClientUploadRoute.ts
+++ b/packages/storage-vercel-blob/src/getClientUploadRoute.ts
@@ -9,6 +9,7 @@ type Args = {
     req: PayloadRequest
   }) => boolean | Promise<boolean>
   addRandomSuffix?: boolean
+  allowOverwrite?: boolean
   cacheControlMaxAge?: number
   token: string
 }
@@ -16,7 +17,13 @@ type Args = {
 const defaultAccess: Args['access'] = ({ req }) => !!req.user
 
 export const getClientUploadRoute =
-  ({ access = defaultAccess, addRandomSuffix, cacheControlMaxAge, token }: Args): PayloadHandler =>
+  ({
+    access = defaultAccess,
+    addRandomSuffix,
+    allowOverwrite,
+    cacheControlMaxAge,
+    token,
+  }: Args): PayloadHandler =>
   async (req) => {
     const body = (await req.json!()) as HandleUploadBody
 
@@ -34,6 +41,7 @@ export const getClientUploadRoute =
 
           return Promise.resolve({
             addRandomSuffix,
+            allowOverwrite,
             cacheControlMaxAge,
           })
         },

--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -30,6 +30,16 @@ export type VercelBlobStorageOptions = {
   addRandomSuffix?: boolean
 
   /**
+   * Allow overwriting an existing blob with the same key. Passed through to
+   * `@vercel/blob`'s `put()`. Useful when `addRandomSuffix: false` is combined
+   * with `clientUploads: true`, where a failed upload can leave an orphan blob
+   * that blocks a retry with `"This blob already exists"`.
+   *
+   * @default false
+   */
+  allowOverwrite?: boolean
+
+  /**
    * When enabled, fields (like the prefix field) will always be inserted into
    * the collection schema regardless of whether the plugin is enabled. This
    * ensures a consistent schema across all environments.
@@ -91,6 +101,7 @@ export type VercelBlobStorageOptions = {
 const defaultUploadOptions: Partial<VercelBlobStorageOptions> = {
   access: 'public',
   addRandomSuffix: false,
+  allowOverwrite: false,
   cacheControlMaxAge: 60 * 60 * 24 * 365, // 1 year
   enabled: true,
 }
@@ -140,6 +151,7 @@ export const vercelBlobStorage: VercelBlobStoragePlugin =
         access:
           typeof options.clientUploads === 'object' ? options.clientUploads.access : undefined,
         addRandomSuffix: optionsWithDefaults.addRandomSuffix,
+        allowOverwrite: optionsWithDefaults.allowOverwrite,
         cacheControlMaxAge: options.cacheControlMaxAge,
         token: options.token ?? '',
       }),
@@ -171,6 +183,7 @@ export const vercelBlobStorage: VercelBlobStoragePlugin =
     const adapter = createVercelBlobAdapter({
       access: optionsWithDefaults.access ?? 'public',
       addRandomSuffix: optionsWithDefaults.addRandomSuffix,
+      allowOverwrite: optionsWithDefaults.allowOverwrite,
       baseUrl,
       cacheControlMaxAge: optionsWithDefaults.cacheControlMaxAge ?? 60 * 60 * 24 * 365,
       clientUploads: optionsWithDefaults.clientUploads,

--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -145,6 +145,7 @@ export const vercelBlobStorage: VercelBlobStoragePlugin =
       enabled: !isPluginDisabled && Boolean(options.clientUploads),
       extraClientHandlerProps: () => ({
         addRandomSuffix: !!optionsWithDefaults.addRandomSuffix,
+        allowOverwrite: !!optionsWithDefaults.allowOverwrite,
         useCompositePrefixes: !!options.useCompositePrefixes,
       }),
       serverHandler: getClientUploadRoute({

--- a/packages/storage-vercel-blob/src/uploadFile.ts
+++ b/packages/storage-vercel-blob/src/uploadFile.ts
@@ -5,6 +5,7 @@ import path from 'path'
 interface UploadFileArgs {
   access: 'public'
   addRandomSuffix?: boolean
+  allowOverwrite?: boolean
   buffer: Buffer
   cacheControlMaxAge?: number
   collectionPrefix?: string
@@ -22,6 +23,7 @@ interface UploadFileResult {
 export async function uploadFile({
   access,
   addRandomSuffix,
+  allowOverwrite,
   buffer,
   cacheControlMaxAge,
   collectionPrefix = '',
@@ -41,6 +43,7 @@ export async function uploadFile({
   const result = await put(fileKey, buffer, {
     access,
     addRandomSuffix,
+    allowOverwrite,
     cacheControlMaxAge,
     contentType: mimeType,
     token,


### PR DESCRIPTION
> ⚠️ This is a re-open of #16078. The original PR was auto-closed when I accidentally deleted my fork during a cleanup. GitHub's deleted-repos page indicates fork restoration requires support intervention (which I can't access on a free plan), so I've re-forked and re-pushed the same two commits to a new fork. cc @denolfe @rchlfryn

## Summary

Adds a new `allowOverwrite` option to `VercelBlobStorageOptions` that passes through to all `@vercel/blob` `put()` calls — both server-side uploads (`uploadFile.ts`) and client upload token generation (`getClientUploadRoute.ts`).

## Problem

When using `clientUploads: true` with `addRandomSuffix: false`, failed uploads leave orphan blobs in Vercel Blob storage. The blob is created successfully, but Payload's server-side processing (image size generation, `generateFileData`) can fail with a 400 error — leaving a blob without a corresponding Payload media record.

Subsequent uploads of the same filename then fail with:

```
Vercel Blob: This blob already exists, use allowOverwrite: true if you want to overwrite it.
```

This is particularly frustrating because the user has no way to clean up the orphan blob through the Payload admin — the media record was never created, so there's nothing to delete.

Related: #14709

## Solution

The `@vercel/blob` SDK already supports `allowOverwrite: true` on `put()` calls, but the Payload adapter didn't expose this option. This PR adds it as a top-level config option:

```ts
vercelBlobStorage({
  token: process.env.BLOB_READ_WRITE_TOKEN,
  collections: { media: true },
  allowOverwrite: true, // new option
})
```

### Changes

This is ported from #16078 to the current package structure (the storage-vercel-blob package was refactored in #16231 — `handleUpload.ts` is now `uploadFile.ts`, with a new `adapter.ts` wiring layer):

- **`index.ts`**: Added `allowOverwrite` to `VercelBlobStorageOptions` type with JSDoc, included in `defaultUploadOptions`, passed to both `createVercelBlobAdapter` and `getClientUploadRoute`, included in `extraClientHandlerProps`.
- **`uploadFile.ts`**: Added `allowOverwrite` to `UploadFileArgs` and passed it to the `put()` call for server-side uploads.
- **`adapter.ts`**: Added `allowOverwrite` to `CreateVercelBlobAdapterArgs` and passed it through to `uploadFile`.
- **`getClientUploadRoute.ts`**: Added `allowOverwrite` to `Args` and the `onBeforeGenerateToken` return value, so it flows through to the client upload token.
- **`client/VercelBlobClientUploadHandler.ts`**: Added `allowOverwrite` to `VercelBlobClientUploadHandlerExtra` for type consistency with `addRandomSuffix`.

### Default behavior

`allowOverwrite` defaults to `false`, preserving the current behavior. No breaking changes.

## Commits

The two commits mirror the original PR (the second was added in response to @rchlfryn's review feedback on #16078):

1. `feat(storage-vercel-blob): add allowOverwrite option` — main change
2. `fix: pass allowOverwrite through to client handler` — adds it to `extraClientHandlerProps` and the client handler's `extra` type for consistency
