### PR TITLE
fix(richtext-lexical): add spacing between editor and field description

### DIFF
--- a/packages/richtext-lexical/src/field/index.css
+++ b/packages/richtext-lexical/src/field/index.css
@@ -35,6 +35,10 @@
   .rich-text-lexical__wrap {
     width: 100%;
     position: relative;
+
+    > .field-description {
+      margin-top: var(--spacer-2);
+    }
   }
 
   .rich-text-lexical--read-only {

--- a/test/v4/collections/RichText/index.ts
+++ b/test/v4/collections/RichText/index.ts
@@ -20,6 +20,9 @@ const RichTextFields: CollectionConfig = {
     {
       name: 'content',
       type: 'richText',
+      admin: {
+        description: 'The main content of the document.',
+      },
       editor: lexicalEditor({
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,


### PR DESCRIPTION
## What?

Adds vertical spacing between the Lexical editor and its field description, so it matches the spacing other field types get from `.field-type__wrap`.

A shared flex `gap` can't be reused here since it would also space out the editor toolbar, so the spacing is applied directly to the description via `margin-top`.

#### Before
<img width="1135" height="149" alt="Screenshot 2026-06-10 at 4 10 54 PM" src="https://github.com/user-attachments/assets/4ded57b3-3e6b-49ab-a6ae-76c537f8a9a5" />

#### After
<img width="1132" height="164" alt="Screenshot 2026-06-10 at 4 10 42 PM" src="https://github.com/user-attachments/assets/9130b1cd-1f04-4b0a-ac46-67f0958377c5" />