### PR TITLE
ci: pull test service images from GHCR instead of Docker Hub

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -84,7 +84,7 @@ services:
   # Connection: mongodb://payload:payload@localhost:27018/payload?authSource=admin&directConnection=true&replicaSet=rs0
   mongodb:
     profiles: [all, mongodb]
-    image: mongodb/mongodb-community-server:8.2-ubi9
+    image: ghcr.io/payloadcms/mongodb-community-server:8.2.9-ubi9
     container_name: mongodb-payload-test
     ports:
       - '27018:27017'
@@ -117,7 +117,7 @@ services:
   # mongot - MongoDB Community Search for $search and $vectorSearch
   mongot:
     profiles: [all, mongodb]
-    image: mongodb/mongodb-community-search:latest
+    image: ghcr.io/payloadcms/mongodb-community-search:1.67.1
     container_name: mongot-payload-test
     depends_on:
       mongodb:
@@ -146,7 +146,7 @@ services:
   # Connection: mongodb://localhost:27019/payload?directConnection=true&replicaSet=mongodb-atlas-local
   mongodb-atlas:
     profiles: [all, mongodb-atlas]
-    image: mongodb/mongodb-atlas-local:latest
+    image: ghcr.io/payloadcms/mongodb-atlas-local:8.2.4
     container_name: mongodb-atlas-payload-test
     hostname: mongodb-atlas-local
     ports:
@@ -168,7 +168,7 @@ services:
   # ── LocalStack (S3 emulator) ────────────────────────────────
   localstack:
     profiles: [all, storage]
-    image: localstack/localstack:4.14.0
+    image: ghcr.io/payloadcms/localstack:4.14.0
     container_name: localstack_demo
     ports:
       - '4563-4599:4563-4599'
@@ -199,7 +199,7 @@ services:
   # ── Google Cloud Storage (fake-gcs-server) ──────────────────
   google-cloud-storage:
     profiles: [all, storage]
-    image: fsouza/fake-gcs-server
+    image: ghcr.io/payloadcms/fake-gcs-server:1.54.0
     restart: always
     command:
       [
@@ -237,7 +237,7 @@ services:
   # Connection: redis://localhost:6379
   redis:
     profiles: [all, redis]
-    image: redis:7-alpine
+    image: ghcr.io/payloadcms/redis:7.4.9-alpine
     container_name: redis-payload-test
     ports:
       - '6379:6379'


### PR DESCRIPTION
# Overview

The `start-services` action intermittently fails when pulling test service images, with Docker Hub registry timeouts (`Get "https://registry-1.docker.io/v2/": context deadline exceeded`). In failing runs, only the Docker Hub images error while images already served from GHCR and Microsoft Container Registry pull normally on GitHub-hosted runners.

This moves the remaining Docker Hub test-service images to the `payloadcms` GHCR namespace and repoints `test/docker-compose.yml` at them, so the test stack no longer depends on Docker Hub.

## Key Changes

- **Mirror the six Docker Hub images to GHCR**
  - Copied each image to `ghcr.io/payloadcms/*` as a public, multi-arch package, pinned to an explicit version. These were pushed once with `docker buildx imagetools create` (registry-to-registry, preserving all platforms); there is no mirror automation.

- **Repoint `test/docker-compose.yml`**
  - The six image references now point at the GHCR copies. Every image in the file is now served from GHCR or MCR.

  | Service | Before | After |
  |---|---|---|
  | mongodb-community-server | `mongodb/mongodb-community-server:8.2-ubi9` | `ghcr.io/payloadcms/mongodb-community-server:8.2.9-ubi9` |
  | mongodb-community-search | `mongodb/mongodb-community-search:latest` | `ghcr.io/payloadcms/mongodb-community-search:1.67.1` |
  | mongodb-atlas-local | `mongodb/mongodb-atlas-local:latest` | `ghcr.io/payloadcms/mongodb-atlas-local:8.2.4` |
  | localstack | `localstack/localstack:4.14.0` | `ghcr.io/payloadcms/localstack:4.14.0` |
  | fake-gcs-server | `fsouza/fake-gcs-server` | `ghcr.io/payloadcms/fake-gcs-server:1.54.0` |
  | redis | `redis:7-alpine` | `ghcr.io/payloadcms/redis:7.4.9-alpine` |

## Design Decisions

- **Why GHCR.** GitHub-hosted runners pull GHCR and MCR reliably, while anonymous Docker Hub pulls time out under load and rate limits. The repo already serves `postgis-vector` and `vercel-blob-emulator` from `ghcr.io/payloadcms/*`, so this extends an existing pattern rather than introducing new infrastructure.
- **Public packages.** The GHCR packages are public so CI on external contributor forks (where `GITHUB_TOKEN` is read-only and cannot read private org packages) can pull them anonymously.
- **Pinned versions.** Floating tags (`latest`, untagged, `7-alpine`) are replaced with explicit versions for reproducible CI. A future version bump is a deliberate two-step change: push the new pinned tag to GHCR, then update the tag here. New tags inherit the existing public visibility.

## References / Links

- Example failing run: https://github.com/payloadcms/payload/actions/runs/26840052429/job/79145763022
