### PR TITLE
fix(ui): remove sidebar collapse transition

### DIFF
--- a/packages/next/src/elements/Nav/NavWrapper/index.scss
+++ b/packages/next/src/elements/Nav/NavWrapper/index.scss
@@ -9,19 +9,9 @@
     height: 100vh;
     width: var(--nav-width);
     border-right: 1px solid var(--theme-elevation-100);
-    opacity: 0;
-
     [dir='rtl'] & {
       border-right: none;
       border-left: 1px solid var(--theme-elevation-100);
-    }
-
-    &--nav-animate {
-      transition: opacity var(--nav-trans-time) ease-in-out;
-    }
-
-    &--nav-open {
-      opacity: 1;
     }
   }
 }

--- a/packages/next/src/elements/Nav/NavWrapper/index.tsx
+++ b/packages/next/src/elements/Nav/NavWrapper/index.tsx
@@ -13,14 +13,13 @@ export const NavWrapper: React.FC<{
 }> = (props) => {
   const { baseClass, children } = props
 
-  const { hydrated, navOpen, navRef, shouldAnimate } = useNav()
+  const { hydrated, navOpen, navRef } = useNav()
 
   return (
     <aside
       className={[
         baseClass,
         navOpen && `${baseClass}--nav-open`,
-        shouldAnimate && `${baseClass}--nav-animate`,
         hydrated && `${baseClass}--nav-hydrated`,
       ]
         .filter(Boolean)

--- a/packages/next/src/elements/Nav/index.css
+++ b/packages/next/src/elements/Nav/index.css
@@ -7,7 +7,6 @@
     height: 100vh;
     width: var(--nav-width);
     border-right: 1px solid var(--color-border);
-    opacity: 0;
     overflow: hidden;
     --nav-padding-inline-start: var(--spacer-2-5);
     --nav-padding-inline-end: var(--spacer-2-5);
@@ -18,14 +17,6 @@
   [dir='rtl'] .nav {
     border-right: none;
     border-left: 1px solid var(--color-border);
-  }
-
-  .nav--nav-animate {
-    transition: opacity var(--nav-trans-time) ease-in-out;
-  }
-
-  .nav--nav-open {
-    opacity: 1;
   }
 
   .nav__mobile-close {

--- a/packages/next/src/templates/Default/Wrapper/index.css
+++ b/packages/next/src/templates/Default/Wrapper/index.css
@@ -4,18 +4,6 @@
     display: grid;
     position: relative;
     isolation: isolate;
-
-    @media (prefers-reduced-motion) {
-      transition: none;
-    }
-  }
-
-  .template-default--nav-animate {
-    transition: grid-template-columns var(--nav-trans-time) linear;
-  }
-
-  .template-default--nav-open .template-default__nav-overlay {
-    transition: opacity var(--nav-trans-time) linear;
   }
 
   @media (min-width: 1441px) {

--- a/packages/next/src/templates/Default/Wrapper/index.tsx
+++ b/packages/next/src/templates/Default/Wrapper/index.tsx
@@ -10,7 +10,7 @@ export const Wrapper: React.FC<{
   className?: string
 }> = (props) => {
   const { baseClass, children, className } = props
-  const { hydrated, navOpen, shouldAnimate } = useNav()
+  const { hydrated, navOpen } = useNav()
 
   return (
     <div
@@ -18,7 +18,6 @@ export const Wrapper: React.FC<{
         baseClass,
         className,
         navOpen && `${baseClass}--nav-open`,
-        shouldAnimate && `${baseClass}--nav-animate`,
         hydrated && `${baseClass}--nav-hydrated`,
       ]
         .filter(Boolean)

--- a/packages/next/src/templates/Default/index.css
+++ b/packages/next/src/templates/Default/index.css
@@ -13,17 +13,6 @@
     flex-direction: column;
     background-color: var(--color-bg);
 
-    &:before {
-      content: '';
-      display: block;
-      position: absolute;
-      inset: 0;
-      background-color: inherit;
-      opacity: 0;
-      z-index: var(--z-status);
-      visibility: hidden;
-      transition: all var(--nav-trans-time) linear;
-    }
   }
 
   @media (max-width: 768px) {

--- a/packages/ui/src/elements/Nav/context.tsx
+++ b/packages/ui/src/elements/Nav/context.tsx
@@ -11,7 +11,6 @@ type NavContextType = {
   navOpen: boolean
   navRef: React.RefObject<HTMLDivElement | null>
   setNavOpen: (value: boolean) => void
-  shouldAnimate: boolean
 }
 
 /**
@@ -22,7 +21,6 @@ export const NavContext = React.createContext<NavContextType>({
   navOpen: true,
   navRef: null,
   setNavOpen: () => {},
-  shouldAnimate: false,
 })
 
 export const useNav = () => React.use(NavContext)
@@ -59,7 +57,6 @@ export const NavProvider: React.FC<{
   // we will open it after the preference is loaded
   const [navOpen, setNavOpen] = React.useState(initialIsOpen)
 
-  const [shouldAnimate, setShouldAnimate] = React.useState(false)
   const [hydrated, setHydrated] = React.useState(false)
 
   // on load check the user's preference and set "initial" state
@@ -102,13 +99,6 @@ export const NavProvider: React.FC<{
       setNavOpen(false)
     }
     setHydrated(true)
-
-    const timeout = setTimeout(() => {
-      setShouldAnimate(true)
-    }, 100)
-    return () => {
-      clearTimeout(timeout)
-    }
   }, [largeBreak, midBreak, smallBreak])
 
   // when the component unmounts, clear all body scroll locks
@@ -120,9 +110,5 @@ export const NavProvider: React.FC<{
     }
   }, [])
 
-  return (
-    <NavContext value={{ hydrated, navOpen, navRef, setNavOpen, shouldAnimate }}>
-      {children}
-    </NavContext>
-  )
+  return <NavContext value={{ hydrated, navOpen, navRef, setNavOpen }}>{children}</NavContext>
 }

--- a/packages/ui/src/scss/app.scss
+++ b/packages/ui/src/scss/app.scss
@@ -41,7 +41,6 @@
     --spacing-view-bottom: var(--gutter-h);
     --doc-controls-height: calc(var(--text-body-large-line-height) + var(--spacer-4));
     --nav-width: 275px;
-    --nav-trans-time: 150ms;
 
     @include large-break {
       --gutter-h: var(--spacer-4);

--- a/test/__helpers/e2e/toggleNav.ts
+++ b/test/__helpers/e2e/toggleNav.ts
@@ -26,7 +26,6 @@ export async function openNav(page: Page): Promise<{ nav: ReturnType<Page['locat
 
   // desktop uses .app-header__sidebar-toggle, mobile uses .nav-toggler
   await page.locator('.app-header__sidebar-toggle').click()
-  await expect(page.locator('.nav--nav-animate[inert], .nav--nav-hydrated[inert]')).toBeHidden()
   await expect(page.locator('.template-default.template-default--nav-open')).toBeVisible()
 
   return {


### PR DESCRIPTION
Removes the animated open/close transition from the admin sidebar, along with all the supporting CSS, state, and class machinery that existed solely to drive it.