### PR TITLE
ci: avoid registry rate limits for supabase cli and azurite image

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -95,7 +95,10 @@ runs:
       if: inputs.database == 'supabase'
       uses: supabase/setup-cli@v1
       with:
-        version: latest
+        # Pinned instead of `latest` to skip setup-cli's GitHub API release lookup,
+        # which flakes on shared CI runners with "rate limit exceeded" (unauthenticated
+        # 60 req/hr limit). A fixed version short-circuits that call entirely.
+        version: 2.104.0
 
     - name: Initialize Supabase
       if: inputs.database == 'supabase'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
               - 'templates/**'
             needs_tests:
               - '.github/workflows/main.yml'
+              - '.github/actions/start-services/**'
               - 'packages/**'
               - 'test/**'
               - 'pnpm-lock.yaml'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -185,7 +185,7 @@ services:
   # ── Azure Storage (Azurite emulator) ────────────────────────
   azure-storage:
     profiles: [all, storage]
-    image: mcr.microsoft.com/azure-storage/azurite:latest
+    image: ghcr.io/payloadcms/azurite:3.35.0
     platform: linux/amd64
     restart: always
     command: 'azurite --loose --blobHost 0.0.0.0 --tableHost 0.0.0.0 --queueHost 0.0.0.0 --skipApiVersionCheck'


### PR DESCRIPTION
# Overview

Removes two sources of intermittent `Start services` CI failures, both caused by external registries blocking or rate-limiting unauthenticated requests.

## Key Changes

- **Pin the Supabase CLI version (`start-services` action)**
  - `supabase/setup-cli` resolved `version: latest` through an unauthenticated GitHub releases API call (60 requests/hour per IP), which exhausted on shared runners and failed with `Failed to resolve latest Supabase CLI release: rate limit exceeded`. Pinning to `2.104.0` makes `setup-cli` skip that lookup entirely.

- **Pull the azurite image from GHCR instead of MCR (`test/docker-compose.yml`)**
  - `mcr.microsoft.com/azure-storage/azurite:latest` started returning `The request is blocked` from Microsoft Container Registry, failing the storage profile pull through all three retries. The image is now `ghcr.io/payloadcms/azurite:3.35.0`, mirrored to the same `payloadcms` GHCR namespace as the other six test-service images.

## Design Decisions

- **Extends the existing GHCR mirroring pattern.** PR #16842 moved every Docker Hub test-service image to `ghcr.io/payloadcms/*`, leaving azurite on MCR as the lone external dependency. With MCR now blocking pulls, azurite joins the same namespace, so the storage stack pulls entirely from GHCR.
- **Mirror is a manual prerequisite.** As with the other GHCR images, there is no mirror automation. The azurite copy was pushed registry-to-registry with `docker buildx imagetools create` before this change, preserving all platforms, as a public package so contributor-fork CI can pull it anonymously.
- **Pinned versions over floating tags.** Both `2.104.0` and `3.35.0` replace `latest`, matching the repo's convention of explicit versions for reproducible CI. Bumps are deliberate.
