### PR TITLE
refactor(ui)!: consolidate DeleteMany component

### DIFF
--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientCollectionConfig, ViewTypes, Where } from 'payload'
+import type { ViewTypes, Where } from 'payload'
 
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
@@ -9,128 +9,14 @@ import React from 'react'
 import { toast } from 'sonner'
 
 import { CheckboxInput } from '../../fields/Checkbox/Input.js'
-import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
-import { useRouteCache } from '../../providers/RouteCache/index.js'
-import { useRouter, useSearchParams } from '../../providers/RouterAdapter/index.js'
-import { SelectAllStatus, useSelection } from '../../providers/Selection/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { requests } from '../../utilities/api.js'
-import { parseSearchParams } from '../../utilities/parseSearchParams.js'
 import { shouldPermanentlyDelete } from '../../utilities/shouldPermanentlyDelete.js'
 import { ConfirmationModal } from '../ConfirmationModal/index.js'
 import { ListSelectionButton } from '../ListSelection/index.js'
 import { Translation } from '../Translation/index.js'
-
-export type Props = {
-  collection: ClientCollectionConfig
-  /**
-   * Whether the user has permission to permanently delete documents.
-   * If provided, uses this instead of reading from auth context.
-   */
-  hasDeletePermission?: boolean
-  /**
-   * Whether the user has permission to trash (soft delete) documents.
-   * If provided, uses this instead of reading from auth context.
-   */
-  hasTrashPermission?: boolean
-  /**
-   * When multiple DeleteMany components are rendered on the page, this will differentiate them.
-   */
-  modalPrefix?: string
-  /**
-   * When multiple PublishMany components are rendered on the page, this will differentiate them.
-   */
-  title?: string
-  viewType?: ViewTypes
-}
-
-export const DeleteMany: React.FC<Props> = (props) => {
-  const { viewType } = props
-  const {
-    collection: { slug, trash } = {},
-    hasDeletePermission: hasDeletePermissionFromProps,
-    hasTrashPermission: hasTrashPermissionFromProps,
-    modalPrefix,
-  } = props
-
-  const { permissions } = useAuth()
-  const { count, selectAll, selectedIDs, toggleAll } = useSelection()
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const { clearRouteCache } = useRouteCache()
-
-  const collectionPermissions = permissions?.collections?.[slug]
-
-  const hasDeletePermission =
-    hasDeletePermissionFromProps !== undefined
-      ? hasDeletePermissionFromProps
-      : Boolean(collectionPermissions?.delete)
-  const hasTrashPermission =
-    hasTrashPermissionFromProps !== undefined ? hasTrashPermissionFromProps : hasDeletePermission
-
-  const selectingAll = selectAll === SelectAllStatus.AllAvailable
-
-  const ids = selectingAll ? [] : selectedIDs
-
-  const isTrashView = viewType === 'trash'
-  const canShowDeleteButton = isTrashView
-    ? hasDeletePermission
-    : hasDeletePermission || hasTrashPermission
-
-  if (selectAll === SelectAllStatus.None || !canShowDeleteButton) {
-    return null
-  }
-
-  const baseWhere = parseSearchParams(searchParams)?.where as Where
-
-  const finalWhere =
-    viewType === 'trash'
-      ? {
-          and: [
-            ...(Array.isArray(baseWhere?.and) ? baseWhere.and : baseWhere ? [baseWhere] : []),
-            { deletedAt: { exists: true } },
-          ],
-        }
-      : baseWhere
-
-  return (
-    <React.Fragment>
-      <DeleteMany_v4
-        afterDelete={() => {
-          toggleAll()
-
-          router.replace(
-            qs.stringify(
-              {
-                ...parseSearchParams(searchParams),
-                page: selectAll ? '1' : undefined,
-              },
-              { addQueryPrefix: true },
-            ),
-          )
-
-          clearRouteCache()
-        }}
-        hasDeletePermission={hasDeletePermission}
-        hasTrashPermission={hasTrashPermission}
-        modalPrefix={modalPrefix}
-        search={parseSearchParams(searchParams)?.search as string}
-        selections={{
-          [slug]: {
-            all: selectAll === SelectAllStatus.AllAvailable,
-            ids,
-            totalCount: selectingAll ? count : ids.length,
-          },
-        }}
-        trash={trash}
-        viewType={viewType}
-        where={finalWhere}
-      />
-    </React.Fragment>
-  )
-}
 
 type AfterDeleteResult = {
   [relationTo: string]: {
@@ -140,7 +26,7 @@ type AfterDeleteResult = {
     totalCount: number
   }
 }
-type DeleteMany_v4Props = {
+export type DeleteManyProps = {
   /**
    * A callback function to be called after the delete request is completed.
    */
@@ -196,7 +82,7 @@ type DeleteMany_v4Props = {
  *
  * If you are deleting monomorphic documents, shape your `selections` to match the polymorphic structure.
  */
-export function DeleteMany_v4({
+export function DeleteMany({
   afterDelete,
   hasDeletePermission = false,
   hasTrashPermission = false,
@@ -206,7 +92,7 @@ export function DeleteMany_v4({
   trash,
   viewType,
   where,
-}: DeleteMany_v4Props) {
+}: DeleteManyProps) {
   const { t } = useTranslation()
 
   const {

--- a/packages/ui/src/views/HierarchyList/DocumentListSelection/index.tsx
+++ b/packages/ui/src/views/HierarchyList/DocumentListSelection/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { Fragment } from 'react'
 
-import { DeleteMany_v4 } from '../../../elements/DeleteMany/index.js'
+import { DeleteMany } from '../../../elements/DeleteMany/index.js'
 import { useDocumentDrawer } from '../../../elements/DocumentDrawer/index.js'
 import { EditMany_v4 } from '../../../elements/EditMany/index.js'
 import { MoveMany } from '../../../elements/Hierarchy/MoveMany/index.js'
@@ -140,7 +140,7 @@ export const DocumentListSelection: React.FC<DocumentListSelectionProps> = ({
             </Fragment>
           ),
         !disableBulkDelete && (
-          <DeleteMany_v4
+          <DeleteMany
             afterDelete={handleActionSuccess}
             key="bulk-delete"
             modalPrefix="hierarchy-list"

--- a/packages/ui/src/views/List/ListSelection/index.tsx
+++ b/packages/ui/src/views/List/ListSelection/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import type { ClientCollectionConfig, ViewTypes, Where } from 'payload'
 
+import * as qs from 'qs-esm'
 import React, { Fragment, useCallback } from 'react'
 
 import { DeleteMany } from '../../../elements/DeleteMany/index.js'
@@ -9,8 +10,12 @@ import { ListSelection_v4, ListSelectionButton } from '../../../elements/ListSel
 import { PublishMany_v4 } from '../../../elements/PublishMany/index.js'
 import { RestoreMany } from '../../../elements/RestoreMany/index.js'
 import { UnpublishMany_v4 } from '../../../elements/UnpublishMany/index.js'
+import { useAuth } from '../../../providers/Auth/index.js'
+import { useRouteCache } from '../../../providers/RouteCache/index.js'
+import { useRouter, useSearchParams } from '../../../providers/RouterAdapter/index.js'
 import { SelectAllStatus, useSelection } from '../../../providers/Selection/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
+import { parseSearchParams } from '../../../utilities/parseSearchParams.js'
 
 export type ListSelectionProps = {
   collectionConfig?: ClientCollectionConfig
@@ -29,8 +34,8 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
   collectionConfig,
   disableBulkDelete,
   disableBulkEdit,
-  hasDeletePermission,
-  hasTrashPermission,
+  hasDeletePermission: hasDeletePermissionFromProps,
+  hasTrashPermission: hasTrashPermissionFromProps,
   label,
   modalPrefix,
   showSelectAllAcrossPages = true,
@@ -39,6 +44,10 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
 }) => {
   const { count, selectAll, selectedIDs, toggleAll, totalDocs } = useSelection()
   const { t } = useTranslation()
+  const { permissions } = useAuth()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { clearRouteCache } = useRouteCache()
 
   const onActionSuccess = useCallback(() => toggleAll(), [toggleAll])
 
@@ -47,6 +56,29 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
   }
 
   const isTrashView = collectionConfig?.trash && viewType === 'trash'
+
+  const collectionPermissions = permissions?.collections?.[collectionConfig?.slug]
+  const hasDeletePermission =
+    hasDeletePermissionFromProps !== undefined
+      ? hasDeletePermissionFromProps
+      : Boolean(collectionPermissions?.delete)
+  const hasTrashPermission =
+    hasTrashPermissionFromProps !== undefined ? hasTrashPermissionFromProps : hasDeletePermission
+  const canShowDeleteButton =
+    viewType === 'trash' ? hasDeletePermission : hasDeletePermission || hasTrashPermission
+
+  const selectingAll = selectAll === SelectAllStatus.AllAvailable
+  const deleteIDs = selectingAll ? [] : selectedIDs
+  const baseWhere = parseSearchParams(searchParams)?.where as Where
+  const deleteWhere =
+    viewType === 'trash'
+      ? {
+          and: [
+            ...(Array.isArray(baseWhere?.and) ? baseWhere.and : baseWhere ? [baseWhere] : []),
+            { deletedAt: { exists: true } },
+          ],
+        }
+      : baseWhere
 
   return (
     <ListSelection_v4
@@ -100,14 +132,38 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
         isTrashView && (
           <RestoreMany collection={collectionConfig} key="bulk-restore" viewType={viewType} />
         ),
-        !disableBulkDelete && (
+        !disableBulkDelete && canShowDeleteButton && collectionConfig && (
           <DeleteMany
-            collection={collectionConfig}
+            afterDelete={() => {
+              toggleAll()
+
+              router.replace(
+                qs.stringify(
+                  {
+                    ...parseSearchParams(searchParams),
+                    page: selectAll ? '1' : undefined,
+                  },
+                  { addQueryPrefix: true },
+                ),
+              )
+
+              clearRouteCache()
+            }}
             hasDeletePermission={hasDeletePermission}
             hasTrashPermission={hasTrashPermission}
             key="bulk-delete"
             modalPrefix={modalPrefix}
+            search={parseSearchParams(searchParams)?.search as string}
+            selections={{
+              [collectionConfig.slug]: {
+                all: selectingAll,
+                ids: deleteIDs,
+                totalCount: selectingAll ? count : deleteIDs.length,
+              },
+            }}
+            trash={collectionConfig?.trash}
             viewType={viewType}
+            where={deleteWhere}
           />
         ),
       ].filter(Boolean)}


### PR DESCRIPTION
## What changed

Consolidates the `DeleteMany` element. The thin `DeleteMany` wrapper that read `useSelection()`, auth, router, and route cache internally is gone. The polymorphic core that actually does the work (previously `DeleteMany_v4`) is now the public `DeleteMany`, and callers pass in selection state and side effects explicitly.

## Element changes (`elements/DeleteMany`)

- Removed the wrapper `DeleteMany` component and its `Props` type.
- Promoted the polymorphic implementation: `DeleteMany_v4` is now `DeleteMany`, and `DeleteMany_v4Props` is now the exported `DeleteManyProps`.
- Dropped the now-unused imports it no longer needs (`useAuth`, `useRouter`, `useSearchParams`, `useRouteCache`, `useSelection` / `SelectAllStatus`, `parseSearchParams`, `ClientCollectionConfig`).

## Consumer changes

- **`views/List/ListSelection`**: now owns the logic the old wrapper used to handle. It resolves delete/trash permissions (still falling back to `useAuth` so `GroupByHeader` keeps working without passing them in), shapes the polymorphic `selections`, builds the trash-aware `where`, and wires up the `afterDelete` side effect (clear selection, reset page, clear route cache). The incoming permission props are renamed to `hasDeletePermissionFromProps` / `hasTrashPermissionFromProps` so the resolved values can keep the clean `hasDeletePermission` / `hasTrashPermission` names.
- **`views/HierarchyList/DocumentListSelection`**: was already using `DeleteMany_v4` directly, so this is just the rename to `DeleteMany`.

## Breaking change / migration

The exported `DeleteMany` component changed its props contract. It no longer reads selection state from `useSelection()` internally, so callers now pass selection and side effects explicitly:

```tsx
// Before
<DeleteMany collection={collection} />

// After
<DeleteMany
  afterDelete={handleAfterDelete}
  hasDeletePermission={hasDeletePermission}
  hasTrashPermission={hasTrashPermission}
  modalPrefix={modalPrefix}
  selections={{
    [collection.slug]: {
      all: selectingAll,
      ids,
      totalCount: selectingAll ? count : ids.length,
    },
  }}
  trash={collection.trash}
  viewType={viewType}
  where={where}
/>
```

The in-repo consumers (`ListSelection` and `HierarchyList/DocumentListSelection`) are already updated.