### PR TITLE
feat: collection-level disableBulkDelete

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -87,6 +87,7 @@ The following options are available:
 | `defaultPopulate`    | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultpopulate-collection-config-property).                                                                                      |
 | `indexes`            | Define compound indexes for this collection. This can be used to either speed up querying/sorting by 2 or more fields at the same time or to ensure uniqueness between several fields.                                                                     |
 | `select`             | Function that receives the current `operation`, `req`, and caller's `select`, and returns the final `select` to apply. Useful for forcing fields to be populated for hooks / access control. [More details](../queries/select#entity-level-select-config). |
+| `disableBulkDelete`  | Disable the bulk delete operation for the collection in the admin panel and the REST API                                                                                                                                                                   |
 | `disableBulkEdit`    | Disable the bulk edit operation for the collection in the admin panel and the REST API                                                                                                                                                                     |
 
 _\* An asterisk denotes that a property is required._

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -575,6 +575,10 @@ export type CollectionConfig<TSlug extends CollectionSlug = any> = {
    */
   defaultSort?: Sort
   /**
+   * Disable the bulk delete operation for the collection in the admin panel and the API
+   */
+  disableBulkDelete?: boolean
+  /**
    * Disable the bulk edit operation for the collection in the admin panel and the API
    */
   disableBulkEdit?: boolean

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -53,6 +53,10 @@ export const deleteOperation = async <
 ): Promise<BulkOperationResult<TSlug, TSelect>> => {
   let args = incomingArgs
 
+  if (args.collection.config.disableBulkDelete && !args.overrideAccess) {
+    throw new APIError(`Collection ${args.collection.config.slug} has disabled bulk delete`, 403)
+  }
+
   try {
     const shouldCommit = !args.disableTransaction && (await initTransaction(args.req))
     // /////////////////////////////////////

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -497,7 +497,7 @@ export const renderListView = async (
       baseFilter: baseFilterConstraint,
       collectionSlug,
       columnState,
-      disableBulkDelete,
+      disableBulkDelete: collectionConfig.disableBulkDelete ?? disableBulkDelete,
       disableBulkEdit: collectionConfig.disableBulkEdit ?? disableBulkEdit,
       disableQueryPresets,
       enableRowSelections,

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -290,6 +290,17 @@ export default buildConfigWithDefaults({
       disableBulkEdit: true,
       versions: false,
     },
+    {
+      slug: 'disabled-bulk-delete-docs',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+      ],
+      disableBulkDelete: true,
+      versions: false,
+    },
     LargeDocuments,
   ],
   bodyParser: {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -1919,6 +1919,38 @@ describe('collections-rest', () => {
       }),
     ).resolves.toBeTruthy()
   })
+
+  it('should disable bulk delete for the collection with disableBulkDelete: true', async () => {
+    const res = await restClient.DELETE('/disabled-bulk-delete-docs?where[id][equals]=0')
+    expect(res.status).toBe(403)
+
+    await expect(
+      payload.delete({
+        collection: 'disabled-bulk-delete-docs',
+        where: {},
+        overrideAccess: false,
+      }),
+    ).rejects.toBeInstanceOf(APIError)
+
+    const doc = await payload.create({
+      collection: 'disabled-bulk-delete-docs',
+      data: { text: 'should be deletable by id' },
+    })
+
+    await expect(
+      payload.delete({
+        collection: 'disabled-bulk-delete-docs',
+        id: doc.id,
+      }),
+    ).resolves.toBeTruthy()
+
+    await expect(
+      payload.delete({
+        collection: 'disabled-bulk-delete-docs',
+        where: {},
+      }),
+    ).resolves.toBeTruthy()
+  })
 })
 
 async function createPost(overrides?: Partial<Post>) {

--- a/test/collections-rest/payload-types.ts
+++ b/test/collections-rest/payload-types.ts
@@ -77,6 +77,7 @@ export interface Config {
     'error-on-hooks': ErrorOnHook;
     endpoints: Endpoint;
     'disabled-bulk-edit-docs': DisabledBulkEditDoc;
+    'disabled-bulk-delete-docs': DisabledBulkDeleteDoc;
     'large-documents': LargeDocument;
     users: User;
     'payload-mcp-api-keys': PayloadMcpApiKey;
@@ -96,6 +97,7 @@ export interface Config {
     'error-on-hooks': ErrorOnHooksSelect<false> | ErrorOnHooksSelect<true>;
     endpoints: EndpointsSelect<false> | EndpointsSelect<true>;
     'disabled-bulk-edit-docs': DisabledBulkEditDocsSelect<false> | DisabledBulkEditDocsSelect<true>;
+    'disabled-bulk-delete-docs': DisabledBulkDeleteDocsSelect<false> | DisabledBulkDeleteDocsSelect<true>;
     'large-documents': LargeDocumentsSelect<false> | LargeDocumentsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
@@ -288,6 +290,16 @@ export interface DisabledBulkEditDoc {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "disabled-bulk-delete-docs".
+ */
+export interface DisabledBulkDeleteDoc {
+  id: string;
+  text?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "large-documents".
  */
 export interface LargeDocument {
@@ -428,6 +440,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'disabled-bulk-edit-docs';
         value: string | DisabledBulkEditDoc;
+      } | null)
+    | ({
+        relationTo: 'disabled-bulk-delete-docs';
+        value: string | DisabledBulkDeleteDoc;
       } | null)
     | ({
         relationTo: 'large-documents';
@@ -595,6 +611,15 @@ export interface EndpointsSelect<T extends boolean = true> {
  * via the `definition` "disabled-bulk-edit-docs_select".
  */
 export interface DisabledBulkEditDocsSelect<T extends boolean = true> {
+  text?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "disabled-bulk-delete-docs_select".
+ */
+export interface DisabledBulkDeleteDocsSelect<T extends boolean = true> {
   text?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
## Summary

Adds a collection-level `disableBulkDelete` config option, completing the work started in #12850 (which added collection-level `disableBulkEdit`).

Previously, `disableBulkDelete` only existed as a List View UI prop, so setting it hid the bulk delete button but did **not** prevent bulk deletes via the REST, GraphQL, or Local API. A user with `delete` permission could still delete every document at once through `payload.delete({ where })` or `DELETE /api/:collection?where=...`.

This brings `disableBulkDelete` to full parity with `disableBulkEdit`:

- New collection config option `disableBulkDelete`.
- Server-side enforcement: the bulk `deleteOperation` now throws a `403` when `disableBulkDelete` is set and access is not overridden, mirroring the existing guard in `updateOperation`.
- The bulk delete UI action is hidden automatically, because the option is threaded into the List view props (which also covers the trash and hierarchy views, since they all route through `renderListView`).

Single-document deletes (`deleteByID`) are unaffected, so "delete one, not delete many" works out of the box without a custom `access.delete` check.

## Background and timeline

`disableBulkEdit` and `disableBulkDelete` both started life as List View component props, but only `disableBulkEdit` was ever promoted to a real collection config option with API enforcement. This PR closes that asymmetry.

| Layer                                     | `disableBulkEdit` | `disableBulkDelete` (before) | `disableBulkDelete` (this PR) |
| ----------------------------------------- | ----------------- | ---------------------------- | ----------------------------- |
| List View UI prop (hides the button)      | Yes, since #2346  | Yes, since #7796             | Yes (unchanged)               |
| Collection config option                  | Yes, since #12850 | No                           | Yes (new)                     |
| Server / API enforcement (403 on bulk op) | Yes, since #12850 | No                           | Yes (new)                     |

Timeline:

1. #2346 (`feat: bulk-operations`): `disableBulkEdit` introduced as a UI prop.
2. #7796: `disableBulkDelete` introduced as a List View UI prop (UI only, never promoted).
3. #12850 (`feat: collection-level disableBulkEdit`): `disableBulkEdit` promoted to a collection config option with API enforcement. `disableBulkDelete` was left behind.
4. This PR: promotes `disableBulkDelete` to the same level.

## Note on trash / soft delete

This scopes `disableBulkDelete` to the bulk delete operation, exactly mirroring how `disableBulkEdit` guards the bulk update operation. In Payload, bulk "move to trash" is a bulk update (it sets `deletedAt`), so it runs through `updateOperation` and is therefore governed by `disableBulkEdit`, not `disableBulkDelete`. Restore is also an update. A collection that wants to lock down both bulk edits and bulk removals can set both flags, and they compose cleanly. Finer-grained trash UX can be a follow-up if desired.

## Test plan

- [x] Added a `disabled-bulk-delete-docs` collection with `disableBulkDelete: true` in `test/collections-rest`.
- [x] Added an integration test mirroring the existing `disableBulkEdit` test: REST bulk `DELETE` returns `403`, Local API bulk delete with `overrideAccess: false` rejects with `APIError`, single-document delete by `id` still works, and bulk delete still works when access is overridden.
- [x] `pnpm run test:int collections-rest -t "bulk"` passes.
