### PR TITLE
fix(ui): rename SearchBar to ListSearchFilter, fix e2e search selectors

### DIFF
--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -15,8 +15,8 @@ import { AnimateHeight } from '../AnimateHeight/index.js'
 import { Button } from '../Button/index.js'
 import { ColumnsButton } from '../ColumnsButton/index.js'
 import { GroupByControl } from '../GroupByControl/index.js'
+import { ListSearchFilter } from '../ListSearchFilter/index.js'
 import { QueryPresetBar } from '../QueryPresets/QueryPresetBar/index.js'
-import { SearchBar } from '../SearchBar/index.js'
 import { WhereBuilder } from '../WhereBuilder/index.js'
 import './index.css'
 
@@ -76,7 +76,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
     <div className={baseClass}>
       <div className={`${baseClass}__search-row`}>
         <div className={`${baseClass}__left`}>
-          <SearchBar
+          <ListSearchFilter
             key={collectionSlug}
             label={searchLabelTranslated}
             onSearchChange={handleSearchChange}

--- a/packages/ui/src/elements/ListSearchFilter/index.tsx
+++ b/packages/ui/src/elements/ListSearchFilter/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useDebounce } from '../../hooks/useDebounce.js'
 import { SearchInput } from '../SearchInput/index.js'
 
-type SearchBarProps = {
+type ListSearchFilterProps = {
   className?: string
   disabled?: boolean
   label?: string
@@ -13,13 +13,13 @@ type SearchBarProps = {
   searchQueryParam?: string
 }
 
-export function SearchBar({
+export function ListSearchFilter({
   className,
   disabled,
   label = 'Search...',
   onSearchChange,
   searchQueryParam,
-}: SearchBarProps) {
+}: ListSearchFilterProps) {
   const [search, setSearch] = useState(
     typeof searchQueryParam === 'string' ? searchQueryParam : undefined,
   )

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -229,7 +229,7 @@ import { toast } from 'sonner'
 export { toast }
 export { UnpublishMany } from '../../elements/UnpublishMany/index.js'
 export { Upload } from '../../elements/Upload/index.js'
-export { SearchBar } from '../../elements/SearchBar/index.js'
+export { ListSearchFilter } from '../../elements/ListSearchFilter/index.js'
 export { SearchInput } from '../../elements/SearchInput/index.js'
 export { FilterTrigger } from '../../elements/FilterTrigger/index.js'
 export { EditUpload } from '../../elements/EditUpload/index.js'

--- a/packages/ui/src/views/HierarchyList/index.tsx
+++ b/packages/ui/src/views/HierarchyList/index.tsx
@@ -13,8 +13,8 @@ import type { StepNavItem } from '../../elements/StepNav/index.js'
 import { CreateDocumentButton } from '../../elements/CreateDocumentButton/index.js'
 import { ListControlsBar } from '../../elements/ListControlsBar/index.js'
 import { useListDrawerContext } from '../../elements/ListDrawer/Provider.js'
+import { ListSearchFilter } from '../../elements/ListSearchFilter/index.js'
 import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
-import { SearchBar } from '../../elements/SearchBar/index.js'
 import { useStepNav } from '../../elements/StepNav/index.js'
 import { ViewDescription } from '../../elements/ViewDescription/index.js'
 import { useConfig } from '../../providers/Config/index.js'
@@ -88,7 +88,7 @@ export function HierarchyListView(props: ListViewClientProps) {
   // Get search from URL params
   const searchFromURL = searchParams.get('search') || ''
 
-  // Update URL when search changes (debouncing is handled by SearchBar)
+  // Update URL when search changes (debouncing is handled by ListSearchFilter)
   // This triggers a server refetch via Next.js router
   const handleSearchChange = useCallback(
     (value: string) => {
@@ -354,7 +354,7 @@ export function HierarchyListView(props: ListViewClientProps) {
 
             <ListControlsBar className={`${baseClass}__controls`}>
               <div className={`${baseClass}__controls-left`}>
-                <SearchBar
+                <ListSearchFilter
                   label={t('general:searchBy', {
                     label: getTranslation(collectionConfig?.admin?.useAsTitle || 'id', i18n),
                   })}

--- a/test/__helpers/e2e/goToListDoc.ts
+++ b/test/__helpers/e2e/goToListDoc.ts
@@ -24,7 +24,7 @@ export async function goToListDoc({
   await page.goto(urlUtil.list)
 
   if (search) {
-    const searchInput = page.locator('.search-filter__input')
+    const searchInput = page.locator('#search-filter-input')
     await searchInput.fill(search)
     await page.waitForLoadState('networkidle')
   }

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -274,7 +274,7 @@ describe('List View', () => {
       await page.goto(`${postsUrl.list}?search=dennis`)
 
       // input should be filled out, list should filter
-      await expect(page.locator('.search-filter__input')).toHaveValue('dennis')
+      await expect(page.locator('#search-filter-input')).toHaveValue('dennis')
       await expect(page.locator(tableRowLocator)).toHaveCount(1)
     })
 
@@ -300,10 +300,10 @@ describe('List View', () => {
         title: 'find me',
       })
 
-      await page.locator('.search-filter__input').fill('find me')
+      await page.locator('#search-filter-input').fill('find me')
       await expect(page.locator(tableRowLocator)).toHaveCount(1)
 
-      await page.locator('.search-filter__input').fill('this is fun')
+      await page.locator('#search-filter-input').fill('this is fun')
       await expect(page.locator(tableRowLocator)).toHaveCount(1)
     })
 

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -876,7 +876,7 @@ describe('relationship', () => {
 
     const relationshipField = page.locator('#field-relationshipDrawer')
     await relationshipField.click()
-    const searchField = page.locator('.list-drawer .search-filter')
+    const searchField = page.locator('.list-drawer .search-input')
     await expect(searchField).toBeVisible()
 
     const searchInput = searchField.locator('input')

--- a/test/i18n/e2e.spec.ts
+++ b/test/i18n/e2e.spec.ts
@@ -225,7 +225,7 @@ describe('i18n', () => {
       await expect(
         page.locator('#heading-i18nFieldLabel .sort-column__label', { hasText: 'es-label' }),
       ).toBeVisible()
-      await expect(page.locator('.search-filter input')).toHaveAttribute('placeholder', 'Buscar')
+      await expect(page.locator('#search-filter-input')).toHaveAttribute('placeholder', 'Buscar')
     })
 
     test('should display translated collections and globals config options', async () => {

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -786,7 +786,7 @@ describe('Localization', () => {
 
   test('should use label in search filter when string or object', async () => {
     await page.goto(url.list)
-    const searchInput = page.locator('.search-filter__input')
+    const searchInput = page.locator('#search-filter-input')
     await expect(searchInput).toBeVisible()
     await expect(searchInput).toHaveAttribute('placeholder', 'Search')
   })


### PR DESCRIPTION
## Summary

The `SearchBar` component was a stateful wrapper around `SearchInput` that debounces and syncs search state with URL query params via `ListQueryProvider`. Renaming it to `ListSearchFilter` better communicates that intent and distinguishes it from `SearchInput`, the pure presentational component. This also fixes broken e2e test selectors — the old `.search-filter__input` class was removed when `SearchFilter` was deleted, so tests now target the stable `#search-filter-input` ID that `ListSearchFilter` passes down to `SearchInput`.