### PR TITLE
chore(plugin-search)!: remove deprecated apiBasePath config

### DIFF
--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -38,13 +38,6 @@ export type SkipSyncFunction<ConfigTypes = unknown> = (args: {
 }) => boolean | Promise<boolean>
 
 export type SearchPluginConfig<ConfigTypes = unknown> = {
-  /**
-   * @deprecated
-   * This plugin gets the api route from the config directly and does not need to be passed in.
-   * As long as you have `routes.api` set in your Payload config, the plugin will use that.
-   * This property will be removed in the next major version.
-   */
-  apiBasePath?: string
   beforeSync?: BeforeSync
   collections?: string[]
   defaultPriorities?: {


### PR DESCRIPTION
Removes a deprecated `apiBasePath` in favour of internally handling it based on root config