### PR TITLE
fix(ui): strip customComponents from rows in reduceToSerializableFields

### DIFF
--- a/packages/ui/src/forms/Form/reduceToSerializableFields.ts
+++ b/packages/ui/src/forms/Form/reduceToSerializableFields.ts
@@ -10,6 +10,11 @@ const sanitizeField = (incomingField: FormField): FormField => {
     delete field[key]
   }
 
+  // Rows carry their own customComponents (RowLabel). Strip those too.
+  if (Array.isArray(field.rows)) {
+    field.rows = field.rows.map(({ customComponents: _customComponents, ...rest }) => rest)
+  }
+
   return field
 }
 


### PR DESCRIPTION
### What?
Make `reduceToSerializableFields` also strip `customComponents` from each entry in `rows[]`.

### Why?
The reducer only stripped customComponents from top-level field entries. Each Row carries its own customComponents (RowLabel) that can hold non-serializable refs. Under the Mongo adapter the rendered tree closes back to BasePayload via db.payload, so JSON.stringify on form state throws. This breaks PreviewField and the Auto-generate buttons in plugin-seo.

Fixes #
#16786
