### PR TITLE
test: fix group-by suite flakes

### DIFF
--- a/test/__helpers/e2e/filters/openListFilters.ts
+++ b/test/__helpers/e2e/filters/openListFilters.ts
@@ -18,16 +18,23 @@ export const openListFilters = async (
 ): Promise<{
   filterContainer: Locator
 }> => {
-  await expect(page.locator(togglerSelector)).toBeVisible()
-  const filterContainer = page.locator(filterContainerSelector).first()
+  const toggler = page.locator(togglerSelector).first()
+  await expect(toggler).toBeVisible()
 
-  const isAlreadyOpen = await filterContainer.isVisible()
+  // Drive the drawer open off the toggler's `aria-expanded` state (the source of truth)
+  // rather than a point-in-time visibility check of the container. The container flickers
+  // visible mid-animation, and a preceding re-render (e.g. a group-by/sort change) can drop
+  // the open click before it updates React state. Retrying the toggle until `aria-expanded`
+  // reports open makes this idempotent and resilient to that race.
+  await expect(async () => {
+    if ((await toggler.getAttribute('aria-expanded')) !== 'true') {
+      await toggler.click()
+    }
 
-  if (!isAlreadyOpen) {
-    await page.locator(togglerSelector).first().click()
-  }
+    await expect(toggler).toHaveAttribute('aria-expanded', 'true')
+  }).toPass()
 
   await expect(page.locator(`${filterContainerSelector}.rah-static--height-auto`)).toBeVisible()
 
-  return { filterContainer }
+  return { filterContainer: page.locator(filterContainerSelector).first() }
 }


### PR DESCRIPTION
# Overview

Fixes a deterministic CI-only failure in the `group-by` E2E suite by hardening the shared `openListFilters` test helper.

`E2E - group-by` has failed on every recent `main` run at `should apply filters to the distinct results of the group-by field`, across all 6 attempts (original plus 5 retries):

```
expect(locator).toBeVisible() failed
Locator: locator('#list-controls-where.rah-static--height-auto')
  at openListFilters (test/__helpers/e2e/filters/openListFilters.ts)
```

## Key Changes

- **`openListFilters` opens the drawer off `aria-expanded` and retries the toggle**
  - The helper previously decided whether to open the drawer from a single `filterContainer.isVisible()` reading, then clicked the toggler once and asserted the expanded container. It now reads the toggler's `aria-expanded` attribute as the open/closed signal and retries the click via `expect().toPass()` until the toggle reports open. The happy path is unchanged.

## Design Decisions

The CI Playwright trace showed the `#toggle-list-filters` button ending with `aria-expanded="false"` — the drawer never opened, so the open click was dropped.

Two factors combined under CI timing. The `#list-controls-where` `AnimateHeight` container is briefly visible mid-animation, so `isVisible()` is not a reliable open/closed signal. And the toggle is a plain React `useState`: in the failing test, `addGroupBy` runs immediately before the first filter, mutating the URL and re-rendering `ListControls`. On slower CI hardware the toggle click lands during that re-render and its state update is lost, so the single un-verified click never opens the drawer.

Reading `aria-expanded` (the toggle's source of truth) and retrying until it reports open makes the helper idempotent and resilient to a dropped click. All `openListFilters` callers use the default `#toggle-list-filters` toggler, which exposes `aria-expanded`; the custom `togglerSelector` overrides elsewhere are for the columns helpers and are unaffected.

The failure does not reproduce locally. It passes in every local configuration tried (dev and prod builds, isolated and full-suite, the exact CI command, and under 8x CPU plus network throttling). Root cause and fix come from the CI trace, so CI on this branch is the real validation.
