### PR TITLE
fix(ui): pass selected prop to query preset select button when preset is active

### DIFF
--- a/packages/ui/src/elements/FilterTrigger/index.tsx
+++ b/packages/ui/src/elements/FilterTrigger/index.tsx
@@ -44,7 +44,7 @@ export function FilterTrigger({
         iconPosition="left"
         id={id}
         onClick={onClick}
-        selected={popupActive}
+        selected={isActive || popupActive}
         size="medium"
       >
         {children}


### PR DESCRIPTION
## What

Pass `selected` to the `Button` inside `FilterTrigger` when a query preset is active, so the button shows the selected/active visual state when a preset is applied.

## Why

Previously `selected` was only `true` when the popup was open (`popupActive`). When a preset was selected and the popup was closed, the button reverted to its default unselected appearance, giving no visual indication that a preset was active. Now `selected={isActive || popupActive}` keeps the button highlighted whenever a preset is active.

## Change

`packages/ui/src/elements/FilterTrigger/index.tsx`
- `selected={popupActive}` → `selected={isActive || popupActive}`

<img width="1204" height="922" alt="CleanShot 2026-06-03 at 14 46 55" src="https://github.com/user-attachments/assets/285ba83f-b4f8-4be4-baae-456fd10e91e6" />
