### PR TITLE
feat!: remove deprecated title and setDocumentTitle from DocumentInfoContext

### DIFF
--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -801,9 +801,7 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`preferencesKey`**               | The `preferences` key to use when interacting with document-level user preferences. [More details](./preferences).                               |
 | **`data`**                         | The saved data of the document.                                                                                                                  |
 | **`setDocFieldPreferences`**       | Method to set preferences for a specific field. [More details](./preferences).                                                                   |
-| **`setDocumentTitle`**             | Method to set the document title.                                                                                                                |
 | **`setHasPublishedDoc`**           | Method to update whether the document has been published.                                                                                        |
-| **`title`**                        | The title of the document.                                                                                                                       |
 | **`unlockDocument`**               | Method to unlock a document. [More details](./locked-documents).                                                                                 |
 | **`unpublishedVersionCount`**      | The number of unpublished versions of the document.                                                                                              |
 | **`updateDocumentEditor`**         | Method to update who is currently editing the document. [More details](./locked-documents).                                                      |
@@ -834,6 +832,27 @@ const LinkFromCategoryToPosts: React.FC = () => {
       View posts
     </a>
   )
+}
+```
+
+## useDocumentTitle
+
+The `useDocumentTitle` hook returns the current document's rendered title and a setter to override it. It is split out of `useDocumentInfo` so that components which only depend on the title do not re-render when other document state changes.
+
+| Property               | Description                           |
+| ---------------------- | ------------------------------------- |
+| **`title`**            | The current title of the document.    |
+| **`setDocumentTitle`** | Method to imperatively set the title. |
+
+**Example:**
+
+```tsx
+'use client'
+import { useDocumentTitle } from '@payloadcms/ui'
+
+const Heading: React.FC = () => {
+  const { title } = useDocumentTitle()
+  return <h2>{title}</h2>
 }
 ```
 

--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -110,3 +110,23 @@ export const PostsCollection: CollectionConfig = {
 ```
 
 Run `npx @payloadcms/codemod --transform remove-hide-api-url` to migrate automatically.
+
+### `title` and `setDocumentTitle` removed from `useDocumentInfo`
+
+For performance reasons, the document title state has been split out of `DocumentInfoContext` into its own `DocumentTitleContext`. Access it through the `useDocumentTitle` hook, which exposes the same `title` and `setDocumentTitle` API. Components that subscribed to `useDocumentInfo` solely for the title will no longer re-render when unrelated document state changes.
+
+```diff
+'use client'
+- import { useDocumentInfo } from '@payloadcms/ui'
++ import { useDocumentTitle } from '@payloadcms/ui'
+
+const Heading: React.FC = () => {
+-  const { title, setDocumentTitle } = useDocumentInfo()
++  const { title, setDocumentTitle } = useDocumentTitle()
+  return <h2>{title}</h2>
+}
+```
+
+If you only used `useDocumentInfo` for `title` / `setDocumentTitle`, drop the import entirely. If you used it for other properties as well, leave the original `useDocumentInfo()` call in place and add a separate `useDocumentTitle()` call alongside it.
+
+Run `npx @payloadcms/codemod --transform migrate-document-title-context` to migrate automatically. The codemod splits mixed destructures, removes the `useDocumentInfo` import when no other properties are still used, and preserves any rename aliases (e.g. `{ title: docTitle }`).

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -30,6 +30,7 @@ The tool loads your project via [ts-morph](https://ts-morph.com/), using your `t
 - `globals-components-edit` — Globals: rename `admin.components.elements` to `admin.components.edit` and hoist `Description` to top-level `admin.components.Description` to match Collection conventions.
 - `migrate-force-select` — migrates `forceSelect: { ... }` on Collection/Global configs to a `select` function that augments the caller's `select` when present and returns `undefined` (preserving full-document reads) when not. Shallow values become a spread (`{ ...select, ... }`); nested values use `deepMergeSimple` from `payload/shared` (auto-imported) to preserve the previous deep-merge semantics. Non-literal values, sibling `select` already present, and unsupported member kinds are surfaced as notes for manual review.
 - `migrate-hide-api-url` — migrates `admin.hideAPIURL: true` to `admin.components.views.edit.api.tab.condition: () => false` on collection and global configs.
+- `migrate-document-title-context` — migrates `title` and `setDocumentTitle` destructured from `useDocumentInfo()` to `useDocumentTitle()`. They were removed from `DocumentInfoContext` in v4 and now live on `DocumentTitleContext`.
 
 ## Contributing
 

--- a/packages/codemod/src/registry.ts
+++ b/packages/codemod/src/registry.ts
@@ -3,6 +3,7 @@ import type { Transform } from './types.js'
 import { exampleNoop } from './transforms/example-noop/index.js'
 import { globalsComponentsEdit } from './transforms/globals-components-edit/index.js'
 import { migrateDisabledFields } from './transforms/migrate-disabled-fields/index.js'
+import { migrateDocumentTitleContext } from './transforms/migrate-document-title-context/index.js'
 import { migrateForceSelect } from './transforms/migrate-force-select/index.js'
 import { migrateHideAPIURL } from './transforms/migrate-hide-api-url/index.js'
 import { migrateListViewSelectAPI } from './transforms/migrate-list-view-select-api/index.js'
@@ -14,4 +15,5 @@ export const transforms: Transform[] = [
   migrateListViewSelectAPI,
   migrateDisabledFields,
   migrateForceSelect,
+  migrateDocumentTitleContext,
 ]

--- a/packages/codemod/src/transforms/migrate-document-title-context/basic.input.ts
+++ b/packages/codemod/src/transforms/migrate-document-title-context/basic.input.ts
@@ -1,0 +1,16 @@
+import { useDocumentInfo } from '@payloadcms/ui'
+
+export const Mixed = () => {
+  const { id, collectionSlug, title, setDocumentTitle } = useDocumentInfo()
+  return { id, collectionSlug, title, setDocumentTitle }
+}
+
+export const OnlyTitle = () => {
+  const { title } = useDocumentInfo()
+  return title
+}
+
+export const Aliased = () => {
+  const { title: docTitle, id } = useDocumentInfo()
+  return { docTitle, id }
+}

--- a/packages/codemod/src/transforms/migrate-document-title-context/basic.output.ts
+++ b/packages/codemod/src/transforms/migrate-document-title-context/basic.output.ts
@@ -1,0 +1,18 @@
+import { useDocumentInfo, useDocumentTitle } from '@payloadcms/ui'
+
+export const Mixed = () => {
+  const { id, collectionSlug } = useDocumentInfo()
+  const { title, setDocumentTitle } = useDocumentTitle()
+  return { id, collectionSlug, title, setDocumentTitle }
+}
+
+export const OnlyTitle = () => {
+  const { title } = useDocumentTitle()
+  return title
+}
+
+export const Aliased = () => {
+  const { id } = useDocumentInfo()
+  const { title: docTitle } = useDocumentTitle()
+  return { docTitle, id }
+}

--- a/packages/codemod/src/transforms/migrate-document-title-context/index.test.ts
+++ b/packages/codemod/src/transforms/migrate-document-title-context/index.test.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { runTransform } from '../../utils/test-helpers.js'
+import { migrateDocumentTitleContext } from './index.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixture = (name: string) => readFile(join(here, name), 'utf8')
+
+describe('migrate-document-title-context', () => {
+  it('migrates title and setDocumentTitle to useDocumentTitle()', async () => {
+    const input = await fixture('basic.input.ts')
+    const output = await fixture('basic.output.ts')
+
+    const result = await runTransform({ source: input, transform: migrateDocumentTitleContext })
+
+    expect(result).toBe(output)
+  })
+
+  it('is idempotent', async () => {
+    const output = await fixture('basic.output.ts')
+
+    const result = await runTransform({ source: output, transform: migrateDocumentTitleContext })
+
+    expect(result).toBe(output)
+  })
+
+  it('no-ops on unrelated code', async () => {
+    const input = await fixture('no-match.input.ts')
+    const output = await fixture('no-match.output.ts')
+
+    const result = await runTransform({ source: input, transform: migrateDocumentTitleContext })
+
+    expect(result).toBe(output)
+  })
+
+  it('removes useDocumentInfo import when no other properties are used', async () => {
+    const input = `import { useDocumentInfo } from '@payloadcms/ui'
+
+export const C = () => {
+  const { title, setDocumentTitle } = useDocumentInfo()
+  return { title, setDocumentTitle }
+}
+`
+
+    const result = await runTransform({
+      source: input,
+      transform: migrateDocumentTitleContext,
+    })
+
+    expect(result).not.toContain('useDocumentInfo')
+    expect(result).toContain("import { useDocumentTitle } from '@payloadcms/ui'")
+    expect(result).toContain('const { title, setDocumentTitle } = useDocumentTitle()')
+  })
+
+  it('reuses an existing @payloadcms/ui import for useDocumentTitle', async () => {
+    const input = `import { useDocumentInfo, useTranslation } from '@payloadcms/ui'
+
+export const C = () => {
+  const { id, title } = useDocumentInfo()
+  useTranslation()
+  return { id, title }
+}
+`
+
+    const result = await runTransform({
+      source: input,
+      transform: migrateDocumentTitleContext,
+    })
+
+    const importMatches = result.match(/from '@payloadcms\/ui'/g) ?? []
+    expect(importMatches.length).toBe(1)
+    expect(result).toContain('useDocumentTitle')
+    expect(result).toContain('useDocumentInfo')
+  })
+
+  it('skips destructure with default value and emits a note', async () => {
+    const input = `import { useDocumentInfo } from '@payloadcms/ui'
+
+export const C = () => {
+  const { title = 'fallback' } = useDocumentInfo()
+  return title
+}
+`
+
+    const result = await runTransform({
+      source: input,
+      transform: migrateDocumentTitleContext,
+    })
+
+    expect(result).toBe(input)
+  })
+})

--- a/packages/codemod/src/transforms/migrate-document-title-context/index.ts
+++ b/packages/codemod/src/transforms/migrate-document-title-context/index.ts
@@ -1,0 +1,186 @@
+import type { SourceFile } from 'ts-morph'
+
+import { Node, SyntaxKind } from 'ts-morph'
+
+import type { Transform } from '../../types.js'
+
+const UI_MODULE = '@payloadcms/ui'
+const SOURCE_HOOK = 'useDocumentInfo'
+const TARGET_HOOK = 'useDocumentTitle'
+const MOVED_PROPERTIES = new Set(['setDocumentTitle', 'title'])
+
+export const migrateDocumentTitleContext: Transform = {
+  name: 'migrate-document-title-context',
+  apply: ({ project }) => {
+    const filesChanged = new Set<string>()
+    const notes: string[] = []
+
+    for (const sourceFile of project.getSourceFiles()) {
+      if (!hasUseDocumentInfoFromUI(sourceFile)) {
+        continue
+      }
+
+      let fileChanged = false
+
+      for (const decl of sourceFile.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
+        const initializer = decl.getInitializer()
+        if (!initializer || !Node.isCallExpression(initializer)) {
+          continue
+        }
+
+        const callee = initializer.getExpression()
+        if (!Node.isIdentifier(callee) || callee.getText() !== SOURCE_HOOK) {
+          continue
+        }
+
+        const nameNode = decl.getNameNode()
+        if (!Node.isObjectBindingPattern(nameNode)) {
+          continue
+        }
+
+        const elements = nameNode.getElements()
+        const moved: { alias: null | string; name: string }[] = []
+        const remainingTexts: string[] = []
+        let bailed = false
+
+        for (const el of elements) {
+          const propertyNameNode = el.getPropertyNameNode()
+          const sourceName = propertyNameNode
+            ? propertyNameNode.getText()
+            : el.getNameNode().getText()
+          const localName = el.getNameNode().getText()
+          const isRest = Boolean(el.getDotDotDotToken())
+
+          if (isRest || !MOVED_PROPERTIES.has(sourceName)) {
+            remainingTexts.push(el.getText())
+            continue
+          }
+
+          if (el.getInitializer()) {
+            notes.push(
+              `${sourceFile.getFilePath()}: '${sourceName}' destructured from useDocumentInfo() with a default value — migrate manually.`,
+            )
+            bailed = true
+            break
+          }
+
+          const alias = propertyNameNode ? localName : null
+          moved.push({ name: sourceName, alias })
+        }
+
+        if (bailed || moved.length === 0) {
+          continue
+        }
+
+        const variableStatement = decl.getFirstAncestorByKind(SyntaxKind.VariableStatement)
+        if (!variableStatement) {
+          notes.push(
+            `${sourceFile.getFilePath()}: useDocumentInfo() destructure of ${moved
+              .map((m) => `'${m.name}'`)
+              .join(', ')} is not at statement scope — migrate manually.`,
+          )
+          continue
+        }
+
+        const parent = variableStatement.getParent()
+        if (!Node.isSourceFile(parent) && !Node.isBlock(parent) && !Node.isModuleBlock(parent)) {
+          notes.push(
+            `${sourceFile.getFilePath()}: useDocumentInfo() destructure of ${moved
+              .map((m) => `'${m.name}'`)
+              .join(', ')} is in an unsupported scope — migrate manually.`,
+          )
+          continue
+        }
+
+        const insertIndex = variableStatement.getChildIndex() + 1
+
+        if (remainingTexts.length === 0) {
+          variableStatement.remove()
+        } else {
+          nameNode.replaceWithText(`{ ${remainingTexts.join(', ')} }`)
+        }
+
+        const properties = moved.map((m) => (m.alias ? `${m.name}: ${m.alias}` : m.name)).join(', ')
+        const statementText = `const { ${properties} } = ${TARGET_HOOK}()`
+
+        const targetIndex = remainingTexts.length === 0 ? insertIndex - 1 : insertIndex
+        parent.insertStatements(targetIndex, statementText)
+
+        fileChanged = true
+      }
+
+      if (fileChanged) {
+        ensureUseDocumentTitleImport(sourceFile)
+        removeUseDocumentInfoImportIfUnused(sourceFile)
+        filesChanged.add(sourceFile.getFilePath())
+      }
+    }
+
+    return {
+      filesChanged: Array.from(filesChanged),
+      ...(notes.length > 0 ? { notes } : {}),
+    }
+  },
+  description:
+    'Migrate `title` and `setDocumentTitle` destructured from useDocumentInfo() to useDocumentTitle() (DocumentTitleContext). Removed from DocumentInfoContext in v4.',
+}
+
+function hasUseDocumentInfoFromUI(sourceFile: SourceFile): boolean {
+  return sourceFile
+    .getImportDeclarations()
+    .some(
+      (decl) =>
+        decl.getModuleSpecifierValue() === UI_MODULE &&
+        decl.getNamedImports().some((named) => named.getName() === SOURCE_HOOK),
+    )
+}
+
+function ensureUseDocumentTitleImport(sourceFile: SourceFile): void {
+  const uiImport = sourceFile
+    .getImportDeclarations()
+    .find((decl) => decl.getModuleSpecifierValue() === UI_MODULE)
+
+  if (!uiImport) {
+    sourceFile.addImportDeclaration({
+      moduleSpecifier: UI_MODULE,
+      namedImports: [TARGET_HOOK],
+    })
+    return
+  }
+
+  const alreadyImported = uiImport
+    .getNamedImports()
+    .some((named) => named.getName() === TARGET_HOOK)
+
+  if (!alreadyImported) {
+    uiImport.addNamedImport(TARGET_HOOK)
+  }
+}
+
+function removeUseDocumentInfoImportIfUnused(sourceFile: SourceFile): void {
+  const uiImport = sourceFile
+    .getImportDeclarations()
+    .find((decl) => decl.getModuleSpecifierValue() === UI_MODULE)
+
+  if (!uiImport) {
+    return
+  }
+
+  const docInfoImport = uiImport.getNamedImports().find((named) => named.getName() === SOURCE_HOOK)
+
+  if (!docInfoImport) {
+    return
+  }
+
+  const stillUsed = sourceFile
+    .getDescendantsOfKind(SyntaxKind.Identifier)
+    .filter((id) => id.getText() === SOURCE_HOOK)
+    .some((id) => {
+      const ancestorImport = id.getFirstAncestorByKind(SyntaxKind.ImportDeclaration)
+      return !ancestorImport
+    })
+
+  if (!stillUsed) {
+    docInfoImport.remove()
+  }
+}

--- a/packages/codemod/src/transforms/migrate-document-title-context/no-match.input.ts
+++ b/packages/codemod/src/transforms/migrate-document-title-context/no-match.input.ts
@@ -1,0 +1,13 @@
+import { useDocumentInfo } from '@payloadcms/ui'
+
+export const Untouched = () => {
+  const { id, collectionSlug } = useDocumentInfo()
+  return { id, collectionSlug }
+}
+
+const customHook = () => ({ title: 'x', setDocumentTitle: (_: string) => {} })
+
+export const FromOtherHook = () => {
+  const { title, setDocumentTitle } = customHook()
+  return { title, setDocumentTitle }
+}

--- a/packages/codemod/src/transforms/migrate-document-title-context/no-match.output.ts
+++ b/packages/codemod/src/transforms/migrate-document-title-context/no-match.output.ts
@@ -1,0 +1,13 @@
+import { useDocumentInfo } from '@payloadcms/ui'
+
+export const Untouched = () => {
+  const { id, collectionSlug } = useDocumentInfo()
+  return { id, collectionSlug }
+}
+
+const customHook = () => ({ title: 'x', setDocumentTitle: (_: string) => {} })
+
+export const FromOtherHook = () => {
+  const { title, setDocumentTitle } = customHook()
+  return { title, setDocumentTitle }
+}

--- a/packages/plugin-seo/src/types.ts
+++ b/packages/plugin-seo/src/types.ts
@@ -1,4 +1,4 @@
-import type { DocumentInfoContext } from '@payloadcms/ui'
+import type { DocumentInfoContext, DocumentTitleContext } from '@payloadcms/ui'
 import type {
   CollectionConfig,
   CollectionSlug,
@@ -23,9 +23,9 @@ export type PartialDocumentInfoContext = Pick<
   | 'initialData'
   | 'initialState'
   | 'preferencesKey'
-  | 'title'
   | 'versionCount'
->
+> &
+  Pick<DocumentTitleContext, 'title'>
 
 export type GenerateTitle<T = any> = (
   args: {

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -372,6 +372,7 @@ export { ConfigProvider, PageConfigProvider, useConfig } from '../../providers/C
 export { DocumentEventsProvider, useDocumentEvents } from '../../providers/DocumentEvents/index.js'
 export { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 export { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
+export type { DocumentTitleContext } from '../../providers/DocumentTitle/index.js'
 export type { DocumentInfoContext, DocumentInfoProps } from '../../providers/DocumentInfo/index.js'
 export { useUploadControls } from '../../providers/UploadControls/index.js'
 export { EditDepthProvider, useEditDepth } from '../../providers/EditDepth/index.js'

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -10,7 +10,6 @@ import type { DocumentInfoContext, DocumentInfoProps } from './types.js'
 import { useControllableState } from '../../hooks/useControllableState.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { requests } from '../../utilities/api.js'
-import { formatDocTitle } from '../../utilities/formatDocTitle/index.js'
 import { useConfig } from '../Config/index.js'
 import { DocumentTitleProvider } from '../DocumentTitle/index.js'
 import { useLocale, useLocaleLoading } from '../Locale/index.js'
@@ -81,21 +80,6 @@ const DocumentInfo: React.FC<
   const { i18n } = useTranslation()
 
   const { uploadEdits } = useUploadEdits()
-
-  /**
-   * @deprecated This state will be removed in v4.
-   * This is for performance reasons. Use the `DocumentTitleContext` instead.
-   */
-  const [title, setDocumentTitle] = useState(() =>
-    formatDocTitle({
-      collectionConfig,
-      data: { ...(initialData || {}), id },
-      dateFormat,
-      fallback: id?.toString(),
-      globalConfig,
-      i18n,
-    }),
-  )
 
   const [mostRecentVersionIsAutosaved, setMostRecentVersionIsAutosaved] = useState(
     mostRecentVersionIsAutosavedFromProps,
@@ -326,23 +310,6 @@ const DocumentInfo: React.FC<
     }
   }, [collectionConfig, globalConfig, versionCount])
 
-  /**
-   * @todo: Remove this in v4
-   * Users should use the `DocumentTitleContext` instead.
-   */
-  useEffect(() => {
-    setDocumentTitle(
-      formatDocTitle({
-        collectionConfig,
-        data: { ...data, id },
-        dateFormat,
-        fallback: id?.toString(),
-        globalConfig,
-        i18n,
-      }),
-    )
-  }, [collectionConfig, globalConfig, data, dateFormat, i18n, id])
-
   // clean on unmount
   useEffect(() => {
     const re1 = abortControllerRef.current
@@ -400,13 +367,11 @@ const DocumentInfo: React.FC<
     setData,
     setDocFieldPreferences,
     setDocumentIsLocked,
-    setDocumentTitle,
     setHasPublishedDoc,
     setLastUpdateTime,
     setMostRecentVersionIsAutosaved,
     setUnpublishedVersionCount,
     setUploadStatus: updateUploadStatus,
-    title,
     unlockDocument,
     unpublishedVersionCount,
     updateDocumentEditor,

--- a/packages/ui/src/providers/DocumentInfo/types.ts
+++ b/packages/ui/src/providers/DocumentInfo/types.ts
@@ -83,33 +83,11 @@ export type DocumentInfoContext = {
     fieldPreferences: { [key: string]: unknown } & Partial<InsideFieldsPreferences>,
   ) => void
   setDocumentIsLocked?: React.Dispatch<React.SetStateAction<boolean>>
-  /**
-   * @deprecated This property is deprecated and will be removed in v4.
-   * This is for performance reasons. Use the `DocumentTitleContext` instead
-   * via the `useDocumentTitle` hook.
-   * @example
-   * ```tsx
-   * import { useDocumentTitle } from '@payloadcms/ui'
-   * const { setDocumentTitle } = useDocumentTitle()
-   * ```
-   */
-  setDocumentTitle: React.Dispatch<React.SetStateAction<string>>
   setHasPublishedDoc: React.Dispatch<React.SetStateAction<boolean>>
   setLastUpdateTime: React.Dispatch<React.SetStateAction<number>>
   setMostRecentVersionIsAutosaved: React.Dispatch<React.SetStateAction<boolean>>
   setUnpublishedVersionCount: React.Dispatch<React.SetStateAction<number>>
   setUploadStatus?: (status: 'failed' | 'idle' | 'uploading') => void
-  /**
-   * @deprecated This property is deprecated and will be removed in v4.
-   * This is for performance reasons. Use the `DocumentTitleContext` instead
-   * via the `useDocumentTitle` hook.
-   * @example
-   * ```tsx
-   * import { useDocumentTitle } from '@payloadcms/ui'
-   * const { title } = useDocumentTitle()
-   * ```
-   */
-  title: string
   unlockDocument: (docID: number | string, slug: string) => Promise<void>
   unpublishedVersionCount: number
   updateDocumentEditor: (docID: number | string, slug: string, user: ClientUser) => Promise<void>

--- a/packages/ui/src/providers/DocumentTitle/index.tsx
+++ b/packages/ui/src/providers/DocumentTitle/index.tsx
@@ -7,14 +7,14 @@ import { useConfig } from '../Config/index.js'
 import { useDocumentInfo } from '../DocumentInfo/index.js'
 import { useTranslation } from '../Translation/index.js'
 
-type IDocumentTitleContext = {
+export type DocumentTitleContext = {
   setDocumentTitle: (title: string) => void
   title: string
 }
 
-const DocumentTitleContext = createContext({} as IDocumentTitleContext)
+const Context = createContext({} as DocumentTitleContext)
 
-export const useDocumentTitle = (): IDocumentTitleContext => use(DocumentTitleContext)
+export const useDocumentTitle = (): DocumentTitleContext => use(Context)
 
 export const DocumentTitleProvider: React.FC<{
   children: React.ReactNode
@@ -53,5 +53,5 @@ export const DocumentTitleProvider: React.FC<{
     )
   }, [data, dateFormat, i18n, id, collectionSlug, docConfig, globalSlug])
 
-  return <DocumentTitleContext value={{ setDocumentTitle, title }}>{children}</DocumentTitleContext>
+  return <Context value={{ setDocumentTitle, title }}>{children}</Context>
 }


### PR DESCRIPTION
As of https://github.com/payloadcms/payload/pull/12436, the document's title is maintained within its own standalone context for performance reasons. For backwards compatibility, the old `title` property and `setDocumentTitle` method were kept in place.

This PR removes this backward compatibility. Users should subscribe to the new `DocumentTitleContext` instead.

```diff
import type { React } from 'react'
- import { useDocumentInfo } from '@payloadcms/ui'
+ import { useDocumentTitle } from '@payloadcms/ui'

const MyComponent: React.FC = () => {
- const { title, setDocumentTitle } = useDocumentInfo()
+ const { title, setDocumentTitle } = useDocumentTitle()
}
```

#### Codemod

To migrate automatically, there's a codemod for this change available by running:

```bash
npx @payloadcms/codemod --transform migrate-document-title-context
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215458388514607