### PR TITLE
fix: block reordering leaves orphaned rows in _rels tables

### DIFF
--- a/packages/drizzle/src/transform/write/blocks.ts
+++ b/packages/drizzle/src/transform/write/blocks.ts
@@ -144,4 +144,9 @@ export const transformBlocks = ({
 
     blocks[blockTableName].push(newRow)
   })
+
+  relationshipsToDelete.push({
+    path: `${path || ''}${field.name}.`,
+    prefix: true,
+  })
 }

--- a/packages/drizzle/src/transform/write/types.ts
+++ b/packages/drizzle/src/transform/write/types.ts
@@ -28,6 +28,7 @@ export type RelationshipToDelete = {
   itemToRemove?: any // For $remove operations - stores the item data to match
   locale?: string
   path: string
+  prefix?: boolean // For blocks fields - delete all paths starting with this prefix
   relationTo?: string // For simple relationships - stores the relationTo field
 }
 

--- a/packages/drizzle/src/upsertRow/deleteExistingRowsByPath.ts
+++ b/packages/drizzle/src/upsertRow/deleteExistingRowsByPath.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, like } from 'drizzle-orm'
 
 import type { DrizzleAdapter, DrizzleTransaction } from '../types.js'
 
@@ -25,13 +25,22 @@ export const deleteExistingRowsByPath = async ({
 }: Args): Promise<void> => {
   const localizedPathsToDelete = new Set<string>()
   const pathsToDelete = new Set<string>()
+  const localizedPrefixPathsToDelete = new Set<string>()
+  const prefixPathsToDelete = new Set<string>()
   const table = adapter.tables[tableName]
 
   rows.forEach((row) => {
     const path = row[pathColumnName]
     const localeData = row[localeColumnName]
+    const prefix = row.prefix as boolean | undefined
     if (typeof path === 'string') {
-      if (typeof localeData === 'string') {
+      if (prefix) {
+        if (typeof localeData === 'string') {
+          localizedPrefixPathsToDelete.add(path)
+        } else {
+          prefixPathsToDelete.add(path)
+        }
+      } else if (typeof localeData === 'string') {
         localizedPathsToDelete.add(path)
       } else {
         pathsToDelete.add(path)
@@ -65,5 +74,35 @@ export const deleteExistingRowsByPath = async ({
       tableName,
       where: and(...whereConstraints),
     })
+  }
+
+  if (localizedPrefixPathsToDelete.size > 0) {
+    for (const prefix of localizedPrefixPathsToDelete) {
+      const whereConstraints = [
+        eq(table[parentColumnName], parentID),
+        like(table[pathColumnName], `${prefix}%`),
+      ]
+
+      await adapter.deleteWhere({
+        db,
+        tableName,
+        where: and(...whereConstraints),
+      })
+    }
+  }
+
+  if (prefixPathsToDelete.size > 0) {
+    for (const prefix of prefixPathsToDelete) {
+      const whereConstraints = [
+        eq(table[parentColumnName], parentID),
+        like(table[pathColumnName], `${prefix}%`),
+      ]
+
+      await adapter.deleteWhere({
+        db,
+        tableName,
+        where: and(...whereConstraints),
+      })
+    }
   }
 }


### PR DESCRIPTION
## Description

When blocks are reordered in the admin UI, orphaned rows remain in the \_rels\ join tables because the existing row cleanup logic doesn't properly track and remove stale relationship entries after block position changes.

### Root Cause

The \deleteExistingRowsByPath\ function in the drizzle adapter wasn't accounting for block reordering scenarios where paths change but the block content remains. This left orphaned \_rels\ rows that reference old block positions.

### Fix

- Enhanced \deleteExistingRowsByPath\ to properly handle path changes during block reordering
- Added block-specific tracking in the write transformation layer
- Ensures all stale relationship entries are cleaned up when blocks are reordered

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)