### PR TITLE
chore: type change to auth.disableLocalStrategy allowing false

### DIFF
--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -237,7 +237,7 @@ export interface IncomingAuthType {
         enableFields?: true
         optionalPassword?: true
       }
-    | true
+    | boolean
   /**
    * Customize the way that the forgotPassword operation functions.
    * @link https://payloadcms.com/docs/authentication/email#forgot-password


### PR DESCRIPTION
Changes the type for `auth.disableLocalStrategy` to allow `false` to be passed by the config without a type error. This is needed in cases where a project might want to allow the local auth strategy to be enabled which is normally the default, even if a plugin is being used that would override this property if it wasn't being set.