### PR TITLE
feat!: scope default access control to the admin user collection

### DIFF
--- a/docs/access-control/overview.mdx
+++ b/docs/access-control/overview.mdx
@@ -29,15 +29,17 @@ There are three main types of Access Control in Payload:
 
 ## Default Access Control
 
-Payload provides default Access Control so that your data is secured behind [Authentication](../authentication/overview) without additional configuration. To do this, Payload sets a default function that simply checks if a user is present on the request. You can override this default behavior by defining your own Access Control functions as needed.
+Payload provides default Access Control so that your data is secured behind [Authentication](../authentication/overview) without additional configuration. To do this, Payload sets a default function that checks that a user is present on the request _and_ that the user belongs to the collection used to access the [Admin Panel](../admin/overview#the-admin-user-collection) (`config.admin.user`). You can override this default behavior by defining your own Access Control functions as needed.
+
+This means that adding a second [Authentication](../authentication/overview)-enabled collection does not automatically grant its users access to everything. Users from collections other than `config.admin.user` are denied by default unless you provide your own Access Control functions.
 
 Here is the default Access Control that Payload provides:
 
 ```ts
-const defaultPayloadAccess = ({ req: { user } }) => {
-  // Return `true` if a user is found
-  // and `false` if it is undefined or null
-  return Boolean(user) // highlight-line
+const defaultPayloadAccess = ({ req: { payload, user } }) => {
+  // Return `true` only if a user is found
+  // and that user belongs to the admin user collection
+  return Boolean(user) && user.collection === payload.config.admin.user // highlight-line
 }
 ```
 

--- a/packages/payload/src/auth/defaultAccess.ts
+++ b/packages/payload/src/auth/defaultAccess.ts
@@ -1,3 +1,4 @@
 import type { PayloadRequest } from '../types/index.js'
 
-export const defaultAccess = ({ req: { user } }: { req: PayloadRequest }): boolean => Boolean(user)
+export const defaultAccess = ({ req: { payload, user } }: { req: PayloadRequest }): boolean =>
+  Boolean(user) && user!.collection === payload.config.admin.user

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -26,11 +26,14 @@ import {
   hiddenAccessSlug,
   hiddenFieldsSlug,
   hooksSlug,
+  publicUserEmail,
+  publicUsersSlug,
   relyOnRequestHeadersSlug,
   restrictedVersionsSlug,
   secondArrayText,
   siblingDataSlug,
   slug,
+  unrestrictedSlug,
 } from './shared.js'
 
 let payload: Payload
@@ -861,6 +864,49 @@ describe('Access Control', () => {
         read: { permission: true },
         update: { permission: true },
       } satisfies CollectionPermission)
+    })
+  })
+
+  describe('Default access - admin auth collection scoping', () => {
+    let adminUser: Record<string, unknown>
+    let publicUser: Record<string, unknown>
+
+    beforeAll(async () => {
+      const { docs: adminDocs } = await payload.find({
+        collection: 'users',
+        limit: 1,
+        where: { email: { equals: 'dev@payloadcms.com' } },
+      })
+      adminUser = { ...adminDocs[0], collection: 'users' }
+
+      const { docs: publicDocs } = await payload.find({
+        collection: publicUsersSlug,
+        limit: 1,
+        where: { email: { equals: publicUserEmail } },
+      })
+      publicUser = { ...publicDocs[0], collection: publicUsersSlug }
+    })
+
+    it('should grant default access to a user from the admin auth collection', async () => {
+      const doc = await payload.create({
+        collection: unrestrictedSlug,
+        data: { name: 'created by admin user' },
+        overrideAccess: false,
+        user: adminUser as any,
+      })
+
+      expect(doc.id).toBeDefined()
+    })
+
+    it('should deny default access to a user from a non-admin auth collection', async () => {
+      await expect(
+        payload.create({
+          collection: unrestrictedSlug,
+          data: { name: 'created by public user' },
+          overrideAccess: false,
+          user: publicUser as any,
+        }),
+      ).rejects.toThrow(Forbidden)
     })
   })
 })


### PR DESCRIPTION
Scopes Payload's default Access Control to the collection used to access the Admin Panel. `defaultAccess` now returns `true` only when a user is present on the request **and** that user belongs to the `config.admin.user` collection, instead of granting access to any authenticated user.

Previously, adding a second [Authentication](https://payloadcms.com/docs/authentication/overview)-enabled collection silently granted its users access to every collection, global, locked document, query preset, and job that relied on the default. This closes that gap: secondary auth collections start with no default access and must opt in via their own Access Control functions.

## Breaking Changes

This only affects projects with more than one auth-enabled collection that rely on Payload's default Access Control (i.e. collections, globals, or other entities with no custom `access` functions defined). Users authenticated from a collection other than `config.admin.user` are now denied by default.

The default function changed as follows:

```diff
- const defaultAccess = ({ req: { user } }) => Boolean(user)
+ const defaultAccess = ({ req: { payload, user } }) =>
+   Boolean(user) && user.collection === payload.config.admin.user
```

To restore the previous behavior for an entity, define an explicit Access Control function that checks only for a user:

```ts
export const MyCollection: CollectionConfig = {
  slug: 'my-collection',
  access: {
    read: ({ req: { user } }) => Boolean(user),
    create: ({ req: { user } }) => Boolean(user),
    update: ({ req: { user } }) => Boolean(user),
    delete: ({ req: { user } }) => Boolean(user),
  },
  fields: [
    // ...
  ],
}
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214259839775112