### PR TITLE
feat(plugin-import-export): out of beta and added support for collection-level and field-level hooks

### DIFF
--- a/docs/plugins/import-export.mdx
+++ b/docs/plugins/import-export.mdx
@@ -8,11 +8,6 @@ keywords: plugins, plugin, import, export, csv, JSON, data, ETL, download
 
 ![https://www.npmjs.com/package/@payloadcms/plugin-import-export](https://img.shields.io/npm/v/@payloadcms/plugin-import-export)
 
-<Banner type="warning">
-  **Note**: This plugin is in **beta** as some aspects of it may change on any
-  minor releases. It is under development.
-</Banner>
-
 This plugin adds features that give admin users the ability to download or create export data as an upload collection and import it back into a project.
 
 <YouTube
@@ -132,6 +127,7 @@ Each item in the `collections` array can have the following properties:
 | `disableJobsQueue`   | boolean              | Run exports synchronously for this collection.                                                   |
 | `disableSave`        | boolean              | Disable save button for this collection.                                                         |
 | `format`             | string               | Force format (`csv` or `json`) for this collection.                                              |
+| `hooks`              | object               | Lifecycle hooks — `before` and `after`. See [Hooks](#hooks).                                     |
 | `limit`              | `number \| function` | Maximum documents to export. Set to `0` for unlimited (default). Overrides global `exportLimit`. |
 | `overrideCollection` | function             | Override the export collection config for this specific target.                                  |
 
@@ -142,6 +138,7 @@ Each item in the `collections` array can have the following properties:
 | `batchSize`            | number               | Documents per batch during import. Default: `100`.                                               |
 | `defaultVersionStatus` | string               | Default status for imported docs (`draft` or `published`).                                       |
 | `disableJobsQueue`     | boolean              | Run imports synchronously for this collection.                                                   |
+| `hooks`                | object               | Lifecycle hooks — `before` and `after`. See [Hooks](#hooks).                                     |
 | `limit`                | `number \| function` | Maximum documents to import. Set to `0` for unlimited (default). Overrides global `importLimit`. |
 | `overrideCollection`   | function             | Override the import collection config for this specific target.                                  |
 
@@ -370,15 +367,238 @@ importExportPlugin({
 })
 ```
 
+## Hooks
+
+Collection-level hooks let you intercept each batch of documents before it is written (to file on export, or to the database on import) and after it has been written. Hooks fire once per batch and work for both `csv` and `json` formats.
+
+### Hook arguments
+
+All hooks receive:
+
+| Argument       | Type                        | Description                                                          |
+| -------------- | --------------------------- | -------------------------------------------------------------------- |
+| `batchNumber`  | number                      | Current batch, starting at `1`.                                      |
+| `data`         | `Record<string, unknown>[]` | Transformed batch — flat rows for CSV export, nested docs otherwise. |
+| `format`       | string                      | Export/import format. Open-ended (`'csv' \| 'json' \| string`).      |
+| `originalData` | array                       | Source data before transformation. Read-only — do not mutate.        |
+| `req`          | `PayloadRequest`            | The full request object.                                             |
+| `totalBatches` | number                      | Total number of batches in this operation.                           |
+
+`ImportAfterHook` additionally receives `result: ImportResult` (per-batch counts and errors) instead of `data`/`originalData`.
+
+### before hooks — modify data
+
+`before` hooks return the (optionally modified) `data` array, which replaces the batch going into the write step. Returning an empty array skips the write for that batch without aborting remaining batches.
+
+```ts
+import { importExportPlugin } from '@payloadcms/plugin-import-export'
+
+importExportPlugin({
+  collections: [
+    {
+      slug: 'users',
+      export: {
+        hooks: {
+          // Mask sensitive fields before the batch is written to file
+          before: ({ data, format }) => {
+            return data.map((row) => {
+              const { passwordHash: _ph, ssn: _ssn, ...safe } = row
+              return safe
+            })
+          },
+        },
+      },
+      import: {
+        hooks: {
+          // Normalise incoming data before it is written to the database
+          before: ({ data }) => {
+            return data.map((doc) => ({
+              ...doc,
+              email:
+                typeof doc.email === 'string'
+                  ? doc.email.toLowerCase()
+                  : doc.email,
+            }))
+          },
+        },
+      },
+    },
+  ],
+})
+```
+
+### after hooks — logging and observability
+
+`after` hooks fire after the write has completed. Their return value is ignored — use them for logging, metrics, or notifications.
+
+```ts
+importExportPlugin({
+  collections: [
+    {
+      slug: 'orders',
+      export: {
+        hooks: {
+          after: ({ batchNumber, totalBatches, data, format, req }) => {
+            req.payload.logger.info({
+              msg: `Export batch ${batchNumber}/${totalBatches} written`,
+              format,
+              docsInBatch: data.length,
+            })
+          },
+        },
+      },
+      import: {
+        hooks: {
+          after: ({ batchNumber, totalBatches, result, req }) => {
+            req.payload.logger.info({
+              msg: `Import batch ${batchNumber}/${totalBatches} complete`,
+              imported: result.imported,
+              updated: result.updated,
+              errors: result.errors.length,
+            })
+          },
+        },
+      },
+    },
+  ],
+})
+```
+
+### Using originalData for context
+
+`originalData` gives you the raw source before any transformation. For exports it is the original DB documents; for imports it is the raw parsed file rows. This is useful when you need context from the full document while building modified flat rows.
+
+```ts
+export: {
+  hooks: {
+    before: ({ data, originalData }) => {
+      return data.map((row, i) => ({
+        ...row,
+        // Add a computed column not present in the DB document
+        displayName: `${originalData[i]?.firstName} ${originalData[i]?.lastName}`,
+      }))
+    },
+  },
+},
+```
+
+### Column name mapping for foreign systems
+
+When importing from or exporting to a foreign system, column names rarely match your Payload field names. Use the batch `before` hooks to rename keys on the way in or out.
+
+#### Exporting with renamed CSV columns
+
+Use `export.hooks.before` to rewrite every row's keys to the foreign system's column names. The returned shape is what gets written to the file.
+
+```ts
+import { importExportPlugin } from '@payloadcms/plugin-import-export'
+
+const exportRenameMap: Record<string, string> = {
+  title: 'Post Title',
+  excerpt: 'Summary',
+  count: 'View Count',
+}
+
+importExportPlugin({
+  collections: [
+    {
+      slug: 'posts',
+      export: {
+        hooks: {
+          before: ({ data }) =>
+            data.map((row) => {
+              const renamed: Record<string, unknown> = {}
+              for (const [key, value] of Object.entries(row)) {
+                renamed[exportRenameMap[key] ?? key] = value
+              }
+              return renamed
+            }),
+        },
+      },
+    },
+  ],
+})
+```
+
+JSON exports work the same way — the hook receives the fully-transformed batch, and the returned keys become the top-level JSON keys.
+
+#### Importing from foreign CSV columns
+
+Use `import.hooks.before` to rewrite incoming keys back to Payload field names. The hook receives already-unflattened documents, so foreign top-level keys like `Post Title` are still present and can be remapped to `title` before the DB write. Keys you don't include in the returned object are dropped.
+
+```ts
+const importRenameMap: Record<string, string> = {
+  'Post Title': 'title',
+  Summary: 'excerpt',
+  'View Count': 'count',
+}
+
+importExportPlugin({
+  collections: [
+    {
+      slug: 'posts',
+      import: {
+        hooks: {
+          before: ({ data }) =>
+            data.map((doc) => {
+              const renamed: Record<string, unknown> = {}
+              for (const [key, value] of Object.entries(doc)) {
+                const payloadKey = importRenameMap[key]
+                if (payloadKey) {
+                  renamed[payloadKey] = value
+                }
+                // Foreign keys not present in the rename map are dropped.
+              }
+              return renamed
+            }),
+        },
+      },
+    },
+  ],
+})
+```
+
+CSV cell values arrive as strings. Payload coerces basic scalar types automatically on write, but if a target field has stricter validation you can coerce inside the hook (`renamed.count = Number(value)`).
+
+#### Field-level export rename for shared fields
+
+When a field definition is shared across collections and the rename should travel with the field, use the field's own `hooks.beforeExport`. Mutate `siblingData` to add the renamed key and return `undefined` so the original field key is dropped from the output:
+
+```ts
+import type { FieldBeforeExportHook } from '@payloadcms/plugin-import-export'
+
+const sharedNameField = {
+  name: 'sharedName',
+  type: 'text' as const,
+  custom: {
+    'plugin-import-export': {
+      hooks: {
+        beforeExport: (({ siblingData, value }) => {
+          siblingData['Display Name'] = value
+          return undefined
+        }) satisfies FieldBeforeExportHook,
+      },
+    },
+  },
+}
+```
+
+This pattern is export-only. Field-level `hooks.beforeImport` does **not** fire for foreign columns — it's keyed by the incoming column name, so it can't pick up a column whose name doesn't already match a Payload field. For the reverse direction, use the collection-level `import.hooks.before` recipe above.
+
 ## Field Options
 
-In addition to the above plugin configuration options, you can granularly set the following field level options using the `custom['plugin-import-export']` properties in any of your collections.
+In addition to collection-level hooks, you can configure field-level export and import behavior directly on any field's `custom['plugin-import-export']` config. This is especially useful when:
 
-| Property   | Type     | Description                                                                                                                   |
-| ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `disabled` | boolean  | When `true` the field is completely excluded from the import-export plugin.                                                   |
-| `toCSV`    | function | Custom function used to modify the outgoing CSV data by manipulating the data, siblingData or by returning the desired value. |
-| `fromCSV`  | function | Custom function used to transform incoming CSV data during import.                                                            |
+- You share a field definition across multiple collections and want the behavior to travel with the field
+- You need to transform a deeply nested field without navigating the full document structure in a collection-level hook
+
+| Property             | Type     | Description                                                                 |
+| -------------------- | -------- | --------------------------------------------------------------------------- |
+| `disabled`           | boolean  | When `true` the field is completely excluded from the import-export plugin. |
+| `hooks.beforeExport` | function | Runs before a field value is exported. Works for CSV and JSON.              |
+| `hooks.beforeImport` | function | Runs before a field value is imported. Works for CSV and JSON.              |
+| `toCSV`              | function | **Deprecated** — use `hooks.beforeExport` instead. Will be removed in v4.   |
+| `fromCSV`            | function | **Deprecated** — use `hooks.beforeImport` instead. Will be removed in v4.   |
 
 ### Disabling Fields
 
@@ -402,95 +622,136 @@ When a field is disabled:
 - It will be ignored during import operations
 - Nested fields inside disabled parent fields are also excluded
 
-### Customizing Export Data with toCSV
+### hooks.beforeExport
 
-To manipulate the data that a field exports, you can add `toCSV` custom functions. This allows you to modify the outgoing CSV data by manipulating the row object or by returning the desired value.
+Use `hooks.beforeExport` to transform a field's value before it is exported. Works for both `csv` and `json` formats.
 
-The `toCSV` function receives an object with the following properties:
+The `beforeExport` function receives:
 
-| Property     | Type    | Description                                                       |
-| ------------ | ------- | ----------------------------------------------------------------- |
-| `columnName` | string  | The CSV column name given to the field.                           |
-| `doc`        | object  | The top level document.                                           |
-| `row`        | object  | The object data that can be manipulated to assign data to the CSV |
-| `siblingDoc` | object  | The document data at the level where it belongs.                  |
-| `value`      | unknown | The data for the field.                                           |
+| Property      | Type    | Description                                                                                                     |
+| ------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `columnName`  | string  | Column/field path, underscore-separated for nested fields (includes array indices).                             |
+| `data`        | object  | The top-level document being exported.                                                                          |
+| `format`      | string  | `'csv'` or `'json'`.                                                                                            |
+| `siblingData` | object  | Writable output at the current level. CSV: the flat row accumulator. JSON: the sibling output object.           |
+| `siblingDoc`  | object  | Read-only source at the current level, before any transformation. Use this to read another sibling's raw value. |
+| `value`       | unknown | The field value from the source document.                                                                       |
 
-Example - splitting a relationship into multiple columns:
+Return a value to replace the field, `undefined` to use default behavior, or mutate `siblingData` to add extra columns at the same level.
+
+Example — splitting a relationship into multiple columns:
 
 ```ts
-const pages: CollectionConfig = {
-  slug: 'pages',
-  fields: [
-    {
-      name: 'author',
-      type: 'relationship',
-      relationTo: 'users',
-      custom: {
-        'plugin-import-export': {
-          toCSV: ({ value, columnName, row }) => {
-            // Add both `author_id` and the `author_email` to the CSV export
-            if (
-              value &&
-              typeof value === 'object' &&
-              'id' in value &&
-              'email' in value
-            ) {
-              row[`${columnName}_id`] = (value as { id: number | string }).id
-              row[`${columnName}_email`] = (value as { email: string }).email
-            }
-          },
-        },
+import type { FieldBeforeExportHook } from '@payloadcms/plugin-import-export'
+
+const authorFieldWithHooks = {
+  name: 'author',
+  type: 'relationship',
+  relationTo: 'users',
+  custom: {
+    'plugin-import-export': {
+      hooks: {
+        beforeExport: (({ value, columnName, siblingData, format }) => {
+          if (
+            format === 'csv' &&
+            value &&
+            typeof value === 'object' &&
+            'id' in value &&
+            'email' in value
+          ) {
+            siblingData[`${columnName}_id`] = (
+              value as { id: number | string }
+            ).id
+            siblingData[`${columnName}_email`] = (
+              value as { email: string }
+            ).email
+            return undefined
+          }
+          return value
+        }) satisfies FieldBeforeExportHook,
       },
     },
-  ],
+  },
 }
 ```
 
-### Customizing Import Data with fromCSV
+Because the hook is defined on the field itself, you can share `authorFieldWithHooks` across multiple collections and each will get the same export behavior automatically.
 
-To transform data during import, add `fromCSV` custom functions. This allows you to transform incoming CSV data before it's saved to the database.
+### hooks.beforeImport
 
-The `fromCSV` function receives an object with the following properties:
+Use `hooks.beforeImport` to transform a field's value before it is imported. Works for both `csv` and `json` formats.
 
-| Property      | Type    | Description                                 |
-| ------------- | ------- | ------------------------------------------- |
-| `columnName`  | string  | The CSV column name for the field.          |
-| `data`        | object  | The full document data being built.         |
-| `siblingData` | object  | The data at the sibling level of the field. |
-| `value`       | unknown | The raw CSV value for the field.            |
+The `beforeImport` function receives:
 
-Return values:
+| Property      | Type    | Description                                                                              |
+| ------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `columnName`  | string  | Column/field path.                                                                       |
+| `data`        | object  | The full flat row (CSV) or top-level parsed document (JSON) being imported.              |
+| `format`      | string  | `'csv'` or `'json'`.                                                                     |
+| `siblingData` | object  | Data at the current level. CSV: same reference as `data`. JSON: the parent-level object. |
+| `siblingDoc`  | object  | Read-only source at the current level, before any transformation. CSV: same as `data`.   |
+| `value`       | unknown | The raw value from the import file.                                                      |
 
-- Return a value to use that value for the field
-- Return `undefined` to skip setting the field (keeps existing value)
-- Return `null` to explicitly set the field to null
-
-Example - reconstructing a relationship from split columns:
+Return the transformed value, `undefined` to skip, or `null` to explicitly set `null`.
 
 ```ts
-const pages: CollectionConfig = {
-  slug: 'pages',
-  fields: [
-    {
-      name: 'author',
-      type: 'relationship',
-      relationTo: 'users',
-      custom: {
-        'plugin-import-export': {
-          fromCSV: ({ data, columnName }) => {
-            // Reconstruct the relationship from the split columns created by toCSV
+import type { FieldBeforeImportHook } from '@payloadcms/plugin-import-export'
+
+{
+  name: 'author',
+  type: 'relationship',
+  relationTo: 'users',
+  custom: {
+    'plugin-import-export': {
+      hooks: {
+        beforeImport: (({ value, columnName, data, format }) => {
+          if (format === 'csv') {
             const id = data[`${columnName}_id`]
-            if (id) {
-              return id // Return just the ID for the relationship
-            }
-            return undefined // Skip if no ID provided
-          },
-        },
+            return id ?? undefined
+          }
+          return value
+        }) satisfies FieldBeforeImportHook,
       },
     },
-  ],
+  },
 }
+```
+
+### Execution Order
+
+Field-level hooks run **before** collection-level hooks:
+
+1. **Field-level `hooks.beforeExport`/`hooks.beforeImport`**: run per-field, per-document, during transformation
+2. **Collection-level `export.hooks.before`/`import.hooks.before`**: run per-batch, on the already-field-transformed data
+
+### Migrating from toCSV / fromCSV
+
+`toCSV` and `fromCSV` are deprecated and will be removed in v4. Existing hooks continue to work unchanged. New code should use `hooks.beforeExport` / `hooks.beforeImport`, which also run for JSON exports and imports.
+
+```ts
+// Before
+custom: {
+  'plugin-import-export': {
+    toCSV: ({ value, columnName, row, doc }) => {
+      row[`${columnName}_id`] = (value as any).id
+      return doc.title
+    },
+    fromCSV: ({ value, data }) => data[`${value}_key`],
+  },
+},
+
+// After
+custom: {
+  'plugin-import-export': {
+    hooks: {
+      beforeExport: ({ value, columnName, siblingData, data, format }) => {
+        siblingData[`${columnName}_id`] = (value as any).id
+        return data.title
+      },
+      beforeImport: ({ value, data, format }) => data[`${value}_key`],
+    },
+  },
+},
 ```
 
 ### Virtual Fields

--- a/packages/plugin-import-export/src/export/batchProcessor.ts
+++ b/packages/plugin-import-export/src/export/batchProcessor.ts
@@ -4,6 +4,8 @@
  */
 import type { PayloadRequest, SelectType, Sort, TypedUser, Where } from 'payload'
 
+import type { ExportAfterHook, ExportBeforeHook } from '../types.js'
+
 import { type BatchProcessorOptions } from '../utilities/useBatchProcessor.js'
 
 /**
@@ -46,6 +48,11 @@ export interface ExportProcessOptions<TDoc = unknown> {
    * The export format - affects column tracking for CSV
    */
   format: 'csv' | 'json'
+  /** Lifecycle hooks for this export operation */
+  hooks?: {
+    after?: ExportAfterHook
+    before?: ExportBeforeHook
+  }
   /**
    * Maximum number of documents to export
    */
@@ -58,6 +65,8 @@ export interface ExportProcessOptions<TDoc = unknown> {
    * Starting page for pagination (default: 1)
    */
   startPage?: number
+  /** Total number of docs available (used to compute totalBatches for hooks) */
+  totalDocs?: number
   /**
    * Transform function to apply to each document
    */
@@ -98,13 +107,21 @@ export interface ExportResult {
  *   format: 'csv',
  *   maxDocs: 1000,
  *   req,
- *   transformDoc: (doc) => flattenObject({ doc }),
+ *   transformDoc: (doc) => flattenObject({ data: doc }),
  * })
  * ```
  */
 export function createExportBatchProcessor(options: ExportBatchProcessorOptions = {}) {
   const batchSize = options.batchSize ?? 100
   const debug = options.debug ?? false
+
+  const computeTotalBatches = (totalDocs: number | undefined, maxDocs: number): number => {
+    const effectiveDocs =
+      totalDocs !== undefined
+        ? Math.min(totalDocs, maxDocs === Number.POSITIVE_INFINITY ? totalDocs : maxDocs)
+        : 0
+    return effectiveDocs > 0 ? Math.ceil(effectiveDocs / batchSize) : 1
+  }
 
   /**
    * Process an export operation by fetching and transforming documents in batches.
@@ -115,7 +132,18 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
   const processExport = async <TDoc>(
     processOptions: ExportProcessOptions<TDoc>,
   ): Promise<ExportResult> => {
-    const { findArgs, format, maxDocs, req, startPage = 1, transformDoc } = processOptions
+    const {
+      findArgs,
+      format,
+      hooks,
+      maxDocs,
+      req,
+      startPage = 1,
+      totalDocs,
+      transformDoc,
+    } = processOptions
+
+    const totalBatches = computeTotalBatches(totalDocs, maxDocs)
 
     const docs: Record<string, unknown>[] = []
     const columnsSet = new Set<string>()
@@ -144,19 +172,44 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
         )
       }
 
-      for (const doc of result.docs) {
-        const transformedDoc = transformDoc(doc as TDoc)
-        docs.push(transformedDoc)
+      const batchNumber = currentPage - startPage + 1
+      const originalDocs = result.docs as Record<string, unknown>[]
+      const batchData = result.docs.map((doc) => transformDoc(doc as TDoc))
 
-        // Track columns for CSV format
+      const dataToWrite =
+        hooks?.before && batchData.length > 0
+          ? await hooks.before({
+              batchNumber,
+              data: batchData,
+              format,
+              originalData: originalDocs,
+              req,
+              totalBatches,
+            })
+          : batchData
+
+      for (const row of dataToWrite) {
+        docs.push(row)
+
         if (format === 'csv') {
-          for (const key of Object.keys(transformedDoc)) {
+          for (const key of Object.keys(row)) {
             if (!columnsSet.has(key)) {
               columnsSet.add(key)
               columns.push(key)
             }
           }
         }
+      }
+
+      if (hooks?.after && dataToWrite.length > 0) {
+        await hooks.after({
+          batchNumber,
+          data: dataToWrite,
+          format,
+          originalData: originalDocs,
+          req,
+          totalBatches,
+        })
       }
 
       fetched += result.docs.length
@@ -187,7 +240,18 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
   async function* streamExport<TDoc>(
     processOptions: ExportProcessOptions<TDoc>,
   ): AsyncGenerator<{ columns: string[]; docs: Record<string, unknown>[] }> {
-    const { findArgs, format, maxDocs, req, startPage = 1, transformDoc } = processOptions
+    const {
+      findArgs,
+      format,
+      hooks,
+      maxDocs,
+      req,
+      startPage = 1,
+      totalDocs,
+      transformDoc,
+    } = processOptions
+
+    const totalBatches = computeTotalBatches(totalDocs, maxDocs)
 
     const columnsSet = new Set<string>()
     const columns: string[] = []
@@ -215,15 +279,25 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
         )
       }
 
-      const batchDocs: Record<string, unknown>[] = []
+      const batchNumber = currentPage - startPage + 1
+      const originalDocs = result.docs as Record<string, unknown>[]
+      const batchData = result.docs.map((doc) => transformDoc(doc as TDoc))
 
-      for (const doc of result.docs) {
-        const transformedDoc = transformDoc(doc as TDoc)
-        batchDocs.push(transformedDoc)
+      const dataToWrite =
+        hooks?.before && batchData.length > 0
+          ? await hooks.before({
+              batchNumber,
+              data: batchData,
+              format,
+              originalData: originalDocs,
+              req,
+              totalBatches,
+            })
+          : batchData
 
-        // Track columns for CSV format
+      for (const row of dataToWrite) {
         if (format === 'csv') {
-          for (const key of Object.keys(transformedDoc)) {
+          for (const key of Object.keys(row)) {
             if (!columnsSet.has(key)) {
               columnsSet.add(key)
               columns.push(key)
@@ -232,7 +306,18 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
         }
       }
 
-      yield { columns: [...columns], docs: batchDocs }
+      yield { columns: [...columns], docs: dataToWrite }
+
+      if (hooks?.after && dataToWrite.length > 0) {
+        await hooks.after({
+          batchNumber,
+          data: dataToWrite,
+          format,
+          originalData: originalDocs,
+          req,
+          totalBatches,
+        })
+      }
 
       fetched += result.docs.length
       hasNextPage = result.hasNextPage && fetched < maxDocs

--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -5,6 +5,7 @@ import { stringify } from 'csv-stringify/sync'
 import { APIError } from 'payload'
 import { Readable } from 'stream'
 
+import { applyFieldHooks } from '../utilities/applyFieldHooks.js'
 import { buildDisabledFieldRegex } from '../utilities/buildDisabledFieldRegex.js'
 import { flattenObject } from '../utilities/flattenObject.js'
 import { getExportFieldFunctions } from '../utilities/getExportFieldFunctions.js'
@@ -132,7 +133,7 @@ export const createExport = async (args: CreateExportArgs) => {
   const select = Array.isArray(fields) && fields.length > 0 ? getSelect(fields) : undefined
 
   if (debug) {
-    req.payload.logger.debug({ message: 'Export configuration:', name, isCSV, locale })
+    req.payload.logger.debug({ isCSV, locale, msg: 'Export configuration:', name })
   }
 
   // Determine maximum export documents:
@@ -171,8 +172,8 @@ export const createExport = async (args: CreateExportArgs) => {
     accessDenied = true
     if (debug) {
       req.payload.logger.debug({
-        message: 'Access denied for collection, creating empty export',
         collectionSlug,
+        msg: 'Access denied for collection, creating empty export',
       })
     }
   }
@@ -196,12 +197,14 @@ export const createExport = async (args: CreateExportArgs) => {
   }
 
   if (debug) {
-    req.payload.logger.debug({ message: 'Find arguments:', findArgs })
+    req.payload.logger.debug({ findArgs, msg: 'Find arguments:' })
   }
 
-  const toCSVFunctions = getExportFieldFunctions({
+  const exportFieldHooks = getExportFieldFunctions({
     fields: collectionConfig.flattenedFields,
   })
+
+  const exportHooks = collectionConfig.custom?.['plugin-import-export']?.exportHooks
 
   const disabledFields =
     collectionConfig.admin?.custom?.['plugin-import-export']?.disabledFields ?? []
@@ -221,7 +224,7 @@ export const createExport = async (args: CreateExportArgs) => {
     return filtered
   }
 
-  const filterDisabledJSON = (doc: any, parentPath = ''): any => {
+  const filterDisabledJSON = (doc: unknown, parentPath = ''): unknown => {
     if (Array.isArray(doc)) {
       return doc.map((item) => filterDisabledJSON(item, parentPath))
     }
@@ -230,8 +233,8 @@ export const createExport = async (args: CreateExportArgs) => {
       return doc
     }
 
-    const filtered: Record<string, any> = {}
-    for (const [key, value] of Object.entries(doc)) {
+    const filtered: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(doc as Record<string, unknown>)) {
       const currentPath = parentPath ? `${parentPath}.${key}` : key
 
       // Only remove if this exact path is disabled
@@ -286,6 +289,11 @@ export const createExport = async (args: CreateExportArgs) => {
     const maxDocs =
       typeof maxExportDocuments === 'number' ? maxExportDocuments : Number.POSITIVE_INFINITY
 
+    const effectiveStreamDocs =
+      typeof maxExportDocuments === 'number' ? Math.min(totalDocs, maxExportDocuments) : totalDocs
+    const totalBatches = effectiveStreamDocs > 0 ? Math.ceil(effectiveStreamDocs / batchSize) : 1
+    let streamBatchNumber = 0
+
     const stream = new Readable({
       async read() {
         const remaining = Math.max(0, maxDocs - fetched)
@@ -321,23 +329,40 @@ export const createExport = async (args: CreateExportArgs) => {
           return
         }
 
+        streamBatchNumber++
+
         if (isCSV) {
           // --- CSV Streaming ---
           const batchRows = result.docs.map((doc) =>
             filterDisabledCSV(
               flattenObject({
-                doc,
+                data: doc as Record<string, unknown>,
                 fields,
-                toCSVFunctions,
+                format,
+                exportFieldHooks,
+                req,
               }),
             ),
           )
+
+          const originalDocs = result.docs as Record<string, unknown>[]
+          let batchRowsToWrite = batchRows
+          if (exportHooks?.before && batchRows.length > 0) {
+            batchRowsToWrite = await exportHooks.before({
+              batchNumber: streamBatchNumber,
+              data: batchRows,
+              format,
+              originalData: originalDocs,
+              req,
+              totalBatches,
+            })
+          }
 
           // On first batch, discover additional columns from data and merge with schema
           if (!columnsFinalized) {
             const dataColumns: string[] = []
             const seenCols = new Set<string>()
-            for (const row of batchRows) {
+            for (const row of batchRowsToWrite) {
               for (const key of Object.keys(row)) {
                 if (!seenCols.has(key)) {
                   seenCols.add(key)
@@ -345,8 +370,14 @@ export const createExport = async (args: CreateExportArgs) => {
                 }
               }
             }
-            // Merge schema columns with data-discovered columns
-            allColumns = mergeColumns(schemaColumns, dataColumns)
+            // Merge schema columns with data-discovered columns.
+            // When a before hook is active and rows exist, restrict to columns actually present
+            // in the data so that the hook can remove fields by not returning them.
+            const mergedColumns = mergeColumns(schemaColumns, dataColumns)
+            allColumns =
+              Boolean(exportHooks?.before) && batchRowsToWrite.length > 0
+                ? mergedColumns.filter((col) => dataColumns.includes(col))
+                : mergedColumns
             columnsFinalized = true
 
             if (debug) {
@@ -358,7 +389,7 @@ export const createExport = async (args: CreateExportArgs) => {
             }
           }
 
-          const paddedRows = batchRows.map((row) => {
+          const paddedRows = batchRowsToWrite.map((row) => {
             const fullRow: Record<string, unknown> = {}
             for (const col of allColumns) {
               fullRow[col] = row[col] ?? ''
@@ -373,17 +404,65 @@ export const createExport = async (args: CreateExportArgs) => {
           })
 
           this.push(encoder.encode(csvString))
+
+          if (exportHooks?.after && batchRowsToWrite.length > 0) {
+            await exportHooks.after({
+              batchNumber: streamBatchNumber,
+              data: batchRowsToWrite,
+              format,
+              originalData: originalDocs,
+              req,
+              totalBatches,
+            })
+          }
         } else {
           // --- JSON Streaming ---
-          const batchRows = result.docs.map((doc) => filterDisabledJSON(doc))
+          const batchRows = result.docs.map(
+            (doc) =>
+              filterDisabledJSON(
+                applyFieldHooks({
+                  data: doc as Record<string, unknown>,
+                  fieldHooks: exportFieldHooks,
+                  fields: collectionConfig.flattenedFields,
+                  format,
+                  operation: 'export',
+                  req,
+                  type: 'beforeExport',
+                }),
+              ) as Record<string, unknown>,
+          )
+
+          const originalDocs = result.docs as Record<string, unknown>[]
+          let batchRowsToWrite = batchRows
+          if (exportHooks?.before && batchRows.length > 0) {
+            batchRowsToWrite = await exportHooks.before({
+              batchNumber: streamBatchNumber,
+              data: batchRows,
+              format,
+              originalData: originalDocs,
+              req,
+              totalBatches,
+            })
+          }
 
           // Convert each filtered/flattened row into JSON string
-          const batchJSON = batchRows.map((row) => JSON.stringify(row)).join(',')
+          const batchJSON = batchRowsToWrite.map((row) => JSON.stringify(row)).join(',')
 
           if (isFirstBatch) {
             this.push(encoder.encode('[' + batchJSON))
           } else {
             this.push(encoder.encode(',' + batchJSON))
+          }
+
+          if (exportHooks?.after && batchRowsToWrite.length > 0) {
+            await exportHooks.after({
+              batchNumber: streamBatchNumber,
+              data: batchRowsToWrite,
+              format,
+              originalData: originalDocs,
+              req,
+              totalBatches,
+            })
           }
         }
 
@@ -424,12 +503,24 @@ export const createExport = async (args: CreateExportArgs) => {
     isCSV
       ? filterDisabledCSV(
           flattenObject({
-            doc,
+            data: doc as Record<string, unknown>,
             fields,
-            toCSVFunctions,
+            format,
+            exportFieldHooks,
+            req,
           }),
         )
-      : filterDisabledJSON(doc)
+      : (filterDisabledJSON(
+          applyFieldHooks({
+            data: doc as Record<string, unknown>,
+            fieldHooks: exportFieldHooks,
+            fields: collectionConfig.flattenedFields,
+            format,
+            operation: 'export',
+            req,
+            type: 'beforeExport',
+          }),
+        ) as Record<string, unknown>)
 
   // Skip fetching if access was denied - we'll create an empty export
   let exportResult = {
@@ -443,10 +534,12 @@ export const createExport = async (args: CreateExportArgs) => {
       collectionSlug,
       findArgs: findArgs as ExportFindArgs,
       format,
+      hooks: exportHooks,
       maxDocs:
         typeof maxExportDocuments === 'number' ? maxExportDocuments : Number.POSITIVE_INFINITY,
       req,
       startPage: adjustedPage,
+      totalDocs,
       transformDoc,
     })
   }
@@ -472,7 +565,13 @@ export const createExport = async (args: CreateExportArgs) => {
 
     // Merge schema columns with data-discovered columns
     // Schema provides ordering, data provides additional columns (e.g., array indices > 0)
-    const finalColumns = mergeColumns(schemaColumns, dataColumns)
+    // When a before hook is active and rows exist, restrict to columns actually present in the data
+    // so that the hook can remove fields by not returning them
+    const mergedColumns = mergeColumns(schemaColumns, dataColumns)
+    const finalColumns =
+      Boolean(exportHooks?.before) && rows.length > 0
+        ? mergedColumns.filter((col) => dataColumns.includes(col))
+        : mergedColumns
 
     const paddedRows = rows.map((row) => {
       const fullRow: Record<string, unknown> = {}

--- a/packages/plugin-import-export/src/export/handlePreview.ts
+++ b/packages/plugin-import-export/src/export/handlePreview.ts
@@ -1,9 +1,9 @@
-import type { FlattenedField, PayloadRequest, Where } from 'payload'
+import type { PayloadRequest, Sort, Where } from 'payload'
 
 import { addDataAndFileToRequest } from 'payload'
 import { getObjectDotNotation } from 'payload/shared'
 
-import type { ExportPreviewResponse } from '../types.js'
+import type { ExportBeforeHook, ExportPreviewResponse } from '../types.js'
 
 import {
   DEFAULT_PREVIEW_LIMIT,
@@ -11,6 +11,7 @@ import {
   MIN_PREVIEW_LIMIT,
   MIN_PREVIEW_PAGE,
 } from '../constants.js'
+import { applyFieldHooks } from '../utilities/applyFieldHooks.js'
 import { flattenObject } from '../utilities/flattenObject.js'
 import { getExportFieldFunctions } from '../utilities/getExportFieldFunctions.js'
 import { getFlattenedFieldKeys } from '../utilities/getFlattenedFieldKeys.js'
@@ -19,6 +20,26 @@ import { getSelect } from '../utilities/getSelect.js'
 import { removeDisabledFields } from '../utilities/removeDisabledFields.js'
 import { resolveLimit } from '../utilities/resolveLimit.js'
 import { setNestedValue } from '../utilities/setNestedValue.js'
+
+const applyExportBeforeHook = async (
+  hook: ExportBeforeHook | undefined,
+  data: Record<string, unknown>[],
+  originalDocs: unknown[],
+  format: 'csv' | 'json' | ({} & string),
+  req: PayloadRequest,
+): Promise<Record<string, unknown>[]> => {
+  if (!hook || data.length === 0) {
+    return data
+  }
+  return hook({
+    batchNumber: 1,
+    data,
+    format,
+    originalData: originalDocs as Record<string, unknown>[],
+    req,
+    totalBatches: 1,
+  })
+}
 
 export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
   await addDataAndFileToRequest(req)
@@ -42,8 +63,8 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
     locale?: string
     previewLimit?: number
     previewPage?: number
-    sort?: any
-    where?: any
+    sort?: Sort
+    where?: Where
   }
 
   // Validate and clamp pagination values to safe bounds
@@ -178,29 +199,31 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
   // Transform docs based on format
   let transformed: Record<string, unknown>[]
 
-  if (isCSV) {
-    const toCSVFunctions = getExportFieldFunctions({
-      fields: targetCollection.config.fields as FlattenedField[],
-    })
+  const exportFieldHooks = getExportFieldFunctions({
+    fields: targetCollection.config.flattenedFields,
+  })
 
-    const possibleKeys = getFlattenedFieldKeys(
-      targetCollection.config.fields as FlattenedField[],
-      '',
-      { localeCodes },
-    )
+  const exportHooks = targetCollection.config.custom?.['plugin-import-export']?.exportHooks
+
+  if (isCSV) {
+    const possibleKeys = getFlattenedFieldKeys(targetCollection.config.flattenedFields, '', {
+      localeCodes,
+    })
 
     // Flatten docs without padding yet. This preserves the exact keys produced by toCSV hooks,
     // allowing mergeColumns to detect which schema columns were replaced with derived ones.
     transformed = docs.map((doc) =>
       flattenObject({
-        doc,
+        data: doc,
+        exportFieldHooks,
         fields,
-        toCSVFunctions,
+        format: 'csv',
+        req,
       }),
     )
 
-    // Merge schema columns with data-discovered columns (e.g., derived columns from toCSV)
-    // This ensures the preview headers match what the actual export will produce
+    transformed = await applyExportBeforeHook(exportHooks?.before, transformed, docs, 'csv', req)
+
     if (schemaColumns && transformed.length > 0) {
       const dataColumns: string[] = []
       const seenCols = new Set<string>()
@@ -212,7 +235,11 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
           }
         }
       }
-      columns = mergeColumns(schemaColumns, dataColumns)
+      const mergedColumns = mergeColumns(schemaColumns, dataColumns)
+      columns =
+        Boolean(exportHooks?.before) && transformed.length > 0
+          ? mergedColumns.filter((col) => dataColumns.includes(col))
+          : mergedColumns
     }
 
     // Pad rows with null for missing columns (uses merged columns, not raw schema)
@@ -228,9 +255,18 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
     }
   } else {
     transformed = docs.map((doc) => {
-      let output: Record<string, unknown> = { ...doc }
+      // Apply field-level export hooks for JSON format
+      let output: Record<string, unknown> = applyFieldHooks({
+        type: 'beforeExport',
+        data: doc as Record<string, unknown>,
+        fieldHooks: exportFieldHooks,
+        fields: targetCollection.config.flattenedFields,
+        format: 'json',
+        operation: 'export',
+        req,
+      })
 
-      // Remove disabled fields first
+      // Remove disabled fields
       output = removeDisabledFields(output, disabledFields)
 
       // Then trim to selected fields only (if fields are provided)
@@ -247,6 +283,8 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
 
       return output
     })
+
+    transformed = await applyExportBeforeHook(exportHooks?.before, transformed, docs, 'json', req)
   }
 
   const hasNextPage = previewPage < previewTotalPages

--- a/packages/plugin-import-export/src/exports/types.ts
+++ b/packages/plugin-import-export/src/exports/types.ts
@@ -1,1 +1,14 @@
-export type { ImportExportPluginConfig, Limit, LimitFunction, ToCSVFunction } from '../types.js'
+export type {
+  ExportAfterHook,
+  ExportBeforeHook,
+  FieldBeforeExportHook,
+  FieldBeforeImportHook,
+  FromCSVFunction,
+  ImportAfterHook,
+  ImportBeforeHook,
+  ImportExportPluginConfig,
+  ImportResult,
+  Limit,
+  LimitFunction,
+  ToCSVFunction,
+} from '../types.js'

--- a/packages/plugin-import-export/src/import/batchProcessor.ts
+++ b/packages/plugin-import-export/src/import/batchProcessor.ts
@@ -2,7 +2,8 @@ import type { PayloadRequest, TypedUser } from 'payload'
 
 import { isolateObjectProperty } from 'payload'
 
-import type { ImportMode, ImportResult } from './createImport.js'
+import type { ImportAfterHook, ImportBeforeHook, ImportResult } from '../types.js'
+import type { ImportMode } from './createImport.js'
 
 import {
   type BatchError,
@@ -47,10 +48,21 @@ export interface ImportBatchResult {
  */
 export interface ImportProcessOptions {
   collectionSlug: string
-  documents: Record<string, unknown>[]
+  docs: Record<string, unknown>[]
+  /** Export format — passed through to hook args */
+  format?: 'csv' | 'json'
+  /** Lifecycle hooks for this import operation */
+  hooks?: {
+    after?: ImportAfterHook
+    before?: ImportBeforeHook
+  }
   importMode: ImportMode
   matchField?: string
+  /** Raw parsed rows before unflattening — used as originalData in hooks */
+  originalDocs?: Record<string, unknown>[]
   req: PayloadRequest
+  /** Total number of batches (pre-computed for hook args) */
+  totalBatches?: number
   user?: TypedUser
 }
 
@@ -238,22 +250,19 @@ async function processImportBatch({
             user,
           })
 
-          // Update for other locales
           if (savedDocument && Object.keys(localeUpdates).length > 0) {
             for (const [locale, localeData] of Object.entries(localeUpdates)) {
               try {
-                const localeReq = { ...req, locale }
                 await req.payload.update({
                   id: savedDocument.id as number | string,
                   collection: collectionSlug,
                   data: localeData,
                   draft: collectionHasVersions ? false : undefined,
                   overrideAccess: false,
-                  req: localeReq,
+                  req: { ...req, locale },
                   user,
                 })
               } catch (error) {
-                // Log but don't fail the entire import if a locale update fails
                 req.payload.logger.error({
                   err: error,
                   msg: `Failed to update locale ${locale} for document ${String(savedDocument.id)}`,
@@ -386,24 +395,19 @@ async function processImportBatch({
               user,
             })
 
-            // Update for other locales
             if (savedDocument && Object.keys(localeUpdates).length > 0) {
               for (const [locale, localeData] of Object.entries(localeUpdates)) {
                 try {
-                  // Clone the request with the specific locale
-                  const localeReq = { ...req, locale }
                   await req.payload.update({
                     id: existingDoc.id as number | string,
                     collection: collectionSlug,
                     data: localeData,
                     depth: 0,
-                    // Don't specify draft - this creates a new draft for versioned collections
                     overrideAccess: false,
-                    req: localeReq,
+                    req: { ...req, locale },
                     user,
                   })
                 } catch (error) {
-                  // Log but don't fail the entire import if a locale update fails
                   req.payload.logger.error({
                     err: error,
                     msg: `Failed to update locale ${locale} for document ${String(existingDoc.id)}`,
@@ -499,22 +503,19 @@ async function processImportBatch({
               user,
             })
 
-            // Update for other locales
             if (savedDocument && Object.keys(localeUpdates).length > 0) {
               for (const [locale, localeData] of Object.entries(localeUpdates)) {
                 try {
-                  // Clone the request with the specific locale
-                  const localeReq = { ...req, locale }
                   await req.payload.update({
                     id: savedDocument.id as number | string,
                     collection: collectionSlug,
                     data: localeData,
                     draft: collectionHasVersions ? false : undefined,
                     overrideAccess: false,
-                    req: localeReq,
+                    req: { ...req, locale },
+                    user,
                   })
                 } catch (error) {
-                  // Log but don't fail the entire import if a locale update fails
                   req.payload.logger.error({
                     err: error,
                     msg: `Failed to update locale ${locale} for document ${String(savedDocument.id)}`,
@@ -610,8 +611,20 @@ export function createImportBatchProcessor(options: ImportBatchProcessorOptions 
   }
 
   const processImport = async (processOptions: ImportProcessOptions): Promise<ImportResult> => {
-    const { collectionSlug, documents, importMode, matchField, req, user } = processOptions
+    const {
+      collectionSlug,
+      docs: documents,
+      format = 'csv',
+      hooks,
+      importMode,
+      matchField,
+      originalDocs: originalDocs,
+      req,
+      totalBatches: totalBatchesFromOptions,
+      user,
+    } = processOptions
     const batches = createBatches(documents, processorOptions.batchSize)
+    const totalBatches = totalBatchesFromOptions ?? batches.length
 
     const result: ImportResult = {
       errors: [],
@@ -626,8 +639,26 @@ export function createImportBatchProcessor(options: ImportBatchProcessorOptions 
         continue
       }
 
+      const batchNumber = i + 1
+      const batchStart = i * processorOptions.batchSize
+      const originalBatch = originalDocs
+        ? originalDocs.slice(batchStart, batchStart + currentBatch.length)
+        : currentBatch
+
+      const batchToProcess: Record<string, unknown>[] =
+        hooks?.before && currentBatch.length > 0
+          ? ((await hooks.before({
+              batchNumber,
+              data: currentBatch as Parameters<ImportBeforeHook>[0]['data'],
+              format,
+              originalData: originalBatch,
+              req,
+              totalBatches,
+            })) as Record<string, unknown>[])
+          : currentBatch
+
       const batchResult = await processImportBatch({
-        batch: currentBatch,
+        batch: batchToProcess,
         batchIndex: i,
         collectionSlug,
         importMode,
@@ -637,18 +668,23 @@ export function createImportBatchProcessor(options: ImportBatchProcessorOptions 
         user,
       })
 
-      // Update results
+      let batchImported = 0
+      let batchUpdated = 0
       for (const success of batchResult.successful) {
         if (success.operation === 'created') {
           result.imported++
+          batchImported++
         } else if (success.operation === 'updated') {
           result.updated++
+          batchUpdated++
         } else {
           // Fallback
           if (importMode === 'create') {
             result.imported++
+            batchImported++
           } else {
             result.updated++
+            batchUpdated++
           }
         }
       }
@@ -658,6 +694,24 @@ export function createImportBatchProcessor(options: ImportBatchProcessorOptions 
           doc: error.documentData,
           error: error.error,
           index: error.rowNumber - 1, // Convert back to 0-indexed
+        })
+      }
+
+      if (hooks?.after) {
+        const batchHookResult: ImportResult = {
+          errors:
+            batchResult.failed.length > 0 ? result.errors.slice(-batchResult.failed.length) : [],
+          imported: batchImported,
+          total: batchToProcess.length,
+          updated: batchUpdated,
+        }
+        await hooks.after({
+          batchNumber,
+          format,
+          originalData: originalBatch,
+          req,
+          result: batchHookResult,
+          totalBatches,
         })
       }
     }

--- a/packages/plugin-import-export/src/import/createImport.ts
+++ b/packages/plugin-import-export/src/import/createImport.ts
@@ -2,6 +2,9 @@ import type { PayloadRequest, TypedUser } from 'payload'
 
 import { APIError } from 'payload'
 
+import type { ImportResult } from '../types.js'
+
+import { applyFieldHooks } from '../utilities/applyFieldHooks.js'
 import { getImportFieldFunctions } from '../utilities/getImportFieldFunctions.js'
 import { parseCSV } from '../utilities/parseCSV.js'
 import { parseJSON } from '../utilities/parseJSON.js'
@@ -49,17 +52,6 @@ export type CreateImportArgs = {
   req: PayloadRequest
 } & Import
 
-export type ImportResult = {
-  errors: Array<{
-    doc: Record<string, unknown>
-    error: string
-    index: number
-  }>
-  imported: number
-  total: number
-  updated: number
-}
-
 export const createImport = async ({
   batchSize = 100,
   collectionSlug,
@@ -94,7 +86,7 @@ export const createImport = async ({
       format,
       importMode,
       matchField,
-      message: 'Starting import process with args:',
+      msg: 'Starting import process with args:',
       transactionID: req.transactionID, // Log transaction ID to verify we're in same transaction
     })
   }
@@ -111,8 +103,8 @@ export const createImport = async ({
     req.payload.logger.debug({
       fileName: file.name,
       fileSize: file.data.length,
-      message: 'File info',
       mimeType: file.mimetype,
+      msg: 'File info',
     })
   }
 
@@ -131,12 +123,15 @@ export const createImport = async ({
   const disabledFields =
     collectionConfig.admin?.custom?.['plugin-import-export']?.disabledFields ?? []
 
+  const importHooks = collectionConfig.custom?.['plugin-import-export']?.importHooks
+
   // Get fromCSV functions for field transformations
-  const fromCSVFunctions = getImportFieldFunctions({
+  const importFieldHooks = getImportFieldFunctions({
     fields: collectionConfig.flattenedFields || [],
   })
 
   // Parse the file data
+  let originalDocs: Record<string, unknown>[] | undefined
   let documents: Record<string, unknown>[]
   if (format === 'csv') {
     const rawData = await parseCSV({
@@ -144,25 +139,7 @@ export const createImport = async ({
       req,
     })
 
-    // Debug logging
-    if (debug && rawData.length > 0) {
-      req.payload.logger.info({
-        firstRow: rawData[0], // Show the complete first row
-        msg: 'Parsed CSV data - FULL',
-      })
-      req.payload.logger.info({
-        msg: 'Parsed CSV data',
-        rows: rawData.map((row, i) => ({
-          excerpt: row.excerpt,
-          hasManyNumber: row.hasManyNumber, // Add this to see what we get from CSV
-          hasOnePolymorphic_id: row.hasOnePolymorphic_id,
-          hasOnePolymorphic_relationTo: row.hasOnePolymorphic_relationTo,
-          index: i,
-          title: row.title,
-        })),
-      })
-    }
-
+    originalDocs = rawData
     documents = rawData
 
     // Unflatten CSV data
@@ -171,56 +148,46 @@ export const createImport = async ({
         const unflattened = unflattenObject({
           data: doc,
           fields: collectionConfig.flattenedFields ?? [],
-          fromCSVFunctions,
+          format,
+          importFieldHooks,
           req,
         })
         return unflattened ?? {}
       })
       .filter((doc) => doc && Object.keys(doc).length > 0)
 
-    // Debug after unflatten
-    if (debug && documents.length > 0) {
-      req.payload.logger.info({
-        msg: 'After unflatten',
-        rows: documents.map((row, i) => ({
-          hasManyNumber: row.hasManyNumber, // Add this to see the actual value
-          hasManyPolymorphic: row.hasManyPolymorphic,
-          hasOnePolymorphic: row.hasOnePolymorphic,
-          hasTitle: 'title' in row,
-          index: i,
-          title: row.title,
-        })),
-      })
-    }
-
     if (debug) {
       req.payload.logger.debug({
         documentCount: documents.length,
-        message: 'After unflattening CSV',
+        msg: 'After unflattening CSV',
         rawDataCount: rawData.length,
       })
-
-      // Debug: show a sample of raw vs unflattened
-      if (rawData.length > 0 && documents.length > 0) {
-        req.payload.logger.debug({
-          message: 'Sample data transformation',
-          raw: Object.keys(rawData[0] || {}).filter((k) => k.includes('localized')),
-          unflattened: JSON.stringify(documents[0], null, 2),
-        })
-      }
     }
   } else {
-    documents = parseJSON({ data: file.data, req })
+    const parsedDocs = parseJSON({ data: file.data, req })
+    originalDocs = parsedDocs
+    // Apply field-level import hooks for JSON format
+    documents = parsedDocs.map((doc) =>
+      applyFieldHooks({
+        type: 'beforeImport',
+        data: doc,
+        fieldHooks: importFieldHooks,
+        fields: collectionConfig.flattenedFields ?? [],
+        format,
+        operation: 'import',
+        req,
+      }),
+    )
   }
 
   if (debug) {
     req.payload.logger.debug({
-      message: `Parsed ${documents.length} documents from ${format} file`,
+      msg: `Parsed ${documents.length} documents from ${format} file`,
     })
     if (documents.length > 0) {
       req.payload.logger.debug({
         doc: documents[0],
-        message: 'First document sample:',
+        msg: 'First document sample:',
       })
     }
   }
@@ -244,7 +211,7 @@ export const createImport = async ({
     req.payload.logger.debug({
       batchSize,
       documentCount: documents.length,
-      message: 'Processing import in batches',
+      msg: 'Processing import in batches',
     })
   }
 
@@ -254,13 +221,19 @@ export const createImport = async ({
     defaultVersionStatus,
   })
 
+  const totalBatches = documents.length > 0 ? Math.ceil(documents.length / batchSize) : 1
+
   // Process import with batch processor
   const result = await processor.processImport({
     collectionSlug,
-    documents,
+    docs: documents,
+    format,
+    hooks: importHooks,
     importMode,
     matchField,
+    originalDocs,
     req,
+    totalBatches,
     user,
   })
 
@@ -268,7 +241,7 @@ export const createImport = async ({
     req.payload.logger.info({
       errors: result.errors.length,
       imported: result.imported,
-      message: 'Import completed',
+      msg: 'Import completed',
       total: result.total,
       updated: result.updated,
     })

--- a/packages/plugin-import-export/src/import/handlePreview.ts
+++ b/packages/plugin-import-export/src/import/handlePreview.ts
@@ -10,6 +10,7 @@ import {
   MIN_PREVIEW_LIMIT,
   MIN_PREVIEW_PAGE,
 } from '../constants.js'
+import { applyFieldHooks } from '../utilities/applyFieldHooks.js'
 import { getImportFieldFunctions } from '../utilities/getImportFieldFunctions.js'
 import { parseCSV } from '../utilities/parseCSV.js'
 import { parseJSON } from '../utilities/parseJSON.js'
@@ -60,15 +61,16 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
   try {
     // Parse the file data
     let parsedData: Record<string, unknown>[]
+    let originalDocs: Record<string, unknown>[] = []
     const buffer = Buffer.from(fileData, 'base64')
+
+    const importFieldHooks = getImportFieldFunctions({
+      fields: targetCollection.config.flattenedFields || [],
+    })
 
     if (format === 'csv') {
       const rawData = await parseCSV({ data: buffer, req })
-
-      // Get fromCSV functions for field transformations
-      const fromCSVFunctions = getImportFieldFunctions({
-        fields: targetCollection.config.flattenedFields || [],
-      })
+      originalDocs = rawData
 
       // Unflatten CSV data
       parsedData = rawData
@@ -76,14 +78,41 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
           const unflattened = unflattenObject({
             data: doc,
             fields: targetCollection.config.flattenedFields ?? [],
-            fromCSVFunctions,
+            format: 'csv',
+            importFieldHooks,
             req,
           })
           return unflattened ?? {}
         })
         .filter((doc) => doc && Object.keys(doc).length > 0)
     } else {
-      parsedData = parseJSON({ data: buffer, req })
+      const parsedDocs = parseJSON({ data: buffer, req })
+      originalDocs = parsedDocs
+      // Apply field-level import hooks for JSON format
+      parsedData = parsedDocs.map((doc) =>
+        applyFieldHooks({
+          type: 'beforeImport',
+          data: doc,
+          fieldHooks: importFieldHooks,
+          fields: targetCollection.config.flattenedFields ?? [],
+          format: 'json',
+          operation: 'import',
+          req,
+        }),
+      )
+    }
+
+    const importHooks = targetCollection.config.custom?.['plugin-import-export']?.importHooks
+    if (importHooks?.before && parsedData.length > 0) {
+      const result = await importHooks.before({
+        batchNumber: 1,
+        data: parsedData as unknown as Parameters<typeof importHooks.before>[0]['data'],
+        format: format ?? 'csv',
+        originalData: originalDocs,
+        req,
+        totalBatches: 1,
+      })
+      parsedData = result as unknown as Record<string, unknown>[]
     }
 
     // Remove disabled fields from the documents

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -4,7 +4,13 @@ import { deepMergeSimple } from 'payload'
 
 import type { PluginDefaultTranslationsObject } from './translations/types.js'
 import type {
+  ExportAfterHook,
+  ExportBeforeHook,
+  FieldBeforeExportHook,
+  FieldBeforeImportHook,
   FromCSVFunction,
+  ImportAfterHook,
+  ImportBeforeHook,
   ImportExportPluginConfig,
   Limit,
   PluginCollectionConfig,
@@ -17,6 +23,16 @@ import { translations } from './translations/index.js'
 import { collectDisabledFieldPaths } from './utilities/collectDisabledFieldPaths.js'
 import { getPluginCollections } from './utilities/getPluginCollections.js'
 
+/**
+ * Adds CSV/JSON import and export functionality to selected collections.
+ *
+ * Registers two upload collections (`exports`, `imports`) that drive the admin
+ * UI flow, plus the `createCollectionExport` and `createCollectionImport` jobs
+ * that run the work asynchronously. Per-collection settings (batch size, limits,
+ * format, lifecycle hooks, override) live on each entry of `collections`.
+ *
+ * @see https://payloadcms.com/docs/plugins/import-export
+ */
 export const importExportPlugin =
   (pluginConfig: ImportExportPluginConfig) =>
   async (config: Config): Promise<Config> => {
@@ -148,9 +164,11 @@ export const importExportPlugin =
       const importBatchSize = importConfig?.batchSize
 
       const exportLimit = exportConfig?.limit ?? pluginConfig.exportLimit
+      const exportHooks = exportConfig?.hooks
 
       const importLimit = importConfig?.limit ?? pluginConfig.importLimit
       const importDefaultVersionStatus = importConfig?.defaultVersionStatus
+      const importHooks = importConfig?.hooks
 
       collection.admin.custom = {
         ...(collection.admin.custom || {}),
@@ -180,6 +198,8 @@ export const importExportPlugin =
           ...(importDefaultVersionStatus !== undefined && {
             defaultVersionStatus: importDefaultVersionStatus,
           }),
+          ...(exportHooks !== undefined && { exportHooks }),
+          ...(importHooks !== undefined && { importHooks }),
         },
       }
 
@@ -220,9 +240,30 @@ declare module 'payload' {
        * @default false
        */
       disabled?: boolean
+      /**
+       * @deprecated use `hooks.beforeImport` instead.
+       * Still functional, but will be removed in a future major version.
+       */
       fromCSV?: FromCSVFunction
       /**
-       * Custom function used to modify the outgoing csv data by manipulating the data, siblingData or by returning the desired value
+       * Field-level lifecycle hooks for import/export transformations.
+       * Works for both CSV and JSON formats.
+       */
+      hooks?: {
+        /**
+         * Runs before a field value is exported. Return a transformed value,
+         * `undefined` to use default behavior, or mutate `siblingData` to add
+         * extra columns at the same level.
+         */
+        beforeExport?: FieldBeforeExportHook
+        /**
+         * Runs before a field value is imported. Return the transformed value.
+         */
+        beforeImport?: FieldBeforeImportHook
+      }
+      /**
+       * @deprecated use `hooks.beforeExport` instead.
+       * Still functional, but will be removed in a future major version.
        */
       toCSV?: ToCSVFunction
     }
@@ -257,9 +298,17 @@ declare module 'payload' {
   }
 
   export interface CollectionCustom {
+    /**
+     * @internal
+     * Server-side storage for resolved plugin config. Users should configure
+     * import/export via `importExportPlugin({ collections: [{ slug, export: { ... }, import: { ... } }] })`.
+     * These fields are populated automatically and are not part of the public
+     * API — the names here intentionally diverge from the user-facing nested
+     * `export.hooks` / `import.hooks` config and may change without notice.
+     */
     'plugin-import-export'?: {
       /**
-       * Default version status for imported documents when _status field is not provided.
+       * @internal Default version status for imported documents when _status field is not provided.
        * Only applies to collections with versions enabled.
        * @default 'published'
        */
@@ -274,6 +323,11 @@ declare module 'payload' {
        * @default false
        */
       exportDisableJobsQueue?: boolean
+      /**
+       * Lifecycle hooks for export operations. Stored server-side since functions
+       * cannot be serialized to the client.
+       */
+      exportHooks?: { after?: ExportAfterHook; before?: ExportBeforeHook }
       /**
        * Maximum number of documents that can be exported from this collection.
        * Set to 0 for unlimited (default). Can be a number or function.
@@ -290,6 +344,11 @@ declare module 'payload' {
        * @default false
        */
       importDisableJobsQueue?: boolean
+      /**
+       * Lifecycle hooks for import operations. Stored server-side since functions
+       * cannot be serialized to the client.
+       */
+      importHooks?: { after?: ImportAfterHook; before?: ImportBeforeHook }
       /**
        * Maximum number of documents that can be imported to this collection.
        * Set to 0 for unlimited (default). Can be a number or function.

--- a/packages/plugin-import-export/src/types.ts
+++ b/packages/plugin-import-export/src/types.ts
@@ -1,4 +1,9 @@
-import type { CollectionConfig, CollectionSlug, PayloadRequest } from 'payload'
+import type {
+  CollectionConfig,
+  CollectionSlug,
+  DataFromCollectionSlug,
+  PayloadRequest,
+} from 'payload'
 
 /**
  * Function to dynamically determine the limit based on request context
@@ -20,7 +25,117 @@ export type CollectionOverride = ({
   collection: CollectionConfig
 }) => CollectionConfig | Promise<CollectionConfig>
 
-export type ExportConfig = {
+/**
+ * Result of a completed import operation (or a single batch within one)
+ */
+export type ImportResult = {
+  errors: Array<{
+    doc: Record<string, unknown>
+    error: string
+    index: number
+  }>
+  imported: number
+  total: number
+  updated: number
+}
+
+/**
+ * Hook called before each export batch is written to file.
+ * Receives the transformed batch data and the original DB documents.
+ * Return the modified data array — it replaces `data` for the write step.
+ */
+export type ExportBeforeHook<TSlug extends CollectionSlug = CollectionSlug> = (args: {
+  /** Current batch number, starting at 1 */
+  batchNumber: number
+  /** Transformed batch — flat rows for CSV, nested docs for JSON. Modify and return this. */
+  data: Record<string, unknown>[]
+  /** Export format. Open-ended to support custom formats in the future. */
+  format: 'csv' | 'json' | ({} & string)
+  /**
+   * Raw DB documents before format-specific transformation. Read-only reference.
+   *
+   * Typed as a union so call sites that don't know the collection slug at
+   * compile time (e.g. job tasks) don't need `as any` casts. To get the
+   * narrower typed shape, declare your hook with a slug:
+   * `const hook: ExportBeforeHook<'posts'> = (args) => { ... }`.
+   */
+  originalData: DataFromCollectionSlug<TSlug>[] | Record<string, unknown>[]
+  req: PayloadRequest
+  /** Total number of batches for this export operation */
+  totalBatches: number
+}) => Promise<Record<string, unknown>[]> | Record<string, unknown>[]
+
+/**
+ * Hook called after each export batch has been written to file.
+ * For logging and observability only — return value is ignored.
+ */
+export type ExportAfterHook = (args: {
+  /** Current batch number, starting at 1 */
+  batchNumber: number
+  /** The batch data that was written */
+  data: Record<string, unknown>[]
+  /** Export format */
+  format: 'csv' | 'json' | ({} & string)
+  /** Raw DB documents before transformation */
+  originalData: Record<string, unknown>[]
+  req: PayloadRequest
+  /** Total number of batches for this export operation */
+  totalBatches: number
+}) => Promise<void> | void
+
+/**
+ * Hook called before each import batch is written to the database.
+ * Receives the processed (unflattened) documents and the raw file rows.
+ * Return the modified documents array — it replaces `data` for the DB write step.
+ */
+export type ImportBeforeHook<TSlug extends CollectionSlug = CollectionSlug> = (args: {
+  /** Current batch number, starting at 1 */
+  batchNumber: number
+  /**
+   * Unflattened documents ready to be written to the database. Modify and
+   * return this. Typed as `Partial<...>` because rows from a CSV or JSON
+   * import are not guaranteed to include every required field of the
+   * collection — required fields are validated at write time.
+   */
+  data: Partial<DataFromCollectionSlug<TSlug>>[]
+  /** Import format. Open-ended to support custom formats in the future. */
+  format: 'csv' | 'json' | ({} & string)
+  /** Raw parsed file rows before unflattening. Read-only reference. */
+  originalData: Record<string, unknown>[]
+  req: PayloadRequest
+  /** Total number of batches for this import operation */
+  totalBatches: number
+}) => Partial<DataFromCollectionSlug<TSlug>>[] | Promise<Partial<DataFromCollectionSlug<TSlug>>[]>
+
+/**
+ * Hook called after each import batch has been written to the database.
+ * For logging and observability only — return value is ignored.
+ */
+export type ImportAfterHook = (args: {
+  /** Current batch number, starting at 1 */
+  batchNumber: number
+  /** Import format */
+  format: 'csv' | 'json' | ({} & string)
+  /**
+   * Raw parsed file rows for this batch before unflattening and before-hook
+   * transformation. For CSV this is the flat key/value row; for JSON this is
+   * the top-level parsed document. Read-only reference.
+   */
+  originalData: Record<string, unknown>[]
+  req: PayloadRequest
+  /** Result of this batch — counts and errors. Not the cumulative total. */
+  result: ImportResult
+  /** Total number of batches for this import operation */
+  totalBatches: number
+}) => Promise<void> | void
+
+/**
+ * Per-collection export configuration. Set on each entry of
+ * ```
+ * importExportPlugin({ collections: [{ slug, export: { ... } }] })
+ * ```
+ */
+export type ExportConfig<TSlug extends CollectionSlug = CollectionSlug> = {
   /**
    * Number of documents to process in each batch during export. This config is applied to both jobs and synchronous exports.
    *
@@ -50,6 +165,22 @@ export type ExportConfig = {
    */
   format?: 'csv' | 'json'
   /**
+   * Lifecycle hooks for export operations on this collection.
+   * Hooks fire once per batch.
+   */
+  hooks?: {
+    /**
+     * Called after each batch is written to file. For logging/observability only.
+     * Return value is ignored.
+     */
+    after?: ExportAfterHook
+    /**
+     * Called before each batch is written to file.
+     * Return value replaces the batch data for the write step.
+     */
+    before?: ExportBeforeHook<TSlug>
+  }
+  /**
    * Maximum number of documents that can be exported in a single operation.
    * Can be a number or a function that returns a number based on request context.
    * Set to 0 for unlimited (default). Overrides the global exportLimit if set.
@@ -63,7 +194,13 @@ export type ExportConfig = {
   overrideCollection?: CollectionOverride
 }
 
-export type ImportConfig = {
+/**
+ * Per-collection import configuration. Set on each entry of
+ * ```
+ * importExportPlugin({ collections: [{ slug, import: { ... } }] })
+ * ```
+ */
+export type ImportConfig<TSlug extends CollectionSlug = CollectionSlug> = {
   /**
    * Number of documents to process in each batch during import. This config is applied to both jobs and synchronous imports.
    *
@@ -82,6 +219,22 @@ export type ImportConfig = {
    */
   disableJobsQueue?: boolean
   /**
+   * Lifecycle hooks for import operations on this collection.
+   * Hooks fire once per batch.
+   */
+  hooks?: {
+    /**
+     * Called after each batch is written to the database. For logging/observability only.
+     * Return value is ignored.
+     */
+    after?: ImportAfterHook
+    /**
+     * Called before each batch is written to the database.
+     * Return value replaces the batch data for the DB write step.
+     */
+    before?: ImportBeforeHook<TSlug>
+  }
+  /**
    * Maximum number of documents that can be imported in a single operation.
    * Can be a number or a function that returns a number based on request context.
    * Set to 0 for unlimited (default). Overrides the global importLimit if set.
@@ -95,23 +248,27 @@ export type ImportConfig = {
   overrideCollection?: CollectionOverride
 }
 
-export type PluginCollectionConfig = {
+/**
+ * Per-collection plugin entry. Identifies a target collection by `slug` and
+ * configures its export/import behavior; either side can be disabled with `false`.
+ */
+export type PluginCollectionConfig<TSlug extends CollectionSlug = CollectionSlug> = {
   /**
    * Override the import collection for this collection or disable it entirely with `false`.
    *
    * @default true
    */
-  export?: boolean | ExportConfig
+  export?: boolean | ExportConfig<TSlug>
   /**
    * Override the export collection for this collection or disable it entirely with `false`.
    *
    * @default true
    */
-  import?: boolean | ImportConfig
+  import?: boolean | ImportConfig<TSlug>
   /**
    * Target collection's slug for import/export functionality
    */
-  slug: CollectionSlug
+  slug: TSlug
 }
 
 /**
@@ -130,7 +287,7 @@ export type ImportExportPluginConfig = {
    * If not specified, all collections will have import/export enabled.
    * @default undefined (all collections)
    */
-  collections: PluginCollectionConfig[]
+  collections: PluginCollectionConfig<CollectionSlug>[]
 
   /**
    * Enable debug logging for troubleshooting import/export operations
@@ -180,53 +337,81 @@ export type ImportExportPluginConfig = {
 }
 
 /**
- * Custom function used to modify the outgoing csv data by manipulating the data, siblingData or by returning the desired value
+ * Field-level hook that runs before a field value is exported. Works for both
+ * CSV and JSON. Return a value to replace the field, or `undefined` to fall
+ * back to default behavior. Mutate `siblingData` to add or remove columns at
+ * the same level.
+ *
+ * Return `null` (CSV only) when the hook has already written its replacement
+ * columns to `siblingData` and default flattening should be skipped — used by
+ * built-in handlers for polymorphic relationships to avoid duplicate columns.
  */
-export type ToCSVFunction = (args: {
-  /**
-   * The path of the column for the field, for arrays this includes the index (zero-based)
-   */
+export type FieldBeforeExportHook = (args: {
+  /** Runtime column path, underscore-separated (includes array indices, e.g. `items_0_note`). */
   columnName: string
-  /**
-   * Alias for `row`, the object that accumulates CSV output.
-   * Use this to write additional fields into the exported row.
-   */
+  /** The top-level document being exported. */
   data: Record<string, unknown>
-  /**
-   * The top level document
-   */
-  doc: Document
-  /**
-   * The object data that can be manipulated to assign data to the CSV
-   */
-  row: Record<string, unknown>
-  /**
-   * The document data at the level where it belongs
-   */
+  format: 'csv' | 'json' | ({} & string)
+  /** Writable output at the current level. CSV: the flat row accumulator. JSON: the sibling output object. */
+  siblingData: Record<string, unknown>
+  /** Read-only source at the current level, before any transformation. */
   siblingDoc: Record<string, unknown>
-  /**
-   * The data for the field.
-   */
   value: unknown
 }) => unknown
 
 /**
- * Custom function used to transform incoming CSV data during import
+ * Field-level hook that runs before a field value is imported. Works for both
+ * CSV and JSON. Return the transformed value to use for this field.
  */
-export type FromCSVFunction = (args: {
-  /**
-   * The path of the column for the field
-   */
+export type FieldBeforeImportHook = (args: {
   columnName: string
-  /**
-   * The current row data being processed
-   */
+  /** Full flat row (CSV) or top-level parsed document (JSON). */
   data: Record<string, unknown>
-  /**
-   * The value being imported for this field
-   */
+  format: 'csv' | 'json' | ({} & string)
+  /** Data at the current level. CSV: same reference as `data`. JSON: the parent-level object. */
+  siblingData: Record<string, unknown>
+  /** Read-only source at the current level, before any transformation. CSV: same as `data`. */
+  siblingDoc: Record<string, unknown>
   value: unknown
 }) => unknown
+
+/**
+ * @deprecated use `hooks.beforeExport`. Will be removed in a future major version.
+ * Original arg shape preserved for backwards compatibility.
+ */
+export type ToCSVFunction = (args: {
+  columnName: string
+  /** Alias for `row`. */
+  data: Record<string, unknown>
+  /** The top-level document being exported. */
+  doc: Record<string, unknown>
+  /** Flat row accumulator at the current level. Mutate to add columns. */
+  row: Record<string, unknown>
+  /** Source document at the current level. */
+  siblingDoc: Record<string, unknown>
+  value: unknown
+}) => unknown
+
+/**
+ * @deprecated use `hooks.beforeImport`. Will be removed in a future major version.
+ * Original arg shape preserved for backwards compatibility.
+ */
+export type FromCSVFunction = (args: {
+  columnName: string
+  /** The full flat row being imported. */
+  data: Record<string, unknown>
+  value: unknown
+}) => unknown
+
+/** @internal */
+export type ExportFieldHookEntry =
+  | { fn: FieldBeforeExportHook; type: 'beforeExport' }
+  | { fn: ToCSVFunction; type: 'toCSV' }
+
+/** @internal */
+export type ImportFieldHookEntry =
+  | { fn: FieldBeforeImportHook; type: 'beforeImport' }
+  | { fn: FromCSVFunction; type: 'fromCSV' }
 
 /**
  * Base pagination data returned from preview endpoints

--- a/packages/plugin-import-export/src/utilities/applyFieldHooks.spec.ts
+++ b/packages/plugin-import-export/src/utilities/applyFieldHooks.spec.ts
@@ -1,0 +1,167 @@
+import { FlattenedField, PayloadRequest } from 'payload'
+
+import type { ExportFieldHookEntry, ImportFieldHookEntry } from '../types.js'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { applyFieldHooks } from './applyFieldHooks.js'
+
+const mockReq = {
+  payload: {
+    logger: {
+      error: vi.fn(),
+    },
+  },
+} as unknown as PayloadRequest
+
+describe('applyFieldHooks parent + child traversal', () => {
+  it('should run a parent group hook and still run child field hooks against the transformed value (export)', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'meta',
+        type: 'group',
+        flattenedFields: [{ name: 'slug', type: 'text' } as FlattenedField],
+      } as unknown as FlattenedField,
+    ]
+
+    const fieldHooks: Record<string, ExportFieldHookEntry> = {
+      meta: {
+        type: 'beforeExport',
+        fn: ({ value }) => {
+          const obj = (value ?? {}) as Record<string, unknown>
+          return { ...obj, slug: `${obj.slug ?? ''}-from-parent` }
+        },
+      },
+      meta_slug: {
+        type: 'beforeExport',
+        fn: ({ value }) => `${value}-from-child`,
+      },
+    }
+
+    const result = applyFieldHooks({
+      type: 'beforeExport',
+      data: { meta: { slug: 'raw' } },
+      fieldHooks,
+      fields,
+      format: 'json',
+      operation: 'export',
+      req: mockReq,
+    })
+
+    // Parent hook ran first ('raw' → 'raw-from-parent'), then child hook ran against
+    // the transformed value ('raw-from-parent' → 'raw-from-parent-from-child').
+    expect(result.meta).toEqual({ slug: 'raw-from-parent-from-child' })
+  })
+
+  it('should run a parent group hook and still run child field hooks (import)', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'meta',
+        type: 'group',
+        flattenedFields: [{ name: 'slug', type: 'text' } as FlattenedField],
+      } as unknown as FlattenedField,
+    ]
+
+    const fieldHooks: Record<string, ImportFieldHookEntry> = {
+      meta: {
+        type: 'beforeImport',
+        fn: ({ value }) => {
+          const obj = (value ?? {}) as Record<string, unknown>
+          return { ...obj, slug: `${obj.slug ?? ''}-from-parent` }
+        },
+      },
+      meta_slug: {
+        type: 'beforeImport',
+        fn: ({ value }) => `${value}-from-child`,
+      },
+    }
+
+    const result = applyFieldHooks({
+      type: 'beforeImport',
+      data: { meta: { slug: 'raw' } },
+      fieldHooks,
+      fields,
+      format: 'json',
+      operation: 'import',
+      req: mockReq,
+    })
+
+    expect(result.meta).toEqual({ slug: 'raw-from-parent-from-child' })
+  })
+
+  it('should run a parent array hook then child hooks for each item', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'items',
+        type: 'array',
+        flattenedFields: [{ name: 'note', type: 'text' } as FlattenedField],
+      } as unknown as FlattenedField,
+    ]
+
+    const fieldHooks: Record<string, ExportFieldHookEntry> = {
+      items: {
+        type: 'beforeExport',
+        fn: ({ value }) => {
+          if (!Array.isArray(value)) {
+            return value
+          }
+          return value.map((item) => ({
+            ...(item as Record<string, unknown>),
+            note: `${(item as Record<string, unknown>).note ?? ''}-parent`,
+          }))
+        },
+      },
+      items_note: {
+        type: 'beforeExport',
+        fn: ({ value }) => `${value}-child`,
+      },
+    }
+
+    const result = applyFieldHooks({
+      type: 'beforeExport',
+      data: { items: [{ note: 'a' }, { note: 'b' }] },
+      fieldHooks,
+      fields,
+      format: 'json',
+      operation: 'export',
+      req: mockReq,
+    })
+
+    expect(result.items).toEqual([{ note: 'a-parent-child' }, { note: 'b-parent-child' }])
+  })
+
+  it('should not recurse into children when the parent hook returns a primitive', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'meta',
+        type: 'group',
+        flattenedFields: [{ name: 'slug', type: 'text' } as FlattenedField],
+      } as unknown as FlattenedField,
+    ]
+
+    const childFn = vi.fn(({ value }: { value: unknown }) => `${value}-from-child`)
+    const fieldHooks: Record<string, ExportFieldHookEntry> = {
+      meta: {
+        type: 'beforeExport',
+        fn: () => 'serialized',
+      },
+      meta_slug: {
+        type: 'beforeExport',
+        fn: childFn,
+      },
+    }
+
+    const result = applyFieldHooks({
+      type: 'beforeExport',
+      data: { meta: { slug: 'raw' } },
+      fieldHooks,
+      fields,
+      format: 'json',
+      operation: 'export',
+      req: mockReq,
+    })
+
+    expect(result.meta).toBe('serialized')
+    expect(childFn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/plugin-import-export/src/utilities/applyFieldHooks.ts
+++ b/packages/plugin-import-export/src/utilities/applyFieldHooks.ts
@@ -1,0 +1,166 @@
+import type { FlattenedField, PayloadRequest } from 'payload'
+
+import type {
+  ExportFieldHookEntry,
+  FieldBeforeExportHook,
+  FieldBeforeImportHook,
+  ImportFieldHookEntry,
+} from '../types.js'
+
+import { isPlainObject } from './isPlainObject.js'
+
+export type FieldHook = FieldBeforeExportHook | FieldBeforeImportHook
+
+export type FieldHookEntry = ExportFieldHookEntry | ImportFieldHookEntry
+
+const joinPath = (parent: string | undefined, segment: string): string =>
+  parent ? `${parent}_${segment}` : segment
+
+export type Args = {
+  data: Record<string, unknown>
+  fieldHooks: Record<string, FieldHookEntry>
+  fields: FlattenedField[]
+  format: 'csv' | 'json' | ({} & string)
+  operation: 'export' | 'import'
+  req: PayloadRequest
+  type: 'beforeExport' | 'beforeImport'
+}
+
+const operationLabel = { export: 'Export', import: 'Import' } as const
+
+type TraverseArgs = {
+  path: string | undefined
+  schemaPath: string | undefined
+  siblingData: Record<string, unknown>
+} & Args
+
+const traverseFields = ({
+  type,
+  data,
+  fieldHooks,
+  fields,
+  format,
+  operation,
+  path,
+  req,
+  schemaPath,
+  siblingData,
+}: TraverseArgs): Record<string, unknown> => {
+  const result: Record<string, unknown> = { ...siblingData }
+
+  for (const field of fields) {
+    if (!('name' in field) || !field.name) {
+      continue
+    }
+
+    const fieldPath = joinPath(path, field.name)
+    const fieldSchemaPath = joinPath(schemaPath, field.name)
+    const entry = fieldHooks[fieldSchemaPath]
+    const hook = entry?.type === type ? (entry.fn as FieldHook) : undefined
+
+    if (typeof hook === 'function' && field.name in result) {
+      try {
+        const transformed = hook({
+          columnName: fieldPath,
+          data,
+          format,
+          siblingData: result,
+          siblingDoc: siblingData,
+          value: result[field.name],
+        })
+
+        if (typeof transformed !== 'undefined') {
+          result[field.name] = transformed
+        }
+      } catch (error) {
+        req.payload.logger.error({
+          err: error,
+          msg: `[plugin-import-export] Field-level before${operationLabel[operation]} hook for "${fieldPath}" threw — falling back to original value`,
+        })
+      }
+    }
+
+    if (!(field.name in result)) {
+      continue
+    }
+
+    const value = result[field.name]
+
+    if ((field.type === 'group' || field.type === 'tab') && isPlainObject(value)) {
+      result[field.name] = traverseFields({
+        type,
+        data,
+        fieldHooks,
+        fields: field.flattenedFields,
+        format,
+        operation,
+        path: fieldPath,
+        req,
+        schemaPath: fieldSchemaPath,
+        siblingData: value,
+      })
+    } else if (field.type === 'array' && Array.isArray(value)) {
+      result[field.name] = value.map((item, index) => {
+        if (!isPlainObject(item)) {
+          return item
+        }
+        return traverseFields({
+          type,
+          data,
+          fieldHooks,
+          fields: field.flattenedFields,
+          format,
+          operation,
+          path: `${fieldPath}_${index}`,
+          req,
+          schemaPath: fieldSchemaPath,
+          siblingData: item,
+        })
+      })
+    } else if (field.type === 'blocks' && Array.isArray(value)) {
+      result[field.name] = value.map((item, index) => {
+        if (!isPlainObject(item)) {
+          return item
+        }
+        const blockType = typeof item.blockType === 'string' ? item.blockType : undefined
+        const block = blockType ? field.blocks.find((b) => b.slug === blockType) : undefined
+        return traverseFields({
+          type,
+          data,
+          fieldHooks,
+          fields: block?.flattenedFields ?? [],
+          format,
+          operation,
+          path: blockType ? `${fieldPath}_${index}_${blockType}` : `${fieldPath}_${index}`,
+          req,
+          schemaPath: blockType ? `${fieldSchemaPath}_${blockType}` : fieldSchemaPath,
+          siblingData: item,
+        })
+      })
+    }
+  }
+
+  return result
+}
+
+/**
+ * Walks a nested document and applies each field's `beforeExport` or
+ * `beforeImport` hook. Legacy `toCSV` / `fromCSV` hooks are handled by the
+ * flat CSV pipelines and skipped here.
+ *
+ * Field-level hook errors are logged and the field falls back to its
+ * original value so a single bad doc does not abort the batch.
+ */
+export const applyFieldHooks = (args: Args): Record<string, unknown> => {
+  const { data, fieldHooks } = args
+  if (!data || typeof data !== 'object' || Object.keys(fieldHooks).length === 0) {
+    return data
+  }
+
+  return traverseFields({
+    ...args,
+    path: undefined,
+    schemaPath: undefined,
+    siblingData: data,
+  })
+}

--- a/packages/plugin-import-export/src/utilities/collectDisabledFieldPaths.ts
+++ b/packages/plugin-import-export/src/utilities/collectDisabledFieldPaths.ts
@@ -32,8 +32,8 @@ export const collectDisabledFieldPaths = (fields: Field[]): string[] => {
             const tabPath = parentPath ? `${parentPath}.${tab.name}` : tab.name
 
             // Prepare a ref for this named tab's children to inherit the path
-            const refObj = ref as Record<string, any>
-            const tabRef = refObj[tab.name] ?? {}
+            const refObj = ref as Record<string, unknown>
+            const tabRef = (refObj[tab.name] as Record<string, unknown>) ?? {}
             tabRef.path = tabPath
             tabRef.__manualRef = true // flag this as a manually constructed parentRef
             refObj[tab.name] = tabRef
@@ -59,15 +59,18 @@ export const collectDisabledFieldPaths = (fields: Field[]): string[] => {
         typeof (parentRef as { path?: unknown }).path === 'string'
       ) {
         parentPath = (parentRef as { path: string }).path
-      } else if ((ref as any)?.__manualRef && typeof (ref as any)?.path === 'string') {
+      } else if (
+        (ref as Record<string, unknown>).__manualRef &&
+        typeof (ref as Record<string, unknown>).path === 'string'
+      ) {
         // Fallback: if current ref is a manual tabRef, use its path
-        parentPath = (ref as any).path
+        parentPath = (ref as Record<string, unknown>).path as string
       }
 
       const fullPath = parentPath ? `${parentPath}.${field.name}` : field.name
 
       // Store current path for any nested children to use
-      ;(ref as any).path = fullPath
+      ;(ref as Record<string, unknown>).path = fullPath
 
       // If field is a data-affecting field and disabled via plugin config, collect its path
       if (fieldAffectsData(field) && field.custom?.['plugin-import-export']?.disabled) {

--- a/packages/plugin-import-export/src/utilities/flattenObject.spec.ts
+++ b/packages/plugin-import-export/src/utilities/flattenObject.spec.ts
@@ -1,0 +1,145 @@
+import { PayloadRequest } from 'payload'
+
+import type { ExportFieldHookEntry } from '../types.js'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { flattenObject } from './flattenObject.js'
+
+const mockReq = {
+  payload: {
+    logger: {
+      error: vi.fn(),
+    },
+  },
+} as unknown as PayloadRequest
+
+describe('flattenObject parent + child traversal', () => {
+  it('should run a parent group hook and still apply child field hooks against the transformed value', () => {
+    const exportFieldHooks: Record<string, ExportFieldHookEntry> = {
+      meta: {
+        type: 'beforeExport',
+        fn: ({ value }) => {
+          const obj = (value ?? {}) as Record<string, unknown>
+          return { ...obj, slug: `${obj.slug ?? ''}-from-parent` }
+        },
+      },
+      meta_slug: {
+        type: 'beforeExport',
+        fn: ({ value }) => `${value}-from-child`,
+      },
+    }
+
+    const row = flattenObject({
+      data: { meta: { slug: 'raw' } },
+      exportFieldHooks,
+      format: 'csv',
+      req: mockReq,
+    })
+
+    expect(row.meta_slug).toBe('raw-from-parent-from-child')
+  })
+
+  it('should still recurse into children when the parent group hook returns undefined', () => {
+    const childCalls: unknown[] = []
+    const exportFieldHooks: Record<string, ExportFieldHookEntry> = {
+      meta: {
+        type: 'beforeExport',
+        fn: () => undefined,
+      },
+      meta_slug: {
+        type: 'beforeExport',
+        fn: ({ value }) => {
+          childCalls.push(value)
+          return `${value}-from-child`
+        },
+      },
+    }
+
+    const row = flattenObject({
+      data: { meta: { slug: 'raw' } },
+      exportFieldHooks,
+      format: 'csv',
+      req: mockReq,
+    })
+
+    expect(childCalls).toEqual(['raw'])
+    expect(row.meta_slug).toBe('raw-from-child')
+  })
+
+  it('should not recurse into children when the parent hook returns a primitive', () => {
+    const childFn = vi.fn(({ value }: { value: unknown }) => `${value}-from-child`)
+    const exportFieldHooks: Record<string, ExportFieldHookEntry> = {
+      meta: {
+        type: 'beforeExport',
+        fn: () => 'serialized',
+      },
+      meta_slug: {
+        type: 'beforeExport',
+        fn: childFn,
+      },
+    }
+
+    const row = flattenObject({
+      data: { meta: { slug: 'raw' } },
+      exportFieldHooks,
+      format: 'csv',
+      req: mockReq,
+    })
+
+    expect(row.meta).toBe('serialized')
+    expect(row.meta_slug).toBeUndefined()
+    expect(childFn).not.toHaveBeenCalled()
+  })
+
+  it('should fall back to default array flattening when an undefined-returning hook did not write any keys, even if a sibling key with a matching prefix exists', () => {
+    const exportFieldHooks: Record<string, ExportFieldHookEntry> = {
+      tag: {
+        type: 'beforeExport',
+        fn: () => undefined,
+      },
+    }
+
+    const row = flattenObject({
+      data: { tag_meta: 'sibling-set-first', tag: ['a', 'b'] },
+      exportFieldHooks,
+      format: 'csv',
+      req: mockReq,
+    })
+
+    expect(row.tag_meta).toBe('sibling-set-first')
+    expect(row.tag_0).toBe('a')
+    expect(row.tag_1).toBe('b')
+  })
+
+  it('should run a parent array hook then child hooks for each item', () => {
+    const exportFieldHooks: Record<string, ExportFieldHookEntry> = {
+      items: {
+        type: 'beforeExport',
+        fn: ({ value }) => {
+          if (!Array.isArray(value)) {
+            return value
+          }
+          return value.map((item) => ({
+            ...(item as Record<string, unknown>),
+            note: `${(item as Record<string, unknown>).note ?? ''}-parent`,
+          }))
+        },
+      },
+      items_note: {
+        type: 'beforeExport',
+        fn: ({ value }) => `${value}-child`,
+      },
+    }
+
+    const row = flattenObject({
+      data: { items: [{ note: 'a' }, { note: 'b' }] },
+      exportFieldHooks,
+      format: 'csv',
+      req: mockReq,
+    })
+
+    expect(row.items_0_note).toBe('a-parent-child')
+    expect(row.items_1_note).toBe('b-parent-child')
+  })
+})

--- a/packages/plugin-import-export/src/utilities/flattenObject.ts
+++ b/packages/plugin-import-export/src/utilities/flattenObject.ts
@@ -1,171 +1,194 @@
-import type { Document } from 'payload'
+import type { PayloadRequest } from 'payload'
 
-import type { ToCSVFunction } from '../types.js'
+import type { ExportFieldHookEntry } from '../types.js'
 
 import { fieldToRegex } from './fieldToRegex.js'
+import { isPlainObject } from './isPlainObject.js'
+import { getPolymorphicRelId, isPolymorphicRelValue } from './polymorphicRel.js'
 
 type Args = {
-  doc: Document
+  data: Record<string, unknown>
+  exportFieldHooks: Record<string, ExportFieldHookEntry>
   fields?: string[]
-  prefix?: string
-  toCSVFunctions: Record<string, ToCSVFunction>
+  format: 'csv' | 'json' | ({} & string)
+  path?: string
+  req: PayloadRequest
 }
 
 export const flattenObject = ({
-  doc,
+  data,
+  exportFieldHooks,
   fields,
-  prefix,
-  toCSVFunctions,
+  format,
+  path,
+  req,
 }: Args): Record<string, unknown> => {
   const row: Record<string, unknown> = {}
 
-  // Helper to get toCSV function by full path or base field name
-  // This allows functions registered for field names (e.g., 'richText') to work
-  // even when the field is nested in arrays/blocks (e.g., 'blocks_0_content_richText')
-  const getToCSVFunction = (fullPath: string, baseFieldName: string): ToCSVFunction | undefined => {
-    return toCSVFunctions?.[fullPath] ?? toCSVFunctions?.[baseFieldName]
+  const invokeHook = (
+    entry: ExportFieldHookEntry,
+    columnName: string,
+    value: unknown,
+    siblingSource: Record<string, unknown>,
+  ): unknown => {
+    if (entry.type === 'beforeExport') {
+      return entry.fn({
+        columnName,
+        data,
+        format,
+        siblingData: row,
+        siblingDoc: siblingSource,
+        value,
+      })
+    }
+    return entry.fn({
+      columnName,
+      data: row,
+      doc: data,
+      row,
+      siblingDoc: siblingSource,
+      value,
+    })
   }
 
-  // When fields are selected, build a set of top-level document keys to process.
-  // This prevents sibling fields with similar prefixes from being included
-  // (e.g. selecting 'dateWithTimezone' won't pull in 'dateWithTimezone_tz')
   const selectedTopLevelKeys =
     Array.isArray(fields) && fields.length > 0
       ? new Set(fields.map((f) => f.split('.')[0]))
       : undefined
 
-  const flattenWithFilter = (siblingDoc: Document, currentPrefix?: string) => {
-    Object.entries(siblingDoc).forEach(([key, value]) => {
-      // At the document root, skip keys that don't match any selected field
-      if (!currentPrefix && selectedTopLevelKeys && !selectedTopLevelKeys.has(key)) {
+  const flattenWithFilter = (
+    siblingSource: Record<string, unknown>,
+    currentPath: string | undefined,
+    currentSchemaPath: string | undefined,
+  ) => {
+    Object.entries(siblingSource).forEach(([key, value]) => {
+      if (!currentPath && selectedTopLevelKeys && !selectedTopLevelKeys.has(key)) {
         return
       }
 
-      const newKey = currentPrefix ? `${currentPrefix}_${key}` : key
-      const toCSVFn = getToCSVFunction(newKey, key)
+      const fieldPath = currentPath ? `${currentPath}_${key}` : key
+      const fieldSchemaPath = currentSchemaPath ? `${currentSchemaPath}_${key}` : key
+      const hookEntry = exportFieldHooks?.[fieldSchemaPath]
+
+      const flattenArray = (items: unknown[], arrayPath: string, arraySchemaPath: string): void => {
+        items.forEach((item, index) => {
+          if (!isPlainObject(item)) {
+            row[`${arrayPath}_${index}`] = item
+            return
+          }
+
+          const blockType = typeof item.blockType === 'string' ? item.blockType : undefined
+          const itemPath = blockType
+            ? `${arrayPath}_${index}_${blockType}`
+            : `${arrayPath}_${index}`
+          const itemSchemaPath = blockType ? `${arraySchemaPath}_${blockType}` : arraySchemaPath
+
+          if (isPolymorphicRelValue(item) && isPlainObject(item.value)) {
+            const id = getPolymorphicRelId(item)
+            if (id !== undefined) {
+              row[`${itemPath}_relationTo`] = item.relationTo
+              row[`${itemPath}_id`] = id
+              return
+            }
+          }
+
+          flattenWithFilter(item, itemPath, itemSchemaPath)
+        })
+      }
 
       if (Array.isArray(value)) {
-        if (toCSVFn) {
+        if (hookEntry) {
           try {
-            const result = toCSVFn({
-              columnName: newKey,
-              data: row,
-              doc,
-              row,
-              siblingDoc,
-              value,
-            })
+            const result = invokeHook(hookEntry, fieldPath, value, siblingSource)
 
-            if (typeof result !== 'undefined') {
-              row[newKey] = result
+            if (result === null) {
               return
             }
 
-            for (const k in row) {
-              if (k === newKey || k.startsWith(`${newKey}_`)) {
-                return
-              }
+            if (Array.isArray(result)) {
+              flattenArray(result, fieldPath, fieldSchemaPath)
+              return
+            }
+
+            if (typeof result !== 'undefined') {
+              row[fieldPath] = result
+              return
             }
           } catch (error) {
-            throw new Error(
-              `Error in toCSVFunction for array "${newKey}": ${JSON.stringify(value)}\n${
-                (error as Error).message
-              }`,
-            )
+            req.payload.logger.error({
+              err: error,
+              msg: `[plugin-import-export] Field-level beforeExport hook for "${fieldPath}" threw — falling back to default flattening`,
+            })
           }
         }
 
-        value.forEach((item, index) => {
-          if (typeof item === 'object' && item !== null) {
-            const blockType = typeof item.blockType === 'string' ? item.blockType : undefined
-            const itemPrefix = blockType ? `${newKey}_${index}_${blockType}` : `${newKey}_${index}`
-
-            if (
-              'relationTo' in item &&
-              'value' in item &&
-              typeof item.value === 'object' &&
-              item.value !== null
-            ) {
-              row[`${itemPrefix}_relationTo`] = item.relationTo
-              row[`${itemPrefix}_id`] = item.value.id
+        flattenArray(value, fieldPath, fieldSchemaPath)
+      } else if (typeof value === 'object' && value !== null) {
+        if (!hookEntry) {
+          flattenWithFilter(value as Record<string, unknown>, fieldPath, fieldSchemaPath)
+        } else {
+          const keysBeforeHook = new Set(Object.keys(row))
+          try {
+            const result = invokeHook(hookEntry, fieldPath, value, siblingSource)
+            if (result === null) {
               return
             }
-
-            flattenWithFilter(item, itemPrefix)
-          } else {
-            row[`${newKey}_${index}`] = item
-          }
-        })
-      } else if (typeof value === 'object' && value !== null) {
-        if (!toCSVFn) {
-          flattenWithFilter(value, newKey)
-        } else {
-          try {
-            const result = toCSVFn({
-              columnName: newKey,
-              data: row,
-              doc,
-              row,
-              siblingDoc,
-              value,
-            })
-            if (typeof result !== 'undefined') {
-              row[newKey] = result
+            if (typeof result === 'undefined') {
+              const hookWroteForField = Object.keys(row).some(
+                (k) => !keysBeforeHook.has(k) && (k === fieldPath || k.startsWith(`${fieldPath}_`)),
+              )
+              if (hookWroteForField) {
+                return
+              }
+              flattenWithFilter(value as Record<string, unknown>, fieldPath, fieldSchemaPath)
+            } else if (typeof result === 'object' && !Array.isArray(result)) {
+              flattenWithFilter(result as Record<string, unknown>, fieldPath, fieldSchemaPath)
+            } else {
+              row[fieldPath] = result
             }
           } catch (error) {
-            throw new Error(
-              `Error in toCSVFunction for nested object "${newKey}": ${JSON.stringify(value)}\n${
-                (error as Error).message
-              }`,
-            )
+            req.payload.logger.error({
+              err: error,
+              msg: `[plugin-import-export] Field-level beforeExport hook for "${fieldPath}" threw — falling back to default flattening`,
+            })
+            flattenWithFilter(value as Record<string, unknown>, fieldPath, fieldSchemaPath)
           }
         }
       } else {
-        if (toCSVFn) {
+        if (hookEntry) {
           try {
-            const result = toCSVFn({
-              columnName: newKey,
-              data: row,
-              doc,
-              row,
-              siblingDoc,
-              value,
-            })
+            const result = invokeHook(hookEntry, fieldPath, value, siblingSource)
             if (typeof result !== 'undefined') {
-              row[newKey] = result
+              row[fieldPath] = result
             }
           } catch (error) {
-            throw new Error(
-              `Error in toCSVFunction for field "${newKey}": ${JSON.stringify(value)}\n${
-                (error as Error).message
-              }`,
-            )
+            req.payload.logger.error({
+              err: error,
+              msg: `[plugin-import-export] Field-level beforeExport hook for "${fieldPath}" threw — falling back to original value`,
+            })
+            row[fieldPath] = value
           }
         } else {
-          row[newKey] = value
+          row[fieldPath] = value
         }
       }
     })
   }
 
-  flattenWithFilter(doc, prefix)
+  flattenWithFilter(data, path, path)
 
   if (Array.isArray(fields) && fields.length > 0) {
     const orderedResult: Record<string, unknown> = {}
 
-    // Build all field regexes once
     const fieldPatterns = fields.map((field) => ({
       field,
       regex: fieldToRegex(field),
     }))
 
-    // Single pass through row keys - O(keys * fields) regex tests but only one iteration
     const rowKeys = Object.keys(row)
 
-    // Process in field order to maintain user's specified ordering
     for (const { regex } of fieldPatterns) {
       for (const key of rowKeys) {
-        // Skip if already added (a key might match multiple field patterns)
         if (key in orderedResult) {
           continue
         }

--- a/packages/plugin-import-export/src/utilities/flattenedFields.ts
+++ b/packages/plugin-import-export/src/utilities/flattenedFields.ts
@@ -1,0 +1,55 @@
+import type { FlattenedField } from 'payload'
+
+/**
+ * Returns the `flattenedFields` of a group/tab/array field, or undefined for
+ * field types that don't carry nested fields. Concentrates the cast for the
+ * Payload core typing oversight (`FlattenedField` doesn't expose
+ * `flattenedFields` on every variant).
+ */
+export const getNestedFlattenedFields = (field: FlattenedField): FlattenedField[] | undefined =>
+  (field as { flattenedFields?: FlattenedField[] }).flattenedFields
+
+/**
+ * Returns the `flattenedFields` of a `BlocksField` block (always an array).
+ */
+export const getBlockFlattenedFields = (block: {
+  flattenedFields?: FlattenedField[]
+}): FlattenedField[] => block.flattenedFields ?? []
+
+/**
+ * Traverses a flattened field schema and calls `registerHandler` for each
+ * named field. Handles blocks (keyed by block slug), groups, tabs, and arrays.
+ * Shared by `getExportFieldFunctions` and `getImportFieldFunctions`.
+ */
+export const registerFieldHooks = <TEntry>(
+  fields: FlattenedField[],
+  parentPath: string,
+  result: Record<string, TEntry>,
+  registerHandler: (field: FlattenedField, fullKey: string, result: Record<string, TEntry>) => void,
+): void => {
+  for (const field of fields) {
+    if (!('name' in field) || !field.name) {
+      continue
+    }
+
+    if (field.type === 'blocks') {
+      const base = parentPath ? `${parentPath}_${field.name}` : field.name
+      for (const block of field.blocks ?? []) {
+        registerFieldHooks(
+          getBlockFlattenedFields(block),
+          `${base}_${block.slug}`,
+          result,
+          registerHandler,
+        )
+      }
+      continue
+    }
+
+    const fullKey = parentPath ? `${parentPath}_${field.name}` : field.name
+    registerHandler(field, fullKey, result)
+
+    if (field.type === 'group' || field.type === 'tab' || field.type === 'array') {
+      registerFieldHooks(getNestedFlattenedFields(field) ?? [], fullKey, result, registerHandler)
+    }
+  }
+}

--- a/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
+++ b/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
@@ -1,0 +1,39 @@
+import { FlattenedField } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { getExportFieldFunctions } from './getExportFieldFunctions.js'
+
+describe('getExportFieldFunctions registration', () => {
+  it('should not collide bare-key entries when two same-named fields with built-in handlers exist in different positions', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'groupA',
+        type: 'group',
+        flattenedFields: [{ name: 'data', type: 'json' } as FlattenedField],
+      } as unknown as FlattenedField,
+      {
+        name: 'groupB',
+        type: 'group',
+        flattenedFields: [{ name: 'data', type: 'json' } as FlattenedField],
+      } as unknown as FlattenedField,
+    ]
+
+    const result = getExportFieldFunctions({ fields })
+
+    // Both nested paths must be registered (not overwritten by collision)
+    expect(result['groupA_data']).toBeDefined()
+    expect(result['groupB_data']).toBeDefined()
+
+    // No bare-key fallback should exist for nested fields — that's the bug
+    expect(result['data']).toBeUndefined()
+  })
+
+  it('should still register a top-level field at its name', () => {
+    const fields: FlattenedField[] = [{ name: 'topLevelData', type: 'json' } as FlattenedField]
+
+    const result = getExportFieldFunctions({ fields })
+
+    expect(result['topLevelData']).toBeDefined()
+  })
+})

--- a/packages/plugin-import-export/src/utilities/getExportFieldFunctions.ts
+++ b/packages/plugin-import-export/src/utilities/getExportFieldFunctions.ts
@@ -1,130 +1,120 @@
-import { type FlattenedField, traverseFields, type TraverseFieldsCallback } from 'payload'
+import type { FlattenedField } from 'payload'
 
-import type { ToCSVFunction } from '../types.js'
+import type { ExportFieldHookEntry, FieldBeforeExportHook } from '../types.js'
+
+import { registerFieldHooks } from './flattenedFields.js'
+import { getPolymorphicRelId, isPolymorphicRelValue } from './polymorphicRel.js'
 
 type Args = {
   fields: FlattenedField[]
 }
 
 /**
- * Gets custom toCSV field functions for export.
- * These functions transform field values when flattening documents for CSV export.
+ * Builds a map from logical field path (e.g. `content_textBlock_body`) to
+ * the export hook entry. Paths include block slugs but never array indices.
  */
-export const getExportFieldFunctions = ({ fields }: Args): Record<string, ToCSVFunction> => {
-  const result: Record<string, ToCSVFunction> = {}
+export const getExportFieldFunctions = ({ fields }: Args): Record<string, ExportFieldHookEntry> => {
+  const result: Record<string, ExportFieldHookEntry> = {}
+  registerFieldHooks(fields, '', result, registerExportHandler)
+  return result
+}
 
-  const buildCustomFunctions: TraverseFieldsCallback = ({ field, parentRef, ref }) => {
-    // @ts-expect-error ref is untyped
-    ref.prefix = parentRef.prefix || ''
-    if (field.type === 'group' || field.type === 'tab') {
-      // @ts-expect-error ref is untyped
-      const parentPrefix = parentRef?.prefix ? `${parentRef.prefix}_` : ''
-      // @ts-expect-error ref is untyped
-      ref.prefix = `${parentPrefix}${field.name}_`
-    }
+const registerExportHandler = (
+  field: FlattenedField,
+  fullKey: string,
+  result: Record<string, ExportFieldHookEntry>,
+): void => {
+  const beforeExport = field.custom?.['plugin-import-export']?.hooks?.beforeExport
 
-    if (typeof field.custom?.['plugin-import-export']?.toCSV === 'function') {
-      // @ts-expect-error ref is untyped
-      result[`${ref.prefix}${field.name}`] = field.custom['plugin-import-export']?.toCSV
-    } else if (field.type === 'json' || field.type === 'richText') {
-      // Serialize JSON and richText fields as JSON strings in a single column
-      // This prevents them from being flattened into multiple columns
-      // @ts-expect-error ref is untyped
-      result[`${ref.prefix}${field.name}`] = ({ value }) => {
-        if (value === null || value === undefined) {
-          return value
-        }
-        if (typeof value === 'object') {
-          return JSON.stringify(value)
-        }
-        return value
-      }
-    } else if (field.type === 'date') {
-      // Handle date fields - return value as-is (ISO string format)
-      // This prevents the flattener from treating the document as having
-      // nested sibling properties like _tz that shouldn't be auto-included
-      // @ts-expect-error ref is untyped
-      const fieldKey = `${ref.prefix}${field.name}`
+  const toCSV = field.custom?.['plugin-import-export']?.toCSV
 
-      result[fieldKey] = ({ value }) => value
-    } else if (field.type === 'relationship' || field.type === 'upload') {
-      if (field.hasMany !== true) {
-        if (!Array.isArray(field.relationTo)) {
-          // monomorphic single
-          // @ts-expect-error ref is untyped
-          result[`${ref.prefix}${field.name}`] = ({ value }) =>
-            typeof value === 'object' && value && 'id' in value ? value.id : value
-        } else {
-          // polymorphic single
-          // @ts-expect-error ref is untyped
-          result[`${ref.prefix}${field.name}`] = ({ data, value }) => {
-            if (value && typeof value === 'object' && 'relationTo' in value && 'value' in value) {
-              const relationTo = (value as { relationTo: string; value: { id: number | string } })
-                .relationTo
-              const relatedDoc = (value as { relationTo: string; value: { id: number | string } })
-                .value
-              if (relatedDoc && typeof relatedDoc === 'object') {
-                // @ts-expect-error ref is untyped
-                data[`${ref.prefix}${field.name}_id`] = relatedDoc.id
-                // @ts-expect-error ref is untyped
-                data[`${ref.prefix}${field.name}_relationTo`] = relationTo
-              }
-            }
-            return undefined // prevents further flattening
-          }
-        }
-      } else {
-        if (!Array.isArray(field.relationTo)) {
-          // monomorphic many
-          // @ts-expect-error ref is untyped
-          result[`${ref.prefix}${field.name}`] = ({
-            data,
-            value,
-          }: {
-            data: Record<string, unknown>
-            value: Array<number | Record<string, any> | string> | undefined
-          }) => {
-            if (Array.isArray(value)) {
-              value.forEach((val, i) => {
-                const id = typeof val === 'object' && val ? val.id : val
-                // @ts-expect-error ref is untyped
-                data[`${ref.prefix}${field.name}_${i}_id`] = id
-              })
-            }
-            return undefined // prevents further flattening
-          }
-        } else {
-          // polymorphic many
-          // @ts-expect-error ref is untyped
-          result[`${ref.prefix}${field.name}`] = ({
-            data,
-            value,
-          }: {
-            data: Record<string, unknown>
-            value: Array<Record<string, any>> | undefined
-          }) => {
-            if (Array.isArray(value)) {
-              value.forEach((val, i) => {
-                if (val && typeof val === 'object') {
-                  const relationTo = val.relationTo
-                  const relatedDoc = val.value
-                  if (relationTo && relatedDoc && typeof relatedDoc === 'object') {
-                    // @ts-expect-error ref is untyped
-                    data[`${ref.prefix}${field.name}_${i}_id`] = relatedDoc.id
-                    // @ts-expect-error ref is untyped
-                    data[`${ref.prefix}${field.name}_${i}_relationTo`] = relationTo
-                  }
-                }
-              })
-            }
-            return undefined
-          }
-        }
-      }
-    }
+  if (typeof beforeExport === 'function') {
+    result[fullKey] = { type: 'beforeExport', fn: beforeExport }
+    return
   }
 
-  traverseFields({ callback: buildCustomFunctions, fields })
+  if (typeof toCSV === 'function') {
+    result[fullKey] = { type: 'toCSV', fn: toCSV }
+    return
+  }
 
-  return result
+  const registerHandler = (handler: FieldBeforeExportHook) => {
+    result[fullKey] = { type: 'beforeExport', fn: handler }
+  }
+
+  if (field.type === 'json' || field.type === 'richText') {
+    registerHandler(({ format, value }) => {
+      if (format === 'json') {
+        return value
+      }
+      if (value === null || value === undefined) {
+        return value
+      }
+      if (typeof value === 'object') {
+        return JSON.stringify(value)
+      }
+      return value
+    })
+    return
+  }
+
+  if (field.type === 'date') {
+    registerHandler(({ value }) => value)
+    return
+  }
+
+  if (field.type !== 'relationship' && field.type !== 'upload') {
+    return
+  }
+
+  if (field.hasMany !== true) {
+    if (!Array.isArray(field.relationTo)) {
+      registerHandler(({ value }) =>
+        typeof value === 'object' && value && 'id' in value ? value.id : value,
+      )
+      return
+    }
+
+    registerHandler(({ siblingData, value }) => {
+      if (isPolymorphicRelValue(value)) {
+        const id = getPolymorphicRelId(value)
+        if (id !== undefined) {
+          siblingData[`${fullKey}_id`] = id
+          siblingData[`${fullKey}_relationTo`] = value.relationTo
+        }
+      }
+      return null
+    })
+    return
+  }
+
+  if (!Array.isArray(field.relationTo)) {
+    registerHandler(({ siblingData, value }) => {
+      if (Array.isArray(value)) {
+        value.forEach((val, i) => {
+          const id = typeof val === 'object' && val ? (val as { id: unknown }).id : val
+          siblingData[`${fullKey}_${i}_id`] = id
+        })
+        return null
+      }
+      return undefined
+    })
+    return
+  }
+
+  registerHandler(({ siblingData, value }) => {
+    if (Array.isArray(value)) {
+      value.forEach((val, i) => {
+        if (isPolymorphicRelValue(val)) {
+          const id = getPolymorphicRelId(val)
+          if (id !== undefined) {
+            siblingData[`${fullKey}_${i}_id`] = id
+            siblingData[`${fullKey}_${i}_relationTo`] = val.relationTo
+          }
+        }
+      })
+      return null
+    }
+    return undefined
+  })
 }

--- a/packages/plugin-import-export/src/utilities/getImportFieldFunctions.spec.ts
+++ b/packages/plugin-import-export/src/utilities/getImportFieldFunctions.spec.ts
@@ -1,0 +1,139 @@
+import { FlattenedField, PayloadRequest } from 'payload'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { getImportFieldFunctions } from './getImportFieldFunctions.js'
+
+const mockReq = {
+  payload: {
+    logger: {
+      error: vi.fn(),
+    },
+  },
+} as unknown as PayloadRequest
+
+const callHook = (
+  hooks: ReturnType<typeof getImportFieldFunctions>,
+  key: string,
+  value: unknown,
+) => {
+  const entry = hooks[key]
+  if (!entry || entry.type !== 'beforeImport') {
+    throw new Error(`Expected beforeImport hook for ${key}`)
+  }
+  return entry.fn({
+    columnName: key,
+    data: {},
+    format: 'csv',
+    operation: 'create',
+    req: mockReq,
+    siblingData: {},
+    siblingDoc: {},
+    value,
+  })
+}
+
+describe('getImportFieldFunctions empty-cell guards', () => {
+  describe('checkbox', () => {
+    const fields: FlattenedField[] = [{ name: 'flag', type: 'checkbox' } as FlattenedField]
+
+    it('should return undefined for empty string instead of false', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'flag', '')).toBeUndefined()
+    })
+
+    it('should return undefined for null', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'flag', null)).toBeUndefined()
+    })
+
+    it('should return undefined for undefined', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'flag', undefined)).toBeUndefined()
+    })
+
+    it('should still parse "true" as true', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'flag', 'true')).toBe(true)
+    })
+
+    it('should still parse "false" as false', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'flag', 'false')).toBe(false)
+    })
+
+    it('should still pass through real booleans', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'flag', true)).toBe(true)
+      expect(callHook(hooks, 'flag', false)).toBe(false)
+    })
+  })
+
+  describe('number (without hasMany)', () => {
+    const fields: FlattenedField[] = [{ name: 'count', type: 'number' } as FlattenedField]
+
+    it('should return undefined for empty string instead of 0', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'count', '')).toBeUndefined()
+    })
+
+    it('should return undefined for null', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'count', null)).toBeUndefined()
+    })
+
+    it('should return undefined for undefined', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'count', undefined)).toBeUndefined()
+    })
+
+    it('should still parse a numeric string', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'count', '42')).toBe(42)
+    })
+
+    it('should still pass through a real number', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'count', 7)).toBe(7)
+    })
+  })
+
+  describe('date', () => {
+    const fields: FlattenedField[] = [{ name: 'when', type: 'date' } as FlattenedField]
+
+    it('should return undefined for empty string', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'when', '')).toBeUndefined()
+    })
+
+    it('should return undefined for null', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'when', null)).toBeUndefined()
+    })
+
+    it('should still parse a valid ISO date', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      const iso = '2026-05-06T00:00:00.000Z'
+      expect(callHook(hooks, 'when', iso)).toBe(iso)
+    })
+  })
+
+  describe('json', () => {
+    const fields: FlattenedField[] = [{ name: 'meta', type: 'json' } as FlattenedField]
+
+    it('should return undefined for empty string', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'meta', '')).toBeUndefined()
+    })
+
+    it('should return undefined for null', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'meta', null)).toBeUndefined()
+    })
+
+    it('should still parse a valid JSON string', () => {
+      const hooks = getImportFieldFunctions({ fields })
+      expect(callHook(hooks, 'meta', '{"a":1}')).toEqual({ a: 1 })
+    })
+  })
+})

--- a/packages/plugin-import-export/src/utilities/getImportFieldFunctions.ts
+++ b/packages/plugin-import-export/src/utilities/getImportFieldFunctions.ts
@@ -1,123 +1,131 @@
-import { type FlattenedField, traverseFields, type TraverseFieldsCallback } from 'payload'
+import type { FlattenedField } from 'payload'
 
-import type { FromCSVFunction } from '../types.js'
+import type { FieldBeforeImportHook, ImportFieldHookEntry } from '../types.js'
+
+import { registerFieldHooks } from './flattenedFields.js'
 
 type Args = {
   fields: FlattenedField[]
 }
 
 /**
- * Gets custom fromCSV field functions for import.
- * These functions transform field values when unflattening CSV data for import.
+ * Builds a map from logical field path (e.g. `content_textBlock_body`) to
+ * the import hook entry. Paths include block slugs but never array indices.
  */
-export const getImportFieldFunctions = ({ fields }: Args): Record<string, FromCSVFunction> => {
-  const result: Record<string, FromCSVFunction> = {}
+export const getImportFieldFunctions = ({ fields }: Args): Record<string, ImportFieldHookEntry> => {
+  const result: Record<string, ImportFieldHookEntry> = {}
+  registerFieldHooks(fields, '', result, registerImportHandler)
+  return result
+}
 
-  const buildCustomFunctions: TraverseFieldsCallback = ({ field, parentRef, ref }) => {
-    // @ts-expect-error ref is untyped
-    ref.prefix = parentRef.prefix || ''
-    if (field.type === 'group' || field.type === 'tab') {
-      // @ts-expect-error ref is untyped
-      const parentPrefix = parentRef?.prefix ? `${parentRef.prefix}_` : ''
-      // @ts-expect-error ref is untyped
-      ref.prefix = `${parentPrefix}${field.name}_`
+const registerImportHandler = (
+  field: FlattenedField,
+  fullKey: string,
+  result: Record<string, ImportFieldHookEntry>,
+): void => {
+  const beforeImport = field.custom?.['plugin-import-export']?.hooks?.beforeImport
+
+  const fromCSV = field.custom?.['plugin-import-export']?.fromCSV
+
+  if (typeof beforeImport === 'function') {
+    result[fullKey] = { type: 'beforeImport', fn: beforeImport }
+    return
+  }
+
+  if (typeof fromCSV === 'function') {
+    result[fullKey] = { type: 'fromCSV', fn: fromCSV }
+    return
+  }
+
+  const registerBeforeImport = (fn: FieldBeforeImportHook) => {
+    result[fullKey] = { type: 'beforeImport', fn }
+  }
+
+  if (field.type === 'relationship' || field.type === 'upload') {
+    if (field.hasMany !== true) {
+      if (!Array.isArray(field.relationTo)) {
+        registerBeforeImport(({ value }) => value)
+      }
+    } else if (!Array.isArray(field.relationTo)) {
+      registerBeforeImport(({ value }) => value)
     }
+    return
+  }
 
-    if (typeof field.custom?.['plugin-import-export']?.fromCSV === 'function') {
-      // @ts-expect-error ref is untyped
-      result[`${ref.prefix}${field.name}`] = field.custom['plugin-import-export']?.fromCSV
-    } else if (field.type === 'relationship' || field.type === 'upload') {
-      if (field.hasMany !== true) {
-        if (!Array.isArray(field.relationTo)) {
-          // monomorphic single relationship - simple ID to value conversion
-          // @ts-expect-error ref is untyped
-          result[`${ref.prefix}${field.name}`] = ({ value }) => {
-            // If it's already an object (from JSON import), return as-is
-            if (typeof value === 'object' && value !== null) {
-              return value
-            }
-            // Convert string/number ID to relationship value
-            return value
-          }
-        } else {
-          // Polymorphic single: handled in unflattenObject via _id/_relationTo columns
-        }
-      } else {
-        if (!Array.isArray(field.relationTo)) {
-          // @ts-expect-error ref is untyped
-          result[`${ref.prefix}${field.name}`] = ({ value }) => {
-            if (Array.isArray(value)) {
-              return value
-            }
-            return value
-          }
-        } else {
-          // Polymorphic many: handled in unflattenObject
-        }
+  if (field.type === 'number') {
+    if (field.hasMany) {
+      registerBeforeImport(({ value }) => value)
+      return
+    }
+    registerBeforeImport(({ value }) => {
+      if (isEmptyImportValue(value)) {
+        return undefined
       }
-    } else if (field.type === 'number') {
-      if (field.hasMany) {
-        // @ts-expect-error ref is untyped
-        result[`${ref.prefix}${field.name}`] = ({ value }) => value
-      } else {
-        // @ts-expect-error ref is untyped
-        result[`${ref.prefix}${field.name}`] = ({ value }) => {
-          if (typeof value === 'number') {
-            return value
-          }
-          if (typeof value === 'string') {
-            const parsed = parseFloat(value)
-            return isNaN(parsed) ? 0 : parsed
-          }
-          return value
-        }
+      if (typeof value === 'number') {
+        return value
       }
-    } else if (field.type === 'checkbox') {
-      // @ts-expect-error ref is untyped
-      result[`${ref.prefix}${field.name}`] = ({ value }) => {
-        if (typeof value === 'boolean') {
-          return value
-        }
-        if (typeof value === 'string') {
-          return value.toLowerCase() === 'true' || value === '1'
-        }
-        return Boolean(value)
+      if (typeof value === 'string') {
+        const parsed = parseFloat(value)
+        return isNaN(parsed) ? undefined : parsed
       }
-    } else if (field.type === 'date') {
-      // @ts-expect-error ref is untyped
-      result[`${ref.prefix}${field.name}`] = ({ value }) => {
-        if (!value) {
-          return value
-        }
-        if (typeof value === 'string' && !isNaN(Date.parse(value))) {
-          return value
-        }
+      return value
+    })
+    return
+  }
+
+  if (field.type === 'checkbox') {
+    registerBeforeImport(({ value }) => {
+      if (isEmptyImportValue(value)) {
+        return undefined
+      }
+      if (typeof value === 'boolean') {
+        return value
+      }
+      if (typeof value === 'string') {
+        return value.toLowerCase() === 'true' || value === '1'
+      }
+      return Boolean(value)
+    })
+    return
+  }
+
+  if (field.type === 'date') {
+    registerBeforeImport(({ value }) => {
+      if (isEmptyImportValue(value)) {
+        return undefined
+      }
+      if (typeof value === 'string' && !isNaN(Date.parse(value))) {
+        return value
+      }
+      try {
+        const date = new Date(value as string)
+        return isNaN(date.getTime()) ? value : date.toISOString()
+      } catch {
+        return value
+      }
+    })
+    return
+  }
+
+  if (field.type === 'json' || field.type === 'richText') {
+    registerBeforeImport(({ value }) => {
+      if (isEmptyImportValue(value)) {
+        return undefined
+      }
+      if (typeof value === 'object') {
+        return value
+      }
+      if (typeof value === 'string') {
         try {
-          const date = new Date(value as string)
-          return isNaN(date.getTime()) ? value : date.toISOString()
+          return JSON.parse(value)
         } catch {
           return value
         }
       }
-    } else if (field.type === 'json' || field.type === 'richText') {
-      // @ts-expect-error ref is untyped
-      result[`${ref.prefix}${field.name}`] = ({ value }) => {
-        if (typeof value === 'object') {
-          return value
-        }
-        if (typeof value === 'string') {
-          try {
-            return JSON.parse(value)
-          } catch {
-            return value
-          }
-        }
-        return value
-      }
-    }
+      return value
+    })
   }
-
-  traverseFields({ callback: buildCustomFunctions, fields })
-
-  return result
 }
+
+const isEmptyImportValue = (value: unknown): boolean =>
+  value === '' || value === null || value === undefined

--- a/packages/plugin-import-export/src/utilities/isPlainObject.ts
+++ b/packages/plugin-import-export/src/utilities/isPlainObject.ts
@@ -1,0 +1,2 @@
+export const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/packages/plugin-import-export/src/utilities/legacyHookDispatch.spec.ts
+++ b/packages/plugin-import-export/src/utilities/legacyHookDispatch.spec.ts
@@ -1,0 +1,224 @@
+import { FlattenedField, PayloadRequest } from 'payload'
+
+import type { FromCSVFunction, ToCSVFunction } from '../types.js'
+
+import { flattenObject } from './flattenObject.js'
+import { getExportFieldFunctions } from './getExportFieldFunctions.js'
+import { getImportFieldFunctions } from './getImportFieldFunctions.js'
+import { unflattenObject } from './unflattenObject.js'
+
+import { describe, expect, it, vi } from 'vitest'
+
+const mockReq = {
+  payload: {
+    logger: {
+      error: vi.fn(),
+    },
+  },
+} as unknown as PayloadRequest
+
+describe('legacy toCSV / fromCSV argument shape', () => {
+  describe('toCSV receives { columnName, data, doc, row, siblingDoc, value }', () => {
+    it('should pass row as flat row accumulator, doc as top-level doc, and siblingDoc as source doc', () => {
+      const received: Parameters<ToCSVFunction>[0][] = []
+
+      const fields: FlattenedField[] = [
+        {
+          name: 'legacy',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              toCSV: ((args) => {
+                received.push(args)
+                args.row[`${args.columnName}_extra`] = 'added'
+                return String(args.value) + '_transformed'
+              }) satisfies ToCSVFunction,
+            },
+          },
+        } as FlattenedField,
+      ]
+
+      const exportFieldHooks = getExportFieldFunctions({ fields })
+
+      const doc = { legacy: 'hello', title: 'Top' }
+      const result = flattenObject({
+        data: doc,
+        exportFieldHooks,
+        format: 'csv',
+        req: mockReq,
+      })
+
+      expect(received).toHaveLength(1)
+      const args = received[0]!
+      expect(args.columnName).toBe('legacy')
+      expect(args.value).toBe('hello')
+      // doc should be the top-level document
+      expect(args.doc).toBe(doc)
+      // siblingDoc should be the source doc at the current nesting level (top-level == doc)
+      expect(args.siblingDoc).toBe(doc)
+      // row should be the flat row accumulator (a different object from doc)
+      expect(args.row).not.toBe(doc)
+      // data is kept as alias for row to avoid breaking legacy usage
+      expect(args.data).toBe(args.row)
+
+      expect(result.legacy).toBe('hello_transformed')
+      expect(result.legacy_extra).toBe('added')
+    })
+
+    it('should not pass legacy args to hooks.beforeExport', () => {
+      const received: Array<Record<string, unknown>> = []
+
+      const fields: FlattenedField[] = [
+        {
+          name: 'modern',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeExport: (args) => {
+                  received.push(args as unknown as Record<string, unknown>)
+                  return String(args.value) + '_modern'
+                },
+              },
+            },
+          },
+        } as FlattenedField,
+      ]
+
+      const exportFieldHooks = getExportFieldFunctions({ fields })
+
+      const doc = { modern: 'v', title: 'Top' }
+      flattenObject({ data: doc, exportFieldHooks, format: 'csv', req: mockReq })
+
+      expect(received).toHaveLength(1)
+      const args = received[0]!
+      // Modern signature: data === top-level doc
+      expect(args.data).toBe(doc)
+      // Modern signature: siblingData === flat row accumulator (not source doc)
+      expect(args.siblingData).not.toBe(doc)
+      expect(args.format).toBe('csv')
+      // Legacy-only args should not be present
+      expect(args.doc).toBeUndefined()
+      expect(args.row).toBeUndefined()
+      // `siblingDoc` is part of the modern signature too (read-only source view)
+      expect(args.siblingDoc).toBeDefined()
+    })
+
+    it('should prefer hooks.beforeExport when both are defined on a field', () => {
+      const legacyCalls: string[] = []
+      const modernCalls: string[] = []
+
+      const fields: FlattenedField[] = [
+        {
+          name: 'both',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeExport: ({ value }) => {
+                  modernCalls.push(String(value))
+                  return `${value}_modern`
+                },
+              },
+              toCSV: ({ value }: { value: unknown }) => {
+                legacyCalls.push(String(value))
+                return `${value}_legacy`
+              },
+            },
+          },
+        } as FlattenedField,
+      ]
+
+      const exportFieldHooks = getExportFieldFunctions({ fields })
+      const result = flattenObject({
+        data: { both: 'x' },
+        exportFieldHooks,
+        format: 'csv',
+        req: mockReq,
+      })
+
+      expect(modernCalls).toEqual(['x'])
+      expect(legacyCalls).toEqual([])
+      expect(result.both).toBe('x_modern')
+    })
+  })
+
+  describe('fromCSV receives { columnName, data, value } with data as full flat row', () => {
+    it('should pass the full flat row as data', () => {
+      const received: Parameters<FromCSVFunction>[0][] = []
+
+      const fields: FlattenedField[] = [
+        {
+          name: 'legacy',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              fromCSV: ((args) => {
+                received.push(args)
+                return String(args.value) + '_imported'
+              }) satisfies FromCSVFunction,
+            },
+          },
+        } as FlattenedField,
+      ]
+
+      const importFieldHooks = getImportFieldFunctions({ fields })
+
+      const flatRow = { legacy: 'incoming', title: 'Top' }
+      const result = unflattenObject({
+        data: flatRow,
+        fields,
+        format: 'csv',
+        importFieldHooks,
+        req: mockReq,
+      })
+
+      expect(received).toHaveLength(1)
+      expect(received[0]!.columnName).toBe('legacy')
+      expect(received[0]!.value).toBe('incoming')
+      // data should be the full flat row
+      expect(received[0]!.data).toBe(flatRow)
+
+      expect(result.legacy).toBe('incoming_imported')
+    })
+
+    it('should prefer hooks.beforeImport when both are defined on a field', () => {
+      const legacyCalls: string[] = []
+      const modernCalls: string[] = []
+
+      const fields: FlattenedField[] = [
+        {
+          name: 'both',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              fromCSV: ({ value }: { value: unknown }) => {
+                legacyCalls.push(String(value))
+                return `${value}_legacy`
+              },
+              hooks: {
+                beforeImport: ({ value }) => {
+                  modernCalls.push(String(value))
+                  return `${value}_modern`
+                },
+              },
+            },
+          },
+        } as FlattenedField,
+      ]
+
+      const importFieldHooks = getImportFieldFunctions({ fields })
+      const result = unflattenObject({
+        data: { both: 'x' },
+        fields,
+        format: 'csv',
+        importFieldHooks,
+        req: mockReq,
+      })
+
+      expect(modernCalls).toEqual(['x'])
+      expect(legacyCalls).toEqual([])
+      expect(result.both).toBe('x_modern')
+    })
+  })
+})

--- a/packages/plugin-import-export/src/utilities/polymorphicRel.ts
+++ b/packages/plugin-import-export/src/utilities/polymorphicRel.ts
@@ -1,0 +1,23 @@
+export type PolymorphicRelValue = {
+  relationTo: string
+  value: { id: number | string } | number | string
+}
+
+export const isPolymorphicRelValue = (v: unknown): v is PolymorphicRelValue =>
+  typeof v === 'object' && v !== null && 'relationTo' in v && 'value' in v
+
+/**
+ * Returns the id of a populated polymorphic relationship value, or `undefined`
+ * if the inner value is missing. Handles both depth=0 (`value` is the bare id)
+ * and depth>=1 (`value` is the populated doc).
+ */
+export const getPolymorphicRelId = (v: PolymorphicRelValue): number | string | undefined => {
+  const inner = v.value
+  if (inner == null) {
+    return undefined
+  }
+  if (typeof inner === 'object') {
+    return (inner as { id?: number | string }).id
+  }
+  return inner
+}

--- a/packages/plugin-import-export/src/utilities/processRichTextField.ts
+++ b/packages/plugin-import-export/src/utilities/processRichTextField.ts
@@ -19,14 +19,14 @@ export const processRichTextField = (value: unknown): unknown => {
     'textStyle',
   ]
 
-  const processNode = (node: any): any => {
+  const processNode = (node: unknown): unknown => {
     if (!node || typeof node !== 'object') {
       return node
     }
 
     // Process current node's properties
-    const processed: any = {}
-    for (const [key, val] of Object.entries(node)) {
+    const processed: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(node as Record<string, unknown>)) {
       if (numericProperties.includes(key) && typeof val === 'string') {
         // Convert string numbers to actual numbers
         const num = parseFloat(val)

--- a/packages/plugin-import-export/src/utilities/removeDisabledFields.ts
+++ b/packages/plugin-import-export/src/utilities/removeDisabledFields.ts
@@ -33,7 +33,7 @@ export const removeDisabledFields = (
      * @param target - The current object or array being traversed
      * @param i - The index of the current path part
      */
-    const removeRecursively = (target: any, i = 0): void => {
+    const removeRecursively = (target: unknown, i = 0): void => {
       if (target == null) {
         return
       }
@@ -46,11 +46,11 @@ export const removeDisabledFields = (
         if (Array.isArray(target)) {
           for (const item of target) {
             if (item && typeof item === 'object' && key !== undefined) {
-              delete item[key as keyof typeof item]
+              delete (item as Record<string, unknown>)[key]
             }
           }
         } else if (typeof target === 'object' && key !== undefined) {
-          delete target[key]
+          delete (target as Record<string, unknown>)[key]
         }
         return
       }
@@ -60,7 +60,7 @@ export const removeDisabledFields = (
       }
 
       // Traverse to the next level in the path
-      const next = target[key]
+      const next = (target as Record<string, unknown>)[key]
 
       if (Array.isArray(next)) {
         // If the next value is an array, recurse into each item

--- a/packages/plugin-import-export/src/utilities/setNestedValue.ts
+++ b/packages/plugin-import-export/src/utilities/setNestedValue.ts
@@ -22,7 +22,7 @@ export const setNestedValue = (
   value: unknown,
 ): void => {
   const parts = path.split('.')
-  let current: any = obj
+  let current: unknown = obj
 
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]
@@ -37,28 +37,32 @@ export const setNestedValue = (
         current = []
       }
 
+      const currentArray = current as unknown[]
+
       // Ensure the array slot is initialized
-      if (!current[index]) {
-        current[index] = {}
+      if (!currentArray[index]) {
+        currentArray[index] = {}
       }
 
       if (isLast) {
-        current[index] = value
+        currentArray[index] = value
       } else {
-        current = current[index] as Record<string, unknown>
+        current = currentArray[index]
       }
     } else {
+      const currentObj = current as Record<string, unknown>
+
       // Ensure the object key exists
       if (isLast) {
         if (typeof part === 'string') {
-          current[part] = value
+          currentObj[part] = value
         }
       } else {
-        if (typeof current[part as string] !== 'object' || current[part as string] === null) {
-          current[part as string] = {}
+        if (typeof currentObj[part as string] !== 'object' || currentObj[part as string] === null) {
+          currentObj[part as string] = {}
         }
 
-        current = current[part as string] as Record<string, unknown>
+        current = currentObj[part as string]
       }
     }
   }

--- a/packages/plugin-import-export/src/utilities/siblingDoc.spec.ts
+++ b/packages/plugin-import-export/src/utilities/siblingDoc.spec.ts
@@ -1,0 +1,259 @@
+import { FlattenedField, PayloadRequest } from 'payload'
+
+import type { FieldBeforeExportHook, FieldBeforeImportHook } from '../types.js'
+
+import { applyFieldHooks } from './applyFieldHooks.js'
+import { flattenObject } from './flattenObject.js'
+import { getExportFieldFunctions } from './getExportFieldFunctions.js'
+import { getImportFieldFunctions } from './getImportFieldFunctions.js'
+import { unflattenObject } from './unflattenObject.js'
+
+import { describe, expect, it, vi } from 'vitest'
+
+const mockReq = {
+  payload: {
+    logger: {
+      error: vi.fn(),
+    },
+  },
+} as unknown as PayloadRequest
+
+describe('beforeExport / beforeImport siblingDoc arg', () => {
+  describe('CSV export (flattenObject)', () => {
+    it('passes the source doc at the current nesting level as siblingDoc', () => {
+      const received: Array<{
+        columnName: string
+        isSiblingDocSource: boolean
+        isSiblingDocRow: boolean
+      }> = []
+
+      const fields: FlattenedField[] = [
+        { name: 'title', type: 'text' } as FlattenedField,
+        {
+          name: 'group',
+          type: 'group',
+          flattenedFields: [
+            {
+              name: 'inner',
+              type: 'text',
+              custom: {
+                'plugin-import-export': {
+                  hooks: {
+                    beforeExport: (({ columnName, siblingData, siblingDoc, value }) => {
+                      received.push({
+                        columnName,
+                        isSiblingDocSource:
+                          siblingDoc &&
+                          typeof siblingDoc === 'object' &&
+                          siblingDoc.inner === value,
+                        isSiblingDocRow: siblingDoc === siblingData,
+                      })
+                      return value
+                    }) satisfies FieldBeforeExportHook,
+                  },
+                },
+              },
+            },
+          ],
+        } as unknown as FlattenedField,
+      ]
+
+      const exportFieldHooks = getExportFieldFunctions({ fields })
+
+      flattenObject({
+        data: { group: { inner: 'deep' }, title: 'Top' },
+        exportFieldHooks,
+        format: 'csv',
+        req: mockReq,
+      })
+
+      expect(received).toEqual([
+        {
+          columnName: 'group_inner',
+          isSiblingDocSource: true,
+          isSiblingDocRow: false,
+        },
+      ])
+    })
+
+    it('lets a hook read another sibling by reading siblingDoc', () => {
+      const fields: FlattenedField[] = [
+        { name: 'firstName', type: 'text' } as FlattenedField,
+        {
+          name: 'fullName',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeExport: (({ siblingDoc, value }) => {
+                  const last = siblingDoc.lastName as string | undefined
+                  const first = siblingDoc.firstName as string | undefined
+                  if (first && last) {
+                    return `${first} ${last}`
+                  }
+                  return value
+                }) satisfies FieldBeforeExportHook,
+              },
+            },
+          },
+        } as FlattenedField,
+        { name: 'lastName', type: 'text' } as FlattenedField,
+      ]
+
+      const exportFieldHooks = getExportFieldFunctions({ fields })
+
+      const result = flattenObject({
+        data: { firstName: 'Ada', fullName: '(computed)', lastName: 'Lovelace' },
+        exportFieldHooks,
+        format: 'csv',
+        req: mockReq,
+      })
+
+      expect(result.fullName).toBe('Ada Lovelace')
+    })
+  })
+
+  describe('JSON export (applyFieldHooks)', () => {
+    it('passes the untouched source sibling as siblingDoc and the mutable output as siblingData', () => {
+      let capturedSiblingDoc: Record<string, unknown> | null = null
+      let capturedSiblingData: Record<string, unknown> | null = null
+
+      const fields: FlattenedField[] = [
+        {
+          name: 'outer',
+          type: 'group',
+          flattenedFields: [
+            {
+              name: 'tracked',
+              type: 'text',
+              custom: {
+                'plugin-import-export': {
+                  hooks: {
+                    beforeExport: (({ siblingData, siblingDoc, value }) => {
+                      capturedSiblingDoc = siblingDoc
+                      capturedSiblingData = siblingData
+                      siblingData.injected = 'written-into-output'
+                      return String(value) + '_changed'
+                    }) satisfies FieldBeforeExportHook,
+                  },
+                },
+              },
+            },
+          ],
+        } as unknown as FlattenedField,
+      ]
+
+      const exportFieldHooks = getExportFieldFunctions({ fields })
+
+      const source = { outer: { tracked: 'original' } }
+
+      applyFieldHooks({
+        data: source,
+        fieldHooks: exportFieldHooks,
+        fields,
+        format: 'json',
+        operation: 'export',
+        req: mockReq,
+        type: 'beforeExport',
+      })
+
+      expect(capturedSiblingDoc).toEqual({ tracked: 'original' })
+      // The hook's mutation lives on siblingData, not siblingDoc
+      expect((capturedSiblingData as unknown as Record<string, unknown>)?.injected).toBe(
+        'written-into-output',
+      )
+      expect((capturedSiblingDoc as unknown as Record<string, unknown>)?.injected).toBeUndefined()
+      // And the source object itself is not mutated
+      expect(source).toEqual({ outer: { tracked: 'original' } })
+    })
+  })
+
+  describe('CSV import (unflattenObject)', () => {
+    it('passes the full flat row as siblingDoc (equal to data)', () => {
+      const received: Array<{ siblingDocIsData: boolean }> = []
+
+      const fields: FlattenedField[] = [
+        { name: 'title', type: 'text' } as FlattenedField,
+        {
+          name: 'note',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeImport: (({ data, siblingDoc, value }) => {
+                  received.push({ siblingDocIsData: siblingDoc === data })
+                  return value
+                }) satisfies FieldBeforeImportHook,
+              },
+            },
+          },
+        } as FlattenedField,
+      ]
+
+      const importFieldHooks = getImportFieldFunctions({ fields })
+
+      unflattenObject({
+        data: { note: 'hello', title: 'Top' },
+        fields,
+        format: 'csv',
+        importFieldHooks,
+        req: mockReq,
+      })
+
+      expect(received).toEqual([{ siblingDocIsData: true }])
+    })
+  })
+
+  describe('JSON import (applyFieldHooks)', () => {
+    it('passes the untouched source sibling as siblingDoc and the mutable output as siblingData', () => {
+      let capturedSiblingDoc: Record<string, unknown> | null = null
+      let capturedSiblingData: Record<string, unknown> | null = null
+
+      const fields: FlattenedField[] = [
+        {
+          name: 'outer',
+          type: 'group',
+          flattenedFields: [
+            {
+              name: 'tracked',
+              type: 'text',
+              custom: {
+                'plugin-import-export': {
+                  hooks: {
+                    beforeImport: (({ siblingData, siblingDoc, value }) => {
+                      capturedSiblingDoc = siblingDoc
+                      capturedSiblingData = siblingData
+                      siblingData.injected = 'written-into-output'
+                      return value
+                    }) satisfies FieldBeforeImportHook,
+                  },
+                },
+              },
+            },
+          ],
+        } as unknown as FlattenedField,
+      ]
+
+      const importFieldHooks = getImportFieldFunctions({ fields })
+
+      const source = { outer: { tracked: 'original' } }
+
+      applyFieldHooks({
+        data: source,
+        fieldHooks: importFieldHooks,
+        fields,
+        format: 'json',
+        operation: 'import',
+        req: mockReq,
+        type: 'beforeImport',
+      })
+
+      expect(capturedSiblingDoc).toEqual({ tracked: 'original' })
+      expect((capturedSiblingData as unknown as Record<string, unknown>)?.injected).toBe(
+        'written-into-output',
+      )
+      expect((capturedSiblingDoc as unknown as Record<string, unknown>)?.injected).toBeUndefined()
+      expect(source).toEqual({ outer: { tracked: 'original' } })
+    })
+  })
+})

--- a/packages/plugin-import-export/src/utilities/unflattenObject.spec.ts
+++ b/packages/plugin-import-export/src/utilities/unflattenObject.spec.ts
@@ -533,6 +533,37 @@ describe('unflattenObject', () => {
     })
   })
 
+  describe('field-hook key resolution', () => {
+    it('should fire an import hook on a digit-only field name nested inside an array', () => {
+      const fields: FlattenedField[] = [
+        {
+          name: 'archives',
+          type: 'array',
+          flattenedFields: [{ name: '2024', type: 'text' }],
+        } as unknown as FlattenedField,
+      ]
+
+      const importFieldHooks = {
+        archives_2024: {
+          type: 'beforeImport' as const,
+          fn: ({ value }: { value: unknown }) => `transformed-${value as string}`,
+        },
+      }
+
+      const data = { archives_0_2024: 'raw' }
+
+      const result = unflattenObject({
+        data,
+        fields,
+        importFieldHooks,
+        req: mockReq,
+      })
+
+      const archives = result.archives as Array<Record<string, unknown>>
+      expect(archives[0]!['2024']).toBe('transformed-raw')
+    })
+  })
+
   describe('edge cases', () => {
     it('should handle empty data', () => {
       const result = unflattenObject({ data: {}, fields: [], req: mockReq })

--- a/packages/plugin-import-export/src/utilities/unflattenObject.ts
+++ b/packages/plugin-import-export/src/utilities/unflattenObject.ts
@@ -1,14 +1,47 @@
 import type { FlattenedField, PayloadRequest } from 'payload'
 
-import type { FromCSVFunction } from '../types.js'
+import type { ImportFieldHookEntry } from '../types.js'
 
-import { processRichTextField } from './processRichTextField.js'
+import { getNestedFlattenedFields } from './flattenedFields.js'
+import { postProcessDocument } from './unflattenPostProcess.js'
 
 type UnflattenArgs = {
   data: Record<string, unknown>
   fields: FlattenedField[]
-  fromCSVFunctions?: Record<string, FromCSVFunction>
+  format?: 'csv' | 'json' | ({} & string)
+  importFieldHooks?: Record<string, ImportFieldHookEntry>
   req: PayloadRequest
+}
+
+const indexSegment = /^\d+$/
+
+const collectArrayLikeNames = (fields: FlattenedField[], into: Set<string>): void => {
+  for (const field of fields) {
+    if (!('name' in field) || !field.name) {
+      continue
+    }
+    if (field.type === 'array' || field.type === 'blocks') {
+      into.add(field.name)
+    }
+    const nested = getNestedFlattenedFields(field)
+    if (nested) {
+      collectArrayLikeNames(nested, into)
+    }
+  }
+}
+
+/**
+ * Drops numeric array-index segments from a flat key so a runtime key like
+ * `items_0_note` matches the static, index-free key a user hook is registered
+ * under. A digit-only segment is only stripped when the segment immediately
+ * before it names an array or blocks field, so a literal field name like
+ * `2024` is preserved.
+ */
+const toLogicalKey = (flatKey: string, arrayLikeNames: Set<string>): string => {
+  const segments = flatKey.split('_')
+  return segments
+    .filter((seg, i) => !indexSegment.test(seg) || !arrayLikeNames.has(segments[i - 1] ?? ''))
+    .join('_')
 }
 
 /**
@@ -27,7 +60,8 @@ type UnflattenArgs = {
 export const unflattenObject = ({
   data,
   fields,
-  fromCSVFunctions = {},
+  format = 'csv',
+  importFieldHooks = {},
   req,
 }: UnflattenArgs): Record<string, unknown> => {
   if (!data || typeof data !== 'object') {
@@ -35,6 +69,9 @@ export const unflattenObject = ({
   }
 
   const result: Record<string, unknown> = {}
+
+  const arrayLikeNames = new Set<string>()
+  collectArrayLikeNames(fields, arrayLikeNames)
 
   // Sort keys to ensure array indices are processed in order
   const sortedKeys = Object.keys(data).sort((a, b) => {
@@ -118,13 +155,34 @@ export const unflattenObject = ({
       }
     }
 
-    // Apply fromCSV function if available
-    if (fromCSVFunctions[flatKey]) {
-      value = fromCSVFunctions[flatKey]({
-        columnName: flatKey,
-        data,
-        value,
-      })
+    const importHookEntry =
+      importFieldHooks[flatKey] ?? importFieldHooks[toLogicalKey(flatKey, arrayLikeNames)]
+    if (importHookEntry) {
+      try {
+        if (importHookEntry.type === 'beforeImport') {
+          value = importHookEntry.fn({
+            columnName: flatKey,
+            data,
+            format,
+            siblingData: data,
+            siblingDoc: data,
+            value,
+          })
+        } else {
+          value = importHookEntry.fn({
+            columnName: flatKey,
+            data,
+            value,
+          })
+        }
+      } catch (error) {
+        req.payload.logger.error({
+          err: error,
+          msg: `[plugin-import-export] Field-level beforeImport hook for "${flatKey}" threw — falling back to original value`,
+        })
+        // Keep the original value so the row is not dropped — downstream
+        // validation will surface any deeper issue per-row.
+      }
     }
 
     // Example: "blocks_0_content_text" -> ["blocks", "0", "content", "text"]
@@ -364,209 +422,4 @@ const getParentObject = (
   }
 
   return current
-}
-
-/**
- * Post-processes the unflattened document to handle special field types:
- * - Localized fields: transforms field_locale keys to nested { field: { locale: value } }
- * - Number hasMany: converts comma-separated strings or arrays to number arrays
- * - Relationship hasMany: converts comma-separated IDs to arrays
- * - Polymorphic relationships: transforms flat {relationTo, id} to {relationTo, value}
- * - Rich text fields: ensures proper data structure
- */
-const postProcessDocument = (doc: Record<string, unknown>, fields: FlattenedField[]): void => {
-  const localizedFields = fields.filter((field) => field.localized)
-  const processedLocalizedFields = new Set<string>()
-
-  for (const field of localizedFields) {
-    if (processedLocalizedFields.has(field.name)) {
-      continue
-    }
-
-    // Look for all locale-specific keys for this field
-    const localePattern = new RegExp(`^${field.name}_([a-z]{2}(?:_[A-Z]{2})?)$`)
-    const localeData: Record<string, unknown> = {}
-    const keysToDelete: string[] = []
-
-    for (const [key, value] of Object.entries(doc)) {
-      const match = key.match(localePattern)
-      if (match && match[1]) {
-        const locale = match[1]
-        localeData[locale] = value
-        keysToDelete.push(key)
-      }
-    }
-
-    // If we found locale-specific data, restructure it as Payload expects
-    if (Object.keys(localeData).length > 0) {
-      // Payload stores localized fields as nested objects: { field: { en: 'value', es: 'value' } }
-      doc[field.name] = localeData
-      keysToDelete.forEach((key) => delete doc[key])
-      processedLocalizedFields.add(field.name)
-    }
-  }
-
-  // Handle number fields with hasMany - convert string arrays to number arrays
-  const numberFields = fields.filter((field) => field.type === 'number' && field.hasMany)
-  for (const field of numberFields) {
-    const value = doc[field.name]
-
-    // Skip if field doesn't exist in document
-    if (!(field.name in doc)) {
-      continue
-    }
-
-    // Handle comma-separated string (e.g., "1,2,3,4,5")
-    if (typeof value === 'string' && value.includes(',')) {
-      doc[field.name] = value
-        .split(',')
-        .map((v) => v.trim())
-        .filter((v) => v !== '')
-        .map((v) => {
-          const num = parseFloat(v)
-          return isNaN(num) ? 0 : num
-        })
-    }
-    // Handle array of values from indexed columns (e.g., field_0, field_1, etc.)
-    else if (Array.isArray(value)) {
-      // Filter out null, undefined, and empty string values, then convert to numbers
-      doc[field.name] = value
-        .filter((v) => v !== null && v !== undefined && v !== '')
-        .map((v) => {
-          if (typeof v === 'string') {
-            const num = parseFloat(v)
-            return isNaN(num) ? 0 : num
-          }
-          return v
-        })
-    }
-    // Handle single value for hasMany (convert to array)
-    else if (value !== null && value !== undefined && value !== '') {
-      const num = typeof value === 'string' ? parseFloat(value) : value
-      doc[field.name] = isNaN(num as number) ? [] : [num]
-    }
-    // Handle empty/null values - convert to empty array for hasMany
-    else {
-      doc[field.name] = []
-    }
-  }
-
-  // Handle relationship fields with hasMany - convert comma-separated IDs to arrays
-  const relationshipFields = fields.filter(
-    (field) =>
-      (field.type === 'relationship' || field.type === 'upload') &&
-      field.hasMany === true &&
-      !Array.isArray(field.relationTo), // Skip polymorphic for now, handled separately
-  )
-  for (const field of relationshipFields) {
-    const value = doc[field.name]
-
-    // Handle comma-separated string of IDs (e.g., "id1,id2,id3")
-    if (typeof value === 'string' && value.includes(',')) {
-      doc[field.name] = value
-        .split(',')
-        .map((v) => v.trim())
-        .filter((v) => v !== '')
-    }
-    // Keep array as-is if already an array
-    else if (Array.isArray(value)) {
-      doc[field.name] = value.filter((v) => v !== null && v !== undefined && v !== '')
-    }
-    // Convert single value to array for hasMany
-    else if (value !== null && value !== undefined && value !== '') {
-      doc[field.name] = [value]
-    }
-  }
-
-  // Handle polymorphic relationships - transform from flat structure to proper format
-  for (const [key, value] of Object.entries(doc)) {
-    // Handle arrays of polymorphic relationships
-    if (Array.isArray(value)) {
-      // Check if this array contains polymorphic relationship objects
-      const hasPolymorphicItems = value.some(
-        (item) => typeof item === 'object' && item !== null && 'relationTo' in item,
-      )
-
-      if (hasPolymorphicItems) {
-        // Filter out null/invalid polymorphic items and transform valid ones
-        const processedArray = []
-        for (let i = 0; i < value.length; i++) {
-          const item = value[i]
-          if (typeof item === 'object' && item !== null && 'relationTo' in item) {
-            const typedItem = item as Record<string, unknown>
-
-            // Skip if both relationTo and value/id are null/empty
-            if (!typedItem.relationTo || (!typedItem.id && !typedItem.value)) {
-              continue
-            }
-
-            // Transform from {relationTo: 'collection', id: '123'} to {relationTo: 'collection', value: '123'}
-            if ('id' in typedItem) {
-              typedItem.value = typedItem.id
-              delete typedItem.id
-            }
-
-            processedArray.push(typedItem)
-          } else if (item !== null && item !== undefined) {
-            processedArray.push(item)
-          }
-        }
-
-        // Update the array with filtered results
-        if (value.length !== processedArray.length) {
-          doc[key] = processedArray.length > 0 ? processedArray : []
-        }
-      }
-      // For non-polymorphic arrays, preserve null placeholders for sparse arrays
-    }
-    // Handle single polymorphic relationships
-    else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-      // Check if this is a single polymorphic relationship
-      if ('relationTo' in value && ('id' in value || 'value' in value)) {
-        const typedValue = value as Record<string, unknown>
-
-        // If both relationTo and value are null/empty, set the whole field to null
-        if (!typedValue.relationTo || (!typedValue.id && !typedValue.value)) {
-          doc[key] = null
-        } else {
-          // If it has 'id', transform to 'value'
-          if ('id' in typedValue && !('value' in typedValue)) {
-            typedValue.value = typedValue.id
-            delete typedValue.id
-          }
-        }
-      } else {
-        // Recursively process nested objects
-        postProcessDocument(value as Record<string, unknown>, fields)
-      }
-    }
-  }
-
-  // Process rich text fields to ensure proper data types
-  const richTextFields = fields.filter((field) => field.type === 'richText')
-  for (const field of richTextFields) {
-    if (field.name in doc && doc[field.name]) {
-      doc[field.name] = processRichTextField(doc[field.name])
-    }
-  }
-
-  // Also process rich text fields in blocks
-  const blockFields = fields.filter((field) => field.type === 'blocks')
-  for (const field of blockFields) {
-    if (field.name in doc && Array.isArray(doc[field.name])) {
-      const blocks = doc[field.name] as any[]
-      for (const block of blocks) {
-        if (!block || typeof block !== 'object') {
-          continue
-        }
-
-        // Look for richText fields directly in the block
-        for (const [key, value] of Object.entries(block)) {
-          if (key === 'richText' || (typeof key === 'string' && key.includes('richText'))) {
-            block[key] = processRichTextField(value)
-          }
-        }
-      }
-    }
-  }
 }

--- a/packages/plugin-import-export/src/utilities/unflattenPostProcess.ts
+++ b/packages/plugin-import-export/src/utilities/unflattenPostProcess.ts
@@ -1,0 +1,185 @@
+import type { FlattenedField } from 'payload'
+
+import { isPlainObject } from './isPlainObject.js'
+import { processRichTextField } from './processRichTextField.js'
+
+const normalizeLocalizedFields = (doc: Record<string, unknown>, fields: FlattenedField[]): void => {
+  const processed = new Set<string>()
+
+  for (const field of fields.filter((f) => f.localized)) {
+    if (processed.has(field.name)) {
+      continue
+    }
+
+    const localePattern = new RegExp(`^${field.name}_([a-z]{2}(?:_[A-Z]{2})?)$`)
+    const localeData: Record<string, unknown> = {}
+    const keysToDelete: string[] = []
+
+    for (const [key, value] of Object.entries(doc)) {
+      const match = key.match(localePattern)
+      if (match && match[1]) {
+        localeData[match[1]] = value
+        keysToDelete.push(key)
+      }
+    }
+
+    if (Object.keys(localeData).length > 0) {
+      doc[field.name] = localeData
+      keysToDelete.forEach((key) => delete doc[key])
+      processed.add(field.name)
+    }
+  }
+}
+
+const normalizeHasManyNumbers = (doc: Record<string, unknown>, fields: FlattenedField[]): void => {
+  const numberFields = fields.filter((field) => field.type === 'number' && field.hasMany)
+  for (const field of numberFields) {
+    if (!(field.name in doc)) {
+      continue
+    }
+    const value = doc[field.name]
+
+    if (typeof value === 'string' && value.includes(',')) {
+      doc[field.name] = value
+        .split(',')
+        .map((v) => v.trim())
+        .filter((v) => v !== '')
+        .map((v) => {
+          const num = parseFloat(v)
+          return isNaN(num) ? 0 : num
+        })
+    } else if (Array.isArray(value)) {
+      doc[field.name] = value
+        .filter((v) => v !== null && v !== undefined && v !== '')
+        .map((v) => {
+          if (typeof v === 'string') {
+            const num = parseFloat(v)
+            return isNaN(num) ? 0 : num
+          }
+          return v
+        })
+    } else if (value !== null && value !== undefined && value !== '') {
+      const num = typeof value === 'string' ? parseFloat(value) : value
+      doc[field.name] = isNaN(num as number) ? [] : [num]
+    } else {
+      doc[field.name] = []
+    }
+  }
+}
+
+const normalizeHasManyRelationships = (
+  doc: Record<string, unknown>,
+  fields: FlattenedField[],
+): void => {
+  const relationshipFields = fields.filter(
+    (field) =>
+      (field.type === 'relationship' || field.type === 'upload') &&
+      field.hasMany === true &&
+      !Array.isArray(field.relationTo),
+  )
+
+  for (const field of relationshipFields) {
+    const value = doc[field.name]
+
+    if (typeof value === 'string' && value.includes(',')) {
+      doc[field.name] = value
+        .split(',')
+        .map((v) => v.trim())
+        .filter((v) => v !== '')
+    } else if (Array.isArray(value)) {
+      doc[field.name] = value.filter((v) => v !== null && v !== undefined && v !== '')
+    } else if (value !== null && value !== undefined && value !== '') {
+      doc[field.name] = [value]
+    }
+  }
+}
+
+const normalizePolymorphicRelationships = (
+  doc: Record<string, unknown>,
+  fields: FlattenedField[],
+): void => {
+  for (const [key, value] of Object.entries(doc)) {
+    if (Array.isArray(value)) {
+      const hasPolymorphicItems = value.some((item) => isPlainObject(item) && 'relationTo' in item)
+
+      if (!hasPolymorphicItems) {
+        continue
+      }
+
+      const processedArray: unknown[] = []
+      for (const item of value) {
+        if (isPlainObject(item) && 'relationTo' in item) {
+          if (!item.relationTo || (!item.id && !item.value)) {
+            continue
+          }
+          if ('id' in item) {
+            item.value = item.id
+            delete item.id
+          }
+          processedArray.push(item)
+        } else if (item !== null && item !== undefined) {
+          processedArray.push(item)
+        }
+      }
+
+      if (value.length !== processedArray.length) {
+        doc[key] = processedArray.length > 0 ? processedArray : []
+      }
+    } else if (isPlainObject(value)) {
+      if ('relationTo' in value && ('id' in value || 'value' in value)) {
+        if (!value.relationTo || (!value.id && !value.value)) {
+          doc[key] = null
+        } else if ('id' in value && !('value' in value)) {
+          value.value = value.id
+          delete value.id
+        }
+      } else {
+        normalizePolymorphicRelationships(value, fields)
+      }
+    }
+  }
+}
+
+const normalizeRichText = (doc: Record<string, unknown>, fields: FlattenedField[]): void => {
+  for (const field of fields.filter((f) => f.type === 'richText')) {
+    if (field.name in doc && doc[field.name]) {
+      doc[field.name] = processRichTextField(doc[field.name])
+    }
+  }
+
+  for (const field of fields.filter((f) => f.type === 'blocks')) {
+    const blocks = doc[field.name]
+    if (!Array.isArray(blocks)) {
+      continue
+    }
+    for (const block of blocks) {
+      if (!isPlainObject(block)) {
+        continue
+      }
+      for (const [key, value] of Object.entries(block)) {
+        if (key === 'richText' || (typeof key === 'string' && key.includes('richText'))) {
+          block[key] = processRichTextField(value)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Post-processes the unflattened document to handle special field types:
+ * - Localized fields: transforms field_locale keys to nested { field: { locale: value } }
+ * - Number hasMany: converts comma-separated strings or arrays to number arrays
+ * - Relationship hasMany: converts comma-separated IDs to arrays
+ * - Polymorphic relationships: transforms flat {relationTo, id} to {relationTo, value}
+ * - Rich text fields: ensures proper data structure
+ */
+export const postProcessDocument = (
+  doc: Record<string, unknown>,
+  fields: FlattenedField[],
+): void => {
+  normalizeLocalizedFields(doc, fields)
+  normalizeHasManyNumbers(doc, fields)
+  normalizeHasManyRelationships(doc, fields)
+  normalizePolymorphicRelationships(doc, fields)
+  normalizeRichText(doc, fields)
+}

--- a/templates/with-vercel-mongodb/.npmrc
+++ b/templates/with-vercel-mongodb/.npmrc
@@ -1,6 +1,2 @@
 legacy-peer-deps=true
 enable-pre-post-scripts=true
-onlyBuiltDependencies[]=bufferutil
-onlyBuiltDependencies[]=esbuild
-onlyBuiltDependencies[]=sharp
-onlyBuiltDependencies[]=unrs-resolver

--- a/templates/with-vercel-mongodb/.npmrc
+++ b/templates/with-vercel-mongodb/.npmrc
@@ -1,0 +1,6 @@
+legacy-peer-deps=true
+enable-pre-post-scripts=true
+onlyBuiltDependencies[]=bufferutil
+onlyBuiltDependencies[]=esbuild
+onlyBuiltDependencies[]=sharp
+onlyBuiltDependencies[]=unrs-resolver

--- a/templates/with-vercel-mongodb/package.json
+++ b/templates/with-vercel-mongodb/package.json
@@ -18,17 +18,17 @@
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.mts"
   },
   "dependencies": {
+    "@payloadcms/db-mongodb": "3.84.1",
     "@payloadcms/next": "3.84.1",
     "@payloadcms/richtext-lexical": "3.84.1",
+    "@payloadcms/storage-vercel-blob": "3.84.1",
     "@payloadcms/ui": "3.84.1",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",
     "next": "16.2.6",
     "payload": "3.84.1",
     "react": "19.2.6",
-    "react-dom": "19.2.6",
-    "@payloadcms/db-mongodb": "3.84.1",
-    "@payloadcms/storage-vercel-blob": "3.84.1"
+    "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -47,15 +47,16 @@
     "vite-tsconfig-paths": "6.0.5",
     "vitest": "4.0.18"
   },
+  "packageManager": "pnpm@11.0.8",
   "engines": {
     "node": "^18.20.2 || >=20.9.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp",
+      "bufferutil",
       "esbuild",
+      "sharp",
       "unrs-resolver"
     ]
-  },
-  "packageManager": "pnpm@11.0.8"
+  }
 }

--- a/templates/with-vercel-postgres/.npmrc
+++ b/templates/with-vercel-postgres/.npmrc
@@ -1,6 +1,2 @@
 legacy-peer-deps=true
 enable-pre-post-scripts=true
-onlyBuiltDependencies[]=bufferutil
-onlyBuiltDependencies[]=esbuild
-onlyBuiltDependencies[]=sharp
-onlyBuiltDependencies[]=unrs-resolver

--- a/templates/with-vercel-postgres/.npmrc
+++ b/templates/with-vercel-postgres/.npmrc
@@ -1,0 +1,6 @@
+legacy-peer-deps=true
+enable-pre-post-scripts=true
+onlyBuiltDependencies[]=bufferutil
+onlyBuiltDependencies[]=esbuild
+onlyBuiltDependencies[]=sharp
+onlyBuiltDependencies[]=unrs-resolver

--- a/templates/with-vercel-postgres/package.json
+++ b/templates/with-vercel-postgres/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
+    "ci": "payload migrate && pnpm build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
@@ -15,21 +16,20 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:e2e",
     "test:e2e": "cross-env NODE_OPTIONS=\"--no-deprecation --import=tsx/esm\" playwright test --config=playwright.config.ts",
-    "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.mts",
-    "ci": "payload migrate && pnpm build"
+    "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.mts"
   },
   "dependencies": {
+    "@payloadcms/db-vercel-postgres": "3.84.1",
     "@payloadcms/next": "3.84.1",
     "@payloadcms/richtext-lexical": "3.84.1",
+    "@payloadcms/storage-vercel-blob": "3.84.1",
     "@payloadcms/ui": "3.84.1",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",
     "next": "16.2.6",
     "payload": "3.84.1",
     "react": "19.2.6",
-    "react-dom": "19.2.6",
-    "@payloadcms/db-vercel-postgres": "3.84.1",
-    "@payloadcms/storage-vercel-blob": "3.84.1"
+    "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -48,15 +48,16 @@
     "vite-tsconfig-paths": "6.0.5",
     "vitest": "4.0.18"
   },
+  "packageManager": "pnpm@11.0.8",
   "engines": {
     "node": "^18.20.2 || >=20.9.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "sharp",
+      "bufferutil",
       "esbuild",
+      "sharp",
       "unrs-resolver"
     ]
-  },
-  "packageManager": "pnpm@11.0.8"
+  }
 }

--- a/test/plugin-import-export/collections/Pages.ts
+++ b/test/plugin-import-export/collections/Pages.ts
@@ -33,7 +33,7 @@ export const Pages: CollectionConfig = {
       defaultValue: 'my custom csv transformer',
       custom: {
         'plugin-import-export': {
-          toCSV: ({ value, columnName, row, siblingDoc }) => {
+          toCSV: ({ value }) => {
             return String(value) + ' toCSV'
           },
         },
@@ -147,7 +147,7 @@ export const Pages: CollectionConfig = {
           defaultValue: 'my custom csv transformer',
           custom: {
             'plugin-import-export': {
-              toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
+              toCSV: ({ value }) => {
                 return String(value) + ' toCSV'
               },
             },
@@ -167,7 +167,7 @@ export const Pages: CollectionConfig = {
               defaultValue: 'my custom csv transformer',
               custom: {
                 'plugin-import-export': {
-                  toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
+                  toCSV: ({ value }) => {
                     return String(value) + ' toCSV'
                   },
                 },
@@ -187,7 +187,7 @@ export const Pages: CollectionConfig = {
               defaultValue: 'my custom csv transformer',
               custom: {
                 'plugin-import-export': {
-                  toCSV: ({ value, columnName, row, siblingDoc, doc }) => {
+                  toCSV: ({ value }) => {
                     return String(value) + ' toCSV'
                   },
                 },

--- a/test/plugin-import-export/collections/PostsWithColumnMap.ts
+++ b/test/plugin-import-export/collections/PostsWithColumnMap.ts
@@ -1,0 +1,43 @@
+import type { FieldBeforeExportHook } from '@payloadcms/plugin-import-export/types'
+import type { CollectionConfig } from 'payload'
+
+import { postsWithColumnMapSlug } from '../shared.js'
+
+// Payload field name -> foreign system column name.
+// Used by collection-level export.hooks.before in config.ts and mirrored
+// in import.hooks.before.
+export const exportRenameMap: Record<string, string> = {
+  title: 'Post Title',
+  excerpt: 'Summary',
+  count: 'View Count',
+}
+
+export const importRenameMap: Record<string, string> = {
+  'Post Title': 'title',
+  Summary: 'excerpt',
+  'View Count': 'count',
+}
+
+export const PostsWithColumnMap: CollectionConfig = {
+  slug: postsWithColumnMapSlug,
+  admin: { useAsTitle: 'title' },
+  fields: [
+    { name: 'title', type: 'text', required: true },
+    { name: 'excerpt', type: 'text' },
+    { name: 'count', type: 'number' },
+    {
+      name: 'sharedName',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          hooks: {
+            beforeExport: (({ siblingData, value }) => {
+              siblingData['Display Name'] = value
+              return undefined
+            }) satisfies FieldBeforeExportHook,
+          },
+        },
+      },
+    },
+  ],
+}

--- a/test/plugin-import-export/collections/PostsWithFieldHooks.ts
+++ b/test/plugin-import-export/collections/PostsWithFieldHooks.ts
@@ -1,0 +1,330 @@
+import type {
+  FieldBeforeExportHook,
+  FieldBeforeImportHook,
+} from '@payloadcms/plugin-import-export/types'
+import type { CollectionConfig } from 'payload'
+
+import { postsWithFieldHooksSlug } from '../shared.js'
+
+export const emailFieldWithHooks = {
+  name: 'email',
+  type: 'text' as const,
+  custom: {
+    'plugin-import-export': {
+      hooks: {
+        beforeExport: (({ value }) => {
+          if (typeof value === 'string') {
+            return value.toLowerCase()
+          }
+          return value
+        }) satisfies FieldBeforeExportHook,
+        beforeImport: (({ value }) => {
+          if (typeof value === 'string') {
+            return value.toLowerCase()
+          }
+          return value
+        }) satisfies FieldBeforeImportHook,
+      },
+    },
+  },
+}
+
+export const PostsWithFieldHooks: CollectionConfig = {
+  slug: postsWithFieldHooksSlug,
+  admin: { useAsTitle: 'title' },
+  fields: [
+    { name: 'title', type: 'text', required: true },
+    { name: 'secret', type: 'text' },
+    { name: 'count', type: 'number' },
+    {
+      name: 'customExport',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          hooks: {
+            beforeExport: (({ columnName, format, siblingData, value }) => {
+              siblingData[`${columnName}_format`] = format
+              return String(value) + ' exported'
+            }) satisfies FieldBeforeExportHook,
+          },
+        },
+      },
+      defaultValue: 'raw value',
+    },
+    {
+      name: 'customImport',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          hooks: {
+            beforeImport: (({ format, value }) => {
+              if (typeof value === 'string') {
+                return `${value}_imported_${format}`
+              }
+              return value
+            }) satisfies FieldBeforeImportHook,
+          },
+        },
+      },
+    },
+    emailFieldWithHooks,
+    {
+      name: 'group',
+      type: 'group',
+      fields: [
+        {
+          type: 'tabs',
+          tabs: [
+            {
+              name: 'namedTab',
+              fields: [
+                {
+                  name: 'deepField',
+                  type: 'text',
+                  custom: {
+                    'plugin-import-export': {
+                      hooks: {
+                        beforeExport: (({ value }) => {
+                          return String(value) + ' deep_exported'
+                        }) satisfies FieldBeforeExportHook,
+                      },
+                    },
+                  },
+                  defaultValue: 'deep value',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'legacyToCSV',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          toCSV: ({ value }: { value: unknown }) => String(value) + ' legacy_toCSV',
+        },
+      },
+      defaultValue: 'legacy value',
+    },
+    {
+      name: 'legacyToCSVArgs',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          toCSV: ({
+            columnName,
+            data,
+            doc,
+            row,
+            siblingDoc,
+            value,
+          }: {
+            columnName: string
+            data: Record<string, unknown>
+            doc: Record<string, unknown>
+            row: Record<string, unknown>
+            siblingDoc: Record<string, unknown>
+            value: unknown
+          }) => {
+            row[`${columnName}_has_row`] = row === data ? 'yes' : 'no'
+            row[`${columnName}_has_doc`] =
+              doc && typeof doc === 'object' && doc.title === siblingDoc.title ? 'yes' : 'no'
+            row[`${columnName}_has_siblingDoc`] =
+              siblingDoc && typeof siblingDoc === 'object' && 'title' in siblingDoc ? 'yes' : 'no'
+            return String(value) + ' legacy_args'
+          },
+        },
+      },
+      defaultValue: 'args value',
+    },
+    {
+      name: 'legacyFromCSV',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          fromCSV: ({ value }: { value: unknown }) =>
+            typeof value === 'string' ? `${value}_legacy_fromCSV` : value,
+        },
+      },
+    },
+    {
+      name: 'legacyFromCSVArgs',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          fromCSV: ({
+            columnName,
+            data,
+            value,
+          }: {
+            columnName: string
+            data: Record<string, unknown>
+            value: unknown
+          }) => {
+            const hasFlatRow = data && typeof data === 'object' && 'title' in data ? 'yes' : 'no'
+            return typeof value === 'string' ? `${value}:${columnName}:${hasFlatRow}` : value
+          },
+        },
+      },
+    },
+    {
+      name: 'items',
+      type: 'array',
+      fields: [
+        {
+          name: 'note',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeExport: (({ value }) => {
+                  return typeof value === 'string' ? `${value} array_exported` : value
+                }) satisfies FieldBeforeExportHook,
+                beforeImport: (({ value }) => {
+                  return typeof value === 'string' ? `${value}_array_imported` : value
+                }) satisfies FieldBeforeImportHook,
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      name: 'content',
+      type: 'blocks',
+      blocks: [
+        {
+          slug: 'textBlock',
+          fields: [
+            {
+              name: 'body',
+              type: 'text',
+              custom: {
+                'plugin-import-export': {
+                  hooks: {
+                    beforeExport: (({ value }) => {
+                      return typeof value === 'string' ? `${value} block_exported` : value
+                    }) satisfies FieldBeforeExportHook,
+                    beforeImport: (({ value }) => {
+                      return typeof value === 'string' ? `${value}_block_imported` : value
+                    }) satisfies FieldBeforeImportHook,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'mayCrash',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          hooks: {
+            beforeExport: (({ value }) => {
+              if (value === 'CRASH') {
+                throw new Error('Field-level beforeExport hook intentionally crashed')
+              }
+              return typeof value === 'string' ? `${value}_exported` : value
+            }) satisfies FieldBeforeExportHook,
+            beforeImport: (({ value }) => {
+              if (value === 'CRASH') {
+                throw new Error('Field-level beforeImport hook intentionally crashed')
+              }
+              return typeof value === 'string' ? `${value}_imported` : value
+            }) satisfies FieldBeforeImportHook,
+          },
+        },
+      },
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'rowField',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeExport: (({ value }) => {
+                  return typeof value === 'string' ? `${value}_row_exported` : value
+                }) satisfies FieldBeforeExportHook,
+                beforeImport: (({ value }) => {
+                  return typeof value === 'string' ? `${value}_row_imported` : value
+                }) satisfies FieldBeforeImportHook,
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      type: 'collapsible',
+      fields: [
+        {
+          name: 'collapsibleField',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeExport: (({ value }) => {
+                  return typeof value === 'string' ? `${value}_collapsible_exported` : value
+                }) satisfies FieldBeforeExportHook,
+                beforeImport: (({ value }) => {
+                  return typeof value === 'string' ? `${value}_collapsible_imported` : value
+                }) satisfies FieldBeforeImportHook,
+              },
+            },
+          },
+        },
+      ],
+      label: 'Collapsible Section',
+    },
+    {
+      name: 'metadata',
+      type: 'group',
+      fields: [
+        {
+          name: 'slugFromTitle',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeImport: (({ data, value }) => {
+                  if (typeof value === 'string' && value.length > 0) {
+                    return value
+                  }
+                  const topLevelTitle = data.title
+                  if (typeof topLevelTitle === 'string') {
+                    return topLevelTitle.toLowerCase().replace(/\s+/g, '-')
+                  }
+                  return value
+                }) satisfies FieldBeforeImportHook,
+              },
+            },
+          },
+        },
+        {
+          name: 'siblingEcho',
+          type: 'text',
+          custom: {
+            'plugin-import-export': {
+              hooks: {
+                beforeImport: (({ siblingData, value }) => {
+                  const slug = siblingData?.slugFromTitle
+                  if (typeof slug === 'string' && slug.length > 0) {
+                    return `${value ?? ''}:${slug}`
+                  }
+                  return value
+                }) satisfies FieldBeforeImportHook,
+              },
+            },
+          },
+        },
+      ],
+    },
+  ],
+}

--- a/test/plugin-import-export/collections/PostsWithHooks.ts
+++ b/test/plugin-import-export/collections/PostsWithHooks.ts
@@ -1,0 +1,42 @@
+import type { FieldBeforeImportHook } from '@payloadcms/plugin-import-export/types'
+import type { CollectionConfig } from 'payload'
+
+import { postsWithHooksSlug } from '../shared.js'
+
+export const PostsWithHooks: CollectionConfig = {
+  slug: postsWithHooksSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'secret',
+      type: 'text',
+    },
+    {
+      name: 'count',
+      type: 'number',
+    },
+    {
+      name: 'email',
+      type: 'text',
+      custom: {
+        'plugin-import-export': {
+          hooks: {
+            beforeImport: (({ value }) => {
+              if (typeof value === 'string') {
+                return value.toLowerCase()
+              }
+              return value
+            }) satisfies FieldBeforeImportHook,
+          },
+        },
+      },
+    },
+  ],
+}

--- a/test/plugin-import-export/config.ts
+++ b/test/plugin-import-export/config.ts
@@ -17,11 +17,30 @@ import { Posts } from './collections/Posts.js'
 import { PostsExportsOnly } from './collections/PostsExportsOnly.js'
 import { PostsImportsOnly } from './collections/PostsImportsOnly.js'
 import { PostsNoJobsQueue } from './collections/PostsNoJobsQueue.js'
+import {
+  exportRenameMap,
+  importRenameMap,
+  PostsWithColumnMap,
+} from './collections/PostsWithColumnMap.js'
+import { PostsWithFieldHooks } from './collections/PostsWithFieldHooks.js'
+import { PostsWithHooks } from './collections/PostsWithHooks.js'
 import { PostsWithLimits } from './collections/PostsWithLimits.js'
 import { PostsWithS3 } from './collections/PostsWithS3.js'
 import { Users } from './collections/Users.js'
+import {
+  exportAfterHook,
+  exportBeforeHook,
+  importAfterHook,
+  importBeforeHook,
+} from './hookSpies.js'
 import { seed } from './seed/index.js'
-import { customIdPagesSlug, postsWithS3Slug } from './shared.js'
+import {
+  customIdPagesSlug,
+  postsWithColumnMapSlug,
+  postsWithFieldHooksSlug,
+  postsWithHooksSlug,
+  postsWithS3Slug,
+} from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -49,6 +68,9 @@ export default buildConfigWithDefaults({
     PostsNoJobsQueue,
     PostsWithLimits,
     PostsWithS3,
+    PostsWithHooks,
+    PostsWithFieldHooks,
+    PostsWithColumnMap,
     Media,
     CustomIdPages,
   ],
@@ -220,6 +242,98 @@ export default buildConfigWithDefaults({
         },
         {
           slug: customIdPagesSlug,
+        },
+        {
+          slug: postsWithHooksSlug,
+          export: {
+            batchSize: 2,
+            disableJobsQueue: true,
+            hooks: {
+              before: exportBeforeHook,
+              after: exportAfterHook,
+            },
+            overrideCollection: ({ collection }) => {
+              collection.slug = 'posts-with-hooks-export'
+              collection.upload.staticDir = path.resolve(dirname, 'uploads')
+              return collection
+            },
+          },
+          import: {
+            batchSize: 2,
+            disableJobsQueue: true,
+            hooks: {
+              before: importBeforeHook,
+              after: importAfterHook,
+            },
+            overrideCollection: ({ collection }) => {
+              collection.slug = 'posts-with-hooks-import'
+              collection.upload.staticDir = path.resolve(dirname, 'uploads')
+              return collection
+            },
+          },
+        },
+        {
+          slug: postsWithFieldHooksSlug,
+          export: {
+            disableJobsQueue: true,
+            overrideCollection: ({ collection }) => {
+              collection.slug = 'posts-with-field-hooks-export'
+              collection.upload.staticDir = path.resolve(dirname, 'uploads')
+              return collection
+            },
+          },
+          import: {
+            disableJobsQueue: true,
+            overrideCollection: ({ collection }) => {
+              collection.slug = 'posts-with-field-hooks-import'
+              collection.upload.staticDir = path.resolve(dirname, 'uploads')
+              return collection
+            },
+          },
+        },
+        {
+          slug: postsWithColumnMapSlug,
+          export: {
+            disableJobsQueue: true,
+            hooks: {
+              before: ({ data }) => {
+                return data.map((row) => {
+                  const renamed: Record<string, unknown> = {}
+                  for (const [key, value] of Object.entries(row)) {
+                    renamed[exportRenameMap[key] ?? key] = value
+                  }
+                  return renamed
+                })
+              },
+            },
+            overrideCollection: ({ collection }) => {
+              collection.slug = 'posts-with-column-map-export'
+              collection.upload.staticDir = path.resolve(dirname, 'uploads')
+              return collection
+            },
+          },
+          import: {
+            disableJobsQueue: true,
+            hooks: {
+              before: ({ data }) => {
+                return data.map((doc) => {
+                  const renamed: Record<string, unknown> = {}
+                  for (const [key, value] of Object.entries(doc)) {
+                    const payloadKey = importRenameMap[key]
+                    if (payloadKey) {
+                      renamed[payloadKey] = value
+                    }
+                  }
+                  return renamed
+                })
+              },
+            },
+            overrideCollection: ({ collection }) => {
+              collection.slug = 'posts-with-column-map-import'
+              collection.upload.staticDir = path.resolve(dirname, 'uploads')
+              return collection
+            },
+          },
         },
       ],
     }),

--- a/test/plugin-import-export/e2e.spec.ts
+++ b/test/plugin-import-export/e2e.spec.ts
@@ -21,7 +21,14 @@ import {
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
-import { postsWithS3ExportSlug, postsWithS3ImportSlug, postsWithS3Slug } from './shared.js'
+import { readCSV } from './helpers.js'
+import {
+  postsWithColumnMapSlug,
+  postsWithHooksSlug,
+  postsWithS3ExportSlug,
+  postsWithS3ImportSlug,
+  postsWithS3Slug,
+} from './shared.js'
 
 test.describe('Import Export Plugin', () => {
   let page: Page
@@ -1632,6 +1639,244 @@ test.describe('Import Export Plugin', () => {
 
       const importCount = page.locator('.import-preview__import-count')
       await expect(importCount).toContainText('10 documents to import')
+    })
+  })
+
+  test.describe('column mapping e2e', () => {
+    const tempFiles: string[] = []
+    const createdTitles: string[] = []
+
+    test.afterEach(async () => {
+      for (const filePath of tempFiles) {
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath)
+        }
+      }
+      tempFiles.length = 0
+
+      for (const title of createdTitles) {
+        await payload.delete({
+          collection: postsWithColumnMapSlug,
+          where: { title: { equals: title } },
+        })
+      }
+      createdTitles.length = 0
+    })
+
+    test('should import a CSV with foreign column headers through the admin UI', async () => {
+      const csvContent =
+        '"Post Title","Summary","View Count"\n' +
+        '"E2E Foreign A","e2e summary a","11"\n' +
+        '"E2E Foreign B","e2e summary b","22"\n'
+      const csvPath = path.join(__dirname, 'uploads', 'e2e-column-map-import.csv')
+      fs.writeFileSync(csvPath, csvContent)
+      tempFiles.push(csvPath)
+      createdTitles.push('E2E Foreign A', 'E2E Foreign B')
+
+      const columnMapImportsURL = new AdminUrlUtil(serverURL, 'posts-with-column-map-import')
+      await page.goto(columnMapImportsURL.create)
+      await expect(page.locator('.collection-edit')).toBeVisible()
+
+      await page.setInputFiles('input[type="file"]', csvPath)
+      await expect(page.locator('.file-field__filename')).toHaveValue('e2e-column-map-import.csv')
+
+      const importModeField = page.locator('#field-importMode')
+      await importModeField.click()
+      await page.locator('.rs__option:has-text("create")').first().click()
+
+      await saveDocAndAssert(page)
+
+      await expect(async () => {
+        const { docs } = await payload.find({
+          collection: postsWithColumnMapSlug,
+          where: { title: { in: ['E2E Foreign A', 'E2E Foreign B'] } },
+        })
+        expect(docs).toHaveLength(2)
+      }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
+
+      const imported = await payload.find({
+        collection: postsWithColumnMapSlug,
+        sort: 'title',
+        where: { title: { in: ['E2E Foreign A', 'E2E Foreign B'] } },
+      })
+
+      expect(imported.docs[0]!.title).toBe('E2E Foreign A')
+      expect(imported.docs[0]!.excerpt).toBe('e2e summary a')
+      expect(imported.docs[0]!.count).toBe(11)
+      expect(imported.docs[1]!.title).toBe('E2E Foreign B')
+      expect(imported.docs[1]!.count).toBe(22)
+    })
+
+    test('should export CSV with renamed column headers via admin save', async () => {
+      await payload.create({
+        collection: postsWithColumnMapSlug,
+        data: { title: 'E2E Export Rename', excerpt: 'exported summary', count: 99 },
+      })
+      createdTitles.push('E2E Export Rename')
+
+      const columnMapExportsURL = new AdminUrlUtil(serverURL, 'posts-with-column-map-export')
+      await page.goto(columnMapExportsURL.create)
+      await expect(page.locator('.collection-edit')).toBeVisible()
+
+      await saveDocAndAssert(page, '#action-save')
+
+      await expect(async () => {
+        await page.reload()
+        const exportFilename = page.locator('.file-details__main-detail')
+        await expect(exportFilename).toBeVisible()
+        await expect(exportFilename).toContainText('.csv')
+      }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
+
+      const exports = await payload.find({
+        collection: 'posts-with-column-map-export',
+        sort: '-createdAt',
+        limit: 1,
+      })
+
+      expect(exports.docs).toHaveLength(1)
+      const exportDoc = exports.docs[0]! as unknown as { filename: string; id: number | string }
+      const csvPath = path.join(__dirname, 'uploads', exportDoc.filename)
+      const rows = await readCSV(csvPath)
+
+      const matching = rows.find((row) => row['Post Title'] === 'E2E Export Rename')
+      expect(matching).toBeDefined()
+      expect(matching!.Summary).toBe('exported summary')
+      expect(matching!['View Count']).toBe('99')
+      expect(matching!.title).toBeUndefined()
+
+      await payload.delete({
+        collection: 'posts-with-column-map-export',
+        id: exportDoc.id,
+      })
+    })
+  })
+
+  test.describe('Hooks — Preview', () => {
+    const createdPostIds: (number | string)[] = []
+
+    test.beforeAll(async () => {
+      // Seed two posts so the export preview has rows to show
+      for (let i = 1; i <= 2; i++) {
+        const doc = await payload.create({
+          collection: postsWithHooksSlug,
+          data: { title: `Hook Preview Post ${i}`, secret: `secret-${i}`, count: i },
+        })
+        createdPostIds.push(doc.id)
+      }
+    })
+
+    test.afterAll(async () => {
+      for (const id of createdPostIds) {
+        await payload.delete({ collection: postsWithHooksSlug, id }).catch(() => null)
+      }
+    })
+
+    // These tests call the preview REST endpoints directly (POST to /api/.../export-preview
+    // and /api/.../preview-data) rather than driving the browser UI. The preview endpoints
+    // are registered as plain Payload endpoints, not Next.js server actions, so they work
+    // reliably in dev mode without triggering UnrecognizedActionError from hot-reload races.
+
+    test('should apply export.hooks.before in CSV export preview (secret field masked)', async () => {
+      const response = await page.request.post(
+        `${serverURL}/api/posts-with-hooks-export/export-preview`,
+        {
+          data: {
+            collectionSlug: postsWithHooksSlug,
+            format: 'csv',
+          },
+        },
+      )
+
+      expect(response.ok()).toBe(true)
+      const body = await response.json()
+
+      expect(body.docs).toBeDefined()
+      expect(body.docs.length).toBeGreaterThan(0)
+
+      // export.hooks.before removes the `secret` field — it must be absent from all preview rows
+      for (const doc of body.docs) {
+        expect(doc).not.toHaveProperty('secret')
+        expect(doc).toHaveProperty('title')
+      }
+
+      // secret column must not appear in the CSV column list
+      expect(body.columns).toBeDefined()
+      expect(body.columns).not.toContain('secret')
+      expect(body.columns).toContain('title')
+    })
+
+    test('should apply export.hooks.before in JSON export preview (secret field masked)', async () => {
+      const response = await page.request.post(
+        `${serverURL}/api/posts-with-hooks-export/export-preview`,
+        {
+          data: {
+            collectionSlug: postsWithHooksSlug,
+            format: 'json',
+          },
+        },
+      )
+
+      expect(response.ok()).toBe(true)
+      const body = await response.json()
+
+      expect(body.docs).toBeDefined()
+      expect(body.docs.length).toBeGreaterThan(0)
+
+      // export.hooks.before masks secret for JSON format too
+      for (const doc of body.docs) {
+        expect(doc).not.toHaveProperty('secret')
+        expect(doc).toHaveProperty('title')
+      }
+    })
+
+    test('should apply import.hooks.before in CSV import preview (title gets _imported suffix)', async () => {
+      const csvContent = 'title,count\n"Hook Preview Import CSV","1"'
+      const fileData = Buffer.from(csvContent).toString('base64')
+
+      const response = await page.request.post(
+        `${serverURL}/api/posts-with-hooks-import/preview-data`,
+        {
+          data: {
+            collectionSlug: postsWithHooksSlug,
+            format: 'csv',
+            fileData,
+          },
+        },
+      )
+
+      expect(response.ok()).toBe(true)
+      const body = await response.json()
+
+      expect(body.docs).toBeDefined()
+      expect(body.docs).toHaveLength(1)
+
+      // import.hooks.before appends '_imported' to the title
+      expect(body.docs[0].title).toBe('Hook Preview Import CSV_imported')
+    })
+
+    test('should apply import.hooks.before in JSON import preview (title gets _imported suffix)', async () => {
+      const jsonContent = JSON.stringify([{ title: 'Hook Preview Import JSON', count: 2 }])
+      const fileData = Buffer.from(jsonContent).toString('base64')
+
+      const response = await page.request.post(
+        `${serverURL}/api/posts-with-hooks-import/preview-data`,
+        {
+          data: {
+            collectionSlug: postsWithHooksSlug,
+            format: 'json',
+            fileData,
+          },
+        },
+      )
+
+      expect(response.ok()).toBe(true)
+      const body = await response.json()
+
+      expect(body.docs).toBeDefined()
+      expect(body.docs).toHaveLength(1)
+
+      // import.hooks.before appends '_imported' to the title
+      expect(body.docs[0].title).toBe('Hook Preview Import JSON_imported')
     })
   })
 })

--- a/test/plugin-import-export/field-hooks.int.spec.ts
+++ b/test/plugin-import-export/field-hooks.int.spec.ts
@@ -1,0 +1,1245 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { devUser } from '../credentials.js'
+import { readCSV, readJSON } from './helpers.js'
+import { postsWithFieldHooksSlug } from './shared.js'
+
+let payload: Payload
+let restClient: NextRESTClient
+let user: any
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+describe('@payloadcms/plugin-import-export — field-level hooks', () => {
+  beforeAll(async () => {
+    ;({ payload, restClient } = await initPayloadInt(dirname))
+    user = await payload.login({
+      collection: 'users',
+      data: { email: devUser.email, password: devUser.password },
+    })
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  afterEach(async () => {
+    const existing = await payload.find({
+      collection: postsWithFieldHooksSlug,
+      limit: 1000,
+      pagination: false,
+    })
+    for (const doc of existing.docs) {
+      await payload.delete({ collection: postsWithFieldHooksSlug, id: doc.id })
+    }
+  })
+
+  // ─────────────────────────────────────────────
+  // Field-level export hooks
+  // ─────────────────────────────────────────────
+
+  describe('field-level export hooks', () => {
+    it('should transform CSV output using field-level export hook', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { customExport: 'raw value', title: 'Field Export Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // Field-level export hook should have transformed the value
+      expect(rows[0]!.customExport).toBe('raw value exported')
+    })
+
+    it('should receive format: csv during CSV export', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { customExport: 'test', title: 'Format CSV Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // The hook writes format into a side-channel column
+      expect(rows[0]!.customExport_format).toBe('csv')
+    })
+
+    it('should receive format: json during JSON export', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { customExport: 'test', title: 'Format JSON Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const docs = await readJSON(jsonPath)
+
+      // Field-level export hook should have transformed the value for JSON too
+      expect(docs[0]!.customExport).toBe('test exported')
+    })
+
+    it('should transform deeply nested fields (group > named tab > field)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: {
+          group: { namedTab: { deepField: 'deep value' } },
+          title: 'Deep Field Test',
+        },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // Deeply nested field hook should have run
+      expect(rows[0]!.group_namedTab_deepField).toBe('deep value deep_exported')
+    })
+
+    it('should transform deeply nested fields in CSV preview (group > named tab > field)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: {
+          group: { namedTab: { deepField: 'preview deep value' } },
+          title: 'Preview Deep Field Test',
+        },
+      })
+
+      const previewResponse = await restClient
+        .POST('/posts-with-field-hooks-export/export-preview', {
+          body: JSON.stringify({
+            collectionSlug: postsWithFieldHooksSlug,
+            format: 'csv',
+            limit: 5,
+            where: { id: { equals: post.id } },
+          }),
+          headers: { 'Content-Type': 'application/json' },
+        })
+        .then((res) => res.json())
+
+      expect(previewResponse.docs).toBeDefined()
+      expect(previewResponse.docs.length).toBe(1)
+      expect(previewResponse.docs[0]?.group_namedTab_deepField).toBe(
+        'preview deep value deep_exported',
+      )
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Field-level import hooks
+  // ─────────────────────────────────────────────
+
+  describe('field-level import hooks', () => {
+    it('should transform value during CSV import using field-level import hook', async () => {
+      const csvContent = `title,customImport\n"Import Hook Test","original_value"`
+      const file = {
+        name: 'field-hooks-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      // Import hook appends '_imported_csv' to the value
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { customImport: { equals: 'original_value_imported_csv' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+    })
+
+    it('should transform value during JSON import using field-level import hook', async () => {
+      const jsonContent = JSON.stringify([
+        { customImport: 'json_value', title: 'JSON Import Hook Test' },
+      ])
+      const file = {
+        name: 'field-hooks-import.json',
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          importMode: 'create',
+        },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      // Import hook appends '_imported_json' to the value
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { customImport: { equals: 'json_value_imported_json' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Empty-cell preservation on update import
+  // ─────────────────────────────────────────────
+
+  describe('synthetic import hooks should not clobber existing data with empty cells', () => {
+    it('should preserve existing number value when CSV update row has a blank count cell', async () => {
+      const existing = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { count: 5, title: 'Empty Cell Update Number Test' },
+      })
+
+      const csvContent = `id,title,count\n${existing.id},"Empty Cell Update Number Test",`
+      const file = {
+        name: 'empty-number.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          importMode: 'update',
+          matchField: 'id',
+        },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const after = await payload.findByID({
+        id: existing.id,
+        collection: postsWithFieldHooksSlug,
+      })
+
+      expect(after.count).toBe(5)
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Backward compatibility: toCSV/fromCSV
+  // ─────────────────────────────────────────────
+
+  describe('backward compat: toCSV/fromCSV still work', () => {
+    it('should still apply deprecated toCSV during CSV export', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { legacyToCSV: 'legacy value', title: 'Legacy toCSV Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows[0]!.legacyToCSV).toBe('legacy value legacy_toCSV')
+    })
+
+    it('should still pass legacy args (row, doc, siblingDoc, data=row) to toCSV during CSV export', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { title: 'Legacy Args Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows[0]!.legacyToCSVArgs).toBe('args value legacy_args')
+      expect(rows[0]!.legacyToCSVArgs_has_row).toBe('yes')
+      expect(rows[0]!.legacyToCSVArgs_has_doc).toBe('yes')
+      expect(rows[0]!.legacyToCSVArgs_has_siblingDoc).toBe('yes')
+    })
+
+    it('should still pass legacy args (columnName, data=flat row, value) to fromCSV during CSV import', async () => {
+      const csvContent = `title,legacyFromCSVArgs\n"Legacy fromCSV Args Test","incoming"`
+      const file = {
+        name: 'legacy-fromcsv-args-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Legacy fromCSV Args Test' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).legacyFromCSVArgs).toBe('incoming:legacyFromCSVArgs:yes')
+    })
+
+    it('should still apply deprecated fromCSV during CSV import', async () => {
+      const csvContent = `title,legacyFromCSV\n"Legacy fromCSV Test","incoming_value"`
+      const file = {
+        name: 'legacy-fromcsv-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { legacyFromCSV: { equals: 'incoming_value_legacy_fromCSV' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Execution order: field-level before collection-level
+  // ─────────────────────────────────────────────
+
+  describe('execution order', () => {
+    it('should run field-level export hooks before collection-level hooks', async () => {
+      // This test uses the postsWithFieldHooksSlug collection which has
+      // field-level hooks on customExport AND collection-level hooks configured.
+      // The field-level hook transforms the value first, then collection-level
+      // hook can see the already-transformed data.
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { customExport: 'raw', title: 'Order Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // Field-level hook ran first: value should be 'raw exported'
+      // Collection-level hook (if any) would operate on the already-transformed data
+      expect(rows[0]!.customExport).toBe('raw exported')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Reusable field config
+  // ─────────────────────────────────────────────
+
+  describe('reusable field configs', () => {
+    it('should apply field-level hooks from a shared field definition', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { email: 'USER@EXAMPLE.COM', title: 'Reusable Field Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // The reusable email field hook lowercases the value
+      expect(rows[0]!.email).toBe('user@example.com')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Edge cases
+  // ─────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('should prefer export over toCSV when both are set on the same field', async () => {
+      // The PostsWithFieldHooks collection has separate fields for export and toCSV.
+      // This test verifies the export hook fires (not toCSV) on the customExport field,
+      // and toCSV still fires on the legacyToCSV field — confirming the priority chain works.
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { customExport: 'test', legacyToCSV: 'legacy', title: 'Priority Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // export hook ran (appends ' exported')
+      expect(rows[0]!.customExport).toBe('test exported')
+      // toCSV hook ran on its own field (appends ' legacy_toCSV')
+      expect(rows[0]!.legacyToCSV).toBe('legacy legacy_toCSV')
+    })
+
+    it('should use default flattening when export hook returns undefined', async () => {
+      // A field without any hooks should flatten normally (default behavior)
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { secret: 'plain-text', title: 'Default Behavior Test' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // No hook on 'secret' — value passes through unchanged
+      expect(rows[0]!.secret).toBe('plain-text')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Field-level hooks inside arrays and blocks
+  // ─────────────────────────────────────────────
+
+  describe('field-level hooks inside arrays', () => {
+    it('should run field-level export hook on array item sub-fields (CSV)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: {
+          items: [{ note: 'first' }, { note: 'second' }],
+          title: 'Array Export CSV',
+        },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows[0]!.items_0_note).toBe('first array_exported')
+      expect(rows[0]!.items_1_note).toBe('second array_exported')
+    })
+
+    it('should run field-level export hook on array item sub-fields (JSON)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: {
+          items: [{ note: 'alpha' }, { note: 'beta' }],
+          title: 'Array Export JSON',
+        },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const docs = await readJSON(jsonPath)
+
+      expect(docs[0]!.items[0].note).toBe('alpha array_exported')
+      expect(docs[0]!.items[1].note).toBe('beta array_exported')
+    })
+
+    it('should run field-level import hook on array item sub-fields (CSV)', async () => {
+      const csvContent = `title,items_0_note,items_1_note\n"Array Import CSV","one","two"`
+      const file = {
+        name: 'array-items-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Array Import CSV' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).items[0].note).toBe('one_array_imported')
+      expect((imported.docs[0] as any).items[1].note).toBe('two_array_imported')
+    })
+
+    it('should run field-level import hook on array item sub-fields (JSON)', async () => {
+      const jsonContent = JSON.stringify([
+        { items: [{ note: 'uno' }, { note: 'dos' }], title: 'Array Import JSON' },
+      ])
+      const file = {
+        name: 'array-items-import.json',
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          importMode: 'create',
+        },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Array Import JSON' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).items[0].note).toBe('uno_array_imported')
+      expect((imported.docs[0] as any).items[1].note).toBe('dos_array_imported')
+    })
+  })
+
+  describe('field-level hooks inside blocks', () => {
+    it('should run field-level export hook on block sub-fields (CSV)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: {
+          content: [
+            { blockType: 'textBlock', body: 'hello' },
+            { blockType: 'textBlock', body: 'world' },
+          ],
+          title: 'Blocks Export CSV',
+        },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows[0]!.content_0_textBlock_body).toBe('hello block_exported')
+      expect(rows[0]!.content_1_textBlock_body).toBe('world block_exported')
+    })
+
+    it('should run field-level export hook on block sub-fields (JSON)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: {
+          content: [{ blockType: 'textBlock', body: 'foo' }],
+          title: 'Blocks Export JSON',
+        },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const docs = await readJSON(jsonPath)
+
+      expect(docs[0]!.content[0].body).toBe('foo block_exported')
+    })
+
+    it('should run field-level import hook on block sub-fields (CSV)', async () => {
+      const csvContent = `title,content_0_textBlock_body\n"Blocks Import CSV","csv-body"`
+      const file = {
+        name: 'block-body-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Blocks Import CSV' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).content[0].body).toBe('csv-body_block_imported')
+    })
+
+    it('should run field-level import hook on block sub-fields (JSON)', async () => {
+      const jsonContent = JSON.stringify([
+        {
+          content: [{ blockType: 'textBlock', body: 'json-body' }],
+          title: 'Blocks Import JSON',
+        },
+      ])
+      const file = {
+        name: 'block-body-import.json',
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          importMode: 'create',
+        },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Blocks Import JSON' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).content[0].body).toBe('json-body_block_imported')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Hook receives the top-level document in `data` arg
+  // ─────────────────────────────────────────────
+
+  describe('field-level import hook receives sibling-level data', () => {
+    it('should pass the nested parent object as siblingData to hooks inside a group (JSON)', async () => {
+      // The metadata.siblingEcho hook reads siblingData.slugFromTitle — that key
+      // only exists on the parent-level `metadata` object, not on the top-level
+      // document. If the hook received `data` (top-level) instead of `siblingData`,
+      // the assertion below would fail.
+      const jsonContent = JSON.stringify([
+        {
+          metadata: { siblingEcho: 'start', slugFromTitle: 'my-slug' },
+          title: 'Sibling Echo Test',
+        },
+      ])
+      const file = {
+        name: 'sibling-echo-import.json',
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          importMode: 'create',
+        },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Sibling Echo Test' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).metadata.siblingEcho).toBe('start:my-slug')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Hook error isolation: a thrown field-level hook on one row/doc
+  // must not abort the whole batch.
+  // ─────────────────────────────────────────────
+
+  describe('field-level hook error isolation', () => {
+    it('should isolate a thrown beforeImport hook to its row during CSV import', async () => {
+      const csvContent = [
+        'title,mayCrash',
+        '"Crash Row 1","ok1"',
+        '"Crash Row 2","CRASH"',
+        '"Crash Row 3","ok3"',
+      ].join('\n')
+      const file = {
+        name: 'crash-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        sort: 'title',
+        where: { title: { in: ['Crash Row 1', 'Crash Row 2', 'Crash Row 3'] } },
+      })
+
+      expect(imported.docs).toHaveLength(3)
+      const byTitle = Object.fromEntries(imported.docs.map((d: any) => [d.title, d]))
+      expect(byTitle['Crash Row 1']!.mayCrash).toBe('ok1_imported')
+      expect(byTitle['Crash Row 2']!.mayCrash).toBe('CRASH')
+      expect(byTitle['Crash Row 3']!.mayCrash).toBe('ok3_imported')
+    })
+
+    it('should isolate a thrown beforeImport hook to its row during JSON import', async () => {
+      const jsonContent = JSON.stringify([
+        { mayCrash: 'json-ok-1', title: 'JSON Crash 1' },
+        { mayCrash: 'CRASH', title: 'JSON Crash 2' },
+        { mayCrash: 'json-ok-3', title: 'JSON Crash 3' },
+      ])
+      const file = {
+        name: 'crash-import.json',
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          importMode: 'create',
+        },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        sort: 'title',
+        where: { title: { in: ['JSON Crash 1', 'JSON Crash 2', 'JSON Crash 3'] } },
+      })
+
+      expect(imported.docs).toHaveLength(3)
+      const byTitle = Object.fromEntries(imported.docs.map((d: any) => [d.title, d]))
+      expect(byTitle['JSON Crash 1']!.mayCrash).toBe('json-ok-1_imported')
+      expect(byTitle['JSON Crash 2']!.mayCrash).toBe('CRASH')
+      expect(byTitle['JSON Crash 3']!.mayCrash).toBe('json-ok-3_imported')
+    })
+
+    it('should isolate a thrown beforeExport hook to its doc during CSV export', async () => {
+      const docs = await Promise.all([
+        payload.create({
+          collection: postsWithFieldHooksSlug,
+          data: { mayCrash: 'safe-a', title: 'Export Crash A' },
+        }),
+        payload.create({
+          collection: postsWithFieldHooksSlug,
+          data: { mayCrash: 'CRASH', title: 'Export Crash B' },
+        }),
+        payload.create({
+          collection: postsWithFieldHooksSlug,
+          data: { mayCrash: 'safe-c', title: 'Export Crash C' },
+        }),
+      ])
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { in: docs.map((d) => d.id) } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows).toHaveLength(3)
+      const byTitle = Object.fromEntries(rows.map((r: any) => [r.title, r]))
+      expect(byTitle['Export Crash A']!.mayCrash).toBe('safe-a_exported')
+      expect(byTitle['Export Crash B']!.mayCrash).toBe('CRASH')
+      expect(byTitle['Export Crash C']!.mayCrash).toBe('safe-c_exported')
+    })
+
+    it('should isolate a thrown beforeExport hook to its doc during JSON export', async () => {
+      const docs = await Promise.all([
+        payload.create({
+          collection: postsWithFieldHooksSlug,
+          data: { mayCrash: 'json-safe-a', title: 'JSON Export Crash A' },
+        }),
+        payload.create({
+          collection: postsWithFieldHooksSlug,
+          data: { mayCrash: 'CRASH', title: 'JSON Export Crash B' },
+        }),
+        payload.create({
+          collection: postsWithFieldHooksSlug,
+          data: { mayCrash: 'json-safe-c', title: 'JSON Export Crash C' },
+        }),
+      ])
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          where: { id: { in: docs.map((d) => d.id) } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const exportedDocs = await readJSON(jsonPath)
+
+      expect(exportedDocs).toHaveLength(3)
+      const byTitle = Object.fromEntries(exportedDocs.map((d: any) => [d.title, d])) as Record<
+        string,
+        any
+      >
+      expect(byTitle['JSON Export Crash A']!.mayCrash).toBe('json-safe-a_exported')
+      expect(byTitle['JSON Export Crash B']!.mayCrash).toBe('CRASH')
+      expect(byTitle['JSON Export Crash C']!.mayCrash).toBe('json-safe-c_exported')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Hooks on fields wrapped in unnamed presentational containers
+  // (row, collapsible). These wrappers are stripped by flattenedFields,
+  // so child hooks should still register and fire.
+  // ─────────────────────────────────────────────
+
+  describe('field-level hooks under unnamed presentational wrappers', () => {
+    it('should fire export hook on a field nested in a row wrapper (CSV)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { rowField: 'inside-row', title: 'Row Wrapper Export' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows[0]!.rowField).toBe('inside-row_row_exported')
+    })
+
+    it('should fire import hook on a field nested in a row wrapper (CSV)', async () => {
+      const csvContent = `title,rowField\n"Row Wrapper Import","incoming"`
+      const file = {
+        name: 'row-wrapper-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Row Wrapper Import' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).rowField).toBe('incoming_row_imported')
+    })
+
+    it('should fire export hook on a field nested in a collapsible wrapper (CSV)', async () => {
+      const post = await payload.create({
+        collection: postsWithFieldHooksSlug,
+        data: { collapsibleField: 'inside-collapsible', title: 'Collapsible Wrapper Export' },
+      })
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-field-hooks-export',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+        user,
+      })
+
+      exportDoc = await payload.findByID({
+        id: exportDoc.id,
+        collection: 'posts-with-field-hooks-export',
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows[0]!.collapsibleField).toBe('inside-collapsible_collapsible_exported')
+    })
+
+    it('should fire import hook on a field nested in a collapsible wrapper (CSV)', async () => {
+      const csvContent = `title,collapsibleField\n"Collapsible Wrapper Import","incoming"`
+      const file = {
+        name: 'collapsible-wrapper-import.csv',
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Collapsible Wrapper Import' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).collapsibleField).toBe('incoming_collapsible_imported')
+    })
+  })
+
+  describe('field-level import hook receives top-level data', () => {
+    it('should pass the full top-level doc to hooks on nested fields (JSON)', async () => {
+      // The metadata.slugFromTitle hook reads data.title (top-level field)
+      // and uses it to generate a slug when slugFromTitle is empty.
+      const jsonContent = JSON.stringify([
+        { metadata: { slugFromTitle: '' }, title: 'Top Doc Access' },
+      ])
+      const file = {
+        name: 'top-doc-import.json',
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-field-hooks-import',
+        data: {
+          collectionSlug: postsWithFieldHooksSlug,
+          format: 'json',
+          importMode: 'create',
+        },
+        file,
+        user,
+      })
+
+      importDoc = await payload.findByID({
+        id: importDoc.id,
+        collection: 'posts-with-field-hooks-import',
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      const imported = await payload.find({
+        collection: postsWithFieldHooksSlug,
+        where: { title: { equals: 'Top Doc Access' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      expect((imported.docs[0] as any).metadata.slugFromTitle).toBe('top-doc-access')
+    })
+  })
+})

--- a/test/plugin-import-export/hookSpies.ts
+++ b/test/plugin-import-export/hookSpies.ts
@@ -1,0 +1,49 @@
+import type {
+  ExportAfterHook,
+  ExportBeforeHook,
+  ImportAfterHook,
+  ImportBeforeHook,
+} from '@payloadcms/plugin-import-export'
+
+import type { postsWithHooksSlug } from './shared.js'
+
+// Recorded invocations — reset between tests via resetHookSpies()
+export const hookCalls = {
+  exportAfter: [] as Parameters<ExportAfterHook>[0][],
+  exportBefore: [] as Parameters<ExportBeforeHook<typeof postsWithHooksSlug>>[0][],
+  importAfter: [] as Parameters<ImportAfterHook>[0][],
+  importBefore: [] as Parameters<ImportBeforeHook<typeof postsWithHooksSlug>>[0][],
+}
+
+export const resetHookSpies = () => {
+  hookCalls.exportBefore = []
+  hookCalls.exportAfter = []
+  hookCalls.importBefore = []
+  hookCalls.importAfter = []
+}
+
+export const exportBeforeHook: ExportBeforeHook<typeof postsWithHooksSlug> = (args) => {
+  hookCalls.exportBefore.push(args)
+  // Mask the `secret` field from exported data
+  return args.data.map((row) => {
+    const { secret: _secret, ...rest } = row as Record<string, unknown>
+    return rest
+  })
+}
+
+export const exportAfterHook: ExportAfterHook = (args) => {
+  hookCalls.exportAfter.push(args)
+}
+
+export const importBeforeHook: ImportBeforeHook<typeof postsWithHooksSlug> = (args) => {
+  hookCalls.importBefore.push(args)
+  // Append '_imported' suffix to each title for verification
+  return args.data.map((doc) => ({
+    ...doc,
+    title: typeof doc.title === 'string' ? `${doc.title}_imported` : doc.title,
+  }))
+}
+
+export const importAfterHook: ImportAfterHook = (args) => {
+  hookCalls.importAfter.push(args)
+}

--- a/test/plugin-import-export/hooks.int.spec.ts
+++ b/test/plugin-import-export/hooks.int.spec.ts
@@ -1,0 +1,865 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { devUser } from '../credentials.js'
+import { readCSV, readJSON } from './helpers.js'
+import { hookCalls, resetHookSpies } from './hookSpies.js'
+import { postsWithColumnMapSlug, postsWithHooksSlug } from './shared.js'
+
+let payload: Payload
+let restClient: NextRESTClient
+let user: any
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+const createdHookPostIDs: (number | string)[] = []
+
+describe('@payloadcms/plugin-import-export — hooks', () => {
+  beforeAll(async () => {
+    ;({ payload, restClient } = await initPayloadInt(dirname))
+    user = await payload.login({
+      collection: 'users',
+      data: { email: devUser.email, password: devUser.password },
+    })
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  afterEach(async () => {
+    resetHookSpies()
+    for (const id of createdHookPostIDs) {
+      await payload
+        .delete({ collection: postsWithHooksSlug, id })
+        .catch((err) => payload.logger.warn({ err, id, msg: 'hooks.int.spec cleanup failed' }))
+    }
+    createdHookPostIDs.length = 0
+  })
+
+  // ─────────────────────────────────────────────
+  // Export hooks
+  // ─────────────────────────────────────────────
+
+  describe('export hooks', () => {
+    it('should call export.hooks.before with correct args and apply its return value to CSV output', async () => {
+      const post = await payload.create({
+        collection: postsWithHooksSlug,
+        data: { title: 'Hook Test', secret: 'top-secret', count: 1 },
+      })
+      createdHookPostIDs.push(post.id)
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-hooks-export',
+        user,
+        data: {
+          collectionSlug: postsWithHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+      })
+
+      exportDoc = await payload.findByID({
+        collection: 'posts-with-hooks-export',
+        id: exportDoc.id,
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      // before hook should have been called
+      expect(hookCalls.exportBefore).toHaveLength(1)
+      const beforeArgs = hookCalls.exportBefore[0]!
+      expect(beforeArgs.format).toBe('csv')
+      expect(beforeArgs.batchNumber).toBe(1)
+      expect(beforeArgs.totalBatches).toBeGreaterThanOrEqual(1)
+      expect(beforeArgs.req).toBeDefined()
+
+      // originalData should be the raw DB doc
+      expect(beforeArgs.originalData).toHaveLength(1)
+      expect(beforeArgs.originalData[0]!.id).toBe(post.id)
+      expect(beforeArgs.originalData[0]!.secret).toBe('top-secret')
+
+      // before hook masks `secret` — it should be absent from the exported CSV
+      expect(rows[0]!.secret).toBeUndefined()
+      expect(rows[0]!.title).toBe('Hook Test')
+    })
+
+    it('should call export.hooks.after with correct args after write', async () => {
+      const post = await payload.create({
+        collection: postsWithHooksSlug,
+        data: { title: 'After Hook Test', secret: 'hidden', count: 2 },
+      })
+      createdHookPostIDs.push(post.id)
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-hooks-export',
+        user,
+        data: {
+          collectionSlug: postsWithHooksSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+      })
+
+      exportDoc = await payload.findByID({
+        collection: 'posts-with-hooks-export',
+        id: exportDoc.id,
+      })
+
+      expect(hookCalls.exportAfter).toHaveLength(1)
+      const afterArgs = hookCalls.exportAfter[0]!
+      expect(afterArgs.format).toBe('csv')
+      expect(afterArgs.batchNumber).toBe(1)
+      expect(afterArgs.totalBatches).toBeGreaterThanOrEqual(1)
+      expect(afterArgs.req).toBeDefined()
+      // after receives the (already masked) data from before
+      expect(afterArgs.data).toBeDefined()
+      expect(afterArgs.originalData).toBeDefined()
+    })
+
+    it('should call export.hooks.before for JSON exports with nested docs', async () => {
+      const post = await payload.create({
+        collection: postsWithHooksSlug,
+        data: { title: 'JSON Hook Test', secret: 'json-secret', count: 3 },
+      })
+      createdHookPostIDs.push(post.id)
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-hooks-export',
+        user,
+        data: {
+          collectionSlug: postsWithHooksSlug,
+          format: 'json',
+          where: { id: { equals: post.id } },
+        },
+      })
+
+      exportDoc = await payload.findByID({
+        collection: 'posts-with-hooks-export',
+        id: exportDoc.id,
+      })
+
+      const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const jsonDocs = await readJSON(jsonPath)
+
+      expect(hookCalls.exportBefore).toHaveLength(1)
+      expect(hookCalls.exportBefore[0]!.format).toBe('json')
+
+      // before hook masks `secret` — absent from JSON output too
+      expect(jsonDocs[0]!.secret).toBeUndefined()
+      expect(jsonDocs[0]!.title).toBe('JSON Hook Test')
+    })
+
+    it('should call export.hooks.before once per batch when multiple batches occur', async () => {
+      const posts = await Promise.all(
+        Array.from({ length: 5 }, (_, i) =>
+          payload.create({
+            collection: postsWithHooksSlug,
+            data: { title: `Batch Post ${i}`, count: i },
+          }),
+        ),
+      )
+      posts.forEach((p) => createdHookPostIDs.push(p.id))
+
+      // posts-with-hooks is configured with batchSize: 2 — 5 docs → 3 batches
+      let exportDoc = await payload.create({
+        collection: 'posts-with-hooks-export',
+        user,
+        data: {
+          collectionSlug: postsWithHooksSlug,
+          format: 'csv',
+        },
+      })
+
+      exportDoc = await payload.findByID({
+        collection: 'posts-with-hooks-export',
+        id: exportDoc.id,
+      })
+
+      // Should have been called once per batch
+      expect(hookCalls.exportBefore.length).toBeGreaterThanOrEqual(2)
+      // batchNumbers should be sequential starting at 1
+      const batchNumbers = hookCalls.exportBefore.map((c) => c.batchNumber)
+      expect(batchNumbers[0]).toBe(1)
+      expect(batchNumbers[1]).toBe(2)
+    })
+
+    it('should call export.hooks.before via streaming download', async () => {
+      const post = await payload.create({
+        collection: postsWithHooksSlug,
+        data: { title: 'Download Hook Test', secret: 'streamed-secret', count: 4 },
+      })
+      createdHookPostIDs.push(post.id)
+
+      const response = await restClient.POST('/posts-with-hooks-export/download', {
+        body: JSON.stringify({
+          data: {
+            collectionSlug: postsWithHooksSlug,
+            format: 'csv',
+            where: { id: { equals: post.id } },
+          },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      expect(response.status).toBe(200)
+      // Consume the stream to ensure the hook fires before asserting
+      await response.text()
+      expect(hookCalls.exportBefore).toHaveLength(1)
+      expect(hookCalls.exportBefore[0]!.format).toBe('csv')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Import hooks
+  // ─────────────────────────────────────────────
+
+  describe('import hooks', () => {
+    it('should call import.hooks.before with correct args and apply its return value to DB write', async () => {
+      const csvContent = `title,secret,count\n"Original Title","secret-val","10"`
+      const file = {
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        name: 'hooks-import-test.csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-hooks-import',
+        user,
+        data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
+        file,
+      })
+
+      importDoc = await payload.findByID({
+        collection: 'posts-with-hooks-import',
+        id: importDoc.id,
+      })
+
+      expect(importDoc.status).toBe('completed')
+
+      // before hook should have been called
+      expect(hookCalls.importBefore).toHaveLength(1)
+      const beforeArgs = hookCalls.importBefore[0]!
+      expect(beforeArgs.format).toBe('csv')
+      expect(beforeArgs.batchNumber).toBe(1)
+      expect(beforeArgs.totalBatches).toBeGreaterThanOrEqual(1)
+      expect(beforeArgs.req).toBeDefined()
+
+      // originalData is the raw flat parsed rows before unflattening
+      expect(beforeArgs.originalData).toHaveLength(1)
+      expect(beforeArgs.originalData[0]!.title).toBe('Original Title')
+
+      // before hook appends '_imported' to title — verify it landed in DB
+      const importedDocs = await payload.find({
+        collection: postsWithHooksSlug,
+        where: { title: { equals: 'Original Title_imported' } },
+      })
+      expect(importedDocs.docs).toHaveLength(1)
+      importedDocs.docs.forEach((d) => createdHookPostIDs.push(d.id))
+    })
+
+    it('should call import.hooks.after with per-batch ImportResult', async () => {
+      const csvContent = `title,count\n"After Hook Post","99"`
+      const file = {
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        name: 'hooks-after-test.csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-hooks-import',
+        user,
+        data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
+        file,
+      })
+
+      importDoc = await payload.findByID({
+        collection: 'posts-with-hooks-import',
+        id: importDoc.id,
+      })
+
+      expect(importDoc.status).toBe('completed')
+      expect(hookCalls.importAfter).toHaveLength(1)
+
+      const afterArgs = hookCalls.importAfter[0]!
+      expect(afterArgs.format).toBe('csv')
+      expect(afterArgs.batchNumber).toBe(1)
+      expect(afterArgs.result).toBeDefined()
+      expect(afterArgs.result.imported).toBe(1)
+      expect(afterArgs.result.errors).toHaveLength(0)
+
+      const imported = await payload.find({
+        collection: postsWithHooksSlug,
+        where: { title: { equals: 'After Hook Post_imported' } },
+      })
+      imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
+    })
+
+    it('should pass originalData (raw pre-transform rows) to import.hooks.after', async () => {
+      const csvContent = `title,count\n"OriginalData Post","42"`
+      const file = {
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        name: 'hooks-after-originaldata-test.csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-hooks-import',
+        user,
+        data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
+        file,
+      })
+
+      importDoc = await payload.findByID({
+        collection: 'posts-with-hooks-import',
+        id: importDoc.id,
+      })
+
+      expect(importDoc.status).toBe('completed')
+      expect(hookCalls.importAfter).toHaveLength(1)
+
+      const afterArgs = hookCalls.importAfter[0]!
+      expect(afterArgs.originalData).toBeDefined()
+      expect(afterArgs.originalData).toHaveLength(1)
+      expect(afterArgs.originalData[0]).toMatchObject({ title: 'OriginalData Post', count: 42 })
+
+      const imported = await payload.find({
+        collection: postsWithHooksSlug,
+        where: { title: { equals: 'OriginalData Post_imported' } },
+      })
+      imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
+    })
+
+    it('should call import.hooks.before for JSON imports', async () => {
+      const jsonContent = JSON.stringify([{ title: 'JSON Import Hook', count: 5 }])
+      const file = {
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        name: 'hooks-json-test.json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-hooks-import',
+        user,
+        data: { collectionSlug: postsWithHooksSlug, importMode: 'create', format: 'json' },
+        file,
+      })
+
+      importDoc = await payload.findByID({
+        collection: 'posts-with-hooks-import',
+        id: importDoc.id,
+      })
+
+      expect(importDoc.status).toBe('completed')
+      expect(hookCalls.importBefore).toHaveLength(1)
+      expect(hookCalls.importBefore[0]!.format).toBe('json')
+
+      const imported = await payload.find({
+        collection: postsWithHooksSlug,
+        where: { title: { equals: 'JSON Import Hook_imported' } },
+      })
+      expect(imported.docs).toHaveLength(1)
+      imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
+    })
+
+    it('should pass originalData as raw parsed JSON (before field hooks) to import hooks', async () => {
+      // The posts-with-hooks collection has an `email` field with a beforeImport field hook
+      // that lowercases the value. This test verifies that originalData in both the before
+      // and after collection hooks contains the raw parsed JSON value ('TEST@EXAMPLE.COM'),
+      // not the field-hook-transformed value ('test@example.com').
+      const jsonContent = JSON.stringify([
+        { title: 'JSON Original Data Test', count: 7, email: 'TEST@EXAMPLE.COM' },
+      ])
+
+      const file = {
+        data: Buffer.from(jsonContent),
+        mimetype: 'application/json',
+        name: 'hooks-json-originaldata.json',
+        size: Buffer.from(jsonContent).length,
+      }
+
+      let importDoc = await payload.create({
+        collection: 'posts-with-hooks-import',
+        user,
+        data: { collectionSlug: postsWithHooksSlug, importMode: 'create', format: 'json' },
+        file,
+      })
+
+      importDoc = await payload.findByID({
+        collection: 'posts-with-hooks-import',
+        id: importDoc.id,
+      })
+
+      expect(importDoc.status).toBe('completed')
+      expect(hookCalls.importBefore).toHaveLength(1)
+      expect(hookCalls.importAfter).toHaveLength(1)
+
+      // originalData must be the raw parsed JSON — the email field hook (lowercase) must NOT
+      // have been applied yet. With the bug, originalData === data (after field hooks),
+      // so email would be 'test@example.com' instead of the raw 'TEST@EXAMPLE.COM'.
+      const beforeOriginalData = hookCalls.importBefore[0]!.originalData[0] as Record<
+        string,
+        unknown
+      >
+      expect(beforeOriginalData.email).toBe('TEST@EXAMPLE.COM')
+
+      const afterOriginalData = hookCalls.importAfter[0]!.originalData[0] as Record<string, unknown>
+      expect(afterOriginalData.email).toBe('TEST@EXAMPLE.COM')
+
+      const imported = await payload.find({
+        collection: postsWithHooksSlug,
+        where: { title: { equals: 'JSON Original Data Test_imported' } },
+      })
+      imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
+    })
+
+    it('should call import.hooks.before once per batch', async () => {
+      const rows = Array.from({ length: 4 }, (_, i) => `"Batch Import ${i}","${i}"`).join('\n')
+      const csvContent = `title,count\n${rows}`
+      const file = {
+        data: Buffer.from(csvContent),
+        mimetype: 'text/csv',
+        name: 'hooks-batch-import.csv',
+        size: Buffer.from(csvContent).length,
+      }
+
+      // posts-with-hooks is configured with batchSize: 2 — 4 rows → 2 batches
+      let importDoc = await payload.create({
+        collection: 'posts-with-hooks-import',
+        user,
+        data: {
+          collectionSlug: postsWithHooksSlug,
+          importMode: 'create',
+        },
+        file,
+      })
+
+      importDoc = await payload.findByID({
+        collection: 'posts-with-hooks-import',
+        id: importDoc.id,
+      })
+
+      expect(importDoc.status).toBe('completed')
+      expect(hookCalls.importBefore).toHaveLength(2)
+      expect(hookCalls.importBefore[0]!.batchNumber).toBe(1)
+      expect(hookCalls.importBefore[1]!.batchNumber).toBe(2)
+      expect(hookCalls.importBefore[0]!.totalBatches).toBe(2)
+
+      const imported = await payload.find({
+        collection: postsWithHooksSlug,
+        where: { title: { contains: 'Batch Import' } },
+        limit: 10,
+      })
+      imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // Deprecation: toCSV/fromCSV still work
+  // ─────────────────────────────────────────────
+
+  describe('toCSV/fromCSV deprecation (still functional)', () => {
+    it('should still apply field-level toCSV during export without error', async () => {
+      // Pages collection has custom toCSV on its `custom` field per existing tests
+      const page = await payload.create({
+        collection: 'pages',
+        data: { title: 'toCSV Deprecation Test', custom: 'raw-value' } as any,
+      })
+
+      const exportDoc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          format: 'csv',
+          where: { id: { equals: page.id } },
+        },
+      })
+
+      await payload.jobs.run()
+
+      const doc = await payload.findByID({ collection: 'exports', id: exportDoc.id })
+      expect(doc.filename).toBeDefined()
+
+      await payload.delete({ collection: 'pages', id: page.id })
+    })
+  })
+
+  describe('column mapping — export', () => {
+    const createdIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of createdIDs) {
+        await payload.delete({ collection: postsWithColumnMapSlug, id })
+      }
+      createdIDs.length = 0
+    })
+
+    it('should rename CSV columns via collection-level export.hooks.before', async () => {
+      const post = await payload.create({
+        collection: postsWithColumnMapSlug,
+        data: { title: 'Rename Me', excerpt: 'Original excerpt', count: 42 },
+      })
+      createdIDs.push(post.id)
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-column-map-export',
+        user,
+        data: {
+          collectionSlug: postsWithColumnMapSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+      })
+
+      exportDoc = await payload.findByID({
+        collection: 'posts-with-column-map-export',
+        id: exportDoc.id,
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!['Post Title']).toBe('Rename Me')
+      expect(rows[0]!.Summary).toBe('Original excerpt')
+      expect(rows[0]!['View Count']).toBe('42')
+      expect(rows[0]!.title).toBeUndefined()
+      expect(rows[0]!.excerpt).toBeUndefined()
+      expect(rows[0]!.count).toBeUndefined()
+    })
+
+    it('should rename a single CSV column via field-level beforeExport mutation', async () => {
+      const post = await payload.create({
+        collection: postsWithColumnMapSlug,
+        data: { title: 'Field Rename', excerpt: 'x', count: 1, sharedName: 'shared value' },
+      })
+      createdIDs.push(post.id)
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-column-map-export',
+        user,
+        data: {
+          collectionSlug: postsWithColumnMapSlug,
+          format: 'csv',
+          where: { id: { equals: post.id } },
+        },
+      })
+
+      exportDoc = await payload.findByID({
+        collection: 'posts-with-column-map-export',
+        id: exportDoc.id,
+      })
+
+      const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const rows = await readCSV(csvPath)
+
+      expect(rows[0]!['Display Name']).toBe('shared value')
+      expect(rows[0]!.sharedName).toBeUndefined()
+    })
+
+    it('should reflect collection-level export.hooks.before in CSV export preview', async () => {
+      const post = await payload.create({
+        collection: postsWithColumnMapSlug,
+        data: { title: 'Preview Rename', excerpt: 'preview excerpt', count: 11 },
+      })
+      createdIDs.push(post.id)
+
+      const res = await restClient.POST('/posts-with-column-map-export/export-preview', {
+        body: JSON.stringify({
+          collectionSlug: postsWithColumnMapSlug,
+          format: 'csv',
+          previewLimit: 10,
+          previewPage: 1,
+          where: { id: { equals: post.id } },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      expect(res.status).toBe(200)
+      const body: { columns: string[]; docs: Array<Record<string, unknown>> } = await res.json()
+
+      expect(body.docs).toHaveLength(1)
+      expect(body.docs[0]!['Post Title']).toBe('Preview Rename')
+      expect(body.docs[0]!.Summary).toBe('preview excerpt')
+      expect(body.docs[0]!['View Count']).toBe(11)
+      expect(body.docs[0]!.title).toBeUndefined()
+      expect(body.docs[0]!.excerpt).toBeUndefined()
+      expect(body.docs[0]!.count).toBeUndefined()
+
+      expect(body.columns).toContain('Post Title')
+      expect(body.columns).toContain('Summary')
+      expect(body.columns).toContain('View Count')
+      expect(body.columns).not.toContain('title')
+      expect(body.columns).not.toContain('excerpt')
+      expect(body.columns).not.toContain('count')
+    })
+
+    it('should reflect collection-level export.hooks.before in JSON export preview', async () => {
+      const post = await payload.create({
+        collection: postsWithColumnMapSlug,
+        data: { title: 'JSON Preview Rename', excerpt: 'json preview', count: 22 },
+      })
+      createdIDs.push(post.id)
+
+      const res = await restClient.POST('/posts-with-column-map-export/export-preview', {
+        body: JSON.stringify({
+          collectionSlug: postsWithColumnMapSlug,
+          format: 'json',
+          previewLimit: 10,
+          previewPage: 1,
+          where: { id: { equals: post.id } },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      expect(res.status).toBe(200)
+      const body: { docs: Array<Record<string, unknown>> } = await res.json()
+
+      expect(body.docs).toHaveLength(1)
+      expect(body.docs[0]!['Post Title']).toBe('JSON Preview Rename')
+      expect(body.docs[0]!.Summary).toBe('json preview')
+      expect(body.docs[0]!['View Count']).toBe(22)
+      expect(body.docs[0]!.title).toBeUndefined()
+    })
+
+    it('should rename JSON keys via collection-level export.hooks.before', async () => {
+      const post = await payload.create({
+        collection: postsWithColumnMapSlug,
+        data: { title: 'JSON Rename', excerpt: 'json excerpt', count: 7 },
+      })
+      createdIDs.push(post.id)
+
+      let exportDoc = await payload.create({
+        collection: 'posts-with-column-map-export',
+        user,
+        data: {
+          collectionSlug: postsWithColumnMapSlug,
+          format: 'json',
+          where: { id: { equals: post.id } },
+        },
+      })
+
+      exportDoc = await payload.findByID({
+        collection: 'posts-with-column-map-export',
+        id: exportDoc.id,
+      })
+
+      const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
+      const docs = await readJSON(jsonPath)
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0]['Post Title']).toBe('JSON Rename')
+      expect(docs[0].Summary).toBe('json excerpt')
+      expect(docs[0]['View Count']).toBe(7)
+      expect(docs[0].title).toBeUndefined()
+    })
+  })
+
+  describe('column mapping — import', () => {
+    const createdIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of createdIDs) {
+        await payload
+          .delete({ collection: postsWithColumnMapSlug, id })
+          .catch((err) => payload.logger.warn({ err, id, msg: 'column-map cleanup failed' }))
+      }
+      createdIDs.length = 0
+    })
+
+    it('should import a CSV with foreign column names via collection-level import.hooks.before', async () => {
+      const csv =
+        '"Post Title","Summary","View Count","Ignored Column"\n' +
+        '"Imported A","summary a","10","noise"\n' +
+        '"Imported B","summary b","20","noise"\n'
+      const file = {
+        data: Buffer.from(csv),
+        mimetype: 'text/csv',
+        name: 'column-map-foreign-import.csv',
+        size: Buffer.from(csv).length,
+      }
+
+      const importDoc = await payload.create({
+        collection: 'posts-with-column-map-import',
+        user,
+        data: {
+          collectionSlug: postsWithColumnMapSlug,
+          importMode: 'create',
+        },
+        file,
+      })
+
+      expect(importDoc.id).toBeDefined()
+
+      const imported = await payload.find({
+        collection: postsWithColumnMapSlug,
+        sort: 'title',
+        where: { title: { in: ['Imported A', 'Imported B'] } },
+      })
+
+      imported.docs.forEach((doc) => createdIDs.push(doc.id))
+
+      expect(imported.docs).toHaveLength(2)
+      expect(imported.docs[0]!.title).toBe('Imported A')
+      expect(imported.docs[0]!.excerpt).toBe('summary a')
+      expect(imported.docs[0]!.count).toBe(10)
+      expect(imported.docs[1]!.title).toBe('Imported B')
+      expect(imported.docs[1]!.count).toBe(20)
+    })
+
+    it('should import a JSON file with foreign keys via collection-level import.hooks.before', async () => {
+      const content = JSON.stringify([
+        {
+          'Post Title': 'JSON A',
+          Summary: 'json summary a',
+          'View Count': 5,
+          'Ignored Column': 'x',
+        },
+        {
+          'Post Title': 'JSON B',
+          Summary: 'json summary b',
+          'View Count': 6,
+          'Ignored Column': 'y',
+        },
+      ])
+      const file = {
+        data: Buffer.from(content),
+        mimetype: 'application/json',
+        name: 'column-map-foreign-import.json',
+        size: Buffer.from(content).length,
+      }
+
+      await payload.create({
+        collection: 'posts-with-column-map-import',
+        user,
+        data: {
+          collectionSlug: postsWithColumnMapSlug,
+          importMode: 'create',
+        },
+        file,
+      })
+
+      const imported = await payload.find({
+        collection: postsWithColumnMapSlug,
+        sort: 'title',
+        where: { title: { in: ['JSON A', 'JSON B'] } },
+      })
+
+      imported.docs.forEach((doc) => createdIDs.push(doc.id))
+
+      expect(imported.docs).toHaveLength(2)
+      expect(imported.docs[0]!.title).toBe('JSON A')
+      expect(imported.docs[0]!.count).toBe(5)
+      expect(imported.docs[1]!.title).toBe('JSON B')
+      expect(imported.docs[1]!.count).toBe(6)
+    })
+
+    it('should reflect collection-level import.hooks.before in CSV import preview', async () => {
+      const csv =
+        '"Post Title","Summary","View Count","Ignored Column"\n' +
+        '"Preview Imported","preview summary","30","noise"\n'
+
+      const fileData = Buffer.from(csv).toString('base64')
+
+      const res = await restClient.POST('/posts-with-column-map-import/preview-data', {
+        body: JSON.stringify({
+          collectionSlug: postsWithColumnMapSlug,
+          fileData,
+          format: 'csv',
+          previewLimit: 10,
+          previewPage: 1,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      expect(res.status).toBe(200)
+      const body: { docs: Array<Record<string, unknown>> } = await res.json()
+
+      expect(body.docs).toHaveLength(1)
+      expect(body.docs[0]!.title).toBe('Preview Imported')
+      expect(body.docs[0]!.excerpt).toBe('preview summary')
+      expect(body.docs[0]!.count).toBe(30)
+      expect(body.docs[0]!['Post Title']).toBeUndefined()
+      expect(body.docs[0]!.Summary).toBeUndefined()
+      expect(body.docs[0]!['Ignored Column']).toBeUndefined()
+    })
+
+    it('should reflect collection-level import.hooks.before in JSON import preview', async () => {
+      const content = JSON.stringify([
+        {
+          'Post Title': 'JSON Preview Imported',
+          Summary: 'json preview summary',
+          'View Count': 40,
+          'Ignored Column': 'noise',
+        },
+      ])
+
+      const fileData = Buffer.from(content).toString('base64')
+
+      const res = await restClient.POST('/posts-with-column-map-import/preview-data', {
+        body: JSON.stringify({
+          collectionSlug: postsWithColumnMapSlug,
+          fileData,
+          format: 'json',
+          previewLimit: 10,
+          previewPage: 1,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      expect(res.status).toBe(200)
+      const body: { docs: Array<Record<string, unknown>> } = await res.json()
+
+      expect(body.docs).toHaveLength(1)
+      expect(body.docs[0]!.title).toBe('JSON Preview Imported')
+      expect(body.docs[0]!.excerpt).toBe('json preview summary')
+      expect(body.docs[0]!.count).toBe(40)
+      expect(body.docs[0]!['Post Title']).toBeUndefined()
+    })
+
+    it('should drop foreign columns not present in the rename map', async () => {
+      const csv = '"Post Title","Ignored Column"\n' + '"Dropped Test","this should not survive"\n'
+      const file = {
+        data: Buffer.from(csv),
+        mimetype: 'text/csv',
+        name: 'column-map-drop-unknown.csv',
+        size: Buffer.from(csv).length,
+      }
+
+      await payload.create({
+        collection: 'posts-with-column-map-import',
+        user,
+        data: {
+          collectionSlug: postsWithColumnMapSlug,
+          importMode: 'create',
+        },
+        file,
+      })
+
+      const imported = await payload.find({
+        collection: postsWithColumnMapSlug,
+        where: { title: { equals: 'Dropped Test' } },
+      })
+
+      imported.docs.forEach((doc) => createdIDs.push(doc.id))
+
+      expect(imported.docs).toHaveLength(1)
+      const doc = imported.docs[0]! as Record<string, unknown>
+      expect(doc.title).toBe('Dropped Test')
+      expect(doc['Ignored Column']).toBeUndefined()
+    })
+  })
+})

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -956,6 +956,43 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].hasManyPolymorphic_1_relationTo).toBe('posts')
     })
 
+    it('should not produce duplicate columns for hasOne polymorphic relationship export', async () => {
+      const doc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          fields: ['id', 'hasOnePolymorphic'],
+          format: 'csv',
+          where: {
+            title: { contains: 'Polymorphic' },
+          },
+        },
+      })
+
+      await payload.jobs.run()
+
+      const exportDoc = await payload.findByID({
+        collection: 'exports',
+        id: doc.id,
+      })
+
+      expect(exportDoc.filename).toBeDefined()
+      const expectedPath = path.join(dirname, './uploads', exportDoc.filename as string)
+      const buffer = fs.readFileSync(expectedPath)
+      const headerLine = buffer.toString().split('\n')[0] ?? ''
+      const headers = headerLine.split(',').map((h) => h.replace(/^\ufeff/, '').trim())
+
+      expect(headers).toContain('hasOnePolymorphic_id')
+      expect(headers).toContain('hasOnePolymorphic_relationTo')
+
+      const leakedColumns = headers.filter(
+        (h) =>
+          h.startsWith('hasOnePolymorphic_value') || h.startsWith('hasOnePolymorphic_relationTo_'),
+      )
+      expect(leakedColumns).toEqual([])
+    })
+
     it('should export hasMany monomorphic relationship fields to CSV', async () => {
       const doc = await payload.create({
         collection: 'exports',

--- a/test/plugin-import-export/payload-types.ts
+++ b/test/plugin-import-export/payload-types.ts
@@ -76,6 +76,9 @@ export interface Config {
     'posts-no-jobs-queue': PostsNoJobsQueue;
     'posts-with-limits': PostsWithLimit;
     'posts-with-s3': PostsWithS3;
+    'posts-with-hooks': PostsWithHook;
+    'posts-with-field-hooks': PostsWithFieldHook;
+    'posts-with-column-map': PostsWithColumnMap;
     media: Media;
     'custom-id-pages': CustomIdPage;
     exports: Export;
@@ -83,10 +86,16 @@ export interface Config {
     'posts-no-jobs-queue-export': PostsNoJobsQueueExport;
     'posts-with-s3-export': PostsWithS3Export;
     'posts-with-limits-export': PostsWithLimitsExport;
+    'posts-with-hooks-export': PostsWithHooksExport;
+    'posts-with-field-hooks-export': PostsWithFieldHooksExport;
+    'posts-with-column-map-export': PostsWithColumnMapExport;
     imports: Import;
     'posts-import': PostsImport;
     'posts-with-s3-import': PostsWithS3Import;
     'posts-with-limits-import': PostsWithLimitsImport;
+    'posts-with-hooks-import': PostsWithHooksImport;
+    'posts-with-field-hooks-import': PostsWithFieldHooksImport;
+    'posts-with-column-map-import': PostsWithColumnMapImport;
     'payload-kv': PayloadKv;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -103,6 +112,9 @@ export interface Config {
     'posts-no-jobs-queue': PostsNoJobsQueueSelect<false> | PostsNoJobsQueueSelect<true>;
     'posts-with-limits': PostsWithLimitsSelect<false> | PostsWithLimitsSelect<true>;
     'posts-with-s3': PostsWithS3Select<false> | PostsWithS3Select<true>;
+    'posts-with-hooks': PostsWithHooksSelect<false> | PostsWithHooksSelect<true>;
+    'posts-with-field-hooks': PostsWithFieldHooksSelect<false> | PostsWithFieldHooksSelect<true>;
+    'posts-with-column-map': PostsWithColumnMapSelect<false> | PostsWithColumnMapSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     'custom-id-pages': CustomIdPagesSelect<false> | CustomIdPagesSelect<true>;
     exports: ExportsSelect<false> | ExportsSelect<true>;
@@ -110,10 +122,16 @@ export interface Config {
     'posts-no-jobs-queue-export': PostsNoJobsQueueExportSelect<false> | PostsNoJobsQueueExportSelect<true>;
     'posts-with-s3-export': PostsWithS3ExportSelect<false> | PostsWithS3ExportSelect<true>;
     'posts-with-limits-export': PostsWithLimitsExportSelect<false> | PostsWithLimitsExportSelect<true>;
+    'posts-with-hooks-export': PostsWithHooksExportSelect<false> | PostsWithHooksExportSelect<true>;
+    'posts-with-field-hooks-export': PostsWithFieldHooksExportSelect<false> | PostsWithFieldHooksExportSelect<true>;
+    'posts-with-column-map-export': PostsWithColumnMapExportSelect<false> | PostsWithColumnMapExportSelect<true>;
     imports: ImportsSelect<false> | ImportsSelect<true>;
     'posts-import': PostsImportSelect<false> | PostsImportSelect<true>;
     'posts-with-s3-import': PostsWithS3ImportSelect<false> | PostsWithS3ImportSelect<true>;
     'posts-with-limits-import': PostsWithLimitsImportSelect<false> | PostsWithLimitsImportSelect<true>;
+    'posts-with-hooks-import': PostsWithHooksImportSelect<false> | PostsWithHooksImportSelect<true>;
+    'posts-with-field-hooks-import': PostsWithFieldHooksImportSelect<false> | PostsWithFieldHooksImportSelect<true>;
+    'posts-with-column-map-import': PostsWithColumnMapImportSelect<false> | PostsWithColumnMapImportSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -488,6 +506,77 @@ export interface PostsWithS3 {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-hooks".
+ */
+export interface PostsWithHook {
+  id: string;
+  title: string;
+  secret?: string | null;
+  count?: number | null;
+  email?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-field-hooks".
+ */
+export interface PostsWithFieldHook {
+  id: string;
+  title: string;
+  secret?: string | null;
+  count?: number | null;
+  customExport?: string | null;
+  customImport?: string | null;
+  email?: string | null;
+  group?: {
+    namedTab?: {
+      deepField?: string | null;
+    };
+  };
+  legacyToCSV?: string | null;
+  legacyToCSVArgs?: string | null;
+  legacyFromCSV?: string | null;
+  legacyFromCSVArgs?: string | null;
+  items?:
+    | {
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  content?:
+    | {
+        body?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'textBlock';
+      }[]
+    | null;
+  mayCrash?: string | null;
+  rowField?: string | null;
+  collapsibleField?: string | null;
+  metadata?: {
+    slugFromTitle?: string | null;
+    siblingEcho?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-column-map".
+ */
+export interface PostsWithColumnMap {
+  id: string;
+  title: string;
+  excerpt?: string | null;
+  count?: number | null;
+  sharedName?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "custom-id-pages".
  */
 export interface CustomIdPage {
@@ -688,6 +777,120 @@ export interface PostsWithLimitsExport {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-hooks-export".
+ */
+export interface PostsWithHooksExport {
+  id: string;
+  name?: string | null;
+  format: 'csv' | 'json';
+  limit?: number | null;
+  page?: number | null;
+  sort?: string | null;
+  sortOrder?: ('asc' | 'desc') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
+  drafts?: ('yes' | 'no') | null;
+  selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
+  fields?: string[] | null;
+  collectionSlug: string;
+  where?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-field-hooks-export".
+ */
+export interface PostsWithFieldHooksExport {
+  id: string;
+  name?: string | null;
+  format: 'csv' | 'json';
+  limit?: number | null;
+  page?: number | null;
+  sort?: string | null;
+  sortOrder?: ('asc' | 'desc') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
+  drafts?: ('yes' | 'no') | null;
+  selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
+  fields?: string[] | null;
+  collectionSlug: string;
+  where?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-column-map-export".
+ */
+export interface PostsWithColumnMapExport {
+  id: string;
+  name?: string | null;
+  format: 'csv' | 'json';
+  limit?: number | null;
+  page?: number | null;
+  sort?: string | null;
+  sortOrder?: ('asc' | 'desc') | null;
+  locale?: ('all' | 'en' | 'es' | 'de' | 'he') | null;
+  drafts?: ('yes' | 'no') | null;
+  selectionToUse?: ('currentSelection' | 'currentFilters' | 'all') | null;
+  fields?: string[] | null;
+  collectionSlug: string;
+  where?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "imports".
  */
 export interface Import {
@@ -802,6 +1005,117 @@ export interface PostsWithS3Import {
  * via the `definition` "posts-with-limits-import".
  */
 export interface PostsWithLimitsImport {
+  id: string;
+  collectionSlug: string;
+  importMode?: ('create' | 'update' | 'upsert') | null;
+  matchField?: string | null;
+  status?: ('pending' | 'completed' | 'partial' | 'failed') | null;
+  summary?: {
+    imported?: number | null;
+    updated?: number | null;
+    total?: number | null;
+    issues?: number | null;
+    issueDetails?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-hooks-import".
+ */
+export interface PostsWithHooksImport {
+  id: string;
+  collectionSlug: string;
+  importMode?: ('create' | 'update' | 'upsert') | null;
+  matchField?: string | null;
+  status?: ('pending' | 'completed' | 'partial' | 'failed') | null;
+  summary?: {
+    imported?: number | null;
+    updated?: number | null;
+    total?: number | null;
+    issues?: number | null;
+    issueDetails?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-field-hooks-import".
+ */
+export interface PostsWithFieldHooksImport {
+  id: string;
+  collectionSlug: string;
+  importMode?: ('create' | 'update' | 'upsert') | null;
+  matchField?: string | null;
+  status?: ('pending' | 'completed' | 'partial' | 'failed') | null;
+  summary?: {
+    imported?: number | null;
+    updated?: number | null;
+    total?: number | null;
+    issues?: number | null;
+    issueDetails?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-column-map-import".
+ */
+export interface PostsWithColumnMapImport {
   id: string;
   collectionSlug: string;
   importMode?: ('create' | 'update' | 'upsert') | null;
@@ -981,6 +1295,18 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'posts-with-s3';
         value: string | PostsWithS3;
+      } | null)
+    | ({
+        relationTo: 'posts-with-hooks';
+        value: string | PostsWithHook;
+      } | null)
+    | ({
+        relationTo: 'posts-with-field-hooks';
+        value: string | PostsWithFieldHook;
+      } | null)
+    | ({
+        relationTo: 'posts-with-column-map';
+        value: string | PostsWithColumnMap;
       } | null)
     | ({
         relationTo: 'media';
@@ -1207,6 +1533,83 @@ export interface PostsWithS3Select<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-hooks_select".
+ */
+export interface PostsWithHooksSelect<T extends boolean = true> {
+  title?: T;
+  secret?: T;
+  count?: T;
+  email?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-field-hooks_select".
+ */
+export interface PostsWithFieldHooksSelect<T extends boolean = true> {
+  title?: T;
+  secret?: T;
+  count?: T;
+  customExport?: T;
+  customImport?: T;
+  email?: T;
+  group?:
+    | T
+    | {
+        namedTab?:
+          | T
+          | {
+              deepField?: T;
+            };
+      };
+  legacyToCSV?: T;
+  legacyToCSVArgs?: T;
+  legacyFromCSV?: T;
+  legacyFromCSVArgs?: T;
+  items?:
+    | T
+    | {
+        note?: T;
+        id?: T;
+      };
+  content?:
+    | T
+    | {
+        textBlock?:
+          | T
+          | {
+              body?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  mayCrash?: T;
+  rowField?: T;
+  collapsibleField?: T;
+  metadata?:
+    | T
+    | {
+        slugFromTitle?: T;
+        siblingEcho?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-column-map_select".
+ */
+export interface PostsWithColumnMapSelect<T extends boolean = true> {
+  title?: T;
+  excerpt?: T;
+  count?: T;
+  sharedName?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
@@ -1380,6 +1783,93 @@ export interface PostsWithLimitsExportSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-hooks-export_select".
+ */
+export interface PostsWithHooksExportSelect<T extends boolean = true> {
+  name?: T;
+  format?: T;
+  limit?: T;
+  page?: T;
+  sort?: T;
+  sortOrder?: T;
+  locale?: T;
+  drafts?: T;
+  selectionToUse?: T;
+  fields?: T;
+  collectionSlug?: T;
+  where?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-field-hooks-export_select".
+ */
+export interface PostsWithFieldHooksExportSelect<T extends boolean = true> {
+  name?: T;
+  format?: T;
+  limit?: T;
+  page?: T;
+  sort?: T;
+  sortOrder?: T;
+  locale?: T;
+  drafts?: T;
+  selectionToUse?: T;
+  fields?: T;
+  collectionSlug?: T;
+  where?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-column-map-export_select".
+ */
+export interface PostsWithColumnMapExportSelect<T extends boolean = true> {
+  name?: T;
+  format?: T;
+  limit?: T;
+  page?: T;
+  sort?: T;
+  sortOrder?: T;
+  locale?: T;
+  drafts?: T;
+  selectionToUse?: T;
+  fields?: T;
+  collectionSlug?: T;
+  where?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "imports_select".
  */
 export interface ImportsSelect<T extends boolean = true> {
@@ -1473,6 +1963,96 @@ export interface PostsWithS3ImportSelect<T extends boolean = true> {
  * via the `definition` "posts-with-limits-import_select".
  */
 export interface PostsWithLimitsImportSelect<T extends boolean = true> {
+  collectionSlug?: T;
+  importMode?: T;
+  matchField?: T;
+  status?: T;
+  summary?:
+    | T
+    | {
+        imported?: T;
+        updated?: T;
+        total?: T;
+        issues?: T;
+        issueDetails?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-hooks-import_select".
+ */
+export interface PostsWithHooksImportSelect<T extends boolean = true> {
+  collectionSlug?: T;
+  importMode?: T;
+  matchField?: T;
+  status?: T;
+  summary?:
+    | T
+    | {
+        imported?: T;
+        updated?: T;
+        total?: T;
+        issues?: T;
+        issueDetails?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-field-hooks-import_select".
+ */
+export interface PostsWithFieldHooksImportSelect<T extends boolean = true> {
+  collectionSlug?: T;
+  importMode?: T;
+  matchField?: T;
+  status?: T;
+  summary?:
+    | T
+    | {
+        imported?: T;
+        updated?: T;
+        total?: T;
+        issues?: T;
+        issueDetails?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts-with-column-map-import_select".
+ */
+export interface PostsWithColumnMapImportSelect<T extends boolean = true> {
   collectionSlug?: T;
   importMode?: T;
   matchField?: T;
@@ -1597,6 +2177,9 @@ export interface TaskCreateCollectionExport {
       | 'posts-no-jobs-queue'
       | 'posts-with-limits'
       | 'posts-with-s3'
+      | 'posts-with-hooks'
+      | 'posts-with-field-hooks'
+      | 'posts-with-column-map'
       | 'media'
       | 'custom-id-pages'
       | 'exports'
@@ -1604,10 +2187,16 @@ export interface TaskCreateCollectionExport {
       | 'posts-no-jobs-queue-export'
       | 'posts-with-s3-export'
       | 'posts-with-limits-export'
+      | 'posts-with-hooks-export'
+      | 'posts-with-field-hooks-export'
+      | 'posts-with-column-map-export'
       | 'imports'
       | 'posts-import'
       | 'posts-with-s3-import'
-      | 'posts-with-limits-import';
+      | 'posts-with-limits-import'
+      | 'posts-with-hooks-import'
+      | 'posts-with-field-hooks-import'
+      | 'posts-with-column-map-import';
     drafts?: ('yes' | 'no') | null;
     exportCollection: string;
     fields?: string[] | null;

--- a/test/plugin-import-export/shared.ts
+++ b/test/plugin-import-export/shared.ts
@@ -19,3 +19,13 @@ export const postsWithS3ExportSlug = 'posts-with-s3-export'
 export const mediaSlug = 'media'
 
 export const customIdPagesSlug = 'custom-id-pages'
+
+export const postsWithHooksSlug = 'posts-with-hooks'
+
+export const postsWithHooksExportSlug = 'posts-with-hooks-export'
+
+export const postsWithHooksImportSlug = 'posts-with-hooks-import'
+
+export const postsWithFieldHooksSlug = 'posts-with-field-hooks'
+
+export const postsWithColumnMapSlug = 'posts-with-column-map'

--- a/tools/scripts/src/build-template-with-local-pkgs.ts
+++ b/tools/scripts/src/build-template-with-local-pkgs.ts
@@ -79,7 +79,7 @@ async function main() {
   })
 
   // Write package.json back to disk
-  packageJsonObj.pnpm = { overrides }
+  packageJsonObj.pnpm = { ...packageJsonObj.pnpm, overrides }
   await fs.writeFile(packageJsonPath, JSON.stringify(packageJsonObj, null, 2))
 
   execSync('pnpm install --no-frozen-lockfile --ignore-workspace', execOpts)

--- a/tools/scripts/src/build-template-with-local-pkgs.ts
+++ b/tools/scripts/src/build-template-with-local-pkgs.ts
@@ -56,8 +56,7 @@ async function main() {
 
   await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJsonObj, null, 2))
 
-  execSync('pnpm add ./*.tgz --ignore-workspace', execOpts)
-  execSync('pnpm install --ignore-workspace', execOpts)
+  execSync('pnpm add ./*.tgz --ignore-workspace --ignore-scripts', execOpts)
 
   const packageJson = await fs.readFile(packageJsonPath, 'utf-8')
   const packageJsonObj = JSON.parse(packageJson) as {

--- a/tools/scripts/src/build-template-with-local-pkgs.ts
+++ b/tools/scripts/src/build-template-with-local-pkgs.ts
@@ -57,6 +57,7 @@ async function main() {
   await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJsonObj, null, 2))
 
   execSync('pnpm add ./*.tgz --ignore-workspace --ignore-scripts', execOpts)
+  execSync('pnpm install --ignore-workspace', execOpts)
 
   const packageJson = await fs.readFile(packageJsonPath, 'utf-8')
   const packageJsonObj = JSON.parse(packageJson) as {


### PR DESCRIPTION
### Plugin out of beta

The import export plugin is now marked as stable and will be moved out of beta. For v4 we will be removing the deprecated APIs but for v3 they will remain supported.

### Why

Field-level hooks are essential because:

1. **Co-location** — the transform behavior lives next to the field definition, not in a separate collection config
2. **Reusability** — a shared field config carries its hooks to every collection that uses it, zero duplication
3. **Deeply nested fields** — transforming `group.tabs.namedTab.array[0].field` in a collection-level hook requires manually navigating the full document structure; field-level hooks handle this transparently

This PR keeps both levels: field-level hooks for per-field transforms, collection-level hooks for batch-wide operations (masking, logging, filtering).


## Field-level hooks

Defined per-field via `custom['plugin-import-export'].hooks`:

```ts
import type { FieldBeforeExportHook } from '@payloadcms/plugin-import-export'

const authorField = {
  name: 'author',
  type: 'relationship',
  relationTo: 'users',
  custom: {
    'plugin-import-export': {
      hooks: {
        // Runs before the field value is written to the export file
        beforeExport: (({ value, columnName, row, format }) => {
          if (format === 'csv' && value && typeof value === 'object' && 'id' in value) {
            row[`${columnName}_id`] = value.id
            row[`${columnName}_email`] = value.email
            return undefined // let row mutation take effect
          }
          return value
        }) satisfies FieldBeforeExportHook,

        // Runs before the field value is written to the database
        beforeImport: ({ value, columnName, data, format }) => {
          if (format === 'csv') {
            return data[`${columnName}_id`] ?? undefined
          }
          return value
        },
      },
    },
  },
}
```

## Collection-level hooks
Defined in the plugin config:

```ts
importExportPlugin({
  collections: [
    {
      slug: 'users',
      export: {
        hooks: {
          before: ({ data, format }) => {
            // Mask sensitive fields from the entire batch
            return data.map(({ passwordHash, ssn, ...safe }) => safe)
          },
          after: ({ batchNumber, totalBatches, req }) => {
            req.payload.logger.info(`Export batch ${batchNumber}/${totalBatches} written`)
          },
        },
      },
    },
  ],
})
```

#### Execution order

field-level `hooks.beforeExport` / `hooks.beforeImport` run first (per-field, per-document), then collection-level `hooks.before` / `hooks.after` run on the already-transformed batch.

#### Migration from toCSV / fromCSV

toCSV and fromCSV remain fully functional but are deprecated — removed in v4.0. Migration is a 1:1 rename plus the new format parameter:


```ts
// Before (deprecated)
custom: {
  'plugin-import-export': {
    toCSV: ({ value, row }) => { ... },
    fromCSV: ({ value, data }) => { ... },
  },
}

// After
custom: {
  'plugin-import-export': {
    hooks: {
      beforeExport: ({ value, row, format }) => { ... },
      beforeImport: ({ value, data, format }) => { ... },
    },
  },
}

```

## What changed

### New types

`FieldBeforeExportHook` — field-level export hook type (same args as ToCSVFunction + format)
`FieldBeforeImportHook` — field-level import hook type (same args as FromCSVFunction + format)
`ToCSVFunction` / `FromCSVFunction` — now deprecated aliases

#### JSON format support (new)

- Field-level hooks now fire for JSON exports/imports, not just CSV
- New applyFieldExportHooks / applyFieldImportHooks utilities traverse nested JSON documents and apply field hooks at each position
- Preview handlers also apply field hooks for both CSV and JSON

## Bug fixes

- [x] Fixed parentPath key computation in getExportFieldFunctions / getImportFieldFunctions — named tabs inside groups now produce correct underscore-separated keys (pre-existing bug)
- [x] Fixed slice(-0) bug in import batchProcessor.ts — ImportAfterHook was receiving all accumulated errors instead of per-batch errors when a batch had zero failures
- [x] Removed unused fs import from hooks.int.spec.ts

## Renamed internals

- toCSVFunctions → exportFieldHooks throughout all source files
- fromCSVFunctions → importFieldHooks throughout all source files
- Error messages updated from "toCSVFunction" to "field export hook"

## Checklist
- [x] Documentation updated with new API, migration guide, execution order
- [x]  Test collection PostsWithFieldHooks with field-level hooks
- [x] 12 new integration tests (CSV export, JSON export, format parameter, deeply nested fields, CSV import, JSON import, backward compatibility with toCSV, backward compatibility with fromCSV, execution order, reusable field config, priority, default behaviour)

