### PR TITLE
refactor!: remove allowLocalizedWithinLocalized compat flag and PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY env var

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -267,16 +267,6 @@ The Payload Config only lives on the server and is not allowed to contain any cl
 
 Behind the curtains, the Next.js-based Admin Panel generates a ClientConfig, which strips away any server-only code and enriches the config with React Components.
 
-## Compatibility flags
-
-The Payload Config can accept compatibility flags for running the newest versions but with older databases. You should only use these flags if you need to, and should confirm that you need to prior to enabling these flags.
-
-`allowLocalizedWithinLocalized`
-
-Payload localization works on a field-by-field basis. As you can nest fields within other fields, you could potentially nest a localized field within a localized field—but this would be redundant and unnecessary. There would be no reason to define a localized field within a localized parent field, given that the entire data structure from the parent field onward would be localized.
-
-By default, Payload will remove the `localized: true` property from sub-fields if a parent field is localized. Set this compatibility flag to `true` only if you have an existing Payload MongoDB database from pre-3.0, and you have nested localized fields that you would like to maintain without migrating.
-
 ## Logger
 
 Payload uses [Pino](https://getpino.io) as its logger. By default, Payload logs pretty-printed output to stdout. You can customise this through the `logger` option in your config.

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -42,10 +42,6 @@ import { addOrderableEndpoint, addOrderableFieldsAndHook } from './orderable/ind
 const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig> => {
   const sanitizedConfig = { ...configToSanitize }
 
-  if (configToSanitize?.compatibility?.allowLocalizedWithinLocalized) {
-    process.env.NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized = 'true'
-  }
-
   // default logging level will be 'error' if not provided
   sanitizedConfig.loggingLevels = {
     Forbidden: 'info',

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1168,21 +1168,6 @@ export type Config = {
    */
   collections?: CollectionConfig[]
   /**
-   * Compatibility flags for prior Payload versions
-   */
-  compatibility?: {
-    /**
-     * By default, Payload will remove the `localized: true` property
-     * from fields if a parent field is localized. Set this property
-     * to `true` only if you have an existing Payload database from pre-3.0
-     * that you would like to maintain without migrating. This is only
-     * relevant for MongoDB databases.
-     *
-     * @todo Remove in v4
-     */
-    allowLocalizedWithinLocalized: true
-  }
-  /**
    * Prefix a string to all cookies that Payload sets.
    *
    * @default "payload"

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -295,18 +295,7 @@ export const sanitizeField = async ({
     }
 
     if (typeof field.localized !== 'undefined') {
-      let shouldDisableLocalized = !config.localization
-
-      if (
-        process.env.NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized !== 'true' &&
-        parentIsLocalized &&
-        // @todo PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY=true will be the default in 4.0
-        process.env.PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY !== 'true'
-      ) {
-        shouldDisableLocalized = true
-      }
-
-      if (shouldDisableLocalized) {
+      if (!config.localization) {
         delete field.localized
       }
     }

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -2094,12 +2094,7 @@ export function fieldShouldBeLocalized({
   field: ClientField | ClientTab | Field | Tab
   parentIsLocalized: boolean
 }): boolean {
-  return (
-    'localized' in field &&
-    field.localized! &&
-    (!parentIsLocalized ||
-      process.env.NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized === 'true')
-  )
+  return 'localized' in field && field.localized! && !parentIsLocalized
 }
 
 export function fieldIsVirtual(field: Field | Tab): boolean {

--- a/test/dev.ts
+++ b/test/dev.ts
@@ -17,9 +17,6 @@ import { runInit } from './runInit.js'
 import { child } from './safelyRunScript.js'
 import { createTestHooks } from './testHooks.js'
 
-// @todo remove in 4.0 - will behave like this by default in 4.0
-process.env.PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY = 'true'
-
 const prod = process.argv.includes('--prod')
 if (prod) {
   process.argv = process.argv.filter((arg) => arg !== '--prod')

--- a/test/next.config.mjs
+++ b/test/next.config.mjs
@@ -30,8 +30,6 @@ export default withBundleAnalyzer(
       env: {
         PAYLOAD_CORE_DEV: 'true',
         ROOT_DIR: path.resolve(dirname),
-        // @todo remove in 4.0 - will behave like this by default in 4.0
-        PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY: 'true',
       },
       async redirects() {
         return [

--- a/test/runE2E.ts
+++ b/test/runE2E.ts
@@ -10,8 +10,7 @@ import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
-// @todo remove in 4.0 - will behave like this by default in 4.0
-process.env.PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY = 'true'
+
 
 shelljs.env.DISABLE_LOGGING = 'true'
 

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -14,8 +14,6 @@ process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER = 's3'
 
 process.env.NODE_OPTIONS = '--no-deprecation'
 process.env.PAYLOAD_CI_DEPENDENCY_CHECKER = 'true'
-// @todo remove in 4.0 - will behave like this by default in 4.0
-process.env.PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY = 'true'
 
 // // Mock createTestAccount to prevent calling external services
 // jest.spyOn(nodemailer, 'createTestAccount').mockImplementation(() => {


### PR DESCRIPTION
## BREAKING

Removes `config.compatibility.allowLocalizedWithinLocalized` and the `PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY` env var. Sanitize no longer strips `localized: true` from fields nested under a localized parent - `fieldShouldBeLocalized` decides this at runtime instead.

**Who is affected:**

- Users of `compatibility: { allowLocalizedWithinLocalized: true }`
- Anyone with `localized: true` nested under a localized parent - end behavior is unchanged (Payload's own code already uses `fieldShouldBeLocalized`), but `field.localized` is no longer being deleted. Custom plugin/hook code that reads `field.localized` directly will now see `true` where it previously saw `undefined`.

**How to migrate:**

- Remove the `compatibility` block from your config. If your Mongo data still has the redundant nested-localized shape, flatten the config and run a data migration
- Replace any direct `field.localized` reads in custom code with `fieldShouldBeLocalized({ field, parentIsLocalized })` from `payload/shared`.

## Why these existed

**`allowLocalizedWithinLocalized`** ([#7933](https://github.com/payloadcms/payload/pull/7933)) was an opt-out for the new auto-stripping behavior, aimed at pre-3.0 Mongo users with data already written under nested-localized configs. Always marked for removal in 4.0.

**`PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY`** existed because of block references. Blocks defined at the top of the config can be referenced from both localized and non-localized parents, but sanitize visits each block only once (`_sanitized = true`), so whichever parent it sees first locks in the wrong answer for the other. [#11207](https://github.com/payloadcms/payload/pull/11207) fixed this by moving the check to runtime via `fieldShouldBeLocalized({ field, parentIsLocalized })`.

Whether we sanitize the localized properties away or not does not have an impact on this functionality. However, we had to set `PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY` in our monorepo to test against sanitization disabled, in order to guarantee correct runtime handling through our tests.

Removing `PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY` and making it the default behavior ensures that the behavior users will encounter matches what we have and test for in the payload monorepo.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214980013153702