### PR TITLE
fix: await CLI startup in bin entrypoint

### DIFF
--- a/packages/payload/bin.js
+++ b/packages/payload/bin.js
@@ -15,7 +15,7 @@ if (disableTranspile) {
     await bin()
   }
 
-  void start()
+  await start()
 } else {
   const filename = fileURLToPath(import.meta.url)
   const dirname = path.dirname(filename)
@@ -30,7 +30,7 @@ if (disableTranspile) {
       await bin()
     }
 
-    void start()
+    await start()
   } else if (useSwc) {
     const { register } = await import('node:module')
     // Remove --use-swc from arguments
@@ -49,6 +49,6 @@ if (disableTranspile) {
       await bin()
     }
 
-    void start()
+    await start()
   }
 }


### PR DESCRIPTION
### What?

Replaces the three `void start()` calls in `packages/payload/bin.js` with `await start()`.

### Why?

The executable entrypoint starts async CLI work without awaiting it. Awaiting startup ties process lifecycle and failures to the CLI startup promise instead of fire-and-forget execution.

### How?

Uses top-level await in the existing ESM entrypoint. No startup branches or CLI behavior were otherwise changed.

Validation:
- `node --check packages/payload/bin.js`
- `git diff --check -- packages/payload/bin.js`
- `node packages/payload/bin.js info`

Fixes #
