### PR TITLE
docs: restructure getting started and concepts with new Card Block

### DIFF
--- a/docs/getting-started/concepts.mdx
+++ b/docs/getting-started/concepts.mdx
@@ -8,118 +8,79 @@ keywords: documentation, getting started, guide, Content Management System, cms,
 
 Payload is based around a small and intuitive set of high-level concepts. Before starting to work with Payload, it's a good idea to familiarize yourself with these concepts in order to establish a common language and understanding when discussing Payload.
 
-## Config
-
-The Payload Config is central to everything that Payload does. It allows for the deep configuration of your application through a simple and intuitive API. The Payload Config is a fully-typed JavaScript object that can be infinitely extended upon. [More details](../configuration/overview).
-
-## Database
-
-Payload is database agnostic, meaning you can use any type of database behind Payload's familiar APIs through what is known as a Database Adapter. [More details](../database/overview).
-
-## Collections
-
-A Collection is a group of records, called Documents, that all share a common schema. Each Collection is stored in the [Database](../database/overview) based on the [Fields](../fields/overview) that you define. [More details](../configuration/collections).
-
-## Globals
-
-Globals are in many ways similar to [Collections](../configuration/collections), except they correspond to only a single Document. Each Global is stored in the [Database](../database/overview) based on the [Fields](../fields/overview) that you define. [More details](../configuration/globals).
-
-## Fields
-
-Fields are the building blocks of Payload. They define the schema of the Documents that will be stored in the [Database](../database/overview), as well as automatically generate the corresponding UI within the Admin Panel. [More details](../fields/overview).
-
-## Hooks
-
-Hooks allow you to execute your own side effects during specific events of the Document lifecycle, such as before read, after create, etc. [More details](../hooks/overview).
-
-## Authentication
-
-Payload provides a secure, portable way to manage user accounts out of the box. Payload Authentication is designed to be used in both the Admin Panel, as well as your own external applications. [More details](../authentication/overview).
-
-## Access Control
-
-Access Control determines what a user can and cannot do with any given Document, such as read, update, etc., as well as what they can and cannot see within the Admin Panel. [More details](../access-control/overview).
-
-## Admin Panel
-
-Payload dynamically generates a beautiful, fully type-safe interface to manage your users and data. The Admin Panel is a React application built using the Next.js App Router. [More details](../admin/overview).
+<CardGroup>
+  <Card
+    title="Config"
+    description="A deeply typed JavaScript object that drives everything Payload does — the central piece of every project."
+    link="/docs/configuration/overview"
+  />
+  <Card
+    title="Database"
+    description="Plug in Postgres, MongoDB, or SQLite behind Payload's APIs via a Database Adapter — Payload is database agnostic."
+    link="/docs/database/overview"
+  />
+  <Card
+    title="Collections"
+    description="A group of records (Documents) that share a schema. The most common way you'll model data in Payload."
+    link="/docs/configuration/collections"
+  />
+  <Card
+    title="Globals"
+    description="Like Collections, but for content that has only one of — settings, navigation, footer, and so on."
+    link="/docs/configuration/globals"
+  />
+  <Card
+    title="Fields"
+    description="The building blocks of Payload — they define your schema and auto-generate the matching Admin UI."
+    link="/docs/fields/overview"
+  />
+  <Card
+    title="Hooks"
+    description="Run your own side effects at specific points in the Document lifecycle — before read, after create, and more."
+    link="/docs/hooks/overview"
+  />
+  <Card
+    title="Authentication"
+    description="A secure, portable user-account system for both the Admin Panel and your own external applications."
+    link="/docs/authentication/overview"
+  />
+  <Card
+    title="Access Control"
+    description="Decide who can read, update, or delete every Document — and what they see in the Admin Panel."
+    link="/docs/access-control/overview"
+  />
+  <Card
+    title="Admin Panel"
+    description="The auto-generated, fully type-safe React interface editors use to manage your data. Built on Next.js."
+    link="/docs/admin/overview"
+  />
+</CardGroup>
 
 ## Retrieving Data
 
 Everything Payload does (create, read, update, delete, login, logout, etc.) is exposed to you via three APIs:
 
-- [Local API](#local-api) - Extremely fast, direct-to-database access
-- [REST API](#rest-api) - Standard HTTP endpoints for querying and mutating data
-- [GraphQL](#graphql-api) - A full GraphQL API with a GraphQL Playground
+<CardGroup>
+  <Card
+    title="Local API"
+    description="Direct-to-database access with no HTTP overhead — call payload.find from any server context, including React Server Components."
+    link="/docs/local-api/overview"
+  />
+  <Card
+    title="REST API"
+    description="Standard HTTP endpoints mounted at /api — fetch documents from any client with full pagination, depth, and sorting."
+    link="/docs/rest-api/overview"
+  />
+  <Card
+    title="GraphQL"
+    description="A full GraphQL API with a Playground at /api/graphql-playground. Works with graphql-request, Apollo, or any other client."
+    link="/docs/graphql/overview"
+  />
+</CardGroup>
 
 <Banner type="success">
   **Note:** All of these APIs share the exact same query language. [More
   details](../queries/overview).
-</Banner>
-
-### Local API
-
-By far one of the most powerful aspects of Payload is the fact that it gives you direct-to-database access to your data through the [Local API](../local-api/overview). It's _extremely_ fast and does not incur any typical HTTP overhead—you query your database directly in Node.js.
-
-The Local API is written in TypeScript, and so it is strongly typed and extremely nice to use. It works anywhere on the server, including custom Next.js Routes, Payload Hooks, Payload Access Control, and React Server Components.
-
-Here's a quick example of a React Server Component fetching data using the Local API:
-
-```tsx
-import React from 'react'
-import config from '@payload-config'
-import { getPayload } from 'payload'
-
-const MyServerComponent: React.FC = () => {
-  const payload = await getPayload({ config })
-
-  // The `findResult` here will be fully typed as `PaginatedDocs<Page>`,
-  // where you will have the `docs` that are returned as well as
-  // information about how many items are returned / are available in total / etc
-  const findResult = await payload.find({ collection: 'pages' })
-
-  return (
-    <ul>
-      {findResult.docs.map((page) => {
-        // Render whatever here!
-        // The `page` is fully typed as your Pages collection!
-      })}
-    </ul>
-  )
-}
-```
-
-<Banner type="info">
-  For more information about the Local API, [click here](../local-api/overview).
-</Banner>
-
-### REST API
-
-By default, the Payload [REST API](../rest-api/overview) is mounted automatically for you at the `/api` path of your app.
-
-For example, if you have a Collection called `pages`:
-
-```ts
-fetch('https://localhost:3000/api/pages') // highlight-line
-  .then((res) => res.json())
-  .then((data) => console.log(data))
-```
-
-<Banner type="info">
-  For more information about the REST API, [click here](../rest-api/overview).
-</Banner>
-
-### GraphQL API
-
-Payload automatically exposes GraphQL queries and mutations through a dedicated [GraphQL API](../graphql/overview). By default, the GraphQL route handler is mounted at the `/api/graphql` path of your app. You'll also find a full GraphQL Playground which can be accessible at the `/api/graphql-playground` path of your app.
-
-You can use any GraphQL client with Payload's GraphQL endpoint. Here are a few packages:
-
-- [`graphql-request`](https://www.npmjs.com/package/graphql-request) - a very lightweight GraphQL client
-- [`@apollo/client`](https://www.apollographql.com/docs/react/api/core/ApolloClient/) - an industry-standard GraphQL client with lots of nice features
-
-<Banner type="info">
-  For more information about the GraphQL API, [click here](../graphql/overview).
 </Banner>
 
 ## Package Structure

--- a/docs/getting-started/use-cases.mdx
+++ b/docs/getting-started/use-cases.mdx
@@ -1,0 +1,94 @@
+---
+title: Use Cases
+label: Use Cases
+order: 15
+desc: Payload powers headless CMS, internal tools, headless commerce, and DAM workloads. Learn whether Payload is the right framework for your project.
+keywords: use cases, headless CMS, enterprise tools, headless commerce, digital asset management, when to use Payload
+---
+
+Payload started as a headless Content Management System (CMS), but since, we've seen our community leverage Payload in ways far outside of simply managing pages and blog posts. It's grown into a full-stack TypeScript app framework.
+
+Large enterprises use Payload to power significant internal tools, retailers power their entire storefronts without the need for headless Shopify, and massive amounts of digital assets are stored + managed within Payload. Of course, websites large and small still use Payload for content management as well.
+
+### Headless CMS
+
+The biggest barrier in large web projects cited by marketers is engineering. On the flip side, engineers say the opposite. This is a big problem that has yet to be solved even though we have countless CMS options.
+
+Payload has restored a little love back into the dev / marketer equation with features like Live Preview, redirects, form builders, visual editing, static A/B testing, and more. But even with all this focus on marketing efficiency, we aren't compromising on the developer experience. That way engineers and marketers alike can be proud of the products they build.
+
+If you're building a website and your frontend is on Next.js, then Payload is a no-brainer.
+
+<Banner type="success">
+  Instead of going out and signing up for a SaaS vendor that makes it so you
+  have to manage two completely separate concerns, with little to no native
+  connection back and forth, just install Payload in your existing Next.js repo
+  and instantly get a full CMS.
+</Banner>
+
+Get started with Payload as a CMS using our official Website template:
+
+```
+npx create-payload-app@latest -t website
+```
+
+### Enterprise Tool
+
+When a large organization starts up a new software initiative, there's a lot of plumbing to take care of.
+
+- Scaffold the data layer with an ORM or an app framework like Ruby on Rails or Laravel
+- Implement their SSO provider for authentication
+- Design an access control pattern for authorization
+- Open up any REST endpoints required or implement GraphQL queries / mutations
+- Implement a migrations workflow for the database as it changes over time
+- Integrate with other third party solutions by crafting a system of webhooks or similar
+
+And then there's the [Admin Panel](../admin/overview). Most enterprise tools require an admin UI, and building one from scratch can be the most time-consuming aspect of any new enterprise tool. There are off-the-shelf packages for app frameworks like Rails, but often the customization is so involved that using Material UI or similar from scratch might be better.
+
+Then there are no-code admin builders that could be used. However, wiring up access control and the connection to the data layer, with proper version control, makes this a challenging task as well.
+
+That's where Payload comes in. Payload instantly provides all of this out of the box, making complex internal tools extremely simple to both spin up and maintain over time. The only custom code that will need to be written is any custom business logic. That means Payload can expedite timelines, keep budgets low, and allow engineers to focus on their specific requirements rather than complex backend / admin UI plumbing.
+
+Generally, the best place to start for a new enterprise tool is with a blank canvas, where you can define your own functionality:
+
+```
+npx create-payload-app@latest -t blank
+```
+
+### Headless Commerce
+
+Companies who prioritize UX generally run into frontend constraints with traditional commerce vendors. These companies will then opt for frontend frameworks like Next.js which allow them to fine-tune their user experience as much as possible—promoting conversions, personalizing experiences, and optimizing for SEO.
+
+But the challenge with using something like Next.js for headless commerce is that in order for non-technical users to manage the storefront, you instantly need to pair a headless commerce product with a headless CMS. Then, your editors need to bounce back and forth between different admin UIs for different functionality. The code required to seamlessly glue them together on the frontend becomes overly complex.
+
+Payload can integrate with any payment processor like Stripe and its content authoring capabilities allow it to manage every aspect of a storefront—all in one place.
+
+If you can build your storefront with a single backend, and only offload things like payment processing, the code will be simpler and the editing experience will be significantly streamlined. Manage products, catalogs, page content, media, and more—all in one spot.
+
+### Digital Asset Management
+
+Payload's API-first tagging, sorting, and querying engine lends itself perfectly to all types of content that a CMS might ordinarily store, but these strong fundamentals also make it a formidable Digital Asset Management (DAM) tool as well.
+
+Similarly to the Ecommerce use case above, if an organization uses a CMS for its content but a separate DAM for its digital assets, administrators of both tools will need to juggle completely different services for tasks that are closely related. Two subscriptions will need to be managed, two sets of infrastructure will need to be provisioned, and two admin UIs need to be used / learned.
+
+Payload flattens CMS and DAM into a single tool that makes no compromises on either side. Powerful features like folder-based organization, file versioning, bulk upload, and media access control allow Payload to simultaneously function as a full Digital Asset Management platform as well as a Content Management System at the same time.
+
+[Click here](https://payloadcms.com/use-cases/digital-asset-management) for more information on how to get started with Payload as a DAM.
+
+## Is Payload Right For You?
+
+Payload is a great choice for applications of all sizes and types, but it might not be the right choice for every project. Here are some guidelines to help you decide if Payload is the right choice for your project.
+
+### When Payload might be for you
+
+- If data ownership and privacy are important to you, and you don't want to allow another proprietary SaaS vendor to host and own your data
+- If you're building a Next.js site that needs a CMS
+- If you need to re-use your data outside of a SaaS API
+- If what you're building has custom business logic requirements outside of a typical headless CMS
+- You want to deploy serverless on platforms like Vercel
+
+### When Payload might not be for you
+
+- If you can manage your project fully with code, and don't need an admin UI
+- If you are building a website that fits within the limits of a tool like Webflow or Framer
+- If you already have a full database and just need to visualize the data somehow
+- If you are confident that you won't need code / data ownership at any point in the future

--- a/docs/getting-started/what-is-payload.mdx
+++ b/docs/getting-started/what-is-payload.mdx
@@ -11,120 +11,54 @@ keywords: documentation, getting started, guide, Content Management System, cms,
   title="Introduction to Payload — The open-source Next.js backend"
 />
 
-**Payload is the Next.js fullstack framework.** Write a Payload Config and instantly get:
+## Payload is the Next.js fullstack framework.
 
-- A full Admin Panel using React server / client components, matching the shape of your data and completely extensible with your own React components
-- Automatic database schema, including direct DB access and ownership, with migrations, transactions, proper indexing, and more
-- Instant REST, GraphQL, and straight-to-DB Node.js APIs
-- Authentication which can be used in your own apps
-- A deeply customizable access control pattern
-- File storage and image management tools like cropping / focal point selection
-- Live preview - see your frontend render content changes in realtime as you update
-- Lots more
+Write a Payload Config and instantly get a full Admin Panel, a database with migrations, REST and GraphQL APIs, authentication, access control, file storage, live preview, and more — all in one open-source TypeScript codebase you own and deploy anywhere.
 
-### Instant backend superpowers
-
-No matter what you're building, Payload will give you backend superpowers. Your entire Payload config can be installed in one line into any existing Next.js app, and is designed to catapult your development process. Payload takes the most complex and time-consuming parts of any modern web app and makes them simple.
-
-### Open source - deploy anywhere, including Vercel
-
-It's fully open source with an MIT license and you can self-host anywhere that you can run a Node.js app. You can also deploy serverless to hosts like Vercel, right inside your existing Next.js application.
-
-### Code-first and version controlled
-
-In Payload, there are no "click ops" - as in clicking around in an Admin Panel to define your schema. In Payload, everything is done the right way—code-first and version controlled like a proper backend. But once developers define how Payload should work, non-technical users can independently make use of its Admin Panel to manage whatever they need to without having to know code whatsoever.
-
-### Fully extensible
-
-Even in spite of how much you get out of the box, you still have full control over every aspect of your app - be it database, admin UI, or anything else. Every part of Payload has been designed to be extensible and customizable with modern TypeScript / React. And you'll fully understand the code that you write.
-
-## Use Cases
-
-Payload started as a headless Content Management System (CMS), but since, we've seen our community leverage Payload in ways far outside of simply managing pages and blog posts. It's grown into a full-stack TypeScript app framework.
-
-Large enterprises use Payload to power significant internal tools, retailers power their entire storefronts without the need for headless Shopify, and massive amounts of digital assets are stored + managed within Payload. Of course, websites large and small still use Payload for content management as well.
-
-### Headless CMS
-
-The biggest barrier in large web projects cited by marketers is engineering. On the flip side, engineers say the opposite. This is a big problem that has yet to be solved even though we have countless CMS options.
-
-Payload has restored a little love back into the dev / marketer equation with features like Live Preview, redirects, form builders, visual editing, static A/B testing, and more. But even with all this focus on marketing efficiency, we aren't compromising on the developer experience. That way engineers and marketers alike can be proud of the products they build.
-
-If you're building a website and your frontend is on Next.js, then Payload is a no-brainer.
-
-<Banner type="success">
-  Instead of going out and signing up for a SaaS vendor that makes it so you
-  have to manage two completely separate concerns, with little to no native
-  connection back and forth, just install Payload in your existing Next.js repo
-  and instantly get a full CMS.
-</Banner>
-
-Get started with Payload as a CMS using our official Website template:
-
-```
-npx create-payload-app@latest -t website
-```
-
-### Enterprise Tool
-
-When a large organization starts up a new software initiative, there's a lot of plumbing to take care of.
-
-- Scaffold the data layer with an ORM or an app framework like Ruby on Rails or Laravel
-- Implement their SSO provider for authentication
-- Design an access control pattern for authorization
-- Open up any REST endpoints required or implement GraphQL queries / mutations
-- Implement a migrations workflow for the database as it changes over time
-- Integrate with other third party solutions by crafting a system of webhooks or similar
-
-And then there's the [Admin Panel](../admin/overview). Most enterprise tools require an admin UI, and building one from scratch can be the most time-consuming aspect of any new enterprise tool. There are off-the-shelf packages for app frameworks like Rails, but often the customization is so involved that using Material UI or similar from scratch might be better.
-
-Then there are no-code admin builders that could be used. However, wiring up access control and the connection to the data layer, with proper version control, makes this a challenging task as well.
-
-That's where Payload comes in. Payload instantly provides all of this out of the box, making complex internal tools extremely simple to both spin up and maintain over time. The only custom code that will need to be written is any custom business logic. That means Payload can expedite timelines, keep budgets low, and allow engineers to focus on their specific requirements rather than complex backend / admin UI plumbing.
-
-Generally, the best place to start for a new enterprise tool is with a blank canvas, where you can define your own functionality:
-
-```
-npx create-payload-app@latest -t blank
-```
-
-### Headless Commerce
-
-Companies who prioritize UX generally run into frontend constraints with traditional commerce vendors. These companies will then opt for frontend frameworks like Next.js which allow them to fine-tune their user experience as much as possible—promoting conversions, personalizing experiences, and optimizing for SEO.
-
-But the challenge with using something like Next.js for headless commerce is that in order for non-technical users to manage the storefront, you instantly need to pair a headless commerce product with a headless CMS. Then, your editors need to bounce back and forth between different admin UIs for different functionality. The code required to seamlessly glue them together on the frontend becomes overly complex.
-
-Payload can integrate with any payment processor like Stripe and its content authoring capabilities allow it to manage every aspect of a storefront—all in one place.
-
-If you can build your storefront with a single backend, and only offload things like payment processing, the code will be simpler and the editing experience will be significantly streamlined. Manage products, catalogs, page content, media, and more—all in one spot.
-
-### Digital Asset Management
-
-Payload's API-first tagging, sorting, and querying engine lends itself perfectly to all types of content that a CMS might ordinarily store, but these strong fundamentals also make it a formidable Digital Asset Management (DAM) tool as well.
-
-Similarly to the Ecommerce use case above, if an organization uses a CMS for its content but a separate DAM for its digital assets, administrators of both tools will need to juggle completely different services for tasks that are closely related. Two subscriptions will need to be managed, two sets of infrastructure will need to be provisioned, and two admin UIs need to be used / learned.
-
-Payload flattens CMS and DAM into a single tool that makes no compromises on either side. Powerful features like folder-based organization, file versioning, bulk upload, and media access control allow Payload to simultaneously function as a full Digital Asset Management platform as well as a Content Management System at the same time.
-
-[Click here](https://payloadcms.com/use-cases/digital-asset-management) for more information on how to get started with Payload as a DAM.
-
-## Choosing a Framework
-
-Payload is a great choice for applications of all sizes and types, but it might not be the right choice for every project. Here are some guidelines to help you decide if Payload is the right choice for your project.
-
-### When Payload might be for you
-
-- If data ownership and privacy are important to you, and you don't want to allow another proprietary SaaS vendor to host and own your data
-- If you're building a Next.js site that needs a CMS
-- If you need to re-use your data outside of a SaaS API
-- If what you're building has custom business logic requirements outside of a typical headless CMS
-- You want to deploy serverless on platforms like Vercel
-
-### When Payload might not be for you
-
-- If you can manage your project fully with code, and don't need an admin UI
-- If you are building a website that fits within the limits of a tool like Webflow or Framer
-- If you already have a full database and just need to visualize the data somehow
-- If you are confident that you won't need code / data ownership at any point in the future
-
-Ready to get started? First, let's review some high-level concepts that are used in Payload.
+<CardGroup>
+  <Card
+    title="Use Cases"
+    description="See how teams use Payload for headless CMS, internal tools, commerce, and DAM workloads — and whether it fits yours."
+    link="/docs/getting-started/use-cases"
+  />
+  <Card
+    title="Core Concepts"
+    description="Get familiar with the high-level concepts Payload is built around before you write any code."
+    link="/docs/getting-started/concepts"
+  />
+  <Card
+    title="Installation"
+    description="Add Payload to a new or existing Next.js app and get the Admin Panel running in minutes."
+    link="/docs/getting-started/installation"
+  />
+  <Card
+    title="The Admin Panel"
+    description="Explore the auto-generated React UI that matches the shape of your data and extends with your own components."
+    link="/docs/admin/overview"
+  />
+  <Card
+    title="Database & Schema"
+    description="Direct DB access and ownership with migrations, transactions, and proper indexing across MongoDB and Postgres."
+    link="/docs/database/overview"
+  />
+  <Card
+    title="REST & GraphQL APIs"
+    description="Instant REST, GraphQL, and straight-to-DB Node.js APIs generated from your config."
+    link="/docs/rest-api/overview"
+  />
+  <Card
+    title="Authentication"
+    description="A full auth system you can use in your Payload app and reuse in your own frontends."
+    link="/docs/authentication/overview"
+  />
+  <Card
+    title="Access Control"
+    description="A deeply customizable access pattern that runs at the document, field, and operation level."
+    link="/docs/access-control/overview"
+  />
+  <Card
+    title="File Uploads"
+    description="Built-in file storage, image resizing, focal-point cropping, and media access control."
+    link="/docs/upload/overview"
+  />
+</CardGroup>

--- a/docs/graphql/overview.mdx
+++ b/docs/graphql/overview.mdx
@@ -12,6 +12,13 @@ By default, the GraphQL API is exposed via `/api/graphql`, but you can customize
 
 The labels you provide for your Collections and Globals are used to name the GraphQL types that are created to correspond to your config. Special characters and spaces are removed.
 
+## GraphQL Clients
+
+You can use any GraphQL client with Payload's GraphQL endpoint. Here are a few popular packages:
+
+- [`graphql-request`](https://www.npmjs.com/package/graphql-request) - a very lightweight GraphQL client
+- [`@apollo/client`](https://www.apollographql.com/docs/react/api/core/ApolloClient/) - an industry-standard GraphQL client with lots of nice features
+
 ## GraphQL Options
 
 At the top of your Payload Config you can define all the options to manage GraphQL.

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -14,6 +14,14 @@ keywords: rest, api, documentation, Content Management System, cms, headless, ja
 The REST API is a fully functional HTTP client that allows you to interact with your Documents in a RESTful manner. It supports all CRUD operations and is equipped with automatic pagination, depth, and sorting.
 All Payload API routes are mounted and prefixed to your config's `routes.api` URL segment (default: `/api`).
 
+For example, if you have a Collection called `pages`, you can fetch its documents directly from the browser or any HTTP client:
+
+```ts
+fetch('https://localhost:3000/api/pages') // highlight-line
+  .then((res) => res.json())
+  .then((data) => console.log(data))
+```
+
 To enhance DX, you can use [Payload SDK](#payload-rest-api-sdk) to query your REST API.
 
 **REST query parameters:**


### PR DESCRIPTION
Uses the new Card/CardGroup blocks to convert the "What is Payload?" and "Concepts" pages into navigation grids. Long-form evaluative content moves to its own page. Patches a couple of REST/GraphQL overview pages that were duplicating content previously living on Concepts.