### PR TITLE
templates: run website e2e against production build

### DIFF
--- a/templates/website/playwright.config.ts
+++ b/templates/website/playwright.config.ts
@@ -34,8 +34,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm dev',
+    command: 'pnpm build && pnpm start',
     reuseExistingServer: true,
+    timeout: 5 * 60 * 1000,
     url: 'http://localhost:3000',
   },
 })

--- a/templates/website/tests/e2e/admin.e2e.spec.ts
+++ b/templates/website/tests/e2e/admin.e2e.spec.ts
@@ -27,7 +27,7 @@ test.describe('Admin Panel', () => {
 
   test('can navigate to list view', async () => {
     await page.goto('http://localhost:3000/admin/collections/users')
-    await expect(page).toHaveURL('http://localhost:3000/admin/collections/users')
+    await expect(page).toHaveURL(/\/admin\/collections\/users(\?.*)?$/)
     const listViewArtifact = page.locator('h1', { hasText: 'Users' }).first()
     await expect(listViewArtifact).toBeVisible()
   })


### PR DESCRIPTION
# Overview

Makes the `website` template e2e suite reliable. Follow-up to #16926, which fixed the build and selector but exposed a dev-only crash once the suite could run.

## Key Changes

#### Run the e2e webServer against the production build

Under `next dev` (Turbopack) the website admin crashes with `chunk.reason.enqueueModel is not a function` — an upstream React Flight / Turbopack HMR manifest race ([#14419](https://github.com/payloadcms/payload/issues/14419)) triggered by Payload's import-map admin client components (e.g. plugin-seo's `PreviewComponent`). It is dev-only; production rendering is unaffected. The webServer now runs `pnpm build && pnpm start`, so the suite builds and tests the production build and works whether or not the app was built beforehand.

#### Relax the list-view URL assertion

The production list view appends `?depth=1&limit=10`, so the exact-string URL match is now a pathname-tolerant regex.

## References / Links

- https://github.com/payloadcms/payload/issues/14419
- https://github.com/payloadcms/payload/issues/14860
