### PR TITLE
fix(ui): preserve URL where filter on bulk publish/unpublish/edit

### DIFF
--- a/packages/ui/src/views/List/ListHeader/index.tsx
+++ b/packages/ui/src/views/List/ListHeader/index.tsx
@@ -71,7 +71,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
   const { config, getEntityConfig } = useConfig()
   const { drawerSlug, isInDrawer, selectedOption } = useListDrawerContext()
   const isTrashRoute = viewType === 'trash'
-  const { isGroupingBy } = useListQuery()
+  const { isGroupingBy, query } = useListQuery()
 
   if (isInDrawer) {
     return (
@@ -115,6 +115,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
             label={getTranslation(collectionConfig?.labels?.plural, i18n)}
             showSelectAllAcrossPages={!isGroupingBy}
             viewType={viewType}
+            where={query?.where}
           />
         ),
         <DefaultListViewTabs

--- a/packages/ui/src/views/List/ListHeader/index.tsx
+++ b/packages/ui/src/views/List/ListHeader/index.tsx
@@ -60,7 +60,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
   const { config, getEntityConfig } = useConfig()
   const { drawerSlug, isInDrawer, selectedOption } = useListDrawerContext()
   const isTrashRoute = viewType === 'trash'
-  const { isGroupingBy } = useListQuery()
+  const { isGroupingBy, query } = useListQuery()
 
   if (isInDrawer) {
     return (
@@ -104,6 +104,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
             label={getTranslation(collectionConfig?.labels?.plural, i18n)}
             showSelectAllAcrossPages={!isGroupingBy}
             viewType={viewType}
+            where={query?.where}
           />
         ),
         <DefaultListViewTabs

--- a/packages/ui/src/views/List/index.client.tsx
+++ b/packages/ui/src/views/List/index.client.tsx
@@ -338,6 +338,7 @@ export function DefaultListView(props: ListViewClientProps) {
                         disableBulkEdit={disableBulkEdit}
                         label={collectionLabel}
                         showSelectAllAcrossPages={!isGroupingBy}
+                        where={query?.where}
                       />
                       <div className={`${baseClass}__list-selection-actions`}>
                         {enableRowSelections && typeof onBulkSelect === 'function'

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -81,7 +81,7 @@ export function DefaultListView(props: ListViewClientProps) {
   } = useConfig()
   const router = useRouter()
 
-  const { data, isGroupingBy } = useListQuery()
+  const { data, isGroupingBy, query } = useListQuery()
 
   const { openModal } = useModal()
   const { drawerSlug: bulkUploadDrawerSlug, setCollectionSlug, setOnSuccess } = useBulkUpload()
@@ -322,6 +322,7 @@ export function DefaultListView(props: ListViewClientProps) {
                         disableBulkEdit={disableBulkEdit}
                         label={collectionLabel}
                         showSelectAllAcrossPages={!isGroupingBy}
+                        where={query?.where}
                       />
                       <div className={`${baseClass}__list-selection-actions`}>
                         {enableRowSelections && typeof onBulkSelect === 'function'

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -415,6 +415,162 @@ test.describe('Bulk Edit', () => {
     await expect(page.locator('.row-1 .cell-title')).toContainText(updatedTitle)
   })
 
+  test.describe('preserves URL where filter on bulk actions across pages', () => {
+    // Regression coverage for the URL `where` filter being dropped on
+    // "Select all N across pages" + bulk Publish / Unpublish / Edit.
+    // Existing "filters and across pages" tests use the search bar (?search=),
+    // which propagates via a separate code path. The structured ?where[...]
+    // param was silently dropped between the List view and the bulk drawers.
+    const filteredTitlePrefix = 'ATM'
+    const otherTitlePrefix = 'Other'
+    const seedCount = 6 // exceeds defaultLimit of 5, forces the across-pages button
+
+    async function seedFilteredAndOtherPosts({
+      filteredDraft = false,
+      otherDraft = false,
+    }: { filteredDraft?: boolean; otherDraft?: boolean } = {}) {
+      // `_status` defaults to 'draft' (versions/baseFields.ts), so a `draft: false`
+      // arg alone does NOT publish the doc. Set `_status` explicitly per seed.
+      await deleteAllPosts()
+      for (let i = 1; i <= seedCount; i++) {
+        await createPost(
+          {
+            _status: filteredDraft ? 'draft' : 'published',
+            title: `${filteredTitlePrefix} page ${i}`,
+          },
+          { draft: filteredDraft },
+        )
+        await wait(50)
+      }
+      for (let i = 1; i <= seedCount; i++) {
+        await createPost(
+          {
+            _status: otherDraft ? 'draft' : 'published',
+            title: `${otherTitlePrefix} page ${i}`,
+          },
+          { draft: otherDraft },
+        )
+        await wait(50)
+      }
+    }
+
+    // Force `limit=5` in the URL so the assertion below is independent of
+    // collection/user-prefs defaultLimit (which can shift across UI refactors).
+    const filteredListUrl = () =>
+      `${postsUrl.list}?limit=5&where[and][0][title][like]=${encodeURIComponent(filteredTitlePrefix)}`
+
+    test('should preserve URL where filter on bulk unpublish across pages', async () => {
+      await seedFilteredAndOtherPosts()
+
+      await page.goto(filteredListUrl())
+      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('where')
+      await expect(page.locator('.table table > tbody > tr')).toHaveCount(5)
+
+      await page.locator('input#select-all').check()
+      await page.locator('button#select-all-across-pages').click()
+
+      await page.locator('.list-selection__button[aria-label="Unpublish"]').click()
+      await page.locator('#unpublish-posts #confirm-action').click()
+
+      await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+        `Updated ${seedCount} Posts successfully.`,
+      )
+
+      const stillPublishedOthers = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: otherTitlePrefix } }, { _status: { equals: 'published' } }],
+        },
+      })
+      expect(stillPublishedOthers.totalDocs).toBe(seedCount)
+
+      const draftedFiltered = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: filteredTitlePrefix } }, { _status: { equals: 'draft' } }],
+        },
+      })
+      expect(draftedFiltered.totalDocs).toBe(seedCount)
+    })
+
+    test('should preserve URL where filter on bulk publish across pages', async () => {
+      await seedFilteredAndOtherPosts({ filteredDraft: true, otherDraft: true })
+
+      await page.goto(filteredListUrl())
+      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('where')
+      await expect(page.locator('.table table > tbody > tr')).toHaveCount(5)
+
+      await page.locator('input#select-all').check()
+      await page.locator('button#select-all-across-pages').click()
+
+      await page.locator('.list-selection__button[aria-label="Publish"]').click()
+      await page.locator('#publish-posts #confirm-action').click()
+
+      await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+        `Updated ${seedCount} Posts successfully.`,
+      )
+
+      const stillDraftOthers = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: otherTitlePrefix } }, { _status: { equals: 'draft' } }],
+        },
+      })
+      expect(stillDraftOthers.totalDocs).toBe(seedCount)
+
+      const publishedFiltered = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: filteredTitlePrefix } }, { _status: { equals: 'published' } }],
+        },
+      })
+      expect(publishedFiltered.totalDocs).toBe(seedCount)
+    })
+
+    test('should preserve URL where filter on bulk edit across pages', async () => {
+      await seedFilteredAndOtherPosts()
+      const editedDescription = 'Edited via filtered bulk edit'
+
+      await page.goto(filteredListUrl())
+      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('where')
+      await expect(page.locator('.table table > tbody > tr')).toHaveCount(5)
+
+      await page.locator('input#select-all').check()
+      await page.locator('button#select-all-across-pages').click()
+
+      const { field, modal } = await selectFieldToEdit(page, {
+        fieldID: 'description',
+        fieldLabel: 'Description',
+      })
+      await field.fill(editedDescription)
+      await modal.locator('.form-submit button[type="submit"].edit-many__publish').click()
+
+      await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+        `Updated ${seedCount} Posts successfully.`,
+      )
+
+      const editedFiltered = await payload.find({
+        collection: postsSlug,
+        where: { description: { equals: editedDescription } },
+      })
+      expect(editedFiltered.totalDocs).toBe(seedCount)
+      expect(editedFiltered.docs.every((doc) => doc.title?.startsWith(filteredTitlePrefix))).toBe(
+        true,
+      )
+
+      const untouchedOthers = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [
+            { title: { like: otherTitlePrefix } },
+            { description: { not_equals: editedDescription } },
+          ],
+        },
+      })
+      expect(untouchedOthers.totalDocs).toBe(seedCount)
+    })
+  })
+
   test('should not override un-edited values if it has a defaultValue', async () => {
     await deleteAllPosts()
 

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -417,6 +417,162 @@ test.describe('Bulk Edit', () => {
     await expect(page.locator('.row-1 .cell-title')).toContainText(updatedTitle)
   })
 
+  test.describe('preserves URL where filter on bulk actions across pages', () => {
+    // Regression coverage for the URL `where` filter being dropped on
+    // "Select all N across pages" + bulk Publish / Unpublish / Edit.
+    // Existing "filters and across pages" tests use the search bar (?search=),
+    // which propagates via a separate code path. The structured ?where[...]
+    // param was silently dropped between the List view and the bulk drawers.
+    const filteredTitlePrefix = 'ATM'
+    const otherTitlePrefix = 'Other'
+    const seedCount = 6 // exceeds defaultLimit of 5, forces the across-pages button
+
+    async function seedFilteredAndOtherPosts({
+      filteredDraft = false,
+      otherDraft = false,
+    }: { filteredDraft?: boolean; otherDraft?: boolean } = {}) {
+      // `_status` defaults to 'draft' (versions/baseFields.ts), so a `draft: false`
+      // arg alone does NOT publish the doc. Set `_status` explicitly per seed.
+      await deleteAllPosts()
+      for (let i = 1; i <= seedCount; i++) {
+        await createPost(
+          {
+            _status: filteredDraft ? 'draft' : 'published',
+            title: `${filteredTitlePrefix} page ${i}`,
+          },
+          { draft: filteredDraft },
+        )
+        await wait(50)
+      }
+      for (let i = 1; i <= seedCount; i++) {
+        await createPost(
+          {
+            _status: otherDraft ? 'draft' : 'published',
+            title: `${otherTitlePrefix} page ${i}`,
+          },
+          { draft: otherDraft },
+        )
+        await wait(50)
+      }
+    }
+
+    // Force `limit=5` in the URL so the assertion below is independent of
+    // collection/user-prefs defaultLimit (which can shift across UI refactors).
+    const filteredListUrl = () =>
+      `${postsUrl.list}?limit=5&where[and][0][title][like]=${encodeURIComponent(filteredTitlePrefix)}`
+
+    test('should preserve URL where filter on bulk unpublish across pages', async () => {
+      await seedFilteredAndOtherPosts()
+
+      await page.goto(filteredListUrl())
+      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('where')
+      await expect(page.locator('.table table > tbody > tr')).toHaveCount(5)
+
+      await page.locator('input#select-all').check()
+      await page.locator('button#select-all-across-pages').click()
+
+      await page.locator('.list-selection__button[aria-label="Unpublish"]').click()
+      await page.locator('#unpublish-posts #confirm-action').click()
+
+      await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+        `Updated ${seedCount} Posts successfully.`,
+      )
+
+      const stillPublishedOthers = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: otherTitlePrefix } }, { _status: { equals: 'published' } }],
+        },
+      })
+      expect(stillPublishedOthers.totalDocs).toBe(seedCount)
+
+      const draftedFiltered = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: filteredTitlePrefix } }, { _status: { equals: 'draft' } }],
+        },
+      })
+      expect(draftedFiltered.totalDocs).toBe(seedCount)
+    })
+
+    test('should preserve URL where filter on bulk publish across pages', async () => {
+      await seedFilteredAndOtherPosts({ filteredDraft: true, otherDraft: true })
+
+      await page.goto(filteredListUrl())
+      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('where')
+      await expect(page.locator('.table table > tbody > tr')).toHaveCount(5)
+
+      await page.locator('input#select-all').check()
+      await page.locator('button#select-all-across-pages').click()
+
+      await page.locator('.list-selection__button[aria-label="Publish"]').click()
+      await page.locator('#publish-posts #confirm-action').click()
+
+      await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+        `Updated ${seedCount} Posts successfully.`,
+      )
+
+      const stillDraftOthers = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: otherTitlePrefix } }, { _status: { equals: 'draft' } }],
+        },
+      })
+      expect(stillDraftOthers.totalDocs).toBe(seedCount)
+
+      const publishedFiltered = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [{ title: { like: filteredTitlePrefix } }, { _status: { equals: 'published' } }],
+        },
+      })
+      expect(publishedFiltered.totalDocs).toBe(seedCount)
+    })
+
+    test('should preserve URL where filter on bulk edit across pages', async () => {
+      await seedFilteredAndOtherPosts()
+      const editedDescription = 'Edited via filtered bulk edit'
+
+      await page.goto(filteredListUrl())
+      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('where')
+      await expect(page.locator('.table table > tbody > tr')).toHaveCount(5)
+
+      await page.locator('input#select-all').check()
+      await page.locator('button#select-all-across-pages').click()
+
+      const { field, modal } = await selectFieldToEdit(page, {
+        fieldID: 'description',
+        fieldLabel: 'Description',
+      })
+      await field.fill(editedDescription)
+      await modal.locator('.form-submit button[type="submit"].edit-many__publish').click()
+
+      await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+        `Updated ${seedCount} Posts successfully.`,
+      )
+
+      const editedFiltered = await payload.find({
+        collection: postsSlug,
+        where: { description: { equals: editedDescription } },
+      })
+      expect(editedFiltered.totalDocs).toBe(seedCount)
+      expect(editedFiltered.docs.every((doc) => doc.title?.startsWith(filteredTitlePrefix))).toBe(
+        true,
+      )
+
+      const untouchedOthers = await payload.find({
+        collection: postsSlug,
+        where: {
+          and: [
+            { title: { like: otherTitlePrefix } },
+            { description: { not_equals: editedDescription } },
+          ],
+        },
+      })
+      expect(untouchedOthers.totalDocs).toBe(seedCount)
+    })
+  })
+
   test('should not override un-edited values if it has a defaultValue', async () => {
     await deleteAllPosts()
 


### PR DESCRIPTION
### What?
`@payloadcms/ui` List view drops the URL `where` filter when an editor clicks "Select all N across pages" and then triggers a bulk action (Publish / Unpublish / Edit). The outbound PATCH request hits every document matching the action's base constraint (e.g. `_status != draft` for Unpublish), ignoring the filter the user had applied.

Concrete impact: filter to a subset of a collection (e.g.`?where[pageType][equals]=atm`, 598 docs), select all across pages, bulk Unpublish → request unpublishes all published docs in the collection (e.g. 1772), not just the filtered 598.

Manual row ticks were unaffected because that path sends `id IN [ids]`. Search-only (`?search=`) was also unaffected because search propagates through a separate code path. Only the structured `?where[...]` URL param was being dropped.

### Why?
Both List view render sites for `<ListSelection>` — `DefaultListView` (smallBreak path, `packages/ui/src/views/List/index.client.tsx`) and `CollectionListHeader` (desktop path, `packages/ui/src/views/List/ListHeader/index.tsx`) — rendered it without forwarding the URL `where` from `useListQuery()`. Everything downstream was already wired correctly:

- `views/List/ListSelection/index.tsx` accepts `where` and forwards it to `EditMany_v4`, `PublishMany_v4`, `UnpublishMany_v4`.
- Each drawer merges the prop into its base constraint via `combineWhereConstraints`.
- `DeleteMany` independently reads URL `where` via `parseSearchParams(searchParams)?.where` and was unaffected.
- `GroupByHeader` already supplies its own per-group `where`, so it is not part of this fix.

### How?
Forward the URL `where` into `<ListSelection>` at both parent render sites:

- `DefaultListView` (`packages/ui/src/views/List/index.client.tsx`): `query` is already in scope from `useListQuery()`, so this adds `where={query?.where}` to the `<ListSelection>` in the smallBreak `PageControls` slot.
- `CollectionListHeader` (`packages/ui/src/views/List/ListHeader/index.tsx`): destructure `query` from `useListQuery()` and pass `where={query?.where}`.

Without the `ListHeader` wiring, `PublishMany` / `EditMany` masked the gap via their own `parseSearchParams(searchParams)?.where` fallback; `UnpublishMany` has no such fallback, so the bug was only visible on the unpublish path.

Adds three Playwright E2E tests in `test/bulk-edit/e2e.spec.ts` (`Bulk Edit > preserves URL where filter on bulk actions across pages`) that:

1. Seed 6 filtered + 6 unfiltered docs (exceeds default page limit of 5, forces the cross-page selection button). Seeds set `_status: 'published'` explicitly — `payload.create` does NOT default to published for versioned collections (the `_status` field's `defaultValue` is `'draft'` in `versions/baseFields.ts`), so a `draft: false` arg alone leaves the doc as draft.
2. Navigate with `?where[and][0][title][like]=...`.
3. Select-all + select-all-across-pages.
4. Trigger bulk Unpublish / Publish / Edit.
5. Assert via the Payload API that only filtered docs changed and the unfiltered set is untouched.

The existing "filters and across pages" coverage in this file uses the search
bar (`?search=`), which propagates separately, so it never exercised this code
path.

Refs #16325 (same root cause, framed there as a multi-tenant plugin bug).

Fixes #17670
