### PR TITLE
fix(ui): use page background color for primary button popup separator

### DIFF
--- a/packages/ui/src/elements/Button/index.css
+++ b/packages/ui/src/elements/Button/index.css
@@ -284,7 +284,7 @@
   }
 
   .btn--withPopup.btn--style-primary {
-    --separator-color: var(--color-border-brand-strong);
+    --separator-color: var(--color-bg);
     .btn,
     .popup-button {
       color: var(--color-text-onbrand);


### PR DESCRIPTION
## Summary

Changes the separator color between the primary button and its popup dropdown from `--color-border-brand-strong` (blue) to `--color-bg` (page background), creating a subtle visual gap that blends with the surrounding UI.

### Before
<img width="139" height="44" alt="Screenshot 2026-05-15 at 12 12 57 PM" src="https://github.com/user-attachments/assets/524d240f-22f9-4105-9f48-3b6de35e6bd0" />

<img width="143" height="40" alt="Screenshot 2026-05-15 at 12 12 44 PM" src="https://github.com/user-attachments/assets/98d34d1e-2bb4-426c-b449-b64a8bfc2ee5" />


### After
<img width="145" height="42" alt="Screenshot 2026-05-15 at 12 13 06 PM" src="https://github.com/user-attachments/assets/e9007a65-5d8b-458a-beef-97685be48072" />

<img width="143" height="41" alt="Screenshot 2026-05-15 at 12 13 20 PM" src="https://github.com/user-attachments/assets/bc54d125-eeb7-41c5-a12b-1331e94a98e5" />
