### PR TITLE
feat(next): add head prop to RootLayout

### DIFF
--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -35,6 +35,22 @@ export const metadata = {
 type RootLayoutProps = {
   readonly children: React.ReactNode
   readonly config: Promise<SanitizedConfig>
+  /**
+   * Custom content to render inside the admin panel's `<head>` element.
+   *
+   * Use this to inject scripts, meta tags, or links — for example, analytics
+   * snippets via `next/script`, custom favicons, or preconnect hints.
+   *
+   * @example
+   * ```tsx
+   * import Script from 'next/script'
+   *
+   * <RootLayout
+   *   head={<Script src="https://example.com/analytics.js" strategy="afterInteractive" />}
+   *   {...rest}
+   * />
+   * ```
+   */
   readonly head?: React.ReactNode
   readonly htmlProps?: React.HtmlHTMLAttributes<HTMLHtmlElement>
   readonly importMap: ImportMap

--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -35,6 +35,7 @@ export const metadata = {
 type RootLayoutProps = {
   readonly children: React.ReactNode
   readonly config: Promise<SanitizedConfig>
+  readonly head?: React.ReactNode
   readonly htmlProps?: React.HtmlHTMLAttributes<HTMLHtmlElement>
   readonly importMap: ImportMap
   readonly serverFunction: ServerFunctionClient
@@ -43,6 +44,7 @@ type RootLayoutProps = {
 export const RootLayout = ({
   children,
   config: configPromise,
+  head,
   htmlProps,
   importMap,
   serverFunction,
@@ -52,6 +54,7 @@ export const RootLayout = ({
   const content = (
     <RootLayoutContent
       config={configPromise}
+      head={head}
       htmlProps={htmlProps}
       importMap={importMap}
       serverFunction={serverFunction}
@@ -70,6 +73,7 @@ export const RootLayout = ({
 const RootLayoutContent = async ({
   children,
   config: configPromise,
+  head: headFromProps,
   htmlProps = {},
   importMap,
   serverFunction,
@@ -143,6 +147,7 @@ const RootLayoutContent = async ({
     >
       <head>
         <style>{`@layer payload-default, payload;`}</style>
+        {headFromProps}
       </head>
       <body>
         <RootProvider


### PR DESCRIPTION
Adds optional `head` prop to RootLayout, letting consumers inject scripts, meta tags, or links (e.g. next/script analytics) into the admin panel's <head> from their `app/(payload)/layout.tsx`.

```tsx
import { RootLayout } from '@payloadcms/next/layouts'
import Script from 'next/script'

export default function Layout({ children }) {
  return (
    <RootLayout
      config={config}
      head={<Script src="https://example.com/analytics.js" strategy="afterInteractive" />}
      importMap={importMap}
      serverFunction={serverFunction}
    >
      {children}
    </RootLayout>
  )
}
```