### PR TITLE
fix(db-mongodb): bump mongoose to 8.22.1 for GHSA-wpg9-53fq-2r8h

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "husky": "9.0.11",
     "lint-staged": "15.2.7",
     "minimist": "1.2.8",
-    "mongoose": "8.15.1",
+    "mongoose": "8.22.1",
     "next": "16.2.6",
     "node-gyp": "12.3.0",
     "open": "^10.1.0",

--- a/packages/db-mongodb/package.json
+++ b/packages/db-mongodb/package.json
@@ -52,7 +52,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "mongoose": "8.15.1",
+    "mongoose": "8.22.1",
     "mongoose-paginate-v2": "1.9.4",
     "prompts": "2.4.2",
     "uuid": "14.0.0"

--- a/packages/db-mongodb/package.json
+++ b/packages/db-mongodb/package.json
@@ -61,7 +61,7 @@
     "@payloadcms/eslint-config": "workspace:*",
     "@types/mongoose-aggregate-paginate-v2": "1.0.12",
     "@types/prompts": "^2.4.5",
-    "mongodb": "6.16.0",
+    "mongodb": "6.20.0",
     "mongodb-memory-server": "10.1.4",
     "payload": "workspace:*"
   },

--- a/packages/db-mongodb/src/deleteOne.ts
+++ b/packages/db-mongodb/src/deleteOne.ts
@@ -1,3 +1,4 @@
+import type { QueryOptions } from 'mongoose'
 import type { DeleteOne } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -28,7 +29,7 @@ export const deleteOne: DeleteOne = async function deleteOne(
       select,
     }),
     session: await getSession(this, req),
-  }
+  } satisfies QueryOptions
 
   if (returning === false) {
     await Model.deleteOne(query, options)?.lean()

--- a/packages/db-mongodb/src/deleteOne.ts
+++ b/packages/db-mongodb/src/deleteOne.ts
@@ -1,4 +1,3 @@
-import type { MongooseUpdateQueryOptions } from 'mongoose'
 import type { DeleteOne } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -22,7 +21,7 @@ export const deleteOne: DeleteOne = async function deleteOne(
     where,
   })
 
-  const options: MongooseUpdateQueryOptions = {
+  const options = {
     projection: buildProjectionFromSelect({
       adapter: this,
       fields: collectionConfig.flattenedFields,

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -25,7 +25,7 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
     timestamps: false,
   } satisfies QueryOptions
 
-  const findOptions = {
+  const findOptions: QueryOptions = {
     ...baseOptions,
     lean: true,
     new: true,
@@ -34,7 +34,7 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
       fields: globalConfig.flattenedFields,
       select,
     }),
-  } satisfies QueryOptions
+  }
 
   if (returning === false) {
     await Model.updateOne({ globalType: globalSlug }, data, baseOptions)

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -1,3 +1,4 @@
+import type { QueryOptions } from 'mongoose'
 import type { UpdateGlobal } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -28,7 +29,7 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform
     timestamps: false,
-  }
+  } satisfies QueryOptions
 
   if (returning === false) {
     await Model.updateOne({ globalType: globalSlug }, data, options)

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -1,4 +1,3 @@
-import type { MongooseUpdateQueryOptions } from 'mongoose'
 import type { UpdateGlobal } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -18,7 +17,7 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
 
   transform({ adapter: this, data, fields, globalSlug, operation: 'write' })
 
-  const options: MongooseUpdateQueryOptions = {
+  const options = {
     ...optionsArgs,
     new: true,
     projection: buildProjectionFromSelect({

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -18,25 +18,30 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
 
   transform({ adapter: this, data, fields, globalSlug, operation: 'write' })
 
-  const options = {
+  const baseOptions = {
     ...optionsArgs,
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
+  } satisfies QueryOptions
+
+  const findOptions = {
+    ...baseOptions,
+    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,
       fields: globalConfig.flattenedFields,
       select,
     }),
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
   } satisfies QueryOptions
 
   if (returning === false) {
-    await Model.updateOne({ globalType: globalSlug }, data, options)
+    await Model.updateOne({ globalType: globalSlug }, data, baseOptions)
     return null
   }
 
-  const result: any = await Model.findOneAndUpdate({ globalType: globalSlug }, data, options)
+  const result: any = await Model.findOneAndUpdate({ globalType: globalSlug }, data, findOptions)
 
   transform({ adapter: this, data: result, fields, globalSlug, operation: 'read' })
 

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -20,7 +20,6 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
 
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
-    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -1,3 +1,4 @@
+import type { QueryOptions } from 'mongoose'
 import type { JsonObject, UpdateGlobalVersionArgs } from 'payload'
 
 import { buildVersionGlobalFields } from 'payload'
@@ -50,7 +51,7 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform
     timestamps: false,
-  }
+  } satisfies QueryOptions
 
   if (returning === false) {
     await Model.updateOne(query, versionData, options)

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -47,7 +47,7 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
     timestamps: false,
   } satisfies QueryOptions
 
-  const findOptions = {
+  const findOptions: QueryOptions = {
     ...baseOptions,
     lean: true,
     new: true,
@@ -56,7 +56,7 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
       fields: flattenedFields,
       select,
     }),
-  } satisfies QueryOptions
+  }
 
   if (returning === false) {
     await Model.updateOne(query, versionData, baseOptions)

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -40,25 +40,30 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
 
   transform({ adapter: this, data: versionData, fields, operation: 'write' })
 
-  const options = {
+  const baseOptions = {
     ...optionsArgs,
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
+  } satisfies QueryOptions
+
+  const findOptions = {
+    ...baseOptions,
+    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,
       fields: flattenedFields,
       select,
     }),
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
   } satisfies QueryOptions
 
   if (returning === false) {
-    await Model.updateOne(query, versionData, options)
+    await Model.updateOne(query, versionData, baseOptions)
     return null
   }
 
-  const doc = await Model.findOneAndUpdate(query, versionData, options)
+  const doc = await Model.findOneAndUpdate(query, versionData, findOptions)
 
   if (!doc) {
     return null

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -1,4 +1,3 @@
-import type { MongooseUpdateQueryOptions } from 'mongoose'
 import type { JsonObject, UpdateGlobalVersionArgs } from 'payload'
 
 import { buildVersionGlobalFields } from 'payload'
@@ -40,7 +39,7 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
 
   transform({ adapter: this, data: versionData, fields, operation: 'write' })
 
-  const options: MongooseUpdateQueryOptions = {
+  const options = {
     ...optionsArgs,
     new: true,
     projection: buildProjectionFromSelect({

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -42,7 +42,6 @@ export async function updateGlobalVersion<T extends JsonObject = JsonObject>(
 
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
-    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,

--- a/packages/db-mongodb/src/updateJobs.ts
+++ b/packages/db-mongodb/src/updateJobs.ts
@@ -1,4 +1,4 @@
-import type { UpdateQuery } from 'mongoose'
+import type { QueryOptions, UpdateQuery } from 'mongoose'
 import type { Job, UpdateJobs, Where } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -85,7 +85,7 @@ export const updateJobs: UpdateJobs = async function updateMany(
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform
     timestamps: false,
-  }
+  } satisfies QueryOptions
 
   let result: Job[] = []
 

--- a/packages/db-mongodb/src/updateJobs.ts
+++ b/packages/db-mongodb/src/updateJobs.ts
@@ -1,4 +1,4 @@
-import type { MongooseUpdateQueryOptions, UpdateQuery } from 'mongoose'
+import type { UpdateQuery } from 'mongoose'
 import type { Job, UpdateJobs, Where } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -80,7 +80,7 @@ export const updateJobs: UpdateJobs = async function updateMany(
     updateData = updateOps
   }
 
-  const options: MongooseUpdateQueryOptions = {
+  const options = {
     new: true,
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform

--- a/packages/db-mongodb/src/updateJobs.ts
+++ b/packages/db-mongodb/src/updateJobs.ts
@@ -80,24 +80,29 @@ export const updateJobs: UpdateJobs = async function updateMany(
     updateData = updateOps
   }
 
-  const options = {
-    new: true,
+  const baseOptions = {
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform
     timestamps: false,
   } satisfies QueryOptions
+
+  const findOptions: QueryOptions = {
+    ...baseOptions,
+    lean: true,
+    new: true,
+  }
 
   let result: Job[] = []
 
   try {
     if (id) {
       if (returning === false) {
-        await Model.updateOne(query, updateData, options)
+        await Model.updateOne(query, updateData, baseOptions)
         transform({ adapter: this, data, fields: collectionConfig.fields, operation: 'read' })
 
         return null
       } else {
-        const doc = await Model.findOneAndUpdate(query, updateData, options)
+        const doc = await Model.findOneAndUpdate(query, updateData, findOptions)
         result = doc ? [doc] : []
       }
     } else {
@@ -105,7 +110,7 @@ export const updateJobs: UpdateJobs = async function updateMany(
         const documentsToUpdate = await Model.find(
           query,
           {},
-          { ...options, limit, projection: { _id: 1 }, sort },
+          { ...findOptions, limit, projection: { _id: 1 }, sort },
         )
         if (documentsToUpdate.length === 0) {
           return null
@@ -114,20 +119,13 @@ export const updateJobs: UpdateJobs = async function updateMany(
         query = { _id: { $in: documentsToUpdate.map((doc) => doc._id) } }
       }
 
-      await Model.updateMany(query, updateData, options)
+      await Model.updateMany(query, updateData, baseOptions)
 
       if (returning === false) {
         return null
       }
 
-      result = await Model.find(
-        query,
-        {},
-        {
-          ...options,
-          sort,
-        },
-      )
+      result = await Model.find(query, {}, { ...findOptions, sort })
     }
   } catch (error) {
     handleError({ collection: collectionConfig.slug, error, req })

--- a/packages/db-mongodb/src/updateJobs.ts
+++ b/packages/db-mongodb/src/updateJobs.ts
@@ -81,7 +81,6 @@ export const updateJobs: UpdateJobs = async function updateMany(
   }
 
   const options: MongooseUpdateQueryOptions = {
-    lean: true,
     new: true,
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform

--- a/packages/db-mongodb/src/updateMany.ts
+++ b/packages/db-mongodb/src/updateMany.ts
@@ -91,17 +91,22 @@ export const updateMany: UpdateMany = async function updateMany(
     data = updateOps
   }
 
-  const options = {
+  const baseOptions = {
     ...optionsArgs,
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
+  } satisfies QueryOptions
+
+  const findOptions = {
+    ...baseOptions,
+    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,
       fields: collectionConfig.flattenedFields,
       select,
     }),
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
   } satisfies QueryOptions
 
   try {
@@ -109,7 +114,7 @@ export const updateMany: UpdateMany = async function updateMany(
       const documentsToUpdate = await Model.find(
         query,
         {},
-        { ...options, limit, projection: { _id: 1 }, sort },
+        { ...findOptions, limit, projection: { _id: 1 }, sort },
       )
       if (documentsToUpdate.length === 0) {
         return null
@@ -118,7 +123,7 @@ export const updateMany: UpdateMany = async function updateMany(
       query = { _id: { $in: documentsToUpdate.map((doc) => doc._id) } }
     }
 
-    await Model.updateMany(query, data, options)
+    await Model.updateMany(query, data, baseOptions)
   } catch (error) {
     handleError({ collection: collectionSlug, error, req })
   }
@@ -131,7 +136,7 @@ export const updateMany: UpdateMany = async function updateMany(
     query,
     {},
     {
-      ...options,
+      ...findOptions,
       sort,
     },
   )

--- a/packages/db-mongodb/src/updateMany.ts
+++ b/packages/db-mongodb/src/updateMany.ts
@@ -1,4 +1,4 @@
-import type { UpdateQuery } from 'mongoose'
+import type { QueryOptions, UpdateQuery } from 'mongoose'
 
 import { flattenWhereToOperators, type UpdateMany } from 'payload'
 
@@ -102,7 +102,7 @@ export const updateMany: UpdateMany = async function updateMany(
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform
     timestamps: false,
-  }
+  } satisfies QueryOptions
 
   try {
     if (typeof limit === 'number' && limit > 0) {

--- a/packages/db-mongodb/src/updateMany.ts
+++ b/packages/db-mongodb/src/updateMany.ts
@@ -1,4 +1,4 @@
-import type { MongooseUpdateQueryOptions, UpdateQuery } from 'mongoose'
+import type { UpdateQuery } from 'mongoose'
 
 import { flattenWhereToOperators, type UpdateMany } from 'payload'
 
@@ -91,7 +91,7 @@ export const updateMany: UpdateMany = async function updateMany(
     data = updateOps
   }
 
-  const options: MongooseUpdateQueryOptions = {
+  const options = {
     ...optionsArgs,
     new: true,
     projection: buildProjectionFromSelect({

--- a/packages/db-mongodb/src/updateMany.ts
+++ b/packages/db-mongodb/src/updateMany.ts
@@ -98,7 +98,7 @@ export const updateMany: UpdateMany = async function updateMany(
     timestamps: false,
   } satisfies QueryOptions
 
-  const findOptions = {
+  const findOptions: QueryOptions = {
     ...baseOptions,
     lean: true,
     new: true,
@@ -107,7 +107,7 @@ export const updateMany: UpdateMany = async function updateMany(
       fields: collectionConfig.flattenedFields,
       select,
     }),
-  } satisfies QueryOptions
+  }
 
   try {
     if (typeof limit === 'number' && limit > 0) {

--- a/packages/db-mongodb/src/updateMany.ts
+++ b/packages/db-mongodb/src/updateMany.ts
@@ -93,7 +93,6 @@ export const updateMany: UpdateMany = async function updateMany(
 
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
-    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -1,4 +1,4 @@
-import type { UpdateQuery } from 'mongoose'
+import type { QueryOptions, UpdateQuery } from 'mongoose'
 import type { UpdateOne } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -86,7 +86,7 @@ export const updateOne: UpdateOne = async function updateOne(
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform
     timestamps: false,
-  }
+  } satisfies QueryOptions
 
   try {
     if (returning === false) {

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -77,7 +77,6 @@ export const updateOne: UpdateOne = async function updateOne(
 
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
-    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -75,26 +75,31 @@ export const updateOne: UpdateOne = async function updateOne(
     updateData = updateOps
   }
 
-  const options = {
+  const baseOptions = {
     ...optionsArgs,
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
+  } satisfies QueryOptions
+
+  const findOptions = {
+    ...baseOptions,
+    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,
       fields: collectionConfig.flattenedFields,
       select,
     }),
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
   } satisfies QueryOptions
 
   try {
     if (returning === false) {
-      await Model.updateOne(query, updateData, options)
+      await Model.updateOne(query, updateData, baseOptions)
       transform({ adapter: this, data, fields, operation: 'read' })
       return null
     } else {
-      result = await Model.findOneAndUpdate(query, updateData, options)
+      result = await Model.findOneAndUpdate(query, updateData, findOptions)
     }
   } catch (error) {
     handleError({ collection: collectionSlug, error, req })

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -1,4 +1,4 @@
-import type { MongooseUpdateQueryOptions, UpdateQuery } from 'mongoose'
+import type { UpdateQuery } from 'mongoose'
 import type { UpdateOne } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -75,7 +75,7 @@ export const updateOne: UpdateOne = async function updateOne(
     updateData = updateOps
   }
 
-  const options: MongooseUpdateQueryOptions = {
+  const options = {
     ...optionsArgs,
     new: true,
     projection: buildProjectionFromSelect({

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -82,7 +82,7 @@ export const updateOne: UpdateOne = async function updateOne(
     timestamps: false,
   } satisfies QueryOptions
 
-  const findOptions = {
+  const findOptions: QueryOptions = {
     ...baseOptions,
     lean: true,
     new: true,
@@ -91,7 +91,7 @@ export const updateOne: UpdateOne = async function updateOne(
       fields: collectionConfig.flattenedFields,
       select,
     }),
-  } satisfies QueryOptions
+  }
 
   try {
     if (returning === false) {

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -44,25 +44,30 @@ export const updateVersion: UpdateVersion = async function updateVersion(
 
   transform({ adapter: this, data: versionData, fields, operation: 'write' })
 
-  const options = {
+  const baseOptions = {
     ...optionsArgs,
+    session: await getSession(this, req),
+    // Timestamps are manually added by the write transform
+    timestamps: false,
+  } satisfies QueryOptions
+
+  const findOptions = {
+    ...baseOptions,
+    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,
       fields: flattenedFields,
       select,
     }),
-    session: await getSession(this, req),
-    // Timestamps are manually added by the write transform
-    timestamps: false,
   } satisfies QueryOptions
 
   if (returning === false) {
-    await Model.updateOne(query, versionData, options)
+    await Model.updateOne(query, versionData, baseOptions)
     return null
   }
 
-  const doc = await Model.findOneAndUpdate(query, versionData, options)
+  const doc = await Model.findOneAndUpdate(query, versionData, findOptions)
 
   if (!doc) {
     return null

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -51,7 +51,7 @@ export const updateVersion: UpdateVersion = async function updateVersion(
     timestamps: false,
   } satisfies QueryOptions
 
-  const findOptions = {
+  const findOptions: QueryOptions = {
     ...baseOptions,
     lean: true,
     new: true,
@@ -60,7 +60,7 @@ export const updateVersion: UpdateVersion = async function updateVersion(
       fields: flattenedFields,
       select,
     }),
-  } satisfies QueryOptions
+  }
 
   if (returning === false) {
     await Model.updateOne(query, versionData, baseOptions)

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -1,3 +1,5 @@
+import type { QueryOptions } from 'mongoose'
+
 import { buildVersionCollectionFields, type UpdateVersion } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -53,7 +55,7 @@ export const updateVersion: UpdateVersion = async function updateVersion(
     session: await getSession(this, req),
     // Timestamps are manually added by the write transform
     timestamps: false,
-  }
+  } satisfies QueryOptions
 
   if (returning === false) {
     await Model.updateOne(query, versionData, options)

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -46,7 +46,6 @@ export const updateVersion: UpdateVersion = async function updateVersion(
 
   const options: MongooseUpdateQueryOptions = {
     ...optionsArgs,
-    lean: true,
     new: true,
     projection: buildProjectionFromSelect({
       adapter: this,

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -1,5 +1,3 @@
-import type { MongooseUpdateQueryOptions } from 'mongoose'
-
 import { buildVersionCollectionFields, type UpdateVersion } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -44,7 +42,7 @@ export const updateVersion: UpdateVersion = async function updateVersion(
 
   transform({ adapter: this, data: versionData, fields, operation: 'write' })
 
-  const options: MongooseUpdateQueryOptions = {
+  const options = {
     ...optionsArgs,
     new: true,
     projection: buildProjectionFromSelect({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,8 +388,8 @@ importers:
         specifier: ^2.4.5
         version: 2.4.9
       mongodb:
-        specifier: 6.16.0
-        version: 6.16.0(@aws-sdk/credential-providers@3.1045.0)
+        specifier: 6.20.0
+        version: 6.20.0(@aws-sdk/credential-providers@3.1045.0)
       mongodb-memory-server:
         specifier: 10.1.4
         version: 10.1.4(@aws-sdk/credential-providers@3.1045.0)
@@ -1828,7 +1828,7 @@ importers:
         version: 16.8.1
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       payload:
         specifier: workspace:*
         version: link:../../packages/payload
@@ -1865,7 +1865,7 @@ importers:
         version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
+        version: 16.2.6(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
       jsdom:
         specifier: 28.0.0
         version: 28.0.0(@noble/hashes@1.8.0)
@@ -1967,7 +1967,7 @@ importers:
         version: 8.6.0(react@19.2.6)
       geist:
         specifier: ^1.3.0
-        version: 1.7.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
+        version: 1.7.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -1979,7 +1979,7 @@ importers:
         version: 0.563.0(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2055,7 +2055,7 @@ importers:
         version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
+        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.2(jiti@2.7.0))
@@ -12087,33 +12087,6 @@ packages:
   mongodb-memory-server@10.1.4:
     resolution: {integrity: sha512-+oKQ/kc3CX+816oPFRtaF0CN4vNcGKNjpOQe4bHo/21A3pMD+lC7Xz1EX5HP7siCX4iCpVchDMmCOFXVQSGkUg==}
     engines: {node: '>=16.20.1'}
-
-  mongodb@6.16.0:
-    resolution: {integrity: sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==}
-    engines: {node: '>=16.20.1'}
-    peerDependencies:
-      '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
-      gcp-metadata: ^5.2.0
-      kerberos: ^2.0.1
-      mongodb-client-encryption: '>=6.0.0 <7'
-      snappy: ^7.2.2
-      socks: ^2.7.1
-    peerDependenciesMeta:
-      '@aws-sdk/credential-providers':
-        optional: true
-      '@mongodb-js/zstd':
-        optional: true
-      gcp-metadata:
-        optional: true
-      kerberos:
-        optional: true
-      mongodb-client-encryption:
-        optional: true
-      snappy:
-        optional: true
-      socks:
-        optional: true
 
   mongodb@6.20.0:
     resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
@@ -24632,6 +24605,10 @@ snapshots:
       - encoding
       - supports-color
 
+  geist@1.7.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)):
+    dependencies:
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+
   geist@1.7.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)):
     dependencies:
       next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
@@ -26138,7 +26115,7 @@ snapshots:
       find-cache-dir: 3.3.2
       follow-redirects: 1.16.0(debug@4.4.3)
       https-proxy-agent: 7.0.6
-      mongodb: 6.16.0(@aws-sdk/credential-providers@3.1045.0)
+      mongodb: 6.20.0(@aws-sdk/credential-providers@3.1045.0)
       new-find-package-json: 2.0.0
       semver: 7.8.0
       tar-stream: 3.2.0
@@ -26173,14 +26150,6 @@ snapshots:
       - snappy
       - socks
       - supports-color
-
-  mongodb@6.16.0(@aws-sdk/credential-providers@3.1045.0):
-    dependencies:
-      '@mongodb-js/saslprep': 1.4.11
-      bson: 6.10.4
-      mongodb-connection-string-url: 3.0.2
-    optionalDependencies:
-      '@aws-sdk/credential-providers': 3.1045.0
 
   mongodb@6.20.0(@aws-sdk/credential-providers@3.1045.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       mongoose:
-        specifier: 8.15.1
-        version: 8.15.1(@aws-sdk/credential-providers@3.1045.0)
+        specifier: 8.22.1
+        version: 8.22.1(@aws-sdk/credential-providers@3.1045.0)
       next:
         specifier: 16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
@@ -366,11 +366,11 @@ importers:
   packages/db-mongodb:
     dependencies:
       mongoose:
-        specifier: 8.15.1
-        version: 8.15.1(@aws-sdk/credential-providers@3.1045.0)
+        specifier: 8.22.1
+        version: 8.22.1(@aws-sdk/credential-providers@3.1045.0)
       mongoose-paginate-v2:
         specifier: 1.9.4
-        version: 1.9.4(mongoose@8.15.1(@aws-sdk/credential-providers@3.1045.0))
+        version: 1.9.4(mongoose@8.22.1(@aws-sdk/credential-providers@3.1045.0))
       prompts:
         specifier: 2.4.2
         version: 2.4.2
@@ -1865,7 +1865,7 @@ importers:
         version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
+        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
       jsdom:
         specifier: 28.0.0
         version: 28.0.0(@noble/hashes@1.8.0)
@@ -1967,7 +1967,7 @@ importers:
         version: 8.6.0(react@19.2.6)
       geist:
         specifier: ^1.3.0
-        version: 1.7.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
+        version: 1.7.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -1979,7 +1979,7 @@ importers:
         version: 0.563.0(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2055,7 +2055,7 @@ importers:
         version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
+        version: 16.2.6(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.2(jiti@2.7.0))
@@ -2160,7 +2160,7 @@ importers:
         version: 16.4.7
       geist:
         specifier: ^1.3.0
-        version: 1.7.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
+        version: 1.7.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -2169,10 +2169,10 @@ importers:
         version: 0.563.0(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
+        version: 4.2.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
       payload:
         specifier: workspace:*
         version: link:../../packages/payload
@@ -2488,8 +2488,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       mongoose:
-        specifier: 8.15.1
-        version: 8.15.1(@aws-sdk/credential-providers@3.1045.0)
+        specifier: 8.22.1
+        version: 8.22.1(@aws-sdk/credential-providers@3.1045.0)
       next:
         specifier: 16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)
@@ -12115,6 +12115,33 @@ packages:
       socks:
         optional: true
 
+  mongodb@6.20.0:
+    resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.3.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
   mongoose-lean-virtuals@1.1.1:
     resolution: {integrity: sha512-8chOqpVE3bcoWT2pIgcJeIZlXaOfQCavZgQZF4qytUtjRBqsNMyzUoR16qdw9XL2kC478N8iA8z0AA+NSS0d1A==}
     engines: {node: '>=16.20.1'}
@@ -12125,8 +12152,8 @@ packages:
     resolution: {integrity: sha512-0LOsVEQmjrbJKVDi/IvFEhIezmuRjUE4loGgslv57j9nK/NMC+mbKT0QnaPSPpib4lByKVBcy3VbDa1TvlHZjA==}
     engines: {node: '>=4.0.0'}
 
-  mongoose@8.15.1:
-    resolution: {integrity: sha512-RhQ4DzmBi5BNGcS0w4u1vdMRIKcteXTCNzDt1j7XRcdWYBz1MjMjulBhPaeC5jBCHOD1yinuOFTTSOWLLGexWw==}
+  mongoose@8.22.1:
+    resolution: {integrity: sha512-c0bzt7ElI1CwWiyFSgg9bfhlFcblAoPwr+gmDcLCryClyKaeixWhP9KDGnr13kRPE8KPAuUN3ZZ3jSDxSPvoTg==}
     engines: {node: '>=16.20.1'}
 
   mpath@0.8.4:
@@ -21355,7 +21382,7 @@ snapshots:
   '@types/mongoose-aggregate-paginate-v2@1.0.12(@aws-sdk/credential-providers@3.1045.0)':
     dependencies:
       '@types/node': 24.12.3
-      mongoose: 8.15.1(@aws-sdk/credential-providers@3.1045.0)
+      mongoose: 8.22.1(@aws-sdk/credential-providers@3.1045.0)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -24605,9 +24632,9 @@ snapshots:
       - encoding
       - supports-color
 
-  geist@1.7.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)):
+  geist@1.7.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)):
     dependencies:
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
 
   generator-function@2.0.1: {}
 
@@ -26155,22 +26182,30 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.1045.0
 
-  mongoose-lean-virtuals@1.1.1(mongoose@8.15.1(@aws-sdk/credential-providers@3.1045.0)):
+  mongodb@6.20.0(@aws-sdk/credential-providers@3.1045.0):
     dependencies:
-      mongoose: 8.15.1(@aws-sdk/credential-providers@3.1045.0)
+      '@mongodb-js/saslprep': 1.4.11
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
+    optionalDependencies:
+      '@aws-sdk/credential-providers': 3.1045.0
+
+  mongoose-lean-virtuals@1.1.1(mongoose@8.22.1(@aws-sdk/credential-providers@3.1045.0)):
+    dependencies:
+      mongoose: 8.22.1(@aws-sdk/credential-providers@3.1045.0)
       mpath: 0.8.4
 
-  mongoose-paginate-v2@1.9.4(mongoose@8.15.1(@aws-sdk/credential-providers@3.1045.0)):
+  mongoose-paginate-v2@1.9.4(mongoose@8.22.1(@aws-sdk/credential-providers@3.1045.0)):
     dependencies:
-      mongoose-lean-virtuals: 1.1.1(mongoose@8.15.1(@aws-sdk/credential-providers@3.1045.0))
+      mongoose-lean-virtuals: 1.1.1(mongoose@8.22.1(@aws-sdk/credential-providers@3.1045.0))
     transitivePeerDependencies:
       - mongoose
 
-  mongoose@8.15.1(@aws-sdk/credential-providers@3.1045.0):
+  mongoose@8.22.1(@aws-sdk/credential-providers@3.1045.0):
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3
-      mongodb: 6.16.0(@aws-sdk/credential-providers@3.1045.0)
+      mongodb: 6.20.0(@aws-sdk/credential-providers@3.1045.0)
       mpath: 0.9.0
       mquery: 5.0.0
       ms: 2.1.3
@@ -26223,13 +26258,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next-sitemap@4.2.3(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)):
+  next-sitemap@4.2.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:

--- a/test/package.json
+++ b/test/package.json
@@ -98,7 +98,7 @@
     "file-type": "22.0.1",
     "http-status": "2.1.0",
     "jwt-decode": "4.0.0",
-    "mongoose": "8.15.1",
+    "mongoose": "8.22.1",
     "next": "16.2.6",
     "nodemailer": "^8.0.5",
     "object-to-formdata": "4.5.1",


### PR DESCRIPTION
Closes #16650.

Bumps `mongoose` from 8.15.1 to 8.22.1 in `@payloadcms/db-mongodb`.

Also bumps `mongodb` from 6.16.0 to 6.20.0 in `@payloadcms.db-mongodb` to match a transitive dependency within `mongoose` and prevent duplicative installations.

The `mongoose@8.15.1` package is affected by GHSA-wpg9-53fq-2r8h (high severity NoSQL injection via improper $nor sanitization in sanitizeFilter). Patched in >= 8.22.1.

Note: there was a breaking change in v8.17 introduced by https://github.com/Automattic/mongoose/pull/15547. This change removed various properties from the `MongooseUpdateQueryOptions` type, specifically: `lean`, `projection`, and `new`. Using these args throws TS errors.

Instead, we rely on the more broad `QueryOptions` type, and then isolate the options per operation.

Related https://github.com/payloadcms/payload/pull/16688.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214892618486232