### PR TITLE
fix(drizzle): prevent using postgres `returning` in simple collections upsert if `returning` arguments include point fields

### DIFF
--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -24,6 +24,7 @@ import { deleteExistingArrayRows } from './deleteExistingArrayRows.js'
 import { deleteExistingRowsByPath } from './deleteExistingRowsByPath.js'
 import { handleUpsertError } from './handleUpsertError.js'
 import { insertArrays } from './insertArrays.js'
+import { isSqlReturningSafe } from './isSqlReturningSafe.js'
 import { shouldUseOptimizedUpsertRow } from './shouldUseOptimizedUpsertRow.js'
 
 /**
@@ -150,20 +151,24 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
           }
         }
 
-        const docs = await drizzle
-          .update(adapter.tables[tableName])
-          .set(row)
-          .where(eq(adapter.tables[tableName].id, id))
-          .returning(Object.keys(selectedFields).length ? selectedFields : undefined)
+        const useSqlReturning = isSqlReturningSafe({ adapter, fields, selectedFields })
 
-        return transform<T>({
-          adapter,
-          config: adapter.payload.config,
-          data: docs[0],
-          fields,
-          joinQuery: false,
-          tableName,
-        })
+        if (useSqlReturning) {
+          const docs = await drizzle
+            .update(adapter.tables[tableName])
+            .set(row)
+            .where(eq(adapter.tables[tableName].id, id))
+            .returning(Object.keys(selectedFields).length ? selectedFields : undefined)
+
+          return transform<T>({
+            adapter,
+            config: adapter.payload.config,
+            data: docs[0],
+            fields,
+            joinQuery: false,
+            tableName,
+          })
+        }
       }
 
       // DB Update that needs the result, potentially with joins => need to update first, then find. returning() does not work with joins.

--- a/packages/drizzle/src/upsertRow/isSqlReturningSafe.ts
+++ b/packages/drizzle/src/upsertRow/isSqlReturningSafe.ts
@@ -1,0 +1,30 @@
+import type { SelectedFields } from 'drizzle-orm/sqlite-core'
+import type { FlattenedField } from 'payload'
+
+import type { DrizzleAdapter } from '../types.js'
+
+type IsSQLReturningSafe = {
+  adapter: DrizzleAdapter
+  fields: FlattenedField[]
+  selectedFields: SelectedFields
+}
+
+// This function confirms using sql `returning` will return selected fields in the correct format
+// Reason: postgres drizzle returns point fields as arrays of numbers rather than GeoJSON objects
+export const isSqlReturningSafe = ({
+  adapter,
+  fields,
+  selectedFields,
+}: IsSQLReturningSafe): boolean => {
+  let allowSqlReturning = true
+
+  if (adapter.name === 'postgres') {
+    if (Object.keys(selectedFields).length) {
+      allowSqlReturning = !Object.keys(selectedFields).some((key) => fields[key].type === 'point')
+    } else {
+      allowSqlReturning = !fields.some((field) => field.type === 'point')
+    }
+  }
+
+  return allowSqlReturning
+}


### PR DESCRIPTION

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #16729 

-->

## Description
When using `@payloadcms/db-postgres` with a collection that has both a point field and `versions` enabled, updating a document fails while Payload tries to insert the version row into `_v` table.

Upon investigation, this issue only happens when the collection fields are simple. A collection with localizations or nested fields does not throw this issue. The reason is that `upsertRow` optimizes the data update for a simple collection by calling drizzle sql `update` directly and using the output of the sql `returning` clause. Drizzle returns the `point` field as an `array` rather than `GeoJSON`. The output is fed into the `saveVersion` function without any transformation which throws the error detailed in issue #16729.

## Fix
Added
- `upsertRow/isSqlReturningSafe.ts`: function that checks if the fields passed to sql `returning` include a `point` field

Updated
- `upsertRow/index.ts`: 
  - based on `isSqlReturningSafe` output, the optimized sql call with `returning` is either ran or skipped
  - Skipping the optimzed `update` query falls back to `update` then `findFirst` to return the result 

Fixes #16729 