### PR TITLE
fix(drizzle): allow unicode characters in JSON query values

### DIFF
--- a/packages/drizzle/src/utilities/escapeSQLValue.ts
+++ b/packages/drizzle/src/utilities/escapeSQLValue.ts
@@ -1,6 +1,6 @@
 import { APIError } from 'payload'
 
-export const SAFE_STRING_REGEX = /^[\w @.\-+:]*$/
+export const SAFE_STRING_REGEX = /^[\p{L}\p{N}\s @.\-+:_]*$/u
 
 export const escapeSQLValue = (value: unknown): boolean | null | number | string => {
   if (value === null) {


### PR DESCRIPTION
## Description

The \SAFE_STRING_REGEX\ was using \\\w\ which only matches ASCII \[a-zA-Z0-9_]\, blocking any non-ASCII characters (CJK, accented Latin, emoji, etc.) in JSON field queries.

## Fix

Changed to use \\\p{L}\ (Unicode letter) and \\\p{N}\ (Unicode number) with the \/u\ flag, which allows international text while still blocking SQL metacharacters.

Fixes #16401