### PR TITLE
refactor!: merge FileSizeImproved into FileSize and align ImageSize.admin disabled API

### DIFF
--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -202,18 +202,20 @@ Each image size also supports `admin` options to control whether it appears in t
   width: 400,
   height: 300,
   admin: {
-    disableGroupBy: true, // hide from list view groupBy options
-    disableListColumn: true, // hide from list view columns
-    disableListFilter: true, // hide from list view filters
+    disabled: {
+      groupBy: true,  // hide from list view groupBy options
+      column: true,   // hide from list view columns
+      filter: true,   // hide from list view filters
+    },
   },
 }
 ```
 
-| Option                  | Description                                                                                                                              |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **`disableGroupBy`**    | If set to `true`, this image size will not be available as a selectable groupBy option in the collection list view. Defaults to `false`. |
-| **`disableListColumn`** | If set to `true`, this image size will not be available as a selectable column in the collection list view. Defaults to `false`.         |
-| **`disableListFilter`** | If set to `true`, this image size will not be available as a filter option in the collection list view. Defaults to `false`.             |
+| Option                 | Description                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **`disabled.groupBy`** | If set to `true`, this image size will not be available as a selectable groupBy option in the collection list view. Defaults to `false`. |
+| **`disabled.column`**  | If set to `true`, this image size will not be available as a selectable column in the collection list view. Defaults to `false`.         |
+| **`disabled.filter`**  | If set to `true`, this image size will not be available as a filter option in the collection list view. Defaults to `false`.             |
 
 This is useful for hiding large or rarely used image sizes from the list view UI while still keeping them available in the API.
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -26,7 +26,7 @@ The tool loads your project via [ts-morph](https://ts-morph.com/), using your `t
 ## Transforms
 
 - `migrate-list-view-select-api` — Removes `admin.enableListViewSelectAPI` from Collection Configs. The List View's Select API is the default in v4.
-- `migrate-disabled-fields` — migrates `field.admin.disableListColumn`, `disableListFilter`, `disableGroupBy`, `disableBulkEdit` into the consolidated `field.admin.disabled` object form.
+- `migrate-disabled-fields` — migrates `field.admin.disableListColumn`, `disableListFilter`, `disableGroupBy`, `disableBulkEdit` and their equivalents on `imageSize.admin` into the consolidated `disabled` object form.
 - `globals-components-edit` — Globals: rename `admin.components.elements` to `admin.components.edit` and hoist `Description` to top-level `admin.components.Description` to match Collection conventions.
 - `migrate-force-select` — migrates `forceSelect: { ... }` on Collection/Global configs to a `select` function that augments the caller's `select` when present and returns `undefined` (preserving full-document reads) when not. Shallow values become a spread (`{ ...select, ... }`); nested values use `deepMergeSimple` from `payload/shared` (auto-imported) to preserve the previous deep-merge semantics. Non-literal values, sibling `select` already present, and unsupported member kinds are surfaced as notes for manual review.
 - `migrate-hide-api-url` — migrates `admin.hideAPIURL: true` to `admin.components.views.edit.api.tab.condition: () => false` on collection and global configs.

--- a/packages/codemod/src/transforms/migrate-disabled-fields/imagesize.input.ts
+++ b/packages/codemod/src/transforms/migrate-disabled-fields/imagesize.input.ts
@@ -1,0 +1,30 @@
+export const Media = {
+  slug: 'media',
+  upload: {
+    imageSizes: [
+      {
+        name: 'thumbnail',
+        width: 300,
+        height: 300,
+        admin: {
+          disableListColumn: true,
+          disableListFilter: true,
+          disableGroupBy: true,
+        },
+      },
+      {
+        name: 'hero',
+        width: 1920,
+        height: 1080,
+        admin: {
+          disableListColumn: true,
+        },
+      },
+      {
+        name: 'card',
+        width: 600,
+        height: 400,
+      },
+    ],
+  },
+}

--- a/packages/codemod/src/transforms/migrate-disabled-fields/imagesize.output.ts
+++ b/packages/codemod/src/transforms/migrate-disabled-fields/imagesize.output.ts
@@ -1,0 +1,28 @@
+export const Media = {
+  slug: 'media',
+  upload: {
+    imageSizes: [
+      {
+        name: 'thumbnail',
+        width: 300,
+        height: 300,
+        admin: {
+          disabled: { column: true, filter: true, groupBy: true },
+        },
+      },
+      {
+        name: 'hero',
+        width: 1920,
+        height: 1080,
+        admin: {
+          disabled: { column: true },
+        },
+      },
+      {
+        name: 'card',
+        width: 600,
+        height: 400,
+      },
+    ],
+  },
+}

--- a/packages/codemod/src/transforms/migrate-disabled-fields/index.test.ts
+++ b/packages/codemod/src/transforms/migrate-disabled-fields/index.test.ts
@@ -45,6 +45,23 @@ describe('migrate-disabled-fields', () => {
     expect(result).toBe(output)
   })
 
+  it('migrates imageSize admin disable* props', async () => {
+    const input = await fixture('imagesize.input.ts')
+    const output = await fixture('imagesize.output.ts')
+
+    const result = await runTransform({ source: input, transform: migrateDisabledFields })
+
+    expect(result).toBe(output)
+  })
+
+  it('is idempotent on imageSize output', async () => {
+    const output = await fixture('imagesize.output.ts')
+
+    const result = await runTransform({ source: output, transform: migrateDisabledFields })
+
+    expect(result).toBe(output)
+  })
+
   it('no-ops on code without old props', async () => {
     const input = await fixture('non-matching.input.ts')
     const output = await fixture('non-matching.output.ts')

--- a/packages/codemod/src/transforms/migrate-disabled-fields/index.ts
+++ b/packages/codemod/src/transforms/migrate-disabled-fields/index.ts
@@ -31,13 +31,13 @@ export const migrateDisabledFields: Transform = {
         if (!initializer || !Node.isObjectLiteralExpression(initializer)) {
           return
         }
-        // Only treat this as a field admin object when the parent has a `type` sibling
-        // (fields always have `type`; collection-level admin and imageSize.admin don't).
+        // Match field admin objects (parent has `type`) and imageSize admin objects (parent has `name`).
+        // Collection-level admin objects have neither, and also never carry the old disable* props.
         const parent = node.getParent()
         if (!parent || !Node.isObjectLiteralExpression(parent)) {
           return
         }
-        if (!parent.getProperty('type')) {
+        if (!parent.getProperty('type') && !parent.getProperty('name')) {
           return
         }
 
@@ -123,7 +123,7 @@ export const migrateDisabledFields: Transform = {
     return { filesChanged: [...filesChanged], notes }
   },
   description:
-    'Migrate field.admin.disable* props (disableListColumn, disableListFilter, disableGroupBy, disableBulkEdit) into the consolidated disabled object form.',
+    'Migrate field.admin and imageSize.admin disable* props (disableListColumn, disableListFilter, disableGroupBy, disableBulkEdit) into the consolidated disabled object form.',
 }
 
 const mergeAndSortObject = (existing: ObjectLiteralExpression, newKeys: string[]): void => {

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -7,15 +7,13 @@ import { generateFilePathOrURL } from './generateFilePathOrURL.js'
 import { mimeTypeValidator } from './mimeTypeValidator.js'
 
 const disabledFromImageSize = (
-  sizeAdmin:
-    | { disableGroupBy?: boolean; disableListColumn?: boolean; disableListFilter?: boolean }
-    | undefined,
+  sizeAdmin: { disabled?: { column?: boolean; filter?: boolean; groupBy?: boolean } } | undefined,
 ): { disabled: { column: boolean; filter: boolean; groupBy: boolean } } => {
   return {
     disabled: {
-      column: Boolean(sizeAdmin?.disableListColumn),
-      filter: Boolean(sizeAdmin?.disableListFilter),
-      groupBy: Boolean(sizeAdmin?.disableGroupBy),
+      column: sizeAdmin?.disabled?.column ?? false,
+      filter: sizeAdmin?.disabled?.filter ?? false,
+      groupBy: sizeAdmin?.disabled?.groupBy ?? false,
     },
   }
 }

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -10,21 +10,14 @@ const disabledFromImageSize = (
   sizeAdmin:
     | { disableGroupBy?: boolean; disableListColumn?: boolean; disableListFilter?: boolean }
     | undefined,
-): { disabled?: { column?: boolean; filter?: boolean; groupBy?: boolean } } => {
-  if (!sizeAdmin) {
-    return {}
+): { disabled: { column: boolean; filter: boolean; groupBy: boolean } } => {
+  return {
+    disabled: {
+      column: sizeAdmin?.disableListColumn !== false,
+      filter: sizeAdmin?.disableListFilter !== false,
+      groupBy: sizeAdmin?.disableGroupBy !== false,
+    },
   }
-  const disabled: { column?: boolean; filter?: boolean; groupBy?: boolean } = {}
-  if (sizeAdmin.disableGroupBy) {
-    disabled.groupBy = true
-  }
-  if (sizeAdmin.disableListColumn) {
-    disabled.column = true
-  }
-  if (sizeAdmin.disableListFilter) {
-    disabled.filter = true
-  }
-  return Object.keys(disabled).length ? { disabled } : {}
 }
 
 type Options = {
@@ -202,9 +195,6 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
     mimeType.validate = mimeTypeValidator(uploadOptions.mimeTypes)
   }
 
-  // In Payload v4, image size subfields (`url`, `width`, `height`, etc.) should
-  // default to `disabled: { groupBy, column, filter }` to avoid cluttering the
-  // collection list view and filters by default.
   if (uploadOptions.imageSizes) {
     uploadFields = uploadFields.concat([
       {

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -13,9 +13,9 @@ const disabledFromImageSize = (
 ): { disabled: { column: boolean; filter: boolean; groupBy: boolean } } => {
   return {
     disabled: {
-      column: sizeAdmin?.disableListColumn !== false,
-      filter: sizeAdmin?.disableListFilter !== false,
-      groupBy: sizeAdmin?.disableGroupBy !== false,
+      column: Boolean(sizeAdmin?.disableListColumn),
+      filter: Boolean(sizeAdmin?.disableListFilter),
+      groupBy: Boolean(sizeAdmin?.disableGroupBy),
     },
   }
 }

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -10,19 +10,9 @@ export type FileSize = {
   filesize: null | number
   height: null | number
   mimeType: null | string
-  url?: null | string // TODO V4: make non-optional
+  url: null | string
   width: null | number
 }
-
-// TODO: deprecate in Payload v4.
-/**
- * FileSizeImproved is a more precise type, and will replace FileSize in Payload v4.
- * This type is for internal use only as it will be deprecated in the future.
- * @internal
- */
-export type FileSizeImproved = {
-  url: null | string
-} & FileSize
 
 export type FileSizes = {
   [size: string]: FileSize
@@ -72,28 +62,26 @@ export type GenerateImageName = (args: {
 export type ImageSize = {
   /**
    * Admin UI options that control how this image size appears in list views.
-   *
-   * NOTE: In Payload v4, these options (`disableGroupBy`, `disableListColumn` and `disableListFilter`)
-   * should default to `true` so image size subfields are hidden from list columns
-   * and filters by default, reducing noise in the admin UI.
+   * Image size subfields are hidden from list columns, filters, and group-by by default
+   * to reduce noise in the admin UI.
    */
   admin?: {
     /**
      * If set to true, this image size will not be available
      * as a selectable groupBy option in the collection list view.
-     * @default false
+     * @default true
      */
     disableGroupBy?: boolean
     /**
      * If set to true, this image size will not be available
      * as a selectable column in the collection list view.
-     * @default false
+     * @default true
      */
     disableListColumn?: boolean
     /**
      * If set to true, this image size will not be available
      * as a filter option in the collection list view.
-     * @default false
+     * @default true
      */
     disableListFilter?: boolean
   }

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -62,28 +62,21 @@ export type GenerateImageName = (args: {
 export type ImageSize = {
   /**
    * Admin UI options that control how this image size appears in list views.
-   * Image size subfields are hidden from list columns, filters, and group-by by default
-   * to reduce noise in the admin UI.
    */
   admin?: {
     /**
-     * If set to true, this image size will not be available
-     * as a selectable groupBy option in the collection list view.
-     * @default true
+     * Controls visibility of this image size in the collection list view.
+     * Defaults to hiding the image size from columns, filters, and group-by to reduce noise.
+     *
+     * - `column` — whether to hide this size from selectable list columns. @default false
+     * - `filter` — whether to hide this size from filter options. @default false
+     * - `groupBy` — whether to hide this size from group-by options. @default false
      */
-    disableGroupBy?: boolean
-    /**
-     * If set to true, this image size will not be available
-     * as a selectable column in the collection list view.
-     * @default true
-     */
-    disableListColumn?: boolean
-    /**
-     * If set to true, this image size will not be available
-     * as a filter option in the collection list view.
-     * @default true
-     */
-    disableListFilter?: boolean
+    disabled?: {
+      column?: boolean
+      filter?: boolean
+      groupBy?: boolean
+    }
   }
   /**
    * @deprecated prefer position

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/converters/upload.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/converters/upload.ts
@@ -1,4 +1,4 @@
-import type { FileData, FileSizeImproved, TypeWithID } from 'payload'
+import type { FileData, FileSize, TypeWithID } from 'payload'
 
 import escapeHTML from 'escape-html'
 
@@ -56,7 +56,7 @@ export const UploadHTMLConverterAsync: HTMLConvertersAsync<SerializedUploadNode>
     let pictureHTML = ''
 
     for (const size in uploadDoc.sizes) {
-      const imageSize = uploadDoc.sizes[size] as FileSizeImproved
+      const imageSize = uploadDoc.sizes[size] as FileSize
 
       if (
         !imageSize ||

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/sync/converters/upload.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/sync/converters/upload.ts
@@ -1,4 +1,4 @@
-import type { FileData, FileSizeImproved, TypeWithID } from 'payload'
+import type { FileData, FileSize, TypeWithID } from 'payload'
 
 import escapeHTML from 'escape-html'
 
@@ -50,7 +50,7 @@ export const UploadHTMLConverter: HTMLConverters<SerializedUploadNode> = {
     let pictureHTML = ''
 
     for (const size in uploadDoc.sizes) {
-      const imageSize = uploadDoc.sizes[size] as FileSizeImproved
+      const imageSize = uploadDoc.sizes[size] as FileSize
 
       if (
         !imageSize ||

--- a/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/features/converters/lexicalToJSX/converter/converters/upload.tsx
@@ -1,4 +1,4 @@
-import type { FileData, FileSizeImproved, TypeWithID } from 'payload'
+import type { FileData, FileSize, TypeWithID } from 'payload'
 
 import type { SerializedUploadNode } from '../../../../../nodeTypes.js'
 import type { UploadDataImproved } from '../../../../upload/server/nodes/UploadNode.js'
@@ -43,7 +43,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
 
     // Iterate through each size in the data.sizes object
     for (const size in uploadDoc.sizes) {
-      const imageSize = uploadDoc.sizes[size] as FileSizeImproved
+      const imageSize = uploadDoc.sizes[size] as FileSize
 
       // Skip if any property of the size object is null
       if (

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -1041,8 +1041,7 @@ export default buildConfigWithDefaults({
             height: 200,
             width: 200,
             admin: {
-              disableListFilter: true,
-              disableListColumn: true,
+              disabled: { column: true, filter: true },
             },
           },
           {
@@ -1050,7 +1049,7 @@ export default buildConfigWithDefaults({
             height: 300,
             width: 300,
             admin: {
-              disableListColumn: true,
+              disabled: { column: true },
             },
           },
           {
@@ -1058,8 +1057,7 @@ export default buildConfigWithDefaults({
             height: 400,
             width: 400,
             admin: {
-              disableListColumn: false,
-              disableListFilter: true,
+              disabled: { filter: true },
             },
           },
           {


### PR DESCRIPTION
## Breaking changes

### 1. `FileSizeImproved` removed — use `FileSize`

`FileSizeImproved` has been merged into `FileSize`. The `url`, `width`, `height`, `filesize`, `mimeType`, and `filename` properties now accept `null` directly on `FileSize`, matching what the database actually stores for sizes that were not generated.

**Migration:** Replace all `FileSizeImproved` references with `FileSize`.

### 2. `ImageSize.admin` — `disableListColumn` / `disableListFilter` / `disableGroupBy` removed

These three boolean props have been replaced with a single `disabled` object, consistent with the shape used by all other fields.

**Migration (via codemod):**

```bash
npx @payloadcms/codemod migrate-disabled-fields
```

Manual migration:
```
// Before
admin: { disableListColumn: true, disableGroupBy: true }

// After
admin: { disabled: { column: true, groupBy: true } }
```