### PR TITLE
ci: fail publish-prerelease when any package fails to publish

### DIFF
--- a/tools/releaser/src/lib/getWorkspace.ts
+++ b/tools/releaser/src/lib/getWorkspace.ts
@@ -86,6 +86,15 @@ export const getWorkspace = async () => {
         })
         .join('\n') + '\n',
     )
+
+    const failed = results.filter((result) => !result.success)
+    if (failed.length > 0) {
+      throw new Error(
+        `${failed.length} of ${results.length} package(s) failed to publish: ${failed
+          .map((result) => result.name)
+          .join(', ')}`,
+      )
+    }
   }
 
   const publish = async () => {


### PR DESCRIPTION
Any failure when publishing internal releases will now surface the error and show as failed in GitHub Actions