### PR TITLE
ci: fix flaky redis image pulls

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -30,6 +30,16 @@ runs:
         done
         docker compose -f test/docker-compose.yml --profile storage up -d --wait
 
+    - name: Start Redis
+      shell: bash
+      run: |
+        for i in 1 2 3; do
+          docker compose -f test/docker-compose.yml --profile redis pull && break
+          echo "Pull attempt $i/3 for 'redis' profile failed, retrying in 10s..."
+          sleep 10
+        done
+        docker compose -f test/docker-compose.yml --profile redis up -d --wait
+
     - name: Start MongoDB
       id: mongodb
       if: contains(fromJSON('["mongodb", "cosmosdb", "documentdb", "firestore"]'), inputs.database)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,14 +213,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: localstack
       AWS_REGION: us-east-1
 
-    services:
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
-
-        options: --health-cmd "redis-cli ping" --health-timeout 30s --health-retries 3
-
     steps:
       - uses: actions/checkout@v5
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -13,6 +13,7 @@ name: payload-monorepo
 #   --profile mongodb       - MongoDB + mongot only
 #   --profile mongodb-atlas - MongoDB Atlas Local only
 #   --profile storage       - LocalStack (S3), Azure Storage, fake GCS, Vercel Blob
+#   --profile redis         - Redis (kv-redis adapter)
 
 services:
   # ── PostgreSQL (PostGIS + pgvector) ──────────────────────────
@@ -231,6 +232,22 @@ services:
       EMULATOR_BASE_URL: '${VERCEL_BLOB_EMULATOR_URL:-http://localhost:3100}'
     volumes:
       - vercel_blob_data:/data
+
+  # ── Redis (kv-redis adapter) ────────────────────────────────
+  # Connection: redis://localhost:6379
+  redis:
+    profiles: [all, redis]
+    image: redis:7-alpine
+    container_name: redis-payload-test
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 2s
+    restart: unless-stopped
 
 volumes:
   postgres_data:


### PR DESCRIPTION
# Overview

There were intermittent failures on the initialize containers step step with `Docker pull failed with exit code 1`. This step was pulling images from the Docker registry anonymously, which can hit rate limits.

Redis was the last image still pulled this way. Every database and storage image already runs through the `start-services` composite action, which wraps `docker compose pull` in a retry loop.

## Key Changes

- **Moved redis into `test/docker-compose.yml`**
  - Added a `redis` profile pinned to `redis:7-alpine` (previously the unpinned `redis:latest`), with a `redis-cli ping` healthcheck.

- **Start redis through `start-services` with retry**
  - Added an unconditional `Start Redis` step that pulls the `redis` profile in the same 3-attempt retry loop used for storage and database services.

- **Removed the `services: redis` block from `tests-int`**
  - The job no longer pulls anything from Docker Hub during Initialize containers. The only consumer reads `REDIS_URL` (default `redis://127.0.0.1:6379`), which is unchanged.
