### PR TITLE
fix(plugin-import-export): fix CSV import of arrays and richText nested inside blocks

### DIFF
--- a/packages/plugin-import-export/src/utilities/processRichTextField.spec.ts
+++ b/packages/plugin-import-export/src/utilities/processRichTextField.spec.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+
+import { processRichTextField } from './processRichTextField.js'
+
+// Minimal helpers to keep assertions readable
+const asRecord = (v: unknown) => v as Record<string, unknown>
+const asArray = (v: unknown) => v as unknown[]
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const textNode = (overrides: Record<string, unknown> = {}) => ({
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  text: 'Hello',
+  type: 'text',
+  version: 1,
+  ...overrides,
+})
+
+const paragraphNode = (children: unknown[] = [textNode()]) => ({
+  children,
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  type: 'paragraph',
+  version: 1,
+})
+
+const lexicalDoc = (children: unknown[] = [paragraphNode()]) => ({
+  children,
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  type: 'root',
+  version: 1,
+})
+
+// ─── Primitive pass-through ──────────────────────────────────────────────────
+
+describe('processRichTextField — primitive pass-through', () => {
+  it('should return null unchanged', () => {
+    expect(processRichTextField(null)).toBeNull()
+  })
+
+  it('should return undefined unchanged', () => {
+    expect(processRichTextField(undefined)).toBeUndefined()
+  })
+
+  it('should return a number unchanged', () => {
+    expect(processRichTextField(42)).toBe(42)
+  })
+
+  it('should return false unchanged', () => {
+    expect(processRichTextField(false)).toBe(false)
+  })
+})
+
+// ─── String input (the recovered-from-missed-hook path) ─────────────────────
+
+describe('processRichTextField — JSON string input', () => {
+  it('should parse a valid JSON string into an object', () => {
+    const doc = lexicalDoc()
+    expect(processRichTextField(JSON.stringify(doc))).toEqual(doc)
+  })
+
+  it('should return an unparseable string unchanged', () => {
+    expect(processRichTextField('not json')).toBe('not json')
+  })
+
+  it('should return an empty string unchanged', () => {
+    expect(processRichTextField('')).toBe('')
+  })
+
+  it('should parse a string and still convert numeric string properties', () => {
+    const node = { type: 'text', detail: '0', format: '3', indent: '0', version: '1', text: 'hi' }
+    const result = asRecord(processRichTextField(JSON.stringify(node)))
+    expect(result.detail).toBe(0)
+    expect(result.format).toBe(3)
+    expect(result.indent).toBe(0)
+    expect(result.version).toBe(1)
+  })
+})
+
+// ─── Numeric property coercion ───────────────────────────────────────────────
+
+describe('processRichTextField — numeric property coercion', () => {
+  it('should convert detail, format, indent, version from strings to numbers', () => {
+    const input = textNode({ detail: '0', format: '0', indent: '0', version: '1' })
+    const result = asRecord(processRichTextField(input))
+    expect(result.detail).toBe(0)
+    expect(result.format).toBe(0)
+    expect(result.indent).toBe(0)
+    expect(result.version).toBe(1)
+  })
+
+  it('should convert start and value from strings to numbers (list/listitem nodes)', () => {
+    const listItemNode = { type: 'listitem', start: '1', value: '2', version: '1' }
+    const result = asRecord(processRichTextField(listItemNode))
+    expect(result.start).toBe(1)
+    expect(result.value).toBe(2)
+  })
+
+  it('should convert textFormat and textStyle from strings to numbers', () => {
+    const input = { type: 'text', textFormat: '4', textStyle: '0', version: '1', text: 'x' }
+    const result = asRecord(processRichTextField(input))
+    expect(result.textFormat).toBe(4)
+    expect(result.textStyle).toBe(0)
+  })
+
+  it('should leave a non-numeric string in a numeric-property slot unchanged', () => {
+    // Lexical paragraph format can be "" (empty) or alignment strings
+    const input = paragraphNode()
+    const result = asRecord(processRichTextField(input))
+    expect(result.format).toBe('')
+  })
+
+  it('should leave already-numeric values unchanged', () => {
+    const input = textNode({ detail: 0, format: 3, version: 1 })
+    const result = asRecord(processRichTextField(input))
+    expect(result.detail).toBe(0)
+    expect(result.format).toBe(3)
+    expect(result.version).toBe(1)
+  })
+
+  it('should not convert boolean values on numeric-property keys', () => {
+    const input = { type: 'custom', format: true, version: '1' }
+    const result = asRecord(processRichTextField(input))
+    expect(result.format).toBe(true)
+    expect(result.version).toBe(1)
+  })
+})
+
+// ─── Recursive children processing ──────────────────────────────────────────
+
+describe('processRichTextField — recursive children', () => {
+  it('should recursively convert numeric strings inside children arrays', () => {
+    const input = paragraphNode([textNode({ detail: '0', format: '0', version: '1' })])
+    const result = asRecord(processRichTextField(input))
+    const child = asRecord(asArray(result.children)[0])
+    expect(child.detail).toBe(0)
+    expect(child.format).toBe(0)
+    expect(child.version).toBe(1)
+  })
+
+  it('should handle three levels of nesting (root → paragraph → text)', () => {
+    const input = lexicalDoc([paragraphNode([textNode({ version: '1', format: '2' })])])
+    const result = asRecord(processRichTextField(input))
+    const paragraph = asRecord(asArray(result.children)[0])
+    const text = asRecord(asArray(paragraph.children)[0])
+    expect(text.version).toBe(1)
+    expect(text.format).toBe(2)
+  })
+
+  it('should handle multiple children at the same level', () => {
+    const input = lexicalDoc([
+      paragraphNode([
+        textNode({ text: 'Bold', format: '1' }),
+        textNode({ text: ' normal', format: '0' }),
+      ]),
+      paragraphNode([textNode({ text: 'Second para', version: '1' })]),
+    ])
+    const result = asRecord(processRichTextField(input))
+    const firstPara = asRecord(asArray(result.children)[0])
+    const secondPara = asRecord(asArray(result.children)[1])
+    const bold = asRecord(asArray(firstPara.children)[0])
+    const normal = asRecord(asArray(firstPara.children)[1])
+    const secondText = asRecord(asArray(secondPara.children)[0])
+    expect(bold.format).toBe(1)
+    expect(normal.format).toBe(0)
+    expect(secondText.version).toBe(1)
+  })
+
+  it('should skip null and non-object entries in children without throwing', () => {
+    const input = { type: 'root', version: 1, children: [null, undefined, 'stray', textNode()] }
+    const result = asRecord(processRichTextField(input))
+    const children = asArray(result.children)
+    expect(children[0]).toBeNull()
+    expect(children[1]).toBeUndefined()
+    expect(children[2]).toBe('stray')
+    expect(asRecord(children[3]).type).toBe('text')
+  })
+})
+
+// ─── Nested non-children objects ─────────────────────────────────────────────
+
+describe('processRichTextField — nested non-children objects', () => {
+  it('should recurse into plain nested objects (e.g. decorator node data)', () => {
+    const input = {
+      type: 'decorator',
+      version: '1',
+      data: { detail: '2', label: 'keep me' },
+    }
+    const result = asRecord(processRichTextField(input))
+    const data = asRecord(result.data)
+    expect(result.version).toBe(1)
+    expect(data.detail).toBe(2)
+    expect(data.label).toBe('keep me')
+  })
+})
+
+// ─── Full Lexical document round-trips ───────────────────────────────────────
+
+describe('processRichTextField — full document', () => {
+  it('should produce a stable result when called on an already-processed object', () => {
+    const doc = lexicalDoc()
+    const firstPass = processRichTextField(doc)
+    const secondPass = processRichTextField(firstPass)
+    expect(secondPass).toEqual(firstPass)
+  })
+
+  it('should fully round-trip a complex Lexical document serialised to JSON', () => {
+    const doc = lexicalDoc([
+      paragraphNode([
+        textNode({ text: 'Bold', format: '1', detail: '0', indent: '0', version: '1' }),
+        textNode({ text: ' normal', format: '0', version: '1' }),
+      ]),
+      {
+        type: 'list',
+        listType: 'number',
+        start: '1',
+        version: '1',
+        indent: '0',
+        direction: 'ltr',
+        children: [
+          { type: 'listitem', value: '1', detail: '0', format: '0', version: '1', text: 'Item A' },
+          { type: 'listitem', value: '2', detail: '0', format: '0', version: '1', text: 'Item B' },
+        ],
+      },
+    ])
+
+    const result = asRecord(processRichTextField(JSON.stringify(doc)))
+
+    const para = asRecord(asArray(result.children)[0])
+    const boldText = asRecord(asArray(para.children)[0])
+    expect(boldText.format).toBe(1)
+    expect(boldText.detail).toBe(0)
+
+    const list = asRecord(asArray(result.children)[1])
+    expect(list.start).toBe(1)
+    expect(list.indent).toBe(0)
+
+    const itemA = asRecord(asArray(list.children)[0])
+    const itemB = asRecord(asArray(list.children)[1])
+    expect(itemA.value).toBe(1)
+    expect(itemB.value).toBe(2)
+  })
+})

--- a/packages/plugin-import-export/src/utilities/processRichTextField.ts
+++ b/packages/plugin-import-export/src/utilities/processRichTextField.ts
@@ -3,6 +3,14 @@
  * Lexical expects certain properties to be numbers, not strings.
  */
 export const processRichTextField = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return value
+    }
+  }
+
   if (!value || typeof value !== 'object') {
     return value
   }

--- a/packages/plugin-import-export/src/utilities/unflattenObject.spec.ts
+++ b/packages/plugin-import-export/src/utilities/unflattenObject.spec.ts
@@ -1,5 +1,6 @@
 import { FlattenedField, PayloadRequest } from 'payload'
 
+import { getImportFieldFunctions } from './getImportFieldFunctions.js'
 import { unflattenObject } from './unflattenObject.js'
 
 import { describe, it, expect, vi } from 'vitest'
@@ -561,6 +562,95 @@ describe('unflattenObject', () => {
 
       const archives = result.archives as Array<Record<string, unknown>>
       expect(archives[0]!['2024']).toBe('transformed-raw')
+    })
+  })
+
+  describe('blocks with nested arrays', () => {
+    const faqFields: FlattenedField[] = [
+      {
+        name: 'faqContent',
+        type: 'blocks',
+        blocks: [
+          {
+            slug: 'faqSection',
+            flattenedFields: [
+              {
+                name: 'faqs',
+                type: 'array',
+                flattenedFields: [
+                  { name: 'id', type: 'text' },
+                  { name: 'question', type: 'text' },
+                  { name: 'answer', type: 'richText' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as unknown as FlattenedField[]
+
+    it('should unflatten a nested array inside a block as an array, not an object with numeric keys', () => {
+      const data = {
+        faqContent_0_faqSection_id: '6a1714b81e5f4cdbb51f18b1',
+        faqContent_0_faqSection_faqs_0_id: '6a1714c01e5f4cdbb51f18b2',
+        faqContent_0_faqSection_faqs_0_question: 'ipsum',
+        faqContent_0_faqSection_blockType: 'faqSection',
+      }
+
+      const result = unflattenObject({ data, fields: faqFields, req: mockReq })
+
+      const faqContent = result.faqContent as Array<Record<string, unknown>>
+      expect(Array.isArray(faqContent)).toBe(true)
+      expect(faqContent).toHaveLength(1)
+      expect(faqContent[0]!.blockType).toBe('faqSection')
+
+      const faqs = faqContent[0]!.faqs
+      expect(Array.isArray(faqs)).toBe(true)
+
+      const faqItems = faqs as Array<Record<string, unknown>>
+      expect(faqItems[0]!.question).toBe('ipsum')
+      expect(faqItems[0]!.id).toBe('6a1714c01e5f4cdbb51f18b2')
+    })
+
+    it('should parse a richText JSON string inside a nested array within a block', () => {
+      const richTextValue = {
+        root: {
+          children: [
+            {
+              children: [
+                { detail: 0, format: 0, mode: 'normal', text: 'porksum', type: 'text', version: 1 },
+              ],
+              direction: null,
+              format: '',
+              indent: 0,
+              type: 'paragraph',
+              version: 1,
+            },
+          ],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'root',
+          version: 1,
+        },
+      }
+
+      const data = {
+        faqContent_0_faqSection_id: '6a1714b81e5f4cdbb51f18b1',
+        faqContent_0_faqSection_faqs_0_id: '6a1714c01e5f4cdbb51f18b2',
+        faqContent_0_faqSection_faqs_0_question: 'ipsum',
+        faqContent_0_faqSection_faqs_0_answer: JSON.stringify(richTextValue),
+        faqContent_0_faqSection_blockType: 'faqSection',
+      }
+
+      const importFieldHooks = getImportFieldFunctions({ fields: faqFields })
+      const result = unflattenObject({ data, fields: faqFields, importFieldHooks, req: mockReq })
+
+      const faqContent = result.faqContent as Array<Record<string, unknown>>
+      const faqs = faqContent[0]!.faqs as Array<Record<string, unknown>>
+
+      expect(typeof faqs[0]!.answer).not.toBe('string')
+      expect(faqs[0]!.answer).toEqual(richTextValue)
     })
   })
 

--- a/packages/plugin-import-export/src/utilities/unflattenObject.ts
+++ b/packages/plugin-import-export/src/utilities/unflattenObject.ts
@@ -2,7 +2,7 @@ import type { FlattenedField, PayloadRequest } from 'payload'
 
 import type { ImportFieldHookEntry } from '../types.js'
 
-import { getNestedFlattenedFields } from './flattenedFields.js'
+import { getBlockFlattenedFields, getNestedFlattenedFields } from './flattenedFields.js'
 import { postProcessDocument } from './unflattenPostProcess.js'
 
 type UnflattenArgs = {
@@ -22,6 +22,12 @@ const collectArrayLikeNames = (fields: FlattenedField[], into: Set<string>): voi
     }
     if (field.type === 'array' || field.type === 'blocks') {
       into.add(field.name)
+    }
+    if (field.type === 'blocks') {
+      for (const block of (field as { blocks?: Array<{ flattenedFields?: FlattenedField[] }> })
+        .blocks ?? []) {
+        collectArrayLikeNames(getBlockFlattenedFields(block), into)
+      }
     }
     const nested = getNestedFlattenedFields(field)
     if (nested) {
@@ -312,7 +318,10 @@ export const unflattenObject = ({
               blockObject[blockFieldName] = value
             } else {
               if (!blockObject[blockFieldName] || typeof blockObject[blockFieldName] !== 'object') {
-                blockObject[blockFieldName] = {}
+                const segmentAfterBlockField = pathSegments[i + 4]
+                const blockFieldIsArray =
+                  segmentAfterBlockField !== undefined && indexSegment.test(segmentAfterBlockField)
+                blockObject[blockFieldName] = blockFieldIsArray ? [] : {}
               }
               currentObject = blockObject[blockFieldName] as Record<string, unknown>
               i = i + 3
@@ -336,6 +345,18 @@ export const unflattenObject = ({
           currentObject = arr[arrayIndex] as Record<string, unknown>
           i++
         }
+      } else if (Array.isArray(currentObject) && indexSegment.test(segment)) {
+        // currentObject is an array we arrived at via block field traversal — treat the
+        // segment as a numeric index rather than a plain property name.
+        const idx = parseInt(segment, 10)
+        const arr = currentObject as unknown[]
+        while (arr.length <= idx) {
+          arr.push(null)
+        }
+        if (arr[idx] === null || arr[idx] === undefined) {
+          arr[idx] = {}
+        }
+        currentObject = arr[idx] as Record<string, unknown>
       } else {
         // Skip if already set to null (polymorphic relationship already processed)
         if (currentObject[segment] === null && isLast && segment === 'relationTo') {

--- a/packages/plugin-import-export/src/utilities/unflattenPostProcess.ts
+++ b/packages/plugin-import-export/src/utilities/unflattenPostProcess.ts
@@ -1,5 +1,6 @@
 import type { FlattenedField } from 'payload'
 
+import { getBlockFlattenedFields, getNestedFlattenedFields } from './flattenedFields.js'
 import { isPlainObject } from './isPlainObject.js'
 import { processRichTextField } from './processRichTextField.js'
 
@@ -140,29 +141,60 @@ const normalizePolymorphicRelationships = (
   }
 }
 
-const normalizeRichText = (doc: Record<string, unknown>, fields: FlattenedField[]): void => {
-  for (const field of fields.filter((f) => f.type === 'richText')) {
-    if (field.name in doc && doc[field.name]) {
-      doc[field.name] = processRichTextField(doc[field.name])
-    }
-  }
-
-  for (const field of fields.filter((f) => f.type === 'blocks')) {
-    const blocks = doc[field.name]
-    if (!Array.isArray(blocks)) {
+const normalizeRichTextInFields = (
+  doc: Record<string, unknown>,
+  fields: FlattenedField[],
+): void => {
+  for (const field of fields) {
+    if (!('name' in field) || !field.name || !(field.name in doc)) {
       continue
     }
-    for (const block of blocks) {
-      if (!isPlainObject(block)) {
+    const value = doc[field.name]
+    if (value === null || value === undefined) {
+      continue
+    }
+
+    if (field.type === 'richText') {
+      doc[field.name] = processRichTextField(value)
+    } else if (field.type === 'blocks') {
+      if (!Array.isArray(value)) {
         continue
       }
-      for (const [key, value] of Object.entries(block)) {
-        if (key === 'richText' || (typeof key === 'string' && key.includes('richText'))) {
-          block[key] = processRichTextField(value)
+      const blockDefs =
+        (field as { blocks?: Array<{ flattenedFields?: FlattenedField[]; slug: string }> })
+          .blocks ?? []
+      for (const blockItem of value) {
+        if (!isPlainObject(blockItem)) {
+          continue
+        }
+        const blockDef = blockDefs.find((b) => b.slug === blockItem.blockType)
+        if (blockDef) {
+          normalizeRichTextInFields(blockItem, getBlockFlattenedFields(blockDef))
         }
       }
+    } else if (field.type === 'array') {
+      if (!Array.isArray(value)) {
+        continue
+      }
+      const nestedFields = getNestedFlattenedFields(field) ?? []
+      for (const item of value) {
+        if (!isPlainObject(item)) {
+          continue
+        }
+        normalizeRichTextInFields(item, nestedFields)
+      }
+    } else if (field.type === 'group' || field.type === 'tab') {
+      if (!isPlainObject(value)) {
+        continue
+      }
+      const nestedFields = getNestedFlattenedFields(field) ?? []
+      normalizeRichTextInFields(value, nestedFields)
     }
   }
+}
+
+const normalizeRichText = (doc: Record<string, unknown>, fields: FlattenedField[]): void => {
+  normalizeRichTextInFields(doc, fields)
 }
 
 /**

--- a/test/plugin-import-export/collections/Pages.ts
+++ b/test/plugin-import-export/collections/Pages.ts
@@ -229,6 +229,25 @@ export const Pages: CollectionConfig = {
             },
           ],
         },
+        {
+          slug: 'faqSection',
+          fields: [
+            {
+              name: 'faqs',
+              type: 'array',
+              fields: [
+                {
+                  name: 'question',
+                  type: 'text',
+                },
+                {
+                  name: 'answer',
+                  type: 'richText',
+                },
+              ],
+            },
+          ],
+        },
       ],
     },
     {

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -1873,6 +1873,88 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
+      it('should roundtrip a block containing a nested array with richText through CSV export/import', async () => {
+        const testPage = await payload.create({
+          collection: 'pages',
+          data: {
+            title: 'FAQ Block Roundtrip Test',
+            blocks: [
+              {
+                blockType: 'faqSection',
+                faqs: [
+                  { question: 'What is Payload?', answer: richTextData },
+                  { question: 'Is it open source?', answer: richTextData },
+                ],
+              },
+            ],
+          },
+        })
+
+        let exportDoc = await payload.create({
+          collection: 'exports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            format: 'csv',
+            where: { id: { equals: testPage.id } },
+          },
+        })
+
+        await payload.jobs.run()
+
+        exportDoc = await payload.findByID({ collection: 'exports', id: exportDoc.id })
+
+        const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
+
+        await payload.delete({ collection: 'pages', id: testPage.id })
+
+        let importDoc = await payload.create({
+          collection: 'imports',
+          user,
+          data: { collectionSlug: 'pages', importMode: 'create' },
+          file: {
+            data: fs.readFileSync(csvPath),
+            mimetype: 'text/csv',
+            name: 'faq-roundtrip.csv',
+            size: fs.statSync(csvPath).size,
+          },
+        })
+
+        await payload.jobs.run()
+
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        expect(importDoc.status).toBe('completed')
+        expect(importDoc.summary?.imported).toBe(1)
+
+        const importedPages = await payload.find({
+          collection: 'pages',
+          where: { title: { equals: 'FAQ Block Roundtrip Test' } },
+        })
+
+        expect(importedPages.docs).toHaveLength(1)
+        const imported = importedPages.docs[0]
+
+        expect(imported?.blocks).toHaveLength(1)
+        const faqBlock = imported?.blocks?.[0]
+        expect(faqBlock?.blockType).toBe('faqSection')
+
+        const faqs = (faqBlock as any)?.faqs
+        expect(Array.isArray(faqs)).toBe(true)
+        expect(faqs).toHaveLength(2)
+
+        expect(faqs[0]?.question).toBe('What is Payload?')
+        expect(typeof faqs[0]?.answer).not.toBe('string')
+        expect(faqs[0]?.answer?.root?.type).toBe('root')
+
+        expect(faqs[1]?.question).toBe('Is it open source?')
+        expect(typeof faqs[1]?.answer).not.toBe('string')
+
+        await payload.delete({
+          collection: 'pages',
+          where: { title: { equals: 'FAQ Block Roundtrip Test' } },
+        })
+      })
+
       it('should handle json fields in deeply nested array structures', async () => {
         const jsonData = { level: 'nested', data: [1, 2, 3] }
 


### PR DESCRIPTION
## Summary

- Arrays nested inside a block (e.g. a `faqs` array field inside a `faqSection` block) were reconstructed as plain objects with numeric keys (`{"0": {...}}`) instead of proper arrays on import
- richText fields inside those nested arrays were left as raw JSON strings instead of being parsed back to objects

## Root causes

**Bug 1 — wrong container type for array fields inside blocks**

`unflattenObject` has a special-case branch for blocks fields. When the path continued past the block field name (e.g. `faqContent_0_faqSection_faqs_0_question`), it always created `blockObject[fieldName] = {}`, never `[]`. Two fixes applied:
- Detect whether the segment immediately after the field name is a numeric index and create `[]` accordingly
- Add an `else if` branch in the general traversal to handle the case where `currentObject` is already an array and the current segment is a numeric index (which happens after the block-field jump)

**Bug 2 — import hook not firing for richText inside nested arrays**

`toLogicalKey` strips array index segments from flat keys to resolve import hook registrations (e.g. `faqContent_0_faqSection_faqs_0_answer` → `faqContent_faqSection_faqs_answer`). It only strips a numeric segment when the previous segment is in `arrayLikeNames`. `collectArrayLikeNames` recurses via `field.flattenedFields` but not via `field.blocks[i].flattenedFields`, so array field names declared inside block definitions (like `faqs`) were never added to the set. The hook lookup therefore failed and the JSON string was left unparsed.

**Defence-in-depth — `normalizeRichText` key-name heuristic replaced**

The post-processing fallback in `normalizeRichText` previously matched block properties by checking whether the runtime key name contained `"richText"`. This never reached fields nested inside arrays inside blocks. Replaced with a schema-driven recursive walker (`normalizeRichTextInFields`) that handles `richText`, `blocks`, `array`, `group`, and `tab` fields at any depth.