### PR TITLE
fix(ui): invalid CSS nesting in RenderDefaultCell

### DIFF
--- a/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.css
+++ b/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.css
@@ -1,13 +1,11 @@
 @layer payload-default {
-  .default-cell {
-    &__first-cell {
-      border: 0;
-      background-color: transparent;
-      padding: 0;
-      cursor: pointer;
-      text-decoration: underline;
-      text-align: left;
-      white-space: nowrap;
-    }
+  .default-cell__first-cell {
+    border: 0;
+    background-color: transparent;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    text-align: left;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
# Overview

The SCSS→CSS conversion of `RenderDefaultCell` (#16865) left a SCSS-only nesting pattern that is invalid in native CSS, causing esbuild to emit a warning on every `packages/ui` build.

## Key Changes

- **Flatten the invalid `&__first-cell` selector**
  - `.default-cell { &__first-cell { ... } }` is valid SCSS (parent-selector concatenation) but invalid native CSS nesting, since `&` cannot precede a suffix. The parent block had no declarations of its own, so it is replaced with the flat `.default-cell__first-cell` selector. The compiled output is unchanged.
  - This matches the flat BEM convention used by the other conversions on this branch (e.g. `.shimmer-effect__shine`).
