### PR TITLE
docs: clarify fork edit permissions for prs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,12 @@ If you are committing to [templates](./templates) or [examples](./examples), use
 - `chore(templates): adds feature to template`
 - `chore(examples): fixes bug in example`
 
+### Allow edits from maintainers
+
+When opening a PR from a fork, please leave **"Allow edits and access to secrets by maintainers"** enabled on the pull request (it is on by default in the GitHub UI). This lets the Payload team push small fixes — rebases, lint/format cleanup, minor adjustments — directly to your branch so the PR can land without an extra round trip.
+
+If that permission is disabled and we need to push changes to move the PR forward, we may close your PR and re-open an equivalent branch directly in the Payload repository so the team can iterate on it. Your authorship and commit history will be preserved on the new branch.
+
 ## Previewing docs
 
 This is how you can preview changes you made locally to the docs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ If you are committing to [templates](./templates) or [examples](./examples), use
 
 When opening a PR from a fork, please leave **"Allow edits and access to secrets by maintainers"** enabled on the pull request (it is on by default in the GitHub UI). This lets the Payload team push small fixes — rebases, lint/format cleanup, minor adjustments — directly to your branch so the PR can land without an extra round trip.
 
-If that permission is disabled and we need to push changes to move the PR forward, we may close your PR and re-open an equivalent branch directly in the Payload repository so the team can iterate on it. Your authorship and commit history will be preserved on the new branch.
+If that permission is disabled and we need to push changes to move the PR forward, we may close your PR and re-open an equivalent branch directly in the Payload repository so the team can iterate on it.
 
 ## Previewing docs
 


### PR DESCRIPTION
Adds new section to the CONTRIBUTING.md file, specifically addressing permissions for maintainers editing pull requests from forks.

Clarifies that forks should keep "Allow edits and access to secrets by maintainers" enabled so the Payload team can push small fixes — rebases, lint/format cleanup, minor adjustments — directly to the PR branch without an extra round trip.

If that permission is disabled and changes are needed to move the PR forward, the team may close the PR and re-open an equivalent branch directly in the Payload repository so iteration can continue.