### PR TITLE
fix: localizeStatus PG migration db.execute signature

### DIFF
--- a/packages/payload/src/versions/migrations/localizeStatus/sql/down.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/down.ts
@@ -60,40 +60,31 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
   // 1. Restore version__status column to main table
   payload.logger.info({ msg: `Restoring version__status column to ${versionsTable}` })
 
-  await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      ALTER TABLE ${sql.identifier(versionsTable)} ADD COLUMN version__status VARCHAR
-    `,
-  })
+  await db.execute(sql`
+    ALTER TABLE ${sql.identifier(versionsTable)} ADD COLUMN version__status VARCHAR
+  `)
 
   // 2. Copy status from default locale back to main table
   payload.logger.info({
     msg: `Copying status from default locale (${defaultLocale}) back to main table`,
   })
 
-  await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      UPDATE ${sql.identifier(versionsTable)} pv
-      SET version__status = pl.version__status
-      FROM ${sql.identifier(localesTable)} pl
-      WHERE pv.id = pl._parent_id
-      AND pl._locale = ${defaultLocale}
-    `,
-  })
+  await db.execute(sql`
+    UPDATE ${sql.identifier(versionsTable)} pv
+    SET version__status = pl.version__status
+    FROM ${sql.identifier(localesTable)} pl
+    WHERE pv.id = pl._parent_id
+    AND pl._locale = ${defaultLocale}
+  `)
 
   // 3. Check if there are other localized fields besides version__status
-  const columnCheckResult = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT COUNT(*) as count
-      FROM information_schema.columns
-      WHERE table_schema = 'public'
-      AND table_name = ${localesTable}
-      AND column_name NOT IN ('id', '_locale', '_parent_id', 'version__status')
-    `,
-  })
+  const columnCheckResult = await db.execute(sql`
+    SELECT COUNT(*) as count
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = ${localesTable}
+    AND column_name NOT IN ('id', '_locale', '_parent_id', 'version__status')
+  `)
 
   const hasOtherLocalizedFields = Number(columnCheckResult.rows[0]?.count) > 0
 
@@ -101,20 +92,14 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
     // SCENARIO 1 ROLLBACK: No other localized fields, drop entire table
     payload.logger.info({ msg: `Dropping entire locales table: ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`DROP TABLE ${sql.identifier(localesTable)} CASCADE`,
-    })
+    await db.execute(sql`DROP TABLE ${sql.identifier(localesTable)} CASCADE`)
   } else {
     // SCENARIO 2 ROLLBACK: Other localized fields exist, just drop version__status column
     payload.logger.info({ msg: `Dropping version__status column from ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        ALTER TABLE ${sql.identifier(localesTable)} DROP COLUMN version__status
-      `,
-    })
+    await db.execute(sql`
+      ALTER TABLE ${sql.identifier(localesTable)} DROP COLUMN version__status
+    `)
   }
 
   // 4. Restore _status to main collection/global table if it was dropped
@@ -122,78 +107,60 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
   const mainLocalesTable = `${mainTable}_locales`
 
   // Check if _status exists in the main table
-  const statusInMainTableCheck = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.columns
-        WHERE table_schema = 'public'
-        AND table_name = ${mainTable}
-        AND column_name = '_status'
-      ) as exists
-    `,
-  })
+  const statusInMainTableCheck = await db.execute(sql`
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name = ${mainTable}
+      AND column_name = '_status'
+    ) as exists
+  `)
 
   if (!statusInMainTableCheck.rows[0]?.exists) {
     // _status column doesn't exist in main table, need to restore it
     // Check if main collection/global has a locales table
-    const mainLocalesTableCheck = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT EXISTS (
-          SELECT FROM information_schema.tables
-          WHERE table_schema = 'public'
-          AND table_name = ${mainLocalesTable}
-        ) as exists
-      `,
-    })
+    const mainLocalesTableCheck = await db.execute(sql`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = ${mainLocalesTable}
+      ) as exists
+    `)
 
     if (mainLocalesTableCheck.rows[0]?.exists) {
       // Locales table exists - check if _status is there
-      const statusInLocalesCheck = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          SELECT EXISTS (
-            SELECT FROM information_schema.columns
-            WHERE table_schema = 'public'
-            AND table_name = ${mainLocalesTable}
-            AND column_name = '_status'
-          ) as exists
-        `,
-      })
+      const statusInLocalesCheck = await db.execute(sql`
+        SELECT EXISTS (
+          SELECT FROM information_schema.columns
+          WHERE table_schema = 'public'
+          AND table_name = ${mainLocalesTable}
+          AND column_name = '_status'
+        ) as exists
+      `)
 
       if (statusInLocalesCheck.rows[0]?.exists) {
         // Add _status back to main table
         payload.logger.info({ msg: `Restoring _status column to ${mainTable}` })
 
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
-          `,
-        })
+        await db.execute(sql`
+          ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
+        `)
 
         // Copy status from default locale back to main table
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            UPDATE ${sql.identifier(mainTable)} m
-            SET _status = l._status
-            FROM ${sql.identifier(mainLocalesTable)} l
-            WHERE m.id = l._parent_id
-            AND l._locale = ${defaultLocale}
-          `,
-        })
+        await db.execute(sql`
+          UPDATE ${sql.identifier(mainTable)} m
+          SET _status = l._status
+          FROM ${sql.identifier(mainLocalesTable)} l
+          WHERE m.id = l._parent_id
+          AND l._locale = ${defaultLocale}
+        `)
 
         // Drop _status from locales table
         payload.logger.info({ msg: `Dropping _status column from ${mainLocalesTable}` })
 
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            ALTER TABLE ${sql.identifier(mainLocalesTable)} DROP COLUMN _status
-          `,
-        })
+        await db.execute(sql`
+          ALTER TABLE ${sql.identifier(mainLocalesTable)} DROP COLUMN _status
+        `)
       }
     } else {
       // No locales table exists - this means collection/global has no localized fields
@@ -202,46 +169,34 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
         msg: `Restoring _status column to ${mainTable} (no locales table exists)`,
       })
 
-      await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
-        `,
-      })
+      await db.execute(sql`
+        ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
+      `)
 
       // Set default status based on latest version status for each document
       // Get all documents in the collection
-      const documents = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          SELECT DISTINCT id
-          FROM ${sql.identifier(mainTable)}
-        `,
-      })
+      const documents = await db.execute(sql`
+        SELECT DISTINCT id
+        FROM ${sql.identifier(mainTable)}
+      `)
 
       for (const doc of documents.rows) {
         // Get latest version status for this document
-        const latestVersionStatus = await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            SELECT version__status
-            FROM ${sql.identifier(versionsTable)}
-            WHERE parent_id = ${doc.id}
-            ORDER BY created_at DESC
-            LIMIT 1
-          `,
-        })
+        const latestVersionStatus = await db.execute(sql`
+          SELECT version__status
+          FROM ${sql.identifier(versionsTable)}
+          WHERE parent_id = ${doc.id}
+          ORDER BY created_at DESC
+          LIMIT 1
+        `)
 
         const status = latestVersionStatus.rows[0]?.version__status || 'draft'
 
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            UPDATE ${sql.identifier(mainTable)}
-            SET _status = ${status}
-            WHERE id = ${doc.id}
-          `,
-        })
+        await db.execute(sql`
+          UPDATE ${sql.identifier(mainTable)}
+          SET _status = ${status}
+          WHERE id = ${doc.id}
+        `)
       }
 
       payload.logger.info({ msg: `Restored _status for ${documents.rows.length} documents` })

--- a/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainCollection.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainCollection.ts
@@ -26,42 +26,33 @@ export async function migrateMainCollectionStatus({
   payload.logger.info({ msg: `Migrating main collection locales for: ${mainLocalesTable}` })
 
   // Get all documents
-  const documents = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT DISTINCT id
-      FROM ${sql.identifier(mainTable)}
-    `,
-  })
+  const documents = await db.execute(sql`
+    SELECT DISTINCT id
+    FROM ${sql.identifier(mainTable)}
+  `)
 
   for (const doc of documents.rows) {
     // For each locale, get the latest version status
     for (const locale of locales) {
-      const latestVersionStatus = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          SELECT l.version__status as _status
-          FROM ${sql.identifier(versionsTable)} v
-          JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
-          WHERE v.parent_id = ${doc.id}
-          AND l._locale = ${locale}
-          ORDER BY v.created_at DESC
-          LIMIT 1
-        `,
-      })
+      const latestVersionStatus = await db.execute(sql`
+        SELECT l.version__status as _status
+        FROM ${sql.identifier(versionsTable)} v
+        JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
+        WHERE v.parent_id = ${doc.id}
+        AND l._locale = ${locale}
+        ORDER BY v.created_at DESC
+        LIMIT 1
+      `)
 
       const status = latestVersionStatus.rows[0]?._status || 'draft'
 
       // Update the main collection's locales table with this status
-      await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          UPDATE ${sql.identifier(mainLocalesTable)}
-          SET _status = ${status}
-          WHERE _parent_id = ${doc.id}
-          AND _locale = ${locale}
-        `,
-      })
+      await db.execute(sql`
+        UPDATE ${sql.identifier(mainLocalesTable)}
+        SET _status = ${status}
+        WHERE _parent_id = ${doc.id}
+        AND _locale = ${locale}
+      `)
     }
   }
 

--- a/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainGlobal.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainGlobal.ts
@@ -27,27 +27,21 @@ export async function migrateMainGlobalStatus({
 
   // For each locale, get the latest version status
   for (const locale of locales) {
-    const latestVersionStatus = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT l.version__status as _status
-        FROM ${sql.identifier(versionsTable)} v
-        JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
-        WHERE l._locale = ${locale}
-        ORDER BY v.created_at DESC
-        LIMIT 1
-      `,
-    })
+    const latestVersionStatus = await db.execute(sql`
+      SELECT l.version__status as _status
+      FROM ${sql.identifier(versionsTable)} v
+      JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
+      WHERE l._locale = ${locale}
+      ORDER BY v.created_at DESC
+      LIMIT 1
+    `)
 
     const status = latestVersionStatus.rows[0]?._status || 'draft'
 
     // Get the global document ID from the globals table
-    const globalDoc = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT id FROM ${sql.identifier(globalTable)} LIMIT 1
-      `,
-    })
+    const globalDoc = await db.execute(sql`
+      SELECT id FROM ${sql.identifier(globalTable)} LIMIT 1
+    `)
 
     if (globalDoc.rows.length === 0) {
       payload.logger.warn({ msg: `No global document found for ${globalSlug}, skipping` })
@@ -57,15 +51,12 @@ export async function migrateMainGlobalStatus({
     const globalId = globalDoc.rows[0].id
 
     // Update the global's locales table with this status
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        UPDATE ${sql.identifier(globalLocalesTable)}
-        SET _status = ${status}
-        WHERE _parent_id = ${globalId}
-        AND _locale = ${locale}
-      `,
-    })
+    await db.execute(sql`
+      UPDATE ${sql.identifier(globalLocalesTable)}
+      SET _status = ${status}
+      WHERE _parent_id = ${globalId}
+      AND _locale = ${locale}
+    `)
   }
 
   payload.logger.info({ msg: 'Migrated global document' })

--- a/packages/payload/src/versions/migrations/localizeStatus/sql/up.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/up.ts
@@ -79,17 +79,14 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // Validate that version__status column exists before proceeding
-  const columnCheckResult = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
+  const columnCheckResult = await db.execute(sql`
       SELECT EXISTS (
         SELECT FROM information_schema.columns
         WHERE table_schema = 'public'
         AND table_name = ${versionsTable}
         AND column_name = 'version__status'
       ) as exists
-    `,
-  })
+    `)
 
   if (!columnCheckResult.rows[0]?.exists) {
     throw new Error(
@@ -100,16 +97,13 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // 1. Check if the locales table exists
-  const localesTableCheckResult = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
+  const localesTableCheckResult = await db.execute(sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public'
         AND table_name = ${localesTable}
       ) as exists
-    `,
-  })
+    `)
 
   const localesTableExists = localesTableCheckResult.rows[0]?.exists
 
@@ -117,9 +111,7 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
     // SCENARIO 1: Create the locales table (first localized field in versions)
     payload.logger.info({ msg: `Creating new locales table: ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    await db.execute(sql`
         CREATE TABLE ${sql.identifier(localesTable)} (
           id SERIAL PRIMARY KEY,
           _locale VARCHAR NOT NULL,
@@ -128,63 +120,50 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
           UNIQUE(_locale, _parent_id),
           FOREIGN KEY (_parent_id) REFERENCES ${sql.identifier(versionsTable)}(id) ON DELETE CASCADE
         )
-      `,
-    })
+      `)
 
     // Create one row per locale per version record
     // Simple approach: copy the same status to all locales
     for (const locale of locales) {
-      const inserted = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
+      const inserted = await db.execute(sql`
           INSERT INTO ${sql.identifier(localesTable)} (_locale, _parent_id, version__status)
           SELECT ${locale}, id, version__status
           FROM ${sql.identifier(versionsTable)}
           RETURNING id
-        `,
-      })
+        `)
       payload.logger.info({
-        msg: `Inserted ${inserted.length} rows for locale: ${locale}`,
+        msg: `Inserted ${inserted.rows.length} rows for locale: ${locale}`,
       })
     }
   } else {
     // SCENARIO 2: Add version__status column to existing locales table
     payload.logger.info({ msg: `Adding version__status column to existing table: ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    await db.execute(sql`
         ALTER TABLE ${sql.identifier(localesTable)} ADD COLUMN version__status VARCHAR
-      `,
-    })
+      `)
 
     // INTELLIGENT DATA MIGRATION using historical publishedLocale data
     payload.logger.info({ msg: 'Processing version history to determine status per locale...' })
 
     // First, get the list of locales that actually exist in the locales table
     // This is important because the config may have more locales defined than what's in the OLD schema
-    const existingLocalesResult = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    const existingLocalesResult = await db.execute(sql`
         SELECT DISTINCT _locale
         FROM ${sql.identifier(localesTable)}
         ORDER BY _locale
-      `,
-    })
+      `)
     const existingLocales = existingLocalesResult.rows.map((row: any) => row._locale as string)
     payload.logger.info({
       msg: `Found existing locales in table: ${existingLocales.join(', ')}`,
     })
 
     // Get all version records grouped by parent document, ordered chronologically
-    const versionsResult = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    const versionsResult = await db.execute(sql`
         SELECT id, parent_id as parent, version__status as _status, published_locale, snapshot, created_at
         FROM ${sql.identifier(versionsTable)}
         ORDER BY parent_id, created_at ASC
-      `,
-    })
+      `)
 
     // Use shared function to calculate version locale statuses
     // Only process locales that actually exist in the locales table
@@ -200,15 +179,12 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
     let updateCount = 0
     for (const [versionId, localeMap] of versionLocaleStatus.entries()) {
       for (const [locale, status] of localeMap.entries()) {
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
+        await db.execute(sql`
             UPDATE ${sql.identifier(localesTable)}
             SET version__status = ${status}
             WHERE _parent_id = ${versionId}
             AND _locale = ${locale}
-          `,
-        })
+          `)
         updateCount++
       }
     }
@@ -217,12 +193,9 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // 3. Drop the old version__status column from main versions table
-  await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      ALTER TABLE ${sql.identifier(versionsTable)} DROP COLUMN version__status
-    `,
-  })
+  await db.execute(sql`
+    ALTER TABLE ${sql.identifier(versionsTable)} DROP COLUMN version__status
+  `)
 
   // 4. Create and populate _status column in main collection/global locales table
   // With localizeStatus enabled, _status is a localized field stored in the collection's locales table
@@ -230,40 +203,31 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   const mainTable = collectionSlug ? toSnakeCase(collectionSlug) : toSnakeCase(globalSlug!)
   const mainLocalesTable = `${mainTable}_locales`
 
-  const localesTableCheck = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.tables
-        WHERE table_schema = 'public'
-        AND table_name = ${mainLocalesTable}
-      ) as exists
-    `,
-  })
+  const localesTableCheck = await db.execute(sql`
+    SELECT EXISTS (
+      SELECT FROM information_schema.tables
+      WHERE table_schema = 'public'
+      AND table_name = ${mainLocalesTable}
+    ) as exists
+  `)
 
   if (localesTableCheck.rows[0]?.exists) {
     // Check if _status column already exists in the locales table
-    const statusColumnCheck = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT EXISTS (
-          SELECT FROM information_schema.columns
-          WHERE table_schema = 'public'
-          AND table_name = ${mainLocalesTable}
-          AND column_name = '_status'
-        ) as exists
-      `,
-    })
+    const statusColumnCheck = await db.execute(sql`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+        AND table_name = ${mainLocalesTable}
+        AND column_name = '_status'
+      ) as exists
+    `)
 
     if (!statusColumnCheck.rows[0]?.exists) {
       // Add _status column to locales table
-      await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          ALTER TABLE ${sql.identifier(mainLocalesTable)}
-          ADD COLUMN _status VARCHAR DEFAULT 'draft'
-        `,
-      })
+      await db.execute(sql`
+        ALTER TABLE ${sql.identifier(mainLocalesTable)}
+        ADD COLUMN _status VARCHAR DEFAULT 'draft'
+      `)
     }
 
     // Now populate the _status values from the latest version
@@ -286,25 +250,19 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // 5. Drop _status from main table if it exists (it will be in locales table now)
-  const mainTableStatusCheck = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.columns
-        WHERE table_schema = 'public'
-        AND table_name = ${mainTable}
-        AND column_name = '_status'
-      ) as exists
-    `,
-  })
+  const mainTableStatusCheck = await db.execute(sql`
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name = ${mainTable}
+      AND column_name = '_status'
+    ) as exists
+  `)
 
   if (mainTableStatusCheck.rows[0]?.exists) {
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        ALTER TABLE ${sql.identifier(mainTable)} DROP COLUMN _status
-      `,
-    })
+    await db.execute(sql`
+      ALTER TABLE ${sql.identifier(mainTable)} DROP COLUMN _status
+    `)
   }
 
   payload.logger.info({ msg: 'Migration completed successfully' })


### PR DESCRIPTION
## What

Fixes the broken `localizeStatus` migration for PostgreSQL databases.

## Why

All `db.execute` calls in the 4 SQL migration files used the wrong signature:

```ts
// WRONG - db has no .drizzle sub-property
await db.execute({ drizzle: db.drizzle, sql: sql`...` })
```

The `db` parameter passed into migration functions IS the raw Drizzle `PostgresDB` instance — it has no `.drizzle` sub-property. The correct call pattern (used throughout the rest of the drizzle codebase) is:

```ts
// CORRECT
await db.execute(sql`...`)
```

Also fixes `inserted.length` → `inserted.rows.length` in `up.ts` (the result object has a `.rows` array, not a top-level length).

## Files changed

- `sql/up.ts`
- `sql/down.ts`
- `sql/migrateMainCollection.ts`
- `sql/migrateMainGlobal.ts`

These are pure bug fixes with no behaviour changes — the migration logic is identical, only the call signature is corrected.

Created from comments on this PR https://github.com/payloadcms/payload/pull/14667