### PR TITLE
test(evals): variant filter, structured transcripts, skill nudge

### DIFF
--- a/test/evals/cache.ts
+++ b/test/evals/cache.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import type { RunnerKind, SkillInstallMode } from './runner/types.js'
 import type { EvalResult, SystemPromptKey } from './types.js'
 
+import { SKILL_SYSTEM_PROMPT } from './runner/claudeCode.js'
 import { getSkillTreeHash } from './runner/workdir.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -117,6 +118,14 @@ export function codegenKey(params: {
     (params.runnerKind === 'llm' && params.systemPromptKey === 'codegenWithSkill') ||
     (params.runnerKind === 'claude-code' && params.skillInstall === 'embedded')
 
+  // For claude-code embedded runs the runner appends a system-prompt directive
+  // nudging the agent to invoke the skill. Any tweak to that text changes
+  // observable behavior, so factor it into the cache key.
+  const agentSystemPrompt =
+    params.runnerKind === 'claude-code' && params.skillInstall === 'embedded'
+      ? SKILL_SYSTEM_PROMPT
+      : undefined
+
   // agentModel and agentVersion are deliberately omitted: for claude-code runs,
   // modelId is `claude-code/<agentModel>/<version>`, so they're already in the hash.
   return hashKey({
@@ -129,5 +138,6 @@ export function codegenKey(params: {
     systemPromptKey: params.systemPromptKey,
     skillInstall: params.skillInstall,
     skillHash: skillIncluded ? getSkillTreeHash() : undefined,
+    agentSystemPrompt,
   })
 }

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useState } from 'react'
 
+import type { TranscriptEvent } from '../../types.js'
 import type { Variant } from '../../variant.js'
 import type { RenderedCode } from './codeDiff.js'
 import type { EvalEntry, RunSnapshot } from './index.js'
@@ -190,6 +191,145 @@ function TokenDisplay({
   )
 }
 
+function TranscriptView({ events }: { events: TranscriptEvent[] }) {
+  return (
+    <div
+      style={{
+        background: 'var(--theme-elevation-50)',
+        border: '1px solid var(--theme-elevation-150)',
+        borderRadius: '4px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        margin: '6px 0 0',
+        maxHeight: '600px',
+        overflow: 'auto',
+        padding: '10px',
+      }}
+    >
+      {events.map((event, i) => (
+        <TranscriptEventView event={event} key={i} />
+      ))}
+    </div>
+  )
+}
+
+function TranscriptEventView({ event }: { event: TranscriptEvent }) {
+  if (event.type === 'text') {
+    return (
+      <div
+        style={{
+          color: 'var(--theme-elevation-800)',
+          fontSize: '0.8rem',
+          lineHeight: 1.55,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        {event.text}
+      </div>
+    )
+  }
+  if (event.type === 'thinking') {
+    return (
+      <details>
+        <summary
+          style={{
+            color: 'var(--theme-elevation-500)',
+            cursor: 'pointer',
+            fontSize: '0.72rem',
+            fontStyle: 'italic',
+            userSelect: 'none',
+          }}
+        >
+          Thinking
+        </summary>
+        <div
+          style={{
+            color: 'var(--theme-elevation-600)',
+            fontSize: '0.78rem',
+            fontStyle: 'italic',
+            lineHeight: 1.5,
+            marginTop: '4px',
+            paddingLeft: '12px',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {event.text}
+        </div>
+      </details>
+    )
+  }
+  if (event.type === 'tool_use') {
+    return (
+      <details>
+        <summary
+          style={{
+            color: 'var(--theme-elevation-700)',
+            cursor: 'pointer',
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: '0.78rem',
+            userSelect: 'none',
+          }}
+        >
+          → {event.name}
+        </summary>
+        <pre
+          style={{
+            background: 'var(--theme-elevation-0)',
+            border: '1px solid var(--theme-elevation-100)',
+            borderRadius: '3px',
+            color: 'var(--theme-elevation-700)',
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: '0.72rem',
+            margin: '4px 0 0',
+            maxHeight: '300px',
+            overflow: 'auto',
+            padding: '6px 8px',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {JSON.stringify(event.input, null, 2)}
+        </pre>
+      </details>
+    )
+  }
+  // tool_result
+  return (
+    <details>
+      <summary
+        style={{
+          color: event.isError ? 'var(--theme-error-600)' : 'var(--theme-elevation-600)',
+          cursor: 'pointer',
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '0.78rem',
+          userSelect: 'none',
+        }}
+      >
+        ← result{event.isError ? ' (error)' : ''}
+      </summary>
+      <pre
+        style={{
+          background: 'var(--theme-elevation-0)',
+          border: '1px solid var(--theme-elevation-100)',
+          borderRadius: '3px',
+          color: event.isError ? 'var(--theme-error-700)' : 'var(--theme-elevation-700)',
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '0.72rem',
+          margin: '4px 0 0',
+          maxHeight: '300px',
+          overflow: 'auto',
+          padding: '6px 8px',
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {event.content}
+      </pre>
+    </details>
+  )
+}
+
 function ExpandedRow({ entry, rendered }: { entry: EvalEntry; rendered?: RenderedCode }) {
   const { result } = entry
   const sectionStyle: React.CSSProperties = {
@@ -329,7 +469,7 @@ function ExpandedRow({ entry, rendered }: { entry: EvalEntry; rendered?: Rendere
       )}
 
       {/* Transcript (Claude Code runner) */}
-      {result.agentLog && result.agentLog.length > 0 && (
+      {(result.transcript?.length || result.agentLog) && (
         <div style={sectionStyle}>
           <details>
             <summary
@@ -341,23 +481,27 @@ function ExpandedRow({ entry, rendered }: { entry: EvalEntry; rendered?: Rendere
             >
               Transcript
             </summary>
-            <pre
-              style={{
-                background: 'var(--theme-elevation-50)',
-                border: '1px solid var(--theme-elevation-150)',
-                borderRadius: '4px',
-                color: 'var(--theme-elevation-700)',
-                fontFamily: 'var(--font-mono, monospace)',
-                fontSize: '0.75rem',
-                margin: '6px 0 0',
-                maxHeight: '600px',
-                overflow: 'auto',
-                padding: '8px 10px',
-                whiteSpace: 'pre-wrap',
-              }}
-            >
-              {result.agentLog}
-            </pre>
+            {result.transcript && result.transcript.length > 0 ? (
+              <TranscriptView events={result.transcript} />
+            ) : result.agentLog ? (
+              <pre
+                style={{
+                  background: 'var(--theme-elevation-50)',
+                  border: '1px solid var(--theme-elevation-150)',
+                  borderRadius: '4px',
+                  color: 'var(--theme-elevation-700)',
+                  fontFamily: 'var(--font-mono, monospace)',
+                  fontSize: '0.75rem',
+                  margin: '6px 0 0',
+                  maxHeight: '600px',
+                  overflow: 'auto',
+                  padding: '8px 10px',
+                  whiteSpace: 'pre-wrap',
+                }}
+              >
+                {result.agentLog}
+              </pre>
+            ) : null}
           </details>
         </div>
       )}

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -221,13 +221,12 @@ function SkillInvocationBadge({ invoked }: { invoked: boolean }) {
     <span
       style={{
         alignSelf: 'flex-start',
-        background: invoked ? 'var(--theme-success-100)' : 'var(--theme-error-100)',
-        border: `1px solid ${invoked ? 'var(--theme-success-300)' : 'var(--theme-error-300)'}`,
+        background: invoked ? 'var(--color-success-500)' : 'var(--color-error-500)',
         borderRadius: '4px',
-        color: invoked ? 'var(--theme-success-700)' : 'var(--theme-error-700)',
+        color: '#fff',
         fontSize: '0.7rem',
         fontWeight: 600,
-        padding: '2px 8px',
+        padding: '3px 8px',
         whiteSpace: 'nowrap',
       }}
     >

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -328,6 +328,40 @@ function ExpandedRow({ entry, rendered }: { entry: EvalEntry; rendered?: Rendere
         </div>
       )}
 
+      {/* Transcript (Claude Code runner) */}
+      {result.agentLog && result.agentLog.length > 0 && (
+        <div style={sectionStyle}>
+          <details>
+            <summary
+              style={{
+                ...labelStyle,
+                cursor: 'pointer',
+                userSelect: 'none',
+              }}
+            >
+              Transcript
+            </summary>
+            <pre
+              style={{
+                background: 'var(--theme-elevation-50)',
+                border: '1px solid var(--theme-elevation-150)',
+                borderRadius: '4px',
+                color: 'var(--theme-elevation-700)',
+                fontFamily: 'var(--font-mono, monospace)',
+                fontSize: '0.75rem',
+                margin: '6px 0 0',
+                maxHeight: '600px',
+                overflow: 'auto',
+                padding: '8px 10px',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {result.agentLog}
+            </pre>
+          </details>
+        </div>
+      )}
+
       {/* Usage breakdown */}
       {result.usage && (
         <div style={sectionStyle}>

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -15,6 +15,16 @@ export function getVariant(entry: EvalEntry): null | Variant {
   return getVariantFromResult(entry.result)
 }
 
+function variantLabel(variant: Variant): string {
+  const labels: Record<Variant, string> = {
+    'agent-baseline': 'Agent Baseline',
+    'agent-skill': 'Agent Skill',
+    baseline: 'Baseline',
+    skill: 'Skill',
+  }
+  return labels[variant]
+}
+
 function VariantBadge({ variant }: { variant: null | Variant }) {
   if (!variant) {
     return <span style={{ color: 'var(--theme-elevation-300)', fontSize: '0.72rem' }}>—</span>
@@ -388,6 +398,7 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
   const [compareMode, setCompareMode] = useState<'run' | 'variant'>('variant')
   const [statusFilter, setStatusFilter] = useState<FilterStatus>('all')
   const [typeFilter, setTypeFilter] = useState<FilterType>('all')
+  const [variantFilter, setVariantFilter] = useState<'all' | Variant>('all')
   const [categoryFilter, setCategoryFilter] = useState<string>('all')
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [hoveredHash, setHoveredHash] = useState<null | string>(null)
@@ -398,6 +409,17 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
     () => ['all', ...Array.from(new Set(entries.map((e) => e.category))).sort()],
     [entries],
   )
+
+  const variantOptions = useMemo<('all' | Variant)[]>(() => {
+    const seen = new Set<Variant>()
+    for (const e of entries) {
+      const v = getVariant(e)
+      if (v) {
+        seen.add(v)
+      }
+    }
+    return ['all', ...Array.from(seen).sort()]
+  }, [entries])
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -432,6 +454,9 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
         return false
       }
       if (typeFilter !== 'all' && e.type !== typeFilter) {
+        return false
+      }
+      if (variantFilter !== 'all' && getVariant(e) !== variantFilter) {
         return false
       }
       if (categoryFilter !== 'all' && e.category !== categoryFilter) {
@@ -470,7 +495,7 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
       }
       return aVal < bVal ? -dir : aVal > bVal ? dir : 0
     })
-  }, [entries, statusFilter, typeFilter, categoryFilter, sortKey, sortDir])
+  }, [entries, statusFilter, typeFilter, categoryFilter, variantFilter, sortKey, sortDir])
 
   // Summary stats from filtered set
   const stats = useMemo(() => {
@@ -705,6 +730,33 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
                   {t === 'all' ? 'All' : 'Codegen'}
                 </button>
               ))}
+            </div>
+
+            <span
+              aria-hidden="true"
+              style={{
+                background: 'var(--theme-elevation-250)',
+                borderRadius: '1px',
+                display: 'inline-block',
+                height: '18px',
+                width: '1px',
+              }}
+            />
+
+            <div style={{ display: 'flex', gap: '4px' }}>
+              {variantOptions.map((v) => {
+                const isActive = variantFilter === v
+                return (
+                  <button
+                    key={v}
+                    onClick={() => setVariantFilter(v)}
+                    style={filterBtnStyle(isActive)}
+                    type="button"
+                  >
+                    {v === 'all' ? 'All' : variantLabel(v)}
+                  </button>
+                )
+              })}
             </div>
 
             <span

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -493,7 +493,7 @@ function ExpandedRow({ entry, rendered }: { entry: EvalEntry; rendered?: Rendere
       {/* Transcript (Claude Code runner) */}
       {(result.transcript?.length || result.agentLog) && (
         <div style={sectionStyle}>
-          <details>
+          <details open>
             <summary
               style={{
                 ...labelStyle,

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -221,10 +221,10 @@ function SkillInvocationBadge({ invoked }: { invoked: boolean }) {
     <span
       style={{
         alignSelf: 'flex-start',
-        background: invoked ? 'var(--theme-success-100)' : 'var(--theme-elevation-100)',
-        border: `1px solid ${invoked ? 'var(--theme-success-300)' : 'var(--theme-elevation-200)'}`,
+        background: invoked ? 'var(--theme-success-100)' : 'var(--theme-error-100)',
+        border: `1px solid ${invoked ? 'var(--theme-success-300)' : 'var(--theme-error-300)'}`,
         borderRadius: '4px',
-        color: invoked ? 'var(--theme-success-700)' : 'var(--theme-elevation-500)',
+        color: invoked ? 'var(--theme-success-700)' : 'var(--theme-error-700)',
         fontSize: '0.7rem',
         fontWeight: 600,
         padding: '2px 8px',

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -15,7 +15,9 @@ export function getVariant(entry: EvalEntry): null | Variant {
   return getVariantFromResult(entry.result)
 }
 
-function variantLabel(variant: Variant): string {
+type VariantFilter = 'all' | Variant
+
+function getVariantLabel(variant: Variant): string {
   const labels: Record<Variant, string> = {
     'agent-baseline': 'Agent Baseline',
     'agent-skill': 'Agent Skill',
@@ -398,7 +400,7 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
   const [compareMode, setCompareMode] = useState<'run' | 'variant'>('variant')
   const [statusFilter, setStatusFilter] = useState<FilterStatus>('all')
   const [typeFilter, setTypeFilter] = useState<FilterType>('all')
-  const [variantFilter, setVariantFilter] = useState<'all' | Variant>('all')
+  const [variantFilter, setVariantFilter] = useState<VariantFilter>('all')
   const [categoryFilter, setCategoryFilter] = useState<string>('all')
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [hoveredHash, setHoveredHash] = useState<null | string>(null)
@@ -410,7 +412,7 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
     [entries],
   )
 
-  const variantOptions = useMemo<('all' | Variant)[]>(() => {
+  const variantOptions = useMemo<VariantFilter[]>(() => {
     const seen = new Set<Variant>()
     for (const e of entries) {
       const v = getVariant(e)
@@ -753,7 +755,7 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
                     style={filterBtnStyle(isActive)}
                     type="button"
                   >
-                    {v === 'all' ? 'All' : variantLabel(v)}
+                    {v === 'all' ? 'All' : getVariantLabel(v)}
                   </button>
                 )
               })}

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -3,12 +3,10 @@
 import React, { useMemo, useState } from 'react'
 
 import type { Variant } from '../../variant.js'
-import type { Audience } from './audience.js'
 import type { RenderedCode } from './codeDiff.js'
 import type { EvalEntry, RunSnapshot } from './index.js'
 
 import { getVariant as getVariantFromResult } from '../../variant.js'
-import { AUDIENCE_CONFIG } from './audience.js'
 import { CompareTable } from './CompareTable.js'
 
 export type { Variant }
@@ -68,7 +66,6 @@ type ViewMode = 'compare' | 'list'
 
 type FilterStatus = 'all' | 'fail' | 'pass'
 type FilterType = 'all' | 'codegen'
-type FilterAudience = 'all' | Audience
 
 function ScoreBadge({
   pass,
@@ -144,32 +141,6 @@ function TypeBadge({ type }: { type: 'codegen' }) {
       }}
     >
       {type === 'codegen' ? 'Codegen' : null}
-    </span>
-  )
-}
-
-function AudienceBadges({ audiences }: { audiences: Audience[] }) {
-  return (
-    <span style={{ display: 'flex', flexWrap: 'wrap', gap: '3px' }}>
-      {audiences.map((a) => {
-        const { bg, color, label } = AUDIENCE_CONFIG[a]
-        return (
-          <span
-            key={a}
-            style={{
-              background: bg,
-              borderRadius: '4px',
-              color,
-              fontSize: '0.68rem',
-              fontWeight: 600,
-              padding: '2px 5px',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {label}
-          </span>
-        )
-      })}
     </span>
   )
 }
@@ -399,7 +370,7 @@ function ExpandedRow({ entry, rendered }: { entry: EvalEntry; rendered?: Rendere
   )
 }
 
-type SortKey = 'audience' | 'category' | 'question' | 'result' | 'tokens' | 'type' | 'variant'
+type SortKey = 'category' | 'question' | 'result' | 'tokens' | 'type' | 'variant'
 type SortDir = 'asc' | 'desc'
 
 function cycleSort(current: null | SortDir): null | SortDir {
@@ -417,7 +388,6 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
   const [compareMode, setCompareMode] = useState<'run' | 'variant'>('variant')
   const [statusFilter, setStatusFilter] = useState<FilterStatus>('all')
   const [typeFilter, setTypeFilter] = useState<FilterType>('all')
-  const [audienceFilter, setAudienceFilter] = useState<FilterAudience>('all')
   const [categoryFilter, setCategoryFilter] = useState<string>('all')
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [hoveredHash, setHoveredHash] = useState<null | string>(null)
@@ -464,9 +434,6 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
       if (typeFilter !== 'all' && e.type !== typeFilter) {
         return false
       }
-      if (audienceFilter !== 'all' && !e.audience.includes(audienceFilter)) {
-        return false
-      }
       if (categoryFilter !== 'all' && e.category !== categoryFilter) {
         return false
       }
@@ -487,9 +454,6 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
       } else if (sortKey === 'category') {
         aVal = a.category.toLowerCase()
         bVal = b.category.toLowerCase()
-      } else if (sortKey === 'audience') {
-        aVal = [...a.audience].sort().join(',')
-        bVal = [...b.audience].sort().join(',')
       } else if (sortKey === 'type') {
         aVal = a.type
         bVal = b.type
@@ -506,7 +470,7 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
       }
       return aVal < bVal ? -dir : aVal > bVal ? dir : 0
     })
-  }, [entries, statusFilter, typeFilter, audienceFilter, categoryFilter, sortKey, sortDir])
+  }, [entries, statusFilter, typeFilter, categoryFilter, sortKey, sortDir])
 
   // Summary stats from filtered set
   const stats = useMemo(() => {
@@ -754,45 +718,6 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
               }}
             />
 
-            <div style={{ display: 'flex', gap: '4px' }}>
-              {(['all', 'users', 'admins', 'maintainers'] as FilterAudience[]).map((a) => (
-                <button
-                  key={a}
-                  onClick={() => setAudienceFilter(a)}
-                  style={
-                    audienceFilter === a && a !== 'all'
-                      ? {
-                          ...filterBtnStyle(true),
-                          background: AUDIENCE_CONFIG[a].bg,
-                          border: `1px solid ${AUDIENCE_CONFIG[a].color}`,
-                          color: AUDIENCE_CONFIG[a].color,
-                        }
-                      : filterBtnStyle(audienceFilter === a)
-                  }
-                  type="button"
-                >
-                  {a === 'all'
-                    ? 'All'
-                    : a === 'users'
-                      ? 'Users'
-                      : a === 'admins'
-                        ? 'Admins'
-                        : 'Maintainers'}
-                </button>
-              ))}
-            </div>
-
-            <span
-              aria-hidden="true"
-              style={{
-                background: 'var(--theme-elevation-250)',
-                borderRadius: '1px',
-                display: 'inline-block',
-                height: '18px',
-                width: '1px',
-              }}
-            />
-
             <select
               onChange={(e) => setCategoryFilter(e.target.value)}
               style={{
@@ -831,44 +756,38 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
                 fontSize: '0.7rem',
                 fontWeight: 700,
                 gap: '0 12px',
-                gridTemplateColumns: '1fr 100px 120px 70px 80px 100px 100px 32px',
+                gridTemplateColumns: '1fr 100px 70px 80px 100px 100px 32px',
                 letterSpacing: '0.05em',
                 padding: '8px 12px',
                 textTransform: 'uppercase',
               }}
             >
-              {(
-                [
-                  'question',
-                  'category',
-                  'audience',
-                  'type',
-                  'variant',
-                  'result',
-                  'tokens',
-                ] as SortKey[]
-              ).map((key) => (
-                <span
-                  key={key}
-                  onClick={() => handleSort(key)}
-                  onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleSort(key)}
-                  role="button"
-                  style={{
-                    alignItems: 'center',
-                    color:
-                      sortKey === key ? 'var(--theme-elevation-800)' : 'var(--theme-elevation-500)',
-                    cursor: 'pointer',
-                    display: 'inline-flex',
-                    userSelect: 'none',
-                  }}
-                  tabIndex={0}
-                >
-                  {key === 'question'
-                    ? 'Question / Task'
-                    : key.charAt(0).toUpperCase() + key.slice(1)}
-                  {sortIndicator(key)}
-                </span>
-              ))}
+              {(['question', 'category', 'type', 'variant', 'result', 'tokens'] as SortKey[]).map(
+                (key) => (
+                  <span
+                    key={key}
+                    onClick={() => handleSort(key)}
+                    onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleSort(key)}
+                    role="button"
+                    style={{
+                      alignItems: 'center',
+                      color:
+                        sortKey === key
+                          ? 'var(--theme-elevation-800)'
+                          : 'var(--theme-elevation-500)',
+                      cursor: 'pointer',
+                      display: 'inline-flex',
+                      userSelect: 'none',
+                    }}
+                    tabIndex={0}
+                  >
+                    {key === 'question'
+                      ? 'Question / Task'
+                      : key.charAt(0).toUpperCase() + key.slice(1)}
+                    {sortIndicator(key)}
+                  </span>
+                ),
+              )}
               <span />
             </div>
 
@@ -917,7 +836,7 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
                         cursor: 'pointer',
                         display: 'grid',
                         gap: '0 12px',
-                        gridTemplateColumns: '1fr 100px 120px 70px 80px 100px 100px 32px',
+                        gridTemplateColumns: '1fr 100px 70px 80px 100px 100px 32px',
                         padding: '10px 12px',
                         transition: 'background 0.1s',
                       }}
@@ -937,9 +856,6 @@ export function ResultsTable({ codegenHtml, entries, runs }: Props) {
                       </span>
                       <span>
                         <CategoryBadge category={entry.category} />
-                      </span>
-                      <span>
-                        <AudienceBadges audiences={entry.audience} />
                       </span>
                       <span>
                         <TypeBadge type={entry.type} />

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -221,9 +221,9 @@ function SkillInvocationBadge({ invoked }: { invoked: boolean }) {
     <span
       style={{
         alignSelf: 'flex-start',
-        background: invoked ? 'var(--color-success-500)' : 'var(--color-error-500)',
+        background: invoked ? 'var(--color-bg-success)' : 'var(--color-bg-danger)',
         borderRadius: '4px',
-        color: '#fff',
+        color: invoked ? 'var(--color-text-onsuccess)' : 'var(--color-text-ondanger)',
         fontSize: '0.7rem',
         fontWeight: 600,
         padding: '3px 8px',

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -254,7 +254,7 @@ function TranscriptEventView({ event }: { event: TranscriptEvent }) {
   }
   if (event.type === 'thinking') {
     return (
-      <details>
+      <details open>
         <summary
           style={{
             color: 'var(--theme-elevation-500)',
@@ -285,7 +285,7 @@ function TranscriptEventView({ event }: { event: TranscriptEvent }) {
   }
   if (event.type === 'tool_use') {
     return (
-      <details>
+      <details open>
         <summary
           style={{
             color: 'var(--theme-elevation-700)',
@@ -319,7 +319,7 @@ function TranscriptEventView({ event }: { event: TranscriptEvent }) {
   }
   // tool_result
   return (
-    <details>
+    <details open>
       <summary
         style={{
           color: event.isError ? 'var(--theme-error-600)' : 'var(--theme-elevation-600)',

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -192,6 +192,7 @@ function TokenDisplay({
 }
 
 function TranscriptView({ events }: { events: TranscriptEvent[] }) {
+  const skillInvoked = events.some((event) => event.type === 'tool_use' && event.name === 'Skill')
   return (
     <div
       style={{
@@ -207,10 +208,31 @@ function TranscriptView({ events }: { events: TranscriptEvent[] }) {
         padding: '10px',
       }}
     >
+      <SkillInvocationBadge invoked={skillInvoked} />
       {events.map((event, i) => (
         <TranscriptEventView event={event} key={i} />
       ))}
     </div>
+  )
+}
+
+function SkillInvocationBadge({ invoked }: { invoked: boolean }) {
+  return (
+    <span
+      style={{
+        alignSelf: 'flex-start',
+        background: invoked ? 'var(--theme-success-100)' : 'var(--theme-elevation-100)',
+        border: `1px solid ${invoked ? 'var(--theme-success-300)' : 'var(--theme-elevation-200)'}`,
+        borderRadius: '4px',
+        color: invoked ? 'var(--theme-success-700)' : 'var(--theme-elevation-500)',
+        fontSize: '0.7rem',
+        fontWeight: 600,
+        padding: '2px 8px',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {invoked ? '✓ Skill invoked' : '✗ Skill not invoked'}
+    </span>
   )
 }
 

--- a/test/evals/runCodegenDataset.ts
+++ b/test/evals/runCodegenDataset.ts
@@ -97,6 +97,7 @@ export async function runCodegenCase(
   const { confidence, modifiedConfig, usage: runnerUsage } = runnerOutput
   const agentLog = runnerOutput.agentLog
   const agentExitCode = runnerOutput.agentExitCode
+  const transcript = runnerOutput.transcript
 
   const { errors: tscErrors, valid } = await validateConfigTypes(
     modifiedConfig,
@@ -121,6 +122,7 @@ export async function runCodegenCase(
       skillInstall: kind === 'claude-code' ? skillInstall : undefined,
       starterContent: starterConfig,
       systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+      transcript,
       tscErrors,
       usage: {
         runner: runnerUsage,
@@ -169,6 +171,7 @@ export async function runCodegenCase(
       skillInstall: kind === 'claude-code' ? skillInstall : undefined,
       starterContent: starterConfig,
       systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+      transcript,
       usage: {
         runner: runnerUsage,
         total: {
@@ -229,6 +232,7 @@ export async function runCodegenCase(
     skillInstall: kind === 'claude-code' ? skillInstall : undefined,
     starterContent: starterConfig,
     systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+    transcript,
     usage: {
       runner: runnerUsage,
       scorer: scorerUsage,

--- a/test/evals/runner/claudeCode.ts
+++ b/test/evals/runner/claudeCode.ts
@@ -169,6 +169,11 @@ async function spawnAgent({
     })
     child.on('exit', (code) => {
       clearTimeout(timer)
+      if (stdoutBuffer.length > 0) {
+        const events = parseStreamJsonLine(stdoutBuffer)
+        transcript.push(...events)
+        stdoutBuffer = ''
+      }
       finish({ exitCode: code ?? -1, stderr, transcript })
     })
   })

--- a/test/evals/runner/claudeCode.ts
+++ b/test/evals/runner/claudeCode.ts
@@ -15,7 +15,7 @@ const DEFAULT_TIMEOUT_MS = 600_000
 const PROMPT_SUFFIX =
   'IMPORTANT: Do not run package managers (npm, pnpm, yarn) or build/test/dev commands. Modify only payload.config.ts. Just write the file.'
 
-const SKILL_SYSTEM_PROMPT =
+export const SKILL_SYSTEM_PROMPT =
   'A `payload` skill is available in this workdir under .claude/skills/payload/. You MUST invoke it via the Skill tool before modifying payload.config.ts. The skill provides authoritative reference for collections, fields, hooks, access control, and other Payload CMS patterns.'
 
 const limit = pLimit(Number(process.env.EVAL_AGENT_CONCURRENCY ?? '2'))

--- a/test/evals/runner/claudeCode.ts
+++ b/test/evals/runner/claudeCode.ts
@@ -5,7 +5,7 @@ import os from 'node:os'
 import path from 'node:path'
 import pLimit from 'p-limit'
 
-import type { CodegenRunnerResult, TokenUsage } from '../types.js'
+import type { CodegenRunnerResult, TokenUsage, TranscriptEvent } from '../types.js'
 import type { CodegenRunner, CodegenRunnerOptions } from './types.js'
 
 import { cleanup, gitInit, installSkill, materialize, readEntry } from './workdir.js'
@@ -49,7 +49,7 @@ async function runOne(
     await installSkill({ mode: skillInstall, workdir })
 
     const prompt = `${instruction}\n\n${PROMPT_SUFFIX}`
-    const { exitCode, log } = await spawnAgent({
+    const { exitCode, stderr, transcript } = await spawnAgent({
       agentModel,
       prompt,
       sandboxDir: init.sandboxDir,
@@ -61,9 +61,10 @@ async function runOne(
 
     const result: CodegenRunnerResult = {
       agentExitCode: exitCode,
-      agentLog: truncate(log, 10_000),
+      agentLog: stderr.length > 0 ? truncate(stderr, 10_000) : undefined,
       confidence: 0,
       modifiedConfig,
+      transcript: capTranscript(transcript),
       usage: zeroUsage(),
     }
     return result
@@ -84,11 +85,20 @@ async function spawnAgent({
   sandboxDir: string
   timeoutMs: number
   workdir: string
-}): Promise<{ exitCode: number; log: string }> {
+}): Promise<{ exitCode: number; stderr: string; transcript: TranscriptEvent[] }> {
   return new Promise((resolve) => {
     const child = spawn(
       'claude',
-      ['--print', '--model', agentModel, '--dangerously-skip-permissions', prompt],
+      [
+        '--print',
+        '--output-format',
+        'stream-json',
+        '--verbose',
+        '--model',
+        agentModel,
+        '--dangerously-skip-permissions',
+        prompt,
+      ],
       {
         cwd: workdir,
         // detached so timeout can kill the whole process group via -pid;
@@ -98,15 +108,36 @@ async function spawnAgent({
         stdio: ['ignore', 'pipe', 'pipe'],
       },
     )
-    let log = ''
+    const transcript: TranscriptEvent[] = []
+    let stdoutBuffer = ''
+    let stderr = ''
     child.stdout.on('data', (b: Buffer) => {
-      log += b.toString()
+      stdoutBuffer += b.toString()
+      const newlineIdx = stdoutBuffer.lastIndexOf('\n')
+      if (newlineIdx === -1) {
+        return
+      }
+      const complete = stdoutBuffer.slice(0, newlineIdx)
+      stdoutBuffer = stdoutBuffer.slice(newlineIdx + 1)
+      for (const line of complete.split('\n')) {
+        if (line.trim().length === 0) {
+          continue
+        }
+        const events = parseStreamJsonLine(line)
+        for (const event of events) {
+          transcript.push(event)
+        }
+      }
     })
     child.stderr.on('data', (b: Buffer) => {
-      log += b.toString()
+      stderr += b.toString()
     })
     let resolved = false
-    const finish = (result: { exitCode: number; log: string }) => {
+    const finish = (result: {
+      exitCode: number
+      stderr: string
+      transcript: TranscriptEvent[]
+    }) => {
       if (resolved) {
         return
       }
@@ -121,24 +152,24 @@ async function spawnAgent({
           child.kill('SIGKILL')
         }
       } catch (groupKillErr) {
-        log += `\n[runner] process-group kill failed: ${(groupKillErr as Error).message}`
+        stderr += `\n[runner] process-group kill failed: ${(groupKillErr as Error).message}`
         try {
           child.kill('SIGKILL')
         } catch (childKillErr) {
-          log += `\n[runner] child.kill fallback also failed: ${(childKillErr as Error).message}`
+          stderr += `\n[runner] child.kill fallback also failed: ${(childKillErr as Error).message}`
         }
       }
-      log += `\n[runner] killed after ${timeoutMs}ms timeout`
-      finish({ exitCode: -1, log })
+      stderr += `\n[runner] killed after ${timeoutMs}ms timeout`
+      finish({ exitCode: -1, stderr, transcript })
     }, timeoutMs)
     child.on('error', (err) => {
       clearTimeout(timer)
-      log += `\n[runner] spawn error: ${err.message}`
-      finish({ exitCode: -1, log })
+      stderr += `\n[runner] spawn error: ${err.message}`
+      finish({ exitCode: -1, stderr, transcript })
     })
     child.on('exit', (code) => {
       clearTimeout(timer)
-      finish({ exitCode: code ?? -1, log })
+      finish({ exitCode: code ?? -1, stderr, transcript })
     })
   })
 }
@@ -260,4 +291,150 @@ function truncate(s: string, max: number): string {
 
 function zeroUsage(): TokenUsage {
   return { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+}
+
+const TEXT_TRUNCATE_LIMIT = 4_000
+const TRANSCRIPT_EVENT_CAP = 200
+
+function parseStreamJsonLine(line: string): TranscriptEvent[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(line)
+  } catch {
+    return []
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    return []
+  }
+  const event = parsed as { message?: unknown; type?: string }
+  if (event.type === 'assistant') {
+    return extractAssistantBlocks(event.message)
+  }
+  if (event.type === 'user') {
+    return extractUserBlocks(event.message)
+  }
+  return []
+}
+
+function extractAssistantBlocks(message: unknown): TranscriptEvent[] {
+  const content = getContentArray(message)
+  const events: TranscriptEvent[] = []
+  for (const raw of content) {
+    if (raw === null || typeof raw !== 'object') {
+      continue
+    }
+    const block = raw as {
+      id?: unknown
+      input?: unknown
+      name?: unknown
+      text?: unknown
+      thinking?: unknown
+      type?: unknown
+    }
+    if (block.type === 'text' && typeof block.text === 'string') {
+      events.push({ text: truncateText(block.text), type: 'text' })
+      continue
+    }
+    if (block.type === 'thinking' && typeof block.thinking === 'string') {
+      events.push({ text: truncateText(block.thinking), type: 'thinking' })
+      continue
+    }
+    if (
+      block.type === 'tool_use' &&
+      typeof block.id === 'string' &&
+      typeof block.name === 'string'
+    ) {
+      events.push({
+        id: block.id,
+        input: normalizeToolInput(block.input),
+        name: block.name,
+        type: 'tool_use',
+      })
+    }
+  }
+  return events
+}
+
+function extractUserBlocks(message: unknown): TranscriptEvent[] {
+  const content = getContentArray(message)
+  const events: TranscriptEvent[] = []
+  for (const raw of content) {
+    if (raw === null || typeof raw !== 'object') {
+      continue
+    }
+    const block = raw as {
+      content?: unknown
+      is_error?: unknown
+      tool_use_id?: unknown
+      type?: unknown
+    }
+    if (block.type !== 'tool_result' || typeof block.tool_use_id !== 'string') {
+      continue
+    }
+    events.push({
+      content: normalizeToolResultContent(block.content),
+      isError: block.is_error === true ? true : undefined,
+      toolUseId: block.tool_use_id,
+      type: 'tool_result',
+    })
+  }
+  return events
+}
+
+function getContentArray(message: unknown): unknown[] {
+  if (message === null || typeof message !== 'object') {
+    return []
+  }
+  const content = (message as { content?: unknown }).content
+  return Array.isArray(content) ? content : []
+}
+
+function normalizeToolInput(input: unknown): unknown {
+  if (input === undefined) {
+    return {}
+  }
+  const serialized = JSON.stringify(input)
+  if (typeof serialized === 'string' && serialized.length > TEXT_TRUNCATE_LIMIT) {
+    return { __truncated: true, preview: `${serialized.slice(0, TEXT_TRUNCATE_LIMIT)}…` }
+  }
+  return input
+}
+
+function normalizeToolResultContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return truncateText(content)
+  }
+  if (Array.isArray(content)) {
+    const joined = content
+      .map((part) => {
+        if (part !== null && typeof part === 'object') {
+          const text = (part as { text?: unknown }).text
+          if (typeof text === 'string') {
+            return text
+          }
+        }
+        return ''
+      })
+      .join('')
+    return truncateText(joined)
+  }
+  return ''
+}
+
+function truncateText(s: string): string {
+  return s.length <= TEXT_TRUNCATE_LIMIT ? s : `${s.slice(0, TEXT_TRUNCATE_LIMIT)}… [truncated]`
+}
+
+function capTranscript(events: TranscriptEvent[]): TranscriptEvent[] {
+  if (events.length <= TRANSCRIPT_EVENT_CAP) {
+    return events
+  }
+  const head = events.slice(0, 100)
+  const tail = events.slice(events.length - 100)
+  const omitted = events.length - 200
+  const marker: TranscriptEvent = {
+    text: `… [transcript truncated: ${omitted} events omitted]`,
+    type: 'text',
+  }
+  return [...head, marker, ...tail]
 }

--- a/test/evals/runner/claudeCode.ts
+++ b/test/evals/runner/claudeCode.ts
@@ -15,6 +15,9 @@ const DEFAULT_TIMEOUT_MS = 600_000
 const PROMPT_SUFFIX =
   'IMPORTANT: Do not run package managers (npm, pnpm, yarn) or build/test/dev commands. Modify only payload.config.ts. Just write the file.'
 
+const SKILL_SYSTEM_PROMPT =
+  'A `payload` skill is available in this workdir under .claude/skills/payload/. You MUST invoke it via the Skill tool before modifying payload.config.ts. The skill provides authoritative reference for collections, fields, hooks, access control, and other Payload CMS patterns.'
+
 const limit = pLimit(Number(process.env.EVAL_AGENT_CONCURRENCY ?? '2'))
 
 let initPromise: null | Promise<{ sandboxDir: string; version: string }> = null
@@ -49,8 +52,10 @@ async function runOne(
     await installSkill({ mode: skillInstall, workdir })
 
     const prompt = `${instruction}\n\n${PROMPT_SUFFIX}`
+    const appendSystemPrompt = skillInstall === 'embedded' ? SKILL_SYSTEM_PROMPT : undefined
     const { exitCode, stderr, transcript, usage } = await spawnAgent({
       agentModel,
+      appendSystemPrompt,
       prompt,
       sandboxDir: init.sandboxDir,
       timeoutMs,
@@ -75,12 +80,14 @@ async function runOne(
 
 async function spawnAgent({
   agentModel,
+  appendSystemPrompt,
   prompt,
   sandboxDir,
   timeoutMs,
   workdir,
 }: {
   agentModel: string
+  appendSystemPrompt?: string
   prompt: string
   sandboxDir: string
   timeoutMs: number
@@ -91,28 +98,28 @@ async function spawnAgent({
   transcript: TranscriptEvent[]
   usage?: TokenUsage
 }> {
+  const args = [
+    '--print',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--model',
+    agentModel,
+    '--dangerously-skip-permissions',
+  ]
+  if (appendSystemPrompt) {
+    args.push('--append-system-prompt', appendSystemPrompt)
+  }
+  args.push(prompt)
   return new Promise((resolve) => {
-    const child = spawn(
-      'claude',
-      [
-        '--print',
-        '--output-format',
-        'stream-json',
-        '--verbose',
-        '--model',
-        agentModel,
-        '--dangerously-skip-permissions',
-        prompt,
-      ],
-      {
-        cwd: workdir,
-        // detached so timeout can kill the whole process group via -pid;
-        // otherwise grandchild processes (agent's tool subprocesses) leak.
-        detached: true,
-        env: { ...process.env, CLAUDE_CONFIG_DIR: sandboxDir },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      },
-    )
+    const child = spawn('claude', args, {
+      cwd: workdir,
+      // detached so timeout can kill the whole process group via -pid;
+      // otherwise grandchild processes (agent's tool subprocesses) leak.
+      detached: true,
+      env: { ...process.env, CLAUDE_CONFIG_DIR: sandboxDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
     const transcript: TranscriptEvent[] = []
     let usage: TokenUsage | undefined
     let stdoutBuffer = ''

--- a/test/evals/runner/claudeCode.ts
+++ b/test/evals/runner/claudeCode.ts
@@ -49,7 +49,7 @@ async function runOne(
     await installSkill({ mode: skillInstall, workdir })
 
     const prompt = `${instruction}\n\n${PROMPT_SUFFIX}`
-    const { exitCode, stderr, transcript } = await spawnAgent({
+    const { exitCode, stderr, transcript, usage } = await spawnAgent({
       agentModel,
       prompt,
       sandboxDir: init.sandboxDir,
@@ -65,7 +65,7 @@ async function runOne(
       confidence: 0,
       modifiedConfig,
       transcript: capTranscript(transcript),
-      usage: zeroUsage(),
+      usage: usage ?? zeroUsage(),
     }
     return result
   } finally {
@@ -85,7 +85,12 @@ async function spawnAgent({
   sandboxDir: string
   timeoutMs: number
   workdir: string
-}): Promise<{ exitCode: number; stderr: string; transcript: TranscriptEvent[] }> {
+}): Promise<{
+  exitCode: number
+  stderr: string
+  transcript: TranscriptEvent[]
+  usage?: TokenUsage
+}> {
   return new Promise((resolve) => {
     const child = spawn(
       'claude',
@@ -109,8 +114,21 @@ async function spawnAgent({
       },
     )
     const transcript: TranscriptEvent[] = []
+    let usage: TokenUsage | undefined
     let stdoutBuffer = ''
     let stderr = ''
+    const ingestLine = (line: string) => {
+      if (line.trim().length === 0) {
+        return
+      }
+      const { events, usage: lineUsage } = parseStreamJsonLine(line)
+      for (const event of events) {
+        transcript.push(event)
+      }
+      if (lineUsage) {
+        usage = lineUsage
+      }
+    }
     child.stdout.on('data', (b: Buffer) => {
       stdoutBuffer += b.toString()
       const newlineIdx = stdoutBuffer.lastIndexOf('\n')
@@ -120,13 +138,7 @@ async function spawnAgent({
       const complete = stdoutBuffer.slice(0, newlineIdx)
       stdoutBuffer = stdoutBuffer.slice(newlineIdx + 1)
       for (const line of complete.split('\n')) {
-        if (line.trim().length === 0) {
-          continue
-        }
-        const events = parseStreamJsonLine(line)
-        for (const event of events) {
-          transcript.push(event)
-        }
+        ingestLine(line)
       }
     })
     child.stderr.on('data', (b: Buffer) => {
@@ -137,6 +149,7 @@ async function spawnAgent({
       exitCode: number
       stderr: string
       transcript: TranscriptEvent[]
+      usage?: TokenUsage
     }) => {
       if (resolved) {
         return
@@ -160,21 +173,20 @@ async function spawnAgent({
         }
       }
       stderr += `\n[runner] killed after ${timeoutMs}ms timeout`
-      finish({ exitCode: -1, stderr, transcript })
+      finish({ exitCode: -1, stderr, transcript, usage })
     }, timeoutMs)
     child.on('error', (err) => {
       clearTimeout(timer)
       stderr += `\n[runner] spawn error: ${err.message}`
-      finish({ exitCode: -1, stderr, transcript })
+      finish({ exitCode: -1, stderr, transcript, usage })
     })
     child.on('exit', (code) => {
       clearTimeout(timer)
       if (stdoutBuffer.length > 0) {
-        const events = parseStreamJsonLine(stdoutBuffer)
-        transcript.push(...events)
+        ingestLine(stdoutBuffer)
         stdoutBuffer = ''
       }
-      finish({ exitCode: code ?? -1, stderr, transcript })
+      finish({ exitCode: code ?? -1, stderr, transcript, usage })
     })
   })
 }
@@ -301,24 +313,54 @@ function zeroUsage(): TokenUsage {
 const TEXT_TRUNCATE_LIMIT = 4_000
 const TRANSCRIPT_EVENT_CAP = 200
 
-function parseStreamJsonLine(line: string): TranscriptEvent[] {
+type ParsedStreamLine = { events: TranscriptEvent[]; usage?: TokenUsage }
+
+function parseStreamJsonLine(line: string): ParsedStreamLine {
   let parsed: unknown
   try {
     parsed = JSON.parse(line)
   } catch {
-    return []
+    return { events: [] }
   }
   if (parsed === null || typeof parsed !== 'object') {
-    return []
+    return { events: [] }
   }
-  const event = parsed as { message?: unknown; type?: string }
+  const event = parsed as { message?: unknown; type?: string; usage?: unknown }
   if (event.type === 'assistant') {
-    return extractAssistantBlocks(event.message)
+    return { events: extractAssistantBlocks(event.message) }
   }
   if (event.type === 'user') {
-    return extractUserBlocks(event.message)
+    return { events: extractUserBlocks(event.message) }
   }
-  return []
+  if (event.type === 'result') {
+    return { events: [], usage: extractResultUsage(event.usage) }
+  }
+  return { events: [] }
+}
+
+function extractResultUsage(raw: unknown): TokenUsage | undefined {
+  if (raw === null || typeof raw !== 'object') {
+    return undefined
+  }
+  const u = raw as {
+    cache_creation_input_tokens?: unknown
+    cache_read_input_tokens?: unknown
+    input_tokens?: unknown
+    output_tokens?: unknown
+  }
+  const inputTokens = asNumber(u.input_tokens) + asNumber(u.cache_creation_input_tokens)
+  const cachedInputTokens = asNumber(u.cache_read_input_tokens)
+  const outputTokens = asNumber(u.output_tokens)
+  return {
+    cachedInputTokens,
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + cachedInputTokens + outputTokens,
+  }
+}
+
+function asNumber(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
 }
 
 function extractAssistantBlocks(message: unknown): TranscriptEvent[] {

--- a/test/evals/types.ts
+++ b/test/evals/types.ts
@@ -51,13 +51,20 @@ export type EvalUsage = {
 
 // Runner
 export type SystemPromptKey = 'codegenNoSkill' | 'codegenWithSkill'
+export type TranscriptEvent =
+  | { content: string; isError?: boolean; toolUseId: string; type: 'tool_result' }
+  | { id: string; input: unknown; name: string; type: 'tool_use' }
+  | { text: string; type: 'text' }
+  | { text: string; type: 'thinking' }
 export type CodegenRunnerResult = {
   /** For agent results: process exit code. */
   agentExitCode?: number
-  /** For agent results: captured stdout+stderr from the CLI, truncated to ~10,000 characters. */
+  /** For agent results: captured stderr from the CLI (fallback when stream-json parsing yields no events), truncated to ~10,000 characters. */
   agentLog?: string
   confidence: number
   modifiedConfig: string
+  /** For agent results: structured per-event transcript parsed from stream-json output. */
+  transcript?: TranscriptEvent[]
   usage: TokenUsage
 }
 // Scorer
@@ -112,6 +119,8 @@ export type EvalResult = {
   starterContent?: string
   /** Which system prompt variant was used — enables skill vs. baseline comparison in the dashboard */
   systemPromptKey?: SystemPromptKey
+  /** For agent results: structured per-event transcript parsed from stream-json output. */
+  transcript?: TranscriptEvent[]
   /** Populated when TypeScript compilation fails */
   tscErrors?: string[]
   /** Token usage across all LLM calls for this eval case */


### PR DESCRIPTION
# Overview

Improves the evals dashboard and the Claude Code agent runner so we can see, at a glance, whether a run actually exercised the Payload skill, what the agent did, and how much that run cost.

<img width="1270" height="1214" alt="CleanShot 2026-05-14 at 15 39 33@2x" src="https://github.com/user-attachments/assets/e16ac2f1-69fe-44d5-b9c2-d28807b58605" />


## Key Changes

- **Dashboard filter cleanup**
  - Removed the legacy `all / users / admins / maintainers` audience filter row from the results table (audience UI remains in the Compare view).
  - Added a Variant filter strip driven by the shared `getVariant(result)` classifier, with buttons derived from the variants present in the loaded entries (Agent Baseline, Agent Skill, Baseline, Skill).

- **Structured Claude Code transcripts**
  - Runner now invokes `claude --print --output-format stream-json --verbose` and parses the NDJSON event stream.
  - Persists a typed `TranscriptEvent[]` on `CodegenRunnerResult` and `EvalResult` covering text, thinking, tool_use, and tool_result blocks.
  - Per-event content truncated to ~4k chars; total events capped at 200 (first 100 + last 100 + marker) to bound cache size.
  - Token usage is extracted from the stream-json `result` event and populated on the runner result (no more zeros for agent runs).
  - Stderr is captured separately and surfaces in `agentLog` only when non-empty, preserving timeout and spawn-error diagnostics.

- **Transcript UI in the expanded row**
  - New `TranscriptView` renders the event timeline with collapsible blocks for tool_use, tool_result, and thinking.
  - Tool result errors render in red; tool calls show as `→ name`, results as `← result`.
  - The Transcript section opens by default, as do its inner blocks.
  - Falls back to the existing plaintext `<pre>` when only `agentLog` is available (legacy cache entries).

- **Skill invocation visibility**
  - A badge at the top of each transcript indicates whether the agent invoked the `Skill` tool (green when invoked, red when not), using v4 design tokens so it renders in both themes.
  - Agent runner appends a system prompt directing the agent to invoke the `payload` skill, gated on `skillInstall === 'embedded'` so the `agent-baseline` lane stays untouched.
  - That directive is part of the codegen cache key, so future tweaks to it auto-invalidate cached agent-skill results.

## Design Decisions

**Plaintext first, structured second.** The first pass at transcripts kept the existing `agentLog` plaintext and rendered it in a `<pre>`. That only showed the final assistant message because `--print` strips tool calls. We then upgraded to stream-json with a typed event union, but kept `agentLog` on the type as an optional fallback so older cache entries still render and stderr has somewhere to go.

**Shared variant classifier.** The dashboard's per-row Variant value uses the `getVariant(result)` helper from `test/evals/variant.ts` rather than re-inferring from `systemPromptKey`/`modelId` in the table. The Variant filter buttons derive their option set from `entries`, so new variants appear without further changes.

**System-prompt nudge over skill description change.** The `payload` skill description was permissive ("Use when working with Payload CMS projects"), so the agent often skipped it. Rather than rewrite the skill description (which would affect production users), the runner appends a `--append-system-prompt` directive on the agent-skill lane only. This preserves a clean A/B with `agent-baseline`.

**Cache invariance.** The cache key already factored `skillInstall` and `skillHash`. The new directive is included as well so any future copy change forces a fresh run.

**Audience stripped from list view only.** `EvalEntry.audience` and `audience.ts` remain because `CompareTable` still uses them. Scope was kept to the dashboard list as requested.

## Overall Flow

```mermaid
sequenceDiagram
    participant Test as vitest eval case
    participant Runner as runCodegenEval
    participant Claude as claude CLI
    participant Cache as cache.ts
    participant UI as EvalDashboard

    Test->>Runner: run(instruction, fixture, opts)
    Runner->>Cache: codegenKey({ ..., agentSystemPrompt })
    Cache-->>Runner: cached EvalResult?
    alt cache hit
        Runner-->>Test: cached result
    else cache miss (agent-skill)
        Runner->>Claude: --output-format stream-json --append-system-prompt
        Claude-->>Runner: NDJSON (system, assistant, user, result)
        Runner->>Runner: parse to TranscriptEvent[] and usage
        Runner->>Cache: persist EvalResult with transcript, usage, agentLog?
        Runner-->>Test: result
    end
    UI->>UI: read cache, flatten to EvalEntry[]
    UI->>UI: filter by Variant button
    UI->>UI: ExpandedRow renders TranscriptView and SkillInvocationBadge
```
