### PR TITLE
fix(queues): add jitter to exponential backoff retry delay

### DIFF
--- a/packages/payload/src/queues/errors/calculateBackoffWaitUntil.ts
+++ b/packages/payload/src/queues/errors/calculateBackoffWaitUntil.ts
@@ -21,7 +21,11 @@ export function calculateBackoffWaitUntil({
       } else if (retriesConfig.backoff.type === 'exponential') {
         // 2 ^ (attempts - 1) * delay (current attempt is not included in totalTried, thus no need for -1)
         const delay = retriesConfig.backoff.delay ? retriesConfig.backoff.delay : 0
-        waitUntil = new Date(now.getTime() + Math.pow(2, totalTried) * delay)
+        const baseDelay = Math.pow(2, totalTried) * delay
+        // Add decorrelated jitter (±50%) to prevent thundering-herd retry storms
+        // when many concurrent jobs fail at the same time.
+        const jitter = baseDelay * (0.5 + Math.random() * 0.5)
+        waitUntil = new Date(now.getTime() + jitter)
       }
     }
   }


### PR DESCRIPTION
## What

Adds decorrelated jitter (±50%) to the exponential backoff delay in `calculateBackoffWaitUntil`.

**Before:**
```ts
waitUntil = new Date(now.getTime() + Math.pow(2, totalTried) * delay)
```

**After:**
```ts
const baseDelay = Math.pow(2, totalTried) * delay
// Add decorrelated jitter (±50%) to prevent thundering-herd retry storms
// when many concurrent jobs fail at the same time.
const jitter = baseDelay * (0.5 + Math.random() * 0.5)
waitUntil = new Date(now.getTime() + jitter)
```

## Why

When many concurrent jobs fail at the same time (e.g. a downstream service goes down), deterministic exponential backoff causes them all to retry at exactly the same intervals — creating a "thundering herd" that repeatedly hammers the backend in synchronized waves.

Adding ±50% jitter to the base delay breaks the synchronization and spreads retries across time, which is standard practice recommended by AWS, Google Cloud, and most distributed-systems resilience libraries.

- `fixed` backoff type is **not** affected — it continues to use the exact delay as configured.
- The exponential growth curve is preserved; only the variance around it changes.
- No new dependencies. No API changes.

Closes #16318