### PR TITLE
chore(ui): convert RenderDefaultCell to css

### DIFF
--- a/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.css
+++ b/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.css
@@ -1,5 +1,3 @@
-@import '../../../scss/styles.scss';
-
 @layer payload-default {
   .default-cell {
     &__first-cell {

--- a/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.tsx
+++ b/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { useListDrawerContext } from '../../../elements/ListDrawer/Provider.js'
 import { DefaultCell } from '../../../elements/Table/DefaultCell/index.js'
 import { useTableColumns } from '../../../providers/TableColumns/index.js'
-import './index.scss'
+import './index.css'
 
 const baseClass = 'default-cell'
 


### PR DESCRIPTION
### What

Migrates the `RenderDefaultCell` component's styles from SCSS to CSS. Syntax conversion only - no visual changes.
