### PR TITLE
fix(ui): respect admin.condition on row fields

### DIFF
--- a/packages/payload/src/admin/fields/Row.ts
+++ b/packages/payload/src/admin/fields/Row.ts
@@ -22,9 +22,9 @@ import type {
 
 type RowFieldClientWithoutType = MarkOptional<RowFieldClient, 'type'>
 
-type RowFieldBaseClientProps = Omit<FieldPaths, 'path'> & Pick<ClientComponentProps, 'forceRender'>
+type RowFieldBaseClientProps = FieldPaths & Pick<ClientComponentProps, 'forceRender'>
 
-export type RowFieldClientProps = Omit<ClientFieldBase<RowFieldClientWithoutType>, 'path'> &
+export type RowFieldClientProps = ClientFieldBase<RowFieldClientWithoutType> &
   RowFieldBaseClientProps
 
 export type RowFieldServerProps = ServerFieldBase<RowField, RowFieldClientWithoutType>

--- a/packages/payload/src/admin/forms/Field.ts
+++ b/packages/payload/src/admin/forms/Field.ts
@@ -63,10 +63,8 @@ export type FieldPaths = {
    * Nested fields will have a path that includes the parent field names
    * if they are nested within a group, array, block or named tab.
    *
-   * Collapsibles and unnamed tabs will have arbitrary paths
+   * Collapsibles, rows and unnamed tabs will have arbitrary paths
    * that look like _index-0, _index-1, etc.
-   *
-   * Row fields will not have a path.
    *
    * @example 'parentGroupField.childTextField'
    *

--- a/packages/ui/src/forms/RenderFields/RenderField.tsx
+++ b/packages/ui/src/forms/RenderFields/RenderField.tsx
@@ -125,7 +125,7 @@ export function RenderField({
       return <RichTextField {...baseFieldProps} field={clientFieldConfig} path={path} />
 
     case 'row':
-      return <RowField {...iterableFieldProps} field={clientFieldConfig} />
+      return <RowField {...iterableFieldProps} field={clientFieldConfig} path={path} />
 
     case 'select':
       return <SelectField {...baseFieldProps} field={clientFieldConfig} path={path} />

--- a/test/fields/collections/ConditionalLogic/e2e.spec.ts
+++ b/test/fields/collections/ConditionalLogic/e2e.spec.ts
@@ -289,6 +289,15 @@ describe('Conditional Logic', () => {
     await expect(fieldWithOperationCondition).toBeHidden()
   })
 
+  test('should hide row field UI when admin.condition is false', async () => {
+    await page.goto(url.create)
+
+    await toggleConditionAndCheckField(
+      'label[for=field-toggleField]',
+      'label[for=field-rowFieldWithCondition]',
+    )
+  })
+
   test('should hide entire tabs field UI when admin.condition is false', async () => {
     await page.goto(url.create)
 

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -32,6 +32,18 @@ const ConditionalLogic: CollectionConfig = {
       },
     },
     {
+      type: 'row',
+      admin: {
+        condition: ({ toggleField }) => Boolean(toggleField),
+      },
+      fields: [
+        {
+          name: 'rowFieldWithCondition',
+          type: 'text',
+        },
+      ],
+    },
+    {
       name: 'fieldWithOperationCondition',
       type: 'text',
       admin: {


### PR DESCRIPTION
RenderField never forwarded `path` to RowField, so its `withCondition` wrapper looked up `passesCondition` at an undefined path and the row was never hidden. Result in row fields never gets hidden no matter what the `admin.condition` is.

**Fix**
Pass `path` to RowField and stop omitting `path` from RowFieldClientProps so the type matches the other layout fields (e.g. Collapsible).


**Before**

https://github.com/user-attachments/assets/a76c03da-a699-44a7-9ad2-ad0b2083b860



**After**
Also checked other containers like array, tab, group etc.
https://github.com/user-attachments/assets/deedc349-6afe-4bcc-89cb-fad71212f1aa





