### PR TITLE
fix(ui): adds border none comment for live-preview window

### DIFF
--- a/packages/ui/src/elements/DocumentFields/index.css
+++ b/packages/ui/src/elements/DocumentFields/index.css
@@ -107,7 +107,7 @@
   .document-fields--force-sidebar-wrap {
     display: block;
     isolation: isolate;
-    --main-border: none;
+    --main-border: none; /* Reset the sidebar divider — the live preview window provides its own border-left */
   }
 
   .document-fields--force-sidebar-wrap .document-fields__main {


### PR DESCRIPTION
Adds comment explaining why we set `border: none`.