### PR TITLE
fix(ui): use parentFieldName prop in HierarchyTable load more

### DIFF
--- a/packages/ui/src/views/HierarchyList/HierarchyTable/index.tsx
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/index.tsx
@@ -221,11 +221,8 @@ export function HierarchyTable({
       }))
 
       try {
-        // Field name is always _h_{hierarchySlug} by convention (created by createTagField)
-        const fieldName = `_h_${collectionSlug}`
-
         // "in" operator works for both hasMany and single relationship fields
-        const relationshipCondition = { [fieldName]: { in: [parentId] } }
+        const relationshipCondition = { [parentFieldName]: { in: [parentId] } }
 
         const relatedConfig = getEntityConfig({ collectionSlug: relatedSlug })
         const relatedUseAsTitle = relatedConfig?.admin?.useAsTitle || 'id'
@@ -277,6 +274,7 @@ export function HierarchyTable({
       apiRoute,
       collectionSlug,
       getEntityConfig,
+      parentFieldName,
       parentId,
       relatedBaseFilters,
       relatedGroups,


### PR DESCRIPTION
### What

Fixes HierarchyTable's "load more" for related documents when `parentFieldName` is overridden in the hierarchy config.

### Why

The `handleLoadMoreRelated` callback was hardcoding the field name as `_h_${collectionSlug}`, ignoring the `parentFieldName` prop. When configs override `parentFieldName` (e.g., `parentFieldName: 'folder'`), the query would fail to find related documents.

### How

- Use the `parentFieldName` prop directly instead of computing a hardcoded field name
- Add `parentFieldName` to the callback's dependency array