### PR TITLE
fix: correct text-heading-large letter-spacing token value

### DIFF
--- a/packages/next/src/views/CreateFirstUser/index.css
+++ b/packages/next/src/views/CreateFirstUser/index.css
@@ -1,7 +1,5 @@
 @layer payload-default {
   .create-first-user {
-    --header-letter-spacing: -0.408px;
-
     display: flex;
     flex-direction: column;
     gap: var(--spacer-5);
@@ -24,7 +22,7 @@
     font-size: var(--text-heading-large-font-size);
     font-weight: var(--text-heading-large-font-weight);
     line-height: var(--text-heading-large-line-height);
-    letter-spacing: var(--header-letter-spacing);
+    letter-spacing: var(--text-heading-large-letter-spacing);
     color: var(--color-text);
   }
 

--- a/packages/richtext-lexical/src/lexical/theme/EditorTheme.css
+++ b/packages/richtext-lexical/src/lexical/theme/EditorTheme.css
@@ -6,7 +6,7 @@
     --lexical-h1-font-size: 2rem; /* 32px */
     --lexical-h1-letter-spacing: -0.544px;
     --lexical-h2-font-size: 1.5rem; /* 24px */
-    --lexical-h2-letter-spacing: -0.408px;
+    --lexical-h2-letter-spacing: var(--text-heading-large-letter-spacing);
     --lexical-h2-line-height: 2rem; /* 32px */
     --lexical-h3-font-size: 1.25rem; /* 20px */
     --lexical-h3-letter-spacing: -0.34px;

--- a/packages/ui/src/css/typography.css
+++ b/packages/ui/src/css/typography.css
@@ -62,6 +62,6 @@
     --text-heading-large-font-size: 1.5rem; /* 24px */
     --text-heading-large-font-weight: 550;
     --text-heading-large-line-height: 2rem; /* 32px */
-    --text-heading-large-letter-spacing: -1.7px;
+    --text-heading-large-letter-spacing: -0.408px;
   }
 }

--- a/packages/ui/src/elements/RenderTitle/index.css
+++ b/packages/ui/src/elements/RenderTitle/index.css
@@ -1,6 +1,6 @@
 @layer payload-default {
   .render-title {
-    --render-title-letter-spacing: -0.408px;
+    --render-title-letter-spacing: var(--text-heading-large-letter-spacing);
 
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Fixes the `--text-heading-large-letter-spacing` design token value and consolidates hardcoded letter-spacing values across components.

### Changes
- Corrected `--text-heading-large-letter-spacing` from `-1.7px` to `-0.408px`
- Updated `CreateFirstUser`, `RenderTitle`, and Lexical editor theme to use the design token instead of hardcoded values
