### PR TITLE
fix(docs): replace raw HTML in accessibility Banner with markdown link

### DIFF
--- a/docs/admin/accessibility.mdx
+++ b/docs/admin/accessibility.mdx
@@ -9,18 +9,9 @@ keywords: admin, accessibility, a11y, custom, documentation, Content Management 
 Payload is committed to ensuring that our admin panel is accessible to all users, including those with disabilities. We follow best practices and guidelines to create an inclusive experience.
 
 <Banner type="info">
-  <p>
-    We are actively working towards full compliance with WCAG 2.2 AA standards.
-    If you encounter any accessibility issues, please report them in our{' '}
-    <a
-      href="https://github.com/payloadcms/payload/discussions/14489"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      GitHub Discussion
-    </a>{' '}
-    page.
-  </p>
+  We are actively working towards full compliance with WCAG 2.2 AA standards.
+  If you encounter any accessibility issues, please report them in our
+  [GitHub Discussion](https://github.com/payloadcms/payload/discussions/14489) page.
 </Banner>
 
 ## Compliance standards


### PR DESCRIPTION
Closes #16735

The accessibility.mdx doc used raw \<p>\ and \<a>\ tags inside the \<Banner>\ component, which were being rendered as escaped text (\&lt;p&gt;\, \&lt;a&gt;\) instead of being parsed as HTML elements. Replaced with plain markdown formatting, consistent with all other Banner usage patterns across the docs (80+ other files).