### PR TITLE
ci: use postgres 15 for content api tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -502,7 +502,6 @@ jobs:
       contents: read
     services:
       postgres:
-        # This backs only the ephemeral Content API service, which is Figma-hosted and uses PG15+ features.
         image: postgres:15
         env:
           POSTGRES_DB: figma_content_api

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -502,7 +502,8 @@ jobs:
       contents: read
     services:
       postgres:
-        image: postgres:13
+        # This backs only the ephemeral Content API service, which is Figma-hosted and uses PG15+ features.
+        image: postgres:15
         env:
           POSTGRES_DB: figma_content_api
           POSTGRES_USER: postgres


### PR DESCRIPTION
Content API Tests are currently failing because this job boots the latest Figma-hosted Content API image against `postgres:13`. The latest image includes https://github.com/figma/figma/pull/776922, which added PG15-only `UNIQUE NULLS NOT DISTINCT` index syntax, so Content API migrations fail before Payload tests run. cc @asalani-figma

Failed job example:
- Content API Tests on #16702: https://github.com/payloadcms/payload/actions/runs/26216770563/job/77142295149?pr=16702

This updates only the ephemeral database used by the Content API service in Payload CI. That database belongs to Figma-hosted Content API, not Payload or the database adapter, so matching Content API's Postgres requirement is the intended fix here.