### PR TITLE
fix(translations): translate missing hierarchy.noResults in zhTw, bnBd, bnIn, rsLatin

### DIFF
--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -511,7 +511,7 @@ export const bnBdTranslations: DefaultTranslationsObject = {
       'আপনি চলে যাচ্ছেন <1>{{count}} {{label}}</1> রুটে। আপনি কি নিশ্চিত?',
     moveToRoot: 'রুটে যান',
     noParent: 'কোন অভিভাবক নেই',
-    noResults: 'No results for "{{query}}"',
+    noResults: '"{{query}}" এর জন্য কোনো ফলাফল নেই',
     searchLabel: 'অনুসন্ধান করুন {{label}}',
   },
   localization: {

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -510,7 +510,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
       'আপনি <1>{{count}} {{label}}</1> কে রুট এ সরিয়ে দিতে চলেছেন। আপনি কি নিশ্চিত?',
     moveToRoot: 'রুটে সরান',
     noParent: 'কোন মাতা-পিতা নেই',
-    noResults: 'No results for "{{query}}"',
+    noResults: '"{{query}}" এর জন্য কোনো ফলাফল পাওয়া যায়নি',
     searchLabel: '{{label}} অনুসন্ধান করুন',
   },
   localization: {

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -504,7 +504,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
       'Na korak ste da premestite <1>{{count}} {{label}}</1> u korenu. Jeste li sigurni?',
     moveToRoot: 'Premesti se na koren',
     noParent: 'Bez roditelja',
-    noResults: 'No results for "{{query}}"',
+    noResults: 'Nema rezultata za „{{query}}"',
     searchLabel: 'Pretraga {{label}}',
   },
   localization: {

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -481,7 +481,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     moveItemsToRootConfirmation: '您即將將 <1>{{count}} {{label}}</1> 移至根目錄。您確定嗎？',
     moveToRoot: '移至根目錄',
     noParent: '無父項',
-    noResults: 'No results for "{{query}}"',
+    noResults: '「{{query}}」沒有結果',
     searchLabel: '搜尋 {{label}}',
   },
   localization: {


### PR DESCRIPTION
The `hierarchy.noResults` key was left as an untranslated English fallback string in 4 language files:

- `zhTw.ts` (Traditional Chinese)
- `bnBd.ts` (Bengali - Bangladesh)
- `bnIn.ts` (Bengali - India)
- `rsLatin.ts` (Serbian Latin)

All other keys in the `hierarchy` namespace were properly translated in these files. This PR provides the correct translated strings for each language.

No issue reference needed — this is a missing translation fix.