### PR TITLE
ci: strip non-essential services from supabase container start

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -102,4 +102,7 @@ runs:
       shell: bash
       run: |
         supabase init
-        supabase start
+        # Tests connect directly to Postgres on 54322 (see test/dbAdapters.ts), so exclude every
+        # other service. This kills the flaky edge-runtime container whose Deno-dependency boot
+        # fails health checks with a 502 on CI, and slashes startup time/RAM.
+        supabase start -x edge-runtime,studio,postgres-meta,logflare,vector,imgproxy,storage-api,gotrue,realtime,postgrest,kong,mailpit,supavisor

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
           filters: |
             needs_build:
               - '.github/workflows/main.yml'
+              - '.github/actions/start-services/**'
+              - '.github/actions/setup/**'
               - 'packages/**'
               - 'test/**'
               - 'pnpm-lock.yaml'


### PR DESCRIPTION
# Overview

Ran into some issues with non-essential services in the supabase container starting up. This PR strips all ancillary services from starting up.

Detailed failure: During `supabase start` with `Error status 502` from the `edge_runtime` container during health checks. The tests connect directly to Postgres (`127.0.0.1:54322`) and never touch Edge Functions, so this PR excludes every supabase service the tests don't use.

## Key Changes

- **Exclude all non-database services from `supabase start`**
  - Pass `-x edge-runtime,studio,postgres-meta,logflare,vector,imgproxy,storage-api,gotrue,realtime,postgrest,kong,mailpit,supavisor`, leaving only the Postgres `db` container running.
  - This removes the failing `edge-runtime` container, and also cuts startup time and memory (the full stack wants ~7GB of RAM).

## Design Decisions

The supabase adapter in `test/dbAdapters.ts` connects straight to Postgres on port `54322`, bypassing the API gateway, auth, REST, storage, and edge layers. Every service other than `db` is unused by the tests, so excluding them is safe. Dependency-paired services are excluded together (logflare with vector, studio with postgres-meta and kong) to avoid dangling-dependency startup errors.

Excluding the unused services is preferred over the alternatives: `--ignore-health-check` still boots the broken edge-runtime container, pinning the CLI version adds maintenance burden without stopping the `edge_runtime` startup download flakiness, and a retry loop is slow and only papers over the root cause.

## References / Links

- [Example failed run](https://github.com/payloadcms/payload/actions/runs/26878363243/job/79272609703#step:5:2881)
- [supabase/cli#3775](https://github.com/supabase/cli/issues/3775) — `supabase start` 502 from edge-runtime Deno dependency downloads
- [supabase start CLI reference](https://supabase.com/docs/reference/cli/supabase-start) — `-x / --exclude` service list
