### PR TITLE
fix: add `restoreVersion` operation to beforeValidate hook.

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -486,6 +486,7 @@ export interface FieldBase {
   access?: {
     create?: FieldAccess
     read?: FieldAccess
+    restoreVersion?: FieldAccess
     update?: FieldAccess
   }
   admin?: FieldAdmin

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -316,11 +316,19 @@ export const promise = async <T>({
       }
     }
 
-    // Execute access control
-    if (field.access && field.access[operation]) {
+    // Execute access control.
+    //
+    // During `restoreVersion`, look up `field.access.restoreVersion` rather than
+    // `field.access.update`. By default that key is undefined → no per-field enforcement,
+    // which is correct for snapshot replay (already gated by collection-level access).
+    // Authors can opt back in to per-field gating on restore by defining the key.
+    const accessKey = req.context?.isRestoringVersion ? 'restoreVersion' : operation
+    const accessFn = field.access?.[accessKey]
+
+    if (accessFn) {
       const result = overrideAccess
         ? true
-        : await field.access[operation]({
+        : await accessFn({
             id,
             blockData,
             data: data as Partial<T>,

--- a/test/versions/collections/DraftsWithImmutableField.ts
+++ b/test/versions/collections/DraftsWithImmutableField.ts
@@ -1,0 +1,35 @@
+import type { CollectionConfig } from 'payload'
+
+import { draftWithImmutableFieldCollectionSlug } from '../slugs.js'
+
+const DraftsWithImmutableField: CollectionConfig = {
+  slug: draftWithImmutableFieldCollectionSlug,
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'immutable',
+      type: 'text',
+      access: {
+        update: () => false,
+      },
+      required: true,
+    },
+    {
+      name: 'restoreGated',
+      type: 'text',
+      access: {
+        restoreVersion: () => false,
+        update: () => true,
+      },
+    },
+  ],
+  versions: {
+    drafts: true,
+  },
+}
+
+export default DraftsWithImmutableField

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -14,6 +14,7 @@ import DraftPosts from './collections/Drafts.js'
 import DraftsNoReadVersions from './collections/DraftsNoReadVersions.js'
 import DraftWithChangeHook from './collections/DraftsWithChangeHook.js'
 import DraftsWithCustomUnpublish from './collections/DraftsWithCustomUnpublish.js'
+import DraftsWithImmutableField from './collections/DraftsWithImmutableField.js'
 import DraftWithMax from './collections/DraftsWithMax.js'
 import DraftsWithValidate from './collections/DraftsWithValidate.js'
 import ErrorOnUnpublish from './collections/ErrorOnUnpublish.js'
@@ -54,6 +55,7 @@ export default buildConfigWithDefaults({
     DraftsNoReadVersions,
     DraftWithMax,
     DraftWithChangeHook,
+    DraftsWithImmutableField,
     DraftsWithCustomUnpublish,
     DraftsWithValidate,
     ErrorOnUnpublish,

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -26,6 +26,7 @@ import {
   draftCollectionSlug,
   draftGlobalSlug,
   draftUnlimitedGlobalSlug,
+  draftWithImmutableFieldCollectionSlug,
   localizedCollectionSlug,
   localizedGlobalSlug,
   versionCollectionSlug,
@@ -949,6 +950,85 @@ describe('Versions', () => {
         // Block sub-fields should NOT have leaked either
         expect(restored.blocksField?.[0]!.localized).toBeFalsy()
         expect(restored.blocksField?.[0]!.text).toBe('original-text')
+      })
+
+      it('should restore a version when a required field has field-level update access denying writes', async () => {
+        const doc = await payload.create({
+          collection: draftWithImmutableFieldCollectionSlug,
+          data: {
+            immutable: 'set-on-create',
+            title: 'v1',
+          },
+          overrideAccess: true,
+        })
+
+        await payload.update({
+          collection: draftWithImmutableFieldCollectionSlug,
+          id: doc.id,
+          data: { title: 'v2' },
+          overrideAccess: true,
+        })
+
+        const { docs: versions } = await payload.findVersions({
+          collection: draftWithImmutableFieldCollectionSlug,
+          sort: '-createdAt',
+          where: { parent: { equals: doc.id } },
+          overrideAccess: true,
+        })
+
+        const originalVersion = versions[versions.length - 1]
+
+        const restored = await payload.restoreVersion({
+          collection: draftWithImmutableFieldCollectionSlug,
+          id: originalVersion!.id,
+          overrideAccess: false,
+          user,
+        })
+
+        expect(restored.title).toBe('v1')
+        expect(restored.immutable).toBe('set-on-create')
+      })
+
+      it('should honor field.access.restoreVersion when authors opt in to per-field gating on restore', async () => {
+        const doc = await payload.create({
+          collection: draftWithImmutableFieldCollectionSlug,
+          data: {
+            immutable: 'set-on-create',
+            restoreGated: 'v1-gated',
+            title: 'v1',
+          },
+          overrideAccess: true,
+        })
+
+        await payload.update({
+          collection: draftWithImmutableFieldCollectionSlug,
+          id: doc.id,
+          data: { restoreGated: 'v2-gated', title: 'v2' },
+          overrideAccess: true,
+        })
+
+        const { docs: versions } = await payload.findVersions({
+          collection: draftWithImmutableFieldCollectionSlug,
+          sort: '-createdAt',
+          where: { parent: { equals: doc.id } },
+          overrideAccess: true,
+        })
+
+        const originalVersion = versions[versions.length - 1]
+
+        const restored = await payload.restoreVersion({
+          collection: draftWithImmutableFieldCollectionSlug,
+          id: originalVersion!.id,
+          overrideAccess: false,
+          user,
+        })
+
+        // Title rolls back normally. `restoreGated` was stripped from the snapshot
+        // by its `restoreVersion: () => false` access fn before persisting, so the
+        // db update doesn't touch that column and the current value ('v2-gated')
+        // remains — mirroring how `update: () => false` skips writes on normal updates.
+        expect(restored.title).toBe('v1')
+        expect(restored.restoreGated).toBe('v2-gated')
       })
     })
 

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -16,6 +16,8 @@ export const draftWithMaxCollectionSlug = 'draft-with-max-posts'
 
 export const draftWithChangeHookCollectionSlug = 'draft-posts-with-change-hook'
 
+export const draftWithImmutableFieldCollectionSlug = 'draft-with-immutable-field'
+
 export const postCollectionSlug = 'posts'
 
 export const diffCollectionSlug = 'diff'


### PR DESCRIPTION
fix for https://github.com/payloadcms/payload/issues/16718