### PR TITLE
fix(plugin-mcp): accept both Bearer and API-Key authorization patterns

### DIFF
--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -16,9 +16,13 @@ export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
     req.payloadAPI = 'MCP' as const
 
     const getDefaultMcpAccessSettings = async (overrideApiKey?: null | string) => {
+      const authHeader = req.headers.get('Authorization')
+      const isBearer = authHeader?.startsWith('Bearer ')
+      const isAPIKey = authHeader?.startsWith('API-Key ')
+
       const apiKey =
-        (overrideApiKey ?? req.headers.get('Authorization')?.startsWith('Bearer '))
-          ? req.headers.get('Authorization')?.replace('Bearer ', '').trim()
+        (overrideApiKey ?? (isBearer || isAPIKey))
+          ? authHeader?.replace(isBearer ? 'Bearer ' : 'API-Key ', '').trim()
           : null
 
       if (apiKey === null) {


### PR DESCRIPTION
## Description

The MCP plugin endpoint `/api/mcp` currently only accepts `Authorization: Bearer <KEY>` header. This is inconsistent with Payload's standard API-Key authorization pattern which uses `<collection-slug> API-Key <KEY>`.

This PR updates the authorization check in `packages/plugin-mcp/src/endpoints/mcp.ts` to accept both patterns:

- `Authorization: Bearer <KEY>` (existing behavior)
- `Authorization: API-Key <KEY>` (new — matches Payload's standard pattern)

## Related Issue

Fixes #16572

## Changes

- Modified `getDefaultMcpAccessSettings` to check for both `Bearer` and `API-Key` prefixes in the Authorization header
- The API key extraction now handles both patterns correctly