### PR TITLE
refactor!: use `$defs` instead of `definitions` in generated JSON Schema

### DIFF
--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -474,6 +474,38 @@ If you authored a custom lexical feature that hooks into type generation, rename
 
 Rename `typescriptSchema` → `jsonSchema` wherever you set it on a field config.
 
+### Generated JSON Schema uses `$defs` instead of `definitions`
+
+Payload builds a JSON Schema from your config to generate `payload-types.ts`. That schema now stores its reusable types under the modern `$defs` key instead of the older `definitions` key, and every internal reference points at `#/$defs/...` instead of `#/definitions/...`. This follows the current JSON Schema spec.
+
+**Your generated `payload-types.ts` does not change.** You are only affected if you read or write that schema yourself — most commonly through `typescript.schema` on your config, a custom rich text adapter, or a custom Lexical feature.
+
+Update any code that adds to the schema:
+
+```diff
+// payload.config.ts
+{
+  typescript: {
+    schema: [
+      ({ jsonSchema }) => {
+-       jsonSchema.definitions.MyType = { type: 'object', properties: { /* ... */ } }
++       jsonSchema.$defs.MyType = { type: 'object', properties: { /* ... */ } }
+        return jsonSchema
+      },
+    ],
+  },
+}
+```
+
+And update any `$ref` pointers you wrote by hand to point at `$defs`:
+
+```diff
+- { $ref: '#/definitions/posts' }
++ { $ref: '#/$defs/posts' }
+```
+
+Do not keep your additions on `definitions` while new ones land on `$defs`.
+
 ### Jobs: `jobs.depth` and `jobs.runHooks` have been removed ([#16414](https://github.com/payloadcms/payload/pull/16414))
 
 The deprecated `jobs.depth` and `jobs.runHooks` config options have been removed. Job operations now always use direct database calls with depth `0`.

--- a/docs/typescript/generating-types.mdx
+++ b/docs/typescript/generating-types.mdx
@@ -73,7 +73,7 @@ Payload generates your types based on a JSON schema. You can extend that JSON sc
     schema: [
       ({ jsonSchema }) => {
         // Modify the JSON schema here
-        jsonSchema.definitions.Test = {
+        jsonSchema.$defs.Test = {
           type: 'object',
           properties: {
             title: { type: 'string' },
@@ -108,7 +108,7 @@ You can use `$ref` to reference external JSON schema files in your custom schema
   typescript: {
     schema: [
       ({ jsonSchema }) => {
-        jsonSchema.definitions.MyType = {
+        jsonSchema.$defs.MyType = {
           $ref: './schemas/my-type.json',
         }
         return jsonSchema

--- a/packages/payload/src/queues/config/generateJobsJSONSchemas.ts
+++ b/packages/payload/src/queues/config/generateJobsJSONSchemas.ts
@@ -92,8 +92,8 @@ export function generateJobsJSONSchemas(
 
             const toReturn: JSONSchema4 = {
               $ref: task.interfaceName
-                ? `#/definitions/${task.interfaceName}`
-                : `#/definitions/Task${normalizedTaskSlug}`,
+                ? `#/$defs/${task.interfaceName}`
+                : `#/$defs/Task${normalizedTaskSlug}`,
             }
 
             return [task.slug, toReturn]
@@ -159,8 +159,8 @@ export function generateJobsJSONSchemas(
 
             const toReturn: JSONSchema4 = {
               $ref: workflow.interfaceName
-                ? `#/definitions/${workflow.interfaceName}`
-                : `#/definitions/Workflow${normalizedWorkflowSlug}`,
+                ? `#/$defs/${workflow.interfaceName}`
+                : `#/$defs/Workflow${normalizedWorkflowSlug}`,
             }
 
             return [workflow.slug, toReturn]

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -35,7 +35,7 @@ describe('configToJSONSchema', () => {
     const sanitizedConfig = await sanitizeConfig(config)
     const schema = configToJSONSchema(sanitizedConfig, 'text')
 
-    expect(schema?.definitions?.test).toStrictEqual({
+    expect(schema?.$defs?.test).toStrictEqual({
       type: 'object',
       additionalProperties: false,
       properties: {
@@ -122,7 +122,7 @@ describe('configToJSONSchema', () => {
     const sanitizedConfig = await sanitizeConfig(config)
     const schema = configToJSONSchema(sanitizedConfig, 'text')
 
-    expect(schema?.definitions?.test).toStrictEqual({
+    expect(schema?.$defs?.test).toStrictEqual({
       type: 'object',
       additionalProperties: false,
       properties: {
@@ -140,13 +140,13 @@ describe('configToJSONSchema', () => {
         blockFieldWithFields: {
           type: ['array', 'null'],
           items: {
-            oneOf: [{ $ref: '#/definitions/Test' }],
+            oneOf: [{ $ref: '#/$defs/Test' }],
           },
         },
         blockFieldWithFieldsRequired: {
           type: ['array', 'null'],
           items: {
-            oneOf: [{ $ref: '#/definitions/TestRequired' }],
+            oneOf: [{ $ref: '#/$defs/TestRequired' }],
           },
         },
       },
@@ -190,7 +190,7 @@ describe('configToJSONSchema', () => {
 
     const sanitizedConfig = await sanitizeConfig(config)
     const schema = configToJSONSchema(sanitizedConfig, 'text')
-    const defs = schema.definitions!
+    const defs = schema.$defs!
 
     // The first `hero` keeps the clean name; the unique block is unaffected.
     expect(defs.Hero).toBeDefined()
@@ -211,14 +211,14 @@ describe('configToJSONSchema', () => {
       (
         defs[slug] as { properties: { layout: { items: { oneOf: Array<{ $ref: string }> } } } }
       ).properties.layout.items.oneOf.map((r) => r.$ref)
-    expect(refsOf('pages')).toContain('#/definitions/Hero')
-    expect(refsOf('pages')).toContain('#/definitions/Cta')
-    expect(refsOf('posts')).toStrictEqual([`#/definitions/${hashedHeroNames[0]}`])
+    expect(refsOf('pages')).toContain('#/$defs/Hero')
+    expect(refsOf('pages')).toContain('#/$defs/Cta')
+    expect(refsOf('posts')).toStrictEqual([`#/$defs/${hashedHeroNames[0]}`])
 
     // Hashing is deterministic: regenerating yields identical names.
     const schema2 = configToJSONSchema(sanitizedConfig, 'text')
     expect(
-      Object.keys(schema2.definitions!)
+      Object.keys(schema2.$defs!)
         .filter((k) => /^Hero/.test(k))
         .sort(),
     ).toStrictEqual(
@@ -279,7 +279,7 @@ describe('configToJSONSchema', () => {
     const sanitizedConfig = await sanitizeConfig(config)
     const schema = configToJSONSchema(sanitizedConfig, 'text')
 
-    expect(schema?.definitions?.test).toStrictEqual({
+    expect(schema?.$defs?.test).toStrictEqual({
       type: 'object',
       additionalProperties: false,
       properties: {
@@ -354,7 +354,7 @@ describe('configToJSONSchema', () => {
     const sanitizedConfig = await sanitizeConfig(config as Config)
     const schema = configToJSONSchema(sanitizedConfig, 'text')
 
-    expect(schema?.definitions?.test).toStrictEqual({
+    expect(schema?.$defs?.test).toStrictEqual({
       type: 'object',
       additionalProperties: false,
       properties: {
@@ -433,7 +433,7 @@ describe('configToJSONSchema', () => {
       required: ['blockType'],
     }
 
-    expect(schema?.definitions?.test).toStrictEqual({
+    expect(schema?.$defs?.test).toStrictEqual({
       type: 'object',
       additionalProperties: false,
       title: 'Test',
@@ -446,7 +446,7 @@ describe('configToJSONSchema', () => {
           items: {
             oneOf: [
               {
-                $ref: '#/definitions/SharedBlock',
+                $ref: '#/$defs/SharedBlock',
               },
             ],
           },
@@ -456,7 +456,7 @@ describe('configToJSONSchema', () => {
     })
 
     // The definition should still be registered for TypeScript type generation
-    expect(schema?.definitions?.SharedBlock).toStrictEqual(expectedBlockSchema)
+    expect(schema?.$defs?.SharedBlock).toStrictEqual(expectedBlockSchema)
   })
 
   it('should allow overriding required to false', async () => {
@@ -488,7 +488,7 @@ describe('configToJSONSchema', () => {
     const schema = configToJSONSchema(sanitizedConfig, 'text')
 
     // @ts-expect-error
-    expect(schema.definitions.test.properties.title.required).toStrictEqual(false)
+    expect(schema.$defs.test.properties.title.required).toStrictEqual(false)
   })
 
   it('should propagate forceInlineBlocks to nested fields (array, group, tab)', async () => {
@@ -524,21 +524,21 @@ describe('configToJSONSchema', () => {
 
     // Without forceInlineBlocks: blocks field uses $ref
     const schemaDefault = configToJSONSchema(sanitizedConfig, 'text')
-    const arrItemsDefault = schemaDefault.definitions!.test.properties!.arr.items as JSONSchema4
+    const arrItemsDefault = schemaDefault.$defs!.test.properties!.arr.items as JSONSchema4
     const arrBlocksDefault = (arrItemsDefault.properties!.blocks.items as JSONSchema4).oneOf![0]
-    expect(arrBlocksDefault).toStrictEqual({ $ref: '#/definitions/MyBlock' })
+    expect(arrBlocksDefault).toStrictEqual({ $ref: '#/$defs/MyBlock' })
 
     // With forceInlineBlocks: blocks field is inlined, no $ref
     const schemaInline = configToJSONSchema(sanitizedConfig, 'text', undefined, {
       forceInlineBlocks: true,
     })
-    const arrItemsInline = schemaInline.definitions!.test.properties!.arr.items as JSONSchema4
+    const arrItemsInline = schemaInline.$defs!.test.properties!.arr.items as JSONSchema4
     const arrBlocksInline = (arrItemsInline.properties!.blocks.items as JSONSchema4).oneOf![0]
     expect(arrBlocksInline).not.toHaveProperty('$ref')
     expect(arrBlocksInline.properties?.blockType).toStrictEqual({ const: 'myBlock' })
 
     const grpBlocksInline = (
-      schemaInline.definitions!.test.properties!.grp.properties!.blocks.items as JSONSchema4
+      schemaInline.$defs!.test.properties!.grp.properties!.blocks.items as JSONSchema4
     ).oneOf![0]
     expect(grpBlocksInline).not.toHaveProperty('$ref')
     expect(grpBlocksInline.properties?.blockType).toStrictEqual({ const: 'myBlock' })

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -52,7 +52,7 @@ function generateEntitySchemas(
   const properties = [...entities].reduce(
     (acc, { slug }) => {
       acc[slug] = {
-        $ref: `#/definitions/${slug}`,
+        $ref: `#/$defs/${slug}`,
       }
 
       return acc
@@ -74,7 +74,7 @@ function generateEntitySelectSchemas(
   const properties = [...entities].reduce(
     (acc, { slug }) => {
       acc[slug] = {
-        $ref: `#/definitions/${slug}_select`,
+        $ref: `#/$defs/${slug}_select`,
       }
 
       return acc
@@ -218,7 +218,7 @@ function generateWidgetSchemas({
     }
 
     properties[widget.slug] = {
-      $ref: `#/definitions/${definition}`,
+      $ref: `#/$defs/${definition}`,
     }
   }
 
@@ -280,7 +280,7 @@ function generateAuthEntitySchemas(entities: SanitizedCollectionConfig[]): JSONS
   const properties: JSONSchema4[] = [...entities]
     .filter(({ auth }) => Boolean(auth))
     .map(({ slug }) => {
-      return { $ref: `#/definitions/${slug}` }
+      return { $ref: `#/$defs/${slug}` }
     }, {})
 
   return {
@@ -411,7 +411,7 @@ export function fieldsToJSONSchema(
               interfaceNameDefinitions.set(field.interfaceName, fieldSchema)
 
               fieldSchema = {
-                $ref: `#/definitions/${field.interfaceName}`,
+                $ref: `#/$defs/${field.interfaceName}`,
               }
             }
             break
@@ -463,7 +463,7 @@ export function fieldsToJSONSchema(
                       return opts.forceInlineBlocks
                         ? blockSchema
                         : {
-                            $ref: `#/definitions/${registerBlockInterface(block, blockSchema, interfaceNameDefinitions)}`,
+                            $ref: `#/$defs/${registerBlockInterface(block, blockSchema, interfaceNameDefinitions)}`,
                           }
                     }),
                   }
@@ -508,7 +508,7 @@ export function fieldsToJSONSchema(
               if (field.interfaceName) {
                 interfaceNameDefinitions.set(field.interfaceName, fieldSchema)
 
-                fieldSchema = { $ref: `#/definitions/${field.interfaceName}` }
+                fieldSchema = { $ref: `#/$defs/${field.interfaceName}` }
               }
             }
             break
@@ -532,7 +532,7 @@ export function fieldsToJSONSchema(
                           type: collectionIDFieldTypes[collection],
                         },
                         {
-                          $ref: `#/definitions/${collection}`,
+                          $ref: `#/$defs/${collection}`,
                         },
                       ],
                     },
@@ -547,7 +547,7 @@ export function fieldsToJSONSchema(
                     type: collectionIDFieldTypes[field.collection],
                   },
                   {
-                    $ref: `#/definitions/${field.collection}`,
+                    $ref: `#/$defs/${field.collection}`,
                   },
                 ],
               }
@@ -622,7 +622,7 @@ export function fieldsToJSONSchema(
               interfaceNameDefinitions.set(field.interfaceName, fieldSchema)
 
               fieldSchema = {
-                $ref: `#/definitions/${field.interfaceName}`,
+                $ref: `#/$defs/${field.interfaceName}`,
               }
             }
 
@@ -650,7 +650,7 @@ export function fieldsToJSONSchema(
                                 type: collectionIDFieldTypes[relation],
                               },
                               {
-                                $ref: `#/definitions/${relation}`,
+                                $ref: `#/$defs/${relation}`,
                               },
                             ],
                           },
@@ -677,7 +677,7 @@ export function fieldsToJSONSchema(
                               type: collectionIDFieldTypes[relation],
                             },
                             {
-                              $ref: `#/definitions/${relation}`,
+                              $ref: `#/$defs/${relation}`,
                             },
                           ],
                         },
@@ -697,7 +697,7 @@ export function fieldsToJSONSchema(
                       type: collectionIDFieldTypes[field.relationTo],
                     },
                     {
-                      $ref: `#/definitions/${field.relationTo}`,
+                      $ref: `#/$defs/${field.relationTo}`,
                     },
                   ],
                 },
@@ -712,7 +712,7 @@ export function fieldsToJSONSchema(
                       isRequired,
                     ),
                   },
-                  { $ref: `#/definitions/${field.relationTo}` },
+                  { $ref: `#/$defs/${field.relationTo}` },
                 ],
               }
             }
@@ -770,7 +770,7 @@ export function fieldsToJSONSchema(
             // only if the field's options match the global config
             if (isTimezoneField && hasMatchingGlobalTimezones) {
               fieldSchema = {
-                $ref: `#/definitions/supportedTimezones`,
+                $ref: `#/$defs/supportedTimezones`,
               }
             } else {
               if (field.hasMany) {
@@ -798,7 +798,7 @@ export function fieldsToJSONSchema(
                 interfaceNameDefinitions.set(field.interfaceName, fieldSchema)
 
                 fieldSchema = {
-                  $ref: `#/definitions/${field.interfaceName}`,
+                  $ref: `#/$defs/${field.interfaceName}`,
                 }
               }
               break
@@ -824,7 +824,7 @@ export function fieldsToJSONSchema(
             if (field.interfaceName) {
               interfaceNameDefinitions.set(field.interfaceName, fieldSchema)
 
-              fieldSchema = { $ref: `#/definitions/${field.interfaceName}` }
+              fieldSchema = { $ref: `#/$defs/${field.interfaceName}` }
             }
             break
           }
@@ -997,7 +997,7 @@ export function fieldsToSelectJSONSchema({
           interfaceNameDefinitions.set(definition, fieldSchema)
 
           fieldSchema = {
-            $ref: `#/definitions/${definition}`,
+            $ref: `#/$defs/${definition}`,
           }
         }
 
@@ -1035,7 +1035,7 @@ export function fieldsToSelectJSONSchema({
             const definition = `${block.interfaceName}_select`
             interfaceNameDefinitions.set(definition, blockSchema)
             blockSchema = {
-              $ref: `#/definitions/${definition}`,
+              $ref: `#/$defs/${definition}`,
             }
           }
 
@@ -1229,7 +1229,7 @@ function generateAuthOperationSchemas(collections: SanitizedCollectionConfig[]):
     (acc, collection) => {
       if (collection.auth) {
         acc[collection.slug] = {
-          $ref: `#/definitions/auth/${collection.slug}`,
+          $ref: `#/$defs/auth/${collection.slug}`,
         }
       }
       return acc
@@ -1414,21 +1414,21 @@ export function configToJSONSchema(
       }
 
       blocksDefinition.properties![block.slug] = {
-        $ref: `#/definitions/${registerBlockInterface(block, blockSchema, interfaceNameDefinitions)}`,
+        $ref: `#/$defs/${registerBlockInterface(block, blockSchema, interfaceNameDefinitions)}`,
       }
       ;(blocksDefinition.required as string[]).push(block.slug)
     }
   }
 
   let jsonSchema: JSONSchema4 = {
-    additionalProperties: false,
-    definitions: {
+    $defs: {
       supportedTimezones: timezoneDefinitions,
       ...entityDefinitions,
       ...widgetSchemas.definitions,
       ...Object.fromEntries(interfaceNameDefinitions),
       ...authOperationDefinitions,
     },
+    additionalProperties: false,
     // These properties here will be very simple, as all the complexity is in the definitions. These are just the properties for the top-level `Config` type
     type: 'object',
     properties: {
@@ -1474,7 +1474,7 @@ export function configToJSONSchema(
 
   if (jobsSchemas.definitions?.size) {
     for (const [key, value] of jobsSchemas.definitions) {
-      jsonSchema.definitions![key] = value
+      jsonSchema.$defs![key] = value
     }
   }
   if (jobsSchemas.properties) {

--- a/packages/plugin-ecommerce/src/utilities/pushTypeScriptProperties.ts
+++ b/packages/plugin-ecommerce/src/utilities/pushTypeScriptProperties.ts
@@ -25,7 +25,7 @@ export const pushTypeScriptProperties = ({
   const propertiesMap = new Map<string, { $ref: string }>()
 
   Object.entries(collectionSlugMap).forEach(([key, slug]) => {
-    propertiesMap.set(key, { $ref: `#/definitions/${slug}` })
+    propertiesMap.set(key, { $ref: `#/$defs/${slug}` })
 
     requiredCollectionProperties.push(slug)
   })

--- a/packages/plugin-mcp/src/mcp/buildMcpServer.ts
+++ b/packages/plugin-mcp/src/mcp/buildMcpServer.ts
@@ -79,7 +79,7 @@ export const buildMcpServer = ({
           const name = wireName(item.key, item.collectionSlug)
           let inputSchema = tool.input
           if (typeof inputSchema === 'function') {
-            const raw = configSchema.definitions?.[item.collectionSlug]
+            const raw = configSchema.$defs?.[item.collectionSlug]
             if (!raw) {
               throw new APIError(
                 `Collection schema not found for slug: ${item.collectionSlug}`,
@@ -118,7 +118,7 @@ export const buildMcpServer = ({
           const name = wireName(item.key, item.globalSlug)
           let inputSchema = tool.input
           if (typeof inputSchema === 'function') {
-            const raw = configSchema.definitions?.[item.globalSlug]
+            const raw = configSchema.$defs?.[item.globalSlug]
             if (!raw) {
               throw new APIError(`Global schema not found for slug: ${item.globalSlug}`, 500)
             }


### PR DESCRIPTION
**BREAKING**: The JSON Schema that Payload builds to generate your types now uses the modern `$defs` keyword instead of the old `definitions` keyword. All internal references now use `#/$defs/...` instead of `#/definitions/...`.

## Why

`$defs` is the keyword in the current JSON Schema spec - `definitions` is the legacy name. `json-schema-to-typescript` supports `$defs`, so we use the modern form. See https://github.com/bcherny/json-schema-to-typescript/issues/470#issuecomment-1207323381

## Does this affect me?

Your generated `payload-types.ts` is **exactly the same** - nothing changes there.

You are only affected if your own code reads or writes the schema directly, usually through a `config.typescript.schema` or `field.jsonSchema` function.

## How to migrate

Swap `definitions` for `$defs`:

```diff
- jsonSchema.definitions.MyType = { type: 'string' }
+ jsonSchema.$defs.MyType = { type: 'string' }
```

```diff
- { $ref: '#/definitions/posts' }
+ { $ref: '#/$defs/posts' }
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215385258435225