### PR TITLE
chore!: remove sha1 algorithm check from auth strategies

### DIFF
--- a/packages/payload/src/auth/strategies/apiKey.ts
+++ b/packages/payload/src/auth/strategies/apiKey.ts
@@ -13,33 +13,19 @@ export const APIKeyAuthentication =
     if (authHeader?.startsWith(`${collectionConfig.slug} API-Key `)) {
       const apiKey = authHeader.replace(`${collectionConfig.slug} API-Key `, '')
 
-      // TODO: V4 remove extra algorithm check
-      // api keys saved prior to v3.46.0 will have sha1
-      const sha1APIKeyIndex = crypto.createHmac('sha1', payload.secret).update(apiKey).digest('hex')
       const sha256APIKeyIndex = crypto
         .createHmac('sha256', payload.secret)
         .update(apiKey)
         .digest('hex')
-
-      const apiKeyConstraints = [
-        {
-          apiKeyIndex: {
-            equals: sha1APIKeyIndex,
-          },
-        },
-        {
-          apiKeyIndex: {
-            equals: sha256APIKeyIndex,
-          },
-        },
-      ]
 
       try {
         const where: Where = {}
         if (collectionConfig.auth?.verify) {
           where.and = [
             {
-              or: apiKeyConstraints,
+              apiKeyIndex: {
+                equals: sha256APIKeyIndex,
+              },
             },
             {
               _verified: {
@@ -48,7 +34,7 @@ export const APIKeyAuthentication =
             },
           ]
         } else {
-          where.or = apiKeyConstraints
+          where.apiKeyIndex = { equals: sha256APIKeyIndex }
         }
 
         const userQuery = await payload.find({


### PR DESCRIPTION
## Summary

- Removes the sha1 HMAC fallback from API key authentication introduced in v3.46.0
- API keys are now matched exclusively against the sha256 index
- Simplifies the where clause: the non-verify path uses a direct field constraint instead of an `or` array; the verify path uses a single `and` condition instead of nested `or`

## Breaking change

Any API keys hashed with sha1 (created before v3.46.0 and never re-saved) will no longer authenticate. Users must regenerate their API key to receive a sha256 index.
