### PR TITLE
fix(ui): add white-space nowrap to popup buttons

### DIFF
--- a/packages/ui/src/elements/Popup/PopupButtonList/index.css
+++ b/packages/ui/src/elements/Popup/PopupButtonList/index.css
@@ -30,6 +30,7 @@
     cursor: pointer;
     text-align: inherit;
     text-decoration: none;
+    white-space: nowrap;
     border-radius: var(--radius-medium);
     display: flex;
     align-items: stretch;


### PR DESCRIPTION
## What changed

Added `white-space: nowrap` to `.popup-button-list__button` in the `PopupButtonList` component.

## Why

Popup button labels were wrapping onto multiple lines, which breaks the intended single-line layout of popup menu items.