### PR TITLE
fix(ui): hierarchy list improvements and custom parent field support

### DIFF
--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -282,16 +282,21 @@ export const renderListView = async (
 
   // Check for hierarchy parent param
   const isHierarchyCollection = Boolean(collectionConfig.hierarchy)
+  const hierarchyParentFieldName =
+    typeof collectionConfig.hierarchy === 'object'
+      ? (collectionConfig.hierarchy.parentFieldName ?? 'parent')
+      : 'parent'
   let hierarchyParentId: null | number | string = null
 
   if (isHierarchyCollection) {
-    if (searchParams?.parent === 'null' || searchParams?.parent === undefined) {
+    const parentParam = searchParams?.[hierarchyParentFieldName]
+    if (parentParam === 'null' || parentParam === undefined) {
       hierarchyParentId = null
-    } else if (typeof searchParams?.parent === 'string') {
+    } else if (typeof parentParam === 'string') {
       hierarchyParentId =
-        payload.db.defaultIDType === 'number' && isNumber(searchParams.parent)
-          ? Number(searchParams.parent)
-          : searchParams.parent
+        payload.db.defaultIDType === 'number' && isNumber(parentParam)
+          ? Number(parentParam)
+          : parentParam
     }
   }
 

--- a/packages/ui/src/elements/CheckboxPopup/index.scss
+++ b/packages/ui/src/elements/CheckboxPopup/index.scss
@@ -5,8 +5,8 @@
     &__options {
       display: flex;
       flex-direction: column;
-      gap: calc(var(--base) * 0.5);
-      padding: 0 3px;
+      gap: var(--spacer-2);
+      padding: 0 var(--spacer-2-5);
       margin: 3px 0;
     }
 

--- a/packages/ui/src/elements/CreateDocumentButton/index.tsx
+++ b/packages/ui/src/elements/CreateDocumentButton/index.tsx
@@ -121,6 +121,8 @@ export function CreateDocumentButton({
         }
         buttonType="custom"
         className={`${baseClass}__popup`}
+        horizontalAlign="right"
+        size="medium"
       >
         <PopupList.ButtonGroup>
           {collections.map((collection) => (

--- a/packages/ui/src/elements/Hierarchy/ColumnBrowser/Column/index.css
+++ b/packages/ui/src/elements/Hierarchy/ColumnBrowser/Column/index.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   .hierarchy-column {
-    width: 360px;
-    min-width: 360px;
+    width: 280px;
+    min-width: 280px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -15,7 +15,7 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--spacer-2);
-    padding: var(--spacer-2) var(--spacer-4);
+    padding: var(--spacer-1) var(--spacer-3);
     flex-shrink: 0;
     margin-bottom: var(--spacer-2);
     border-bottom: 1px solid var(--color-border);
@@ -23,7 +23,6 @@
 
   .hierarchy-column__add-button {
     flex-shrink: 0;
-    padding-right: 0;
   }
 
   .hierarchy-column__header-checkbox {
@@ -46,7 +45,7 @@
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-    margin: 0 var(--spacer-3);
+    margin: 0 var(--spacer-2);
     gap: var(--spacer-1);
   }
 

--- a/packages/ui/src/elements/Hierarchy/ColumnBrowser/Column/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/ColumnBrowser/Column/index.tsx
@@ -60,7 +60,7 @@ export const Column: React.FC<ColumnProps> = ({
             buttonStyle="ghost"
             className={`${baseClass}__add-button`}
             disabled={disabled}
-            icon={<PlusIcon />}
+            icon={<PlusIcon size={16} />}
             iconPosition="left"
             margin={false}
             onClick={handleCreateNew}

--- a/packages/ui/src/elements/Hierarchy/ColumnBrowser/index.css
+++ b/packages/ui/src/elements/Hierarchy/ColumnBrowser/index.css
@@ -7,11 +7,6 @@
 
   .hierarchy-column-browser__column-wrapper {
     flex-shrink: 0;
-
-    &:first-child {
-      margin-left: var(--gutter-h);
-      border-left: 1px solid var(--color-border);
-    }
   }
 
   .hierarchy-column-browser__column-wrapper--loading {

--- a/packages/ui/src/elements/Hierarchy/Drawer/index.css
+++ b/packages/ui/src/elements/Hierarchy/Drawer/index.css
@@ -1,16 +1,46 @@
 @layer payload-default {
+  /* Override drawer to be a centered modal instead of side panel */
+  .hierarchy-drawer.drawer {
+    justify-content: center;
+    align-items: center;
+  }
+
+  .hierarchy-drawer .drawer__blur-bg {
+    background: var(--color-modalbackdrop);
+  }
+
+  .hierarchy-drawer .drawer__content {
+    width: min(900px, calc(100vw - var(--spacer-6)));
+    height: min(700px, calc(100vh - var(--spacer-6)));
+    border-radius: var(--radius-large);
+    transform: none;
+    box-shadow: var(--elevation-500-dialog);
+  }
+
+  .hierarchy-drawer .drawer__close {
+    position: absolute;
+    inset: 0;
+    background: transparent;
+  }
+
   .hierarchy-drawer__content {
     display: flex;
     flex-direction: column;
     height: 100%;
     background: var(--color-bg);
+    border-radius: var(--radius-large);
+    overflow: clip;
+
+    .drawer-action-header {
+      padding: var(--spacer-2) var(--spacer-3);
+    }
   }
 
   .hierarchy-drawer__subheader {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: var(--spacer-3) var(--gutter-h);
+    padding: var(--spacer-2) var(--gutter-h);
     border-bottom: 1px solid var(--color-border);
     flex-shrink: 0;
   }

--- a/packages/ui/src/elements/Hierarchy/Search/index.css
+++ b/packages/ui/src/elements/Hierarchy/Search/index.css
@@ -106,6 +106,7 @@
     max-height: calc(100vh - 200px);
     width: calc(100% + var(--nav-padding-inline-start) + var(--nav-padding-inline-end));
     margin-left: calc(-1 * var(--nav-padding-inline-start));
+    margin-top: var(--spacer-2);
   }
 
   .hierarchy-search-results__list {

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
@@ -56,8 +56,12 @@ export const HierarchySidebarTabServer: React.FC<HierarchySidebarTabServerProps>
   )
 
   try {
-    // Get selected node from URL (?parent=<id>)
-    selectedNodeId = searchParams?.parent ? String(searchParams.parent) : null
+    // Get parentFieldName from config first (needed for URL parsing)
+    parentFieldName = hierarchyConfig?.parentFieldName ?? 'parent'
+
+    // Get selected node from URL (?<parentFieldName>=<id>)
+    const selectedNodeParam = searchParams?.[parentFieldName]
+    selectedNodeId = selectedNodeParam ? String(selectedNodeParam) : null
 
     // STEP 1: Load user's expanded node preferences
     const preferenceKey = `${PREFERENCE_KEYS.HIERARCHY_TREE}-${hierarchyCollectionSlug}`
@@ -87,7 +91,6 @@ export const HierarchySidebarTabServer: React.FC<HierarchySidebarTabServerProps>
     }
 
     // STEP 2: Get remaining config values
-    parentFieldName = hierarchyConfig?.parentFieldName
     treeLimit = hierarchyConfig?.admin?.treeLimit
     typeFieldName =
       hierarchyConfig?.collectionSpecific && typeof hierarchyConfig.collectionSpecific === 'object'

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
@@ -73,7 +73,7 @@ export const HierarchySidebarTab: React.FC<
   }, [treeRefreshKey, sidebarTabs, tabSlug])
 
   // Only highlight selected node when this tab is active
-  const parentParam = searchParams.get('parent')
+  const parentParam = searchParams.get(parentFieldName ?? 'parent')
   const isActiveTab = sidebarTabs?.activeTabSlug === tabSlug
   const selectedNodeId = isActiveTab
     ? (parentParam ?? selectedNodeIdFromServer ?? undefined)
@@ -91,16 +91,17 @@ export const HierarchySidebarTab: React.FC<
 
   const handleNavigateToParent = useCallback(
     ({ id }: { id: number | string }) => {
+      const queryParam = parentFieldName ?? 'parent'
       const url = formatAdminURL({
         adminRoute,
-        path: `/collections/${hierarchyCollectionSlug}/hierarchy?parent=${id}`,
+        path: `/collections/${hierarchyCollectionSlug}/hierarchy?${queryParam}=${id}`,
       })
       startRouteTransition(() => {
         router.push(url)
         router.refresh()
       })
     },
-    [adminRoute, hierarchyCollectionSlug, router, startRouteTransition],
+    [adminRoute, hierarchyCollectionSlug, parentFieldName, router, startRouteTransition],
   )
   return (
     <>

--- a/packages/ui/src/elements/LoadMoreRow/index.scss
+++ b/packages/ui/src/elements/LoadMoreRow/index.scss
@@ -25,6 +25,10 @@
       margin: 0;
       color: var(--theme-elevation-400);
       white-space: nowrap;
+
+      display: flex;
+      align-items: center;
+      gap: var(--spacer-1);
     }
 
     &__button {

--- a/packages/ui/src/elements/SearchBar/index.css
+++ b/packages/ui/src/elements/SearchBar/index.css
@@ -2,7 +2,6 @@
   .search-bar {
     display: flex;
     align-items: center;
-    width: 100%;
     background-color: var(--color-bg-secondary);
     border-radius: var(--radius-medium);
     outline: var(--stroke-width-small) solid transparent;

--- a/packages/ui/src/providers/Hierarchy/index.tsx
+++ b/packages/ui/src/providers/Hierarchy/index.tsx
@@ -246,14 +246,15 @@ export const HierarchyProvider: React.FC<HierarchyProviderProps> = ({ children }
         return
       }
 
+      const queryParam = parentFieldName || 'parent'
       const url = formatAdminURL({
         adminRoute,
-        path: `/collections/${collectionSlug}${id !== null ? `?parent=${id}` : ''}`,
+        path: `/collections/${collectionSlug}${id !== null ? `?${queryParam}=${id}` : ''}`,
       })
       router.push(url)
       router.refresh()
     },
-    [adminRoute, collectionSlug, router],
+    [adminRoute, collectionSlug, parentFieldName, router],
   )
 
   const loadMoreChildren = useCallback(

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -150,10 +150,16 @@ export function renderCell({
           hierarchyIcon = RenderServerComponent({
             Component: iconComponent,
             importMap: payload.importMap,
+            key: `hierarchy-icon-${relationTo}`,
           })
         } else {
           // Use default icon based on allowHasMany
-          hierarchyIcon = hierarchyConfig.allowHasMany === false ? <FolderIcon /> : <TagIcon />
+          hierarchyIcon =
+            hierarchyConfig.allowHasMany === false ? (
+              <FolderIcon key={`hierarchy-icon-${relationTo}`} />
+            ) : (
+              <TagIcon key={`hierarchy-icon-${relationTo}`} />
+            )
         }
       }
     }

--- a/packages/ui/src/views/HierarchyList/HierarchyListHeader/index.tsx
+++ b/packages/ui/src/views/HierarchyList/HierarchyListHeader/index.tsx
@@ -6,14 +6,9 @@ import type { ClientCollectionConfig, ViewTypes } from 'payload'
 import { getTranslation } from '@payloadcms/translations'
 import React from 'react'
 
-import type { CollectionOption } from '../../../elements/CreateDocumentButton/index.js'
-
-import { CreateDocumentButton } from '../../../elements/CreateDocumentButton/index.js'
 import { DefaultListViewTabs } from '../../../elements/DefaultListViewTabs/index.js'
 import { ListHeader } from '../../../elements/ListHeader/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
-import { useHierarchy } from '../../../providers/Hierarchy/index.js'
-import { useRouteCache } from '../../../providers/RouteCache/index.js'
 import { DocumentListSelection } from '../DocumentListSelection/index.js'
 import './index.scss'
 
@@ -21,14 +16,11 @@ const baseClass = 'hierarchy-list-header'
 
 export type HierarchyListHeaderProps = {
   collectionConfig: ClientCollectionConfig
-  /** Collections available for creation with their initial data */
-  collections: CollectionOption[]
   /** Title to display - defaults to collection label if not provided */
   currentItemTitle?: string
   Description?: React.ReactNode
   disableBulkDelete?: boolean
   disableBulkEdit?: boolean
-  hasCreatePermission: boolean
   /** Icon to display in the move drawer */
   HierarchyIcon?: React.ReactNode
   i18n: I18nClient
@@ -37,12 +29,10 @@ export type HierarchyListHeaderProps = {
 
 export function HierarchyListHeader({
   collectionConfig,
-  collections,
   currentItemTitle,
   Description,
   disableBulkDelete,
   disableBulkEdit,
-  hasCreatePermission,
   HierarchyIcon,
   i18n,
   viewType,
@@ -50,13 +40,6 @@ export function HierarchyListHeader({
   const { config } = useConfig()
   const { labels } = collectionConfig
   const title = currentItemTitle || getTranslation(labels?.plural, i18n)
-  const { clearRouteCache } = useRouteCache()
-  const { refreshTree } = useHierarchy()
-
-  const handleSave = () => {
-    clearRouteCache()
-    refreshTree(collectionConfig.slug)
-  }
 
   return (
     <ListHeader
@@ -78,18 +61,6 @@ export function HierarchyListHeader({
       AfterListHeaderContent={Description}
       className={baseClass}
       title={title}
-      TitleActions={
-        hasCreatePermission && collections.length > 0
-          ? [
-              <CreateDocumentButton
-                collections={collections}
-                drawerSlug={`hierarchy-create-${collectionConfig.slug}`}
-                key="hierarchy-create-button"
-                onSave={handleSave}
-              />,
-            ]
-          : undefined
-      }
     />
   )
 }

--- a/packages/ui/src/views/HierarchyList/HierarchyTable/ChildNameCell.tsx
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/ChildNameCell.tsx
@@ -31,11 +31,12 @@ export const ChildNameCell: SlotColumn<TableRow>['Cell'] = ({ row }) => {
       ? row[titleField]
       : row.id
   const title = typeof rawTitle === 'object' ? JSON.stringify(rawTitle) : String(rawTitle)
-  const isFolder = Boolean(
-    collectionConfig?.hierarchy &&
-      typeof collectionConfig.hierarchy === 'object' &&
-      collectionConfig.hierarchy.allowHasMany === false,
-  )
+  const hierarchyConfig =
+    collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
+      ? collectionConfig.hierarchy
+      : undefined
+  const isFolder = Boolean(hierarchyConfig && hierarchyConfig.allowHasMany === false)
+  const parentFieldName = hierarchyConfig?.parentFieldName || 'parent'
 
   const documentURL = formatAdminURL({
     adminRoute,
@@ -44,7 +45,7 @@ export const ChildNameCell: SlotColumn<TableRow>['Cell'] = ({ row }) => {
 
   const hierarchyURL = formatAdminURL({
     adminRoute,
-    path: `/collections/${row._collectionSlug}?parent=${row.id}`,
+    path: `/collections/${row._collectionSlug}?${parentFieldName}=${row.id}`,
   })
 
   const DefaultIcon = isFolder ? <FolderIcon /> : <TagIcon />

--- a/packages/ui/src/views/HierarchyList/index.scss
+++ b/packages/ui/src/views/HierarchyList/index.scss
@@ -20,7 +20,7 @@
 
     &__allowed-types {
       color: var(--theme-elevation-500);
-      padding-top: calc(var(--base) * 0.2);
+      padding-top: var(--spacer-1);
     }
 
     &__sub-header {
@@ -37,8 +37,15 @@
 
     &__controls {
       display: flex;
-      gap: var(--spacing-sm);
       align-items: center;
+      gap: var(--spacer-2);
+    }
+
+    &__controls-left {
+      display: flex;
+      align-items: center;
+      gap: var(--spacer-2);
+      flex: 1;
     }
 
     &__no-results {

--- a/packages/ui/src/views/HierarchyList/index.tsx
+++ b/packages/ui/src/views/HierarchyList/index.tsx
@@ -11,6 +11,7 @@ import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'reac
 import type { CollectionOption } from '../../elements/CreateDocumentButton/index.js'
 import type { StepNavItem } from '../../elements/StepNav/index.js'
 
+import { CreateDocumentButton } from '../../elements/CreateDocumentButton/index.js'
 import { Gutter } from '../../elements/Gutter/index.js'
 import { useListDrawerContext } from '../../elements/ListDrawer/Provider.js'
 import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
@@ -21,6 +22,7 @@ import { TagIcon } from '../../icons/Tag/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { DocumentSelectionProvider } from '../../providers/DocumentSelection/index.js'
 import { useHierarchy } from '../../providers/Hierarchy/index.js'
+import { useRouteCache } from '../../providers/RouteCache/index.js'
 import { useRouteTransition } from '../../providers/RouteTransition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { HierarchyListHeader } from './HierarchyListHeader/index.js'
@@ -64,11 +66,24 @@ export function HierarchyListView(props: ListViewClientProps) {
   const collectionConfig = getEntityConfig({ collectionSlug })
   const { labels } = collectionConfig
 
+  const hierarchyConfig =
+    collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
+      ? collectionConfig.hierarchy
+      : undefined
+  const parentFieldName = hierarchyConfig?.parentFieldName
+
   const { i18n, t } = useTranslation()
   const collectionLabel = getTranslation(labels?.plural, i18n)
 
   const { setStepNav } = useStepNav()
-  const { parent } = useHierarchy()
+  const { parent, refreshTree } = useHierarchy()
+  const { clearRouteCache } = useRouteCache()
+
+  // Callback for when a new document is created
+  const handleSave = useCallback(() => {
+    clearRouteCache()
+    refreshTree(collectionSlug)
+  }, [clearRouteCache, collectionSlug, refreshTree])
 
   // Get search from URL params
   const searchFromURL = searchParams.get('search') || ''
@@ -128,11 +143,12 @@ export function HierarchyListView(props: ListViewClientProps) {
       let navItems = [baseLabel]
 
       if (ancestorBreadcrumbs.length > 0) {
+        const queryParam = parentFieldName || 'parent'
         const hierarchyBreadcrumbs: StepNavItem[] = ancestorBreadcrumbs.map((crumb) => ({
           label: crumb.title,
           url: formatAdminURL({
             adminRoute,
-            path: `/collections/${collectionSlug}?parent=${crumb.id}`,
+            path: `/collections/${collectionSlug}?${queryParam}=${crumb.id}`,
           }),
         }))
         navItems = [...navItems, ...hierarchyBreadcrumbs]
@@ -150,13 +166,9 @@ export function HierarchyListView(props: ListViewClientProps) {
     currentItemTitle,
     parent,
     HierarchyIcon,
+    parentFieldName,
   ])
 
-  const hierarchyConfig =
-    collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
-      ? collectionConfig.hierarchy
-      : undefined
-  const parentFieldName = hierarchyConfig?.parentFieldName
   const parentId = hierarchyData?.parentId ?? null
 
   // Build collections array for create button
@@ -319,7 +331,6 @@ export function HierarchyListView(props: ListViewClientProps) {
           <Gutter className={`${baseClass}__wrap`}>
             <HierarchyListHeader
               collectionConfig={collectionConfig}
-              collections={collections}
               currentItemTitle={currentItemTitle}
               Description={
                 <React.Fragment>
@@ -345,27 +356,36 @@ export function HierarchyListView(props: ListViewClientProps) {
                   ) : null}
                 </React.Fragment>
               }
-              hasCreatePermission={hasCreatePermission}
               HierarchyIcon={HierarchyIcon}
               i18n={i18n}
               viewType={viewType}
             />
 
             <div className={`${baseClass}__controls`}>
-              <SearchBar
-                label={t('general:searchBy', {
-                  label: getTranslation(collectionConfig?.admin?.useAsTitle || 'id', i18n),
-                })}
-                onSearchChange={handleSearchChange}
-                searchQueryParam={searchFromURL}
-              />
-              <TypeFilter
-                i18n={i18n}
-                key={`type-filter-${hierarchyData.parent ? hierarchyData.parent.id : 'root'}`}
-                onChange={handleTypeFilterChange}
-                options={typeOptions}
-                selectedValues={selectedTypes}
-              />
+              <div className={`${baseClass}__controls-left`}>
+                <SearchBar
+                  label={t('general:searchBy', {
+                    label: getTranslation(collectionConfig?.admin?.useAsTitle || 'id', i18n),
+                  })}
+                  onSearchChange={handleSearchChange}
+                  searchQueryParam={searchFromURL}
+                />
+                <TypeFilter
+                  i18n={i18n}
+                  key={`type-filter-${hierarchyData.parent ? hierarchyData.parent.id : 'root'}`}
+                  onChange={handleTypeFilterChange}
+                  options={typeOptions}
+                  selectedValues={selectedTypes}
+                />
+              </div>
+              {hasCreatePermission && collections.length > 0 && (
+                <CreateDocumentButton
+                  buttonStyle="primary"
+                  collections={collections}
+                  drawerSlug={`hierarchy-create-${collectionSlug}`}
+                  onSave={handleSave}
+                />
+              )}
             </div>
 
             <HierarchyTable

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -148,6 +148,7 @@ export function DefaultListView(props: ListViewClientProps) {
 
       // Add hierarchy breadcrumbs
       if (hierarchyData?.breadcrumbs) {
+        const queryParam = hierarchyData.parentFieldName || 'parent'
         const hierarchyBreadcrumbs = hierarchyData.breadcrumbs.map((crumb, index) => {
           const isLast = index === hierarchyData.breadcrumbs.length - 1
           return {
@@ -156,7 +157,7 @@ export function DefaultListView(props: ListViewClientProps) {
               ? undefined
               : formatAdminURL({
                   adminRoute,
-                  path: `/collections/${collectionSlug}?parent=${crumb.id}`,
+                  path: `/collections/${collectionSlug}?${queryParam}=${crumb.id}`,
                 }),
           }
         })

--- a/test/hierarchy/e2e.spec.ts
+++ b/test/hierarchy/e2e.spec.ts
@@ -464,13 +464,13 @@ test.describe('Hierarchy Sidebar', () => {
       // Wait for filter to apply - Products Only should be hidden
       await expect(tree.getByText('Products Only', { exact: true })).toBeHidden()
 
-      // Create a new folder via the Create New button in the list header
+      // Create a new folder via the Create New button in the list controls
       const uniqueSuffix = Date.now()
       const newFolderName = `Filter Test Folder ${uniqueSuffix}`
 
-      // Click Create New button in the list header
-      const listHeader = page.locator('.hierarchy-list-header')
-      await listHeader.getByRole('button', { name: 'Create New' }).first().click()
+      // Click Create New button in the list controls
+      const listControls = page.locator('.hierarchy-list__controls')
+      await listControls.getByRole('button', { name: 'Create New' }).first().click()
 
       // Select "Folder" from the popup menu
       await page.getByRole('button', { name: 'Folder', exact: true }).click()
@@ -532,8 +532,8 @@ test.describe('Hierarchy Sidebar', () => {
       const uniqueSuffix = Date.now()
       const newFolderName = `Products Only Folder ${uniqueSuffix}`
 
-      const listHeader = page.locator('.hierarchy-list-header')
-      await listHeader.getByRole('button', { name: 'Create New' }).first().click()
+      const listControls = page.locator('.hierarchy-list__controls')
+      await listControls.getByRole('button', { name: 'Create New' }).first().click()
       await page.getByRole('button', { name: 'Folder', exact: true }).click()
 
       const drawer = page.locator('.drawer__content')


### PR DESCRIPTION
## What

Fixes and improvements to the hierarchy list view:

- Uses custom `parentFieldName` in breadcrumb URLs instead of hardcoded `parent`
- Adds `onSave` callback to refresh hierarchy tree and clear route cache when creating new documents
- Various CSS fixes for hierarchy drawer, column browser, and list views
- Removes unused props from `HierarchyListHeader`

## Why

Custom hierarchy configurations with different parent field names weren't working correctly for breadcrumb navigation. Additionally, creating new documents wasn't refreshing the hierarchy tree properly.