### PR TITLE
fix: write per-locale values from siblingData when req.locale is 'all'

### DIFF
--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -270,11 +270,27 @@ export const promise = async ({
       mergeLocaleActions.push(() => {
         const localeData: Record<string, unknown> = {}
 
+        const incomingAllLocales =
+          req.locale === 'all' &&
+          siblingData[field.name!] &&
+          typeof siblingData[field.name!] === 'object' &&
+          !Array.isArray(siblingData[field.name!])
+            ? (siblingData[field.name!] as Record<string, unknown>)
+            : undefined
+
         for (const locale of localization.localeCodes) {
-          const fieldValue =
-            locale === req.locale
-              ? siblingData[field.name!]
-              : siblingDocWithLocales?.[field.name!]?.[locale]
+          let fieldValue: unknown
+          if (incomingAllLocales) {
+            fieldValue =
+              locale in incomingAllLocales
+                ? incomingAllLocales[locale]
+                : siblingDocWithLocales?.[field.name!]?.[locale]
+          } else {
+            fieldValue =
+              locale === req.locale
+                ? siblingData[field.name!]
+                : siblingDocWithLocales?.[field.name!]?.[locale]
+          }
 
           // update locale value if it's not undefined
           if (typeof fieldValue !== 'undefined') {


### PR DESCRIPTION
Fixes #16345.

The beforeChange merge-locale loop in `fields/hooks/beforeChange/promise.ts` only writes a localized field's incoming value when `locale === req.locale`. When the caller passes `locale: 'all'`, no real locale code ever equals `'all'`, so the incoming value is never written and the field appears not to update — every existing per-locale value is preserved instead.

Read-side already treats `locale === 'all'` as meaning *"the field holds a `{ [locale]: value }` map"* — see e.g. the explicit comment in `fields/hooks/afterRead/promise.ts` (`shouldRunHookOnAllLocales`). The write side should mirror that: when `req.locale === 'all'`, `siblingData[field.name]` is the same `{ [locale]: value }` shape and should be merged key-by-key.

### Change

In the merge action, detect the `'all'` case and treat `siblingData[field.name]` as a per-locale map:

- If a locale key is present in the incoming map → use that value
- Otherwise → fall back to the existing `siblingDocWithLocales[field.name][locale]`

For any other `req.locale` the original `locale === req.locale ? ... : ...` branch runs unchanged, so single-locale updates behave exactly as before.

### Cases I traced

- `req.locale = 'en'`, payload `{ title: 'new' }` — unchanged (raw value goes to `en`, other locales preserved).
- `req.locale = 'all'`, payload `{ title: { en: 'a', es: 'b' } }` — `en` and `es` updated, other locales preserved.
- `req.locale = 'all'`, payload `{ title: { en: 'a' } }` — only `en` updated, `es`/`de`/... preserved.
- `req.locale = 'all'`, payload `{ title: 'a' }` (malformed — not an object) — `incomingAllLocales` resolves to `undefined`, loop hits the original branch where no locale matches `'all'`, so behavior matches today (no-op). No new regression for malformed input.

Reporter's repro at https://github.com/MartijnDeRoode/payload-reproductions should produce updates to all three text fields after this change.

I didn't run the integration suite locally — the change is scoped to one merge-action block and the existing behavior is preserved for every code path that wasn't `req.locale === 'all'`. Happy to add a targeted test if there's a preferred suite for this path.