### PR TITLE
feat!: remove croner sloppyRanges compatibility setting

### DIFF
--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -43,8 +43,6 @@ export const bin = async () => {
       {
         // Do not run consecutive crons if previous crons still ongoing
         protect: true,
-        // TODO: Remove this compatibility option in 4.0. This only exists to ensure backwards-compatibility between Croner v9 and Croner v10 cron syntax
-        sloppyRanges: true,
       },
     )
 

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -761,8 +761,6 @@ export class BasePayload {
               },
               // Do not run consecutive crons if previous crons still ongoing
               protect: true,
-              // TODO: Remove this compatibility option in 4.0. This only exists to ensure backwards-compatibility between Croner v9 and Croner v10 cron syntax
-              sloppyRanges: true,
             },
           )
 

--- a/packages/payload/src/queues/operations/handleSchedules/index.ts
+++ b/packages/payload/src/queues/operations/handleSchedules/index.ts
@@ -141,10 +141,7 @@ export function checkQueueableTimeConstraints({
     ? queueScheduleStats?.tasks?.[taskConfig.slug]?.lastScheduledRun
     : queueScheduleStats?.workflows?.[workflowConfig?.slug ?? '']?.lastScheduledRun
 
-  const nextRun = new Cron(scheduleConfig.cron, {
-    // TODO: Remove this compatibility option in 4.0. This only exists to ensure backwards-compatibility between Croner v9 and Croner v10 cron syntax
-    sloppyRanges: true,
-  }).nextRun(lastScheduledRun ?? undefined)
+  const nextRun = new Cron(scheduleConfig.cron).nextRun(lastScheduledRun ?? undefined)
 
   if (!nextRun) {
     return false


### PR DESCRIPTION
**BREAKING: removes the `sloppyRanges: true` setting that kept Croner v9 stepping syntax working after the v10 upgrade. Croner now enforces stricter cron parsing rules, so stepping expressions must use either `*` or an explicit range before the `/`.**

Affects job autorun crons (`jobs.autoRun[].cron`), scheduled task/workflow runs (`schedule.cron`), and the `payload` bin script `--cron` flag.

## What changed

In strict mode (now the default), only these stepping forms are valid:

- `*/N` - wildcard with step
- `start-end/N` - explicit range with step

These forms now throw a `TypeError` at registration:

- `/N` - missing prefix
- `M/N` - numeric prefix (single number before `/`)

## Migration — before / after

### 1. Missing prefix

```diff
- cron: '/10 * * * *'
+ cron: '*/10 * * * *'
```

Both fire every 10 minutes. The leading `*` is now required.

### 2. Numeric prefix meaning "every N starting from M"

```diff
- cron: '5/15 * * * *'
+ cron: '5-59/15 * * * *'
```

Fires at minutes 5, 20, 35, 50. The new form makes the range explicit.

### 3. Numeric prefix that produces a single value

```diff
- cron: '30/30 * * * *'
+ cron: '30 * * * *'
```

Only ever fires at minute 30 (60 is out of the field's range), so the step adds nothing - drop it.