### PR TITLE
fix(ui): various version view style and UX fixes

### DIFF
--- a/packages/ui/src/elements/GroupByControl/index.tsx
+++ b/packages/ui/src/elements/GroupByControl/index.tsx
@@ -4,7 +4,6 @@ import type { ClientField, Field, SanitizedCollectionConfig } from 'payload'
 import { isFieldDisabled } from 'payload/shared'
 import React, { useCallback, useMemo, useRef } from 'react'
 
-import { CheckIcon } from '../../icons/Check/index.js'
 import { ChevronIcon } from '../../icons/Chevron/index.js'
 import { TrashIcon } from '../../icons/Trash/index.js'
 import { XIcon } from '../../icons/X/index.js'
@@ -171,15 +170,10 @@ export const GroupByControl: React.FC<GroupByControlProps> = ({ collectionSlug, 
                     className={`${baseClass}__select-popup`}
                     horizontalAlign="right"
                     render={({ close: closeFieldPopup }) => (
-                      <PopupList.ButtonGroup>
+                      <PopupList.RadioGroup>
                         {filteredFields.map((field, i) => (
-                          <PopupList.Button
+                          <PopupList.RadioGroupItem
                             active={field.fieldPath === groupByFieldName}
-                            icon={
-                              field.fieldPath === groupByFieldName ? (
-                                <CheckIcon size={16} />
-                              ) : undefined
-                            }
                             key={i}
                             onClick={() => {
                               handleFieldSelect(field.fieldPath)
@@ -187,9 +181,9 @@ export const GroupByControl: React.FC<GroupByControlProps> = ({ collectionSlug, 
                             }}
                           >
                             {field.label}
-                          </PopupList.Button>
+                          </PopupList.RadioGroupItem>
                         ))}
-                      </PopupList.ButtonGroup>
+                      </PopupList.RadioGroup>
                     )}
                     renderButton={({ active, onClick, onKeyDown }) => (
                       <button

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -54,6 +54,7 @@ export const Localizer: React.FC<{
                 return (
                   <PopupList.RadioGroupItem
                     active={locale.code === localeOption.code}
+                    disabled={locale.code === localeOption.code}
                     key={localeOption.code}
                     onClick={() => {
                       setLocaleIsLoading(true)

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -47,14 +47,13 @@ export const Localizer: React.FC<{
         <Popup
           horizontalAlign="right"
           render={({ close }) => (
-            <PopupList.ButtonGroup>
+            <PopupList.RadioGroup>
               {locales.map((localeOption) => {
                 const localeOptionLabel = getTranslation(localeOption.label, i18n)
 
                 return (
-                  <PopupList.Button
+                  <PopupList.RadioGroupItem
                     active={locale.code === localeOption.code}
-                    disabled={locale.code === localeOption.code}
                     key={localeOption.code}
                     onClick={() => {
                       setLocaleIsLoading(true)
@@ -95,10 +94,10 @@ export const Localizer: React.FC<{
                         {localeOptionLabel}
                       </span>
                     )}
-                  </PopupList.Button>
+                  </PopupList.RadioGroupItem>
                 )
               })}
-            </PopupList.ButtonGroup>
+            </PopupList.RadioGroup>
           )}
           renderButton={
             renderButton ??
@@ -120,7 +119,6 @@ export const Localizer: React.FC<{
             ))
           }
           showScrollbar
-          size="large"
         />
       </div>
     )

--- a/packages/ui/src/elements/Popup/PopupButtonList/index.css
+++ b/packages/ui/src/elements/Popup/PopupButtonList/index.css
@@ -86,6 +86,17 @@
     display: none;
   }
 
+  /* RadioGroup - selected items show only the checkmark, no background fill */
+  .popup-button-list--with-icons .popup-button-list__button--selected {
+    background-color: transparent;
+    color: var(--popup-item-color, var(--color-text));
+  }
+
+  .popup-button-list--with-icons .popup-button-list__button--selected:hover {
+    background-color: var(--popup-item-bg-hover, var(--color-bg-selected-strong));
+    color: var(--popup-item-color-hover, var(--color-text-onselected-strong));
+  }
+
   /* RadioGroup - for radio-style selection rows with 16px icons */
   .popup-button-list--with-icons .popup-button-list__button {
     padding-right: var(--spacer-2);

--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -48,11 +48,6 @@
         padding: var(--spacer-2) var(--spacer-2-5);
         min-height: calc(var(--spacer-4) * 2);
       }
-
-      &:first-child > a {
-        padding-inline-start: var(--spacer-2);
-        padding-inline-end: var(--spacer-2);
-      }
     }
 
     #heading-_select,

--- a/packages/ui/src/views/Version/Default/index.css
+++ b/packages/ui/src/views/Version/Default/index.css
@@ -10,7 +10,7 @@
 
   .view-version-controls-top {
     border-bottom: var(--stroke-width-small) solid var(--color-border);
-    padding: var(--spacer-2) var(--spacer-4);
+    padding: var(--spacer-2) var(--gutter-h);
   }
 
   .view-version-controls-top__wrapper {
@@ -39,7 +39,7 @@
 
   .view-version-controls-bottom {
     border-bottom: var(--stroke-width-small) solid var(--color-border);
-    padding: var(--spacer-2-5) var(--spacer-4);
+    padding: var(--spacer-2-5) var(--gutter-h);
     position: relative;
 
     /* Vertical separator line */
@@ -138,7 +138,7 @@
   }
 
   .view-version__diff-wrap {
-    padding: var(--spacer-3) var(--spacer-4);
+    padding: var(--spacer-3) var(--gutter-h);
     display: flex;
     flex-direction: column;
     gap: var(--spacer-3);
@@ -190,12 +190,10 @@
 
     .view-version-controls-top {
       order: 2;
-      padding-inline: var(--spacer-3);
     }
 
     .view-version__diff-wrap {
       order: 3;
-      padding: var(--spacer-3);
 
       /* Hide vertical separator on mobile */
       &::after {

--- a/packages/ui/src/views/Version/Default/index.tsx
+++ b/packages/ui/src/views/Version/Default/index.tsx
@@ -5,10 +5,8 @@ import React, { type FormEventHandler, useCallback, useEffect, useMemo, useState
 import type { SelectablePill } from '../../../elements/PillSelector/index.js'
 import type { CompareOption, DefaultVersionsViewProps } from './types.js'
 
-import { Button } from '../../../elements/Button/index.js'
 import { Gutter } from '../../../elements/Gutter/index.js'
 import { CheckboxInput } from '../../../fields/Checkbox/Input.js'
-import { ChevronIcon } from '../../../icons/Chevron/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useDocumentInfo } from '../../../providers/DocumentInfo/index.js'
 import { useLocale } from '../../../providers/Locale/index.js'
@@ -44,7 +42,6 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
   const { i18n, t } = useTranslation()
 
   const [locales, setLocales] = useState<SelectablePill[]>([])
-  const [localeSelectorOpen, setLocaleSelectorOpen] = React.useState(false)
 
   useEffect(() => {
     if (config.localization) {
@@ -191,37 +188,9 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
                 onToggle={onToggleModifiedOnly}
               />
             </span>
-            {localization && (
-              <Button
-                aria-controls={`${baseClass}-locales`}
-                aria-expanded={localeSelectorOpen}
-                buttonStyle="pill"
-                className={`${baseClass}__toggle-locales`}
-                icon={<ChevronIcon direction={localeSelectorOpen ? 'up' : 'down'} />}
-                onClick={() => setLocaleSelectorOpen((localeSelectorOpen) => !localeSelectorOpen)}
-                size="medium"
-              >
-                <span className={`${baseClass}__toggle-locales-label`}>
-                  {t('general:locales')}:{' '}
-                </span>
-                <span className={`${baseClass}__toggle-locales-list`}>
-                  {locales
-                    .filter((locale) => locale.selected)
-                    .map((locale) => locale.name)
-                    .join(', ')}
-                </span>
-              </Button>
-            )}
+            {localization && <SelectLocales locales={locales} onChange={onChangeSelectedLocales} />}
           </div>
         </div>
-
-        {localization && (
-          <SelectLocales
-            locales={locales}
-            localeSelectorOpen={localeSelectorOpen}
-            onChange={onChangeSelectedLocales}
-          />
-        )}
       </Gutter>
       <Gutter className={`${baseClass}-controls-bottom`}>
         <div className={`${baseClass}-controls-bottom__wrapper`}>

--- a/packages/ui/src/views/Version/Restore/index.css
+++ b/packages/ui/src/views/Version/Restore/index.css
@@ -16,11 +16,11 @@
   .restore-version__restore-as-draft-button {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    padding: 0;
   }
 
   .restore-version__restore-as-draft-button:focus {
-    border-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
     outline-offset: 0;
   }
 }

--- a/packages/ui/src/views/Version/SelectLocales/index.tsx
+++ b/packages/ui/src/views/Version/SelectLocales/index.tsx
@@ -2,41 +2,60 @@
 
 import React from 'react'
 
-import { AnimateHeight } from '../../../elements/AnimateHeight/index.js'
-import { PillSelector, type SelectablePill } from '../../../elements/PillSelector/index.js'
+import type { SelectablePill } from '../../../elements/PillSelector/index.js'
+
+import { Button } from '../../../elements/Button/index.js'
+import { Popup, PopupList } from '../../../elements/Popup/index.js'
+import { ChevronIcon } from '../../../icons/Chevron/index.js'
+import { useTranslation } from '../../../providers/Translation/index.js'
 
 const baseClass = 'select-version-locales'
 
 export type SelectedLocaleOnChange = (args: { locales: SelectablePill[] }) => void
 export type Props = {
   locales: SelectablePill[]
-  localeSelectorOpen: boolean
   onChange: SelectedLocaleOnChange
 }
 
-export const SelectLocales: React.FC<Props> = ({ locales, localeSelectorOpen, onChange }) => {
+export const SelectLocales: React.FC<Props> = ({ locales, onChange }) => {
+  const { t } = useTranslation()
+
   return (
-    <AnimateHeight
+    <Popup
       className={baseClass}
-      height={localeSelectorOpen ? 'auto' : 0}
-      id={`${baseClass}-locales`}
-    >
-      <PillSelector
-        onClick={({ pill }) => {
-          const newLocales = locales.map((locale) => {
-            if (locale.name === pill.name) {
-              return {
-                ...locale,
-                selected: !pill.selected,
-              }
-            } else {
-              return locale
-            }
-          })
-          onChange({ locales: newLocales })
-        }}
-        pills={locales}
-      />
-    </AnimateHeight>
+      horizontalAlign="right"
+      render={() => (
+        <PopupList.RadioGroup>
+          {locales.map((locale) => (
+            <PopupList.RadioGroupItem
+              active={locale.selected}
+              key={locale.name}
+              onClick={() => {
+                const newLocales = locales.map((l) =>
+                  l.name === locale.name ? { ...l, selected: !l.selected } : l,
+                )
+                onChange({ locales: newLocales })
+              }}
+            >
+              {locale.name}
+            </PopupList.RadioGroupItem>
+          ))}
+        </PopupList.RadioGroup>
+      )}
+      renderButton={({ active, ...buttonProps }) => (
+        <Button
+          {...buttonProps}
+          buttonStyle="secondary"
+          className={`view-version__toggle-locales`}
+          icon={<ChevronIcon direction={active ? 'up' : 'down'} size={16} />}
+          selected={locales.some((locale) => locale.selected)}
+          size="medium"
+        >
+          {t('general:locales')}
+        </Button>
+      )}
+      size="small"
+      theme="dark"
+    />
   )
 }

--- a/packages/ui/src/views/Versions/index.css
+++ b/packages/ui/src/views/Versions/index.css
@@ -7,7 +7,6 @@
   }
 
   .versions__wrap {
-    padding: 0 var(--gutter-h) var(--spacing-view-bottom) var(--gutter-h);
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -39,11 +38,11 @@
   }
 
   .versions .table th:first-child {
-    padding-inline-start: var(--spacer-2-5);
+    padding-inline-start: var(--gutter-h);
   }
 
   .versions .table td:first-child:not(.cell--linked) {
-    padding-inline-start: var(--spacer-2-5);
+    padding-inline-start: var(--gutter-h);
   }
 
   .versions .table td.cell--linked {
@@ -51,7 +50,7 @@
   }
 
   .versions .table td.cell--linked > a {
-    padding: 0 var(--spacer-2-5);
+    padding-inline-start: var(--gutter-h);
     width: 100%;
   }
 
@@ -62,18 +61,11 @@
   /* on mobile, extend the table all the way to the viewport edges */
   /* this is to visually indicate overflowing content */
   @media (max-width: 768px) {
-    .versions__wrap {
-      padding: 0 0 var(--spacing-view-bottom) 0;
-      margin-top: 0;
-    }
-
     .versions .table {
       display: flex;
-      width: calc(100% + calc(var(--gutter-h) * 2));
+      flex-direction: column;
       max-width: unset;
-      left: calc(var(--gutter-h) * -1);
       position: relative;
-      padding-left: var(--gutter-h);
     }
 
     .versions .table::after {

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -27,8 +27,8 @@ import { navigateToDoc } from '../__helpers/e2e/navigateToDoc.js'
 import { openDocControls } from '../__helpers/e2e/openDocControls.js'
 import { upsertPreferences } from '../__helpers/e2e/preferences.js'
 import { runAxeScan } from '../__helpers/e2e/runAxeScan.js'
-import { openDocDrawer } from '../__helpers/e2e/toggleDocDrawer.js'
 import { getSelectMenu } from '../__helpers/e2e/selectInput.js'
+import { openDocDrawer } from '../__helpers/e2e/toggleDocDrawer.js'
 import { waitForAutoSaveToRunAndComplete } from '../__helpers/e2e/waitForAutoSaveToRunAndComplete.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
@@ -156,8 +156,8 @@ describe('Localization', () => {
       await expect(page.locator('.view-version__toggle-locales')).toBeVisible()
       await page.locator('.view-version__toggle-locales').click()
 
-      await expect(page.locator('.select-version-locales .pill-selector')).toBeVisible()
-      await expect(page.locator('.select-version-locales .pill-selector')).not.toContainText(
+      await expect(page.locator('.select-version-locales .popup__content')).toBeVisible()
+      await expect(page.locator('.select-version-locales .popup__content')).not.toContainText(
         'FILTERED',
       )
     })

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -156,10 +156,8 @@ describe('Localization', () => {
       await expect(page.locator('.view-version__toggle-locales')).toBeVisible()
       await page.locator('.view-version__toggle-locales').click()
 
-      await expect(page.locator('.select-version-locales .popup__content')).toBeVisible()
-      await expect(page.locator('.select-version-locales .popup__content')).not.toContainText(
-        'FILTERED',
-      )
+      await expect(page.locator('.popup__content')).toBeVisible()
+      await expect(page.locator('.popup__content')).not.toContainText('FILTERED')
     })
 
     test('should disable control for active locale', async () => {


### PR DESCRIPTION
Fixes several style and UX issues in the version comparison and versions list views.

**Restore button:** removes erroneous `padding: 0` from `.restore-version__restore-as-draft-button` and corrects the `:focus` rule to only zero right-side border radii instead of all four corners.

**Versions list table:** removes horizontal gutter padding from `.versions__wrap` (it was doubling the indent already applied by the table), sets the first `th`/`td` `padding-inline-start` to `var(--gutter-h)` to match the default list view, and moves the linked-cell padding from the shorthand `padding` on `> a` to an explicit `padding-inline-start: var(--gutter-h)` with `width: 100%` so the full cell remains clickable. Removes a stale `&:first-child > a` override in `Table/index.css` that was adding extra indent on top of this.

**Locale selector:** replaces the `AnimateHeight` + `PillSelector` with a dark-themed `Popup` containing a `PopupList.RadioGroup`. Each locale row shows a checkmark when selected. The trigger button now reads "Locales" and uses the `selected` prop rather than listing the active locale codes in the label.

**`PopupList` selected-item background:** selected items inside `.popup-button-list--with-icons` (i.e. `RadioGroup`) no longer show a blue fill — only the checkmark indicates selection. Hover state is preserved.

**`GroupByControl` field picker:** switches from `PopupList.ButtonGroup` + manual `CheckIcon` to `PopupList.RadioGroup` + `RadioGroupItem`, bringing it in line with the same no-fill-on-selected behaviour and removing the manual icon wiring.

Updates the localization e2e test that was asserting on `.pill-selector` (now gone) to assert on `.popup__content` instead.


### Before

https://github.com/user-attachments/assets/7128ad46-c432-4e86-af45-ce5f45ce5cf4

### After

https://github.com/user-attachments/assets/1dfdbc16-a7d7-4245-b4b9-ca4b6c7a258e