### PR TITLE
ci: re-enable template builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -424,6 +424,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [changes, build]
     if: needs.changes.outputs.needs_build == 'true'
+    # Non-blocking until templates are updated for 4.x breaking changes.
+    continue-on-error: true
     name: build-template-${{ matrix.template }}-${{ matrix.database }}
     strategy:
       fail-fast: false
@@ -468,7 +470,7 @@ jobs:
 
       - name: Build Template
         run: |
-          pnpm run script:pack --dest templates/${{ matrix.template }}
+          pnpm run script:pack --all --dest templates/${{ matrix.template }}
           pnpm run script:build-template-with-local-pkgs ${{ matrix.template }} $DB_CONNECTION
         env:
           NODE_OPTIONS: --max-old-space-size=8096

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -423,9 +423,7 @@ jobs:
   build-and-test-templates:
     runs-on: ubuntu-24.04
     needs: [changes, build]
-    # Temporarily disabled: template builds require a published beta of workspace packages.
-    # Re-enable once the next 4.x beta is published on npm.
-    if: false
+    if: needs.changes.outputs.needs_build == 'true'
     name: build-template-${{ matrix.template }}-${{ matrix.database }}
     strategy:
       fail-fast: false

--- a/tools/scripts/src/build-template-with-local-pkgs.ts
+++ b/tools/scripts/src/build-template-with-local-pkgs.ts
@@ -51,8 +51,13 @@ async function main() {
   const initialPackageJsonObj = JSON.parse(initialPackageJson)
 
   // Update the package.json dependencies to use any specific version instead of `workspace:*`, so that
-  // the next pnpm add command can install the local packages correctly.
-  updatePackageJSONDependencies({ latestVersion: '3.42.0', packageJson: initialPackageJsonObj })
+  // the next pnpm add command can install the local packages correctly. Whitelisted packages are
+  // overridden by the local .tgz files below; this version is the npm fallback for any @payloadcms
+  // dependency not packed locally, so it must resolve to a published release on the current major.
+  updatePackageJSONDependencies({
+    latestVersion: '4.0.0-canary.0',
+    packageJson: initialPackageJsonObj,
+  })
 
   await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJsonObj, null, 2))
 

--- a/tools/scripts/src/build-template-with-local-pkgs.ts
+++ b/tools/scripts/src/build-template-with-local-pkgs.ts
@@ -31,60 +31,59 @@ async function main() {
     stdio: 'inherit' as const,
   }
 
+  // Map every packed .tgz (produced by `script:pack --all`) to its package name and a local
+  // `file:` spec, e.g. `@payloadcms/translations` -> `file:./payloadcms-translations-4.0.0.tgz`.
   const allFiles = await fs.readdir(templatePath, { withFileTypes: true })
-  const allTgzs = allFiles
-    .filter((file) => file.isFile())
-    .map((file) => file.name)
-    .filter((file) => file.endsWith('.tgz'))
+  const fileSpecByPackageName = Object.fromEntries(
+    allFiles
+      .filter(
+        (file) =>
+          file.isFile() &&
+          file.name.endsWith('.tgz') &&
+          (file.name.startsWith('payload-') || file.name.startsWith('payloadcms-')),
+      )
+      .map((file) => [tgzToPackageName(file.name), `file:./${file.name}`]),
+  )
 
-  console.log({
-    allTgzs,
-  })
-
-  // remove node_modules
-  await fs.rm(path.join(templatePath, 'node_modules'), { recursive: true, force: true })
-  // replace workspace:* from package.json with a real version so that it can be installed with pnpm
-  // without this step, even though the packages are built locally as tars
-  // it will error as it cannot contain workspace dependencies when installing with --ignore-workspace
-  const packageJsonPath = path.join(templatePath, 'package.json')
-  const initialPackageJson = await fs.readFile(packageJsonPath, 'utf-8')
-  const initialPackageJsonObj = JSON.parse(initialPackageJson)
-
-  // Update the package.json dependencies to use any specific version instead of `workspace:*`, so that
-  // the next pnpm add command can install the local packages correctly. Whitelisted packages are
-  // overridden by the local .tgz files below; this version is the npm fallback for any @payloadcms
-  // dependency not packed locally, so it must resolve to a published release on the current major.
-  updatePackageJSONDependencies({
-    latestVersion: '4.0.0-canary.0',
-    packageJson: initialPackageJsonObj,
-  })
-
-  await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJsonObj, null, 2))
-
-  execSync('pnpm add ./*.tgz --ignore-workspace', execOpts)
-  execSync('pnpm install --ignore-workspace', execOpts)
-
-  const packageJson = await fs.readFile(packageJsonPath, 'utf-8')
-  const packageJsonObj = JSON.parse(packageJson) as {
-    dependencies: Record<string, string>
-    pnpm?: { overrides: Record<string, string> }
+  if (Object.keys(fileSpecByPackageName).length === 0) {
+    throw new Error(
+      `No packed .tgz files found in ${templatePath}. Run \`pnpm run script:pack --all --dest ${templatePath}\` first.`,
+    )
   }
 
-  // Get key/value pairs for any package that starts with '@payloadcms'
-  const payloadValues =
-    packageJsonObj.dependencies &&
-    Object.entries(packageJsonObj.dependencies).filter(
-      ([key, value]) => key.startsWith('@payloadcms') || key === 'payload',
-    )
+  console.log({ fileSpecByPackageName })
 
-  // Add each package to the overrides
-  const overrides = packageJsonObj.pnpm?.overrides || {}
-  payloadValues.forEach(([key, value]) => {
-    overrides[key] = value
-  })
+  await fs.rm(path.join(templatePath, 'node_modules'), { recursive: true, force: true })
 
-  // Write package.json back to disk
-  packageJsonObj.pnpm = { overrides }
+  const packageJsonPath = path.join(templatePath, 'package.json')
+  const packageJsonObj = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8')) as {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+    pnpm?: { overrides?: Record<string, string> }
+  }
+
+  // Point every workspace dependency the template declares at its local tarball. This also
+  // replaces `workspace:*` specs, which pnpm cannot install with --ignore-workspace.
+  for (const depKey of ['dependencies', 'devDependencies'] as const) {
+    const deps = packageJsonObj[depKey]
+    if (!deps) {
+      continue
+    }
+    for (const name of Object.keys(deps)) {
+      if (fileSpecByPackageName[name]) {
+        deps[name] = fileSpecByPackageName[name]
+      }
+    }
+  }
+
+  // Force the local tarballs across the entire dependency tree via overrides. Without this, the
+  // packed tarballs request their sibling @payloadcms packages at the in-repo version (e.g. a beta
+  // that is not published to npm), and the install fails with ERR_PNPM_NO_MATCHING_VERSION.
+  packageJsonObj.pnpm = {
+    ...packageJsonObj.pnpm,
+    overrides: { ...packageJsonObj.pnpm?.overrides, ...fileSpecByPackageName },
+  }
+
   await fs.writeFile(packageJsonPath, JSON.stringify(packageJsonObj, null, 2))
 
   execSync('pnpm install --no-frozen-lockfile --ignore-workspace', execOpts)
@@ -167,26 +166,14 @@ async function runBuildWithWarningsCheck(args: {
 }
 
 /**
- * Recursively updates a JSON object to replace all instances of `workspace:` with the latest version pinned.
- *
- * Does not return and instead modifies the `packageJson` object in place.
+ * Derives a package name from a `pnpm pack` tarball filename, e.g.
+ * `payload-4.0.0.tgz` -> `payload` and `payloadcms-db-mongodb-4.0.0.tgz` -> `@payloadcms/db-mongodb`.
+ * pnpm names scoped tarballs `<scope>-<name>-<version>.tgz`, so the version is the first
+ * hyphen-delimited segment that starts with a digit.
  */
-export function updatePackageJSONDependencies(args: {
-  latestVersion: string
-  packageJson: Record<string, unknown>
-}): void {
-  const { latestVersion, packageJson } = args
-
-  const updatedDependencies = Object.entries(packageJson.dependencies || {}).reduce(
-    (acc, [key, value]) => {
-      if (typeof value === 'string' && value.startsWith('workspace:')) {
-        acc[key] = `${latestVersion}`
-      } else {
-        acc[key] = value
-      }
-      return acc
-    },
-    {} as Record<string, string>,
-  )
-  packageJson.dependencies = updatedDependencies
+export function tgzToPackageName(tgzFileName: string): string {
+  const nameWithoutVersion = tgzFileName.replace(/-\d.*\.tgz$/, '')
+  return nameWithoutVersion === 'payload'
+    ? 'payload'
+    : `@payloadcms/${nameWithoutVersion.replace(/^payloadcms-/, '')}`
 }

--- a/tools/scripts/src/pack-all-to-dest.ts
+++ b/tools/scripts/src/pack-all-to-dest.ts
@@ -37,7 +37,6 @@ async function main() {
     ? undefined
     : [
         'payload',
-        'admin-bar',
         'db-mongodb',
         'db-postgres',
         'db-d1-sqlite',
@@ -55,7 +54,6 @@ async function main() {
         'plugin-search',
         'plugin-seo',
         'richtext-lexical',
-        'storage-vercel-blob',
         'translations',
         'ui',
       ]

--- a/tools/scripts/src/pack-all-to-dest.ts
+++ b/tools/scripts/src/pack-all-to-dest.ts
@@ -37,6 +37,7 @@ async function main() {
     ? undefined
     : [
         'payload',
+        'admin-bar',
         'db-mongodb',
         'db-postgres',
         'db-d1-sqlite',
@@ -54,6 +55,7 @@ async function main() {
         'plugin-search',
         'plugin-seo',
         'richtext-lexical',
+        'storage-vercel-blob',
         'translations',
         'ui',
       ]


### PR DESCRIPTION
# Overview

Re-enables the `build-and-test-templates` CI job, disabled in #16371 while it required a published 4.x release of the workspace packages on npm.

The job now builds templates against fully local packages and runs non-blocking, so it surfaces template breakage on 4.x without gating PRs.

## Key Changes

- **Re-enabled the job, non-blocking**
  - Restored `if: needs.changes.outputs.needs_build == 'true'` (was `if: false`) and added `continue-on-error: true`, matching the existing `tests-content-api` pattern. Failures show up in CI but do not fail the `all-green` gate until templates are updated for 4.x breaking changes.

- **Made the local package install hermetic**
  - The build now packs all workspace packages (`script:pack --all`) and rewrites `build-template-with-local-pkgs` to point every `@payloadcms/*` (and `payload`) dependency at its local `file:` tarball, in both the dependency entries and `pnpm.overrides`, before a single install.

## Design Decisions

The previous flow ran `pnpm add ./*.tgz` before setting overrides. That first install resolved the tarballs' internal cross-dependencies (`@payloadcms/translations`, `@payloadcms/plugin-cloud-storage`, and others) from npm at the in-repo version, which during 4.x beta is unpublished, so it failed with `ERR_PNPM_NO_MATCHING_VERSION`. That is what kept the job disabled.

Setting `file:` overrides for the full set of packed packages up front forces every workspace dependency, direct and transitive, to resolve to a local tarball. The install no longer touches npm for any `@payloadcms` package, so the job works regardless of what is published. This mirrors the approach already used by `test/setupProd.ts` for the prod E2E job.

Templates still pin the 3.x config API (for example, storage adapters passed to `plugins` rather than the 4.x `storage` array), so the builds currently fail once packages resolve. Running the job non-blocking surfaces that work without holding up merges; the `continue-on-error` flag comes off once the templates are migrated.
