### PR TITLE
chore(plugin-mcp): clean up int tests

### DIFF
--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -39,8 +39,10 @@ export const testEslintConfig = [
     settings: {
       vitest: {
         // See https://github.com/vitest-dev/eslint-plugin-vitest?tab=readme-ov-file#custom-fixtures
-        // This ensures that the eslint plugin recognizes the `it` wrapper function in our helpers/int/vitest.ts file.
-        vitestImports: [/helpers\/int\/vitest/],
+        // Ensures the eslint plugin recognizes our custom `it`/`test` wrappers:
+        // - `test/__helpers/int/vitest.ts` (db-aware wrapper)
+        // - any suite-local `helpers/**/*Fixtures.ts` re-exporting an `it` extended via `test.extend()`
+        vitestImports: [/helpers\/int\/vitest/, /helpers\/.*Fixtures/],
       },
     },
     rules: {

--- a/test/plugin-mcp/helpers/mcpClient.ts
+++ b/test/plugin-mcp/helpers/mcpClient.ts
@@ -1,0 +1,131 @@
+import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
+
+export type McpToolResultContent = {
+  text: string
+  type: string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- tool inputSchemas are JSON Schemas with arbitrary nested shapes
+export type McpTool = { description?: string; inputSchema: any; name: string }
+
+export type McpError = { code: number; data?: unknown; message: string }
+
+/**
+ * Envelope for a JSON-RPC response from the MCP endpoint. `TResult` narrows
+ * the `result` payload per method (e.g. `{ content }` for tool calls, `{ tools }`
+ * for tool listings). `result` is non-optional because the helpers below only
+ * cover the success path; auth/error responses go through `rawPost`.
+ */
+export type McpResponse<TResult = Record<string, unknown>> = {
+  error?: McpError
+  id: number
+  jsonrpc: '2.0'
+  result: TResult
+}
+
+export type McpToolCallResult = {
+  content: McpToolResultContent[]
+}
+
+export type McpListToolsResult = {
+  tools: McpTool[]
+}
+
+async function parseMcpStream<TResult = Record<string, unknown>>(
+  response: Response,
+): Promise<McpResponse<TResult>> {
+  const reader = response.body?.getReader()
+  const decoder = new TextDecoder()
+
+  let streamData = ''
+  while (true) {
+    const { done, value } = (await reader?.read()) || { done: false, value: new Uint8Array() }
+    if (done) {
+      break
+    }
+    streamData += decoder.decode(value, { stream: true })
+  }
+
+  const dataLine = streamData
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('data:'))
+    .pop()
+
+  const jsonString = dataLine ? dataLine.slice('data:'.length).trim() : streamData.trim()
+  return JSON.parse(jsonString)
+}
+
+export type McpClient = {
+  callTool: (args: {
+    apiKey: string
+    args?: Record<string, unknown>
+    id?: number
+    name: string
+  }) => Promise<McpResponse<McpToolCallResult>>
+  listTools: (args: { apiKey: string; id?: number }) => Promise<McpResponse<McpListToolsResult>>
+  rawPost: (args: { apiKey?: string; body: unknown }) => Promise<Response>
+  request: <TResult = Record<string, unknown>>(args: {
+    apiKey: string
+    id?: number
+    method: string
+    params?: Record<string, unknown>
+  }) => Promise<McpResponse<TResult>>
+}
+
+export function createMcpClient(restClient: NextRESTClient): McpClient {
+  const post = async ({ apiKey, body }: { apiKey?: string; body: unknown }): Promise<Response> =>
+    restClient.POST('/mcp', {
+      body: JSON.stringify(body),
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+        'Content-Type': 'application/json',
+      },
+    })
+
+  const request: McpClient['request'] = async ({ apiKey, id = 1, method, params = {} }) => {
+    const response = await post({ apiKey, body: { id, jsonrpc: '2.0', method, params } })
+    return parseMcpStream(response)
+  }
+
+  return {
+    callTool: ({ apiKey, args = {}, id, name }) =>
+      request<McpToolCallResult>({
+        apiKey,
+        id,
+        method: 'tools/call',
+        params: { arguments: args, name },
+      }),
+    listTools: ({ apiKey, id }) =>
+      request<McpListToolsResult>({ apiKey, id, method: 'tools/list' }),
+    rawPost: post,
+    request,
+  }
+}
+
+/**
+ * Returns the first text content block from a tool/call response
+ */
+export function getToolText(response: McpResponse<McpToolCallResult>): string {
+  const text = response.result.content?.[0]?.text
+  if (typeof text !== 'string') {
+    throw new Error(`MCP response has no text content: ${JSON.stringify(response, null, 2)}`)
+  }
+  return text
+}
+
+/**
+ * Extracts the JSON document block (```json ... ```) from a tool/call response
+ * text.
+ */
+export function getToolDoc<T = Record<string, unknown>>(
+  response: McpResponse<McpToolCallResult>,
+): T {
+  const text = getToolText(response)
+  const match = text.match(/```json\n([\s\S]*?)\n```/)
+  if (!match) {
+    throw new Error(`MCP response text contained no \`\`\`json block: ${text}`)
+  }
+  return JSON.parse(match[1]!) as T
+}

--- a/test/plugin-mcp/helpers/mcpFixtures.ts
+++ b/test/plugin-mcp/helpers/mcpFixtures.ts
@@ -1,0 +1,85 @@
+import type { Payload } from 'payload'
+
+import { randomUUID } from 'crypto'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { test as base } from 'vitest'
+
+import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
+
+import { initPayloadInt } from '../../__helpers/shared/initPayloadInt.js'
+import { devUser } from '../../credentials.js'
+import { createMcpClient, type McpClient } from './mcpClient.js'
+
+export let payload: Payload
+export let restClient: NextRESTClient
+export let userId: string
+
+export type GetApiKeyOptions = {
+  enableDelete?: boolean
+  enableUpdate?: boolean
+  globalFind?: boolean
+  globalUpdate?: boolean
+}
+
+export async function getApiKey({
+  enableDelete = false,
+  enableUpdate = false,
+  globalFind = false,
+  globalUpdate = false,
+}: GetApiKeyOptions = {}): Promise<string> {
+  const doc = await payload.create({
+    collection: 'payload-mcp-api-keys',
+    data: {
+      access: {
+        collections: {
+          posts: { create: true, delete: enableDelete, find: true, update: enableUpdate },
+          products: { find: true },
+        },
+        ...(globalFind || globalUpdate
+          ? { globals: { 'site-settings': { find: globalFind, update: globalUpdate } } }
+          : {}),
+      },
+      apiKey: randomUUID(),
+      enableAPIKey: true,
+      label: 'Test API Key',
+      user: userId,
+    },
+  })
+  return doc.apiKey as string
+}
+
+const fixtureDir = path.dirname(fileURLToPath(import.meta.url))
+const suiteDir = path.resolve(fixtureDir, '..')
+
+type ScopedFixtures = {
+  $test: { mcp: McpClient }
+  $worker: { _setup: void }
+}
+
+export const it = base.extend<ScopedFixtures>({
+  _setup: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      const initialized = await initPayloadInt(suiteDir)
+      payload = initialized.payload
+      restClient = initialized.restClient
+
+      const loginResponse: { user: { id: string } } = await restClient
+        .POST('/users/login', {
+          body: JSON.stringify({ email: devUser.email, password: devUser.password }),
+        })
+        .then((res) => res.json())
+      userId = loginResponse.user.id
+
+      await use()
+
+      await payload.destroy()
+    },
+    { auto: true, scope: 'worker' },
+  ],
+  // eslint-disable-next-line no-empty-pattern
+  mcp: async ({}, use) => {
+    await use(createMcpClient(restClient))
+  },
+})

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -1,135 +1,14 @@
-import type { Payload } from 'payload'
-
 import { randomUUID } from 'crypto'
-import path from 'path'
-import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { devUser } from '../credentials.js'
-
-let payload: Payload
-let token: string
-let userId: string
-let restClient: NextRESTClient
-
-const { email, password } = devUser
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-async function parseStreamResponse(response: Response): Promise<any> {
-  try {
-    const reader = response.body?.getReader()
-    const decoder = new TextDecoder()
-
-    let streamData = ''
-    while (true) {
-      const { done, value } = (await reader?.read()) || { done: false, value: new Uint8Array() }
-      if (done) {
-        break
-      }
-      streamData += decoder.decode(value, { stream: true })
-    }
-
-    const streamJSONDataLine = streamData
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.startsWith('data:'))
-      .pop()
-
-    const streamJSONString = streamJSONDataLine
-      ? streamJSONDataLine.slice('data:'.length).trim()
-      : streamData.trim()
-
-    return JSON.parse(streamJSONString)
-  } catch (error) {
-    console.error(error)
-    throw error
-  }
-}
-
-function extractJsonBlock(text: string): any {
-  const match = text.match(/```json\n([\s\S]*?)\n```/)
-  expect(match).toBeDefined()
-  return JSON.parse(match![1]!)
-}
-
-const getApiKey = async (
-  enableUpdate: boolean = false,
-  enableDelete: boolean = false,
-  globalFind: boolean = false,
-  globalUpdate: boolean = false,
-): Promise<string> => {
-  const doc = await payload.create({
-    collection: 'payload-mcp-api-keys',
-    data: {
-      enableAPIKey: true,
-      label: 'Test API Key',
-      access: {
-        collections: {
-          posts: { create: true, delete: enableDelete, find: true, update: enableUpdate },
-          products: { find: true },
-        },
-        ...(globalFind || globalUpdate
-          ? {
-              globals: {
-                'site-settings': { find: globalFind, update: globalUpdate },
-              },
-            }
-          : {}),
-      },
-      apiKey: randomUUID(),
-      user: userId,
-    },
-  })
-
-  return doc.apiKey as string
-}
+import { getToolDoc, getToolText } from './helpers/mcpClient.js'
+import { getApiKey, it, payload, restClient, userId } from './helpers/mcpFixtures.js'
 
 describe('@payloadcms/plugin-mcp', () => {
-  beforeAll(async () => {
-    const initialized = await initPayloadInt(dirname)
-    ;({ payload, restClient } = initialized)
-
-    const data = await restClient
-      .POST('/users/login', {
-        body: JSON.stringify({
-          email,
-          password,
-        }),
-      })
-      .then((res) => res.json())
-
-    // @ts-expect-error - data is not a valid property
-    token = data.token
-    // @ts-expect-error - data.user is a valid property
-    userId = data.user.id
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should ping', async () => {
+  it('should ping', async ({ mcp }) => {
     const apiKey = await getApiKey()
-    const response = await restClient.POST('/mcp', {
-      body: JSON.stringify({
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'ping',
-        params: {},
-      }),
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-    })
-
-    const json = await parseStreamResponse(response)
-    expect(json).toBeDefined()
+    const pingResponse = await mcp.request({ apiKey, method: 'ping' })
+    expect(pingResponse).toBeDefined()
   })
 
   describe('API Keyed Access', () => {
@@ -200,33 +79,19 @@ describe('@payloadcms/plugin-mcp', () => {
   })
 
   describe('List', () => {
-    it('should list tools', async () => {
+    it('should list tools', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
-
-      const json = await parseStreamResponse(response)
-      expect(json).toBeDefined()
-      expect(json.id).toBe(1)
-      expect(json.jsonrpc).toBe('2.0')
-      expect(json.result).toBeDefined()
-      expect(json.result.tools).toBeDefined()
-      expect(Array.isArray(json.result.tools)).toBe(true)
-      expect(json.result.tools.length).toBeGreaterThan(0)
+      const toolsResponse = await mcp.listTools({ apiKey })
+      expect(toolsResponse).toBeDefined()
+      expect(toolsResponse.id).toBe(1)
+      expect(toolsResponse.jsonrpc).toBe('2.0')
+      expect(toolsResponse.result).toBeDefined()
+      expect(toolsResponse.result.tools).toBeDefined()
+      expect(Array.isArray(toolsResponse.result.tools)).toBe(true)
+      expect(toolsResponse.result.tools.length).toBeGreaterThan(0)
 
       const toolsByName: Record<string, any> = Object.fromEntries(
-        json.result.tools.map((t: { name: string }) => [t.name, t]),
+        toolsResponse.result.tools.map((t: { name: string }) => [t.name, t]),
       )
 
       // findProducts: built-in find (no override) — uses default description
@@ -322,24 +187,10 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(diceRoll.inputSchema.properties.sides.maximum).toBe(1000)
     })
 
-    it('should list tools injected by other plugins via slug and options', async () => {
+    it('should list tools injected by other plugins via slug and options', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
-
-      const json = await parseStreamResponse(response)
-      const toolNames = json.result.tools.map((t: { name: string }) => t.name)
+      const toolsResponse = await mcp.listTools({ apiKey })
+      const toolNames = toolsResponse.result.tools.map((t: { name: string }) => t.name)
 
       // Both plugins inject tools into mcp's options via slug discovery,
       // regardless of whether they are listed before or after mcp in the plugins array
@@ -347,96 +198,54 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(toolNames).toContain('injectedAfter')
     })
 
-    it('should list resources', async () => {
+    it('should list resources', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'resources/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+      const resourcesResponse = await mcp.request({ apiKey, method: 'resources/list' })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.id).toBe(1)
-      expect(json.jsonrpc).toBe('2.0')
-      expect(json.result).toBeDefined()
-      expect(json.result.resources).toBeDefined()
-      expect(json.result.resources).toHaveLength(1)
-      expect(json.result.resources[0].name).toBe('data')
-      expect(json.result.resources[0].title).toBe('Data')
-      expect(json.result.resources[0].uri).toBe('data://app')
-      expect(json.result.resources[0].description).toBe(
+      expect(resourcesResponse).toBeDefined()
+      expect(resourcesResponse.id).toBe(1)
+      expect(resourcesResponse.jsonrpc).toBe('2.0')
+      expect(resourcesResponse.result).toBeDefined()
+      expect(resourcesResponse.result.resources).toBeDefined()
+      expect(resourcesResponse.result.resources).toHaveLength(1)
+      expect(resourcesResponse.result.resources[0].name).toBe('data')
+      expect(resourcesResponse.result.resources[0].title).toBe('Data')
+      expect(resourcesResponse.result.resources[0].uri).toBe('data://app')
+      expect(resourcesResponse.result.resources[0].description).toBe(
         'Data is a resource that contains special data.',
       )
-      expect(json.result.resources[0].mimeType).toBe('text/plain')
+      expect(resourcesResponse.result.resources[0].mimeType).toBe('text/plain')
     })
 
-    it('should list prompts', async () => {
+    it('should list prompts', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'prompts/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+      const promptsResponse = await mcp.request({ apiKey, method: 'prompts/list' })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.id).toBe(1)
-      expect(json.jsonrpc).toBe('2.0')
-      expect(json.result).toBeDefined()
-      expect(json.result.prompts).toBeDefined()
-      expect(json.result.prompts).toHaveLength(1)
-      expect(json.result.prompts[0].name).toBe('echo')
-      expect(json.result.prompts[0].title).toBe('Echo Prompt')
-      expect(json.result.prompts[0].description).toBe('Creates a prompt to process a message')
-      expect(json.result.prompts[0].arguments).toBeDefined()
-      expect(json.result.prompts[0].arguments).toHaveLength(1)
-      expect(json.result.prompts[0].arguments[0].name).toBe('message')
-      expect(json.result.prompts[0].arguments[0].required).toBe(true)
+      expect(promptsResponse).toBeDefined()
+      expect(promptsResponse.id).toBe(1)
+      expect(promptsResponse.jsonrpc).toBe('2.0')
+      expect(promptsResponse.result).toBeDefined()
+      expect(promptsResponse.result.prompts).toBeDefined()
+      expect(promptsResponse.result.prompts).toHaveLength(1)
+      expect(promptsResponse.result.prompts[0].name).toBe('echo')
+      expect(promptsResponse.result.prompts[0].title).toBe('Echo Prompt')
+      expect(promptsResponse.result.prompts[0].description).toBe('Creates a prompt to process a message')
+      expect(promptsResponse.result.prompts[0].arguments).toBeDefined()
+      expect(promptsResponse.result.prompts[0].arguments).toHaveLength(1)
+      expect(promptsResponse.result.prompts[0].arguments[0].name).toBe('message')
+      expect(promptsResponse.result.prompts[0].arguments[0].required).toBe(true)
     })
 
-    it('should list globals', async () => {
-      const apiKey = await getApiKey(false, false, true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+    it('should list globals', async ({ mcp }) => {
+      const apiKey = await getApiKey({ globalFind: true, globalUpdate: true })
+      const toolsResponse = await mcp.listTools({ apiKey })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.tools).toBeDefined()
+      expect(toolsResponse).toBeDefined()
+      expect(toolsResponse.result).toBeDefined()
+      expect(toolsResponse.result.tools).toBeDefined()
 
       // The global's description (from plugin config) overrides the built-in tool description
-      const findGlobalTool = json.result.tools.find((t: any) => t.name === 'findSiteSettings')
+      const findGlobalTool = toolsResponse.result.tools.find((t: any) => t.name === 'findSiteSettings')
       expect(findGlobalTool).toBeDefined()
       expect(findGlobalTool.description).toContain('Site-wide configuration settings.')
       expect(findGlobalTool.inputSchema.properties.select).toBeDefined()
@@ -445,7 +254,7 @@ describe('@payloadcms/plugin-mcp', () => {
         "Optional: define exactly which fields you'd like to return in the response (JSON), e.g., '{\"title\": true}'",
       )
 
-      const updateGlobalTool = json.result.tools.find((t: any) => t.name === 'updateSiteSettings')
+      const updateGlobalTool = toolsResponse.result.tools.find((t: any) => t.name === 'updateSiteSettings')
       expect(updateGlobalTool).toBeDefined()
       expect(updateGlobalTool.description).toContain('Site-wide configuration settings.')
       expect(updateGlobalTool.inputSchema.properties.select).toBeDefined()
@@ -455,25 +264,11 @@ describe('@payloadcms/plugin-mcp', () => {
       )
     })
 
-    it('should list updatePosts when API key permits update and include select schema', async () => {
-      const apiKey = await getApiKey(true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+    it('should list updatePosts when API key permits update and include select schema', async ({ mcp }) => {
+      const apiKey = await getApiKey({ enableUpdate: true })
+      const toolsResponse = await mcp.listTools({ apiKey })
 
-      const json = await parseStreamResponse(response)
-
-      const updateToolSchema = json.result.tools.find((t: any) => t.name === 'updatePosts')
+      const updateToolSchema = toolsResponse.result.tools.find((t: any) => t.name === 'updatePosts')
       expect(updateToolSchema).toBeDefined()
       expect(updateToolSchema.inputSchema.properties.select).toBeDefined()
       expect(updateToolSchema.inputSchema.properties.select.type).toBe('string')
@@ -484,36 +279,26 @@ describe('@payloadcms/plugin-mcp', () => {
   })
 
   describe('Prompts', () => {
-    it('should get echo prompt', async () => {
+    it('should get echo prompt', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'prompts/get',
-          params: {
-            name: 'echo',
-            arguments: {
-              message: 'Hello, world!',
-            },
+      const promptResponse = await mcp.request({
+        apiKey,
+        method: 'prompts/get',
+        params: {
+          name: 'echo',
+          arguments: {
+            message: 'Hello, world!',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.messages).toHaveLength(2)
-      expect(json.result.messages[0].content.type).toBe('text')
-      expect(json.result.messages[0].content.text).toContain('This prompt was sent: Hello, world!')
-      expect(json.result.messages[1].content.type).toBe('text')
-      expect(json.result.messages[1].content.text).toContain(
+      expect(promptResponse).toBeDefined()
+      expect(promptResponse.result).toBeDefined()
+      expect(promptResponse.result.messages).toHaveLength(2)
+      expect(promptResponse.result.messages[0].content.type).toBe('text')
+      expect(promptResponse.result.messages[0].content.text).toContain('This prompt was sent: Hello, world!')
+      expect(promptResponse.result.messages[1].content.type).toBe('text')
+      expect(promptResponse.result.messages[1].content.text).toContain(
         `This prompt was sent by userId: ${userId}`,
       )
 
@@ -535,32 +320,22 @@ describe('@payloadcms/plugin-mcp', () => {
   })
 
   describe('Resources', () => {
-    it('should read the data resource', async () => {
+    it('should read the data resource', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'resources/read',
-          params: {
-            uri: 'data://app',
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const resourceResponse = await mcp.request({
+        apiKey,
+        method: 'resources/read',
+        params: {
+          uri: 'data://app',
         },
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.contents).toHaveLength(2)
-      expect(json.result.contents[0].uri).toBe('data://app')
-      expect(json.result.contents[0].text).toContain('My special data.')
-      expect(json.result.contents[1].text).toContain(`This was requested by user: ${userId}`)
+      expect(resourceResponse).toBeDefined()
+      expect(resourceResponse.result).toBeDefined()
+      expect(resourceResponse.result.contents).toHaveLength(2)
+      expect(resourceResponse.result.contents[0].uri).toBe('data://app')
+      expect(resourceResponse.result.contents[0].text).toContain('My special data.')
+      expect(resourceResponse.result.contents[1].text).toContain(`This was requested by user: ${userId}`)
 
       const { docs } = await payload.find({
         collection: 'returned-resources',
@@ -578,32 +353,22 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(returnedResource?.user?.id).toBe(userId)
     })
 
-    it('should read the dataByID resource', async () => {
+    it('should read the dataByID resource', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'resources/read',
-          params: {
-            uri: 'data://app/1',
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const resourceResponse = await mcp.request({
+        apiKey,
+        method: 'resources/read',
+        params: {
+          uri: 'data://app/1',
         },
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.contents).toHaveLength(2)
-      expect(json.result.contents[0].uri).toBe('data://app/1')
-      expect(json.result.contents[0].text).toContain('My special data for ID: 1')
-      expect(json.result.contents[1].text).toContain(`This was requested by user: ${userId}`)
+      expect(resourceResponse).toBeDefined()
+      expect(resourceResponse.result).toBeDefined()
+      expect(resourceResponse.result.contents).toHaveLength(2)
+      expect(resourceResponse.result.contents[0].uri).toBe('data://app/1')
+      expect(resourceResponse.result.contents[0].text).toContain('My special data for ID: 1')
+      expect(resourceResponse.result.contents[1].text).toContain(`This was requested by user: ${userId}`)
 
       const { docs } = await payload.find({
         collection: 'returned-resources',
@@ -623,37 +388,24 @@ describe('@payloadcms/plugin-mcp', () => {
   })
 
   describe('Custom MCP Tools', () => {
-    it('should call diceRoll', async () => {
+    it('should call diceRoll', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'diceRoll',
-            arguments: {
-              sides: 6,
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          sides: 6,
         },
+        name: 'diceRoll',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(1)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain('**Sides:** 6')
-      expect(json.result.content[0].text).toContain('**Result:**')
-      expect(json.result.content[0].text).toContain('🎲 You rolled a **')
-      expect(json.result.content[0].text).toContain('** on a 6-sided die!')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(1)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain('**Sides:** 6')
+      expect(callResponse.result.content[0].text).toContain('**Result:**')
+      expect(callResponse.result.content[0].text).toContain('🎲 You rolled a **')
+      expect(callResponse.result.content[0].text).toContain('** on a 6-sided die!')
 
       const { docs } = await payload.find({
         collection: 'rolls',
@@ -673,118 +425,79 @@ describe('@payloadcms/plugin-mcp', () => {
   })
 
   describe('Collections', () => {
-    it('createPosts data validation: ensure invalid data is rejected', async () => {
+    it('createPosts data validation: ensure invalid data is rejected', async ({ mcp }) => {
       const apiKey = await getApiKey()
 
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPosts',
-            arguments: {
-              data: {
-                content: 'test content',
-                title: 'test title',
-                badProperty: 'not in schema',
-              },
-            },
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            content: 'test content',
+            title: 'test title',
+            badProperty: 'not in schema',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'createPosts',
       })
-
-      const json = await parseStreamResponse(response)
       const validationRejected =
-        json.error !== undefined ||
-        json.result?.isError === true ||
-        (typeof json.result?.content?.[0]?.text === 'string' &&
-          json.result.content[0].text
+        callResponse.error !== undefined ||
+        callResponse.result?.isError === true ||
+        (typeof callResponse.result?.content?.[0]?.text === 'string' &&
+          callResponse.result.content[0].text
             .toLowerCase()
             .includes('input validation error: invalid arguments for tool createposts'))
       expect(validationRejected).toBe(true)
     })
 
-    it('should call createPosts', async () => {
+    it('should call createPosts', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPosts',
-            arguments: {
-              data: {
-                content: 'Content for test post.',
-                title: 'Test Post',
-              },
-            },
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            content: 'Content for test post.',
+            title: 'Test Post',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'createPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain(
         'Document created successfully in collection "posts"!',
       )
-      expect(json.result.content[0].text).toContain('Created document:')
-      expect(json.result.content[0].text).toContain('```json')
-      expect(json.result.content[0].text).toContain('"title":"Test Post"')
-      expect(json.result.content[0].text).toContain('"content":"Content for test post."')
-      expect(json.result.content[1].type).toBe('text')
-      expect(json.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.result.content[0].text).toContain('Created document:')
+      expect(callResponse.result.content[0].text).toContain('```json')
+      expect(callResponse.result.content[0].text).toContain('"title":"Test Post"')
+      expect(callResponse.result.content[0].text).toContain('"content":"Content for test post."')
+      expect(callResponse.result.content[1].type).toBe('text')
+      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
     })
 
-    it('should call createPosts with select to limit returned fields', async () => {
+    it('should call createPosts with select to limit returned fields', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPosts',
-            arguments: {
-              data: {
-                content: 'Content should be omitted',
-                title: 'Select Create Post',
-              },
-              select: '{"title": true}',
-            },
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            content: 'Content should be omitted',
+            title: 'Select Create Post',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+          select: '{"title": true}',
         },
+        name: 'createPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].text).toContain('"title":"Select Create Post"')
-      expect(json.result.content[0].text).not.toContain('Content should be omitted')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content[0].text).toContain('"title":"Select Create Post"')
+      expect(callResponse.result.content[0].text).not.toContain('Content should be omitted')
     })
 
-    it('should call findPosts', async () => {
+    it('should call findPosts', async ({ mcp }) => {
       await payload.create({
         collection: 'posts',
         data: {
@@ -794,43 +507,30 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              limit: 1,
-              page: 1,
-              where: '{"title": {"contains": "Test Post for Finding"}}',
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          limit: 1,
+          page: 1,
+          where: '{"title": {"contains": "Test Post for Finding"}}',
         },
+        name: 'findPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain('Collection: "posts"')
-      expect(json.result.content[0].text).toContain('Total: 1 documents')
-      expect(json.result.content[0].text).toContain('Page: 1 of 1')
-      expect(json.result.content[0].text).toContain('```json')
-      expect(json.result.content[0].text).toContain('"content":"Content for test post."')
-      expect(json.result.content[1].type).toBe('text')
-      expect(json.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain('Collection: "posts"')
+      expect(callResponse.result.content[0].text).toContain('Total: 1 documents')
+      expect(callResponse.result.content[0].text).toContain('Page: 1 of 1')
+      expect(callResponse.result.content[0].text).toContain('```json')
+      expect(callResponse.result.content[0].text).toContain('"content":"Content for test post."')
+      expect(callResponse.result.content[1].type).toBe('text')
+      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
     })
 
-    it('should call findPosts with select and return only requested fields', async () => {
+    it('should call findPosts with select and return only requested fields', async ({ mcp }) => {
       await payload.create({
         collection: 'posts',
         data: {
@@ -840,40 +540,27 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              limit: 1,
-              page: 1,
-              select: '{"title": true}',
-              where: '{"title": {"contains": "Select Test Post"}}',
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          limit: 1,
+          page: 1,
+          select: '{"title": true}',
+          where: '{"title": {"contains": "Select Test Post"}}',
         },
+        name: 'findPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      const responseText: string = json.result.content[0].text
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      const responseText: string = callResponse.result.content[0].text
       expect(responseText).toContain('Collection: "posts"')
       expect(responseText).toContain('"title":"Select Test Post (MCP Hook Override)"')
       expect(responseText).not.toContain('"content": "Content that should be omitted"')
     })
 
-    it('should call updatePosts', async () => {
+    it('should call updatePosts', async ({ mcp }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -882,46 +569,33 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const apiKey = await getApiKey(true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePosts',
-            arguments: {
-              id: post.id,
-              data: {
-                content: 'Updated content for test post to update.',
-              },
-            },
+      const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          data: {
+            content: 'Updated content for test post to update.',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'updatePosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
-      expect(json.result.content[0].text).toContain('Updated document:')
-      expect(json.result.content[0].text).toContain('```json')
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse.result.content[0].text).toContain('Updated document:')
+      expect(callResponse.result.content[0].text).toContain('```json')
+      expect(callResponse.result.content[0].text).toContain(
         '"content":"Updated content for test post to update."',
       )
     })
 
-    it('should call updatePosts with nullable union type field set to null', async () => {
+    it('should call updatePosts with nullable union type field set to null', async ({ mcp }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -930,43 +604,30 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const apiKey = await getApiKey(true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePosts',
-            arguments: {
-              id: post.id,
-              data: {
-                content: null,
-              },
-            },
+      const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          data: {
+            content: null,
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'updatePosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
-      expect(json.result.content[0].text).toContain('"content":null')
+      expect(callResponse.result.content[0].text).toContain('"content":null')
 
       await payload.delete({ id: post.id, collection: 'posts' })
     })
 
-    it('should call updatePosts with relationship union type field', async () => {
+    it('should call updatePosts with relationship union type field', async ({ mcp }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -974,45 +635,32 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const apiKey = await getApiKey(true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePosts',
-            arguments: {
-              id: post.id,
-              data: {
-                author: userId,
-              },
-            },
+      const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          data: {
+            author: userId,
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'updatePosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
 
-      const updatedDoc = extractJsonBlock(json.result.content[0].text)
+      const updatedDoc = getToolDoc(callResponse)
       expect(updatedDoc.author).toBe(userId)
 
       await payload.delete({ id: post.id, collection: 'posts' })
     })
 
-    it('should call updatePosts with select to limit returned fields', async () => {
+    it('should call updatePosts with select to limit returned fields', async ({ mcp }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1021,42 +669,29 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const apiKey = await getApiKey(true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePosts',
-            arguments: {
-              id: post.id,
-              data: {
-                content: 'Updated but should be omitted',
-                title: 'Select Update Post Edited',
-              },
-              select: '{"title": true}',
-            },
+      const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          data: {
+            content: 'Updated but should be omitted',
+            title: 'Select Update Post Edited',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+          select: '{"title": true}',
         },
+        name: 'updatePosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      const responseText: string = json.result.content[0].text
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      const responseText: string = callResponse.result.content[0].text
       expect(responseText).toContain('"title":"Select Update Post Edited"')
       expect(responseText).not.toContain('Updated but should be omitted')
       expect(responseText).not.toContain('"content":')
     })
 
-    it('should call deletePosts', async () => {
+    it('should call deletePosts', async ({ mcp }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1065,88 +700,62 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const apiKey = await getApiKey(false, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'deletePosts',
-            arguments: {
-              id: post.id,
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const apiKey = await getApiKey({ enableDelete: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
         },
+        name: 'deletePosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain(
         'Document deleted successfully from collection "posts"!',
       )
-      expect(json.result.content[0].text).toContain('Deleted document:')
-      expect(json.result.content[0].text).toContain('```json')
-      expect(json.result.content[0].text).toContain('"content":"Content for test post to delete."')
+      expect(callResponse.result.content[0].text).toContain('Deleted document:')
+      expect(callResponse.result.content[0].text).toContain('```json')
+      expect(callResponse.result.content[0].text).toContain('"content":"Content for test post to delete."')
     })
 
-    it('should handle point fields with object format in createPosts', async () => {
+    it('should handle point fields with object format in createPosts', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPosts',
-            arguments: {
-              data: {
-                content: 'Testing point field transformation',
-                location: {
-                  latitude: 40.7128,
-                  longitude: -74.006,
-                },
-                title: 'Post with Location',
-              },
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            content: 'Testing point field transformation',
+            location: {
+              latitude: 40.7128,
+              longitude: -74.006,
             },
+            title: 'Post with Location',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'createPosts',
       })
 
-      const json = await parseStreamResponse(response)
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain('Document created successfully')
 
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain('Document created successfully')
-
-      const createdDoc = extractJsonBlock(json.result.content[0].text)
+      const createdDoc = getToolDoc(callResponse)
 
       expect(createdDoc.location).toEqual([-74.006, 40.7128])
 
-      expect(json.result.content[1].type).toBe('text')
-      expect(json.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.result.content[1].type).toBe('text')
+      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
 
       await payload.delete({ id: createdDoc.id, collection: 'posts' })
     })
 
-    it('should handle point fields with object format in updatePosts', async () => {
-      const apiKey = await getApiKey(true)
+    it('should handle point fields with object format in updatePosts', async ({ mcp }) => {
+      const apiKey = await getApiKey({ enableUpdate: true })
 
       const createdPost = await payload.create({
         collection: 'posts',
@@ -1156,45 +765,32 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePosts',
-            arguments: {
-              id: createdPost.id,
-              data: {
-                location: {
-                  latitude: 51.5074,
-                  longitude: -0.1278,
-                },
-              },
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: createdPost.id,
+          data: {
+            location: {
+              latitude: 51.5074,
+              longitude: -0.1278,
             },
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'updatePosts',
       })
 
-      const json = await parseStreamResponse(response)
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain('Document updated successfully')
 
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain('Document updated successfully')
-
-      const updatedDoc = extractJsonBlock(json.result.content[0].text)
+      const updatedDoc = getToolDoc(callResponse)
 
       expect(updatedDoc.location).toEqual([-0.1278, 51.5074])
 
-      expect(json.result.content[1].type).toBe('text')
-      expect(json.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.result.content[1].type).toBe('text')
+      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
 
       await payload.delete({ id: createdPost.id, collection: 'posts' })
     })
@@ -1223,97 +819,71 @@ describe('@payloadcms/plugin-mcp', () => {
       return doc.apiKey as string
     }
 
-    it('should create a page with a block', async () => {
+    it('should create a page with a block', async ({ mcp }) => {
       const apiKey = await getPagesApiKey()
 
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPages',
-            arguments: {
-              data: {
-                title: 'Hero Page',
-                layout: [
-                  {
-                    blockType: 'hero',
-                    heading: 'Welcome to our site',
-                    subheading: 'Discover amazing things',
-                  },
-                ],
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            title: 'Hero Page',
+            layout: [
+              {
+                blockType: 'hero',
+                heading: 'Welcome to our site',
+                subheading: 'Discover amazing things',
               },
-            },
+            ],
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'createPages',
       })
 
-      const json = await parseStreamResponse(response)
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.isError).toBeFalsy()
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain('"title":"Hero Page"')
+      expect(callResponse.result.content[0].text).toContain('"blockType":"hero"')
+      expect(callResponse.result.content[0].text).toContain('"heading":"Welcome to our site"')
 
-      expect(json.result).toBeDefined()
-      expect(json.result.isError).toBeFalsy()
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain('"title":"Hero Page"')
-      expect(json.result.content[0].text).toContain('"blockType":"hero"')
-      expect(json.result.content[0].text).toContain('"heading":"Welcome to our site"')
-
-      createdPageIds.push(extractJsonBlock(json.result.content[0].text).id)
+      createdPageIds.push(getToolDoc(callResponse).id)
     })
 
-    it('should create a page with multiple block types', async () => {
+    it('should create a page with multiple block types', async ({ mcp }) => {
       const apiKey = await getPagesApiKey()
 
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPages',
-            arguments: {
-              data: {
-                title: 'Multi-block Page',
-                layout: [
-                  {
-                    blockType: 'hero',
-                    heading: 'Page Hero',
-                    subheading: 'Hero subtitle',
-                  },
-                  {
-                    blockType: 'textContent',
-                    body: 'This is the body text.',
-                  },
-                ],
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            title: 'Multi-block Page',
+            layout: [
+              {
+                blockType: 'hero',
+                heading: 'Page Hero',
+                subheading: 'Hero subtitle',
               },
-            },
+              {
+                blockType: 'textContent',
+                body: 'This is the body text.',
+              },
+            ],
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'createPages',
       })
 
-      const json = await parseStreamResponse(response)
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.isError).toBeFalsy()
+      expect(callResponse.result.content[0].text).toContain('"blockType":"hero"')
+      expect(callResponse.result.content[0].text).toContain('"blockType":"textContent"')
+      expect(callResponse.result.content[0].text).toContain('"heading":"Page Hero"')
+      expect(callResponse.result.content[0].text).toContain('"body":"This is the body text."')
 
-      expect(json.result).toBeDefined()
-      expect(json.result.isError).toBeFalsy()
-      expect(json.result.content[0].text).toContain('"blockType":"hero"')
-      expect(json.result.content[0].text).toContain('"blockType":"textContent"')
-      expect(json.result.content[0].text).toContain('"heading":"Page Hero"')
-      expect(json.result.content[0].text).toContain('"body":"This is the body text."')
-
-      createdPageIds.push(extractJsonBlock(json.result.content[0].text).id)
+      createdPageIds.push(getToolDoc(callResponse).id)
     })
 
-    it('should update a page layout that contains blocks', async () => {
+    it('should update a page layout that contains blocks', async ({ mcp }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -1326,45 +896,32 @@ describe('@payloadcms/plugin-mcp', () => {
 
       const apiKey = await getPagesApiKey(true)
 
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePages',
-            arguments: {
-              id: page.id,
-              data: {
-                layout: [
-                  {
-                    blockType: 'hero',
-                    heading: 'Updated Hero Heading',
-                  },
-                  {
-                    blockType: 'textContent',
-                    body: 'Updated body text.',
-                  },
-                ],
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: page.id,
+          data: {
+            layout: [
+              {
+                blockType: 'hero',
+                heading: 'Updated Hero Heading',
               },
-            },
+              {
+                blockType: 'textContent',
+                body: 'Updated body text.',
+              },
+            ],
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'updatePages',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json.result).toBeDefined()
-      expect(json.result.isError).toBeFalsy()
-      expect(json.result.content[0].text).toContain('"blockType":"hero"')
-      expect(json.result.content[0].text).toContain('"heading":"Updated Hero Heading"')
-      expect(json.result.content[0].text).toContain('"blockType":"textContent"')
-      expect(json.result.content[0].text).toContain('"body":"Updated body text."')
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.isError).toBeFalsy()
+      expect(callResponse.result.content[0].text).toContain('"blockType":"hero"')
+      expect(callResponse.result.content[0].text).toContain('"heading":"Updated Hero Heading"')
+      expect(callResponse.result.content[0].text).toContain('"blockType":"textContent"')
+      expect(callResponse.result.content[0].text).toContain('"body":"Updated body text."')
 
       const updatedPage = await payload.findByID({
         collection: 'pages',
@@ -1378,138 +935,77 @@ describe('@payloadcms/plugin-mcp', () => {
   })
 
   describe('Virtual Fields', () => {
-    it('should not include virtual fields in createPosts tool schema', async () => {
-      const apiKey = await getApiKey(true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+    it('should not include virtual fields in createPosts tool schema', async ({ mcp }) => {
+      const apiKey = await getApiKey({ enableUpdate: true })
+      const toolsResponse = await mcp.listTools({ apiKey })
 
-      const json = await parseStreamResponse(response)
-
-      const createTool = json.result.tools.find((t: any) => t.name === 'createPosts')
+      const createTool = toolsResponse.result?.tools?.find((t) => t.name === 'createPosts')
       expect(createTool).toBeDefined()
-      expect(createTool.inputSchema.properties.data).toBeDefined()
-      expect(createTool.inputSchema.properties.data.properties.computedTitle).toBeUndefined()
+      expect(createTool?.inputSchema.properties.data).toBeDefined()
+      expect(createTool?.inputSchema.properties.data.properties.computedTitle).toBeUndefined()
     })
 
-    it('should not include virtual fields in updatePosts tool schema', async () => {
-      const apiKey = await getApiKey(true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+    it('should not include virtual fields in updatePosts tool schema', async ({ mcp }) => {
+      const apiKey = await getApiKey({ enableUpdate: true })
+      const toolsResponse = await mcp.listTools({ apiKey })
 
-      const json = await parseStreamResponse(response)
-
-      const updateTool = json.result.tools.find((t: any) => t.name === 'updatePosts')
+      const updateTool = toolsResponse.result?.tools?.find((t) => t.name === 'updatePosts')
       expect(updateTool).toBeDefined()
-      expect(updateTool.inputSchema.properties.data).toBeDefined()
-      expect(updateTool.inputSchema.properties.data.properties.computedTitle).toBeUndefined()
+      expect(updateTool?.inputSchema.properties.data).toBeDefined()
+      expect(updateTool?.inputSchema.properties.data.properties.computedTitle).toBeUndefined()
     })
 
-    it('should ignore virtual fields when creating a post via MCP', async () => {
+    it('should ignore virtual fields when creating a post via MCP', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPosts',
-            arguments: {
-              data: {
-                title: 'Virtual Field Create Test',
-                content: 'Testing virtual field exclusion on create',
-              },
-            },
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            title: 'Virtual Field Create Test',
+            content: 'Testing virtual field exclusion on create',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'createPosts',
       })
 
-      const json = await parseStreamResponse(response)
+      const text = getToolText(callResponse)
+      expect(text).toContain('Document created successfully in collection "posts"!')
+      expect(text).toContain('"title":"Virtual Field Create Test"')
+      expect(text).not.toContain('"computedTitle"')
 
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].text).toContain(
-        'Document created successfully in collection "posts"!',
-      )
-      expect(json.result.content[0].text).toContain('"title":"Virtual Field Create Test"')
-      expect(json.result.content[0].text).not.toContain('"computedTitle"')
-
-      // Clean up
-      const createdId = JSON.parse(
-        json.result.content[0].text.match(/```json\n([\s\S]*?)\n```/)?.[1] || '{}',
-      ).id
+      const { id: createdId } = getToolDoc<{ id: string }>(callResponse)
       if (createdId) {
         await payload.delete({ id: createdId, collection: 'posts' })
       }
     })
 
-    it('should ignore virtual fields when updating a post via MCP', async () => {
+    it('should ignore virtual fields when updating a post via MCP', async ({ mcp }) => {
       const post = await payload.create({
         collection: 'posts',
         data: { title: 'Virtual Field Update Test' },
       })
 
-      const apiKey = await getApiKey(true, false)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePosts',
-            arguments: {
-              id: post.id,
-              data: {
-                title: 'Virtual Field Updated Title',
-              },
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const apiKey = await getApiKey({ enableUpdate: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          data: { title: 'Virtual Field Updated Title' },
         },
+        name: 'updatePosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].text).toContain('Document updated successfully')
-      expect(json.result.content[0].text).toContain('"title":"Virtual Field Updated Title"')
-      expect(json.result.content[0].text).not.toContain('"computedTitle"')
+      const text = getToolText(callResponse)
+      expect(text).toContain('Document updated successfully')
+      expect(text).toContain('"title":"Virtual Field Updated Title"')
+      expect(text).not.toContain('"computedTitle"')
 
       await payload.delete({ id: post.id, collection: 'posts' })
     })
   })
 
   describe('payloadAPI context', () => {
-    it('should call operations with the payloadAPI context as MCP', async () => {
+    it('should call operations with the payloadAPI context as MCP', async ({ mcp }) => {
       await payload.create({
         collection: 'posts',
         data: {
@@ -1519,68 +1015,38 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              limit: 1,
-              page: 1,
-              where: '{"title": {"contains": "Test Post for Finding"}}',
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          limit: 1,
+          page: 1,
+          where: '{"title": {"contains": "Test Post for Finding"}}',
         },
+        name: 'findPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toHaveLength(2)
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toHaveLength(2)
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain(
         '"title":"Test Post for Finding (MCP Hook Override)"',
       )
     })
 
-    it('should find site-settings global', async () => {
-      const apiKey = await getApiKey(false, false, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findSiteSettings',
-            arguments: {},
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+    it('should find site-settings global', async ({ mcp }) => {
+      const apiKey = await getApiKey({ globalFind: true })
+      const callResponse = await mcp.callTool({ apiKey, name: 'findSiteSettings' })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toBeDefined()
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain('Global "site-settings"')
-      expect(json.result.content[0].text).toContain('```json')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toBeDefined()
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain('Global "site-settings"')
+      expect(callResponse.result.content[0].text).toContain('```json')
     })
 
-    it('should find site-settings global with select', async () => {
+    it('should find site-settings global with select', async ({ mcp }) => {
       await payload.updateGlobal({
         slug: 'site-settings',
         data: {
@@ -1591,106 +1057,67 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const apiKey = await getApiKey(false, false, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findSiteSettings',
-            arguments: {
-              select: '{"siteName": true}',
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const apiKey = await getApiKey({ globalFind: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          select: '{"siteName": true}',
         },
+        name: 'findSiteSettings',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toBeDefined()
-      expect(json.result.content[0].type).toBe('text')
-      const responseText: string = json.result.content[0].text
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toBeDefined()
+      expect(callResponse.result.content[0].type).toBe('text')
+      const responseText: string = callResponse.result.content[0].text
       expect(responseText).toContain('"siteName":"MCP Site"')
       expect(responseText).not.toContain('siteDescription')
       expect(responseText).not.toContain('contactEmail')
       expect(responseText).not.toContain('maintenanceMode')
     })
 
-    it('should update site-settings global', async () => {
-      const apiKey = await getApiKey(false, false, true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updateSiteSettings',
-            arguments: {
-              data: {
-                maintenanceMode: false,
-                siteDescription: 'A test site for MCP global operations',
-                siteName: 'MCP Test Site',
-              },
-            },
+    it('should update site-settings global', async ({ mcp }) => {
+      const apiKey = await getApiKey({ globalFind: true, globalUpdate: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            maintenanceMode: false,
+            siteDescription: 'A test site for MCP global operations',
+            siteName: 'MCP Test Site',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
         },
+        name: 'updateSiteSettings',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toBeDefined()
-      expect(json.result.content[0].type).toBe('text')
-      expect(json.result.content[0].text).toContain('Global "site-settings" updated successfully')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toBeDefined()
+      expect(callResponse.result.content[0].type).toBe('text')
+      expect(callResponse.result.content[0].text).toContain('Global "site-settings" updated successfully')
     })
 
-    it('should update site-settings global with select', async () => {
-      const apiKey = await getApiKey(false, false, true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updateSiteSettings',
-            arguments: {
-              data: {
-                maintenanceMode: false,
-                siteDescription: 'Should not appear',
-                siteName: 'MCP Test Site Select',
-              },
-              select: '{"siteName": true}',
-            },
+    it('should update site-settings global with select', async ({ mcp }) => {
+      const apiKey = await getApiKey({ globalFind: true, globalUpdate: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            maintenanceMode: false,
+            siteDescription: 'Should not appear',
+            siteName: 'MCP Test Site Select',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+          select: '{"siteName": true}',
         },
+        name: 'updateSiteSettings',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toBeDefined()
-      expect(json.result.content[0].type).toBe('text')
-      const responseText: string = json.result.content[0].text
+      expect(callResponse).toBeDefined()
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content).toBeDefined()
+      expect(callResponse.result.content[0].type).toBe('text')
+      const responseText: string = callResponse.result.content[0].text
       expect(responseText).toContain('"siteName":"MCP Test Site Select"')
       expect(responseText).not.toContain('siteDescription')
       expect(responseText).not.toContain('maintenanceMode')
@@ -1708,7 +1135,7 @@ describe('@payloadcms/plugin-mcp', () => {
       createdIDs.length = 0
     })
 
-    it('should return minified JSON without newlines or indentation in resource responses', async () => {
+    it('should return minified JSON without newlines or indentation in resource responses', async ({ mcp }) => {
       const doc = await payload.create({
         collection: 'posts',
         data: {
@@ -1720,30 +1147,17 @@ describe('@payloadcms/plugin-mcp', () => {
       createdIDs.push(doc.id)
 
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          limit: 1,
+          page: 1,
+          where: '{"title": {"equals": "Minified JSON Test"}}',
         },
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              limit: 1,
-              page: 1,
-              where: '{"title": {"equals": "Minified JSON Test"}}',
-            },
-          },
-        }),
+        name: 'findPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      const responseText: string = json.result.content[0].text
+      const responseText: string = callResponse.result.content[0].text
       const jsonBlocks = responseText.match(/```json\n[\s\S]*?```/g)
 
       expect(jsonBlocks).toBeTruthy()
@@ -1756,28 +1170,11 @@ describe('@payloadcms/plugin-mcp', () => {
       }
     })
 
-    it('should return minified JSON in global responses', async () => {
-      const apiKey = await getApiKey(false, false, true)
-      const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findSiteSettings',
-            arguments: {},
-          },
-        }),
-      })
+    it('should return minified JSON in global responses', async ({ mcp }) => {
+      const apiKey = await getApiKey({ globalFind: true })
+      const callResponse = await mcp.callTool({ apiKey, name: 'findSiteSettings' })
 
-      const json = await parseStreamResponse(response)
-
-      const responseText: string = json.result.content[0].text
+      const responseText: string = callResponse.result.content[0].text
       const jsonBlocks = responseText.match(/```json\n[\s\S]*?```/g)
 
       expect(jsonBlocks).toBeTruthy()
@@ -1788,7 +1185,7 @@ describe('@payloadcms/plugin-mcp', () => {
       }
     })
 
-    it('should return minified JSON in findByID resource responses', async () => {
+    it('should return minified JSON in findByID resource responses', async ({ mcp }) => {
       const doc = await payload.create({
         collection: 'posts',
         data: {
@@ -1800,28 +1197,15 @@ describe('@payloadcms/plugin-mcp', () => {
       createdIDs.push(doc.id)
 
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json, text/event-stream',
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: doc.id,
         },
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              id: doc.id,
-            },
-          },
-        }),
+        name: 'findPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      const responseText: string = json.result.content[0].text
+      const responseText: string = callResponse.result.content[0].text
       // findByID response format: `Resource from collection "posts":\n${JSON.stringify(doc)}`
       // (no fenced code block — extract the JSON from the second line)
       const jsonPart = responseText.split('\n').slice(1).join('\n')
@@ -1834,28 +1218,14 @@ describe('@payloadcms/plugin-mcp', () => {
   })
 
   describe('Localization', () => {
-    it('should include locale parameters in tool schemas', async () => {
-      const apiKey = await getApiKey(true, true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: {},
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      })
+    it('should include locale parameters in tool schemas', async ({ mcp }) => {
+      const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
+      const toolsResponse = await mcp.listTools({ apiKey })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json.result.tools).toBeDefined()
+      expect(toolsResponse.result.tools).toBeDefined()
 
       // Check createPosts has locale parameters
-      const createTool = json.result.tools.find((t: any) => t.name === 'createPosts')
+      const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createPosts')
       expect(createTool).toBeDefined()
       expect(createTool.inputSchema.properties.locale).toBeDefined()
       expect(createTool.inputSchema.properties.locale.type).toBe('string')
@@ -1863,58 +1233,45 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(createTool.inputSchema.properties.fallbackLocale).toBeDefined()
 
       // Check updatePosts has locale parameters
-      const updateTool = json.result.tools.find((t: any) => t.name === 'updatePosts')
+      const updateTool = toolsResponse.result.tools.find((t: any) => t.name === 'updatePosts')
       expect(updateTool).toBeDefined()
       expect(updateTool.inputSchema.properties.locale).toBeDefined()
       expect(updateTool.inputSchema.properties.fallbackLocale).toBeDefined()
 
       // Check findPosts has locale parameters
-      const findTool = json.result.tools.find((t: any) => t.name === 'findPosts')
+      const findTool = toolsResponse.result.tools.find((t: any) => t.name === 'findPosts')
       expect(findTool).toBeDefined()
       expect(findTool.inputSchema.properties.locale).toBeDefined()
       expect(findTool.inputSchema.properties.fallbackLocale).toBeDefined()
 
       // Check deletePosts has locale parameters
-      const deleteTool = json.result.tools.find((t: any) => t.name === 'deletePosts')
+      const deleteTool = toolsResponse.result.tools.find((t: any) => t.name === 'deletePosts')
       expect(deleteTool).toBeDefined()
       expect(deleteTool.inputSchema.properties.locale).toBeDefined()
       expect(deleteTool.inputSchema.properties.fallbackLocale).toBeDefined()
     })
 
-    it('should create post with specific locale', async () => {
+    it('should create post with specific locale', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'createPosts',
-            arguments: {
-              data: {
-                content: 'This is my first post in English',
-                title: 'Hello World',
-              },
-              locale: 'en',
-            },
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          data: {
+            content: 'This is my first post in English',
+            title: 'Hello World',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+          locale: 'en',
         },
+        name: 'createPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].text).toContain('Document created successfully')
-      expect(json.result.content[0].text).toContain('"title":"Hello World"')
-      expect(json.result.content[0].text).toContain('"content":"This is my first post in English"')
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content[0].text).toContain('Document created successfully')
+      expect(callResponse.result.content[0].text).toContain('"title":"Hello World"')
+      expect(callResponse.result.content[0].text).toContain('"content":"This is my first post in English"')
     })
 
-    it('should update post to add translation', async () => {
+    it('should update post to add translation', async ({ mcp }) => {
       // First create a post in English
       const englishPost = await payload.create({
         collection: 'posts',
@@ -1925,40 +1282,27 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       // Update with Spanish translation via MCP
-      const apiKey = await getApiKey(true)
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'updatePosts',
-            arguments: {
-              id: englishPost.id,
-              data: {
-                content: 'Contenido Español',
-                title: 'Título Español',
-              },
-              locale: 'es',
-            },
+      const apiKey = await getApiKey({ enableUpdate: true })
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: englishPost.id,
+          data: {
+            content: 'Contenido Español',
+            title: 'Título Español',
           },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+          locale: 'es',
         },
+        name: 'updatePosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].text).toContain('Document updated successfully')
-      expect(json.result.content[0].text).toContain('"title":"Título Español"')
-      expect(json.result.content[0].text).toContain('"content":"Contenido Español"')
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content[0].text).toContain('Document updated successfully')
+      expect(callResponse.result.content[0].text).toContain('"title":"Título Español"')
+      expect(callResponse.result.content[0].text).toContain('"content":"Contenido Español"')
     })
 
-    it('should find post in specific locale', async () => {
+    it('should find post in specific locale', async ({ mcp }) => {
       // Create a post with English and Spanish translations
       const post = await payload.create({
         collection: 'posts',
@@ -1980,36 +1324,23 @@ describe('@payloadcms/plugin-mcp', () => {
 
       // Find in Spanish via MCP
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              id: post.id,
-              locale: 'es',
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          locale: 'es',
         },
+        name: 'findPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json.result).toBeDefined()
-      expect(json.result.content[0].text).toContain(
+      expect(callResponse.result).toBeDefined()
+      expect(callResponse.result.content[0].text).toContain(
         '"title":"Publicación Española (MCP Hook Override)"',
       )
-      expect(json.result.content[0].text).toContain('"content":"Contenido Español"')
+      expect(callResponse.result.content[0].text).toContain('"content":"Contenido Español"')
     })
 
-    it('should find post with locale "all"', async () => {
+    it('should find post with locale "all"', async ({ mcp }) => {
       // Create a post with multiple translations
       const post = await payload.create({
         collection: 'posts',
@@ -2041,30 +1372,17 @@ describe('@payloadcms/plugin-mcp', () => {
 
       // Find with locale: all via MCP
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              id: post.id,
-              locale: 'all',
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const callResponse = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          locale: 'all',
         },
+        name: 'findPosts',
       })
 
-      const json = await parseStreamResponse(response)
-
-      expect(json.result).toBeDefined()
-      const responseText = json.result.content[0].text
+      expect(callResponse.result).toBeDefined()
+      const responseText = callResponse.result.content[0].text
 
       // Should contain locale objects with all translations
       expect(responseText).toContain('"en":')
@@ -2075,7 +1393,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(responseText).toContain('Titre Français (MCP Hook Override)')
     })
 
-    it('should use fallback locale when translation does not exist', async () => {
+    it('should use fallback locale when translation does not exist', async ({ mcp }) => {
       // Create a post only in English with explicit content
       const post = await payload.create({
         collection: 'posts',
@@ -2087,27 +1405,14 @@ describe('@payloadcms/plugin-mcp', () => {
 
       // Try to find in French (which doesn't exist)
       const apiKey = await getApiKey()
-      const response = await restClient.POST('/mcp', {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'findPosts',
-            arguments: {
-              id: post.id,
-              locale: 'fr',
-            },
-          },
-        }),
-        headers: {
-          Accept: 'application/json, text/event-stream',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+      const json = await mcp.callTool({
+        apiKey,
+        args: {
+          id: post.id,
+          locale: 'fr',
         },
+        name: 'findPosts',
       })
-
-      const json = await parseStreamResponse(response)
 
       expect(json).toBeDefined()
       expect(json.result).toBeDefined()
@@ -2148,50 +1453,22 @@ describe('@payloadcms/plugin-mcp', () => {
     }
 
     describe('Schema validation', () => {
-      it('should not include ui field in create tool schema', async () => {
+      it('should not include ui field in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
+        const toolsResponse = await mcp.listTools({ apiKey })
 
-        const json = await parseStreamResponse(response)
-
-        expect(json.result.tools).toBeDefined()
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        expect(toolsResponse.result.tools).toBeDefined()
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         expect(createTool).toBeDefined()
 
         const inputProps = createTool.inputSchema.properties.data.properties
         expect(inputProps).not.toHaveProperty('uiField')
       })
 
-      it('should include group field as nested object in create tool schema', async () => {
+      it('should include group field as nested object in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        const json = await parseStreamResponse(response)
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const toolsResponse = await mcp.listTools({ apiKey })
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         const inputProps = createTool.inputSchema.properties.data.properties
 
         expect(inputProps.groupField).toBeDefined()
@@ -2201,24 +1478,10 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(inputProps.groupField.properties.groupNumber).toBeDefined()
       })
 
-      it('should include collapsible children as top-level fields in create tool schema', async () => {
+      it('should include collapsible children as top-level fields in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        const json = await parseStreamResponse(response)
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const toolsResponse = await mcp.listTools({ apiKey })
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         const inputProps = createTool.inputSchema.properties.data.properties
 
         // Children of collapsible appear at the top level, not under a `collapsible` key
@@ -2228,24 +1491,10 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(inputProps.collapsibleText.anyOf.some((t: any) => t.type === 'string')).toBe(true)
       })
 
-      it('should include row children as top-level fields in create tool schema', async () => {
+      it('should include row children as top-level fields in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        const json = await parseStreamResponse(response)
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const toolsResponse = await mcp.listTools({ apiKey })
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         const inputProps = createTool.inputSchema.properties.data.properties
 
         // Children of row appear at the top level, not under a `row` key
@@ -2254,24 +1503,10 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(inputProps.rowText.anyOf.some((t: any) => t.type === 'string')).toBe(true)
       })
 
-      it('should include named tab as nested object and unnamed tab children at top level in create tool schema', async () => {
+      it('should include named tab as nested object and unnamed tab children at top level in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        const json = await parseStreamResponse(response)
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const toolsResponse = await mcp.listTools({ apiKey })
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         const inputProps = createTool.inputSchema.properties.data.properties
 
         // Named tab appears as a nested object
@@ -2286,24 +1521,10 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(inputProps.unnamedTabText.anyOf.some((t: any) => t.type === 'string')).toBe(true)
       })
 
-      it('should include select field with enum values in create tool schema', async () => {
+      it('should include select field with enum values in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        const json = await parseStreamResponse(response)
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const toolsResponse = await mcp.listTools({ apiKey })
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         const inputProps = createTool.inputSchema.properties.data.properties
 
         expect(inputProps.selectField).toBeDefined()
@@ -2313,24 +1534,10 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(inputProps.selectField.enum).toContain('option3')
       })
 
-      it('should include radio field with enum values in create tool schema', async () => {
+      it('should include radio field with enum values in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        const json = await parseStreamResponse(response)
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const toolsResponse = await mcp.listTools({ apiKey })
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         const inputProps = createTool.inputSchema.properties.data.properties
 
         expect(inputProps.radioField).toBeDefined()
@@ -2340,24 +1547,10 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(inputProps.radioField.enum).toContain('radio3')
       })
 
-      it('should include array field with item schema in create tool schema', async () => {
+      it('should include array field with item schema in create tool schema', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/list',
-            params: {},
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        const json = await parseStreamResponse(response)
-        const createTool = json.result.tools.find((t: any) => t.name === 'createFieldTypes')
+        const toolsResponse = await mcp.listTools({ apiKey })
+        const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createFieldTypes')
         const inputProps = createTool.inputSchema.properties.data.properties
 
         expect(inputProps.arrayField).toBeDefined()
@@ -2370,43 +1563,30 @@ describe('@payloadcms/plugin-mcp', () => {
     })
 
     describe('Create + round-trip', () => {
-      it('should create and find document with atomic data fields (text, textarea, number, email, checkbox)', async () => {
+      it('should create and find document with atomic data fields (text, textarea, number, email, checkbox)', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Hello MCP',
-                  textareaField: 'Multi-line\ntext content',
-                  numberField: 42,
-                  emailField: 'test@example.com',
-                  checkboxField: true,
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Hello MCP',
+              textareaField: 'Multi-line\ntext content',
+              numberField: 42,
+              emailField: 'test@example.com',
+              checkboxField: true,
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
-
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-        expect(json.result.content[0].type).toBe('text')
-        expect(json.result.content[0].text).toContain(
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse.result.content[0].type).toBe('text')
+        expect(callResponse.result.content[0].text).toContain(
           'Document created successfully in collection "field-types"!',
         )
 
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.textField).toBe('Hello MCP')
         expect(doc.textareaField).toBe('Multi-line\ntext content')
@@ -2417,39 +1597,26 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with date, code, and json fields', async () => {
+      it('should create document with date, code, and json fields', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
         const testDate = '2024-01-15T10:30:00.000Z'
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Date/Code/JSON test',
-                  dateField: testDate,
-                  codeField: 'const x = 42;',
-                  jsonField: { key: 'value', nested: { count: 1 } },
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Date/Code/JSON test',
+              dateField: testDate,
+              codeField: 'const x = 42;',
+              jsonField: { key: 'value', nested: { count: 1 } },
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.codeField).toBe('const x = 42;')
         expect(doc.jsonField).toMatchObject({ key: 'value', nested: { count: 1 } })
@@ -2458,111 +1625,72 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with select field', async () => {
+      it('should create document with select field', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Select test',
-                  selectField: 'option2',
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Select test',
+              selectField: 'option2',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.selectField).toBe('option2')
 
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with radio field', async () => {
+      it('should create document with radio field', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Radio test',
-                  radioField: 'radio3',
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Radio test',
+              radioField: 'radio3',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.radioField).toBe('radio3')
 
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with group field (nested object)', async () => {
+      it('should create document with group field (nested object)', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Group test',
-                  groupField: {
-                    groupText: 'Inside the group',
-                    groupNumber: 99,
-                  },
-                },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Group test',
+              groupField: {
+                groupText: 'Inside the group',
+                groupNumber: 99,
               },
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.groupField).toBeDefined()
         expect(doc.groupField.groupText).toBe('Inside the group')
@@ -2571,36 +1699,23 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with collapsible children at top level', async () => {
+      it('should create document with collapsible children at top level', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Collapsible test',
-                  collapsibleText: 'Text inside collapsible',
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Collapsible test',
+              collapsibleText: 'Text inside collapsible',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         // collapsibleText is stored at the top level of the document
         expect(doc.collapsibleText).toBe('Text inside collapsible')
@@ -2608,36 +1723,23 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with row children at top level', async () => {
+      it('should create document with row children at top level', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Row test',
-                  rowText: 'Text inside row',
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Row test',
+              rowText: 'Text inside row',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         // rowText is stored at the top level of the document
         expect(doc.rowText).toBe('Text inside row')
@@ -2645,39 +1747,26 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with tabs fields (named tab as object, unnamed tab children at top level)', async () => {
+      it('should create document with tabs fields (named tab as object, unnamed tab children at top level)', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Tabs test',
-                  namedTab: {
-                    namedTabText: 'Inside named tab',
-                  },
-                  unnamedTabText: 'Inside unnamed tab',
-                },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Tabs test',
+              namedTab: {
+                namedTabText: 'Inside named tab',
               },
+              unnamedTabText: 'Inside unnamed tab',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         // Named tab stored as nested object
         expect(doc.namedTab).toBeDefined()
@@ -2689,39 +1778,26 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create document with array field', async () => {
+      it('should create document with array field', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'Array test',
-                  arrayField: [
-                    { item: 'First item', itemNumber: 1 },
-                    { item: 'Second item', itemNumber: 2 },
-                  ],
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'Array test',
+              arrayField: [
+                { item: 'First item', itemNumber: 1 },
+                { item: 'Second item', itemNumber: 2 },
+              ],
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.arrayField).toHaveLength(2)
         expect(doc.arrayField[0].item).toBe('First item')
@@ -2732,7 +1808,7 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should find documents in field-types collection', async () => {
+      it('should find documents in field-types collection', async ({ mcp }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
           data: { textField: 'Findable doc', numberField: 7 },
@@ -2740,37 +1816,24 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey()
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'findFieldTypes',
-              arguments: {
-                where: '{"textField": {"equals": "Findable doc"}}',
-              },
-            },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            where: '{"textField": {"equals": "Findable doc"}}',
           },
+          name: 'findFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
-
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-        expect(json.result.content[0].text).toContain('Collection: "field-types"')
-        expect(json.result.content[0].text).toContain('"textField":"Findable doc"')
-        expect(json.result.content[0].text).toContain('"numberField":7')
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse.result.content[0].text).toContain('Collection: "field-types"')
+        expect(callResponse.result.content[0].text).toContain('"textField":"Findable doc"')
+        expect(callResponse.result.content[0].text).toContain('"numberField":7')
       })
     })
 
     describe('Update', () => {
-      it('should update document with group field', async () => {
+      it('should update document with group field', async ({ mcp }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
           data: {
@@ -2781,46 +1844,33 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey(true, false)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'updateFieldTypes',
-              arguments: {
-                id: created.id,
-                data: {
-                  groupField: {
-                    groupText: 'Updated group text',
-                    groupNumber: 100,
-                  },
-                },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            id: created.id,
+            data: {
+              groupField: {
+                groupText: 'Updated group text',
+                groupNumber: 100,
               },
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'updateFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
-
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-        expect(json.result.content[0].text).toContain(
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse.result.content[0].text).toContain(
           'Document updated successfully in collection "field-types"!',
         )
 
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.groupField.groupText).toBe('Updated group text')
         expect(doc.groupField.groupNumber).toBe(100)
       })
 
-      it('should update document with collapsible field (children at top level)', async () => {
+      it('should update document with collapsible field (children at top level)', async ({ mcp }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
           data: {
@@ -2831,39 +1881,26 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey(true, false)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'updateFieldTypes',
-              arguments: {
-                id: created.id,
-                data: {
-                  collapsibleText: 'Updated collapsible text',
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            id: created.id,
+            data: {
+              collapsibleText: 'Updated collapsible text',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'updateFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.collapsibleText).toBe('Updated collapsible text')
       })
 
-      it('should update document with array field', async () => {
+      it('should update document with array field', async ({ mcp }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
           data: {
@@ -2874,38 +1911,25 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey(true, false)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'updateFieldTypes',
-              arguments: {
-                id: created.id,
-                data: {
-                  arrayField: [
-                    { item: 'Updated item A', itemNumber: 10 },
-                    { item: 'Updated item B', itemNumber: 20 },
-                    { item: 'Updated item C', itemNumber: 30 },
-                  ],
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            id: created.id,
+            data: {
+              arrayField: [
+                { item: 'Updated item A', itemNumber: 10 },
+                { item: 'Updated item B', itemNumber: 20 },
+                { item: 'Updated item C', itemNumber: 30 },
+              ],
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'updateFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         expect(doc.arrayField).toHaveLength(3)
         expect(doc.arrayField[0].item).toBe('Updated item A')
@@ -2914,38 +1938,25 @@ describe('@payloadcms/plugin-mcp', () => {
     })
 
     describe('Display field safety', () => {
-      it('should create document with ui field present without errors and ui field absent from response', async () => {
+      it('should create document with ui field present without errors and ui field absent from response', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
 
         // Create a doc without passing any `uiField` value (it has no stored data)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'UI field safety test',
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'UI field safety test',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse.result.content[0].text).toContain('Document created successfully')
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-        expect(json.result.content[0].text).toContain('Document created successfully')
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         // uiField has no stored data and should not appear in the document
         expect(doc).not.toHaveProperty('uiField')
@@ -2953,40 +1964,27 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(doc.id)
       })
 
-      it('should create and find document with all structural layout fields populated', async () => {
+      it('should create and find document with all structural layout fields populated', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const response = await restClient.POST('/mcp', {
-          body: JSON.stringify({
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'tools/call',
-            params: {
-              name: 'createFieldTypes',
-              arguments: {
-                data: {
-                  textField: 'All layout fields test',
-                  groupField: { groupText: 'Group value', groupNumber: 5 },
-                  collapsibleText: 'Collapsible value',
-                  rowText: 'Row value',
-                  namedTab: { namedTabText: 'Named tab value' },
-                  unnamedTabText: 'Unnamed tab value',
-                },
-              },
+        const callResponse = await mcp.callTool({
+          apiKey,
+          args: {
+            data: {
+              textField: 'All layout fields test',
+              groupField: { groupText: 'Group value', groupNumber: 5 },
+              collapsibleText: 'Collapsible value',
+              rowText: 'Row value',
+              namedTab: { namedTabText: 'Named tab value' },
+              unnamedTabText: 'Unnamed tab value',
             },
-          }),
-          headers: {
-            Accept: 'application/json, text/event-stream',
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
           },
+          name: 'createFieldTypes',
         })
 
-        const json = await parseStreamResponse(response)
+        expect(callResponse.result).toBeDefined()
+        expect(callResponse.result.isError).toBeFalsy()
 
-        expect(json.result).toBeDefined()
-        expect(json.result.isError).toBeFalsy()
-
-        const doc = extractJsonBlock(json.result.content[0].text)
+        const doc = getToolDoc(callResponse)
 
         // All data fields are stored correctly regardless of their container type
         expect(doc.groupField.groupText).toBe('Group value')


### PR DESCRIPTION
This PR add vitest fixtures for the mcp plugin to clean up the int tests and dramatically reduce duplicative code.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215338403644506