### PR TITLE
fix(ui): remove invalid scss import from PopupDivider css

### DIFF
--- a/packages/ui/src/elements/Popup/PopupDivider/index.css
+++ b/packages/ui/src/elements/Popup/PopupDivider/index.css
@@ -1,5 +1,3 @@
-@import '../../../scss/styles.scss';
-
 @layer payload-default {
   .popup-divider {
     height: var(--stroke-width-small);


### PR DESCRIPTION
### What

Removes a stray `@import '../../../scss/styles.scss';` from `PopupDivider/index.css`. 