### PR TITLE
test: deflake sort e2e against prod cold start

### DIFF
--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../__helpers/shared/sdk/index.js'
 import type { Config } from './payload-types.js'
 
+import { goToListDoc } from '../__helpers/e2e/goToListDoc.js'
 import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
@@ -127,13 +128,18 @@ describe('Sort functionality', () => {
 
   test('Orderable join fields', async () => {
     const url = new AdminUrlUtil(serverURL, orderableJoinSlug)
-    await page.goto(url.list)
 
-    await page.getByText('Join A').click()
+    // Navigate via the row's href + hard `page.goto` instead of a soft Next.js
+    // navigation. Under `--prod`, the edit route compiles lazily on first hit and
+    // the soft navigation's URL only updates after the RSC payload arrives, which
+    // can stall past the test timeout on a cold CI server.
+    await goToListDoc({
+      page,
+      cellClass: '.cell-title',
+      textToMatch: 'Join A',
+      urlUtil: url,
+    })
 
-    // The first hit to the edit route compiles lazily under `--prod`, which can
-    // exceed the default navigation timeout on a cold CI server.
-    await page.waitForURL(new RegExp(`${orderableJoinSlug}/`), { timeout: TEST_TIMEOUT_LONG })
     await scrollEntirePage(page)
 
     await expect(page.locator('button.sort-header')).toHaveCount(3)

--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -51,16 +51,22 @@ describe('Sort functionality', () => {
   test.beforeEach(async () => {
     // await throttleTest({ page, context, delay: 'Fast 4G' })
 
-    const seedResponsePromise = page.waitForResponse(
-      (response) => response.url().includes('/api/seed') && response.status() === 200,
-    )
-
-    await page.evaluate(async () => {
-      const response = await fetch('/api/seed', { method: 'POST' })
-      return response.json()
-    })
-
-    await seedResponsePromise
+    // The prod server may still be cold-starting in CI, so the first requests can
+    // be refused (`fetch failed`). Poll the seed endpoint until it responds 200.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async () => {
+            try {
+              const response = await fetch('/api/seed', { method: 'POST' })
+              return response.status
+            } catch {
+              return 0
+            }
+          }),
+        { timeout: TEST_TIMEOUT_LONG },
+      )
+      .toBe(200)
   })
 
   // eslint-disable-next-line playwright/expect-expect
@@ -125,7 +131,9 @@ describe('Sort functionality', () => {
 
     await page.getByText('Join A').click()
 
-    await page.waitForURL(new RegExp(`${orderableJoinSlug}/`))
+    // The first hit to the edit route compiles lazily under `--prod`, which can
+    // exceed the default navigation timeout on a cold CI server.
+    await page.waitForURL(new RegExp(`${orderableJoinSlug}/`), { timeout: TEST_TIMEOUT_LONG })
     await scrollEntirePage(page)
 
     await expect(page.locator('button.sort-header')).toHaveCount(3)


### PR DESCRIPTION
### What

Deflakes the `sort` e2e suite, which intermittently failed in CI under `--prod`.

### Why

Two failures both stemmed from the prod server cold-starting in CI:

- `beforeEach` fired `fetch('/api/seed')` with no readiness guard, throwing `TypeError: fetch failed` against a not-yet-bound port (instant `0ms` failures).
- "Orderable join fields" clicked the row and waited via a soft Next.js navigation. The App Router only updates the URL after the edit route's RSC payload resolves, so a cold lazy route compile left `waitForURL` hanging until the test timed out.

### Changes

- Poll `/api/seed` until it returns `200` (bounded by `TEST_TIMEOUT_LONG`) instead of a single unguarded fetch.
- Navigate to the join doc via `goToListDoc` (reads the row href + hard `page.goto` + `networkidle`) instead of a soft click, forcing the lazy prod route compile to complete deterministically.

No assertions changed.
