### PR TITLE
feat(ui): add SmallIcon support to hierarchy collections for compact contexts

### DIFF
--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -387,6 +387,7 @@ export const renderListView = async (
 
   // Fetch hierarchy data only for hierarchy view
   let HierarchyIcon: React.ReactNode | undefined
+  let HierarchySmallIcon: React.ReactNode | undefined
   const isHierarchyView = viewType === 'hierarchy'
 
   if (isHierarchyCollection && isHierarchyView) {
@@ -420,6 +421,16 @@ export const renderListView = async (
       importMap: payload.importMap,
       key: `hierarchy-icon-${collectionSlug}`,
     })
+
+    const smallIconComponent = hierarchyConfig?.admin?.components?.SmallIcon
+    HierarchySmallIcon =
+      smallIconComponent === hierarchyConfig?.admin?.components?.Icon
+        ? HierarchyIcon
+        : RenderServerComponent({
+            Component: smallIconComponent,
+            importMap: payload.importMap,
+            key: `hierarchy-small-icon-${collectionSlug}`,
+          })
   }
 
   const renderedFilters = renderFilters(collectionConfig.fields, req.payload.importMap)
@@ -503,6 +514,7 @@ export const renderListView = async (
       hasTrashPermission,
       hierarchyData,
       HierarchyIcon,
+      HierarchySmallIcon,
       listPreferences: collectionPreferences,
       newDocumentURL,
       queryPreset,

--- a/packages/payload/src/admin/views/list.ts
+++ b/packages/payload/src/admin/views/list.ts
@@ -81,9 +81,13 @@ export type ListViewClientProps = {
    */
   hierarchyData?: HierarchyViewData
   /**
-   * Resolved icon component for hierarchy collections
+   * Resolved full-size icon component for hierarchy collections (used in drawer subheader)
    */
   HierarchyIcon?: React.ReactNode
+  /**
+   * Resolved small icon component for hierarchy collections (used in table rows)
+   */
+  HierarchySmallIcon?: React.ReactNode
   /**
    * @deprecated
    */

--- a/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
+++ b/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
@@ -103,6 +103,7 @@ export const sanitizeHierarchyCollection = (
     collectionConfig.hierarchy.slugify ?? ((text: string) => defaultSlugify(text) ?? '')
   const treeLimit = collectionConfig.hierarchy.admin?.treeLimit ?? DEFAULT_HIERARCHY_TREE_LIMIT
   const iconComponent = collectionConfig.hierarchy.admin?.components?.Icon
+  const smallIconComponent = collectionConfig.hierarchy.admin?.components?.SmallIcon
 
   const slugField = collectionConfig.hierarchy.slugField
 
@@ -143,6 +144,7 @@ export const sanitizeHierarchyCollection = (
     admin: {
       components: {
         Icon: iconComponent || '@payloadcms/ui#TagIcon',
+        SmallIcon: smallIconComponent || iconComponent || '@payloadcms/ui#TagIcon',
       },
       injectSidebarTab,
       treeLimit,

--- a/packages/payload/src/hierarchy/types.ts
+++ b/packages/payload/src/hierarchy/types.ts
@@ -25,9 +25,15 @@ export type HierarchyConfig = {
      */
     components?: {
       /**
-       * Custom icon component for hierarchy items
+       * Custom icon component for hierarchy items.
+       * - 24x24 size icon.
        */
       Icon?: PayloadComponent
+      /**
+       * Small icon component for compact hierarchy contexts:
+       * - 16x16 size icon.
+       */
+      SmallIcon?: PayloadComponent
     }
     /**
      * Whether to inject a sidebar tab for this hierarchy collection
@@ -112,6 +118,7 @@ export type SanitizedHierarchyConfig = {
   admin: {
     components: {
       Icon: PayloadComponent
+      SmallIcon: PayloadComponent
     }
     injectSidebarTab: boolean
     treeLimit: number

--- a/packages/ui/src/elements/Hierarchy/DocHeaderButton/index.server.tsx
+++ b/packages/ui/src/elements/Hierarchy/DocHeaderButton/index.server.tsx
@@ -28,6 +28,7 @@ export const HierarchyButton: React.FC<HierarchyButtonServerProps> = ({
       ? hierarchyCollectionConfig.hierarchy
       : undefined
   const IconComponent = hierarchyConfig?.admin.components.Icon
+  const SmallIconComponent = hierarchyConfig?.admin.components.SmallIcon
 
   // Render the custom icon if provided, otherwise use FolderIcon directly
   // Important: Must render the icon here on server to avoid hydration mismatch
@@ -43,12 +44,30 @@ export const HierarchyButton: React.FC<HierarchyButtonServerProps> = ({
     })
   )
 
+  // Render the small icon for compact display (pill button)
+  // Reuse the full icon if SmallIcon is the same component
+  const isDefaultSmallIcon =
+    !SmallIconComponent || SmallIconComponent === '@payloadcms/ui#FolderIcon'
+  const renderedSmallIcon =
+    SmallIconComponent === IconComponent ? (
+      renderedIcon
+    ) : isDefaultSmallIcon ? (
+      <FolderIcon />
+    ) : (
+      RenderServerComponent({
+        Component: SmallIconComponent,
+        importMap: payload.importMap,
+        key: `hierarchy-button-small-icon-${hierarchyCollectionSlug}`,
+      })
+    )
+
   return (
     <HierarchyButtonClient
       fieldName={fieldName}
       hasMany={hasMany}
       hierarchyCollectionSlug={hierarchyCollectionSlug}
       Icon={renderedIcon}
+      SmallIcon={renderedSmallIcon}
     />
   )
 }

--- a/packages/ui/src/elements/Hierarchy/DocHeaderButton/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/DocHeaderButton/index.tsx
@@ -20,6 +20,7 @@ export type HierarchyButtonClientProps = {
   hierarchyCollectionSlug: string
   Icon?: React.ReactNode
   readOnly?: boolean
+  SmallIcon?: React.ReactNode
 }
 
 export const HierarchyButtonClient: React.FC<HierarchyButtonClientProps> = ({
@@ -28,6 +29,7 @@ export const HierarchyButtonClient: React.FC<HierarchyButtonClientProps> = ({
   hierarchyCollectionSlug,
   Icon,
   readOnly,
+  SmallIcon,
 }) => {
   const { t } = useTranslation()
   const { config, getEntityConfig } = useConfig()
@@ -135,7 +137,7 @@ export const HierarchyButtonClient: React.FC<HierarchyButtonClientProps> = ({
         buttonStyle="pill"
         className={[baseClass, readOnly && `${baseClass}--read-only`].filter(Boolean).join(' ')}
         disabled={readOnly}
-        icon={Icon}
+        icon={SmallIcon ?? Icon}
         iconPosition="left"
         margin={false}
         onClick={handleClick}

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
@@ -44,15 +44,16 @@ export const HierarchySidebarTabServer: React.FC<HierarchySidebarTabServerProps>
       ? collectionConfig.hierarchy
       : undefined
 
-  const IconComponent = hierarchyConfig?.admin?.components?.Icon
+  const IconComponent = hierarchyConfig?.admin?.components?.SmallIcon
   const icon = IconComponent ? (
     RenderServerComponent({
+      clientProps: { size: 16 },
       Component: IconComponent,
       importMap: payload.importMap,
       key: `hierarchy-sidebar-icon-${hierarchyCollectionSlug}`,
     })
   ) : (
-    <TagIcon />
+    <TagIcon size={16} />
   )
 
   try {

--- a/packages/ui/src/elements/SidebarRow/index.css
+++ b/packages/ui/src/elements/SidebarRow/index.css
@@ -52,8 +52,6 @@
     justify-content: center;
     flex-shrink: 0;
     color: var(--color-icon-secondary);
-    width: var(--spacer-3);
-    height: var(--spacer-3);
   }
 
   .sidebar-row__title {

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Hierarchy/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Hierarchy/index.tsx
@@ -54,8 +54,9 @@ export const HierarchyCell: React.FC<HierarchyCellProps> = ({
       ? hierarchyCollectionConfig.hierarchy
       : undefined
 
-  // Pre-rendered icon from server (supports custom icons)
+  // Pre-rendered icons from server (supports custom icons)
   const preRenderedIcon = customCellProps?.hierarchyIcon as React.ReactNode | undefined
+  const preRenderedSmallIcon = customCellProps?.hierarchySmallIcon as React.ReactNode | undefined
 
   // Fallback icon for client-side rendering
   const fallbackIcon = useMemo(() => {
@@ -67,7 +68,10 @@ export const HierarchyCell: React.FC<HierarchyCellProps> = ({
     return <IconComponent />
   }, [hierarchyConfig, preRenderedIcon])
 
+  // Full icon for drawer subheader
   const drawerIcon = preRenderedIcon || fallbackIcon
+  // Small icon for compact display (pill button)
+  const displayIcon = preRenderedSmallIcon ?? drawerIcon
 
   // Set up the hierarchy drawer
   const [HierarchyDrawer, , { openDrawer }] = useHierarchyDrawer({
@@ -203,7 +207,7 @@ export const HierarchyCell: React.FC<HierarchyCellProps> = ({
       <Button
         buttonStyle="pill"
         className={`${baseClass}__pill`}
-        icon={drawerIcon}
+        icon={displayIcon}
         iconPosition="left"
         margin={false}
         onClick={openDrawer}

--- a/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/renderCell.tsx
@@ -138,6 +138,7 @@ export function renderCell({
 
   // Check if this is a hierarchy relationship field and pre-render the icon
   let hierarchyIcon: React.ReactNode = undefined
+  let hierarchySmallIcon: React.ReactNode = undefined
   if (clientField.type === 'relationship' && 'relationTo' in clientField) {
     const relationTo = clientField.relationTo
     if (typeof relationTo === 'string') {
@@ -145,6 +146,7 @@ export function renderCell({
       const hierarchyConfig = relatedCollectionConfig?.hierarchy
       if (hierarchyConfig && typeof hierarchyConfig === 'object') {
         const iconComponent = hierarchyConfig.admin?.components?.Icon
+        const smallIconComponent = hierarchyConfig.admin?.components?.SmallIcon
         if (iconComponent) {
           // Pre-render the custom icon
           hierarchyIcon = RenderServerComponent({
@@ -161,6 +163,16 @@ export function renderCell({
               <TagIcon key={`hierarchy-icon-${relationTo}`} />
             )
         }
+        // Pre-render the small icon (used in compact display contexts)
+        if (smallIconComponent && smallIconComponent !== iconComponent) {
+          hierarchySmallIcon = RenderServerComponent({
+            Component: smallIconComponent,
+            importMap: payload.importMap,
+            key: `hierarchy-small-icon-${relationTo}`,
+          })
+        } else {
+          hierarchySmallIcon = hierarchyIcon
+        }
       }
     }
   }
@@ -171,6 +183,7 @@ export function renderCell({
     customCellProps: {
       ...baseCellClientProps.customCellProps,
       ...(hierarchyIcon ? { hierarchyIcon } : {}),
+      ...(hierarchySmallIcon ? { hierarchySmallIcon } : {}),
     },
     field: enrichedClientField,
     link: shouldLink,

--- a/packages/ui/src/views/HierarchyList/index.tsx
+++ b/packages/ui/src/views/HierarchyList/index.tsx
@@ -41,6 +41,7 @@ export function HierarchyListView(props: ListViewClientProps) {
     hasCreatePermission: hasCreatePermissionFromProps,
     hierarchyData,
     HierarchyIcon,
+    HierarchySmallIcon,
     viewType,
   } = props
 
@@ -384,7 +385,7 @@ export function HierarchyListView(props: ListViewClientProps) {
               collections={collections}
               collectionSlug={collectionSlug}
               hasCreatePermission={hasCreatePermission}
-              HierarchyIcon={HierarchyIcon}
+              HierarchyIcon={HierarchySmallIcon ?? HierarchyIcon}
               hierarchyLabel={collectionLabel}
               key={`${collectionSlug}-${parentId}-${searchFromURL}-${JSON.stringify(baseFilter)}-${filteredChildrenData?.totalDocs}-${Object.entries(
                 hierarchyData?.relatedDocumentsByCollection || {},


### PR DESCRIPTION
## Summary

Hierarchy collections can now define a `SmallIcon` component alongside the existing `Icon`. Previously a single icon was used everywhere, and scaling it for compact contexts (sidebar tree nodes, table row cells, pill buttons) required CSS workarounds that couldn't scale properly.

With this change, `Icon` is reserved for the hierarchy drawer subheader, and `SmallIcon` is used in compact display contexts. If `SmallIcon` is omitted it falls back to `Icon`, maintaining full backwards compatibility. The split is threaded through all four entry points that open the hierarchy drawer: the sidebar tab, the list view table rows, the relationship cell pill button, and the doc header field button.