### PR TITLE
chore: add input stepper to v4 test suite

### DIFF
--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -109,6 +109,8 @@ export { Gutter } from '../../elements/Gutter/index.js'
 export { Hamburger } from '../../elements/Hamburger/index.js'
 export { HydrateAuthProvider } from '../../elements/HydrateAuthProvider/index.js'
 export { HydrateHierarchyProvider } from '../../elements/Hierarchy/HydrateProvider/index.js'
+export { InputStepper } from '../../elements/InputStepper/index.js'
+export type { InputStepperProps } from '../../elements/InputStepper/index.js'
 
 export { Locked } from '../../elements/Locked/index.js'
 export { ListControls } from '../../elements/ListControls/index.js'

--- a/test/v4/views/Components/index.tsx
+++ b/test/v4/views/Components/index.tsx
@@ -12,6 +12,7 @@ import { CardSection } from './sections/Card.js'
 import { CheckboxSection } from './sections/Checkbox.js'
 import { DrawerSection } from './sections/DrawerSection.js'
 import { IconsSection } from './sections/Icons.js'
+import { InputStepperSection } from './sections/InputStepper.js'
 import { LexicalIconsSection } from './sections/LexicalIcons.js'
 import { LoadingSection } from './sections/LoadingSection.js'
 import { ModalSection } from './sections/ModalSection.js'
@@ -48,7 +49,7 @@ type ComponentId =
   | 'email-field'
   | 'email-username-field'
   | 'icons'
-  | 'input'
+  | 'input-stepper'
   | 'json-field'
   | 'lexical-icons'
   | 'loading-overlay'
@@ -84,7 +85,7 @@ const componentOptions: ComponentOption[] = [
   { category: 'primitives', label: 'Card', value: 'card' },
   { category: 'primitives', label: 'Checkbox', value: 'checkbox' },
   { category: 'primitives', label: 'Icons', value: 'icons' },
-  { category: 'primitives', label: 'Input', value: 'input' },
+  { category: 'primitives', label: 'Input Stepper', value: 'input-stepper' },
   { category: 'primitives', label: 'Lexical Icons', value: 'lexical-icons' },
   { category: 'primitives', label: 'Pill', value: 'pill' },
   { category: 'primitives', label: 'Popup', value: 'popup' },
@@ -220,6 +221,9 @@ export const ComponentsView: React.FC = () => {
         {shouldShow('popup', 'primitives') && <PopupSection selectedComponent="popup" />}
         {shouldShow('card', 'primitives') && <CardSection selectedComponent="card" />}
         {shouldShow('banner', 'primitives') && <BannerSection selectedComponent="banner" />}
+        {shouldShow('input-stepper', 'primitives') && (
+          <InputStepperSection selectedComponent="input-stepper" />
+        )}
 
         {/* Patterns */}
         {(selectedCategory === 'all' || selectedCategory === 'patterns') &&

--- a/test/v4/views/Components/sections/InputStepper.tsx
+++ b/test/v4/views/Components/sections/InputStepper.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { InputStepper } from '@payloadcms/ui'
+import React from 'react'
+
+import { Section, Variant } from '../shared.js'
+
+export const InputStepperSection: React.FC<{ selectedComponent: string }> = ({
+  selectedComponent,
+}) => (
+  <Section id="input-stepper" selectedComponent={selectedComponent} title="Input Stepper">
+    <Variant label="Default">
+      <InputStepper onDecrement={() => {}} onIncrement={() => {}} />
+    </Variant>
+    <Variant label="Disabled">
+      <InputStepper disabled onDecrement={() => {}} onIncrement={() => {}} />
+    </Variant>
+  </Section>
+)


### PR DESCRIPTION
Adds `inputStepper` to the v4 custom component view for ease of review.

Note: currently the hover and pressed state are the same, this is how the v4 design has it. 