### PR TITLE
feat: add new payload property to get collections or globals by slug

### DIFF
--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -21,6 +21,7 @@ import { type ClientGlobalConfig, createClientGlobalConfigs } from '../globals/c
 export type ServerOnlyRootProperties = keyof Pick<
   SanitizedConfig,
   | 'bin'
+  | 'collectionsBySlug'
   | 'cors'
   | 'csrf'
   | 'custom'
@@ -28,6 +29,7 @@ export type ServerOnlyRootProperties = keyof Pick<
   | 'editor'
   | 'email'
   | 'endpoints'
+  | 'globalsBySlug'
   | 'graphQL'
   | 'hooks'
   | 'i18n'
@@ -99,6 +101,8 @@ export const serverOnlyConfigProperties: readonly Partial<ServerOnlyRootProperti
   'logger',
   'kv',
   'queryPresets',
+  'collectionsBySlug',
+  'globalsBySlug',
   // `admin`, `onInit`, `localization`, `collections`, and `globals` are all handled separately
 ]
 

--- a/packages/payload/src/config/sanitize.spec.ts
+++ b/packages/payload/src/config/sanitize.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeConfig } from './sanitize.js'
+
+describe('sanitizeConfig', () => {
+  it('should populate collectionsBySlug map from collections array', async () => {
+    const config = await sanitizeConfig({
+      collections: [
+        { slug: 'posts', fields: [] },
+        { slug: 'users', auth: true, fields: [] },
+      ],
+      globals: [{ slug: 'settings', fields: [] }],
+    } as any)
+
+    expect(config.collectionsBySlug).toBeInstanceOf(Map)
+    expect(config.collectionsBySlug.size).toBe(config.collections.length)
+    expect(config.collectionsBySlug.get('posts')).toBe(
+      config.collections.find((c) => c.slug === 'posts'),
+    )
+  })
+
+  it('should populate globalsBySlug map from globals array', async () => {
+    const config = await sanitizeConfig({
+      collections: [],
+      globals: [
+        { slug: 'settings', fields: [] },
+        { slug: 'nav', fields: [] },
+      ],
+    } as any)
+
+    expect(config.globalsBySlug).toBeInstanceOf(Map)
+    expect(config.globalsBySlug.size).toBe(config.globals.length)
+    expect(config.globalsBySlug.get('settings')).toBe(
+      config.globals.find((g) => g.slug === 'settings'),
+    )
+  })
+})

--- a/packages/payload/src/config/sanitize.spec.ts
+++ b/packages/payload/src/config/sanitize.spec.ts
@@ -12,9 +12,9 @@ describe('sanitizeConfig', () => {
       globals: [{ slug: 'settings', fields: [] }],
     } as any)
 
-    expect(config.collectionsBySlug).toBeInstanceOf(Map)
-    expect(config.collectionsBySlug.size).toBe(config.collections.length)
-    expect(config.collectionsBySlug.get('posts')).toBe(
+    expect(config.collectionsBySlug).toEqual(expect.objectContaining({ posts: expect.any(Object) }))
+    expect(Object.keys(config.collectionsBySlug).length).toBe(config.collections.length)
+    expect(config.collectionsBySlug['posts']).toBe(
       config.collections.find((c) => c.slug === 'posts'),
     )
   })
@@ -28,10 +28,8 @@ describe('sanitizeConfig', () => {
       ],
     } as any)
 
-    expect(config.globalsBySlug).toBeInstanceOf(Map)
-    expect(config.globalsBySlug.size).toBe(config.globals.length)
-    expect(config.globalsBySlug.get('settings')).toBe(
-      config.globals.find((g) => g.slug === 'settings'),
-    )
+    expect(config.globalsBySlug).toEqual(expect.objectContaining({ settings: expect.any(Object) }))
+    expect(Object.keys(config.globalsBySlug).length).toBe(config.globals.length)
+    expect(config.globalsBySlug['settings']).toBe(config.globals.find((g) => g.slug === 'settings'))
   })
 })

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -509,14 +509,14 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
 
   await Promise.all(promises)
 
-  const collectionsBySlug = new Map<string, SanitizedCollectionConfig>()
+  const collectionsBySlug: Record<string, SanitizedCollectionConfig> = {}
   for (const collection of config.collections as SanitizedCollectionConfig[]) {
-    collectionsBySlug.set(collection.slug, collection)
+    collectionsBySlug[collection.slug] = collection
   }
 
-  const globalsBySlug = new Map<string, SanitizedGlobalConfig>()
+  const globalsBySlug: Record<string, SanitizedGlobalConfig> = {}
   for (const global of config.globals ?? []) {
-    globalsBySlug.set(global.slug, global)
+    globalsBySlug[global.slug] = global
   }
 
   return { ...config, collectionsBySlug, globalsBySlug } as SanitizedConfig

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -4,7 +4,12 @@ import { en } from '@payloadcms/translations/languages/en'
 import { deepMergeSimple } from '@payloadcms/translations/utilities'
 
 import type { OrderableJoinInfo } from '../fields/config/sanitizeJoinField.js'
-import type { CollectionSlug, GlobalSlug, SanitizedCollectionConfig } from '../index.js'
+import type {
+  CollectionSlug,
+  GlobalSlug,
+  SanitizedCollectionConfig,
+  SanitizedGlobalConfig,
+} from '../index.js'
 import type { SanitizedJobsConfig } from '../queues/config/types/index.js'
 import type {
   Config,
@@ -504,5 +509,15 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
 
   await Promise.all(promises)
 
-  return config as SanitizedConfig
+  const collectionsBySlug = new Map<string, SanitizedCollectionConfig>()
+  for (const collection of config.collections as SanitizedCollectionConfig[]) {
+    collectionsBySlug.set(collection.slug, collection)
+  }
+
+  const globalsBySlug = new Map<string, SanitizedGlobalConfig>()
+  for (const global of config.globals ?? []) {
+    globalsBySlug.set(global.slug, global)
+  }
+
+  return { ...config, collectionsBySlug, globalsBySlug } as SanitizedConfig
 }

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -519,5 +519,7 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
     globalsBySlug[global.slug] = global
   }
 
-  return { ...config, collectionsBySlug, globalsBySlug } as SanitizedConfig
+  config.collectionsBySlug = collectionsBySlug
+  config.globalsBySlug = globalsBySlug
+  return config as SanitizedConfig
 }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1586,12 +1586,12 @@ export type SanitizedConfig = {
   } & DeepRequired<Config['admin']>
   blocks?: FlattenedBlock[]
   collections: SanitizedCollectionConfig[]
-  collectionsBySlug: Map<string, SanitizedCollectionConfig>
+  collectionsBySlug: Record<string, SanitizedCollectionConfig>
   /** Default richtext editor to use for richText fields */
   editor?: RichTextAdapter<any, any, any>
   endpoints: Endpoint[]
   globals: SanitizedGlobalConfig[]
-  globalsBySlug: Map<string, SanitizedGlobalConfig>
+  globalsBySlug: Record<string, SanitizedGlobalConfig>
   i18n: Required<I18nOptions>
   jobs: SanitizedJobsConfig
   localization: false | SanitizedLocalizationConfig

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1586,10 +1586,12 @@ export type SanitizedConfig = {
   } & DeepRequired<Config['admin']>
   blocks?: FlattenedBlock[]
   collections: SanitizedCollectionConfig[]
+  collectionsBySlug: Map<string, SanitizedCollectionConfig>
   /** Default richtext editor to use for richText fields */
   editor?: RichTextAdapter<any, any, any>
   endpoints: Endpoint[]
   globals: SanitizedGlobalConfig[]
+  globalsBySlug: Map<string, SanitizedGlobalConfig>
   i18n: Required<I18nOptions>
   jobs: SanitizedJobsConfig
   localization: false | SanitizedLocalizationConfig

--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -92,7 +92,7 @@ export const createExport = async (args: CreateExportArgs) => {
   }
 
   const locale = localeFromInput ?? localeFromReq
-  const collectionConfig = payload.config.collections.find(({ slug }) => slug === collectionSlug)
+  const collectionConfig = payload.config.collectionsBySlug.get(collectionSlug)
 
   if (!collectionConfig) {
     throw new APIError(`Collection with slug ${collectionSlug} not found.`)

--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -92,7 +92,7 @@ export const createExport = async (args: CreateExportArgs) => {
   }
 
   const locale = localeFromInput ?? localeFromReq
-  const collectionConfig = payload.config.collectionsBySlug.get(collectionSlug)
+  const collectionConfig = payload.config.collectionsBySlug[collectionSlug]
 
   if (!collectionConfig) {
     throw new APIError(`Collection with slug ${collectionSlug} not found.`)

--- a/packages/plugin-import-export/src/import/createImport.ts
+++ b/packages/plugin-import-export/src/import/createImport.ts
@@ -116,7 +116,7 @@ export const createImport = async ({
     })
   }
 
-  const collectionConfig = req.payload.config.collectionsBySlug.get(collectionSlug)
+  const collectionConfig = req.payload.config.collectionsBySlug[collectionSlug]
 
   if (!collectionConfig) {
     if (!collectionSlug) {

--- a/packages/plugin-import-export/src/import/createImport.ts
+++ b/packages/plugin-import-export/src/import/createImport.ts
@@ -116,9 +116,7 @@ export const createImport = async ({
     })
   }
 
-  const collectionConfig = req.payload.config.collections.find(
-    ({ slug }) => slug === collectionSlug,
-  )
+  const collectionConfig = req.payload.config.collectionsBySlug.get(collectionSlug)
 
   if (!collectionConfig) {
     if (!collectionSlug) {

--- a/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
+++ b/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
@@ -47,9 +47,7 @@ export const getCreateCollectionImportTask = (
       }
 
       // Get the collection config for the imports collection
-      const collectionConfig = req.payload.config.collections.find(
-        (c) => c.slug === importCollection,
-      )
+      const collectionConfig = req.payload.config.collectionsBySlug.get(importCollection)
 
       if (!collectionConfig) {
         throw new Error(`Collection config not found for: ${importCollection}`)

--- a/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
+++ b/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
@@ -47,7 +47,7 @@ export const getCreateCollectionImportTask = (
       }
 
       // Get the collection config for the imports collection
-      const collectionConfig = req.payload.config.collectionsBySlug.get(importCollection)
+      const collectionConfig = req.payload.config.collectionsBySlug[importCollection]
 
       if (!collectionConfig) {
         throw new Error(`Collection config not found for: ${importCollection}`)

--- a/packages/plugin-mcp/src/utils/getVirtualFieldNames.ts
+++ b/packages/plugin-mcp/src/utils/getVirtualFieldNames.ts
@@ -6,7 +6,7 @@ import { fieldIsVirtual } from 'payload/shared'
  * Returns the names of all top-level virtual fields for a given collection slug.
  */
 export function getCollectionVirtualFieldNames(config: SanitizedConfig, slug: string): string[] {
-  const collection = config.collections.find((c) => c.slug === slug)
+  const collection = config.collectionsBySlug.get(slug)
 
   if (!collection) {
     return []
@@ -21,7 +21,7 @@ export function getCollectionVirtualFieldNames(config: SanitizedConfig, slug: st
  * Returns the names of all top-level virtual fields for a given global slug.
  */
 export function getGlobalVirtualFieldNames(config: SanitizedConfig, slug: string): string[] {
-  const global = config.globals.find((g) => g.slug === slug)
+  const global = config.globalsBySlug.get(slug)
 
   if (!global) {
     return []

--- a/packages/plugin-mcp/src/utils/getVirtualFieldNames.ts
+++ b/packages/plugin-mcp/src/utils/getVirtualFieldNames.ts
@@ -6,7 +6,7 @@ import { fieldIsVirtual } from 'payload/shared'
  * Returns the names of all top-level virtual fields for a given collection slug.
  */
 export function getCollectionVirtualFieldNames(config: SanitizedConfig, slug: string): string[] {
-  const collection = config.collectionsBySlug.get(slug)
+  const collection = config.collectionsBySlug[slug]
 
   if (!collection) {
     return []
@@ -21,7 +21,7 @@ export function getCollectionVirtualFieldNames(config: SanitizedConfig, slug: st
  * Returns the names of all top-level virtual fields for a given global slug.
  */
 export function getGlobalVirtualFieldNames(config: SanitizedConfig, slug: string): string[] {
-  const global = config.globalsBySlug.get(slug)
+  const global = config.globalsBySlug[slug]
 
   if (!global) {
     return []

--- a/packages/plugin-seo/src/index.ts
+++ b/packages/plugin-seo/src/index.ts
@@ -144,10 +144,9 @@ export const seoPlugin =
             const result = pluginConfig.generateTitle
               ? await pluginConfig.generateTitle({
                   ...data,
-                  collectionConfig: req.payload.config.collectionsBySlug.get(
-                    reqData.collectionSlug ?? '',
-                  ),
-                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
+                  collectionConfig:
+                    req.payload.config.collectionsBySlug[reqData.collectionSlug ?? ''],
+                  globalConfig: req.payload.config.globalsBySlug[reqData.globalSlug ?? ''],
                   req,
                 } satisfies Parameters<GenerateTitle>[0])
               : ''
@@ -168,10 +167,9 @@ export const seoPlugin =
             const result = pluginConfig.generateDescription
               ? await pluginConfig.generateDescription({
                   ...data,
-                  collectionConfig: req.payload.config.collectionsBySlug.get(
-                    reqData.collectionSlug ?? '',
-                  ),
-                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
+                  collectionConfig:
+                    req.payload.config.collectionsBySlug[reqData.collectionSlug ?? ''],
+                  globalConfig: req.payload.config.globalsBySlug[reqData.globalSlug ?? ''],
                   req,
                 } satisfies Parameters<GenerateDescription>[0])
               : ''
@@ -192,10 +190,9 @@ export const seoPlugin =
             const result = pluginConfig.generateURL
               ? await pluginConfig.generateURL({
                   ...data,
-                  collectionConfig: req.payload.config.collectionsBySlug.get(
-                    reqData.collectionSlug ?? '',
-                  ),
-                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
+                  collectionConfig:
+                    req.payload.config.collectionsBySlug[reqData.collectionSlug ?? ''],
+                  globalConfig: req.payload.config.globalsBySlug[reqData.globalSlug ?? ''],
                   req,
                 } satisfies Parameters<GenerateURL>[0])
               : ''
@@ -216,10 +213,9 @@ export const seoPlugin =
             const result = pluginConfig.generateImage
               ? await pluginConfig.generateImage({
                   ...data,
-                  collectionConfig: req.payload.config.collectionsBySlug.get(
-                    reqData.collectionSlug ?? '',
-                  ),
-                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
+                  collectionConfig:
+                    req.payload.config.collectionsBySlug[reqData.collectionSlug ?? ''],
+                  globalConfig: req.payload.config.globalsBySlug[reqData.globalSlug ?? ''],
                   req,
                 } satisfies Parameters<GenerateImage>[0])
               : ''

--- a/packages/plugin-seo/src/index.ts
+++ b/packages/plugin-seo/src/index.ts
@@ -144,10 +144,10 @@ export const seoPlugin =
             const result = pluginConfig.generateTitle
               ? await pluginConfig.generateTitle({
                   ...data,
-                  collectionConfig: config.collections?.find(
-                    (c) => c.slug === reqData.collectionSlug,
+                  collectionConfig: req.payload.config.collectionsBySlug.get(
+                    reqData.collectionSlug ?? '',
                   ),
-                  globalConfig: config.globals?.find((g) => g.slug === reqData.globalSlug),
+                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
                   req,
                 } satisfies Parameters<GenerateTitle>[0])
               : ''
@@ -168,10 +168,10 @@ export const seoPlugin =
             const result = pluginConfig.generateDescription
               ? await pluginConfig.generateDescription({
                   ...data,
-                  collectionConfig: config.collections?.find(
-                    (c) => c.slug === reqData.collectionSlug,
+                  collectionConfig: req.payload.config.collectionsBySlug.get(
+                    reqData.collectionSlug ?? '',
                   ),
-                  globalConfig: config.globals?.find((g) => g.slug === reqData.globalSlug),
+                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
                   req,
                 } satisfies Parameters<GenerateDescription>[0])
               : ''
@@ -192,10 +192,10 @@ export const seoPlugin =
             const result = pluginConfig.generateURL
               ? await pluginConfig.generateURL({
                   ...data,
-                  collectionConfig: config.collections?.find(
-                    (c) => c.slug === reqData.collectionSlug,
+                  collectionConfig: req.payload.config.collectionsBySlug.get(
+                    reqData.collectionSlug ?? '',
                   ),
-                  globalConfig: config.globals?.find((g) => g.slug === reqData.globalSlug),
+                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
                   req,
                 } satisfies Parameters<GenerateURL>[0])
               : ''
@@ -216,10 +216,10 @@ export const seoPlugin =
             const result = pluginConfig.generateImage
               ? await pluginConfig.generateImage({
                   ...data,
-                  collectionConfig: config.collections?.find(
-                    (c) => c.slug === reqData.collectionSlug,
+                  collectionConfig: req.payload.config.collectionsBySlug.get(
+                    reqData.collectionSlug ?? '',
                   ),
-                  globalConfig: config.globals?.find((g) => g.slug === reqData.globalSlug),
+                  globalConfig: req.payload.config.globalsBySlug.get(reqData.globalSlug ?? ''),
                   req,
                 } satisfies Parameters<GenerateImage>[0])
               : ''


### PR DESCRIPTION
Added new `config.collectionsBySlug` and `config.globalsBySlug` object records accessible on the config via `payload.config.` in order to help with optimisation.

Based on [comment here](https://github.com/payloadcms/payload/pull/16518#discussion_r3203446649).

## Why

Finding collections or globals is something that a lot of plugins need to do in order to inject per-collection config. Previously they'd have to do this find themselves which makes it more inefficient when it's happening in multiple plugins.

Now they can use these Records to get the target collection a lot more efficiently so this compute is done only once.