### PR TITLE
fix(ui): use explicit relative paths for internal SCSS imports v4

### DIFF
--- a/packages/ui/src/scss/app.scss
+++ b/packages/ui/src/scss/app.scss
@@ -1,6 +1,6 @@
 @layer payload-default, payload;
 
-@import 'styles';
+@import './styles';
 @import './toasts.scss';
 @import './colors.scss';
 @import '../styles.css';

--- a/packages/ui/src/scss/styles.scss
+++ b/packages/ui/src/scss/styles.scss
@@ -1,9 +1,9 @@
-@import 'vars';
-@import 'z-index';
+@import './vars';
+@import './z-index';
 
 //////////////////////////////
 // IMPORT OVERRIDES
 //////////////////////////////
 
-@import 'queries';
-@import 'svg';
+@import './queries';
+@import './svg';

--- a/packages/ui/src/scss/toastify.scss
+++ b/packages/ui/src/scss/toastify.scss
@@ -1,5 +1,5 @@
-@import 'vars';
-@import 'queries';
+@import './vars';
+@import './queries';
 
 @layer payload-default {
   .Toastify {


### PR DESCRIPTION
### What?

Replace bare `@import` statements in `@payloadcms/ui` SCSS entry points with explicit `./`-prefixed relative paths. Three files changed, **+7 / -7 lines** on `main` (v4).

| File | Imports fixed |
|---|---|
| `packages/ui/src/scss/styles.scss` | `vars`, `z-index`, `queries`, `svg` |
| `packages/ui/src/scss/toastify.scss` | `vars`, `queries` |
| `packages/ui/src/scss/app.scss` | `styles` |

### Why?

Bare `@import` resolution depends on the Sass loader adding the current file's directory to the load path. This is **not** true for:

- Turbopack + `resolve-url-loader` (Next.js 16 default)
- Some webpack `sass-loader` setups with restricted `include` paths
- Standalone `sass` CLI runs that don't pre-add the SCSS directory

In those environments, the build fails with:

```
Error evaluating Node.js code
Error: Can't find stylesheet to import.
  ╷
1 │ @import 'vars';
  │         ^^^^^^╡
```

The `dist/` published to npm is built from these `src/` files via `pnpm copyfiles`, so the same fragile dist ships in every release. A published package should not require a downstream patch to compile.

### How?

Mechanical, byte-for-byte equivalent refactor: prefix each internal bare `@import` with `./`. No new files, no deletions, no JS / TS / API changes. Output CSS is identical.

```diff
-@import 'vars';
+@import './vars';
```

### Backward compatibility

Pure SCSS source refactor. Compiled CSS is byte-identical. No runtime, API, or public surface change.

### Follow-up (separate PR)

The legacy `@import` rule itself is deprecated in Dart Sass 3.0 (the codebase already emits `DEPRECATION WARNING [import]` on every build). A future PR should migrate the whole SCSS tree to `@use` / `@forward`. This PR keeps the diff min$

Relates to #15011  (tracked on 3.x; same fix applied in 3.x PR #16827).