### PR TITLE
fix(ui): add consistent spacing between ConfirmationModal body elements

### DIFF
--- a/packages/ui/src/elements/ConfirmationModal/index.css
+++ b/packages/ui/src/elements/ConfirmationModal/index.css
@@ -2,6 +2,6 @@
   .confirmation-modal__body {
     display: flex;
     flex-direction: column;
-    gap: var(--spacer-2-5);
+    gap: var(--spacer-2);
   }
 }

--- a/packages/ui/src/elements/ConfirmationModal/index.css
+++ b/packages/ui/src/elements/ConfirmationModal/index.css
@@ -1,0 +1,7 @@
+@layer payload-default {
+  .confirmation-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacer-2-5);
+  }
+}

--- a/packages/ui/src/elements/ConfirmationModal/index.tsx
+++ b/packages/ui/src/elements/ConfirmationModal/index.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogModal,
 } from '../Dialog/index.js'
+import './index.css'
 
 export type OnCancel = () => void
 
@@ -40,7 +41,11 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
   return (
     <DialogModal className={className} slug={modalSlug}>
       <DialogHeader showClose title={heading} />
-      <DialogBody>{typeof body === 'string' ? <p>{body}</p> : body}</DialogBody>
+      <DialogBody>
+        <div className="confirmation-modal__body">
+          {typeof body === 'string' ? <p>{body}</p> : body}
+        </div>
+      </DialogBody>
       <DialogFooter>
         <DialogCancel label={cancelLabel} onClick={onCancel} />
         <DialogConfirm label={confirmLabel} loadingLabel={confirmingLabel} onClick={onConfirm} />


### PR DESCRIPTION
## What

Adds vertical spacing between sibling elements in a `ConfirmationModal` body (e.g. description + checkbox), which previously rendered with no gap.

## How

`DeleteDocument`, `DeleteMany`, `RestoreButton`, and `RestoreMany` all pass multi-element bodies through the shared `ConfirmationModal`. Instead of duplicating a wrapper in each, the gap is owned by `ConfirmationModal`: its body content is wrapped in a flex column with `gap: var(--spacer-2-5)`.

The generic `Dialog` primitive is untouched, and single-element bodies are unaffected since `gap` only applies between siblings.

#### Before
<img width="395" height="248" alt="Screenshot 2026-06-10 at 3 54 05 PM" src="https://github.com/user-attachments/assets/fa3a8a58-eef1-4337-8b83-1656e36aba86" />

#### After
<img width="339" height="245" alt="Screenshot 2026-06-10 at 4 17 24 PM" src="https://github.com/user-attachments/assets/41d4adfa-1765-4466-90ce-3c66ccd14f00" />

