### PR TITLE
fix: skip empty object write for untouched localized fields in mergeLocalizedData

### DIFF
--- a/packages/payload/src/utilities/mergeLocalizedData.spec.ts
+++ b/packages/payload/src/utilities/mergeLocalizedData.spec.ts
@@ -95,6 +95,52 @@ describe('mergeLocalizedData', () => {
 
       expect(updatedData.title).toBe('Updated Title')
     })
+
+    it('should not write an empty object when localized field has no value in any locale', () => {
+      const fields: Field[] = [
+        {
+          name: 'subtitle',
+          type: 'text',
+          localized: true,
+        },
+      ]
+
+      const result = mergeLocalizedData({
+        configBlockReferences: [],
+        dataWithLocales: {
+          subtitle: undefined,
+        },
+        docWithLocales: {},
+        fields,
+        selectedLocales,
+      })
+
+      expect('subtitle' in result).toBe(false)
+    })
+
+    it('should preserve existing locale data on a localized field when new value is undefined', () => {
+      const fields: Field[] = [
+        {
+          name: 'subtitle',
+          type: 'text',
+          localized: true,
+        },
+      ]
+
+      const result = mergeLocalizedData({
+        configBlockReferences: [],
+        dataWithLocales: {
+          subtitle: undefined,
+        },
+        docWithLocales: {
+          subtitle: { es: 'Spanish Subtitle' },
+        },
+        fields,
+        selectedLocales,
+      })
+
+      expect(result.subtitle).toEqual({ es: 'Spanish Subtitle' })
+    })
   })
 
   describe('groups', () => {

--- a/packages/payload/src/utilities/mergeLocalizedData.ts
+++ b/packages/payload/src/utilities/mergeLocalizedData.ts
@@ -224,11 +224,15 @@ export function mergeLocalizedData({
           if (fieldIsLocalized) {
             if (field.name in dataWithLocales) {
               const newValue = dataWithLocales[field.name]
-              const existingValue = docWithLocales[field.name] || {}
+              const existingValue = docWithLocales[field.name]
+              const existingValueObject =
+                existingValue && typeof existingValue === 'object' && !Array.isArray(existingValue)
+                  ? (existingValue as Record<string, unknown>)
+                  : undefined
 
               // If localized, handle locale keys
               if (newValue && typeof newValue === 'object' && !Array.isArray(newValue)) {
-                const merged: Record<string, unknown> = { ...existingValue }
+                const merged: Record<string, unknown> = { ...(existingValueObject || {}) }
 
                 for (const locale of selectedLocales) {
                   if (locale in newValue) {
@@ -240,10 +244,12 @@ export function mergeLocalizedData({
               } else if (parentIsLocalized) {
                 // Child of localized parent - replace with new value
                 result[field.name] = newValue
-              } else {
-                // Preserve existing value if new value is not a valid object
-                result[field.name] = existingValue
+              } else if (existingValueObject) {
+                // Preserve existing locale data when new value is not a valid object
+                result[field.name] = existingValueObject
               }
+              // If newValue is not an object and there is no existing locale data,
+              // leave the field absent rather than writing an empty object.
             }
           } else if (parentIsLocalized) {
             result[field.name] = dataWithLocales[field.name]


### PR DESCRIPTION
### What?

Stop `mergeLocalizedData` from writing `{}` for a localized field that has no value in any locale and no incoming value.

In `packages/payload/src/utilities/mergeLocalizedData.ts`, the `default` case of the localized branch:

- Reads `existingValue` from the doc and only treats it as locale data when it is a plain object (not arrays, not nullish, not other primitives).
- Drops the previous `else` that unconditionally assigned `existingValue` (which had been defaulted to `{}`). The preservation path now only runs when there is real existing locale data.
- When `newValue` is not a valid object and there is no existing locale data, the field is left absent on the result instead of being written as `{}`.

Two unit tests added under the existing `simple fields` group:

- `should not write an empty object when localized field has no value in any locale`
- `should preserve existing locale data on a localized field when new value is undefined`

### Why?

Fixes #16296.

When `publishSpecificLocale` is used on a document where a localized field has never been written in any locale, the merge path took `docWithLocales[field.name] || {}` and then fell through to `result[field.name] = existingValue`. That wrote `{}` to the DB for the untouched field, so a later read with `locale: 'all'` returned `subtitle: {}` instead of the field being absent.

The repro from the issue exercises this through `_community` integration tests; the unit-level behavior is the same and is now covered directly in `mergeLocalizedData.spec.ts`.

### How?

Scope is limited to the `default` case of the localized branch in `mergeLocalizedData`. Behavior in the other branches (arrays, blocks, groups, tabs) is unchanged.

Walk-through of cases in the modified branch:

- Incoming locale object on a previously-empty field: still merges into a fresh `{}` and writes the new locales — unchanged.
- Incoming locale object on a field that already has other locales: still merges over the existing locales — unchanged.
- No incoming value, existing locales present: still preserved.
- No incoming value, no existing locales: **previously wrote `{}`, now leaves the field absent.**
- Child of a localized parent: still replaces with the new value — unchanged.

No other call sites needed to change. `mergeLocalizedData` always returns a plain object whose `field.name` may or may not be present; callers already handle the absent case the same way they would have handled `undefined`.