### PR TITLE
fix(plugin-search): opt out of versions by default on search collection

### DIFF
--- a/packages/plugin-search/src/Search/index.ts
+++ b/packages/plugin-search/src/Search/index.ts
@@ -110,6 +110,7 @@ export const generateSearchCollection = (
         singular: 'Search Result',
       }),
     },
+    versions: pluginConfig?.searchOverrides?.versions ?? false,
   }
 
   return newConfig


### PR DESCRIPTION
## Summary

- Adds `versions: false` as the default for the auto-generated search collection in `plugin-search`, opting it out of the versions-by-default behaviour introduced in #16871
- Can still be overridden by passing `versions` in `searchOverrides`

## Motivation

Search result documents are auto-managed by the plugin and have no need for version history. Storing versions would add unnecessary database overhead for every sync operation.
