### PR TITLE
fix: support @next/env without default export on Next.js 15.5+

### DIFF
--- a/packages/payload/src/bin/loadEnv.ts
+++ b/packages/payload/src/bin/loadEnv.ts
@@ -1,7 +1,7 @@
-import nextEnvImport from '@next/env'
+import * as nextEnvImport from '@next/env'
 
 import { findUpSync } from '../utilities/findUp.js'
-const { loadEnvConfig } = nextEnvImport
+const { loadEnvConfig } = (nextEnvImport as any).default ?? nextEnvImport
 
 /**
  * Try to find user's env files and load it. Uses the same algorithm next.js uses to parse env files, meaning this also supports .env.local, .env.development, .env.production, etc.


### PR DESCRIPTION
Fixes #16674.

On Next.js 15.5+, `@next/env` no longer ships a `default` export — only named exports remain. `bin/loadEnv.ts` does `import nextEnvImport from '@next/env'` and then `const { loadEnvConfig } = nextEnvImport`, which throws `TypeError: Cannot destructure property 'loadEnvConfig' of 'import_env.default' as it is undefined.` whenever the module is loaded through interop paths (e.g. running scripts via `tsx`).

Switching to a namespace import and falling back from `.default` to the namespace itself keeps both shapes working:

- Next.js ≥ 15.5: `nextEnvImport.default` is `undefined`, so we destructure from the namespace.
- Next.js < 15.5: `nextEnvImport.default` is the legacy CJS default object, so we destructure from that (matches the previous behaviour).

The patch is exactly what the issue proposes.