### PR TITLE
fix(next): externalize file-type to fix turbopack dynamic import error

### DIFF
--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -125,6 +125,17 @@ export const withPayload = (nextConfig = {}, options = {}) => {
       // WHY: without externalizing graphql, a graphql version error will be thrown
       // during runtime ("Ensure that there is only one instance of \"graphql\" in the node_modules\ndirectory.")
       'graphql',
+      'drizzle-kit',
+      'drizzle-kit/api',
+      'sharp',
+      'libsql',
+      'require-in-the-middle',
+      'json-schema-to-typescript',
+      // Prevents turbopack build errors by the thread-stream package which is installed by pino
+      'pino',
+      // file-type v22 uses `import(specifier)` with a non-literal specifier, which Turbopack rejects
+      // with "Cannot find module as expression is too dynamic"
+      'file-type',
       ...(process.env.NODE_ENV === 'development' && options.devBundleServerPackages !== true
         ? /**
            * Unless explicitly disabled by the user, by passing `devBundleServerPackages: true` to withPayload, we
@@ -253,20 +264,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
     baseConfig.env.NEXT_BASE_PATH = nextConfig.basePath
   }
 
-  return {
-    ...baseConfig,
-    serverExternalPackages: [
-      ...(baseConfig.serverExternalPackages || []),
-      'drizzle-kit',
-      'drizzle-kit/api',
-      'sharp',
-      'libsql',
-      'require-in-the-middle',
-      'json-schema-to-typescript',
-      // Prevents turbopack build errors by the thread-stream package which is installed by pino
-      'pino',
-    ],
-  }
+  return baseConfig
 }
 
 export default withPayload


### PR DESCRIPTION
file-type v22 uses `import(specifier)`, which Turbopack rejects with `Cannot find module as expression is too dynamic` when bundling. Adding it to `serverExternalPackages` keeps Next.js from bundling it and resolves the error in dev and build.

<img width="1602" height="844" alt="screenshot 2026-05-13 at 13 52 18@2x" src="https://github.com/user-attachments/assets/a1b53c7c-43f6-4bc4-8477-cb829a038c0d" />

<img width="1696" height="650" alt="screenshot 2026-05-13 at 13 52 29@2x" src="https://github.com/user-attachments/assets/87208db2-bc1f-445f-b863-0823968d06c5" />

<img width="1708" height="868" alt="screenshot 2026-05-13 at 13 52 57@2x" src="https://github.com/user-attachments/assets/fce06658-6588-483a-a704-8a0c1670495e" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214786520820562