### PR TITLE
fix(plugin-seo): disable tabs while form initializes and wait for form ready in e2e tests

### DIFF
--- a/packages/ui/src/fields/Tabs/Tab/index.tsx
+++ b/packages/ui/src/fields/Tabs/Tab/index.tsx
@@ -7,6 +7,7 @@ import { tabHasName } from 'payload/shared'
 import React, { useState } from 'react'
 
 import { ErrorPill } from '../../../elements/ErrorPill/index.js'
+import { useFormInitializing } from '../../../forms/Form/context.js'
 import { WatchChildErrors } from '../../../forms/WatchChildErrors/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 import './index.css'
@@ -29,6 +30,7 @@ export const TabComponent: React.FC<TabProps> = ({
   tab,
 }) => {
   const { i18n } = useTranslation()
+  const isInitializing = useFormInitializing()
   const [errorCount, setErrorCount] = useState(undefined)
 
   const path = [
@@ -51,6 +53,7 @@ export const TabComponent: React.FC<TabProps> = ({
         ]
           .filter(Boolean)
           .join(' ')}
+        disabled={isInitializing}
         onClick={setIsActive}
         type="button"
       >

--- a/test/plugin-seo/e2e.spec.ts
+++ b/test/plugin-seo/e2e.spec.ts
@@ -13,6 +13,7 @@ import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
   switchTab,
+  waitForFormReady,
 } from '../__helpers/e2e/helpers.js'
 import { runAxeScan } from '../__helpers/e2e/runAxeScan.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
@@ -84,6 +85,7 @@ describe('SEO Plugin', () => {
 
     test('Should auto-generate meta title when button is clicked in tabs', async () => {
       await page.goto(url.edit(id))
+      await waitForFormReady(page)
       const autoGenerateButtonClass = '.group-field__wrap .render-fields div:nth-of-type(1) button'
       const metaTitleClass = '#field-meta__title'
 
@@ -111,6 +113,7 @@ describe('SEO Plugin', () => {
 
     test('Indicator should be orangered and characters counted', async () => {
       await page.goto(url.edit(id))
+      await waitForFormReady(page)
       const autoGenerateButtonClass = '.group-field__wrap .render-fields div:nth-of-type(1) button'
 
       await switchTab(page, '.tabs-field__tab-button:has-text("SEO")')
@@ -132,6 +135,7 @@ describe('SEO Plugin', () => {
 
     test('Should generate a search result preview based on content', async () => {
       await page.goto(url.edit(id))
+      await waitForFormReady(page)
       const metaDescriptionClass = '#field-meta__description'
       const previewClass = '#field-meta > div > div.render-fields > div:nth-child(5)'
 
@@ -150,6 +154,7 @@ describe('SEO Plugin', () => {
   describe('i18n', () => {
     test('support for another language', async () => {
       await page.goto(url.edit(id))
+      await waitForFormReady(page)
       const autoGenerateButtonClass = '.group-field__wrap .render-fields div:nth-of-type(1) button'
       const seoTabSelector = '.tabs-field__tab-button:has-text("SEO")'
 
@@ -174,6 +179,7 @@ describe('SEO Plugin', () => {
 
       // Navigate back to the page
       await page.goto(url.edit(id))
+      await waitForFormReady(page)
 
       await switchTab(page, seoTabSelector)
 


### PR DESCRIPTION
## Summary

The SEO plugin e2e tests were flaking because `switchTab` was called immediately after `page.goto`, before the form had finished loading. This caused the test to switch tabs during initialization and then lose track of which tab was active.

The fix has two parts: `waitForFormReady` is now called after `page.goto` in all plugin-seo e2e tests that switch tabs, consistent with how other test suites handle this. More importantly, `TabComponent` now reads from `InitializingContext` (the same context already used by `Submit` and `DocumentControls`) and sets `disabled={isInitializing}` on the button, so tabs are non-interactive while the form is loading — preventing this class of race condition at the component level rather than only in tests.