### PR TITLE
fix(core): handle @next/env default export removal in Next.js 15.5+

### DIFF
--- a/docs/admin/accessibility.mdx
+++ b/docs/admin/accessibility.mdx
@@ -9,18 +9,9 @@ keywords: admin, accessibility, a11y, custom, documentation, Content Management 
 Payload is committed to ensuring that our admin panel is accessible to all users, including those with disabilities. We follow best practices and guidelines to create an inclusive experience.
 
 <Banner type="info">
-  <p>
-    We are actively working towards full compliance with WCAG 2.2 AA standards.
-    If you encounter any accessibility issues, please report them in our{' '}
-    <a
-      href="https://github.com/payloadcms/payload/discussions/14489"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      GitHub Discussion
-    </a>{' '}
-    page.
-  </p>
+  We are actively working towards full compliance with WCAG 2.2 AA standards.
+  If you encounter any accessibility issues, please report them in our
+  [GitHub Discussion](https://github.com/payloadcms/payload/discussions/14489) page.
 </Banner>
 
 ## Compliance standards

--- a/packages/payload/src/bin/loadEnv.ts
+++ b/packages/payload/src/bin/loadEnv.ts
@@ -1,7 +1,7 @@
-import nextEnvImport from '@next/env'
+import * as nextEnvImport from '@next/env'
 
 import { findUpSync } from '../utilities/findUp.js'
-const { loadEnvConfig } = nextEnvImport
+const { loadEnvConfig } = nextEnvImport.default ?? nextEnvImport
 
 /**
  * Try to find user's env files and load it. Uses the same algorithm next.js uses to parse env files, meaning this also supports .env.local, .env.development, .env.production, etc.


### PR DESCRIPTION
Closes #16674

Next.js 15.5+ removed the default export from \@next/env\ — only named exports remain. Changed the import from default to namespace import and use \
extEnvImport.default ?? nextEnvImport\ to destructure \loadEnvConfig\, maintaining compatibility with both versions.

This was previously patched via \patch-package\ by the reporter and confirmed to resolve the error.