### PR TITLE
docs: fix broken html rendering in accessibility banner

### DIFF
--- a/docs/admin/accessibility.mdx
+++ b/docs/admin/accessibility.mdx
@@ -9,18 +9,9 @@ keywords: admin, accessibility, a11y, custom, documentation, Content Management 
 Payload is committed to ensuring that our admin panel is accessible to all users, including those with disabilities. We follow best practices and guidelines to create an inclusive experience.
 
 <Banner type="info">
-  <p>
-    We are actively working towards full compliance with WCAG 2.2 AA standards.
-    If you encounter any accessibility issues, please report them in our{' '}
-    <a
-      href="https://github.com/payloadcms/payload/discussions/14489"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      GitHub Discussion
-    </a>{' '}
-    page.
-  </p>
+  We are actively working towards full compliance with WCAG 2.2 AA standards. If
+  you encounter any accessibility issues, please report them in our [GitHub
+  Discussion](https://github.com/payloadcms/payload/discussions/14489) page.
 </Banner>
 
 ## Compliance standards


### PR DESCRIPTION
### What?
Fixed an issue where raw HTML tags were being displayed as plain text within the Accessibility page banner.

### Why?
The `Banner` component in the documentation site does not automatically transform raw HTML strings (like `<p>` and `<a>`) into rendered elements. This resulted in users seeing the literal code instead of the intended message and link. Switching to standard Markdown ensures the content is correctly parsed and rendered by the MDX provider.

### How?
Updated `docs/admin/accessibility.mdx` to replace the non-rendering raw HTML with standard Markdown syntax inside the `<Banner>` component.

Fixes https://github.com/payloadcms/payload/issues/16735