### PR TITLE
feat!: remove deprecated min/max from relationship and upload fields

### DIFF
--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -264,20 +264,6 @@ export const sanitizeField = async ({
         }
       })
     }
-
-    if (field.min && !field.minRows) {
-      console.warn(
-        `(payload): The "min" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "minRows" instead.`,
-      )
-      field.minRows = field.min
-    }
-
-    if (field.max && !field.maxRows) {
-      console.warn(
-        `(payload): The "max" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "maxRows" instead.`,
-      )
-      field.maxRows = field.max
-    }
   }
 
   // Upload isSortable default

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -987,29 +987,13 @@ type SharedUploadProperties = {
 } & (
   | {
       hasMany: true
-      /**
-       * @deprecated Use 'maxRows' instead
-       */
-      max?: number
       maxRows?: number
-      /**
-       * @deprecated Use 'minRows' instead
-       */
-      min?: number
       minRows?: number
       validate?: UploadFieldManyValidation
     }
   | {
       hasMany?: false | undefined
-      /**
-       * @deprecated Use 'maxRows' instead
-       */
-      max?: undefined
       maxRows?: undefined
-      /**
-       * @deprecated Use 'minRows' instead
-       */
-      min?: undefined
       minRows?: undefined
       validate?: UploadFieldSingleValidation
     }
@@ -1018,10 +1002,7 @@ type SharedUploadProperties = {
   Omit<FieldBase, 'validate'>
 
 type SharedUploadPropertiesClient = FieldBaseClient &
-  Pick<
-    SharedUploadProperties,
-    'hasMany' | 'max' | 'maxDepth' | 'maxRows' | 'min' | 'minRows' | 'type'
-  >
+  Pick<SharedUploadProperties, 'hasMany' | 'maxDepth' | 'maxRows' | 'minRows' | 'type'>
 
 type UploadAdmin = {
   allowCreate?: boolean
@@ -1198,29 +1179,13 @@ type SharedRelationshipProperties = {
 } & (
   | {
       hasMany: true
-      /**
-       * @deprecated Use 'maxRows' instead
-       */
-      max?: number
       maxRows?: number
-      /**
-       * @deprecated Use 'minRows' instead
-       */
-      min?: number
       minRows?: number
       validate?: RelationshipFieldManyValidation
     }
   | {
       hasMany?: false | undefined
-      /**
-       * @deprecated Use 'maxRows' instead
-       */
-      max?: undefined
       maxRows?: undefined
-      /**
-       * @deprecated Use 'minRows' instead
-       */
-      min?: undefined
       minRows?: undefined
       validate?: RelationshipFieldSingleValidation
     }
@@ -1229,10 +1194,7 @@ type SharedRelationshipProperties = {
   Omit<FieldBase, 'validate'>
 
 type SharedRelationshipPropertiesClient = FieldBaseClient &
-  Pick<
-    SharedRelationshipProperties,
-    'hasMany' | 'max' | 'maxDepth' | 'maxRows' | 'min' | 'minRows' | 'type'
-  >
+  Pick<SharedRelationshipProperties, 'hasMany' | 'maxDepth' | 'maxRows' | 'minRows' | 'type'>
 
 type RelationshipAdmin = {
   allowCreate?: boolean


### PR DESCRIPTION
**BREAKING: removes the deprecated `min` and `max` properties from `relationship` and `upload` fields with `hasMany: true`. Use `minRows` and `maxRows` instead.**

## Migration

```diff
  {
    name: 'tags',
    type: 'relationship',
    relationTo: 'tags',
    hasMany: true,
-   min: 1,
-   max: 5,
+   minRows: 1,
+   maxRows: 5,
  }
```

Same change applies to upload fields with hasMany: true.

