### PR TITLE
chore(db-mongodb)!: remove deprecated useFacet property

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -93,8 +93,7 @@ Out of the box, Payload templates pass the `process.env.DATABASE_URL` environmen
 ### DocumentDB
 
 When using AWS DocumentDB, you will need to configure connection options for authentication in the `connectOptions`
-passed to the `mongooseAdapter` . You also need to set `connectOptions.useFacet` to `false` to disable use of the
-unsupported `$facet` aggregation.
+passed to the `mongooseAdapter`.
 
 ### CosmosDB
 

--- a/packages/db-mongodb/src/connect.ts
+++ b/packages/db-mongodb/src/connect.ts
@@ -24,10 +24,9 @@ export const connect: Connect = async function connect(
 
   const urlToConnect = this.url
 
-  const connectionOptions: { useFacet: undefined } & ConnectOptions = {
+  const connectionOptions: ConnectOptions = {
     autoIndex: true,
     ...this.connectOptions,
-    useFacet: undefined,
   }
 
   if (hotReload) {

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -125,13 +125,7 @@ export interface Args {
 
   collectionsSchemaOptions?: Partial<Record<CollectionSlug, SchemaOptions>>
   /** Extra configuration options */
-  connectOptions?: {
-    /**
-     * Set false to disable $facet aggregation in non-supporting databases, Defaults to true
-     * @deprecated Payload doesn't use `$facet` anymore anywhere.
-     */
-    useFacet?: boolean
-  } & ConnectOptions
+  connectOptions?: ConnectOptions
   /**
    * We add a secondary sort based on `createdAt` to ensure that results are always returned in the same order when sorting by a non-unique field.
    * This is because MongoDB does not guarantee the order of results, however in very large datasets this could affect performance.


### PR DESCRIPTION
### Summary

- Removes `useFacet` from the `connectOptions` type — Payload no longer uses `$facet` aggregation anywhere so the option has no effect
- Cleans up the `connect.ts` workaround that was stripping `useFacet: undefined` before passing options to mongoose
- Updates the DocumentDB deployment docs to remove the now-invalid guidance to set `connectOptions.useFacet: false`

### Breaking change

If you have `useFacet` set in your `mongooseAdapter` config, remove it:

```diff
mongooseAdapter({
  connectOptions: {
-   useFacet: false,
    // ...other options
  }
})
