### PR TITLE
fix(ui): restore auth view button styling

### DIFF
--- a/packages/ui/src/views/ForgotPassword/ForgotPasswordForm/index.css
+++ b/packages/ui/src/views/ForgotPassword/ForgotPasswordForm/index.css
@@ -16,21 +16,9 @@
     gap: var(--spacer-3);
   }
 
-  .forgot-password__form__actions {
+  .forgot-password__form__submit {
     display: flex;
-    flex-direction: column;
-    gap: var(--spacer-2);
     align-items: center;
-    width: 100%;
-  }
-
-  .forgot-password__form__actions .form-submit {
-    width: 100%;
-  }
-
-  .forgot-password__form__actions .form-submit .btn {
-    width: 100%;
-    height: var(--spacer-4);
     justify-content: center;
   }
 }

--- a/packages/ui/src/views/ForgotPassword/ForgotPasswordForm/index.tsx
+++ b/packages/ui/src/views/ForgotPassword/ForgotPasswordForm/index.tsx
@@ -14,6 +14,9 @@ import { Form } from '../../../forms/Form/index.js'
 import { FormSubmit } from '../../../forms/Submit/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import './index.css'
+
+const baseClass = 'forgot-password__form'
 
 export const ForgotPasswordForm: React.FC = () => {
   const { config, getEntityConfig } = useConfig()
@@ -75,6 +78,7 @@ export const ForgotPasswordForm: React.FC = () => {
         apiRoute,
         path: `/${userSlug}/forgot-password`,
       })}
+      className={baseClass}
       handleResponse={handleResponse}
       initialState={initialState}
       method="POST"
@@ -88,62 +92,64 @@ export const ForgotPasswordForm: React.FC = () => {
         heading={t('authentication:forgotPassword')}
       />
 
-      {loginWithUsername ? (
-        <TextField
-          field={{
-            name: 'username',
-            label: t('authentication:username'),
-            required: true,
-          }}
-          path="username"
-          validate={(value) =>
-            text(value, {
+      <div className={`${baseClass}__inputWrap`}>
+        {loginWithUsername ? (
+          <TextField
+            field={{
               name: 'username',
-              type: 'text',
-              blockData: {},
-              data: {},
-              event: 'onChange',
-              path: ['username'],
-              preferences: { fields: {} },
-              req: {
-                payload: {
-                  config,
-                },
-                t,
-              } as unknown as PayloadRequest,
+              label: t('authentication:username'),
               required: true,
-              siblingData: {},
-            })
-          }
-        />
-      ) : (
-        <EmailField
-          field={{
-            name: 'email',
-            admin: {
-              autoComplete: 'email',
-            },
-            label: t('general:email'),
-            required: true,
-          }}
-          path="email"
-          validate={(value) =>
-            email(value, {
+            }}
+            path="username"
+            validate={(value) =>
+              text(value, {
+                name: 'username',
+                type: 'text',
+                blockData: {},
+                data: {},
+                event: 'onChange',
+                path: ['username'],
+                preferences: { fields: {} },
+                req: {
+                  payload: {
+                    config,
+                  },
+                  t,
+                } as unknown as PayloadRequest,
+                required: true,
+                siblingData: {},
+              })
+            }
+          />
+        ) : (
+          <EmailField
+            field={{
               name: 'email',
-              type: 'email',
-              blockData: {},
-              data: {},
-              event: 'onChange',
-              path: ['email'],
-              preferences: { fields: {} },
-              req: { payload: { config }, t } as unknown as PayloadRequest,
+              admin: {
+                autoComplete: 'email',
+              },
+              label: t('general:email'),
               required: true,
-              siblingData: {},
-            })
-          }
-        />
-      )}
-      <FormSubmit size="large">{t('general:submit')}</FormSubmit>
+            }}
+            path="email"
+            validate={(value) =>
+              email(value, {
+                name: 'email',
+                type: 'email',
+                blockData: {},
+                data: {},
+                event: 'onChange',
+                path: ['email'],
+                preferences: { fields: {} },
+                req: { payload: { config }, t } as unknown as PayloadRequest,
+                required: true,
+                siblingData: {},
+              })
+            }
+          />
+        )}
+      </div>
+      <FormSubmit className={`${baseClass}__submit`}>{t('general:submit')}</FormSubmit>
     </Form>
   )
 }

--- a/packages/ui/src/views/ForgotPassword/index.css
+++ b/packages/ui/src/views/ForgotPassword/index.css
@@ -1,21 +1,12 @@
 @layer payload-default {
   .forgot-password__back {
     display: flex;
-    flex: 1 0 0;
     gap: var(--spacer-1);
     align-items: center;
     justify-content: center;
     min-height: var(--spacer-4);
     margin-top: var(--spacer-2);
     padding: 0 var(--spacer-2);
-    width: 100%;
-  }
-
-  .forgot-password__back a {
-    display: flex;
-    gap: var(--spacer-1);
-    align-items: center;
-    padding: var(--spacer-1) 0;
     color: var(--color-text-brand);
   }
 }

--- a/packages/ui/src/views/ForgotPassword/index.tsx
+++ b/packages/ui/src/views/ForgotPassword/index.tsx
@@ -54,7 +54,15 @@ export function ForgotPasswordView({ initPageResult }: AdminViewServerProps) {
           }
           heading={i18n.t('authentication:alreadyLoggedIn')}
         />
-        <Button buttonStyle="secondary" el="link" size="large" to={adminRoute}>
+        <Button
+          buttonStyle="ghost"
+          className={`${forgotPasswordBaseClass}__back`}
+          el="link"
+          url={formatAdminURL({
+            adminRoute,
+            path: loginRoute,
+          })}
+        >
           {i18n.t('general:backToDashboard')}
         </Button>
       </Fragment>
@@ -64,17 +72,17 @@ export function ForgotPasswordView({ initPageResult }: AdminViewServerProps) {
   return (
     <Fragment>
       <ForgotPasswordForm />
-      <div className={`${forgotPasswordBaseClass}__back`}>
-        <Link
-          href={formatAdminURL({
-            adminRoute,
-            path: loginRoute,
-          })}
-          prefetch={false}
-        >
-          {i18n.t('authentication:backToLogin')}
-        </Link>
-      </div>
+      <Button
+        buttonStyle="ghost"
+        className={`${forgotPasswordBaseClass}__back`}
+        el="link"
+        url={formatAdminURL({
+          adminRoute,
+          path: loginRoute,
+        })}
+      >
+        {i18n.t('authentication:backToLogin')}
+      </Button>
     </Fragment>
   )
 }

--- a/packages/ui/src/views/Login/LoginForm/index.tsx
+++ b/packages/ui/src/views/Login/LoginForm/index.tsx
@@ -8,12 +8,12 @@ import React from 'react'
 import type { UserWithToken } from '../../../providers/Auth/index.js'
 import type { LoginFieldProps } from '../LoginField/index.js'
 
+import { Button } from '../../../elements/Button/index.js'
 import { PasswordField } from '../../../fields/Password/index.js'
 import { Form } from '../../../forms/Form/index.js'
 import { FormSubmit } from '../../../forms/Submit/index.js'
 import { useAuth } from '../../../providers/Auth/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
-import { PayloadLink } from '../../../providers/RouterAdapter/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 import { LoginField } from '../LoginField/index.js'
 import './index.css'
@@ -106,18 +106,18 @@ export const LoginForm: React.FC<{
         />
       </div>
       <div className={`${baseClass}__actions`}>
-        <FormSubmit size="large">{t('authentication:login')}</FormSubmit>
-        <div className={`${baseClass}__forgotPassword`}>
-          <PayloadLink
-            href={formatAdminURL({
-              adminRoute,
-              path: forgotRoute,
-            })}
-            prefetch={false}
-          >
-            {t('authentication:forgotPasswordQuestion')}
-          </PayloadLink>
-        </div>
+        <FormSubmit>{t('authentication:login')}</FormSubmit>
+        <Button
+          buttonStyle="ghost"
+          className={`${baseClass}__forgotPassword`}
+          el="link"
+          url={formatAdminURL({
+            adminRoute,
+            path: forgotRoute,
+          })}
+        >
+          {t('authentication:forgotPasswordQuestion')}
+        </Button>
       </div>
     </Form>
   )

--- a/packages/ui/src/views/ResetPassword/ResetPasswordForm/index.css
+++ b/packages/ui/src/views/ResetPassword/ResetPasswordForm/index.css
@@ -16,21 +16,9 @@
     gap: var(--spacer-3);
   }
 
-  .reset-password__form__actions {
+  .reset-password__form__submit {
     display: flex;
-    flex-direction: column;
-    gap: var(--spacer-2);
     align-items: center;
-    width: 100%;
-  }
-
-  .reset-password__form__actions .form-submit {
-    width: 100%;
-  }
-
-  .reset-password__form__actions .form-submit .btn {
-    width: 100%;
-    height: var(--spacer-4);
     justify-content: center;
   }
 }

--- a/packages/ui/src/views/ResetPassword/ResetPasswordForm/index.tsx
+++ b/packages/ui/src/views/ResetPassword/ResetPasswordForm/index.tsx
@@ -4,6 +4,7 @@ import { type FormState } from 'payload'
 import { formatAdminURL } from 'payload/shared'
 import React from 'react'
 
+import { FormHeader } from '../../../elements/FormHeader/index.js'
 import { ConfirmPasswordField } from '../../../fields/ConfirmPassword/index.js'
 import { HiddenField } from '../../../fields/Hidden/index.js'
 import { PasswordField } from '../../../fields/Password/index.js'
@@ -13,6 +14,9 @@ import { useAuth } from '../../../providers/Auth/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useRouter } from '../../../providers/RouterAdapter/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import './index.css'
+
+const baseClass = 'reset-password__form'
 
 type Args = {
   readonly token: string
@@ -71,11 +75,13 @@ export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
         apiRoute,
         path: `/${userSlug}/reset-password`,
       })}
+      className={baseClass}
       initialState={initialState}
       method="POST"
       onSuccess={onSuccess}
     >
-      <div className="inputWrap">
+      <FormHeader heading={i18n.t('authentication:resetPassword')} />
+      <div className={`${baseClass}__inputWrap`}>
         <PasswordField
           field={{
             name: 'password',
@@ -88,7 +94,9 @@ export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
         <ConfirmPasswordField />
         <HiddenField path="token" schemaPath={`${userSlug}.token`} value={token} />
       </div>
-      <FormSubmit size="large">{i18n.t('authentication:resetPassword')}</FormSubmit>
+      <FormSubmit className={`${baseClass}__submit`}>
+        {i18n.t('authentication:resetPassword')}
+      </FormSubmit>
     </Form>
   )
 }

--- a/packages/ui/src/views/ResetPassword/index.css
+++ b/packages/ui/src/views/ResetPassword/index.css
@@ -7,21 +7,12 @@
 
   .reset-password__back {
     display: flex;
-    flex: 1 0 0;
     gap: var(--spacer-1);
     align-items: center;
     justify-content: center;
     min-height: var(--spacer-4);
     margin-top: var(--spacer-2);
     padding: 0 var(--spacer-2);
-    width: 100%;
-  }
-
-  .reset-password__back a {
-    display: flex;
-    gap: var(--spacer-1);
-    align-items: center;
-    padding: var(--spacer-1) 0;
     color: var(--color-text-brand);
   }
 }

--- a/packages/ui/src/views/ResetPassword/index.tsx
+++ b/packages/ui/src/views/ResetPassword/index.tsx
@@ -58,7 +58,15 @@ export function ResetPassword({ initPageResult, params }: AdminViewServerProps) 
           }
           heading={i18n.t('authentication:alreadyLoggedIn')}
         />
-        <Button buttonStyle="secondary" el="link" size="large" to={adminRoute}>
+        <Button
+          buttonStyle="ghost"
+          className={`${resetPasswordBaseClass}__back`}
+          el="link"
+          url={formatAdminURL({
+            adminRoute,
+            path: loginRoute,
+          })}
+        >
           {i18n.t('general:backToDashboard')}
         </Button>
       </div>
@@ -68,17 +76,17 @@ export function ResetPassword({ initPageResult, params }: AdminViewServerProps) 
   return (
     <div className={`${resetPasswordBaseClass}__wrap`}>
       <ResetPasswordForm token={token} />
-      <div className={`${resetPasswordBaseClass}__back`}>
-        <Link
-          href={formatAdminURL({
-            adminRoute,
-            path: loginRoute,
-          })}
-          prefetch={false}
-        >
-          {i18n.t('authentication:backToLogin')}
-        </Link>
-      </div>
+      <Button
+        buttonStyle="ghost"
+        className={`${resetPasswordBaseClass}__back`}
+        el="link"
+        url={formatAdminURL({
+          adminRoute,
+          path: loginRoute,
+        })}
+      >
+        {i18n.t('authentication:backToLogin')}
+      </Button>
     </div>
   )
 }


### PR DESCRIPTION
### What

Restores button styling across the Login, Forgot Password, and Reset Password views that was regressed by a separate PR: #16803 

- Restore ghost `Button` components for back-to-login / forgot-password links
- Restore standardized submit buttons (removes full-width styling)
- Restore shared `__inputWrap` container and Reset Password `FormHeader`
- Clean up related CSS