### PR TITLE
fix(db-postgres): release connection back to pool in connectWithReconnect

### DIFF
--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -42,6 +42,7 @@ const connectWithReconnect = async function ({
       // swallow error
     }
   })
+  result.release()
 }
 
 export const connect: Connect = async function connect(


### PR DESCRIPTION
## Description

The \connectWithReconnect\ function calls \pool.connect()\ to check out a client from the connection pool, attaches an error listener to detect ECONNRESET errors, but never calls \esult.release()\ to return the client back to the pool.

This results in a connection leak where every invocation permanently holds a connection from the pool, eventually causing pool exhaustion.

## Fix

Added \esult.release()\ after attaching the error listener. The listener remains active on the pooled connection, so ECONNRESET detection still works when the connection is checked out for actual queries.

Fixes #16772 (connection leak portion)