### PR TITLE
fix: prevent type generation script from hanging on storage-r2

### DIFF
--- a/test/generateTypes.ts
+++ b/test/generateTypes.ts
@@ -35,6 +35,10 @@ async function run() {
 
     setTestEnvPaths(testDir)
     await generateTypes(config)
+
+    // Generation is done; Configs that leave handles open (e.g. storage-r2's undisposed
+    // Cloudflare workerd runtime) shouldn't keep the process alive.
+    process.exit(0)
   } else {
     // Search through every folder in dirname, and if it has a config.ts file, generate types for it
     const foundDirs: string[] = []


### PR DESCRIPTION
Before this change, the type generation script (`test/generateTypes.ts`) would hang indefinitely on the `storage-r2` suite, whose config boots a Cloudflare `workerd` runtime that is never disposed and keeps the Node process alive. The script now exits as soon as generation finishes, so the `storage-r2` suite completes in about 1 second.