### PR TITLE
test: fix flaky UTC date test in scheduled publish

### DIFF
--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1472,9 +1472,13 @@ describe('Versions', () => {
       )
 
       await expect(localPage.locator('#schedule-publish-button')).toBeVisible()
-      await localPage.locator('#schedule-publish-button').click()
 
+      // Retry clicking until the drawer actually opens — the button may be visible before hydration completes
       const drawerContent = localPage.locator('.schedule-publish__scheduler')
+      await expect(async () => {
+        await localPage.locator('#schedule-publish-button').click()
+        await expect(drawerContent).toBeVisible()
+      }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
 
       const dropdownControlSelector = drawerContent.locator(`.timezone-picker .rs__control`)
       const timezoneOptionSelector = drawerContent.locator(

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1471,6 +1471,7 @@ describe('Versions', () => {
         }),
       )
 
+      await expect(localPage.locator('#schedule-publish-button')).toBeVisible()
       await localPage.locator('#schedule-publish-button').click()
 
       const drawerContent = localPage.locator('.schedule-publish__scheduler')

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1361,6 +1361,11 @@ describe('Versions', () => {
   })
 
   describe('Scheduled publish', () => {
+    // Required so test.use applies to the fixture page used in 'correctly sets a UTC date' test
+    test.use({
+      timezoneId: londonTimezone,
+    })
+
     beforeAll(() => {
       url = new AdminUrlUtil(serverURL, draftCollectionSlug)
       autosaveURL = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
@@ -1447,6 +1452,70 @@ describe('Versions', () => {
       }).toPass({
         timeout: POLL_TOPASS_TIMEOUT,
       })
+    })
+
+    test('correctly sets a UTC date for the chosen timezone', async ({ page: localPage }) => {
+      const post = await payload.create({
+        collection: draftCollectionSlug,
+        data: {
+          title: 'new post',
+          description: 'new description',
+        },
+      })
+
+      await localPage.goto(
+        formatAdminURL({
+          adminRoute,
+          path: `/collections/${draftCollectionSlug}/${post.id}`,
+          serverURL,
+        }),
+      )
+
+      await localPage.locator('#schedule-publish-button').click()
+
+      const drawerContent = localPage.locator('.schedule-publish__scheduler')
+
+      const dropdownControlSelector = drawerContent.locator(`.timezone-picker .rs__control`)
+      const timezoneOptionSelector = drawerContent.locator(
+        `.timezone-picker .rs__menu .rs__option:has-text("Paris")`,
+      )
+      await dropdownControlSelector.click()
+      await timezoneOptionSelector.click()
+
+      const dateInput = drawerContent.locator('.date-time-picker__input-wrapper input')
+      // Create a date for 2049-01-01 18:00:00 UTC, so it is timezone-invariant across CI environments
+      const date = new Date(Date.UTC(2049, 0, 1, 18, 0))
+
+      await dateInput.fill(date.toISOString())
+      await localPage.keyboard.press('Enter') // formats the date to the correct format
+
+      const saveButton = drawerContent.locator('.schedule-publish__actions button')
+
+      await saveButton.click()
+
+      const upcomingContent = localPage.locator('.schedule-publish__upcoming')
+      const createdDate = await upcomingContent.locator('.row-1 .cell-waitUntil').textContent()
+
+      await expect(() => {
+        expect(createdDate).toContain('6:00:00 PM')
+      }).toPass({ timeout: 10000, intervals: [100] })
+
+      const {
+        docs: [createdJob],
+      } = await payload.find({
+        collection: 'payload-jobs',
+        where: {
+          'input.doc.value': {
+            equals: String(post.id),
+          },
+        },
+      })
+
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(createdJob).toBeTruthy()
+
+      // eslint-disable-next-line payload/no-flaky-assertions
+      expect(createdJob?.waitUntil).toEqual('2049-01-01T17:00:00.000Z')
     })
   })
 
@@ -2912,76 +2981,6 @@ describe('Versions', () => {
 
       // Cleanup
       await payload.delete({ collection: diffCollectionSlug, id: doc.id })
-    })
-  })
-
-  describe('Scheduled publish', () => {
-    test.use({
-      timezoneId: londonTimezone,
-    })
-
-    test('correctly sets a UTC date for the chosen timezone', async () => {
-      const post = await payload.create({
-        collection: draftCollectionSlug,
-        data: {
-          title: 'new post',
-          description: 'new description',
-        },
-      })
-
-      await page.goto(
-        formatAdminURL({
-          adminRoute,
-          path: `/collections/${draftCollectionSlug}/${post.id}`,
-          serverURL,
-        }),
-      )
-
-      await page.locator('#schedule-publish-button').click()
-
-      const drawerContent = page.locator('.schedule-publish__scheduler')
-
-      const dropdownControlSelector = drawerContent.locator(`.timezone-picker .rs__control`)
-      const timezoneOptionSelector = drawerContent.locator(
-        `.timezone-picker .rs__menu .rs__option:has-text("Paris")`,
-      )
-      await dropdownControlSelector.click()
-      await timezoneOptionSelector.click()
-
-      const dateInput = drawerContent.locator('.date-time-picker__input-wrapper input')
-      // Create a date for 2049-01-01 18:00:00
-      const date = new Date(2049, 0, 1, 18, 0)
-
-      await dateInput.fill(date.toISOString())
-      await page.keyboard.press('Enter') // formats the date to the correct format
-
-      const saveButton = drawerContent.locator('.schedule-publish__actions button')
-
-      await saveButton.click()
-
-      const upcomingContent = page.locator('.schedule-publish__upcoming')
-      const createdDate = await upcomingContent.locator('.row-1 .cell-waitUntil').textContent()
-
-      await expect(() => {
-        expect(createdDate).toContain('6:00:00 PM')
-      }).toPass({ timeout: 10000, intervals: [100] })
-
-      const {
-        docs: [createdJob],
-      } = await payload.find({
-        collection: 'payload-jobs',
-        where: {
-          'input.doc.value': {
-            equals: String(post.id),
-          },
-        },
-      })
-
-      // eslint-disable-next-line payload/no-flaky-assertions
-      expect(createdJob).toBeTruthy()
-
-      // eslint-disable-next-line payload/no-flaky-assertions
-      expect(createdJob?.waitUntil).toEqual('2049-01-01T17:00:00.000Z')
     })
   })
 })

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1471,15 +1471,10 @@ describe('Versions', () => {
         }),
       )
 
-      await expect(localPage.locator('#schedule-publish-button')).toBeVisible()
+      await waitForFormReady(localPage)
+      await localPage.locator('#schedule-publish-button').click()
 
-      // Retry clicking until the drawer actually opens — the button may be visible before hydration completes
       const drawerContent = localPage.locator('.schedule-publish__scheduler')
-      await expect(async () => {
-        await localPage.locator('#schedule-publish-button').click()
-        await expect(drawerContent).toBeVisible()
-      }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
-
       const dropdownControlSelector = drawerContent.locator(`.timezone-picker .rs__control`)
       const timezoneOptionSelector = drawerContent.locator(
         `.timezone-picker .rs__menu .rs__option:has-text("Paris")`,


### PR DESCRIPTION
## Summary

The "correctly sets a UTC date for the chosen timezone" test was flaky on CI because `new Date(2049, 0, 1, 18, 0)` constructs a date in the Node.js process local timezone. On CI machines running in UTC-5 (Eastern), `.toISOString()` would produce `2049-01-01T23:00:00.000Z` instead of the expected `2049-01-01T18:00:00.000Z`, causing the assertion to fail.

There was also a subtler issue: `test.use({ timezoneId })` only applies to the Playwright-provided fixture `page`, not to the outer shared `page` variable created in `beforeAll`. The test was using the shared `page`, so the browser timezone was never actually set to London — meaning the test would pass when run alongside other tests (by coincidence of state) but fail in isolation.

The fix uses `Date.UTC()` to construct a timezone-invariant ISO string, switches the test to use the fixture `page` (as `localPage`) so `test.use` actually takes effect, and consolidates the two separate `describe('Scheduled publish')` blocks into one.