### PR TITLE
fix(ui): correct field error tooltip position calculation

### DIFF
--- a/packages/ui/src/elements/Tooltip/index.css
+++ b/packages/ui/src/elements/Tooltip/index.css
@@ -4,6 +4,7 @@
     --caret-height: 7px;
     --caret-offset: 4px;
     --caret-border-color: var(--color-border);
+    --tooltip-x: -50%;
 
     opacity: 0;
     background-color: var(--color-bg-tooltip);
@@ -86,7 +87,7 @@
 
   .tooltip--position-top {
     top: 0;
-    transform: translate3d(-50%, calc(-100% - var(--caret-height) - var(--caret-offset) + 1px), 0);
+    transform: translate3d(var(--tooltip-x), calc(-100% - var(--caret-height) - var(--caret-offset) + 1px), 0);
 
     .tooltip__caret {
       --color-border: var(--ramp-grey-700);

--- a/packages/ui/src/fields/FieldError/index.css
+++ b/packages/ui/src/fields/FieldError/index.css
@@ -1,9 +1,9 @@
 @layer payload-default {
   .field-error.tooltip {
+    --tooltip-x: 0%;
     left: auto;
     max-width: 75%;
     right: 0;
-    transform: translate3d(0%, calc(-100% - var(--caret-height) - var(--caret-offset) + 1px), 0);
     color: var(--color-text-ondanger);
     background-color: var(--color-bg-danger);
 

--- a/packages/ui/src/fields/FieldError/index.css
+++ b/packages/ui/src/fields/FieldError/index.css
@@ -3,7 +3,7 @@
     left: auto;
     max-width: 75%;
     right: 0;
-    transform: translate3d(0%, calc(-1 * (100% + var(--caret-size))), 0);
+    transform: translate3d(0%, calc(-100% - var(--caret-height) - var(--caret-offset) + 1px), 0);
     color: var(--color-text-ondanger);
     background-color: var(--color-bg-danger);
 


### PR DESCRIPTION
Fixes the tooltip positioning in the FieldError component by using the correct CSS variables.

### What?
Updated the tooltip transform calculation to use `--caret-height` and `--caret-offset` instead of the incorrect `--caret-size` variable.

### Why?
The tooltip was incorrectly positioned because `--caret-size` doesn't account for the actual caret dimensions used by the tooltip system.

### How?
Added a `--tooltip-x` CSS custom property to the base Tooltip component, allowing consumers to override just the X-axis translation. FieldError now simply sets `--tooltip-x: 0%` instead of duplicating the entire transform calculation.

### Before
<img width="1210" height="860" alt="Screenshot 2026-05-15 at 4 20 05 PM" src="https://github.com/user-attachments/assets/3b9100e6-73b4-454a-a8c5-618622854713" />

### After
<img width="1115" height="768" alt="Screenshot 2026-05-15 at 4 29 54 PM" src="https://github.com/user-attachments/assets/7820b708-9035-494d-8c3f-69b3d79ea4f5" />