### PR TITLE
templates: add mcp, localization, and folders/tags to blank template

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1814,6 +1814,9 @@ importers:
       '@payloadcms/next':
         specifier: workspace:*
         version: link:../../packages/next
+      '@payloadcms/plugin-mcp':
+        specifier: workspace:*
+        version: link:../../packages/plugin-mcp
       '@payloadcms/richtext-lexical':
         specifier: workspace:*
         version: link:../../packages/richtext-lexical

--- a/templates/blank/eslint.config.mjs
+++ b/templates/blank/eslint.config.mjs
@@ -1,16 +1,9 @@
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+import nextTypescript from 'eslint-config-next/typescript'
 
 const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     rules: {
       '@typescript-eslint/ban-ts-comment': 'warn',

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@payloadcms/db-mongodb": "workspace:*",
     "@payloadcms/next": "workspace:*",
+    "@payloadcms/plugin-mcp": "workspace:*",
     "@payloadcms/richtext-lexical": "workspace:*",
     "@payloadcms/ui": "workspace:*",
     "cross-env": "10.1.0",

--- a/templates/blank/src/app/(payload)/admin/importMap.js
+++ b/templates/blank/src/app/(payload)/admin/importMap.js
@@ -1,6 +1,8 @@
-import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
+import { AccessField as AccessField_210e1789eef737e0b4d9f054258f19bb } from '@payloadcms/plugin-mcp/client'
+import { CollectionCards as CollectionCards_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
 
 /** @type import('payload').ImportMap */
 export const importMap = {
-  '@payloadcms/next/rsc#CollectionCards': CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1,
+  '@payloadcms/plugin-mcp/client#AccessField': AccessField_210e1789eef737e0b4d9f054258f19bb,
+  '@payloadcms/ui/rsc#CollectionCards': CollectionCards_ab83ff7e88da8d3530831f296ec4756a,
 }

--- a/templates/blank/src/app/(payload)/admin/importMap.js
+++ b/templates/blank/src/app/(payload)/admin/importMap.js
@@ -1,8 +1,21 @@
+import { NullField as NullField_3817bf644402e67bfe6577f60ef982de } from '@payloadcms/ui'
+import { HierarchyField as HierarchyField_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
+import { HierarchyButton as HierarchyButton_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
 import { AccessField as AccessField_210e1789eef737e0b4d9f054258f19bb } from '@payloadcms/plugin-mcp/client'
+import { FolderIcon as FolderIcon_3817bf644402e67bfe6577f60ef982de } from '@payloadcms/ui'
+import { HierarchySidebarTabServer as HierarchySidebarTabServer_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
+import { TagIcon as TagIcon_3817bf644402e67bfe6577f60ef982de } from '@payloadcms/ui'
 import { CollectionCards as CollectionCards_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
 
 /** @type import('payload').ImportMap */
 export const importMap = {
+  '@payloadcms/ui#NullField': NullField_3817bf644402e67bfe6577f60ef982de,
+  '@payloadcms/ui/rsc#HierarchyField': HierarchyField_ab83ff7e88da8d3530831f296ec4756a,
+  '@payloadcms/ui/rsc#HierarchyButton': HierarchyButton_ab83ff7e88da8d3530831f296ec4756a,
   '@payloadcms/plugin-mcp/client#AccessField': AccessField_210e1789eef737e0b4d9f054258f19bb,
+  '@payloadcms/ui#FolderIcon': FolderIcon_3817bf644402e67bfe6577f60ef982de,
+  '@payloadcms/ui/rsc#HierarchySidebarTabServer':
+    HierarchySidebarTabServer_ab83ff7e88da8d3530831f296ec4756a,
+  '@payloadcms/ui#TagIcon': TagIcon_3817bf644402e67bfe6577f60ef982de,
   '@payloadcms/ui/rsc#CollectionCards': CollectionCards_ab83ff7e88da8d3530831f296ec4756a,
 }

--- a/templates/blank/src/collections/Folders.ts
+++ b/templates/blank/src/collections/Folders.ts
@@ -1,0 +1,16 @@
+import type { CollectionConfig } from 'payload'
+
+export const Folders: CollectionConfig = {
+  slug: 'folders',
+  admin: {
+    useAsTitle: 'name',
+  },
+  folders: true,
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/templates/blank/src/collections/Media.ts
+++ b/templates/blank/src/collections/Media.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { createFolderField, createTagField } from 'payload'
+
 export const Media: CollectionConfig = {
   slug: 'media',
   access: {
@@ -11,6 +13,8 @@ export const Media: CollectionConfig = {
       type: 'text',
       required: true,
     },
+    createFolderField({ relationTo: 'folders' }),
+    createTagField({ relationTo: 'tags' }),
   ],
   upload: true,
 }

--- a/templates/blank/src/collections/Tags.ts
+++ b/templates/blank/src/collections/Tags.ts
@@ -1,0 +1,16 @@
+import type { CollectionConfig } from 'payload'
+
+export const Tags: CollectionConfig = {
+  slug: 'tags',
+  admin: {
+    useAsTitle: 'name',
+  },
+  tags: true,
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/templates/blank/src/payload-types.ts
+++ b/templates/blank/src/payload-types.ts
@@ -70,6 +70,8 @@ export interface Config {
   collections: {
     users: User;
     media: Media;
+    folders: Folder;
+    tags: Tag;
     'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -80,6 +82,8 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    folders: FoldersSelect<false> | FoldersSelect<true>;
+    tags: TagsSelect<false> | TagsSelect<true>;
     'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -170,6 +174,8 @@ export interface User {
 export interface Media {
   id: string;
   alt: string;
+  _h_folders?: (string | null) | Folder;
+  _h_tags?: (string | Tag)[] | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -181,6 +187,32 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "folders".
+ */
+export interface Folder {
+  id: string;
+  _h_folders?: (string | null) | Folder;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
+  _h_slugPath?: string | null;
+  _h_titlePath?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags".
+ */
+export interface Tag {
+  id: string;
+  _h_tags?: (string | null) | Tag;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
+  _h_slugPath?: string | null;
+  _h_titlePath?: string | null;
 }
 /**
  * API keys control which collections, resources, tools, and prompts MCP clients can access
@@ -256,6 +288,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media';
         value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'folders';
+        value: string | Folder;
+      } | null)
+    | ({
+        relationTo: 'tags';
+        value: string | Tag;
       } | null)
     | ({
         relationTo: 'payload-mcp-api-keys';
@@ -341,6 +381,8 @@ export interface UsersSelect<T extends boolean = true> {
  */
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
+  _h_folders?: T;
+  _h_tags?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;
@@ -352,6 +394,30 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "folders_select".
+ */
+export interface FoldersSelect<T extends boolean = true> {
+  _h_folders?: T;
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _h_slugPath?: T;
+  _h_titlePath?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags_select".
+ */
+export interface TagsSelect<T extends boolean = true> {
+  _h_tags?: T;
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _h_slugPath?: T;
+  _h_titlePath?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/templates/blank/src/payload-types.ts
+++ b/templates/blank/src/payload-types.ts
@@ -64,11 +64,13 @@ export type SupportedTimezones =
 export interface Config {
   auth: {
     users: UserAuthOperations;
+    'payload-mcp-api-keys': PayloadMcpApiKeyAuthOperations;
   };
   blocks: {};
   collections: {
     users: User;
     media: Media;
+    'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -78,6 +80,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -86,20 +89,38 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
-  fallbackLocale: null;
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | 'en' | 'en'[];
   globals: {};
   globalsSelect: {};
-  locale: null;
+  locale: 'en';
   widgets: {
     collections: CollectionsWidget;
   };
-  user: User;
+  user: User | PayloadMcpApiKey;
   jobs: {
     tasks: unknown;
     workflows: unknown;
   };
 }
 export interface UserAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface PayloadMcpApiKeyAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -162,6 +183,49 @@ export interface Media {
   focalY?: number | null;
 }
 /**
+ * API keys control which collections, resources, tools, and prompts MCP clients can access
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-mcp-api-keys".
+ */
+export interface PayloadMcpApiKey {
+  id: string;
+  /**
+   * The user that the API key is associated with.
+   */
+  user: string | User;
+  /**
+   * A useful label for the API key.
+   */
+  label?: string | null;
+  /**
+   * The purpose of the API key.
+   */
+  description?: string | null;
+  /**
+   * When checked, this key bypasses Payload access control on every operation it performs. Leave unchecked unless you have a specific reason.
+   */
+  overrideAccess?: boolean | null;
+  /**
+   * Access for this API key — uncheck to revoke individual tools.
+   */
+  access?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
+  collection: 'payload-mcp-api-keys';
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -192,12 +256,21 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media';
         value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
       } | null);
   globalSlug?: string | null;
-  user: {
-    relationTo: 'users';
-    value: string | User;
-  };
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
+      };
   updatedAt: string;
   createdAt: string;
 }
@@ -207,10 +280,15 @@ export interface PayloadLockedDocument {
  */
 export interface PayloadPreference {
   id: string;
-  user: {
-    relationTo: 'users';
-    value: string | User;
-  };
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
+      };
   key?: string | null;
   value?:
     | {
@@ -274,6 +352,22 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-mcp-api-keys_select".
+ */
+export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
+  user?: T;
+  label?: T;
+  description?: T;
+  overrideAccess?: T;
+  access?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/templates/blank/src/payload.config.ts
+++ b/templates/blank/src/payload.config.ts
@@ -1,4 +1,5 @@
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { mcpPlugin } from '@payloadcms/plugin-mcp'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import path from 'path'
 import { buildConfig } from 'payload'
@@ -28,5 +29,10 @@ export default buildConfig({
     url: process.env.DATABASE_URL || '',
   }),
   sharp,
-  plugins: [],
+  localization: {
+    locales: ['en'],
+    fallback: true,
+    defaultLocale: 'en',
+  },
+  plugins: [mcpPlugin({})],
 })

--- a/templates/blank/src/payload.config.ts
+++ b/templates/blank/src/payload.config.ts
@@ -8,6 +8,8 @@ import sharp from 'sharp'
 
 import { Users } from './collections/Users'
 import { Media } from './collections/Media'
+import { Folders } from './collections/Folders'
+import { Tags } from './collections/Tags'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -19,7 +21,7 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media],
+  collections: [Users, Media, Folders, Tags],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {


### PR DESCRIPTION
# Overview

Updates the `blank` template to ship with the MCP plugin, single-locale (`en`) localization, and folder/tag hierarchy collections by default, so new projects start with these capabilities pre-wired.

## Key Changes

- **MCP plugin enabled by default**
  - Adds `@payloadcms/plugin-mcp` and registers `mcpPlugin({})`, which exposes default CRUD tools at `/api/mcp` and auto-creates the `payload-mcp-api-keys` collection.

- **Localization turned on with `en`**
  - Configures `localization` with `en` as the only locale and default, giving new projects a working localization setup to extend.

- **Folder and tag collections**
  - Adds a `Folders` collection (`folders: true`) and a `Tags` collection (`tags: true`), and wires `Media` into both via `createFolderField` and `createTagField`.

- **ESLint flat-config migration**
  - Replaces the `FlatCompat` bridge in `eslint.config.mjs` with direct flat-config imports from `eslint-config-next`, and drops the now-unused `@eslint/eslintrc` dependency.

## Design Decisions

Folders and tags are implemented as collection-level hierarchy presets (`folders: true` / `tags: true` plus `createFolderField`/`createTagField`), not a global config. This matches the hierarchy API the branch actually ships; the global `folders` config in the docs no longer exists here.

The ESLint change was required, not cosmetic. The Next 16 bump made `eslint-config-next` a flat config containing circular plugin objects (eslint-plugin-react). Consuming it through `FlatCompat.extends()` routes those objects through the legacy eslintrc validator, which `JSON.stringify`s them and crashes with "Converting circular structure to JSON". Importing the flat config directly bypasses the validator and lets lint (and the pre-commit hook) pass.

The same `FlatCompat` breakage affects the other templates (`_template`, `website`, `ecommerce`, and the `with-*` variants). This PR fixes `blank` only; the broader migration is left as a follow-up.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214712003157146