### PR TITLE
fix(ui): parse columns/queryByGroup from URL to stop escape accumulation

### DIFF
--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -71,6 +71,8 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
       })
 
       if (modifySearchParams) {
+        // `columns`/`queryByGroup` are JSON-encoded here and decoded back in
+        // `sanitizeQuery` on read — keep the two in sync (see #16659).
         const search = `?${qs.stringify({
           ...newQuery,
           columns: JSON.stringify(newQuery.columns),
@@ -141,6 +143,8 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
   const syncPropsToURL = useEffectEvent(() => {
     const newQuery = sanitizeQuery({ ...(query || {}), ...(queryFromProps || {}) })
 
+    // `columns`/`queryByGroup` are JSON-encoded here and decoded back in
+    // `sanitizeQuery` on read — keep the two in sync (see #16659).
     const search = `?${qs.stringify({
       ...newQuery,
       columns: JSON.stringify(newQuery.columns),

--- a/packages/ui/src/providers/ListQuery/sanitizeQuery.spec.ts
+++ b/packages/ui/src/providers/ListQuery/sanitizeQuery.spec.ts
@@ -1,0 +1,100 @@
+import type { ListQuery } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeQuery } from './sanitizeQuery.js'
+
+// `sanitizeQuery` receives URL-parsed input, where `columns` and `queryByGroup`
+// arrive as JSON strings — wider than the `ListQuery` type. Cast in tests to model that.
+const run = (query: Record<string, unknown>): ListQuery => sanitizeQuery(query as ListQuery)
+
+/**
+ * Regression coverage for https://github.com/payloadcms/payload/issues/16659
+ *
+ * `columns` and `queryByGroup` are written to the URL as JSON strings by the
+ * ListQueryProvider (`JSON.stringify(...)`). When read back from the URL they
+ * arrive as strings, so they must be parsed into their canonical array/object
+ * form here — otherwise the next write re-stringifies an already-stringified
+ * value, accumulating an escape layer on every refresh until the URL overflows
+ * the request size limit (414 URI Too Long).
+ */
+describe('sanitizeQuery', () => {
+  describe('columns (#16659)', () => {
+    it('parses a JSON-stringified columns array from the URL back into an array', () => {
+      const result = run({ columns: JSON.stringify(['id', '-slug', 'title']) })
+      expect(result.columns).toEqual(['id', '-slug', 'title'])
+    })
+
+    it('leaves an already-parsed columns array untouched', () => {
+      const result = run({ columns: ['id', '-slug'] })
+      expect(result.columns).toEqual(['id', '-slug'])
+    })
+
+    it('does not accumulate escaping across repeated URL round-trips', () => {
+      // Simulate the provider: each cycle reads from the URL (a JSON string) and
+      // re-writes via JSON.stringify. With the fix this is a fixed point.
+      const original = ['id', 'title']
+      let urlValue = JSON.stringify(original)
+
+      for (let i = 0; i < 10; i++) {
+        const sanitized = run({ columns: urlValue })
+        expect(sanitized.columns).toEqual(original)
+        urlValue = JSON.stringify(sanitized.columns)
+      }
+
+      // The serialized URL value must remain a single-layer JSON array string.
+      expect(urlValue).toBe(JSON.stringify(original))
+    })
+
+    it('recovers a multiply-encoded (already-corrupted) columns value back to an array', () => {
+      // A URL corrupted by the pre-fix bug carries several JSON.stringify layers.
+      let urlValue = JSON.stringify(['id', 'title'])
+      urlValue = JSON.stringify(urlValue) // 2 layers
+      urlValue = JSON.stringify(urlValue) // 3 layers
+      expect(run({ columns: urlValue }).columns).toEqual(['id', 'title'])
+    })
+
+    it('still drops an empty columns array (stringified or not)', () => {
+      expect(run({ columns: '[]' }).columns).toBeUndefined()
+      expect(run({ columns: JSON.stringify('[]') }).columns).toBeUndefined()
+      expect(run({ columns: [] }).columns).toBeUndefined()
+    })
+  })
+
+  describe('queryByGroup (#16659)', () => {
+    it('parses a JSON-stringified queryByGroup object from the URL back into an object', () => {
+      const queryByGroup = { groupA: { page: 2 }, groupB: { sort: '-createdAt' } }
+      const result = run({ queryByGroup: JSON.stringify(queryByGroup) })
+      expect(result.queryByGroup).toEqual(queryByGroup)
+    })
+
+    it('does not accumulate escaping across repeated URL round-trips', () => {
+      const original = { groupA: { page: 2 } }
+      let urlValue = JSON.stringify(original)
+
+      for (let i = 0; i < 10; i++) {
+        const sanitized = run({ queryByGroup: urlValue })
+        expect(sanitized.queryByGroup).toEqual(original)
+        urlValue = JSON.stringify(sanitized.queryByGroup)
+      }
+
+      expect(urlValue).toBe(JSON.stringify(original))
+    })
+  })
+
+  describe('existing sanitization behavior', () => {
+    it('removes empty-string params', () => {
+      expect(run({ preset: '' })).toEqual({})
+    })
+
+    it('coerces numeric limit/page strings', () => {
+      const result = run({ limit: '25', page: '2' })
+      expect(result.limit).toBe(25)
+      expect(result.page).toBe(2)
+    })
+
+    it('drops an empty where object', () => {
+      expect(run({ where: {} }).where).toBeUndefined()
+    })
+  })
+})

--- a/packages/ui/src/providers/ListQuery/sanitizeQuery.ts
+++ b/packages/ui/src/providers/ListQuery/sanitizeQuery.ts
@@ -1,6 +1,24 @@
 import type { ListQuery, Where } from 'payload'
 
 /**
+ * Repeatedly `JSON.parse` a value while it remains a string, unwrapping any number
+ * of accumulated `JSON.stringify` layers back to its canonical form. A malformed
+ * value (parse failure) is returned as-is. Each parse strictly removes one layer, so
+ * this always terminates.
+ */
+const parseJSONLayers = (value: unknown): unknown => {
+  while (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return value
+    }
+  }
+
+  return value
+}
+
+/**
  * Sanitize empty strings from the query, e.g. `?preset=`
  * This is how we determine whether to clear user preferences for certain params
  * Once cleared, they are no longer needed in the URL
@@ -8,11 +26,18 @@ import type { ListQuery, Where } from 'payload'
 export const sanitizeQuery = (toSanitize: ListQuery): ListQuery => {
   const sanitized = { ...toSanitize }
 
+  // `columns` and `queryByGroup` are written to the URL as JSON strings (see
+  // ListQueryProvider's `JSON.stringify(...)`). Parse them back into their canonical
+  // array/object form on read so the next write does not re-stringify an
+  // already-stringified value. Without this, each refresh added another escape layer
+  // until the URL overflowed the request size limit (414 URI Too Long). Unwrapping
+  // every accumulated layer also heals URLs already corrupted by the prior behavior.
+  // See https://github.com/payloadcms/payload/issues/16659
+  sanitized.columns = parseJSONLayers(sanitized.columns) as ListQuery['columns']
+  sanitized.queryByGroup = parseJSONLayers(sanitized.queryByGroup) as ListQuery['queryByGroup']
+
   Object.entries(sanitized).forEach(([key, value]) => {
-    if (
-      key === 'columns' &&
-      (value === '[]' || (Array.isArray(sanitized[key]) && sanitized[key].length === 0))
-    ) {
+    if (key === 'columns' && Array.isArray(sanitized[key]) && sanitized[key].length === 0) {
       delete sanitized[key]
     }
 


### PR DESCRIPTION
Fixes #16659

## Problem

On a collection list view, the `columns` query param accumulates an extra `JSON.stringify` escape layer on **every page refresh** after a specific navigation sequence (toggle a column → open a doc → back → sort → refresh…). The escaping roughly doubles each refresh until the URL exceeds the request size limit (~14KB on Vercel) and the admin panel becomes inaccessible with **`414 URI Too Long`**.

## Root cause

The `columns` / `queryByGroup` URL round-trip is **asymmetric**:

- **Write** — `ListQueryProvider` (`packages/ui/src/providers/ListQuery/index.tsx`) serializes both via `JSON.stringify(newQuery.columns)` on two paths (`refineListData`, `syncPropsToURL`).
- **Read** — `queryFromURL = sanitizeQuery(parseSearchParams(rawSearchParams))` left them as JSON **strings**; `sanitizeQuery` never parsed them back into their canonical array/object form.

So whenever the value being written originated from the URL (a string), `JSON.stringify(string)` adds another layer. Each refresh re-reads the string and re-stringifies → escaping compounds.

(`transformColumnsToPreferences` on the server does `JSON.parse` strings, but the client state path did not — hence the asymmetry.)

## Fix

`sanitizeQuery` now unwraps **every** accumulated `JSON.stringify` layer from `columns`/`queryByGroup` on read, so React state always holds the canonical shape and the existing `JSON.stringify` write becomes idempotent across URL round-trips.

Unwrapping *all* layers (not just one) also **heals URLs already corrupted** by the prior behavior, rather than leaving them in a broken fixed point. The fix lives at the single read boundary (`sanitizeQuery`'s only caller is `ListQueryProvider`), so both write paths are covered. Consumers such as `TableColumns` already require `columns` to be a `string[]`, so the read-side parse is the correct layer (a write-side guard that left a string in state would break them).

## Tests

Added `packages/ui/src/providers/ListQuery/sanitizeQuery.spec.ts`:
- parses a JSON-stringified `columns` array / `queryByGroup` object back from the URL
- leaves already-parsed values untouched
- does not accumulate escaping across repeated URL round-trips (idempotent)
- recovers a multiply-encoded (already-corrupted) value back to its canonical form
- preserves existing sanitization behavior (empty params, numeric coercion, empty `where`/`columns` drop)

Verified red→green (the regression tests fail against the previous `sanitizeQuery`), full `ui` unit suite passes, and `tsc`/eslint/prettier are clean.