### PR TITLE
templates: repair failing blank & website e2e suites

### DIFF
--- a/templates/blank/tests/e2e/admin.e2e.spec.ts
+++ b/templates/blank/tests/e2e/admin.e2e.spec.ts
@@ -21,7 +21,7 @@ test.describe('Admin Panel', () => {
   test('can navigate to dashboard', async () => {
     await page.goto('http://localhost:3000/admin')
     await expect(page).toHaveURL('http://localhost:3000/admin')
-    const dashboardArtifact = page.locator('span[title="Dashboard"]').first()
+    const dashboardArtifact = page.locator('.step-nav__first').first()
     await expect(dashboardArtifact).toBeVisible()
   })
 

--- a/templates/blank/tests/helpers/login.ts
+++ b/templates/blank/tests/helpers/login.ts
@@ -26,6 +26,6 @@ export async function login({
 
   await page.waitForURL(`${serverURL}/admin`)
 
-  const dashboardArtifact = page.locator('span[title="Dashboard"]')
+  const dashboardArtifact = page.locator('.step-nav__first')
   await expect(dashboardArtifact).toBeVisible()
 }

--- a/templates/website/src/blocks/Form/Component.tsx
+++ b/templates/website/src/blocks/Form/Component.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useState } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import RichText from '@/components/RichText'
 import { Button } from '@/components/ui/button'
-import type { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 
 import { fields } from './fields'
 import { getClientSideURL } from '@/utilities/getURL'
@@ -16,7 +16,7 @@ export type FormBlockType = {
   blockType?: 'formBlock'
   enableIntro: boolean
   form: FormType
-  introContent?: DefaultTypedEditorState
+  introContent?: SerializedEditorState
 }
 
 export const FormBlock: React.FC<

--- a/templates/website/src/blocks/Form/Message/index.tsx
+++ b/templates/website/src/blocks/Form/Message/index.tsx
@@ -2,9 +2,9 @@ import RichText from '@/components/RichText'
 import React from 'react'
 
 import { Width } from '../Width'
-import { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 
-export const Message: React.FC<{ message: DefaultTypedEditorState }> = ({ message }) => {
+export const Message: React.FC<{ message: SerializedEditorState }> = ({ message }) => {
   return (
     <Width className="my-12" width="100">
       {message && <RichText data={message} />}

--- a/templates/website/src/blocks/RelatedPosts/Component.tsx
+++ b/templates/website/src/blocks/RelatedPosts/Component.tsx
@@ -5,12 +5,12 @@ import RichText from '@/components/RichText'
 import type { Post } from '@/payload-types'
 
 import { Card } from '../../components/Card'
-import { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 
 export type RelatedPostsProps = {
   className?: string
   docs?: Post[]
-  introContent?: DefaultTypedEditorState
+  introContent?: SerializedEditorState
 }
 
 export const RelatedPosts: React.FC<RelatedPostsProps> = (props) => {

--- a/templates/website/tests/e2e/admin.e2e.spec.ts
+++ b/templates/website/tests/e2e/admin.e2e.spec.ts
@@ -21,7 +21,7 @@ test.describe('Admin Panel', () => {
   test('can navigate to dashboard', async () => {
     await page.goto('http://localhost:3000/admin')
     await expect(page).toHaveURL('http://localhost:3000/admin')
-    const dashboardArtifact = page.locator('span[title="Dashboard"]').first()
+    const dashboardArtifact = page.locator('.step-nav__first').first()
     await expect(dashboardArtifact).toBeVisible()
   })
 

--- a/templates/website/tests/helpers/login.ts
+++ b/templates/website/tests/helpers/login.ts
@@ -26,6 +26,6 @@ export async function login({
 
   await page.waitForURL(`${serverURL}/admin`)
 
-  const dashboardArtifact = page.locator('span[title="Dashboard"]')
+  const dashboardArtifact = page.locator('.step-nav__first')
   await expect(dashboardArtifact).toBeVisible()
 }


### PR DESCRIPTION
# Overview

Fixes the `blank` and `website` template e2e suites, the only two template jobs failing in CI.

## Key Changes

#### Update stale dashboard breadcrumb selector

The admin e2e login helper and dashboard test waited for `span[title="Dashboard"]`, which no longer exists after the StepNav refactor in #16680. The dashboard breadcrumb now renders with class `.step-nav__first`. Applied to both `blank` and `website`.

#### Fix website rich-text prop types

Three website forwarder components (`Form`, `Form/Message`, `RelatedPosts`) typed their rich-text props as `DefaultTypedEditorState`. After #16919, generated fields are typed `LexicalRichText<...>`, which is not assignable to that, so the website `next build` type-check failed. They now use `SerializedEditorState`, matching the `RichText` `data` prop they forward to.

## Design Decisions

`SerializedEditorState` is the type the underlying `RichText` component already accepts for its `data` prop. Typing the forwarder props the same way keeps them consistent with the sink and accepts any generated editor state, which is what other blocks (`Content`, `CallToAction`) already pass through.
