### PR TITLE
feat(ui): improve admin upload error for Vercel 4.5 MB function body limit

### DIFF
--- a/packages/ui/src/forms/Form/errorMessages.ts
+++ b/packages/ui/src/forms/Form/errorMessages.ts
@@ -1,4 +1,44 @@
 'use client'
 export const errorMessages = {
-  413: 'Your request was too large to submit successfully.',
+  413: "Upload failed: the request is too large for this deployment. Hosted / serverless providers (e.g. Vercel Functions, ~4.5 MB) often cap the request body lower than Payload's configured upload.limits.fileSize. For cloud-storage adapters like @payloadcms/storage-vercel-blob, enable clientUploads to bypass this limit, or upload a smaller file.",
+}
+
+const BYTES_PER_MB = 1024 * 1024
+const VERCEL_FUNCTION_LIMIT_MB = 4.5
+
+/**
+ * Format a 413-specific error toast message that includes the actual upload
+ * size when one is present in the FormData. Falls back to the static 413
+ * message above when no file is found in the request body.
+ *
+ * Hosted / serverless providers commonly cap the function request body lower
+ * than Payload's configured `upload.limits.fileSize` — Vercel Functions
+ * documents a ~4.5 MB body limit. Surfacing the actual file size and the
+ * recommended fix (`clientUploads: true` on the storage adapter) in the
+ * upload error toast saves contributors a trip to the network tab.
+ *
+ * Source: https://vercel.com/docs/functions/configuring-functions/runtime#request-body-size-limit
+ */
+export const buildPayloadTooLargeMessage = ({
+  body,
+}: {
+  body?: BodyInit | null
+}): string => {
+  if (!body || !(body instanceof FormData)) {
+    return errorMessages[413]
+  }
+
+  let largestFileBytes = 0
+  body.forEach((value) => {
+    if (value instanceof Blob && value.size > largestFileBytes) {
+      largestFileBytes = value.size
+    }
+  })
+
+  if (largestFileBytes <= 0) {
+    return errorMessages[413]
+  }
+
+  const fileMB = (largestFileBytes / BYTES_PER_MB).toFixed(1)
+  return `Upload failed: this file is ${fileMB} MB, but this deployment can only accept about ${VERCEL_FUNCTION_LIMIT_MB} MB through the server upload route. Hosted / serverless providers (e.g. Vercel Functions) cap the request body lower than Payload's configured upload.limits.fileSize. For cloud-storage adapters like @payloadcms/storage-vercel-blob, enable clientUploads to bypass this limit, or upload a smaller file.`
 }

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -51,7 +51,7 @@ import {
   SubmittedContext,
   useDocumentForm,
 } from './context.js'
-import { errorMessages } from './errorMessages.js'
+import { buildPayloadTooLargeMessage, errorMessages } from './errorMessages.js'
 import { fieldReducer } from './fieldReducer.js'
 import { initContextState } from './initContextState.js'
 
@@ -517,7 +517,10 @@ export const Form: React.FC<FormProps> = (props) => {
             return
           }
 
-          const message = errorMessages?.[res.status] || res?.statusText || t('error:unknown')
+          const message =
+            res.status === 413
+              ? buildPayloadTooLargeMessage({ body: formData })
+              : errorMessages?.[res.status] || res?.statusText || t('error:unknown')
 
           errorToast(message)
         }


### PR DESCRIPTION
## Summary

Closes #16484. When a Payload admin upload hits HTTP **413**, the toast now reports the actual file size and points contributors at the recommended fix (\`clientUploads: true\` on cloud-storage adapters) instead of the generic \"request was too large to submit successfully\".

## Before / After

**Before** (static \`errorMessages[413]\`):

> Your request was too large to submit successfully.

**After** (when a file is present in the FormData — most uploads):

> Upload failed: this file is 5.1 MB, but this deployment can only accept about 4.5 MB through the server upload route. Hosted / serverless providers (e.g. Vercel Functions) cap the request body lower than Payload's configured upload.limits.fileSize. For cloud-storage adapters like @payloadcms/storage-vercel-blob, enable clientUploads to bypass this limit, or upload a smaller file.

The 5.1 MB number is computed from the actual file the user just tried to submit.

## Files

- \`packages/ui/src/forms/Form/errorMessages.ts\` — adds \`buildPayloadTooLargeMessage\` helper + tightens the static fallback string
- \`packages/ui/src/forms/Form/index.tsx\` — branches on \`res.status === 413\` and calls the helper

## How it works

\`\`\`ts
const message =
  res.status === 413
    ? buildPayloadTooLargeMessage({ body: formData })
    : errorMessages?.[res.status] || res?.statusText || t('error:unknown')
\`\`\`

The helper scans the submitted \`FormData\` for the largest \`Blob\`/\`File\` and formats a context-rich message; if the body is not FormData (e.g. a JSON request that happens to 413), it falls back to the static map entry — which now also mentions \`clientUploads\` and the ~4.5 MB Vercel limit so non-FormData 413s still get actionable copy.

## Test plan

- [x] No new dependencies; the helper is pure and uses standard \`FormData\` / \`Blob\` APIs
- [x] Non-413 errors take exactly the same path as before — diff is additive at the 413 branch only
- [ ] Reviewer step: deploy a sandbox to Vercel with \`@payloadcms/storage-vercel-blob\` and \`clientUploads: false\`, attempt to upload a 5+ MB file, confirm the new toast renders with the actual size
- [ ] Reviewer step: upload a 1 MB file (no 413) and confirm normal success path is unchanged

## Notes for review

- Kept the helper next to \`errorMessages.ts\` (rather than a new file) because it's a tiny presentation helper coupled to the same status-code map.
- Source for the 4.5 MB number: [Vercel Functions runtime docs — Request body size limit](https://vercel.com/docs/functions/configuring-functions/runtime#request-body-size-limit).
- i18n: matches the existing pattern in this file (English-only, no translation keys). Happy to wire into \`@payloadcms/translations\` if you'd prefer — wasn't sure if that's overkill for an error string this specific.
- Related prior context: discussion #7569 and issue #8231.