### PR TITLE
fix: follow redirects when fetching uploaded files for MIME type detection

### DIFF
--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -102,6 +102,13 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
           throw new APIError('Expected response from the upload handler.')
         }
 
+        if (response.status >= 300 && response.status < 400) {
+          const redirectUrl = response.headers.get('Location')
+          if (redirectUrl) {
+            response = await fetch(redirectUrl)
+          }
+        }
+
         req.file = {
           name: filename,
           clientUploadContext,


### PR DESCRIPTION
## Summary

- When using S3 (or any storage adapter) with `signedDownloads` enabled, the `staticHandler` returns a `302` redirect to a pre-signed URL. Payload's `addDataAndFileToRequest` utility calls this handler internally to fetch back the just-uploaded file for MIME type detection, but Node.js `fetch` does not automatically follow redirects on a `Response` object returned from an internal handler call — resulting in an empty `ArrayBuffer` and a `DataView.getUint16()` bounds error.
- The existing guard in the S3 `staticHandler` (`if (signedDownloads && !clientUploadContext)`) was meant to skip the redirect for internal upload processing, but fires anyway when `clientUploadContext` is `undefined` (i.e. when no upload context is configured for the collection).
- Added redirect-following between receiving the handler response and consuming its body: if the response is a 3xx redirect, `addDataAndFileToRequest` now follows the `Location` header to retrieve the actual file bytes before processing.