### PR TITLE
test: align MCP plugin codegen eval with plugin-mcp tools config API

### DIFF
--- a/test/evals/datasets/plugins/official/codegen.ts
+++ b/test/evals/datasets/plugins/official/codegen.ts
@@ -53,7 +53,7 @@ export const pluginsOfficialCodegenDataset: CodegenEvalCase[] = [
     input:
       'Add the MCP plugin from "@payloadcms/plugin-mcp" to the config. Enable find and create operations for the "posts" collection, and set its description to "Blog posts for content creation".',
     expected:
-      'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { enabled: { find: true, create: true }, description: "Blog posts for content creation" } } }) added to plugins array',
+      'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { find: true, create: true }, description: "Blog posts for content creation" } } }) added to plugins array',
     category: 'plugins',
     fixturePath: 'plugins/official/codegen/mcp',
   },


### PR DESCRIPTION
The `plugins/official/codegen/mcp` eval expected the per-collection shape `{ enabled: { find, create } }`, but `@payloadcms/plugin-mcp` configures per-collection tools via `{ tools: { find, create } }`. The `enabled` key was removed in the plugin refactor (#16726), so the rubric was penalizing output that correctly follows the current API. This updates the expected shape to `tools`.

## Open question

How should evals (and skills) be maintained across versions, given v4 is still in beta while most users run 3.x? Some options:

1. **Track latest only (v4, even in beta).** Single source of truth and GA-ready, but most users are on 3.x today, so answers/evals serve a version almost nobody runs in prod yet.
2. **Track 3.x now, switch to v4 at GA.** Matches what most users run today, but doesn't help v4 early adopters and needs a coordinated switch at GA.
3. **Version-aware breaking-changes layer.** Feed a breaking-changes registry from the official v3 -> v4 migration guide and per-release notes (rather than maintaining it by hand); on each question the agent checks it and, if an API changed, warns that earlier versions may differ.

My preference is option 3, but that can be implemented in a later PR. This is necessary to unlock the CI of the Payload Agent that runs these evaluations.