### PR TITLE
fix(plugin-nested-docs): add cycle detection to getParents

### DIFF
--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -8,10 +8,23 @@ export const getParents = async (
   collection: CollectionConfig,
   doc: Record<string, unknown>,
   docs: Array<Record<string, unknown>> = [],
+  visited: Set<string> = new Set(),
 ): Promise<Document[]> => {
   const parentSlug = pluginConfig?.parentFieldSlug || 'parent'
   const parent = doc[parentSlug]
   let retrievedParent: null | Record<string, unknown> = null
+
+  // Track visited document IDs to detect circular parent chains.
+  // Without this, a document whose parent references itself (or
+  // forms a cycle A→B→A) causes infinite recursion and a stack
+  // overflow on every save.
+  if (doc?.id != null) {
+    const idKey = String(doc.id)
+    if (visited.has(idKey)) {
+      return docs
+    }
+    visited.add(idKey)
+  }
 
   if (parent) {
     // If not auto-populated, and we have an ID
@@ -35,7 +48,7 @@ export const getParents = async (
         return getParents(req, pluginConfig, collection, retrievedParent, [
           retrievedParent,
           ...docs,
-        ])
+        ], visited)
       }
 
       return [retrievedParent, ...docs]


### PR DESCRIPTION
## Summary

Fixes #16517

`getParents` in `@payloadcms/plugin-nested-docs` walks the parent chain via recursion but has no cycle detection. A document whose `parentFieldSlug` chain forms a cycle (e.g., doc X has X as parent, or A→B→A) causes infinite recursion until Node's stack limit, crashing the request.

## Root Cause

In `packages/plugin-nested-docs/src/utilities/getParents.ts` (lines 47-51), the recursive call passes `retrievedParent` back into `getParents` with no mechanism to detect when a document has already been visited. The function signature has no visited-tracking parameter.

This is called from `hooks/populateBreadcrumbsBeforeChange` on every save — if a cycle exists, every save recurses forever until stack overflow.

## Fix

Added a `visited: Set<string>` parameter (defaults to `new Set()`) that tracks document IDs across the recursive chain:

- Before processing a document, its `id` is checked against the `visited` set
- If already seen, the function returns the collected docs immediately (breaking the cycle)
- Otherwise, the ID is added to `visited` and recursion continues normally

The `visited` set is threaded through the recursive call so it persists across the entire chain traversal.

## Changes

- `packages/plugin-nested-docs/src/utilities/getParents.ts`: add `visited` parameter with cycle detection, thread through recursive call (`+14 -1` lines)

## Testing

- \*\*Self-referencing parent (doc.parent === doc.id)\*\*: cycle detected after one step, returns collected docs without stack overflow ✅
- \*\*Two-document cycle (A→B→A)\*\*: cycle detected, recursion terminates cleanly ✅
- \*\*Normal parent chain (A→B→C, no cycles)\*\*: behavior unchanged, all parents returned ✅
- \*\*Document with no parent\*\*: returns empty array as before ✅