### PR TITLE
fix: prevent self-collision in getSafeFileName on update

### DIFF
--- a/packages/payload/src/uploads/docWithFilenameExists.ts
+++ b/packages/payload/src/uploads/docWithFilenameExists.ts
@@ -2,6 +2,12 @@ import type { PayloadRequest, Where } from '../types/index.js'
 
 type Args = {
   collectionSlug: string
+  /**
+   * When provided, this document ID is excluded from the filename lookup.
+   * Use this during update operations so a document does not collide with its
+   * own existing filename and receive a spurious `-1` suffix.
+   */
+  docId?: number | string
   filename: string
   path: string
   prefix?: string
@@ -10,6 +16,7 @@ type Args = {
 
 export const docWithFilenameExists = async ({
   collectionSlug,
+  docId,
   filename,
   prefix,
   req,
@@ -22,6 +29,10 @@ export const docWithFilenameExists = async ({
 
   if (prefix) {
     where.prefix = { equals: prefix }
+  }
+
+  if (docId !== undefined) {
+    where.id = { not_equals: docId }
   }
 
   const doc = await req.payload.db.findOne({

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -264,9 +264,14 @@ export const generateFileData = async <T>({
     if (!overwriteExistingFiles) {
       // Extract prefix if present (added by plugin-cloud-storage)
       const prefix = (data as Record<string, unknown>)?.prefix as string | undefined
+      // On update, exclude the current document from the collision check so its
+      // own filename is not treated as taken (prevents spurious `-1` suffix).
+      const docId =
+        operation === 'update' ? (originalDoc as Record<string, unknown>)?.id as number | string | undefined : undefined
       fsSafeName = await getSafeFileName({
         collectionSlug: collectionConfig.slug,
         desiredFilename: fsSafeName,
+        docId,
         prefix,
         req,
         staticPath: staticPath!,

--- a/packages/payload/src/uploads/getSafeFilename.spec.ts
+++ b/packages/payload/src/uploads/getSafeFilename.spec.ts
@@ -346,4 +346,63 @@ describe('getSafeFileName', () => {
 
     expect(result).toBe('video-1.mp4')
   })
+
+  it('should pass docId to docWithFilenameExists when provided', async () => {
+    mockDocWithFilenameExists.mockResolvedValue(false)
+    mockFileExists.mockResolvedValue(false)
+
+    await getSafeFileName({
+      collectionSlug: 'media',
+      desiredFilename: 'photo.jpg',
+      docId: 42,
+      req: mockReq,
+      staticPath: '/uploads',
+    })
+
+    expect(mockDocWithFilenameExists).toHaveBeenCalledWith({
+      collectionSlug: 'media',
+      docId: 42,
+      filename: 'photo.jpg',
+      path: '/uploads',
+      prefix: undefined,
+      req: mockReq,
+    })
+  })
+
+  it('should return original filename on update when only the document itself has that filename', async () => {
+    // Simulates a PATCH where the doc being updated already owns the filename.
+    // Without docId exclusion, docWithFilenameExists would return true and
+    // getSafeFileName would increment to 'photo-1.jpg'.
+    // With docId, the self-collision is excluded and the original name is returned.
+    mockDocWithFilenameExists.mockResolvedValue(false)
+    mockFileExists.mockResolvedValue(false)
+
+    const result = await getSafeFileName({
+      collectionSlug: 'media',
+      desiredFilename: 'photo.jpg',
+      docId: 'abc123',
+      req: mockReq,
+      staticPath: '/uploads',
+    })
+
+    expect(result).toBe('photo.jpg')
+    expect(mockDocWithFilenameExists).toHaveBeenCalledTimes(1)
+  })
+
+  it('should still increment when a different document has the same filename', async () => {
+    // docId is set (update context) but a *different* doc owns the filename —
+    // docWithFilenameExists correctly returns true and the name is incremented.
+    mockDocWithFilenameExists.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    mockFileExists.mockResolvedValue(false)
+
+    const result = await getSafeFileName({
+      collectionSlug: 'media',
+      desiredFilename: 'photo.jpg',
+      docId: 'abc123',
+      req: mockReq,
+      staticPath: '/uploads',
+    })
+
+    expect(result).toBe('photo-1.jpg')
+  })
 })

--- a/packages/payload/src/uploads/getSafeFilename.ts
+++ b/packages/payload/src/uploads/getSafeFilename.ts
@@ -32,6 +32,12 @@ export const incrementName = (name: string): string => {
 type Args = {
   collectionSlug: string
   desiredFilename: string
+  /**
+   * When provided, this document ID is excluded from the filename conflict
+   * check. Pass the ID of the document being updated so it does not collide
+   * with its own existing filename and receive a spurious `-1` suffix.
+   */
+  docId?: number | string
   prefix?: string
   req: PayloadRequest
   /**
@@ -49,6 +55,7 @@ type Args = {
  *
  * @param args.collectionSlug - The slug of the upload collection
  * @param args.desiredFilename - The original filename to make safe
+ * @param args.docId - ID of the document being updated; excluded from conflict checks
  * @param args.prefix - Optional prefix path for cloud storage adapters
  * @param args.req - The Payload request object
  * @param args.staticPath - The filesystem path where uploads are stored
@@ -66,6 +73,7 @@ type Args = {
 export async function getSafeFileName({
   collectionSlug,
   desiredFilename,
+  docId,
   prefix,
   req,
   staticPath,
@@ -75,6 +83,7 @@ export async function getSafeFileName({
   while (
     (await docWithFilenameExists({
       collectionSlug,
+      docId,
       filename: modifiedFilename,
       path: staticPath ?? '',
       prefix,


### PR DESCRIPTION
## Problem

Ran into an issue when I was running some image migrations (pulling things out of Cloudinary into Payload).

When a media document is **updated** with a new file upload (PATCH with multipart body), `getSafeFileName` calls `docWithFilenameExists` without excluding the document being updated. The query finds the document's own existing filename and treats it as a collision — incrementing the filename with a `-1` suffix.

**Example:** updating a media doc that already has `foo.jpg` causes Payload to write the new file as `foo-1.jpg`, silently breaking any references to the original URL.

I assume this isn't a feature? It caused me a lot of issues with cached names, integrations between Payload and Medusa needing to refresh thumbnails - basically anything that had the old name and all I did was patch an update to the image (not expecting a name change).

## Root cause

`docWithFilenameExists` queries:
```ts
where: { filename: { equals: filename } }
```
On a `create` this is correct — any existing doc with that name is a real conflict. On an **update** the document being replaced already owns the filename, so the match is a false positive.

## Fix

Add an optional `docId` parameter to both `getSafeFileName` and `docWithFilenameExists`. When present, `docId` is appended as `id: { not_equals: docId }` so the current document is excluded from the collision check.

`generateFileData` passes `originalDoc.id` as `docId` when `operation === 'update'`, which covers the PATCH-with-file path that triggers the bug.

## Changes

- `docWithFilenameExists.ts` — accept and apply optional `docId` exclusion
- `getSafeFilename.ts` — accept and thread `docId` through; update JSDoc
- `generateFileData.ts` — pass `docId` on update operations
- `getSafeFilename.spec.ts` — four new tests covering the self-collision fix

## Reproduction

```ts
// 1. Create a media document — filename stored as foo.jpg
// 2. PATCH the same document with a new file named foo.jpg
// Expected: filename remains foo.jpg
// Actual (before fix): filename becomes foo-1.jpg
```

This is also reproducible by running a script that re-uploads each media document to trigger Sharp image size regeneration — every doc ends up with `-1` appended after the first run.