### PR TITLE
feat(versions)!: make localizeStatus true by default

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -41,6 +41,7 @@ The tool loads your project via [ts-morph](https://ts-morph.com/), using your `t
 - `remove-versions-true` — removes the now-redundant `versions: true` property from `CollectionConfig` and `GlobalConfig` objects. Only removes the bare boolean `true`; object-form configs (e.g. `versions: { drafts: true }`) are left untouched.
 - `rename-typescript-schema-to-json-schema` — renames the `typescriptSchema` field-config property to `jsonSchema` (it always accepted JSON Schema, not TypeScript). Skips any object that already defines a `jsonSchema` sibling and surfaces it as a note for manual review.
 - `migrate-build-script` — rewrites the `build` npm script in `package.json` from `next build` to `payload build`, so the Import Map (and types) are generated before the Next.js build. Matches the `next build` invocation only (leaves `next build-storybook` and the like untouched) and is a no-op when `build` is already `payload build`.
+- `migrate-localize-status` — removes `experimental.localizeStatus` from Payload config. In v4, `localizeStatus` defaults to `true` for localized collections/globals with drafts enabled. If needed, you can still opt out per collection or global by setting `versions.drafts.localizeStatus: false`. If `experimental` becomes empty after removal it is dropped entirely.
 
 ## Contributing
 

--- a/packages/codemod/src/registry.ts
+++ b/packages/codemod/src/registry.ts
@@ -11,6 +11,7 @@ import { migrateForceSelect } from './transforms/migrate-force-select/index.js'
 import { migrateHideAPIURL } from './transforms/migrate-hide-api-url/index.js'
 import { migrateImportExportHooks } from './transforms/migrate-import-export-hooks/index.js'
 import { migrateListViewSelectAPI } from './transforms/migrate-list-view-select-api/index.js'
+import { migrateLocalizeStatus } from './transforms/migrate-localize-status/index.js'
 import { migrateNextSubpathExports } from './transforms/migrate-next-subpath-exports/index.js'
 import { migrateStorageAdaptersToConfig } from './transforms/migrate-storage-adapters-to-config/index.js'
 import { migrateVersionsDefault } from './transforms/migrate-versions-default/index.js'
@@ -36,4 +37,5 @@ export const transforms: Transform[] = [
   migrateVersionsDefault,
   removeVersionsTrue,
   renameTypescriptSchemaToJsonSchema,
+  migrateLocalizeStatus,
 ]

--- a/packages/codemod/src/transforms/migrate-localize-status/index.spec.ts
+++ b/packages/codemod/src/transforms/migrate-localize-status/index.spec.ts
@@ -1,0 +1,46 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { runTransform } from '../../utils/test-helpers.js'
+import { migrateLocalizeStatus } from './index.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixture = (name: string) => readFile(join(here, name), 'utf8')
+
+describe('migrate-localize-status', () => {
+  it('removes experimental.localizeStatus and the empty experimental block', async () => {
+    const input = await fixture('removes-localize-status.input.ts')
+    const output = await fixture('removes-localize-status.output.ts')
+
+    const result = await runTransform({ source: input, transform: migrateLocalizeStatus })
+
+    expect(result).toBe(output)
+  })
+
+  it('is idempotent', async () => {
+    const output = await fixture('removes-localize-status.output.ts')
+
+    const result = await runTransform({ source: output, transform: migrateLocalizeStatus })
+
+    expect(result).toBe(output)
+  })
+
+  it('removes only localizeStatus and preserves other experimental flags', async () => {
+    const input = await fixture('preserves-other-experimental.input.ts')
+    const output = await fixture('preserves-other-experimental.output.ts')
+
+    const result = await runTransform({ source: input, transform: migrateLocalizeStatus })
+
+    expect(result).toBe(output)
+  })
+
+  it('no-ops on config without experimental', async () => {
+    const input = await fixture('no-match.input.ts')
+
+    const result = await runTransform({ source: input, transform: migrateLocalizeStatus })
+
+    expect(result).toBe(input)
+  })
+})

--- a/packages/codemod/src/transforms/migrate-localize-status/index.ts
+++ b/packages/codemod/src/transforms/migrate-localize-status/index.ts
@@ -1,0 +1,51 @@
+import { Node } from 'ts-morph'
+
+import type { Transform } from '../../types.js'
+
+export const migrateLocalizeStatus: Transform = {
+  name: 'migrate-localize-status',
+  apply: ({ project }) => {
+    const filesChanged = new Set<string>()
+
+    for (const sourceFile of project.getSourceFiles()) {
+      let mutated = false
+
+      sourceFile.forEachDescendant((node) => {
+        if (!Node.isPropertyAssignment(node)) {
+          return
+        }
+        if (node.getName() !== 'experimental') {
+          return
+        }
+        const initializer = node.getInitializer()
+        if (!initializer || !Node.isObjectLiteralExpression(initializer)) {
+          return
+        }
+
+        const localizeStatusProp = initializer
+          .getProperties()
+          .find((prop) => Node.isPropertyAssignment(prop) && prop.getName() === 'localizeStatus')
+
+        if (!localizeStatusProp) {
+          return
+        }
+
+        localizeStatusProp.remove()
+        mutated = true
+
+        // If the experimental object is now empty, remove the experimental property too
+        if (initializer.getProperties().length === 0) {
+          node.remove()
+        }
+      })
+
+      if (mutated) {
+        filesChanged.add(sourceFile.getFilePath())
+      }
+    }
+
+    return { filesChanged: [...filesChanged] }
+  },
+  description:
+    'Remove experimental.localizeStatus from Payload config. In v4, localizeStatus defaults to true and can be overridden per collection/global with versions.drafts.localizeStatus: false.',
+}

--- a/packages/codemod/src/transforms/migrate-localize-status/no-match.input.ts
+++ b/packages/codemod/src/transforms/migrate-localize-status/no-match.input.ts
@@ -1,0 +1,5 @@
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  collections: [],
+})

--- a/packages/codemod/src/transforms/migrate-localize-status/preserves-other-experimental.input.ts
+++ b/packages/codemod/src/transforms/migrate-localize-status/preserves-other-experimental.input.ts
@@ -1,0 +1,9 @@
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  experimental: {
+    localizeStatus: true,
+    someOtherFlag: true,
+  },
+  collections: [],
+})

--- a/packages/codemod/src/transforms/migrate-localize-status/preserves-other-experimental.output.ts
+++ b/packages/codemod/src/transforms/migrate-localize-status/preserves-other-experimental.output.ts
@@ -1,0 +1,8 @@
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  experimental: {
+    someOtherFlag: true,
+  },
+  collections: [],
+})

--- a/packages/codemod/src/transforms/migrate-localize-status/removes-localize-status.input.ts
+++ b/packages/codemod/src/transforms/migrate-localize-status/removes-localize-status.input.ts
@@ -1,0 +1,8 @@
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  experimental: {
+    localizeStatus: true,
+  },
+  collections: [],
+})

--- a/packages/codemod/src/transforms/migrate-localize-status/removes-localize-status.output.ts
+++ b/packages/codemod/src/transforms/migrate-localize-status/removes-localize-status.output.ts
@@ -1,0 +1,5 @@
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  collections: [],
+})

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -19,7 +19,6 @@ import { uploadCollectionEndpoints } from '../../uploads/endpoints/index.js'
 import { getBaseUploadFields } from '../../uploads/getBaseFields.js'
 import { flattenAllFields } from '../../utilities/flattenAllFields.js'
 import { formatLabels } from '../../utilities/formatLabels.js'
-import { miniChalk } from '../../utilities/miniChalk.js'
 import { traverseForLocalizedFields } from '../../utilities/traverseForLocalizedFields.js'
 import { baseVersionFields } from '../../versions/baseFields.js'
 import { versionDefaults } from '../../versions/defaults.js'
@@ -277,18 +276,8 @@ export const sanitizeCollection = async (
 
       if (config.localization) {
         if (hasLocalizedFields && sanitized.versions.drafts.localizeStatus === undefined) {
-          sanitized.versions.drafts.localizeStatus = false
+          sanitized.versions.drafts.localizeStatus = true
         }
-      }
-
-      // TODO v4: remove this sanitization check, should not need to enable the experimental flag
-      if (sanitized.versions.drafts.localizeStatus && !config.experimental?.localizeStatus) {
-        sanitized.versions.drafts.localizeStatus = false
-        console.log(
-          miniChalk.yellowBold(
-            `Warning: "localizeStatus" for drafts is an experimental feature. To enable, set "experimental.localizeStatus" to true in your Payload config.`,
-          ),
-        )
       }
 
       if (sanitized.versions.drafts.autosave === true) {

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1250,21 +1250,9 @@ export type Config = {
   /** Custom REST endpoints */
   endpoints?: Endpoint[]
   /**
-   * Experimental features may be unstable or change in future versions.
+   * Enable experimental features. These features may change or be removed in future releases.
    */
-  experimental?: {
-    /**
-     * Enable per-locale status for documents.
-     *
-     * Requires:
-     * - `localization` enabled
-     * - `versions.drafts` enabled
-     * - `versions.drafts.localizeStatus` set at collection or global level
-     *
-     * @experimental
-     */
-    localizeStatus?: boolean
-  }
+  experimental?: Record<string, never>
   /**
    * @see https://payloadcms.com/docs/configuration/globals#global-configs
    */

--- a/packages/payload/src/globals/config/sanitize.ts
+++ b/packages/payload/src/globals/config/sanitize.ts
@@ -121,13 +121,9 @@ export const sanitizeGlobal = async (
 
       if (config.localization && hasLocalizedFields) {
         if (global.versions.drafts.localizeStatus === undefined) {
-          global.versions.drafts.localizeStatus = false
+          global.versions.drafts.localizeStatus = true
         }
       }
-
-      global.versions.drafts.localizeStatus = config.experimental?.localizeStatus
-        ? global.versions.drafts.localizeStatus
-        : false
 
       if (global.versions.drafts.autosave === true) {
         global.versions.drafts.autosave = {

--- a/packages/payload/src/versions/migrations/localizeStatus/sql/down.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/down.ts
@@ -60,40 +60,31 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
   // 1. Restore version__status column to main table
   payload.logger.info({ msg: `Restoring version__status column to ${versionsTable}` })
 
-  await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      ALTER TABLE ${sql.identifier(versionsTable)} ADD COLUMN version__status VARCHAR
-    `,
-  })
+  await db.execute(sql`
+    ALTER TABLE ${sql.identifier(versionsTable)} ADD COLUMN version__status VARCHAR
+  `)
 
   // 2. Copy status from default locale back to main table
   payload.logger.info({
     msg: `Copying status from default locale (${defaultLocale}) back to main table`,
   })
 
-  await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      UPDATE ${sql.identifier(versionsTable)} pv
-      SET version__status = pl.version__status
-      FROM ${sql.identifier(localesTable)} pl
-      WHERE pv.id = pl._parent_id
-      AND pl._locale = ${defaultLocale}
-    `,
-  })
+  await db.execute(sql`
+    UPDATE ${sql.identifier(versionsTable)} pv
+    SET version__status = pl.version__status
+    FROM ${sql.identifier(localesTable)} pl
+    WHERE pv.id = pl._parent_id
+    AND pl._locale = ${defaultLocale}
+  `)
 
   // 3. Check if there are other localized fields besides version__status
-  const columnCheckResult = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT COUNT(*) as count
-      FROM information_schema.columns
-      WHERE table_schema = 'public'
-      AND table_name = ${localesTable}
-      AND column_name NOT IN ('id', '_locale', '_parent_id', 'version__status')
-    `,
-  })
+  const columnCheckResult = await db.execute(sql`
+    SELECT COUNT(*) as count
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = ${localesTable}
+    AND column_name NOT IN ('id', '_locale', '_parent_id', 'version__status')
+  `)
 
   const hasOtherLocalizedFields = Number(columnCheckResult.rows[0]?.count) > 0
 
@@ -101,20 +92,14 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
     // SCENARIO 1 ROLLBACK: No other localized fields, drop entire table
     payload.logger.info({ msg: `Dropping entire locales table: ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`DROP TABLE ${sql.identifier(localesTable)} CASCADE`,
-    })
+    await db.execute(sql`DROP TABLE ${sql.identifier(localesTable)} CASCADE`)
   } else {
     // SCENARIO 2 ROLLBACK: Other localized fields exist, just drop version__status column
     payload.logger.info({ msg: `Dropping version__status column from ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        ALTER TABLE ${sql.identifier(localesTable)} DROP COLUMN version__status
-      `,
-    })
+    await db.execute(sql`
+      ALTER TABLE ${sql.identifier(localesTable)} DROP COLUMN version__status
+    `)
   }
 
   // 4. Restore _status to main collection/global table if it was dropped
@@ -122,78 +107,60 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
   const mainLocalesTable = `${mainTable}_locales`
 
   // Check if _status exists in the main table
-  const statusInMainTableCheck = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.columns
-        WHERE table_schema = 'public'
-        AND table_name = ${mainTable}
-        AND column_name = '_status'
-      ) as exists
-    `,
-  })
+  const statusInMainTableCheck = await db.execute(sql`
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name = ${mainTable}
+      AND column_name = '_status'
+    ) as exists
+  `)
 
   if (!statusInMainTableCheck.rows[0]?.exists) {
     // _status column doesn't exist in main table, need to restore it
     // Check if main collection/global has a locales table
-    const mainLocalesTableCheck = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT EXISTS (
-          SELECT FROM information_schema.tables
-          WHERE table_schema = 'public'
-          AND table_name = ${mainLocalesTable}
-        ) as exists
-      `,
-    })
+    const mainLocalesTableCheck = await db.execute(sql`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = ${mainLocalesTable}
+      ) as exists
+    `)
 
     if (mainLocalesTableCheck.rows[0]?.exists) {
       // Locales table exists - check if _status is there
-      const statusInLocalesCheck = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          SELECT EXISTS (
-            SELECT FROM information_schema.columns
-            WHERE table_schema = 'public'
-            AND table_name = ${mainLocalesTable}
-            AND column_name = '_status'
-          ) as exists
-        `,
-      })
+      const statusInLocalesCheck = await db.execute(sql`
+        SELECT EXISTS (
+          SELECT FROM information_schema.columns
+          WHERE table_schema = 'public'
+          AND table_name = ${mainLocalesTable}
+          AND column_name = '_status'
+        ) as exists
+      `)
 
       if (statusInLocalesCheck.rows[0]?.exists) {
         // Add _status back to main table
         payload.logger.info({ msg: `Restoring _status column to ${mainTable}` })
 
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
-          `,
-        })
+        await db.execute(sql`
+          ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
+        `)
 
         // Copy status from default locale back to main table
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            UPDATE ${sql.identifier(mainTable)} m
-            SET _status = l._status
-            FROM ${sql.identifier(mainLocalesTable)} l
-            WHERE m.id = l._parent_id
-            AND l._locale = ${defaultLocale}
-          `,
-        })
+        await db.execute(sql`
+          UPDATE ${sql.identifier(mainTable)} m
+          SET _status = l._status
+          FROM ${sql.identifier(mainLocalesTable)} l
+          WHERE m.id = l._parent_id
+          AND l._locale = ${defaultLocale}
+        `)
 
         // Drop _status from locales table
         payload.logger.info({ msg: `Dropping _status column from ${mainLocalesTable}` })
 
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            ALTER TABLE ${sql.identifier(mainLocalesTable)} DROP COLUMN _status
-          `,
-        })
+        await db.execute(sql`
+          ALTER TABLE ${sql.identifier(mainLocalesTable)} DROP COLUMN _status
+        `)
       }
     } else {
       // No locales table exists - this means collection/global has no localized fields
@@ -202,46 +169,34 @@ export async function down(args: LocalizeStatusArgs): Promise<void> {
         msg: `Restoring _status column to ${mainTable} (no locales table exists)`,
       })
 
-      await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
-        `,
-      })
+      await db.execute(sql`
+        ALTER TABLE ${sql.identifier(mainTable)} ADD COLUMN _status VARCHAR
+      `)
 
       // Set default status based on latest version status for each document
       // Get all documents in the collection
-      const documents = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          SELECT DISTINCT id
-          FROM ${sql.identifier(mainTable)}
-        `,
-      })
+      const documents = await db.execute(sql`
+        SELECT DISTINCT id
+        FROM ${sql.identifier(mainTable)}
+      `)
 
       for (const doc of documents.rows) {
         // Get latest version status for this document
-        const latestVersionStatus = await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            SELECT version__status
-            FROM ${sql.identifier(versionsTable)}
-            WHERE parent_id = ${doc.id}
-            ORDER BY created_at DESC
-            LIMIT 1
-          `,
-        })
+        const latestVersionStatus = await db.execute(sql`
+          SELECT version__status
+          FROM ${sql.identifier(versionsTable)}
+          WHERE parent_id = ${doc.id}
+          ORDER BY created_at DESC
+          LIMIT 1
+        `)
 
         const status = latestVersionStatus.rows[0]?.version__status || 'draft'
 
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
-            UPDATE ${sql.identifier(mainTable)}
-            SET _status = ${status}
-            WHERE id = ${doc.id}
-          `,
-        })
+        await db.execute(sql`
+          UPDATE ${sql.identifier(mainTable)}
+          SET _status = ${status}
+          WHERE id = ${doc.id}
+        `)
       }
 
       payload.logger.info({ msg: `Restored _status for ${documents.rows.length} documents` })

--- a/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainCollection.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainCollection.ts
@@ -26,42 +26,33 @@ export async function migrateMainCollectionStatus({
   payload.logger.info({ msg: `Migrating main collection locales for: ${mainLocalesTable}` })
 
   // Get all documents
-  const documents = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT DISTINCT id
-      FROM ${sql.identifier(mainTable)}
-    `,
-  })
+  const documents = await db.execute(sql`
+    SELECT DISTINCT id
+    FROM ${sql.identifier(mainTable)}
+  `)
 
   for (const doc of documents.rows) {
     // For each locale, get the latest version status
     for (const locale of locales) {
-      const latestVersionStatus = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          SELECT l.version__status as _status
-          FROM ${sql.identifier(versionsTable)} v
-          JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
-          WHERE v.parent_id = ${doc.id}
-          AND l._locale = ${locale}
-          ORDER BY v.created_at DESC
-          LIMIT 1
-        `,
-      })
+      const latestVersionStatus = await db.execute(sql`
+        SELECT l.version__status as _status
+        FROM ${sql.identifier(versionsTable)} v
+        JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
+        WHERE v.parent_id = ${doc.id}
+        AND l._locale = ${locale}
+        ORDER BY v.created_at DESC
+        LIMIT 1
+      `)
 
       const status = latestVersionStatus.rows[0]?._status || 'draft'
 
       // Update the main collection's locales table with this status
-      await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          UPDATE ${sql.identifier(mainLocalesTable)}
-          SET _status = ${status}
-          WHERE _parent_id = ${doc.id}
-          AND _locale = ${locale}
-        `,
-      })
+      await db.execute(sql`
+        UPDATE ${sql.identifier(mainLocalesTable)}
+        SET _status = ${status}
+        WHERE _parent_id = ${doc.id}
+        AND _locale = ${locale}
+      `)
     }
   }
 

--- a/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainGlobal.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/migrateMainGlobal.ts
@@ -27,27 +27,21 @@ export async function migrateMainGlobalStatus({
 
   // For each locale, get the latest version status
   for (const locale of locales) {
-    const latestVersionStatus = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT l.version__status as _status
-        FROM ${sql.identifier(versionsTable)} v
-        JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
-        WHERE l._locale = ${locale}
-        ORDER BY v.created_at DESC
-        LIMIT 1
-      `,
-    })
+    const latestVersionStatus = await db.execute(sql`
+      SELECT l.version__status as _status
+      FROM ${sql.identifier(versionsTable)} v
+      JOIN ${sql.raw(`${versionsTable}_locales`)} l ON l._parent_id = v.id
+      WHERE l._locale = ${locale}
+      ORDER BY v.created_at DESC
+      LIMIT 1
+    `)
 
     const status = latestVersionStatus.rows[0]?._status || 'draft'
 
     // Get the global document ID from the globals table
-    const globalDoc = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT id FROM ${sql.identifier(globalTable)} LIMIT 1
-      `,
-    })
+    const globalDoc = await db.execute(sql`
+      SELECT id FROM ${sql.identifier(globalTable)} LIMIT 1
+    `)
 
     if (globalDoc.rows.length === 0) {
       payload.logger.warn({ msg: `No global document found for ${globalSlug}, skipping` })
@@ -57,15 +51,12 @@ export async function migrateMainGlobalStatus({
     const globalId = globalDoc.rows[0].id
 
     // Update the global's locales table with this status
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        UPDATE ${sql.identifier(globalLocalesTable)}
-        SET _status = ${status}
-        WHERE _parent_id = ${globalId}
-        AND _locale = ${locale}
-      `,
-    })
+    await db.execute(sql`
+      UPDATE ${sql.identifier(globalLocalesTable)}
+      SET _status = ${status}
+      WHERE _parent_id = ${globalId}
+      AND _locale = ${locale}
+    `)
   }
 
   payload.logger.info({ msg: 'Migrated global document' })

--- a/packages/payload/src/versions/migrations/localizeStatus/sql/up.ts
+++ b/packages/payload/src/versions/migrations/localizeStatus/sql/up.ts
@@ -79,17 +79,14 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // Validate that version__status column exists before proceeding
-  const columnCheckResult = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
+  const columnCheckResult = await db.execute(sql`
       SELECT EXISTS (
         SELECT FROM information_schema.columns
         WHERE table_schema = 'public'
         AND table_name = ${versionsTable}
         AND column_name = 'version__status'
       ) as exists
-    `,
-  })
+    `)
 
   if (!columnCheckResult.rows[0]?.exists) {
     throw new Error(
@@ -100,16 +97,13 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // 1. Check if the locales table exists
-  const localesTableCheckResult = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
+  const localesTableCheckResult = await db.execute(sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public'
         AND table_name = ${localesTable}
       ) as exists
-    `,
-  })
+    `)
 
   const localesTableExists = localesTableCheckResult.rows[0]?.exists
 
@@ -117,9 +111,7 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
     // SCENARIO 1: Create the locales table (first localized field in versions)
     payload.logger.info({ msg: `Creating new locales table: ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    await db.execute(sql`
         CREATE TABLE ${sql.identifier(localesTable)} (
           id SERIAL PRIMARY KEY,
           _locale VARCHAR NOT NULL,
@@ -128,63 +120,50 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
           UNIQUE(_locale, _parent_id),
           FOREIGN KEY (_parent_id) REFERENCES ${sql.identifier(versionsTable)}(id) ON DELETE CASCADE
         )
-      `,
-    })
+      `)
 
     // Create one row per locale per version record
     // Simple approach: copy the same status to all locales
     for (const locale of locales) {
-      const inserted = await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
+      const inserted = await db.execute(sql`
           INSERT INTO ${sql.identifier(localesTable)} (_locale, _parent_id, version__status)
           SELECT ${locale}, id, version__status
           FROM ${sql.identifier(versionsTable)}
           RETURNING id
-        `,
-      })
+        `)
       payload.logger.info({
-        msg: `Inserted ${inserted.length} rows for locale: ${locale}`,
+        msg: `Inserted ${inserted.rows.length} rows for locale: ${locale}`,
       })
     }
   } else {
     // SCENARIO 2: Add version__status column to existing locales table
     payload.logger.info({ msg: `Adding version__status column to existing table: ${localesTable}` })
 
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    await db.execute(sql`
         ALTER TABLE ${sql.identifier(localesTable)} ADD COLUMN version__status VARCHAR
-      `,
-    })
+      `)
 
     // INTELLIGENT DATA MIGRATION using historical publishedLocale data
     payload.logger.info({ msg: 'Processing version history to determine status per locale...' })
 
     // First, get the list of locales that actually exist in the locales table
     // This is important because the config may have more locales defined than what's in the OLD schema
-    const existingLocalesResult = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    const existingLocalesResult = await db.execute(sql`
         SELECT DISTINCT _locale
         FROM ${sql.identifier(localesTable)}
         ORDER BY _locale
-      `,
-    })
+      `)
     const existingLocales = existingLocalesResult.rows.map((row: any) => row._locale as string)
     payload.logger.info({
       msg: `Found existing locales in table: ${existingLocales.join(', ')}`,
     })
 
     // Get all version records grouped by parent document, ordered chronologically
-    const versionsResult = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
+    const versionsResult = await db.execute(sql`
         SELECT id, parent_id as parent, version__status as _status, published_locale, snapshot, created_at
         FROM ${sql.identifier(versionsTable)}
         ORDER BY parent_id, created_at ASC
-      `,
-    })
+      `)
 
     // Use shared function to calculate version locale statuses
     // Only process locales that actually exist in the locales table
@@ -200,15 +179,12 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
     let updateCount = 0
     for (const [versionId, localeMap] of versionLocaleStatus.entries()) {
       for (const [locale, status] of localeMap.entries()) {
-        await db.execute({
-          drizzle: db.drizzle,
-          sql: sql`
+        await db.execute(sql`
             UPDATE ${sql.identifier(localesTable)}
             SET version__status = ${status}
             WHERE _parent_id = ${versionId}
             AND _locale = ${locale}
-          `,
-        })
+          `)
         updateCount++
       }
     }
@@ -217,12 +193,9 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // 3. Drop the old version__status column from main versions table
-  await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      ALTER TABLE ${sql.identifier(versionsTable)} DROP COLUMN version__status
-    `,
-  })
+  await db.execute(sql`
+    ALTER TABLE ${sql.identifier(versionsTable)} DROP COLUMN version__status
+  `)
 
   // 4. Create and populate _status column in main collection/global locales table
   // With localizeStatus enabled, _status is a localized field stored in the collection's locales table
@@ -230,40 +203,31 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   const mainTable = collectionSlug ? toSnakeCase(collectionSlug) : toSnakeCase(globalSlug!)
   const mainLocalesTable = `${mainTable}_locales`
 
-  const localesTableCheck = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.tables
-        WHERE table_schema = 'public'
-        AND table_name = ${mainLocalesTable}
-      ) as exists
-    `,
-  })
+  const localesTableCheck = await db.execute(sql`
+    SELECT EXISTS (
+      SELECT FROM information_schema.tables
+      WHERE table_schema = 'public'
+      AND table_name = ${mainLocalesTable}
+    ) as exists
+  `)
 
   if (localesTableCheck.rows[0]?.exists) {
     // Check if _status column already exists in the locales table
-    const statusColumnCheck = await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        SELECT EXISTS (
-          SELECT FROM information_schema.columns
-          WHERE table_schema = 'public'
-          AND table_name = ${mainLocalesTable}
-          AND column_name = '_status'
-        ) as exists
-      `,
-    })
+    const statusColumnCheck = await db.execute(sql`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+        AND table_name = ${mainLocalesTable}
+        AND column_name = '_status'
+      ) as exists
+    `)
 
     if (!statusColumnCheck.rows[0]?.exists) {
       // Add _status column to locales table
-      await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`
-          ALTER TABLE ${sql.identifier(mainLocalesTable)}
-          ADD COLUMN _status VARCHAR DEFAULT 'draft'
-        `,
-      })
+      await db.execute(sql`
+        ALTER TABLE ${sql.identifier(mainLocalesTable)}
+        ADD COLUMN _status VARCHAR DEFAULT 'draft'
+      `)
     }
 
     // Now populate the _status values from the latest version
@@ -286,25 +250,19 @@ export async function up(args: LocalizeStatusArgs): Promise<void> {
   }
 
   // 5. Drop _status from main table if it exists (it will be in locales table now)
-  const mainTableStatusCheck = await db.execute({
-    drizzle: db.drizzle,
-    sql: sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.columns
-        WHERE table_schema = 'public'
-        AND table_name = ${mainTable}
-        AND column_name = '_status'
-      ) as exists
-    `,
-  })
+  const mainTableStatusCheck = await db.execute(sql`
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name = ${mainTable}
+      AND column_name = '_status'
+    ) as exists
+  `)
 
   if (mainTableStatusCheck.rows[0]?.exists) {
-    await db.execute({
-      drizzle: db.drizzle,
-      sql: sql`
-        ALTER TABLE ${sql.identifier(mainTable)} DROP COLUMN _status
-      `,
-    })
+    await db.execute(sql`
+      ALTER TABLE ${sql.identifier(mainTable)} DROP COLUMN _status
+    `)
   }
 
   payload.logger.info({ msg: 'Migration completed successfully' })

--- a/packages/payload/src/versions/types.ts
+++ b/packages/payload/src/versions/types.ts
@@ -41,10 +41,10 @@ export type IncomingDrafts = {
   /**
    * Localizes the status field.
    *
-   * Only effective if the experimental `experimental.localizeStatus` is enabled.
+   * When enabled, each locale tracks its own draft/published status independently.
+   * Requires `localization` to be enabled in Payload config.
    *
-   * @experimental
-   * @default false
+   * @default true
    */
   localizeStatus?: boolean
   /**
@@ -68,10 +68,10 @@ export type SanitizedDrafts = {
   /**
    * Localizes the status field.
    *
-   * Only effective if the experimental `experimental.localizeStatus` is enabled.
+   * When enabled, each locale tracks its own draft/published status independently.
+   * Requires `localization` to be enabled in Payload config.
    *
-   * @experimental
-   * @default false
+   * @default true
    */
   localizeStatus?: boolean
   /**

--- a/packages/ui/src/elements/UnpublishButton/index.tsx
+++ b/packages/ui/src/elements/UnpublishButton/index.tsx
@@ -172,11 +172,8 @@ export function UnpublishButton({
       return false
     }
 
-    const isLocalizeStatusEnabled = drafts && drafts.localizeStatus === true
-    const isExperimentalEnabled = config.experimental?.localizeStatus === true
-
-    return isLocalizeStatusEnabled && isExperimentalEnabled
-  }, [canUnpublish, hasLocalizedFields, drafts, config.experimental?.localizeStatus])
+    return drafts !== null && drafts !== undefined && drafts.localizeStatus === true
+  }, [canUnpublish, hasLocalizedFields, drafts])
 
   const label = getTranslation(localeLabel, i18n)
 

--- a/test/localization/collections/LocalizedDrafts/index.ts
+++ b/test/localization/collections/LocalizedDrafts/index.ts
@@ -5,9 +5,7 @@ import { localizedDraftsSlug } from '../../shared.js'
 export const LocalizedDrafts: CollectionConfig = {
   slug: localizedDraftsSlug,
   versions: {
-    drafts: {
-      localizeStatus: false,
-    },
+    drafts: true,
   },
   fields: [
     {

--- a/test/localization/collections/LocalizedDrafts/index.ts
+++ b/test/localization/collections/LocalizedDrafts/index.ts
@@ -5,7 +5,9 @@ import { localizedDraftsSlug } from '../../shared.js'
 export const LocalizedDrafts: CollectionConfig = {
   slug: localizedDraftsSlug,
   versions: {
-    drafts: true,
+    drafts: {
+      localizeStatus: false,
+    },
   },
   fields: [
     {

--- a/test/localization/collections/LocalizedDraftsNoLocaleStatus/index.ts
+++ b/test/localization/collections/LocalizedDraftsNoLocaleStatus/index.ts
@@ -1,0 +1,19 @@
+import type { CollectionConfig } from 'payload'
+
+import { localizedDraftsNoLocaleStatusSlug } from '../../shared.js'
+
+export const LocalizedDraftsNoLocaleStatus: CollectionConfig = {
+  slug: localizedDraftsNoLocaleStatusSlug,
+  versions: {
+    drafts: {
+      localizeStatus: false,
+    },
+  },
+  fields: [
+    {
+      type: 'text',
+      name: 'title',
+      localized: true,
+    },
+  ],
+}

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -15,6 +15,7 @@ import { BlocksCollection } from './collections/Blocks/index.js'
 import { Group } from './collections/Group/index.js'
 import { LocalizedDateFields } from './collections/LocalizedDateFields/index.js'
 import { LocalizedDrafts } from './collections/LocalizedDrafts/index.js'
+import { LocalizedDraftsNoLocaleStatus } from './collections/LocalizedDraftsNoLocaleStatus/index.js'
 import { LocalizedWithinLocalized } from './collections/LocalizedWithinLocalized/index.js'
 import { NestedArray } from './collections/NestedArray/index.js'
 import { NestedFields } from './collections/NestedFields/index.js'
@@ -64,15 +65,13 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  experimental: {
-    localizeStatus: true,
-  },
   collections: [
     RichTextCollection,
     BlocksCollection,
     NestedArray,
     NestedFields,
     LocalizedDrafts,
+    LocalizedDraftsNoLocaleStatus,
     LocalizedDateFields,
     AllFieldsLocalized,
     {

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -46,6 +46,7 @@ import {
   hungarianLocale,
   localeRestrictedSlug,
   localizedDraftsSlug,
+  localizedDraftsNoLocaleStatusSlug,
   localizedPostsSlug,
   relationshipLocalizedSlug,
   spanishLocale,
@@ -70,6 +71,7 @@ let urlWithRequiredLocalizedFields: AdminUrlUtil
 let urlRelationshipLocalized: AdminUrlUtil
 let urlCannotCreateDefaultLocale: AdminUrlUtil
 let urlPostsWithDrafts: AdminUrlUtil
+let urlPostsWithDraftsNoLocaleStatus: AdminUrlUtil
 let urlArray: AdminUrlUtil
 let arrayWithFallbackURL: AdminUrlUtil
 let noLocalizedFieldsURL: AdminUrlUtil
@@ -100,6 +102,7 @@ describe('Localization', () => {
     urlWithRequiredLocalizedFields = new AdminUrlUtil(serverURL, withRequiredLocalizedFields)
     urlCannotCreateDefaultLocale = new AdminUrlUtil(serverURL, 'cannot-create-default-locale')
     urlPostsWithDrafts = new AdminUrlUtil(serverURL, localizedDraftsSlug)
+    urlPostsWithDraftsNoLocaleStatus = new AdminUrlUtil(serverURL, localizedDraftsNoLocaleStatusSlug)
     urlArray = new AdminUrlUtil(serverURL, arrayCollectionSlug)
     arrayWithFallbackURL = new AdminUrlUtil(serverURL, arrayWithFallbackCollectionSlug)
     noLocalizedFieldsURL = new AdminUrlUtil(serverURL, noLocalizedFieldsCollectionSlug)
@@ -846,7 +849,7 @@ describe('Localization', () => {
       })
 
       test('should not show unpublish in specific locale when localizeStatus is not enabled', async () => {
-        await page.goto(urlPostsWithDrafts.create)
+        await page.goto(urlPostsWithDraftsNoLocaleStatus.create)
         await page.locator('#field-title').fill('EN Published')
         await saveDocAndAssert(page, '#publish-locale')
         await openDocControls(page)

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -19,6 +19,7 @@ export const withRequiredLocalizedFields = 'localized-required'
 export const localizedSortSlug = 'localized-sort'
 
 export const localizedDraftsSlug = 'localized-drafts'
+export const localizedDraftsNoLocaleStatusSlug = 'localized-drafts-no-locale-status'
 export const usersSlug = 'users'
 export const blocksWithLocalizedSameName = 'blocks-same-name'
 export const cannotCreateDefaultLocale = 'cannot-create-default-locale'

--- a/test/versions/collections/Autosave.ts
+++ b/test/versions/collections/Autosave.ts
@@ -18,6 +18,7 @@ const AutosavePosts: CollectionConfig = {
       autosave: {
         interval: 100,
       },
+      localizeStatus: false,
       schedulePublish: true,
     },
   },

--- a/test/versions/collections/AutosaveWithMultiSelect.ts
+++ b/test/versions/collections/AutosaveWithMultiSelect.ts
@@ -9,6 +9,7 @@ const AutosaveWithMultiSelectPosts: CollectionConfig = {
       autosave: {
         interval: 2000,
       },
+      localizeStatus: false,
     },
   },
   fields: [

--- a/test/versions/collections/Diff/index.ts
+++ b/test/versions/collections/Diff/index.ts
@@ -376,7 +376,9 @@ export const Diff: CollectionConfig = {
     },
   ],
   versions: {
-    drafts: true,
+    drafts: {
+      localizeStatus: false,
+    },
     maxPerDoc: 35,
   },
 }

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -130,6 +130,7 @@ const DraftPosts: CollectionConfig = {
   ],
   versions: {
     drafts: {
+      localizeStatus: false,
       schedulePublish: {
         timeFormat: 'HH:mm',
       },

--- a/test/versions/collections/DraftsWithChangeHook.ts
+++ b/test/versions/collections/DraftsWithChangeHook.ts
@@ -37,6 +37,7 @@ const DraftWithChangeHookPosts: CollectionConfig = {
   ],
   versions: {
     drafts: {
+      localizeStatus: false,
       schedulePublish: {
         timeFormat: 'HH:mm',
       },

--- a/test/versions/collections/DraftsWithMax.ts
+++ b/test/versions/collections/DraftsWithMax.ts
@@ -113,7 +113,9 @@ const DraftWithMaxPosts: CollectionConfig = {
     },
   ],
   versions: {
-    drafts: true,
+    drafts: {
+      localizeStatus: false,
+    },
     maxPerDoc: 1,
   },
 }

--- a/test/versions/collections/Localized.ts
+++ b/test/versions/collections/Localized.ts
@@ -5,7 +5,9 @@ import { localizedCollectionSlug } from '../slugs.js'
 const LocalizedPosts: CollectionConfig = {
   slug: localizedCollectionSlug,
   versions: {
-    drafts: true,
+    drafts: {
+      localizeStatus: false,
+    },
   },
   fields: [
     {

--- a/test/versions/globals/Autosave.ts
+++ b/test/versions/globals/Autosave.ts
@@ -38,6 +38,7 @@ const AutosaveGlobal: GlobalConfig = {
   versions: {
     drafts: {
       autosave: true,
+      localizeStatus: false,
     },
     max: 20,
   },

--- a/test/versions/globals/AutosaveWithDraftButton.ts
+++ b/test/versions/globals/AutosaveWithDraftButton.ts
@@ -19,6 +19,7 @@ const AutosaveWithDraftButtonGlobal: GlobalConfig = {
         showSaveDraftButton: true,
         interval: 1000,
       },
+      localizeStatus: false,
     },
   },
 }

--- a/test/versions/globals/Draft.ts
+++ b/test/versions/globals/Draft.ts
@@ -23,6 +23,7 @@ const DraftGlobal: GlobalConfig = {
   versions: {
     max: 20,
     drafts: {
+      localizeStatus: false,
       schedulePublish: true,
     },
   },

--- a/test/versions/globals/DraftUnlimited.ts
+++ b/test/versions/globals/DraftUnlimited.ts
@@ -23,6 +23,7 @@ const DraftUnlimitedGlobal: GlobalConfig = {
   versions: {
     max: 0,
     drafts: {
+      localizeStatus: false,
       schedulePublish: true,
     },
   },

--- a/test/versions/globals/DraftWithMax.ts
+++ b/test/versions/globals/DraftWithMax.ts
@@ -21,7 +21,9 @@ const DraftWithMaxGlobal: GlobalConfig = {
   },
   versions: {
     max: 1,
-    drafts: true,
+    drafts: {
+      localizeStatus: false,
+    },
   },
   access: {
     read: ({ req: { user } }) => {

--- a/test/versions/globals/LocalizedGlobal.ts
+++ b/test/versions/globals/LocalizedGlobal.ts
@@ -17,7 +17,9 @@ const LocalizedGlobal: GlobalConfig = {
     },
   ],
   versions: {
-    drafts: true,
+    drafts: {
+      localizeStatus: false,
+    },
   },
 }
 


### PR DESCRIPTION
Makes `localizeStatus` default to `true` for any localized collection or global with drafts enabled. The experimental flag that previously gated the feature is removed — users can now opt out per-collection/global by setting `versions.drafts.localizeStatus: false`.

Also fixes a broken Postgres migration that shipped with the original feature (#14667): all `db.execute` calls used the wrong signature (`db.execute({ drizzle: db.drizzle, sql })`) when `db` is the raw Drizzle instance — correct call is `db.execute(sql\`...\`)`. Fixes `inserted.length` → `inserted.rows.length` in the same file.

## Breaking Changes

Any localized collection or global with drafts enabled will now have `localizeStatus: true` by default. Users who opted in via `experimental.localizeStatus` need to remove that flag. Users who do **not** want per-locale status must explicitly opt out.

```diff
 export default buildConfig({
-  experimental: {
-    localizeStatus: true,
-  },
   collections: [
     {
       slug: 'posts',
       versions: { drafts: true },
+      // localizeStatus is now true by default — opt out if needed:
+      // versions: { drafts: { localizeStatus: false } },
     },
   ],
 })
```

#### Codemod

To remove `experimental.localizeStatus` automatically:

```bash
npx @payloadcms/codemod --transform migrate-localize-status
```

Related: https://github.com/payloadcms/payload/pull/16889 (PG migration bug fix back-ported to 3.x)