### PR TITLE
fix(ui): textarea error border now correctly persists on hover

### DIFF
--- a/packages/ui/src/fields/Textarea/index.css
+++ b/packages/ui/src/fields/Textarea/index.css
@@ -38,7 +38,7 @@
       textarea {
         border-color: var(--color-border-danger-strong);
 
-        &:hover {
+        &:hover:not(:focus):not(:disabled) {
           border-color: var(--color-border-danger-strong);
         }
       }


### PR DESCRIPTION
## What

Fixes the textarea field's error border being overridden by the default hover state.

## Why

When a textarea field had a validation error, hovering over it would cause the default hover border style to override the error border, making the error state visually disappear on hover.

## Changes

Updated the error state hover selector to `&:hover:not(:focus):not(:disabled)` to increase specificity and ensure the error border persists on hover.
