### PR TITLE
feat(plugin-nested-docs): support for translations

### DIFF
--- a/packages/plugin-nested-docs/package.json
+++ b/packages/plugin-nested-docs/package.json
@@ -29,6 +29,16 @@
       "import": "./src/exports/types.ts",
       "types": "./src/exports/types.ts",
       "default": "./src/exports/types.ts"
+    },
+    "./translations/languages/all": {
+      "import": "./src/translations/index.ts",
+      "types": "./src/translations/index.ts",
+      "default": "./src/translations/index.ts"
+    },
+    "./translations/languages/*": {
+      "import": "./src/translations/languages/*.ts",
+      "types": "./src/translations/languages/*.ts",
+      "default": "./src/translations/languages/*.ts"
     }
   },
   "main": "./src/index.ts",
@@ -46,10 +56,12 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
-  "devDependencies": {
+  "dependencies": {
     "@payloadcms/translations": "workspace:*",
-    "@payloadcms/eslint-config": "workspace:*",
     "payload": "workspace:*"
+  },
+  "devDependencies": {
+    "@payloadcms/eslint-config": "workspace:*"
   },
   "peerDependencies": {
     "payload": "workspace:*"

--- a/packages/plugin-nested-docs/package.json
+++ b/packages/plugin-nested-docs/package.json
@@ -47,6 +47,7 @@
     "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
+    "@payloadcms/translations": "workspace:*",
     "@payloadcms/eslint-config": "workspace:*",
     "payload": "workspace:*"
   },

--- a/packages/plugin-nested-docs/src/fields/breadcrumbs.ts
+++ b/packages/plugin-nested-docs/src/fields/breadcrumbs.ts
@@ -6,6 +6,12 @@ export const createBreadcrumbsField = (
 ): Field => ({
   name: 'breadcrumbs',
   type: 'array',
+  labels: {
+    // @ts-expect-error - translations are not typed in plugins yet
+    plural: ({ t }) => t('plugin-nested-docs:breadcrumbsPlural'),
+    // @ts-expect-error - translations are not typed in plugins yet
+    singular: ({ t }) => t('plugin-nested-docs:breadcrumbsSingular'),
+  },
   localized: true,
   ...(overrides || {}),
   admin: {
@@ -19,6 +25,8 @@ export const createBreadcrumbsField = (
       admin: {
         disabled: true,
       },
+      // @ts-expect-error - translations are not typed in plugins yet
+      label: ({ t }) => t('plugin-nested-docs:doc'),
       maxDepth: 0,
       relationTo,
     },
@@ -31,7 +39,8 @@ export const createBreadcrumbsField = (
           admin: {
             width: '50%',
           },
-          label: 'URL',
+          // @ts-expect-error - translations are not typed in plugins yet
+          label: ({ t }) => t('plugin-nested-docs:url'),
         },
         {
           name: 'label',
@@ -39,6 +48,8 @@ export const createBreadcrumbsField = (
           admin: {
             width: '50%',
           },
+          // @ts-expect-error - translations are not typed in plugins yet
+          label: ({ t }) => t('plugin-nested-docs:label'),
         },
       ],
     },

--- a/packages/plugin-nested-docs/src/fields/parent.ts
+++ b/packages/plugin-nested-docs/src/fields/parent.ts
@@ -13,6 +13,8 @@ export const createParentField = (
     position: 'sidebar',
     ...(overrides?.admin || {}),
   },
+  // @ts-expect-error - translations are not typed in plugins yet
+  label: ({ t }) => t('plugin-nested-docs:parent'),
   // filterOptions are assigned dynamically based on the pluginConfig
   // filterOptions: parentFilterOptions(),
   type: 'relationship',

--- a/packages/plugin-nested-docs/src/index.ts
+++ b/packages/plugin-nested-docs/src/index.ts
@@ -1,5 +1,7 @@
 import type { Plugin, SingleRelationshipField } from 'payload'
 
+import { deepMergeSimple } from 'payload/shared'
+
 import type { NestedDocsPluginConfig } from './types.js'
 
 import { createBreadcrumbsField } from './fields/breadcrumbs.js'
@@ -8,7 +10,9 @@ import { parentFilterOptions } from './fields/parentFilterOptions.js'
 import { populateBreadcrumbsBeforeChange } from './hooks/populateBreadcrumbsBeforeChange.js'
 import { resaveChildren } from './hooks/resaveChildren.js'
 import { resaveSelfAfterCreate } from './hooks/resaveSelfAfterCreate.js'
+import { translations } from './translations/index.js'
 import { getParents } from './utilities/getParents.js'
+export { translations as nestedDocsTranslations } from './translations/index.js'
 
 export { createBreadcrumbsField, createParentField, getParents }
 
@@ -67,4 +71,8 @@ export const nestedDocsPlugin =
 
       return collection
     }),
+    i18n: {
+      ...config.i18n,
+      translations: deepMergeSimple(translations, config.i18n?.translations ?? {}),
+    },
   })

--- a/packages/plugin-nested-docs/src/translations/index.ts
+++ b/packages/plugin-nested-docs/src/translations/index.ts
@@ -1,0 +1,15 @@
+import type { GenericTranslationsObject, NestedKeysStripped } from '@payloadcms/translations'
+
+import { de } from './languages/de.js'
+import { en } from './languages/en.js'
+import { it } from './languages/it.js'
+
+export const translations = {
+  de,
+  en,
+  it,
+}
+
+export type PluginNestedDocsTranslations = GenericTranslationsObject
+
+export type PluginNestedDocsTranslationKeys = NestedKeysStripped<PluginNestedDocsTranslations>

--- a/packages/plugin-nested-docs/src/translations/languages/de.ts
+++ b/packages/plugin-nested-docs/src/translations/languages/de.ts
@@ -1,0 +1,13 @@
+import type { GenericTranslationsObject } from '@payloadcms/translations'
+
+export const de: GenericTranslationsObject = {
+  $schema: './translation-schema.json',
+  'plugin-nested-docs': {
+    breadcrumbsPlural: 'Navigationspfade',
+    breadcrumbsSingular: 'Navigationspfad',
+    doc: 'Dokument',
+    label: 'Bezeichnung',
+    parent: 'Übergeordnetes Dokument',
+    url: 'URL',
+  },
+}

--- a/packages/plugin-nested-docs/src/translations/languages/de.ts
+++ b/packages/plugin-nested-docs/src/translations/languages/de.ts
@@ -1,7 +1,7 @@
 import type { GenericTranslationsObject } from '@payloadcms/translations'
 
 export const de: GenericTranslationsObject = {
-  $schema: './translation-schema.json',
+  $schema: '../translation-schema.json',
   'plugin-nested-docs': {
     breadcrumbsPlural: 'Navigationspfade',
     breadcrumbsSingular: 'Navigationspfad',

--- a/packages/plugin-nested-docs/src/translations/languages/en.ts
+++ b/packages/plugin-nested-docs/src/translations/languages/en.ts
@@ -1,0 +1,13 @@
+import type { GenericTranslationsObject } from '@payloadcms/translations'
+
+export const en: GenericTranslationsObject = {
+  $schema: './translation-schema.json',
+  'plugin-nested-docs': {
+    breadcrumbsPlural: 'Breadcrumbs',
+    breadcrumbsSingular: 'Breadcrumb',
+    doc: 'Document',
+    label: 'Label',
+    parent: 'Parent Document',
+    url: 'URL',
+  },
+}

--- a/packages/plugin-nested-docs/src/translations/languages/en.ts
+++ b/packages/plugin-nested-docs/src/translations/languages/en.ts
@@ -1,7 +1,7 @@
 import type { GenericTranslationsObject } from '@payloadcms/translations'
 
 export const en: GenericTranslationsObject = {
-  $schema: './translation-schema.json',
+  $schema: '../translation-schema.json',
   'plugin-nested-docs': {
     breadcrumbsPlural: 'Breadcrumbs',
     breadcrumbsSingular: 'Breadcrumb',

--- a/packages/plugin-nested-docs/src/translations/languages/it.ts
+++ b/packages/plugin-nested-docs/src/translations/languages/it.ts
@@ -1,7 +1,7 @@
 import type { GenericTranslationsObject } from '@payloadcms/translations'
 
 export const it: GenericTranslationsObject = {
-  $schema: './translation-schema.json',
+  $schema: '../translation-schema.json',
   'plugin-nested-docs': {
     breadcrumbsPlural: 'Percorsi di navigazione',
     breadcrumbsSingular: 'Percorso di navigazione',

--- a/packages/plugin-nested-docs/src/translations/languages/it.ts
+++ b/packages/plugin-nested-docs/src/translations/languages/it.ts
@@ -1,0 +1,13 @@
+import type { GenericTranslationsObject } from '@payloadcms/translations'
+
+export const it: GenericTranslationsObject = {
+  $schema: './translation-schema.json',
+  'plugin-nested-docs': {
+    breadcrumbsPlural: 'Percorsi di navigazione',
+    breadcrumbsSingular: 'Percorso di navigazione',
+    doc: 'Documento',
+    label: 'Etichetta',
+    parent: 'Documento genitore',
+    url: 'URL',
+  },
+}

--- a/packages/plugin-nested-docs/src/translations/translation-schema.json
+++ b/packages/plugin-nested-docs/src/translations/translation-schema.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "plugin-nested-docs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "breadcrumbsPlural": {
+          "type": "string"
+        },
+        "breadcrumbsSingular": {
+          "type": "string"
+        },
+        "doc": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": ["breadcrumbsPlural", "breadcrumbsSingular", "doc", "label", "parent", "url"]
+    }
+  },
+  "required": ["plugin-nested-docs"]
+}

--- a/packages/plugin-nested-docs/src/translations/types.ts
+++ b/packages/plugin-nested-docs/src/translations/types.ts
@@ -1,0 +1,3 @@
+import type { en } from './languages/en.js'
+
+export type PluginDefaultTranslationsObject = typeof en

--- a/test/plugin-nested-docs/collections/Pages.ts
+++ b/test/plugin-nested-docs/collections/Pages.ts
@@ -39,7 +39,7 @@ export const Pages: CollectionConfig = {
       },
       admin: {
         components: {
-          Field: null,
+          Field: undefined,
         },
       },
     },

--- a/test/plugin-nested-docs/payload-types.ts
+++ b/test/plugin-nested-docs/payload-types.ts
@@ -92,6 +92,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: 'en' | 'es' | 'de';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -125,6 +128,13 @@ export interface Page {
   title: string;
   slug: string;
   fullTitle?: string | null;
+  testArray?:
+    | {
+        testField?: string | null;
+        testField2?: string | null;
+        id?: string | null;
+      }[]
+    | null;
   parent?: (string | null) | Page;
   breadcrumbs?:
     | {
@@ -275,6 +285,13 @@ export interface PagesSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
   fullTitle?: T;
+  testArray?:
+    | T
+    | {
+        testField?: T;
+        testField2?: T;
+        id?: T;
+      };
   parent?: T;
   breadcrumbs?:
     | T
@@ -368,6 +385,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-nested-docs/payload-types.ts
+++ b/test/plugin-nested-docs/payload-types.ts
@@ -128,13 +128,6 @@ export interface Page {
   title: string;
   slug: string;
   fullTitle?: string | null;
-  testArray?:
-    | {
-        testField?: string | null;
-        testField2?: string | null;
-        id?: string | null;
-      }[]
-    | null;
   parent?: (string | null) | Page;
   breadcrumbs?:
     | {
@@ -285,13 +278,6 @@ export interface PagesSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
   fullTitle?: T;
-  testArray?:
-    | T
-    | {
-        testField?: T;
-        testField2?: T;
-        id?: T;
-      };
   parent?: T;
   breadcrumbs?:
     | T


### PR DESCRIPTION
### What?

Adds i18n support to `@payloadcms/plugin-nested-docs`.

Introduces translation keys and default translations for the nested docs plugin fields (breadcrumbs, parent). This enables the plugin to display its UI labels in multiple languages within the Payload admin, improving user experience for internationalized installations.

### Why?

The nested docs plugin currently renders its fields without lables (results in English Language). This makes the plugin inconsistent with Payload’s i18n support and with other plugins that already expose translated admin labels.

The plugin now registers its own translation namespace, allowing its field labels to be localized and overridden through the main Payload i18n configuration.

### How?

Added @payloadcms/translations as a dependency of @payloadcms/plugin-nested-docs
Added en, de and it translation objects under packages/plugin-form-builder/src/translations/languages.
Merged plugin translations into the Payload config using the same pattern as plugin-seo, with user-provided translations taking precedence.
Replaced hardcoded form builder labels and admin descriptions with `t('plugin-nested-docs:...')`.
Added translated labels for breadcrumbs array and parent realtion
Exported `nestedDocsTranslations` so consumers can inspect or reuse the plugin translation object.

### Testing

- `pnpm --filter @payloadcms/plugin-form-builder build`
- `pnpm build:plugin-nested-docs`
- Manually tested the plugin with `pnpm dev plugin-nested-docs` , with German and Italian admin i18n and verified plugin translation keys can be resolved and overridden.

Fixes #