### PR TITLE
feat(ui): toggle columns button chevron when column selector is open

### DIFF
--- a/packages/ui/src/elements/ColumnsButton/index.tsx
+++ b/packages/ui/src/elements/ColumnsButton/index.tsx
@@ -29,7 +29,7 @@ export const ColumnsButton: React.FC<ColumnsButtonProps> = ({ collectionSlug }) 
           {...props}
           buttonStyle="secondary"
           className={`${baseClass}__button`}
-          icon={<ChevronIcon direction="down" size={16} />}
+          icon={<ChevronIcon direction={active ? 'up' : 'down'} size={16} />}
           selected={active}
           size="medium"
         >


### PR DESCRIPTION
### What?

Toggles the columns button chevron to point up when the column selector popup is open, matching the filters button behavior.

### Why?

Keeps the list controls consistent and gives users a clearer cue for which control is expanded.
