### PR TITLE
fix(ui): apply filterOptions to "Add Below" block drawer

### DIFF
--- a/packages/ui/src/fields/Blocks/BlockRow.tsx
+++ b/packages/ui/src/fields/Blocks/BlockRow.tsx
@@ -25,6 +25,7 @@ type BlocksFieldProps = {
   addRow: (rowIndex: number, blockType: string) => Promise<void> | void
   block: ClientBlock
   blocks: (ClientBlock | string)[] | ClientBlock[]
+  blocksToAdd: (ClientBlock | string)[] | ClientBlock[]
   copyRow: (rowIndex: number) => void
   duplicateRow: (rowIndex: number) => void
   errorCount: number
@@ -53,6 +54,7 @@ export const BlockRow: React.FC<BlocksFieldProps> = ({
   attributes,
   block,
   blocks,
+  blocksToAdd,
   copyRow,
   duplicateRow,
   errorCount,
@@ -149,7 +151,7 @@ export const BlockRow: React.FC<BlocksFieldProps> = ({
           !readOnly ? (
             <RowActions
               addRow={addRow}
-              blocks={blocks}
+              blocks={blocksToAdd}
               blockType={row.blockType}
               copyRow={copyRow}
               duplicateRow={duplicateRow}

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -482,6 +482,8 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
                       block={blockConfig}
                       // Pass all blocks, not just clientBlocksAfterFilter, as existing blocks should still be displayed even if they don't match the new filter
                       blocks={clientBlocks}
+                      // Pass only filtered blocks for use in the "Add Below" drawer
+                      blocksToAdd={clientBlocksAfterFilter}
                       copyRow={copyRow}
                       duplicateRow={duplicateRow}
                       errorCount={rowErrorCount}


### PR DESCRIPTION
Closes #15829

### What?

The **Add Below** action on a blocks field row was opening the block-picker drawer with all available blocks, ignoring the field's `filterOptions` configuration. Only the **Add Content** button at the bottom of the list was correctly applying the filter.

### Why?

Both entry points ultimately render a `BlocksDrawer`, but they diverged in which block list they passed:

- **Add Content** (bottom button) → `BlocksDrawer blocks={clientBlocksAfterFilter}` ✓  
- **Add Below** (per-row action) → `BlockRow` → `RowActions` → `BlocksDrawer blocks={blocks}` ✗

`BlockRow` intentionally receives the **unfiltered** `clientBlocks` list so that existing rows can still be rendered even if their block type no longer matches the current filter. This is correct. The bug was that `RowActions` forwarded that same unfiltered list into the block-picker drawer.

### How?

Added a separate `blocksToAdd` prop to `BlockRow` that carries `clientBlocksAfterFilter`. `RowActions` already receives a `blocks` prop whose sole purpose is to populate the drawer; it now receives `blocksToAdd` (the filtered list) while `blocks` (the full list) is kept on `BlockRow` only for rendering existing rows.

**Before:**
```
BlockRow(blocks=clientBlocks) → RowActions(blocks=clientBlocks) → BlocksDrawer(blocks=all)
```

**After:**
```
BlockRow(blocks=clientBlocks, blocksToAdd=clientBlocksAfterFilter) → RowActions(blocks=clientBlocksAfterFilter) → BlocksDrawer(blocks=filtered)
```

The change is 5-line additive — no existing behaviour is altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)