### PR TITLE
fix(drizzle): coalesce jsonb_agg/json_group_array to empty array for hasMany select join-where

### DIFF
--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -544,13 +544,13 @@ export const traverseFields = ({
                 if (adapter.name === 'postgres') {
                   selectFields[path] = sql
                     .raw(
-                      `(select jsonb_agg(${tableName}.value) from ${tableName} where ${tableName}.parent_id = ${parentTable}.id)`,
+                      `(select coalesce(jsonb_agg(${tableName}.value), '[]'::jsonb) from ${tableName} where ${tableName}.parent_id = ${parentTable}.id)`,
                     )
                     .as(path)
                 } else {
                   selectFields[path] = sql
                     .raw(
-                      `(select json_group_array(${tableName}.value) from ${tableName} where ${tableName}.parent_id = ${parentTable}.id)`,
+                      `(select coalesce(json_group_array(${tableName}.value), '[]') from ${tableName} where ${tableName}.parent_id = ${parentTable}.id)`,
                     )
                     .as(path)
                 }


### PR DESCRIPTION
### What?
Fix sub-folders not showing up in the folder browser (e.g. "Browse by folder" drawer) when those folders have no `folderType` set (universal folders).

### Why?
Universal folders have zero rows in the `payload_folders_folder_type` join table. In `drizzle/find/traverseFields.ts`, the subquery that aggregates hasMany select field values uses `jsonb_agg()` (PostgreSQL) / `json_group_array()` (SQLite). When there are zero rows, these aggregates return `NULL` — not an empty array. The subsequent JSON path check `NOT jsonb_path_exists(NULL, '$[*]')` evaluates to `NULL` in SQL (not `TRUE`), so the `WHERE` clause silently excludes universal folders from the results.

```sql
SELECT NOT jsonb_path_exists(NULL, '$[*]');
-- Returns: NULL  -> row excluded from WHERE clause

SELECT NOT jsonb_path_exists(COALESCE(NULL, '[]'::jsonb), '$[*]');
-- Returns: true  -> row correctly included
```

This affects any query using `exists: false` (or any other operator) on a `hasMany` select field used inside a polymorphic join `where` clause.

### How?
Wrap both aggregate subqueries in `COALESCE` so they always return an empty array instead of `NULL` when no rows exist:

```diff
- sql`(select jsonb_agg(t.value) from t where t.parent_id = parent.id)`
+ sql`coalesce((select jsonb_agg(t.value) from t where t.parent_id = parent.id), '[]'::jsonb)`
```
```diff
- sql`(select json_group_array(t.value) from t where t.parent_id = parent.id)`
+ sql`coalesce((select json_group_array(t.value) from t where t.parent_id = parent.id), '[]')`
```

This should also be backported to v3

Fixes #14821