### PR TITLE
test: resolve nested button hydration errors in v4 test suite

### DIFF
--- a/test/v4/views/Components/sections/DrawerSection.tsx
+++ b/test/v4/views/Components/sections/DrawerSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button, Drawer, DrawerToggler, formatDrawerSlug, Gutter } from '@payloadcms/ui'
+import { Button, Drawer, formatDrawerSlug, Gutter, useModal } from '@payloadcms/ui'
 import React from 'react'
 
 import { Section, Variant } from '../shared.js'
@@ -8,36 +8,40 @@ import { Section, Variant } from '../shared.js'
 const DRAWER_SLUG_1 = formatDrawerSlug({ slug: 'demo-drawer-1', depth: 1 })
 const DRAWER_SLUG_2 = formatDrawerSlug({ slug: 'demo-drawer-2', depth: 1 })
 
-export const DrawerSection: React.FC<{ selectedComponent: string }> = ({ selectedComponent }) => (
-  <Section id="drawer" selectedComponent={selectedComponent} title="Drawer">
-    <Variant label="Basic Drawer">
-      <DrawerToggler slug={DRAWER_SLUG_1}>
-        <Button buttonStyle="secondary">Open Basic Drawer</Button>
-      </DrawerToggler>
-      <Drawer slug={DRAWER_SLUG_1} title="Basic Drawer">
-        <Gutter>
-          <p>This is the drawer content. You can put any content here.</p>
-          <p>Drawers slide in from the right side of the screen.</p>
-        </Gutter>
-      </Drawer>
-    </Variant>
+export const DrawerSection: React.FC<{ selectedComponent: string }> = ({ selectedComponent }) => {
+  const { openModal } = useModal()
 
-    <Variant label="With Header Actions">
-      <DrawerToggler slug={DRAWER_SLUG_2}>
-        <Button buttonStyle="secondary">Open Drawer with Actions</Button>
-      </DrawerToggler>
-      <Drawer
-        headerActions={<Button buttonStyle="primary">Save</Button>}
-        slug={DRAWER_SLUG_2}
-        title="Edit Document"
-      >
-        <Gutter>
-          <p>This drawer has action buttons in the header.</p>
-          <p>
-            Use <code>headerActions</code> prop to add buttons.
-          </p>
-        </Gutter>
-      </Drawer>
-    </Variant>
-  </Section>
-)
+  return (
+    <Section id="drawer" selectedComponent={selectedComponent} title="Drawer">
+      <Variant label="Basic Drawer">
+        <Button buttonStyle="secondary" onClick={() => openModal(DRAWER_SLUG_1)}>
+          Open Basic Drawer
+        </Button>
+        <Drawer slug={DRAWER_SLUG_1} title="Basic Drawer">
+          <Gutter>
+            <p>This is the drawer content. You can put any content here.</p>
+            <p>Drawers slide in from the right side of the screen.</p>
+          </Gutter>
+        </Drawer>
+      </Variant>
+
+      <Variant label="With Header Actions">
+        <Button buttonStyle="secondary" onClick={() => openModal(DRAWER_SLUG_2)}>
+          Open Drawer with Actions
+        </Button>
+        <Drawer
+          headerActions={[{ label: 'Save', onClick: () => {}, style: 'primary' }]}
+          slug={DRAWER_SLUG_2}
+          title="Edit Document"
+        >
+          <Gutter>
+            <p>This drawer has action buttons in the header.</p>
+            <p>
+              Use <code>headerActions</code> prop to add buttons.
+            </p>
+          </Gutter>
+        </Drawer>
+      </Variant>
+    </Section>
+  )
+}

--- a/test/v4/views/Components/sections/Popup.tsx
+++ b/test/v4/views/Components/sections/Popup.tsx
@@ -10,6 +10,7 @@ export const PopupSection: React.FC<{ selectedComponent: string }> = ({ selected
     <Variant label="Default">
       <Popup
         button={<Button buttonStyle="secondary">Open Popup</Button>}
+        buttonType="custom"
         render={() => (
           <div style={{ padding: '16px' }}>
             <p>Popup content goes here</p>
@@ -20,6 +21,7 @@ export const PopupSection: React.FC<{ selectedComponent: string }> = ({ selected
     <Variant label="Horizontal: Right">
       <Popup
         button={<Button buttonStyle="secondary">Right Aligned</Button>}
+        buttonType="custom"
         horizontalAlign="right"
         render={() => (
           <div style={{ padding: '16px' }}>


### PR DESCRIPTION
## Summary
Fixes hydration errors in the v4 components gallery caused by invalid HTML nesting where `<button>` elements were nested inside other `<button>` elements.

The Popup section now uses `buttonType="custom"` when passing Button components, which wraps them in a div instead of another button. The Drawer section uses the `useModal` hook directly instead of wrapping Button in DrawerToggler, and also corrects the `headerActions` prop format from a React element to the expected array of action objects.

## Test plan
Run `pnpm dev v4` and navigate to `/admin/components`. Verify no hydration errors appear in the browser console and that Popup and Drawer components function correctly.
