### PR TITLE
fix(next): add type declarations for css export (TypeScript 6 compat)

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -23,6 +23,7 @@
   "type": "module",
   "exports": {
     "./css": {
+      "types": "./src/exports/css.ts",
       "import": "./src/dummy.css",
       "default": "./src/dummy.css"
     },
@@ -138,6 +139,7 @@
   "publishConfig": {
     "exports": {
       "./css": {
+        "types": "./dist/exports/css.d.ts",
         "import": "./dist/prod/styles.css",
         "default": "./dist/prod/styles.css"
       },

--- a/packages/next/src/exports/css.ts
+++ b/packages/next/src/exports/css.ts
@@ -1,0 +1,2 @@
+const styles: void = undefined
+export default styles


### PR DESCRIPTION
# Overview

Add TypeScript type declarations for the `./css` package export in `@payloadcms/next`, porting [#16348](https://github.com/payloadcms/payload/pull/16348) from the `3.x` branch.

TypeScript 6 enables [`noUncheckedSideEffectImports`](https://www.typescriptlang.org/tsconfig/noUncheckedSideEffectImports.html) by default. This makes `import '@payloadcms/next/css'` (present in all of our examples/templates) fail with:

```
error TS2882: Cannot find module or type declarations for side-effect import of '@payloadcms/next/css'.
```

The published `./css` export had no `types` field, so the side-effect import had nothing to resolve against.

## Key Changes

- **Add `src/exports/css.ts`**
  - A regular TypeScript source file, consistent with the other exports, so the existing build pipeline emits `dist/exports/css.d.ts`.

- **Wire `types` into the `./css` export**
  - Added the `types` condition to both the dev and `publishConfig` export maps in `packages/next/package.json`, pointing at the source declaration in dev and the built `.d.ts` when published.
