### PR TITLE
fix(plugin-ecommerce): pass secret to refreshCart

### DIFF
--- a/packages/plugin-ecommerce/src/react/provider/index.tsx
+++ b/packages/plugin-ecommerce/src/react/provider/index.tsx
@@ -239,9 +239,9 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
     if (!cartID) {
       return
     }
-    const updatedCart = await getCart(cartID)
+    const updatedCart = await getCart(cartID, { secret: cartSecret })
     setCart(updatedCart)
-  }, [cartID, getCart])
+  }, [cartID, cartSecret, getCart])
 
   // Persist cart ID and secret to localStorage
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Pass the stored guest cart secret when `refreshCart()` fetches the current cart
- Keep authenticated cart refresh behavior unchanged when no secret is present
- Align `refreshCart()` with the existing secret-aware cart mutation refreshes
