### PR TITLE
fix(ui): add badge cutout to FilterIcon for modified indicator

### DIFF
--- a/packages/ui/src/elements/QueryPresets/QueryPresetBar/index.css
+++ b/packages/ui/src/elements/QueryPresets/QueryPresetBar/index.css
@@ -50,17 +50,6 @@
     background: var(--color-bg-transparent-pressed);
   }
 
-  .query-preset-bar__modified-indicator {
-    position: absolute;
-    top: -3px;
-    left: -3px;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--ramp-red-500);
-    pointer-events: none;
-  }
-
   .query-preset-bar__popup .popup-button-list__button {
     display: flex;
     align-items: center;

--- a/packages/ui/src/elements/QueryPresets/QueryPresetBar/index.tsx
+++ b/packages/ui/src/elements/QueryPresets/QueryPresetBar/index.tsx
@@ -396,7 +396,7 @@ export const QueryPresetBar: React.FC<{
                 buttonStyle="secondary"
                 className={`${baseClass}__trigger`}
                 extraButtonProps={{ onKeyDown }}
-                icon={<FilterIcon size={24} />}
+                icon={<FilterIcon hasBadgeCutout={hasModifiedPreset} size={24} />}
                 iconPosition="left"
                 id="select-preset"
                 onClick={onClick}
@@ -404,7 +404,6 @@ export const QueryPresetBar: React.FC<{
               >
                 {buttonLabel}
               </Button>
-              {hasModifiedPreset && <span className={`${baseClass}__modified-indicator`} />}
               {activePreset && (
                 <button className={`${baseClass}__clear`} onClick={handleClearPreset} type="button">
                   <XIcon size={16} />

--- a/packages/ui/src/icons/Filter/index.css
+++ b/packages/ui/src/icons/Filter/index.css
@@ -2,4 +2,8 @@
   .icon--filter {
     flex-shrink: 0;
   }
+
+  .icon--filter__badge {
+    fill: var(--color-icon-danger);
+  }
 }

--- a/packages/ui/src/icons/Filter/index.tsx
+++ b/packages/ui/src/icons/Filter/index.tsx
@@ -4,6 +4,11 @@ import './index.css'
 
 type Props = {
   readonly className?: string
+  /**
+   * When true, adds a circular cutout in the top-right corner and renders a red indicator badge.
+   * The cutout creates space for the badge to sit cleanly without overlapping the icon.
+   */
+  readonly hasBadgeCutout?: boolean
   readonly size?: 16 | 24
 }
 
@@ -12,15 +17,43 @@ const paths = {
   24: 'M8.5 18a.5.5 0 0 0 .5-.5v-1.55a2.5 2.5 0 0 0 0-4.9V6.5a.5.5 0 0 0-1 0v4.55a2.501 2.501 0 0 0 0 4.9v1.55a.5.5 0 0 0 .5.5m7 0a.5.5 0 0 0 .5-.5v-4.55a2.501 2.501 0 0 0 0-4.9V6.5a.5.5 0 0 0-1 0v1.55a2.5 2.5 0 0 0 0 4.9v4.55a.5.5 0 0 0 .5.5m0-6a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3m-7 3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3',
 }
 
-export const FilterIcon: React.FC<Props> = ({ className, size = 24 }) => (
-  <svg
-    className={['icon', 'icon--filter', className].filter(Boolean).join(' ')}
-    fill="none"
-    height={size}
-    viewBox={`0 0 ${size} ${size}`}
-    width={size}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path d={paths[size]} fill="currentColor" />
-  </svg>
-)
+// Badge positions and cutout dimensions
+// Indicator is 4px diameter, cutout is slightly larger for clean gap
+const badgeConfig = {
+  16: { badgeRadius: 2, cutoutRadius: 3, cx: 12.5, cy: 5 },
+  24: { badgeRadius: 2, cutoutRadius: 4, cx: 18, cy: 7 },
+}
+
+export const FilterIcon: React.FC<Props> = ({ className, hasBadgeCutout, size = 24 }) => {
+  const maskId = hasBadgeCutout ? `filter-badge-cutout-${size}` : undefined
+  const config = badgeConfig[size]
+
+  return (
+    <svg
+      className={['icon', 'icon--filter', className].filter(Boolean).join(' ')}
+      fill="none"
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {hasBadgeCutout && (
+        <defs>
+          <mask id={maskId}>
+            <rect fill="white" height={size} width={size} />
+            <circle cx={config.cx} cy={config.cy} fill="black" r={config.cutoutRadius} />
+          </mask>
+        </defs>
+      )}
+      <path d={paths[size]} fill="currentColor" mask={maskId ? `url(#${maskId})` : undefined} />
+      {hasBadgeCutout && (
+        <circle
+          className="icon--filter__badge"
+          cx={config.cx}
+          cy={config.cy}
+          r={config.badgeRadius}
+        />
+      )}
+    </svg>
+  )
+}

--- a/test/query-presets/e2e.spec.ts
+++ b/test/query-presets/e2e.spec.ts
@@ -335,7 +335,7 @@ describe('Query Presets', () => {
     await expect(idColumnHeader).toBeHidden()
 
     // Verify the modified indicator is hidden
-    await expect(page.locator('.query-preset-bar__modified-indicator')).toBeHidden()
+    await expect(page.locator('.icon--filter__badge')).toBeHidden()
 
     // Verify the reset/save options are hidden (no longer modified)
     await checkPresetModifiedOptions({ page, expectReset: false, expectSave: false })
@@ -347,23 +347,23 @@ describe('Query Presets', () => {
     await navigateToListView({ page, url: pagesUrl.list })
 
     // No modified indicator when no preset selected
-    await expect(page.locator('.query-preset-bar__modified-indicator')).toBeHidden()
+    await expect(page.locator('.icon--filter__badge')).toBeHidden()
 
     await selectPreset({ page, presetTitle: seededData.everyone.title })
 
     // No modified indicator after selecting preset
-    await expect(page.locator('.query-preset-bar__modified-indicator')).toBeHidden()
+    await expect(page.locator('.icon--filter__badge')).toBeHidden()
 
     await toggleColumn(page, { columnLabel: 'ID' })
 
     // Modified indicator visible after change
-    await expect(page.locator('.query-preset-bar__modified-indicator')).toBeVisible()
+    await expect(page.locator('.icon--filter__badge')).toBeVisible()
 
     // Reset changes
     await resetPresetChanges({ page })
 
     // Modified indicator hidden after reset
-    await expect(page.locator('.query-preset-bar__modified-indicator')).toBeHidden()
+    await expect(page.locator('.icon--filter__badge')).toBeHidden()
   })
 
   test('can edit a preset through the document drawer', async ({ page }) => {
@@ -663,7 +663,7 @@ describe('Query Presets', () => {
     await savePresetChanges({ page })
 
     // Wait for the modified indicator to disappear (indicates save completed)
-    await expect(page.locator('.query-preset-bar__modified-indicator')).toBeHidden()
+    await expect(page.locator('.icon--filter__badge')).toBeHidden()
 
     // Clear and reselect the preset to verify groupBy was saved
     await clearSelectedPreset({ page })


### PR DESCRIPTION
## Summary

Adds a proper badge cutout to the FilterIcon SVG for the query preset modified indicator, matching the Figma design.

## Changes

- **FilterIcon**: Added `hasBadgeCutout` prop that renders:
  - SVG mask with circular cutout for clean badge integration
  - Badge circle inside SVG at correct position for both 16px and 24px sizes
  
- **QueryPresetBar**: Uses `hasBadgeCutout={hasModifiedPreset}` - badge is now self-contained in the icon

- **Removed**: External CSS-positioned indicator span (now rendered inside SVG)

- **E2E tests**: Updated selector from `.query-preset-bar__modified-indicator` to `.icon--filter__badge`

## Design

The badge uses `--color-icon-danger` (`--ramp-red-600`) and positions are:
- **16px**: center at (12.5, 5), cutout radius 3, badge radius 2
- **24px**: center at (18, 7), cutout radius 4, badge radius 2

This matches the Figma "Icon Badge Wrapper" pattern where the icon has a notch cut out for the indicator to sit cleanly.