### PR TITLE
fix: prevent reordering from unpublishing documents that have a newer draft

### DIFF
--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -10,8 +10,10 @@ import { APIError } from '../../errors/index.js'
 import { sanitizeField } from '../../fields/config/sanitize.js'
 import { combineWhereConstraints } from '../../utilities/combineWhereConstraints.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
+import { hasDraftsEnabled } from '../../utilities/getVersionsConfig.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { getLatestCollectionVersion } from '../../versions/getLatestCollectionVersion.js'
 import { generateKeyBetween, generateNKeysBetween } from './fractional-indexing.js'
 import { getJoinScopeContext } from './utils/getJoinScopeContext.js'
 import { getJoinScopeWhereFromDocData } from './utils/getJoinScopeWhereFromDocData.js'
@@ -285,8 +287,28 @@ export const addOrderableEndpoint = (
         ? generateNKeysBetween(targetKey, adjacentDocKey, docsToMove.length)
         : generateNKeysBetween(adjacentDocKey, targetKey, docsToMove.length)
 
+    const draftsEnabled = hasDraftsEnabled(collection)
+
     // Update each document with its new order value
     for (const [index, id] of docsToMove.entries()) {
+      let draft: boolean | undefined
+
+      if (draftsEnabled) {
+        const latestVersion = await getLatestCollectionVersion({
+          id,
+          config: collection,
+          payload: req.payload,
+          query: {
+            collection: collection.slug,
+            req,
+            where: { id: { equals: id } },
+          },
+          req,
+        })
+
+        draft = latestVersion?._status === 'draft'
+      }
+
       await req.payload.update({
         id,
         collection: collection.slug,
@@ -294,6 +316,7 @@ export const addOrderableEndpoint = (
           [orderableFieldName]: orderValues[index],
         },
         depth: 0,
+        draft,
         req,
       })
     }

--- a/test/sort/int.spec.ts
+++ b/test/sort/int.spec.ts
@@ -594,6 +594,75 @@ describe('Sort', () => {
         )
       })
 
+      it('should not unpublish a published document with a newer draft when reordering', async () => {
+        const publishedDoc = await payload.create({
+          collection: draftsSlug,
+          data: {
+            text: 'Published with newer draft',
+            _status: 'published',
+          },
+        })
+
+        const target = await payload.create({
+          collection: draftsSlug,
+          data: {
+            text: 'Reorder target',
+            _status: 'published',
+          },
+        })
+
+        // Create a newer draft on top of the published version
+        await payload.update({
+          id: publishedDoc.id,
+          collection: draftsSlug,
+          data: {
+            text: 'Published with newer draft - edited',
+          },
+          draft: true,
+        })
+
+        const beforeReorder = await payload.findByID({
+          id: publishedDoc.id,
+          collection: draftsSlug,
+        })
+
+        expect(beforeReorder._status).toBe('published')
+
+        const res = await restClient.POST('/reorder', {
+          body: JSON.stringify({
+            collectionSlug: draftsSlug,
+            docsToMove: [publishedDoc.id],
+            newKeyWillBe: 'greater',
+            orderableFieldName: '_order',
+            target: {
+              id: target.id,
+              key: target._order,
+            },
+          }),
+        })
+
+        expect(res.status).toStrictEqual(200)
+
+        const afterReorder = await payload.findByID({
+          id: publishedDoc.id,
+          collection: draftsSlug,
+        })
+
+        // Reordering must not unpublish the document
+        expect(afterReorder._status).toBe('published')
+
+        const published = await payload.find({
+          collection: draftsSlug,
+          where: {
+            id: {
+              equals: publishedDoc.id,
+            },
+          },
+        })
+
+        expect(published.docs).toHaveLength(1)
+      })
+
       it('should allow to duplicate with reordable', async () => {
         const doc = await payload.create({
           collection: 'orderable',


### PR DESCRIPTION
## Summary

Reordering a document via the `orderable` drag-and-drop list view could unpublish it when the document had both a published version and a newer draft.

The reorder endpoint updated each moved document with `payload.update` without a `draft` flag. With `draft` defaulting to `false`, the update loaded the document's latest version (the draft) as its base and wrote that draft's `_status: 'draft'` into the published main row, effectively unpublishing the document. A subsequent `status: published` query then returned 404 and no "currently published" version remained.

This fix detects, for drafts-enabled collections, whether the document's latest version is a draft and, if so, performs the order update with `draft: true`. This preserves the published main document (no unpublish) while still updating the order on the version the list view reads (the list queries with `draft: true`). Published-only documents keep the existing behavior.

Reported via support ticket; reproduced on `3.84.1`.

## Changes

- `packages/payload/src/config/orderable/index.ts`: in the reorder endpoint, look up the latest version for drafts-enabled collections and pass `draft: true` when the latest version is a draft.
- `test/sort/int.spec.ts`: add an integration test covering reordering a published document that has a newer draft, asserting it stays published.

## Test plan

- [x] New test fails before the fix (`expected 'draft' to be 'published'`) and passes after.
- [x] Existing reorder tests pass (`pnpm test:int:sqlite sort -t reorder`).
- [ ] Verify on MongoDB (`pnpm test:int sort`) in CI.
- [ ] Manual check: collection with `orderable: true` and `versions: { drafts: true }`; publish a doc, edit it into a newer draft, drag-reorder it in the list view, and confirm it stays published.

Note: the unrelated `should sort by createdAt as fallback` test on `nonUniqueSortSlug` is flaky on SQLite (createdAt tie-breaking) and is not affected by this change.