### PR TITLE
chore(next): disable devIndicators by default

### DIFF
--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -51,6 +51,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
   /** @type {import('next').NextConfig} */
   const baseConfig = {
     ...nextConfig,
+    devIndicators: nextConfig.devIndicators !== undefined ? nextConfig.devIndicators : false,
     env,
     experimental: {
       ...(nextConfig.experimental || {}),

--- a/packages/next/src/withPayload/withPayload.spec.ts
+++ b/packages/next/src/withPayload/withPayload.spec.ts
@@ -26,6 +26,18 @@ describe('withPayload', () => {
     }
   })
 
+  it('should disable devIndicators by default', () => {
+    const result = withPayload({})
+
+    expect(result.devIndicators).toBe(false)
+  })
+
+  it('should use user-provided devIndicators when specified', () => {
+    const result = withPayload({ devIndicators: { appIsrStatus: true } })
+
+    expect(result.devIndicators).toEqual({ appIsrStatus: true })
+  })
+
   it('should not modify process.env.NEXT_BASE_PATH when basePath is not provided', () => {
     const originalBasePath = process.env.NEXT_BASE_PATH
 


### PR DESCRIPTION
Disables the devIndicators in Nextjs config by default so it no longer shows unless explicitly enabled by the end user.