### PR TITLE
fix(ui): use _h_ prefix for tags related document queries

### DIFF
--- a/packages/ui/src/views/HierarchyList/HierarchyTable/index.tsx
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/index.tsx
@@ -221,8 +221,8 @@ export function HierarchyTable({
       }))
 
       try {
-        // Field name is always _t_{hierarchySlug} by convention
-        const fieldName = `_t_${collectionSlug}`
+        // Field name is always _h_{hierarchySlug} by convention (created by createTagField)
+        const fieldName = `_h_${collectionSlug}`
 
         // "in" operator works for both hasMany and single relationship fields
         const relationshipCondition = { [fieldName]: { in: [parentId] } }


### PR DESCRIPTION
## What

Fixes the HierarchyTable component using the wrong field prefix when querying related documents.

## Why

The `HierarchyTable` was using `_t_` prefix when building queries for related documents, but `createTagField` creates fields with `_h_` prefix. This caused a `QueryError: The following path cannot be queried: _t_tags` when browsing tags in the admin panel.

## How

Changed the field name template from `_t_${collectionSlug}` to `_h_${collectionSlug}` to match the actual field names created by `createTagField`.