### PR TITLE
fix: bump uuid package to 14.0.0

### DIFF
--- a/packages/db-d1-sqlite/package.json
+++ b/packages/db-d1-sqlite/package.json
@@ -77,7 +77,7 @@
     "drizzle-orm": "0.45.2",
     "prompts": "2.4.2",
     "to-snake-case": "1.0.0",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/packages/db-mongodb/package.json
+++ b/packages/db-mongodb/package.json
@@ -55,7 +55,7 @@
     "mongoose": "8.15.1",
     "mongoose-paginate-v2": "1.9.4",
     "prompts": "2.4.2",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -82,7 +82,7 @@
     "pg": "8.20.0",
     "prompts": "2.4.2",
     "to-snake-case": "1.0.0",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@hyrious/esbuild-plugin-commonjs": "0.2.6",

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -79,7 +79,7 @@
     "drizzle-orm": "0.45.2",
     "prompts": "2.4.2",
     "to-snake-case": "1.0.0",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/packages/db-vercel-postgres/package.json
+++ b/packages/db-vercel-postgres/package.json
@@ -82,7 +82,7 @@
     "pg": "8.20.0",
     "prompts": "2.4.2",
     "to-snake-case": "1.0.0",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@hyrious/esbuild-plugin-commonjs": "0.2.6",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -62,7 +62,7 @@
     "drizzle-orm": "0.45.2",
     "prompts": "2.4.2",
     "to-snake-case": "1.0.0",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@libsql/client": "0.14.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -123,7 +123,7 @@
     "path-to-regexp": "6.3.0",
     "qs-esm": "8.0.1",
     "sass": "1.77.4",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.27.2",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -128,7 +128,7 @@
     "ts-essentials": "10.0.3",
     "tsx": "4.21.0",
     "undici": "7.24.4",
-    "uuid": "11.1.0",
+    "uuid": "14.0.0",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/packages/plugin-stripe/package.json
+++ b/packages/plugin-stripe/package.json
@@ -66,7 +66,7 @@
     "@payloadcms/ui": "workspace:*",
     "lodash.get": "^4.4.2",
     "stripe": "^10.2.0",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -393,7 +393,7 @@
     "qs-esm": "8.0.1",
     "react-error-boundary": "4.1.2",
     "ts-essentials": "10.0.3",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.27.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -154,7 +154,7 @@
     "sonner": "^1.7.2",
     "ts-essentials": "10.0.3",
     "use-context-selector": "2.0.0",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,8 +347,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -375,8 +375,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -424,8 +424,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@hyrious/esbuild-plugin-commonjs':
         specifier: 0.2.6
@@ -467,8 +467,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -510,8 +510,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@hyrious/esbuild-plugin-commonjs':
         specifier: 0.2.6
@@ -550,8 +550,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@libsql/client':
         specifier: 0.14.0
@@ -835,8 +835,8 @@ importers:
         specifier: 1.77.4
         version: 1.77.4
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@babel/cli':
         specifier: 7.27.2
@@ -977,8 +977,8 @@ importers:
         specifier: 7.24.4
         version: 7.24.4
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
       ws:
         specifier: ^8.16.0
         version: 8.20.0(bufferutil@4.1.0)
@@ -1299,7 +1299,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^9.5.0
-        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(webpack@5.106.2(@swc/core@1.15.3)(esbuild@0.25.12))
+        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(webpack@5.106.2(@swc/core@1.15.3)(esbuild@0.25.12))
       '@sentry/types':
         specifier: ^9.5.0
         version: 9.47.1
@@ -1369,8 +1369,8 @@ importers:
         specifier: ^10.2.0
         version: 10.17.0
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -1487,8 +1487,8 @@ importers:
         specifier: 10.0.3
         version: 10.0.3(typescript@5.7.3)
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@babel/cli':
         specifier: 7.27.2
@@ -1760,8 +1760,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0(react@19.2.6)(scheduler@0.25.0)
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@babel/cli':
         specifier: 7.27.2
@@ -2266,7 +2266,7 @@ importers:
     dependencies:
       recharts:
         specifier: 3.2.1
-        version: 3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1)
+        version: 3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.614.0
@@ -2536,8 +2536,8 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.9)(@vitest/ui@4.1.2)(happy-dom@20.9.0(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@7.3.3(@types/node@22.19.9)(jiti@2.7.0)(lightningcss@1.30.2)(sass-embedded@1.99.0)(sass@1.77.4)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
@@ -14396,8 +14396,8 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@8.3.2:
@@ -20166,7 +20166,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(webpack@5.106.2(@swc/core@1.15.3)(esbuild@0.25.12))':
+  '@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(webpack@5.106.2(@swc/core@1.15.3)(esbuild@0.25.12))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -20179,7 +20179,7 @@ snapshots:
       '@sentry/vercel-edge': 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
       '@sentry/webpack-plugin': 3.6.1(webpack@5.106.2(@swc/core@1.15.3)(esbuild@0.25.12))
       chalk: 3.0.0
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -23737,7 +23737,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -23794,7 +23794,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-import-x: 4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
@@ -23856,7 +23856,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -27384,7 +27384,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts@3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1):
+  recharts@3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
       clsx: 2.1.1
@@ -27394,7 +27394,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
@@ -28975,7 +28975,7 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 

--- a/test/package.json
+++ b/test/package.json
@@ -114,7 +114,7 @@
     "tempy": "^1.0.1",
     "ts-essentials": "10.0.3",
     "typescript": "5.7.3",
-    "uuid": "11.1.0",
+    "uuid": "14.0.0",
     "vitest": "4.1.2",
     "wrangler": "~4.61.1",
     "zod": "^3.25.5"


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/16459

Bumps the uuid package from 11.1.0 to 14.0.0 to fix [GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq)