### PR TITLE
fix: preserve published main document when saving draft

### DIFF
--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -110,9 +110,7 @@ export const updateDocument = async <
       ? unpublishAllLocalesArg === 'true'
       : !!unpublishAllLocalesArg
   const isSavingDraft =
-    Boolean(draftArg && hasDraftsEnabled(collectionConfig)) &&
-    data._status !== 'published' &&
-    !publishAllLocales
+    Boolean(draftArg && hasDraftsEnabled(collectionConfig)) && !publishAllLocales
   const shouldSavePassword = Boolean(
     password &&
       collectionConfig.auth &&
@@ -124,6 +122,13 @@ export const updateDocument = async <
 
   if (isSavingDraft) {
     data._status = 'draft'
+
+    if (!req.context) {
+      req.context = {}
+    }
+
+    // Used by storage plugins to persist adapter metadata without updating the published document
+    req.context.internalSavingDraft = true
   }
 
   // /////////////////////////////////////

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -113,10 +113,7 @@ export const updateOperation = async <
       typeof unpublishAllLocalesArg === 'string'
         ? unpublishAllLocalesArg === 'true'
         : !!unpublishAllLocalesArg
-    const isSavingDraft =
-      Boolean(draftArg && hasDraftsEnabled(globalConfig)) &&
-      data._status !== 'published' &&
-      !publishAllLocales
+    const isSavingDraft = Boolean(draftArg && hasDraftsEnabled(globalConfig)) && !publishAllLocales
 
     if (isSavingDraft) {
       data._status = 'draft'

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -2571,6 +2571,46 @@ describe('Versions', () => {
       expect(jsonByID.parent).toBe(autosavePost.id)
     })
 
+    it('should preserve published main document when saving a draft with _status published', async () => {
+      const initialDoc = await payload.create({
+        collection: draftCollectionSlug,
+        data: {
+          title: 'Published title',
+          description: 'Published description',
+          _status: 'published',
+        },
+      })
+
+      await payload.update({
+        id: initialDoc.id,
+        collection: draftCollectionSlug,
+        data: {
+          title: 'Draft title',
+          _status: 'published',
+        },
+        draft: true,
+      })
+
+      const mainDoc = await payload.findByID({
+        collection: draftCollectionSlug,
+        id: initialDoc.id,
+      })
+
+      expect(mainDoc.title).toBe('Published title')
+      expect(mainDoc._status).toBe('published')
+
+      const versions = await payload.findVersions({
+        collection: draftCollectionSlug,
+        where: {
+          parent: {
+            equals: initialDoc.id,
+          },
+        },
+      })
+
+      expect(versions.docs.some((doc) => doc.version.title === 'Draft title')).toBe(true)
+    })
+
     it('should allow query by latest', async () => {
       async function createVersion({ title }: { title: string }) {
         return payload.create({


### PR DESCRIPTION
fixes https://github.com/payloadcms/payload/issues/16633

fix: draft save no longer mutates published document when _status: 'published' is present

What?
Fixes draft save behavior so draft: true always creates or updates a draft version without mutating the existing published document, even when the incoming data includes _status: 'published'.

Why?
Previously, the draft-save path checked data._status !== 'published' to determine whether to treat an update as a draft. This meant that when the UI re-sent _status: 'published' alongside a draft save request, the published main record could be incorrectly mutated — or even flipped into draft state.

How?
Draft detection now relies solely on draft: true + hasDraftsEnabled(...), with no dependency on data._status.

Updated draft detection in collection update (packages/.../update.ts)
Updated draft detection in global update (packages/.../update.ts)
Added regression test coverage (int.spec.ts)

Fixes #