### PR TITLE
fix(next): restore modular dashboard widget layout

### DIFF
--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.css
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.css
@@ -3,10 +3,6 @@
     padding: calc(var(--spacer-2-5) / 2);
   }
 
-  .modular-dashboard .widget-content > .card {
-    align-items: stretch;
-  }
-
   .modular-dashboard .widget-content {
     height: 100%;
   }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.css
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.css
@@ -1,4 +1,12 @@
 @layer payload-default {
+  .modular-dashboard .widget {
+    padding: calc(var(--spacer-2-5) / 2);
+  }
+
+  .modular-dashboard .widget-content > .card {
+    align-items: stretch;
+  }
+
   .modular-dashboard .widget-content {
     height: 100%;
   }

--- a/packages/next/src/views/Dashboard/Default/ModularDashboard/index.css
+++ b/packages/next/src/views/Dashboard/Default/ModularDashboard/index.css
@@ -1,4 +1,9 @@
 @layer payload-default {
+  .modular-dashboard {
+    margin: calc(var(--spacer-2-5) / -2);
+    width: calc(100% + var(--spacer-2-5));
+  }
+
   .modular-dashboard .widget {
     padding: calc(var(--spacer-2-5) / 2);
   }

--- a/packages/ui/src/elements/Card/index.css
+++ b/packages/ui/src/elements/Card/index.css
@@ -8,7 +8,7 @@
     border-radius: var(--radius-medium);
     border: var(--stroke-width-small) solid var(--color-border);
     display: flex;
-    align-items: flex-start;
+    align-items: stretch;
     gap: var(--spacer-2);
   }
 

--- a/test/__helpers/e2e/checkFocusIndicators.ts
+++ b/test/__helpers/e2e/checkFocusIndicators.ts
@@ -162,6 +162,8 @@ export async function checkFocusIndicators(
   let cycleComplete = false
   let consecutiveBodyFocus = 0
   const maxConsecutiveBodyFocus = 3 // Stop if we focus body 3 times in a row
+  const visitedOutsideScopeElements: Set<string> = new Set()
+  let hasEnteredScope = false
 
   while (!cycleComplete) {
     // Press Tab to focus the next element
@@ -206,7 +208,7 @@ export async function checkFocusIndicators(
             tagName: string
             textContent: string
           }
-        | { outsideScope: true }
+        | { elementPath: string; outsideScope: true }
         | null => {
         const el = document.activeElement
         if (!el || el === document.body) {
@@ -216,15 +218,6 @@ export async function checkFocusIndicators(
         // Skip Next.js portal elements (dev mode only)
         if (el.closest('nextjs-portal')) {
           return null
-        }
-
-        // If we have a scope selector, check if the focused element is within scope
-        if (scopeSelector) {
-          const scopeElement = document.querySelector(scopeSelector)
-          if (scopeElement && !scopeElement.contains(el)) {
-            // Element is outside our scope, return special marker
-            return { outsideScope: true } as const
-          }
         }
 
         // Generate a unique identifier for this element
@@ -259,6 +252,15 @@ export async function checkFocusIndicators(
         }
 
         const elementPath = xpath(el)
+
+        // If we have a scope selector, check if the focused element is within scope
+        if (scopeSelector) {
+          const scopeElement = document.querySelector(scopeSelector)
+          if (scopeElement && !scopeElement.contains(el)) {
+            // Element is outside our scope, return special marker
+            return { elementPath, outsideScope: true } as const
+          }
+        }
 
         // Generate a useful CSS selector for this element
         const generateSelector = (): string => {
@@ -582,6 +584,13 @@ export async function checkFocusIndicators(
 
     // Check if element is outside scope (only relevant when selector is provided)
     if ('outsideScope' in focusInfo) {
+      if (!hasEnteredScope && !visitedOutsideScopeElements.has(focusInfo.elementPath)) {
+        if (verbose) {
+          console.log('Focused element is outside scope before scoped elements, continuing')
+        }
+        visitedOutsideScopeElements.add(focusInfo.elementPath)
+        continue
+      }
       if (verbose) {
         console.log('Focused element is outside scope, tab cycle complete')
       }
@@ -591,6 +600,7 @@ export async function checkFocusIndicators(
 
     // Reset body focus counter since we found a focusable element
     consecutiveBodyFocus = 0
+    hasEnteredScope = true
 
     // At this point, TypeScript knows focusInfo has the full element info
     // Skip if we've seen this element before (we've cycled through)

--- a/test/dashboard/components/Private.tsx
+++ b/test/dashboard/components/Private.tsx
@@ -24,9 +24,9 @@ export default function Private({ widgetSlug }: WidgetServerProps) {
         <h3 style={{ fontSize: '16px', fontWeight: 600, margin: 0 }}>Private Widget</h3>
         <div
           style={{
-            background: 'var(--theme-success-500)',
+            background: 'var(--color-bg-brand)',
             borderRadius: '12px',
-            color: 'var(--theme-elevation-0)',
+            color: 'var(--color-text-onbrand)',
             fontSize: '12px',
             fontWeight: 600,
             padding: '4px 8px',


### PR DESCRIPTION
Fixes a UI regression in the modular dashboard that was introduced by #16619 and #16627.

## Payload v3

Original modular dashboard layout before the regression.

<img width="1095" height="840" alt="image" src="https://github.com/user-attachments/assets/fee798da-8c5c-456a-a343-190e83e3fc94" />

## After #16619 / #16627

Widgets lost their spacing, and the revenue/private widgets no longer stretched correctly.

<img width="1060" height="833" alt="image" src="https://github.com/user-attachments/assets/f33a6d55-607d-4abd-81cd-67f159b803fe" />

## After This PR

Modular dashboard widget spacing and widget card layout are restored.

<img width="1225" height="966" alt="image" src="https://github.com/user-attachments/assets/005483a1-378e-466d-bb05-9bee68ba6fd9" />

## Why fix `align-items` on the global `.card` and not on `.modular-dashboard .widget-content > .card`

I initially scoped the override to `.modular-dashboard` to minimize blast radius. After reviewing how `Card` is actually used I switched to fixing it at the source. The trade-off:

- Inside the monorepo, the `Card` React component is imported in exactly one place (`packages/ui/src/widgets/CollectionCards/index.tsx`), and `CollectionCards` is only registered as the default `collections` widget of the modular dashboard. So today every `.card` in the rendered DOM lives inside `.modular-dashboard`, and the scoped selector was functionally equivalent to a global fix.
- However, `Card` is a public export in `packages/ui/src/exports/client/index.ts`, so third parties can use it in custom admin components or custom widgets. A scoped override would silently leave them on the new `flex-start` behavior, which differs from v3 and is not what the title/actions layout was designed for (the title lost its `width: 100%` and `.card__actions` is now `position: absolute`, so neither of them benefit from `flex-start` over `stretch`).
- Scoping by consumer (`.collections .card`) was also considered but rejected: the behavior we want belongs to the `Card` contract itself, not to `CollectionCards`.

The `.widget` padding stays scoped to `.modular-dashboard` because that is genuinely a dashboard-layout concern, not a Card concern.