### PR TITLE
fix(ui): use accessibility-focus-color for focus styles

### DIFF
--- a/packages/ui/src/css/utilities.css
+++ b/packages/ui/src/css/utilities.css
@@ -1,6 +1,7 @@
 @layer payload-default {
   :root {
-    --accessibility-outline: 1px solid var(--color-border-selected-strong);
+    --accessibility-focus-color: var(--color-border-selected);
+    --accessibility-outline: 1px solid var(--accessibility-focus-color);
     --accessibility-outline-offset: 1px;
   }
 

--- a/packages/ui/src/elements/CodeEditor/index.css
+++ b/packages/ui/src/elements/CodeEditor/index.css
@@ -24,7 +24,7 @@
     transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
 
     &:focus-within {
-      border-color: var(--color-border-selected-strong);
+      border-color: var(--accessibility-focus-color);
     }
 
     &.read-only {

--- a/packages/ui/src/elements/Collapsible/index.css
+++ b/packages/ui/src/elements/Collapsible/index.css
@@ -180,7 +180,7 @@
   }
 
   .collapsible__indicator:focus-visible {
-    border: 1px solid var(--color-border-selected-strong);
+    border: 1px solid var(--accessibility-focus-color);
     border-radius: var(--radius-medium, 0.3125rem);
     background: var(--color-bg-secondary);
   }

--- a/packages/ui/src/elements/ReactSelect/ClearIndicator/index.css
+++ b/packages/ui/src/elements/ReactSelect/ClearIndicator/index.css
@@ -12,9 +12,4 @@
       color: var(--color-icon);
     }
   }
-
-  .clear-indicator__icon {
-    width: var(--spacer-3);
-    height: var(--spacer-3);
-  }
 }

--- a/packages/ui/src/elements/ReactSelect/ClearIndicator/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/ClearIndicator/index.tsx
@@ -31,7 +31,7 @@ export const ClearIndicator: React.FC<ClearIndicatorProps<OptionType, true>> = (
       role="button"
       tabIndex={0}
     >
-      <CircledXIcon className={`${baseClass}__icon`} />
+      <CircledXIcon className={`${baseClass}__icon`} size={24} />
     </div>
   )
 }

--- a/packages/ui/src/elements/ReactSelect/index.css
+++ b/packages/ui/src/elements/ReactSelect/index.css
@@ -28,7 +28,7 @@
       gap: var(--spacer-1);
 
       &.rs__control--is-focused {
-        border-color: var(--color-border-selected);
+        border-color: var(--accessibility-focus-color);
       }
 
       &:has(.clear-indicator) {
@@ -149,7 +149,7 @@
 
   .react-select--error:focus-within {
     div.rs__control {
-      border-color: var(--color-border-selected);
+      border-color: var(--accessibility-focus-color);
     }
   }
 }

--- a/packages/ui/src/elements/ThumbnailCard/index.css
+++ b/packages/ui/src/elements/ThumbnailCard/index.css
@@ -61,11 +61,11 @@
 
   .thumbnail-card--selected.thumbnail-card--has-on-click:hover .thumbnail-card__thumbnail,
   .thumbnail-card--selected.thumbnail-card--has-on-click:focus-visible .thumbnail-card__thumbnail {
-    outline-color: var(--color-border-selected-strong);
+    outline-color: var(--accessibility-focus-color);
   }
 
   .thumbnail-card--selected.thumbnail-card--has-on-click:active .thumbnail-card__thumbnail {
-    outline-color: var(--color-border-selected-strong);
+    outline-color: var(--accessibility-focus-color);
   }
 
   .thumbnail-card__label {

--- a/packages/ui/src/fields/Checkbox/index.css
+++ b/packages/ui/src/fields/Checkbox/index.css
@@ -40,7 +40,7 @@
       &:focus-within,
       &:focus {
         .checkbox-input__input {
-          border-color: var(--color-border-selected-strong);
+          border-color: var(--accessibility-focus-color);
         }
       }
 

--- a/packages/ui/src/fields/Code/index.css
+++ b/packages/ui/src/fields/Code/index.css
@@ -18,7 +18,7 @@
       }
 
       &:focus-within {
-        border-color: var(--color-border-selected);
+        border-color: var(--accessibility-focus-color);
       }
     }
 

--- a/packages/ui/src/fields/DateTime/index.css
+++ b/packages/ui/src/fields/DateTime/index.css
@@ -7,7 +7,7 @@
     }
 
     &:focus {
-      border-color: var(--color-border-selected);
+      border-color: var(--accessibility-focus-color);
     }
   }
 }

--- a/packages/ui/src/fields/JSON/index.css
+++ b/packages/ui/src/fields/JSON/index.css
@@ -14,7 +14,7 @@
         }
 
         &:focus-within {
-          border-color: var(--color-border-selected-strong);
+          border-color: var(--accessibility-focus-color);
         }
       }
 


### PR DESCRIPTION
Consolidates focus styling to use `--accessibility-focus-color` instead of direct color token references.

### Changes
- Replace `--color-border-selected-strong` with `--accessibility-focus-color` in focus states
- Replace `--color-border-selected` with `--accessibility-focus-color` in focus states  
- Update ClearIndicator to use 24px CircledXIcon

### Files updated
- `packages/ui/src/elements/CodeEditor/index.css`
- `packages/ui/src/elements/Collapsible/index.css`
- `packages/ui/src/elements/ReactSelect/index.css`
- `packages/ui/src/elements/ReactSelect/ClearIndicator/index.tsx`
- `packages/ui/src/elements/ThumbnailCard/index.css`
- `packages/ui/src/fields/Checkbox/index.css`
- `packages/ui/src/fields/Code/index.css`
- `packages/ui/src/fields/DateTime/index.css`
- `packages/ui/src/fields/JSON/index.css`