### PR TITLE
fix(plugin-mcp): accept Payload API key auth scheme

### DIFF
--- a/docs/plugins/mcp.mdx
+++ b/docs/plugins/mcp.mdx
@@ -149,9 +149,11 @@ In your Payload admin panel, navigate to **MCP → API Keys**, create a new key,
 toggle the individual capabilities on for each collection, global, tool, prompt, and
 resource you want that key to be able to use.
 
-All MCP requests must include a valid API key as a Bearer token — requests without
-one are rejected immediately. Here is a complete example of an MCP `tools/list` request
-showing the correct headers:
+All MCP requests must include a valid API key. Bearer tokens are supported, and
+the Payload API key scheme for the MCP API key collection is also accepted:
+`Authorization: payload-mcp-api-keys API-Key MCP-USER-API-KEY`. Requests without
+a valid API key are rejected immediately. Here is a complete example of an MCP
+`tools/list` request showing the correct headers:
 
 ```bash
 curl -i 'http://localhost:3000/api/mcp' \
@@ -266,7 +268,8 @@ npx @modelcontextprotocol/inspector
 ```
 
 Open the inspector, set the URL to `http://127.0.0.1:3000/api/mcp`, and add an
-`Authorization: Bearer MCP-USER-API-KEY` header.
+`Authorization: Bearer MCP-USER-API-KEY` header. You can also use Payload's API
+key convention: `Authorization: payload-mcp-api-keys API-Key MCP-USER-API-KEY`.
 
 You can also test directly with `curl`:
 

--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -6,6 +6,24 @@ import type { MCPAccessSettings, MCPPluginConfig } from '../types.js'
 import { createRequestFromPayloadRequest } from '../mcp/createRequest.js'
 import { getMCPHandler } from '../mcp/getMcpHandler.js'
 
+const parseMCPApiKey = (authorization: null | string): null | string => {
+  if (!authorization) {
+    return null
+  }
+
+  const bearerPrefix = 'Bearer '
+  if (authorization.startsWith(bearerPrefix)) {
+    return authorization.slice(bearerPrefix.length).trim()
+  }
+
+  const payloadAPIKeyPrefix = 'payload-mcp-api-keys API-Key '
+  if (authorization.startsWith(payloadAPIKeyPrefix)) {
+    return authorization.slice(payloadAPIKeyPrefix.length).trim()
+  }
+
+  return null
+}
+
 export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
   const mcpHandler: PayloadHandler = async (req) => {
     const { payload } = req
@@ -16,12 +34,9 @@ export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
     req.payloadAPI = 'MCP' as const
 
     const getDefaultMcpAccessSettings = async (overrideApiKey?: null | string) => {
-      const apiKey =
-        (overrideApiKey ?? req.headers.get('Authorization')?.startsWith('Bearer '))
-          ? req.headers.get('Authorization')?.replace('Bearer ', '').trim()
-          : null
+      const apiKey = overrideApiKey ?? parseMCPApiKey(req.headers.get('Authorization'))
 
-      if (apiKey === null) {
+      if (!apiKey) {
         throw new UnauthorizedError()
       }
 

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -273,6 +273,29 @@ describe('@payloadcms/plugin-mcp', () => {
         'Unauthorized, you must be logged in to make this request.',
       )
     })
+
+    it('should allow the Payload API-Key Authorization scheme', async () => {
+      const apiKey = await getApiKey()
+      const response = await restClient.POST('/mcp', {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          params: {},
+        }),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          Authorization: `payload-mcp-api-keys API-Key ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await parseStreamResponse(response)
+
+      expect(response.status).toBe(200)
+      expect(json).toBeDefined()
+      expect(json.result?.tools).toBeDefined()
+    })
   })
 
   describe('List', () => {


### PR DESCRIPTION
## Summary
- parse MCP API keys from both `Authorization: Bearer <key>` and Payload convention `Authorization: payload-mcp-api-keys API-Key <key>`
- fix `getDefaultMcpAccessSettings(overrideApiKey)` so an override key is used directly instead of being lost to the previous `??` / ternary precedence shape
- add integration coverage for `tools/list` using the Payload API-Key authorization scheme
- update MCP docs to mention both accepted authorization forms

## Verification
- `git diff --check`
- `corepack pnpm exec prettier --check packages/plugin-mcp/src/endpoints/mcp.ts test/plugin-mcp/int.spec.ts docs/plugins/mcp.mdx`
- `PAYLOAD_DATABASE=sqlite corepack pnpm exec vitest --run --project int test/plugin-mcp/int.spec.ts --no-cache`

Notes from local setup: the repo currently declares engines requiring Node >=24.15.0; this machine has Node v24.13.0, so pnpm emitted engine warnings for several workspace packages. The targeted SQLite integration suite still passed.

Refs #16572