### PR TITLE
refactor(ui)!: default drawer depth context to 0

### DIFF
--- a/packages/plugin-multi-tenant/src/components/AssignTenantFieldModal/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/AssignTenantFieldModal/index.client.tsx
@@ -106,7 +106,7 @@ export const AssignTenantFieldModal: React.FC<{
       className={baseClass}
       slug={assignTenantModalSlug}
       style={{
-        zIndex: drawerZBase + editDepth,
+        zIndex: drawerZBase + editDepth + 1,
       }}
     >
       <div className={`${baseClass}__bg`} />

--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -277,5 +277,5 @@ export const useBulkUpload = () => React.use(Context)
 export function useBulkUploadDrawerSlug() {
   const depth = useDrawerDepth()
 
-  return `${drawerSlug}-${depth || 1}`
+  return `${drawerSlug}-${depth}`
 }

--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -277,5 +277,5 @@ export const useBulkUpload = () => React.use(Context)
 export function useBulkUploadDrawerSlug() {
   const depth = useDrawerDepth()
 
-  return `${drawerSlug}-${depth}`
+  return `${drawerSlug}-${depth + 1}`
 }

--- a/packages/ui/src/elements/ConfirmationModal/index.tsx
+++ b/packages/ui/src/elements/ConfirmationModal/index.tsx
@@ -102,7 +102,7 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
       }
       slug={modalSlug}
       title={heading}
-      zIndex={drawerZBase + editDepth}
+      zIndex={drawerZBase + editDepth + 1}
     >
       {typeof body === 'string' ? <p>{body}</p> : body}
     </AlertModal>

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -60,7 +60,13 @@ export const DrawerToggler: React.FC<TogglerProps> = ({
   )
 }
 
-export const Drawer: React.FC<Props> = ({
+export const Drawer: React.FC<Props> = (props) => (
+  <DrawerDepthProvider>
+    <DrawerInner {...props} />
+  </DrawerDepthProvider>
+)
+
+const DrawerInner: React.FC<Props> = ({
   slug,
   children,
   className,
@@ -84,82 +90,79 @@ export const Drawer: React.FC<Props> = ({
   if (isOpen) {
     // IMPORTANT: do not render the drawer until it is explicitly open, this is to avoid large html trees especially when nesting drawers
     return (
-      <DrawerDepthProvider>
-        <Modal
-          className={[
-            className,
-            baseClass,
-            animateIn && `${baseClass}--is-open`,
-            drawerDepth > 1 && `${baseClass}--nested`,
-          ]
-            .filter(Boolean)
-            .join(' ')}
-          // Fixes https://github.com/payloadcms/payload/issues/13778
-          closeOnBlur={false}
-          slug={slug}
-          style={{
-            paddingRight:
-              drawerDepth > 1 ? `calc(${drawerDepth - 1} * var(--spacer-3))` : undefined,
-            zIndex: drawerZBase + drawerDepth,
-          }}
-        >
-          {(!drawerDepth || drawerDepth === 1) && <div className={`${baseClass}__blur-bg`} />}
-          <button
-            aria-label={t('general:close')}
-            className={`${baseClass}__close`}
-            id={`close-drawer__${slug}`}
-            onClick={() => closeModal(slug)}
-            type="button"
-          />
-          <div className={`${baseClass}__content`}>
-            <div className={`${baseClass}__blur-bg-content`} />
-            <div className={`${baseClass}__content-children`}>
-              {Header}
-              {Header === undefined && (
-                <div className={`${baseClass}__header`}>
-                  {/* TODO: the `button` HTML element breaks CSS transitions on the drawer for some reason...
-                    i.e. changing to a `div` element will fix the animation issue but will break accessibility
-                  */}
-                  <Button
-                    aria-label={t('general:close')}
-                    buttonStyle="ghost"
-                    className={`${baseClass}__header__close`}
-                    icon={<ChevronIcon direction="left" size={24} />}
-                    onClick={() => closeModal(slug)}
-                  />
-                  <h2 className={`${baseClass}__header__title`} title={hoverTitle ? title : null}>
-                    {title}
-                  </h2>
-                  {headerActions && headerActions.length > 0 && (
-                    <div className={`${baseClass}__header__actions`}>
-                      {headerActions.map((action, i) => (
-                        <Button
-                          buttonStyle={action.style || 'secondary'}
-                          disabled={action.disabled}
-                          key={i}
-                          margin={false}
-                          onClick={action.onClick}
-                          size="medium"
-                        >
-                          {action.label}
-                        </Button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-              {children}
-            </div>
+      <Modal
+        className={[
+          className,
+          baseClass,
+          animateIn && `${baseClass}--is-open`,
+          drawerDepth > 1 && `${baseClass}--nested`,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        // Fixes https://github.com/payloadcms/payload/issues/13778
+        closeOnBlur={false}
+        slug={slug}
+        style={{
+          paddingRight: drawerDepth > 1 ? `calc(${drawerDepth - 1} * var(--spacer-3))` : undefined,
+          zIndex: drawerZBase + drawerDepth,
+        }}
+      >
+        {drawerDepth === 1 && <div className={`${baseClass}__blur-bg`} />}
+        <button
+          aria-label={t('general:close')}
+          className={`${baseClass}__close`}
+          id={`close-drawer__${slug}`}
+          onClick={() => closeModal(slug)}
+          type="button"
+        />
+        <div className={`${baseClass}__content`}>
+          <div className={`${baseClass}__blur-bg-content`} />
+          <div className={`${baseClass}__content-children`}>
+            {Header}
+            {Header === undefined && (
+              <div className={`${baseClass}__header`}>
+                {/* TODO: the `button` HTML element breaks CSS transitions on the drawer for some reason...
+                  i.e. changing to a `div` element will fix the animation issue but will break accessibility
+                */}
+                <Button
+                  aria-label={t('general:close')}
+                  buttonStyle="ghost"
+                  className={`${baseClass}__header__close`}
+                  icon={<ChevronIcon direction="left" size={24} />}
+                  onClick={() => closeModal(slug)}
+                />
+                <h2 className={`${baseClass}__header__title`} title={hoverTitle ? title : null}>
+                  {title}
+                </h2>
+                {headerActions && headerActions.length > 0 && (
+                  <div className={`${baseClass}__header__actions`}>
+                    {headerActions.map((action, i) => (
+                      <Button
+                        buttonStyle={action.style || 'secondary'}
+                        disabled={action.disabled}
+                        key={i}
+                        margin={false}
+                        onClick={action.onClick}
+                        size="medium"
+                      >
+                        {action.label}
+                      </Button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+            {children}
           </div>
-        </Modal>
-      </DrawerDepthProvider>
+        </div>
+      </Modal>
     )
   }
 
   return null
 }
 
-export const DrawerDepthContext = createContext(1)
+export const DrawerDepthContext = createContext(0)
 
 export const DrawerDepthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const parentDepth = useDrawerDepth()

--- a/packages/ui/src/elements/IDLabel/index.tsx
+++ b/packages/ui/src/elements/IDLabel/index.tsx
@@ -27,8 +27,8 @@ export const IDLabel: React.FC<{ className?: string; id: string; prefix?: string
 
   const sanitizedID = sanitizeID(id)
 
-  // Only render as link if we're in a nested drawer and have document context
-  const shouldRenderLink = drawerDepth > 1 && (collectionSlug || globalSlug)
+  // Only render as link if we're inside a drawer and have document context
+  const shouldRenderLink = drawerDepth > 0 && (collectionSlug || globalSlug)
 
   if (shouldRenderLink) {
     const docPath = formatAdminURL({


### PR DESCRIPTION
`DrawerDepthContext` now defaults to 0 (was 1) to meet expected user behavior:
- Outside any drawer = 0
- Inside first drawer = 1
- Second drawer = 2, and so on

This is how the `EditDepthContext` works. These contexts are now fully aligned for consistency.

BREAKING CHANGES

- `DrawerDepthContext` default value changed from `1` to `0`. External code relying on hard-coded depth values must update, e.g. drawer slugs.
- `useDrawerDepth()` values shift down by 1 in most contexts. Any consumer relying on this hook to determine whether a particular component is rendered in a drawer vs. at the root level must update:
  - Component is NOT rendered in a drawer: `depth === 0` (used to be `depth === 1`)
  - Component IS rendered in a drawer: `depth > 0` (used to be `depth > 1`)
- `useBulkUploadDrawerSlug()` slug values shift by `-1`:
  - At the `BulkUploadProvider` mount point (outside any drawer): now `bulk-upload-drawer-slug-0` (was `-1`)
  - Inside a root drawer: now `-1` (was `-2`)

No codemod is provided — comparisons against `useDrawerDepth()` are semantically ambiguous to auto-transform, and slug usages are opaque strings. Manual audit is more reliable.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214834592259658