### PR TITLE
fix: correct icon source path in ui4 skill

### DIFF
--- a/.claude/skills/ui4/SKILL.md
+++ b/.claude/skills/ui4/SKILL.md
@@ -40,7 +40,7 @@ description: Manually invoked skill for reskinning Payload UI components. Requir
 When updating or creating icons, reference the Figma icon library at:
 
 ```
-~/figma/figma/fpl/icons/src/icons/
+~/figma/figma/fpl/components/src/icons/
 ```
 
 Icon naming convention: `icon-{size}-{name}.tsx` (e.g., `icon-16-close.tsx`, `icon-24-chevron-down.tsx`)


### PR DESCRIPTION
## Summary
- Fixed incorrect icon source path in the ui4 skill configuration

- Changed from `~/figma/figma/fpl/icons/src/icons/` to `~/figma/figma/fpl/components/src/icons/`

