### PR TITLE
fix(next): prevent version diff crash when block is newly added between versions

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -18,13 +18,7 @@ import {
   type SanitizedFieldsPermissions,
   type VersionField,
 } from 'payload'
-import {
-  fieldIsID,
-  fieldShouldBeLocalized,
-  getFieldPaths,
-  getUniqueListBy,
-  tabHasName,
-} from 'payload/shared'
+import { fieldIsID, fieldShouldBeLocalized, getFieldPaths, tabHasName } from 'payload/shared'
 
 import { diffComponents } from './fields/index.js'
 
@@ -463,8 +457,21 @@ const buildVersionField = ({
             (block) => typeof block !== 'string' && block.slug === fromBlockSlugToMatch,
           ) as FlattenedBlock | undefined)
 
-        if (fromBlock) {
-          fields = getUniqueListBy<Field>([...toBlock.fields, ...fromBlock.fields], 'name')
+        if (fromBlock && fromBlockSlugToMatch !== toBlock.slug) {
+          // For truly different block types:
+          // Keep toBlock's full field structure at correct positions (including unnamed fields), then append any uniquely-named fields from fromBlock.
+          // `getUniqueListBy` cannot be used here — all unnamed fields will collapse to a single entry, causing incorrect index paths.
+          const toNamedFieldNames = new Set(
+            toBlock.fields
+              .filter((f) => 'name' in f)
+              .map((f) => (f as { name: string } & Field).name),
+          )
+
+          const uniqueFromNamedFields = fromBlock.fields.filter(
+            (f) => 'name' in f && !toNamedFieldNames.has((f as { name: string } & Field).name),
+          )
+
+          fields = [...toBlock.fields, ...uniqueFromNamedFields]
         } else {
           fields = toBlock.fields
         }

--- a/test/versions/collections/Diff/index.ts
+++ b/test/versions/collections/Diff/index.ts
@@ -99,6 +99,28 @@ export const Diff: CollectionConfig = {
           ],
         },
         {
+          // Block with multiple unnamed layout containers (groups/rows) at the top level.
+          // Used to test that version diff rendering correctly resolves schema paths when a block is newly added between versions.
+          // Specifically, when the block contains multiple unnamed fields at the top level.
+          slug: 'GroupsBlock',
+          fields: [
+            {
+              type: 'group',
+              label: 'Section A',
+              fields: [{ name: 'fieldA', type: 'text' }],
+            },
+            {
+              type: 'group',
+              label: 'Section B',
+              fields: [{ name: 'fieldB', type: 'text' }],
+            },
+            {
+              type: 'row',
+              fields: [{ name: 'fieldC', type: 'number' }],
+            },
+          ],
+        },
+        {
           slug: 'TabsBlock',
           fields: [
             {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1230,7 +1230,9 @@ describe('Versions', () => {
       await openDocControls(page)
       await page.locator('#action-duplicate').click()
       await expect(page.locator('.payload-toast-container')).toContainText('successfully')
-      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).not.toContain(publishedDoc.id)
+      await expect
+        .poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT })
+        .not.toContain(publishedDoc.id)
 
       await expect(page.locator('.doc-controls__status .status__value')).toContainText('Draft')
       await waitForFormReady(page)
@@ -3044,6 +3046,53 @@ describe('Versions', () => {
       )
 
       // Cleanup
+      await payload.delete({ collection: diffCollectionSlug, id: doc.id })
+    })
+
+    test('should render diff when a block with unnamed layout containers is newly added', async () => {
+      // Version 1: no blocks. Version 2: adds GroupsBlock.
+      // When comparing v2 vs v1, fromRow.blockType is undefined at that position.
+      // This causes all unnamed fields to collapse to one entry at index 0.
+      // Ultimately, this generates wrong schema paths (e.g. _index-0.fieldC instead of _index-2.fieldC).
+      const doc = await payload.create({
+        collection: diffCollectionSlug,
+        draft: true,
+        data: { text: 'initial' },
+      })
+
+      await payload.update({
+        collection: diffCollectionSlug,
+        id: doc.id,
+        draft: true,
+        data: {
+          blocks: [
+            {
+              blockType: 'GroupsBlock',
+              fieldA: 'a',
+              fieldB: 'b',
+              fieldC: 1,
+            },
+          ],
+        },
+      })
+
+      const versions = await payload.findVersions({
+        collection: diffCollectionSlug,
+        depth: 0,
+        limit: 1,
+        where: { parent: { equals: doc.id } },
+      })
+
+      const versionID = versions?.docs?.[0]?.id
+      const versionURL = formatAdminURL({
+        adminRoute,
+        path: `/collections/${diffCollectionSlug}/${doc.id}/versions/${versionID}`,
+        serverURL,
+      })
+
+      await page.goto(versionURL)
+      await expect(page.locator('.render-field-diffs').first()).toBeVisible()
+
       await payload.delete({ collection: diffCollectionSlug, id: doc.id })
     })
   })

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -64,7 +64,6 @@ export type SupportedTimezones =
 export interface Config {
   auth: {
     users: UserAuthOperations;
-    'payload-mcp-api-keys': PayloadMcpApiKeyAuthOperations;
   };
   blocks: {};
   collections: {
@@ -89,9 +88,8 @@ export interface Config {
     'draft-with-upload': DraftWithUpload;
     media: Media;
     media2: Media2;
-    users: User;
-    'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
+    users: User;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -120,9 +118,8 @@ export interface Config {
     'draft-with-upload': DraftWithUploadSelect<false> | DraftWithUploadSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     media2: Media2Select<false> | Media2Select<true>;
-    users: UsersSelect<false> | UsersSelect<true>;
-    'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
+    users: UsersSelect<false> | UsersSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -158,7 +155,7 @@ export interface Config {
   widgets: {
     collections: CollectionsWidget;
   };
-  user: User | PayloadMcpApiKey;
+  user: User;
   jobs: {
     tasks: {
       schedulePublish: TaskSchedulePublish;
@@ -171,24 +168,6 @@ export interface Config {
   };
 }
 export interface UserAuthOperations {
-  forgotPassword: {
-    email: string;
-    password: string;
-  };
-  login: {
-    email: string;
-    password: string;
-  };
-  registerFirstUser: {
-    email: string;
-    password: string;
-  };
-  unlock: {
-    email: string;
-    password: string;
-  };
-}
-export interface PayloadMcpApiKeyAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -238,11 +217,21 @@ export interface AutosavePost {
   title: string;
   relationship?: (string | null) | Post;
   computedTitle?: string | null;
-  richText?:
-    | {
+  richText?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
         [k: string]: unknown;
-      }[]
-    | null;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   json?:
     | {
         [k: string]: unknown;
@@ -513,6 +502,14 @@ export interface Diff {
             blockType: 'CollapsibleBlock';
           }
         | {
+            fieldA?: string | null;
+            fieldB?: string | null;
+            fieldC?: number | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'GroupsBlock';
+          }
+        | {
             namedTab1InBlock?: {
               textInNamedTab1InBlock?: string | null;
             };
@@ -587,16 +584,36 @@ export interface Diff {
       )[]
     | null;
   zeroDepthRelationship?: (string | null) | User;
-  richtext?:
-    | {
+  richtext?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
         [k: string]: unknown;
-      }[]
-    | null;
-  richtextWithCustomDiff?:
-    | {
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  richtextWithCustomDiff?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
         [k: string]: unknown;
-      }[]
-    | null;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   textInRow?: string | null;
   textCannotRead?: string | null;
   select?: ('option1' | 'option2') | null;
@@ -706,49 +723,6 @@ export interface Media2 {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-}
-/**
- * API keys control which collections, resources, tools, and prompts MCP clients can access
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-mcp-api-keys".
- */
-export interface PayloadMcpApiKey {
-  id: string;
-  /**
-   * The user that the API key is associated with.
-   */
-  user: string | User;
-  /**
-   * A useful label for the API key.
-   */
-  label?: string | null;
-  /**
-   * The purpose of the API key.
-   */
-  description?: string | null;
-  /**
-   * When checked, this key bypasses Payload access control on every operation it performs. Leave unchecked unless you have a specific reason.
-   */
-  overrideAccess?: boolean | null;
-  /**
-   * Access for this API key — uncheck to revoke individual tools.
-   */
-  access?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-  enableAPIKey?: boolean | null;
-  apiKey?: string | null;
-  apiKeyIndex?: string | null;
-  collection: 'payload-mcp-api-keys';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -953,21 +927,12 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'users';
         value: string | User;
-      } | null)
-    | ({
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
       } | null);
   globalSlug?: string | null;
-  user:
-    | {
-        relationTo: 'users';
-        value: string | User;
-      }
-    | {
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
-      };
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
   updatedAt: string;
   createdAt: string;
 }
@@ -977,15 +942,10 @@ export interface PayloadLockedDocument {
  */
 export interface PayloadPreference {
   id: string;
-  user:
-    | {
-        relationTo: 'users';
-        value: string | User;
-      }
-    | {
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
-      };
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
   key?: string | null;
   value?:
     | {
@@ -1293,6 +1253,15 @@ export interface DiffSelect<T extends boolean = true> {
               id?: T;
               blockName?: T;
             };
+        GroupsBlock?:
+          | T
+          | {
+              fieldA?: T;
+              fieldB?: T;
+              fieldC?: T;
+              id?: T;
+              blockName?: T;
+            };
         TabsBlock?:
           | T
           | {
@@ -1417,6 +1386,14 @@ export interface Media2Select<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
@@ -1436,30 +1413,6 @@ export interface UsersSelect<T extends boolean = true> {
         createdAt?: T;
         expiresAt?: T;
       };
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-mcp-api-keys_select".
- */
-export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
-  user?: T;
-  label?: T;
-  description?: T;
-  overrideAccess?: T;
-  access?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  enableAPIKey?: T;
-  apiKey?: T;
-  apiKeyIndex?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-kv_select".
- */
-export interface PayloadKvSelect<T extends boolean = true> {
-  key?: T;
-  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Identical to https://github.com/payloadcms/payload/pull/16929, back-ported for 3.x.