### PR TITLE
chore(ui): migrate EmailAndUsername styles from scss to css

### DIFF
--- a/packages/ui/src/elements/EmailAndUsername/index.css
+++ b/packages/ui/src/elements/EmailAndUsername/index.css
@@ -1,9 +1,7 @@
-@import '../../scss/styles.scss';
-
 @layer payload-default {
   .login-fields {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: var(--spacer-3);
   }
 }

--- a/packages/ui/src/elements/EmailAndUsername/index.tsx
+++ b/packages/ui/src/elements/EmailAndUsername/index.tsx
@@ -8,8 +8,8 @@ import React from 'react'
 
 import { EmailField } from '../../fields/Email/index.js'
 import { TextField } from '../../fields/Text/index.js'
-import './index.scss'
 import { FieldPathContext } from '../../forms/RenderFields/context.js'
+import './index.css'
 
 const baseClass = 'login-fields'
 type RenderEmailAndUsernameFieldsProps = {


### PR DESCRIPTION
### What?

Migrates the `EmailAndUsername` element from SCSS to plain CSS as part of the SCSS deprecation effort.

- Converted `index.scss` → `index.css`, wrapped in `@layer payload-default`
- Replaced legacy `var(--base)` (20px) with `--spacer-3` (16px) to match the surrounding field spacing
- Updated import and deleted the old `index.scss`

No intended visual change beyond the gap aligning to `--spacer-3`.