### PR TITLE
fix(ui): prevent validation tooltip text descender clipping

### DIFF
--- a/packages/ui/src/elements/Tooltip/index.css
+++ b/packages/ui/src/elements/Tooltip/index.css
@@ -38,7 +38,7 @@
     }
 
     .tooltip-content {
-      overflow: hidden;
+      overflow-x: hidden;
       text-overflow: ellipsis;
       width: 100%;
     }


### PR DESCRIPTION
#### What?
Validation error tooltip text clips descenders (q, g).

#### Why?
.tooltip-content used overflow: hidden, which clips vertically.

#### How?
Use overflow-x: hidden instead so ellipsis still works horizontally.

Fixes : #16774