### PR TITLE
templates: fix build type errors and lint config

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,29 @@
+// lint-staged config lives here (not in package.json) so the JS/TS rule can be a
+// function: ESLint's `v10_config_lookup_from_file` flag loads each file's nearest
+// eslint config, and the `templates/*` configs require deps that aren't installed in
+// the monorepo. We filter template files out of ESLint (prettier still formats them);
+// templates are linted standalone via their own `lint` script / build.
+const isTemplateFile = (file) => file.includes('/templates/')
+const quote = (files) => files.map((file) => `'${file}'`).join(' ')
+
+export default {
+  '**/package.json': 'sort-package-json',
+  '*.{md,mdx,yml,json}': 'prettier --write',
+  '*.{js,jsx,ts,tsx}': (files) => {
+    const commands = []
+    const lintable = files.filter((file) => !isTemplateFile(file))
+
+    if (lintable.length) {
+      commands.push(
+        `eslint --flag v10_config_lookup_from_file --cache --fix ${quote(lintable)}`,
+      )
+    }
+
+    commands.push(`prettier --write ${quote(files)}`)
+
+    return commands
+  },
+  'templates/**/pnpm-lock.yaml': 'pnpm runts scripts/remove-template-lock-files.ts',
+  'tsconfig.base.json': 'node scripts/reset-tsconfig.js',
+  'README.md': "sh -c 'cp ./README.md ./packages/payload/README.md'",
+}

--- a/package.json
+++ b/package.json
@@ -158,17 +158,6 @@
     "test:unit": "vitest run --project unit",
     "translateNewKeys": "pnpm --filter @tools/scripts run generateTranslations:core"
   },
-  "lint-staged": {
-    "**/package.json": "sort-package-json",
-    "*.{md,mdx,yml,json}": "prettier --write",
-    "*.{js,jsx,ts,tsx}": [
-      "eslint --flag v10_config_lookup_from_file --cache --fix",
-      "prettier --write"
-    ],
-    "templates/**/pnpm-lock.yaml": "pnpm runts scripts/remove-template-lock-files.ts",
-    "tsconfig.base.json": "node scripts/reset-tsconfig.js",
-    "README.md": "sh -c 'cp ./README.md ./packages/payload/README.md'"
-  },
   "devDependencies": {
     "@ai-sdk/openai": "3.0.30",
     "@axe-core/playwright": "4.11.0",

--- a/templates/blank/src/app/(frontend)/page.tsx
+++ b/templates/blank/src/app/(frontend)/page.tsx
@@ -27,8 +27,11 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome to your new project.</h1>}
-        {user && <h1>Welcome back, {user.email}</h1>}
+        {!user || !('email' in user) ? (
+          <h1>Welcome to your new project.</h1>
+        ) : (
+          <h1>Welcome back, {user.email}</h1>
+        )}
         <div className="links">
           <a
             className="admin"

--- a/templates/with-cloudflare-d1/eslint.config.mjs
+++ b/templates/with-cloudflare-d1/eslint.config.mjs
@@ -1,17 +1,9 @@
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  resolvePluginsRelativeTo: __dirname,
-})
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+import nextTypescript from 'eslint-config-next/typescript'
 
 const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     rules: {
       '@typescript-eslint/ban-ts-comment': 'warn',

--- a/templates/with-cloudflare-d1/package.json
+++ b/templates/with-cloudflare-d1/package.json
@@ -16,7 +16,7 @@
     "generate:types:cloudflare": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "generate:types:payload": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",
     "ii": "pnpm install --ignore-workspace",
-    "lint": "cross-env NODE_OPTIONS=--no-deprecation next lint",
+    "lint": "cross-env NODE_OPTIONS=--no-deprecation eslint .",
     "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview --env=$CLOUDFLARE_ENV",
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",

--- a/templates/with-cloudflare-d1/package.json
+++ b/templates/with-cloudflare-d1/package.json
@@ -40,7 +40,6 @@
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.2.0",
     "@playwright/test": "1.59.1",
     "@testing-library/react": "16.3.0",
     "@types/node": "24.12.3",
@@ -48,7 +47,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "4.5.2",
     "eslint": "^9.16.0",
-    "eslint-config-next": "15.4.11",
+    "eslint-config-next": "16.2.6",
     "jsdom": "28.0.0",
     "prettier": "^3.4.2",
     "tsx": "4.22.4",

--- a/templates/with-cloudflare-d1/src/app/(frontend)/page.tsx
+++ b/templates/with-cloudflare-d1/src/app/(frontend)/page.tsx
@@ -27,8 +27,11 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome to your new project.</h1>}
-        {user && <h1>Welcome back, {user.email}</h1>}
+        {!user || !('email' in user) ? (
+          <h1>Welcome to your new project.</h1>
+        ) : (
+          <h1>Welcome back, {user.email}</h1>
+        )}
         <div className="links">
           <a
             className="admin"

--- a/templates/with-postgres/eslint.config.mjs
+++ b/templates/with-postgres/eslint.config.mjs
@@ -1,16 +1,9 @@
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+import nextTypescript from 'eslint-config-next/typescript'
 
 const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     rules: {
       '@typescript-eslint/ban-ts-comment': 'warn',

--- a/templates/with-postgres/package.json
+++ b/templates/with-postgres/package.json
@@ -32,7 +32,6 @@
     "sharp": "0.34.2"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.2.0",
     "@playwright/test": "1.59.1",
     "@testing-library/react": "16.3.0",
     "@types/node": "24.12.3",

--- a/templates/with-postgres/src/app/(frontend)/page.tsx
+++ b/templates/with-postgres/src/app/(frontend)/page.tsx
@@ -27,8 +27,11 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome to your new project.</h1>}
-        {user && <h1>Welcome back, {user.email}</h1>}
+        {!user || !('email' in user) ? (
+          <h1>Welcome to your new project.</h1>
+        ) : (
+          <h1>Welcome back, {user.email}</h1>
+        )}
         <div className="links">
           <a
             className="admin"

--- a/templates/with-vercel-mongodb/eslint.config.mjs
+++ b/templates/with-vercel-mongodb/eslint.config.mjs
@@ -1,16 +1,9 @@
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+import nextTypescript from 'eslint-config-next/typescript'
 
 const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     rules: {
       '@typescript-eslint/ban-ts-comment': 'warn',

--- a/templates/with-vercel-mongodb/package.json
+++ b/templates/with-vercel-mongodb/package.json
@@ -31,7 +31,6 @@
     "react-dom": "19.2.6"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.2.0",
     "@playwright/test": "1.59.1",
     "@testing-library/react": "16.3.0",
     "@types/node": "24.12.3",

--- a/templates/with-vercel-mongodb/src/app/(frontend)/page.tsx
+++ b/templates/with-vercel-mongodb/src/app/(frontend)/page.tsx
@@ -27,8 +27,11 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome to your new project.</h1>}
-        {user && <h1>Welcome back, {user.email}</h1>}
+        {!user || !('email' in user) ? (
+          <h1>Welcome to your new project.</h1>
+        ) : (
+          <h1>Welcome back, {user.email}</h1>
+        )}
         <div className="links">
           <a
             className="admin"

--- a/templates/with-vercel-postgres/eslint.config.mjs
+++ b/templates/with-vercel-postgres/eslint.config.mjs
@@ -1,16 +1,9 @@
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+import nextTypescript from 'eslint-config-next/typescript'
 
 const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     rules: {
       '@typescript-eslint/ban-ts-comment': 'warn',

--- a/templates/with-vercel-postgres/package.json
+++ b/templates/with-vercel-postgres/package.json
@@ -32,7 +32,6 @@
     "react-dom": "19.2.6"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.2.0",
     "@playwright/test": "1.59.1",
     "@testing-library/react": "16.3.0",
     "@types/node": "24.12.3",

--- a/templates/with-vercel-postgres/src/app/(frontend)/page.tsx
+++ b/templates/with-vercel-postgres/src/app/(frontend)/page.tsx
@@ -27,8 +27,11 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome to your new project.</h1>}
-        {user && <h1>Welcome back, {user.email}</h1>}
+        {!user || !('email' in user) ? (
+          <h1>Welcome to your new project.</h1>
+        ) : (
+          <h1>Welcome back, {user.email}</h1>
+        )}
         <div className="links">
           <a
             className="admin"


### PR DESCRIPTION
# Overview

Fixes misc template build issues

## Key Changes

#### Account for the union admin-user type

The home page in each template now checks for `email` on the user before rendering it, since the authenticated user type is now a union that may not include `email`.

#### Migrate `with-*` eslint configs to flat-config imports

The lagging `with-*` templates now import `eslint-config-next/core-web-vitals` and `/typescript` directly instead of going through `FlatCompat`, matching `templates/blank`. Drops the `@eslint/eslintrc` dependency.

#### Exclude templates from the lint-staged ESLint pass

Moves lint-staged config into `.lintstagedrc.mjs` so the JS/TS rule filters template files out of ESLint. Template files live outside the monorepo workspace, so their per-file eslint configs reference deps that aren't installed, which crashed the pre-commit hook. Prettier still formats them; templates lint standalone via their own `lint` script and CI build.

## Design Decisions

The `templates/**` ignore in the root eslint config is bypassed by lint-staged's `v10_config_lookup_from_file` flag, which resolves each file's nearest config before ignore patterns apply. Filtering the file list in `.lintstagedrc.mjs` is the reliable point to drop template files while keeping prettier formatting for them.
