### PR TITLE
fix: add PDF MIME fallback for uploads

### DIFF
--- a/packages/payload/src/uploads/getFileTypeFallback.spec.ts
+++ b/packages/payload/src/uploads/getFileTypeFallback.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFileTypeFallback } from './getFileTypeFallback.js'
+
+describe('getFileTypeFallback', () => {
+  it('should use application/pdf for PDF files', () => {
+    expect(getFileTypeFallback('document.pdf')).toStrictEqual({
+      ext: 'pdf',
+      mime: 'application/pdf',
+    })
+  })
+
+  it('should fall back to text/plain for unknown extensions', () => {
+    expect(getFileTypeFallback('file.unknown')).toStrictEqual({
+      ext: 'unknown',
+      mime: 'text/plain',
+    })
+  })
+})

--- a/packages/payload/src/uploads/getFileTypeFallback.ts
+++ b/packages/payload/src/uploads/getFileTypeFallback.ts
@@ -13,6 +13,7 @@ const extensionMap: {
   js: 'application/javascript',
   json: 'application/json',
   md: 'text/markdown',
+  pdf: 'application/pdf',
   svg: 'image/svg+xml',
   xml: 'application/xml',
   yml: 'application/x-yaml',


### PR DESCRIPTION
## Summary
- adds .pdf to the upload MIME fallback map as pplication/pdf
- adds a regression test for PDF fallback behavior
- keeps unknown extensions falling back to 	ext/plain

Fixes #16485.

## Testing
- Ran git diff --check
- Not run locally: dependencies are not installed in this fresh checkout