### PR TITLE
fix(ui): restore focus state on sidebar nav tabs

### DIFF
--- a/packages/ui/src/elements/Nav/SidebarTabs/index.css
+++ b/packages/ui/src/elements/Nav/SidebarTabs/index.css
@@ -38,6 +38,12 @@
     &:hover {
       color: var(--color-icon);
     }
+
+    &:focus-visible {
+      outline: var(--accessibility-outline);
+      outline-offset: var(--accessibility-outline-offset);
+      border-radius: var(--button-radius);
+    }
   }
 
   .sidebar-tabs__tab--active {


### PR DESCRIPTION
`.sidebar-tabs__tab` uses `all: unset` which strips the browser's default focus ring. Added a `:focus-visible` rule using `--accessibility-outline` / `--accessibility-outline-offset` to restore keyboard focus visibility, matching the pattern used elsewhere in the UI.