### PR TITLE
fix(ui): add menu role to combobox to satisfy aria-required-parent

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/Block.tsx
+++ b/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/Block.tsx
@@ -80,6 +80,7 @@ export const CodeBlockBlockComponent: React.FC<Pick<AdditionalCodeComponentProps
       Actions={
         <div className={`${baseClass}__actions`}>
           <Combobox
+            aria-label={t('general:language')}
             button={
               <div
                 className={`${baseClass}__language-selector-button`}

--- a/packages/ui/src/elements/Combobox/index.tsx
+++ b/packages/ui/src/elements/Combobox/index.tsx
@@ -22,6 +22,8 @@ export type ComboboxEntry = {
  * @experimental
  */
 export type ComboboxProps = {
+  /** Accessible label for the list of entries */
+  'aria-label'?: string
   entries: ComboboxEntry[]
   /** Minimum number of entries required to show search */
   minEntriesForSearch?: number
@@ -37,6 +39,7 @@ export type ComboboxProps = {
  */
 export const Combobox: React.FC<ComboboxProps> = (props) => {
   const {
+    'aria-label': ariaLabel,
     entries,
     minEntriesForSearch = 8,
     onSelect,
@@ -103,33 +106,35 @@ export const Combobox: React.FC<ComboboxProps> = (props) => {
             </div>
           )}
           <PopupList.ButtonGroup>
-            {filteredEntries.map((entry, index) => {
-              const handleClick = () => {
-                if (onSelect) {
-                  onSelect(entry)
+            <div aria-label={ariaLabel} role="menu">
+              {filteredEntries.map((entry, index) => {
+                const handleClick = () => {
+                  if (onSelect) {
+                    onSelect(entry)
+                  }
+                  close()
                 }
-                close()
-              }
 
-              return (
-                <div
-                  className={`${baseClass}__entry`}
-                  data-popup-prevent-close
-                  key={`${entry.name}-${index}`}
-                  onClick={handleClick}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      handleClick()
-                    }
-                  }}
-                  role="menuitem"
-                  tabIndex={0}
-                >
-                  {entry.Component}
-                </div>
-              )
-            })}
+                return (
+                  <div
+                    className={`${baseClass}__entry`}
+                    data-popup-prevent-close
+                    key={`${entry.name}-${index}`}
+                    onClick={handleClick}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        handleClick()
+                      }
+                    }}
+                    role="menuitem"
+                    tabIndex={0}
+                  >
+                    {entry.Component}
+                  </div>
+                )
+              })}
+            </div>
           </PopupList.ButtonGroup>
         </div>
       )}


### PR DESCRIPTION
### What

Wraps the `Combobox` entries in a `role="menu"` container so the `role="menuitem"` entries have their required parent role, resolving the axe `aria-required-parent` violation.

The search `input` stays outside the menu wrapper to avoid triggering `aria-required-children`, since inputs are not permitted children of a menu role.

Also adds an optional `aria-label` prop to give the menu an accessible name. The generic component intentionally has no default label - the only consumer, the `CodeBlock` language selector, now passes a translated `aria-label={t('general:language')}`, matching the existing pattern used for `searchPlaceholder`.
