### PR TITLE
fix: validate listSearchableFields in collection config

### DIFF
--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -31,6 +31,7 @@ import {
 } from './defaults.js'
 import { sanitizeCompoundIndexes } from './sanitizeCompoundIndexes.js'
 import { validateUseAsTitle } from './useAsTitle.js'
+import { validateListSearchableFields } from './validateListSearchableFields.js'
 
 /**
  * Warns at startup when custom collection views are misconfigured with a missing `path`.
@@ -374,6 +375,8 @@ export const sanitizeCollection = async (
   }
 
   validateUseAsTitle(sanitized)
+
+  validateListSearchableFields(sanitized)
 
   const sanitizedConfig = sanitized as SanitizedCollectionConfig
 

--- a/packages/payload/src/collections/config/validateListSearchableFields.ts
+++ b/packages/payload/src/collections/config/validateListSearchableFields.ts
@@ -1,0 +1,30 @@
+import type { CollectionConfig } from '../../index.js'
+
+import { InvalidConfiguration } from '../../errors/InvalidConfiguration.js'
+import { fieldAffectsData } from '../../fields/config/types.js'
+import { flattenTopLevelFields } from '../../utilities/flattenTopLevelFields.js'
+
+/**
+ * Validate listSearchableFields for collections.
+ * Ensures that all fields specified in admin.listSearchableFields exist in the collection.
+ */
+export const validateListSearchableFields = (config: CollectionConfig) => {
+  if (!config.admin?.listSearchableFields) {
+    return
+  }
+
+  const fields = flattenTopLevelFields(config.fields)
+  const fieldNames = new Set(
+    fields.filter((field) => fieldAffectsData(field)).map((field) => field.name),
+  )
+  // 'id' is always a valid field
+  fieldNames.add('id')
+
+  for (const fieldName of config.admin.listSearchableFields) {
+    if (!fieldNames.has(fieldName)) {
+      throw new InvalidConfiguration(
+        `The field "${fieldName}" specified in "admin.listSearchableFields" does not exist in the collection "${config.slug}". Valid fields are: ${Array.from(fieldNames).join(', ')}`,
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fixes #14904

## Problem
When a collection config specifies `admin.listSearchableFields` with field names that don't exist in the collection, no validation error is thrown during development (`pnpm dev`). The error only surfaces in production builds, causing the admin UI to crash with no useful error message.

## Root Cause
The `listSearchableFields` config is never validated during config sanitization. Unlike `useAsTitle` (which has a dedicated `validateUseAsTitle` function), `listSearchableFields` field names are used directly in `mergeListSearchAndWhere.ts` without checking they exist in the collection schema.

## Fix
Created `validateListSearchableFields.ts` following the same pattern as the existing `validateUseAsTitle.ts`. It:
1. Checks each field name in `listSearchableFields` against the actual field names in the collection
2. Throws an `InvalidConfiguration` error with a clear message listing valid field names if an invalid field is found
3. Is called in `sanitizeCollectionConfig` right after `validateUseAsTitle`

This ensures the error is caught at startup in development mode, not silently failing in production.

## Testing
With a collection config containing:
```ts
admin: {
  listSearchableFields: ['nonExistentField']
}
```
Payload will now throw at startup:
```
The field "nonExistentField" specified in "admin.listSearchableFields" does not exist in the collection "posts". Valid fields are: id, title, ...```