### PR TITLE
fix: prevent client-upload crash when image bytes are unavailable

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -221,8 +221,15 @@ export const generateFileData = async <T>({
 
     if (fileSupportsResize || isImage(file.mimetype)) {
       dimensions = await getImageSize(file)
-      fileData.width = dimensions.width
-      fileData.height = dimensions.height
+
+      // Fall back to client-supplied dimensions when the bytes couldn't be probed
+      // (e.g. a client upload whose handler returned a redirect / empty body).
+      if (!dimensions && typeof file.width === 'number' && typeof file.height === 'number') {
+        dimensions = { height: file.height, width: file.width }
+      }
+
+      fileData.width = dimensions?.width
+      fileData.height = dimensions?.height
     }
 
     if (sharpFile) {

--- a/packages/payload/src/uploads/getImageSize.spec.ts
+++ b/packages/payload/src/uploads/getImageSize.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PayloadRequest } from '../types/index.js'
+
+import { getImageSize } from './getImageSize.js'
+
+// Minimal 1x1 PNG used to assert real images still probe correctly.
+const onePixelPng = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC',
+  'base64',
+)
+
+const makeFile = (overrides: Partial<NonNullable<PayloadRequest['file']>>) =>
+  ({
+    name: 'test.png',
+    data: Buffer.alloc(0),
+    mimetype: 'image/png',
+    size: 0,
+    ...overrides,
+  }) as NonNullable<PayloadRequest['file']>
+
+describe('getImageSize', () => {
+  it('should return undefined dimensions for an empty buffer instead of throwing', async () => {
+    const result = await getImageSize(makeFile({ data: Buffer.alloc(0) }))
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined dimensions for a corrupt (non-empty) buffer instead of throwing', async () => {
+    const result = await getImageSize(makeFile({ data: Buffer.from('not an image') }))
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should probe dimensions for a valid image buffer', async () => {
+    const result = await getImageSize(makeFile({ data: onePixelPng, size: onePixelPng.length }))
+
+    expect(result).toMatchObject({ height: 1, width: 1 })
+  })
+})

--- a/packages/payload/src/uploads/getImageSize.ts
+++ b/packages/payload/src/uploads/getImageSize.ts
@@ -7,14 +7,29 @@ import type { ProbedImageSize } from './types.js'
 
 import { temporaryFileTask } from './tempFile.js'
 
-export async function getImageSize(file: PayloadRequest['file']): Promise<ProbedImageSize> {
+/**
+ * Probes the dimensions of an uploaded image.
+ *
+ * Returns `undefined` when dimensions cannot be determined — e.g. a client-upload
+ * storage adapter returned a redirect/empty body, or the buffer is corrupt. This
+ * keeps a missing/unreadable body from crashing the upload pipeline (`image-size`
+ * throws `RangeError: Offset is outside the bounds of the DataView` on empty input).
+ */
+export async function getImageSize(
+  file: PayloadRequest['file'],
+): Promise<ProbedImageSize | undefined> {
   if (file?.tempFilePath) {
     return imageSizeFromFile(file.tempFilePath)
   }
 
+  // No usable bytes to probe (e.g. a client-upload handler returned a 302 redirect).
+  if (!file?.data?.length) {
+    return undefined
+  }
+
   // Tiff file do not support buffers or streams, so we must write to file first
   // then retrieve dimensions. https://github.com/image-size/image-size/issues/103
-  if (file?.mimetype === 'image/tiff') {
+  if (file.mimetype === 'image/tiff') {
     const dimensions = await temporaryFileTask(
       async (filepath: string) => {
         await fs.writeFile(filepath, file.data)
@@ -25,5 +40,10 @@ export async function getImageSize(file: PayloadRequest['file']): Promise<Probed
     return dimensions
   }
 
-  return imageSize(file!.data)
+  try {
+    return imageSize(file.data)
+  } catch {
+    // Corrupt or unsupported buffer — degrade gracefully rather than failing the upload.
+    return undefined
+  }
 }

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -311,6 +311,11 @@ export type File = {
    */
   data: Buffer
   /**
+   * Pre-computed image height in pixels. Provided by the client during a client upload
+   * so the server can skip probing (and fetching) the file bytes for dimensions.
+   */
+  height?: number
+  /**
    * The mimetype of the file.
    */
   mimetype: string
@@ -326,6 +331,11 @@ export type File = {
    * Path to the temp file on disk when useTempFiles is enabled. In this case file.data will be an empty buffer.
    */
   tempFilePath?: string
+  /**
+   * Pre-computed image width in pixels. Provided by the client during a client upload
+   * so the server can skip probing (and fetching) the file bytes for dimensions.
+   */
+  width?: number
 }
 
 export type FileToSave = {

--- a/packages/payload/src/uploads/uploadRequiresFileData.spec.ts
+++ b/packages/payload/src/uploads/uploadRequiresFileData.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SanitizedUploadConfig } from './types.js'
+
+import { uploadRequiresFileData } from './uploadRequiresFileData.js'
+
+const uploadConfig = (overrides: Partial<SanitizedUploadConfig> = {}): SanitizedUploadConfig =>
+  overrides as SanitizedUploadConfig
+
+const baseConfig = uploadConfig()
+
+describe('uploadRequiresFileData', () => {
+  it('should not require file data when sharp is not configured', () => {
+    expect(
+      uploadRequiresFileData({ hasSharp: false, mimeType: 'image/png', uploadConfig: baseConfig }),
+    ).toBe(false)
+  })
+
+  it('should not require file data for a plain image with no resize config', () => {
+    expect(
+      uploadRequiresFileData({ hasSharp: true, mimeType: 'image/png', uploadConfig: baseConfig }),
+    ).toBe(false)
+  })
+
+  it('should not require file data when only focalPoint is enabled (no imageSizes)', () => {
+    expect(
+      uploadRequiresFileData({
+        hasSharp: true,
+        mimeType: 'image/png',
+        uploadConfig: uploadConfig({ focalPoint: true }),
+      }),
+    ).toBe(false)
+  })
+
+  it('should require file data when imageSizes are configured', () => {
+    expect(
+      uploadRequiresFileData({
+        hasSharp: true,
+        mimeType: 'image/png',
+        uploadConfig: uploadConfig({ imageSizes: [{ name: 'thumb', width: 100 }] }),
+      }),
+    ).toBe(true)
+  })
+
+  it('should require file data when resizeOptions are configured', () => {
+    expect(
+      uploadRequiresFileData({
+        hasSharp: true,
+        mimeType: 'image/png',
+        uploadConfig: uploadConfig({ resizeOptions: { width: 200 } }),
+      }),
+    ).toBe(true)
+  })
+
+  it('should require file data for animated image types', () => {
+    expect(
+      uploadRequiresFileData({ hasSharp: true, mimeType: 'image/gif', uploadConfig: baseConfig }),
+    ).toBe(true)
+  })
+
+  it('should require file data when a crop edit is requested', () => {
+    expect(
+      uploadRequiresFileData({
+        hasSharp: true,
+        mimeType: 'image/png',
+        uploadConfig: baseConfig,
+        uploadEdits: { crop: { height: 10, unit: 'px', width: 10, x: 0, y: 0 } },
+      }),
+    ).toBe(true)
+  })
+
+  it('should not require file data for non-resizable mimetypes', () => {
+    expect(
+      uploadRequiresFileData({
+        hasSharp: true,
+        mimeType: 'application/pdf',
+        uploadConfig: uploadConfig({ imageSizes: [{ name: 'thumb', width: 100 }] }),
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/payload/src/uploads/uploadRequiresFileData.ts
+++ b/packages/payload/src/uploads/uploadRequiresFileData.ts
@@ -1,0 +1,59 @@
+import type { SanitizedUploadConfig, UploadEdits } from './types.js'
+
+import { canResizeImage } from './canResizeImage.js'
+
+const animatedMimeTypes = ['image/avif', 'image/gif', 'image/webp']
+
+/**
+ * Determines whether the server needs the file's bytes to process an upload.
+ *
+ * For client uploads the bytes live in object storage, so the only reason to pull
+ * them back into the server is server-side image work (probing aside). When this
+ * returns `false` and the client supplied dimensions, the caller can skip both the
+ * `staticHandler` fetch-back and `getImageSize`.
+ *
+ * Mirrors the byte-touching branches in `generateFileData`:
+ * - sharp adjustments (`resizeOptions`/`formatOptions`/`trimOptions`/`constructorOptions`)
+ * - animated-image processing
+ * - `imageSizes` generation (`createImageSizes`)
+ * - crop edits (`cropImage`)
+ *
+ * `focalPoint` alone does not require bytes — only `focalX`/`focalY` are stored.
+ */
+export function uploadRequiresFileData({
+  hasSharp,
+  mimeType,
+  uploadConfig,
+  uploadEdits,
+}: {
+  hasSharp: boolean
+  mimeType: string
+  uploadConfig: SanitizedUploadConfig
+  uploadEdits?: UploadEdits
+}): boolean {
+  // Without sharp, no server-side image processing happens regardless of config.
+  if (!hasSharp) {
+    return false
+  }
+
+  // Animated images are always passed through sharp.
+  if (animatedMimeTypes.includes(mimeType)) {
+    return true
+  }
+
+  // Non-resizable mimetypes never trigger sharp work.
+  if (!canResizeImage(mimeType)) {
+    return false
+  }
+
+  const hasImageSizes = Array.isArray(uploadConfig.imageSizes) && uploadConfig.imageSizes.length > 0
+  const hasAdjustments = Boolean(
+    uploadConfig.resizeOptions ||
+      uploadConfig.formatOptions ||
+      uploadConfig.trimOptions ||
+      uploadConfig.constructorOptions,
+  )
+  const hasCrop = Boolean(uploadEdits?.crop)
+
+  return hasImageSizes || hasAdjustments || hasCrop
+}

--- a/packages/payload/src/utilities/addDataAndFileToRequest.spec.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.spec.ts
@@ -6,6 +6,7 @@ import { addDataAndFileToRequest } from './addDataAndFileToRequest.js'
 
 type MinimalReq = Pick<PayloadRequest, 'body' | 'headers' | 'method' | 'payload'> & {
   file?: PayloadRequest['file']
+  query?: PayloadRequest['query']
 }
 
 const createReqWithMultipartBody = (): MinimalReq => {
@@ -34,6 +35,53 @@ const createReqWithMultipartBody = (): MinimalReq => {
   }
 }
 
+const createClientUploadReq = ({
+  collectionUpload = {},
+  fileField,
+  hasSharp = true,
+  staticHandler,
+}: {
+  collectionUpload?: Record<string, unknown>
+  fileField: Record<string, unknown>
+  hasSharp?: boolean
+  staticHandler?: () => Promise<Response> | Response
+}): MinimalReq => {
+  const formData = new FormData()
+  formData.append('_payload', JSON.stringify({}))
+  formData.append('file', JSON.stringify(fileField))
+
+  const request = new Request('http://localhost/api/media', {
+    body: formData,
+    method: 'POST',
+  })
+
+  return {
+    body: request.body,
+    headers: request.headers,
+    method: request.method,
+    payload: {
+      collections: {
+        media: {
+          config: {
+            upload: {
+              handlers: staticHandler ? [staticHandler] : [],
+              ...collectionUpload,
+            },
+          },
+        },
+      },
+      config: {
+        bodyParser: {},
+        sharp: hasSharp ? {} : undefined,
+        upload: {},
+      },
+      logger: {
+        error: () => {},
+      },
+    } as unknown as PayloadRequest['payload'],
+  }
+}
+
 describe('addDataAndFileToRequest', () => {
   it('should parse multipart form-data even when content-length is absent', async () => {
     const req = createReqWithMultipartBody()
@@ -45,5 +93,84 @@ describe('addDataAndFileToRequest', () => {
     expect(req.file).toBeDefined()
     expect(req.file?.name).toBe('hello.txt')
     expect(req.file?.mimetype).toBe('text/plain')
+  })
+
+  describe('client uploads', () => {
+    it('should skip the staticHandler fetch-back when client dimensions are present and no resizing is needed', async () => {
+      let handlerCalled = false
+      const req = createClientUploadReq({
+        fileField: {
+          collectionSlug: 'media',
+          filename: 'photo.png',
+          height: 480,
+          mimeType: 'image/png',
+          size: 1234,
+          width: 640,
+        },
+        staticHandler: () => {
+          handlerCalled = true
+          return Response.redirect('https://example.com/photo.png', 302)
+        },
+      })
+
+      await addDataAndFileToRequest(req as PayloadRequest)
+
+      expect(handlerCalled).toBe(false)
+      expect(req.file?.data.length).toBe(0)
+      expect(req.file?.width).toBe(640)
+      expect(req.file?.height).toBe(480)
+      expect(req.file?.mimetype).toBe('image/png')
+    })
+
+    it('should fetch back via staticHandler when imageSizes are configured, carrying client dimensions through', async () => {
+      let handlerCalled = false
+      const req = createClientUploadReq({
+        collectionUpload: { imageSizes: [{ name: 'thumb', width: 100 }] },
+        fileField: {
+          collectionSlug: 'media',
+          filename: 'photo.png',
+          height: 480,
+          mimeType: 'image/png',
+          size: 1234,
+          width: 640,
+        },
+        staticHandler: () => {
+          handlerCalled = true
+          return new Response(Buffer.from('real-bytes'), {
+            headers: { 'Content-Type': 'image/png' },
+          })
+        },
+      })
+
+      await addDataAndFileToRequest(req as PayloadRequest)
+
+      expect(handlerCalled).toBe(true)
+      expect(req.file?.data.length).toBeGreaterThan(0)
+      expect(req.file?.width).toBe(640)
+      expect(req.file?.height).toBe(480)
+    })
+
+    it('should fetch back via staticHandler when client dimensions are absent', async () => {
+      let handlerCalled = false
+      const req = createClientUploadReq({
+        fileField: {
+          collectionSlug: 'media',
+          filename: 'photo.png',
+          mimeType: 'image/png',
+          size: 1234,
+        },
+        staticHandler: () => {
+          handlerCalled = true
+          return new Response(Buffer.from('real-bytes'), {
+            headers: { 'Content-Type': 'image/png' },
+          })
+        },
+      })
+
+      await addDataAndFileToRequest(req as PayloadRequest)
+
+      expect(handlerCalled).toBe(true)
+      expect(req.file?.data.length).toBeGreaterThan(0)
+    })
   })
 })

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -1,7 +1,9 @@
 import type { PayloadRequest } from '../types/index.js'
+import type { UploadEdits } from '../uploads/types.js'
 
 import { APIError } from '../errors/APIError.js'
 import { processMultipartFormdata } from '../uploads/fetchAPI-multipart/index.js'
+import { uploadRequiresFileData } from '../uploads/uploadRequiresFileData.js'
 
 type AddDataAndFileToRequest = (req: PayloadRequest) => Promise<void>
 
@@ -58,56 +60,83 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
       }
 
       if (!req.file && fields?.file && typeof fields?.file === 'string') {
-        let clientUploadContext, collectionSlug, filename, mimeType, size
+        let clientUploadContext, collectionSlug, filename, height, mimeType, size, width
         try {
-          ;({ clientUploadContext, collectionSlug, filename, mimeType, size } = JSON.parse(
-            fields.file,
-          ))
+          ;({ clientUploadContext, collectionSlug, filename, height, mimeType, size, width } =
+            JSON.parse(fields.file))
         } catch {
           throw new APIError('A file name is required.', 400)
         }
         const uploadConfig = req.payload.collections[collectionSlug]!.config.upload
 
-        if (!uploadConfig.handlers) {
-          throw new APIError('uploadConfig.handlers is not present for ' + collectionSlug)
-        }
+        // When the client supplied dimensions and no server-side image processing is needed,
+        // skip the staticHandler fetch-back entirely — the bytes already live in storage and
+        // never need to enter the server.
+        const hasClientDimensions = typeof width === 'number' && typeof height === 'number'
 
-        let response: null | Response = null
-        let error: unknown
+        if (
+          hasClientDimensions &&
+          !uploadRequiresFileData({
+            hasSharp: Boolean(req.payload.config.sharp),
+            mimeType,
+            uploadConfig,
+            uploadEdits: req.query?.uploadEdits as undefined | UploadEdits,
+          })
+        ) {
+          req.file = {
+            name: filename,
+            clientUploadContext,
+            data: Buffer.alloc(0),
+            height,
+            mimetype: mimeType,
+            size,
+            width,
+          }
+        } else {
+          if (!uploadConfig.handlers) {
+            throw new APIError('uploadConfig.handlers is not present for ' + collectionSlug)
+          }
 
-        for (const handler of uploadConfig.handlers) {
-          try {
-            const result = await handler(req, {
-              doc: null!,
-              params: {
-                clientUploadContext, // Pass additional specific to adapters context returned from UploadHandler, then staticHandler can use them.
-                collection: collectionSlug,
-                filename,
-              },
-            })
-            if (result) {
-              response = result
+          let response: null | Response = null
+          let error: unknown
+
+          for (const handler of uploadConfig.handlers) {
+            try {
+              const result = await handler(req, {
+                doc: null!,
+                params: {
+                  clientUploadContext, // Pass additional specific to adapters context returned from UploadHandler, then staticHandler can use them.
+                  collection: collectionSlug,
+                  filename,
+                },
+              })
+              if (result) {
+                response = result
+              }
+              // If we couldn't get the file from that handler, save the error and try other.
+            } catch (err) {
+              error = err
             }
-            // If we couldn't get the file from that handler, save the error and try other.
-          } catch (err) {
-            error = err
-          }
-        }
-
-        if (!response) {
-          if (error) {
-            payload.logger.error(error)
           }
 
-          throw new APIError('Expected response from the upload handler.')
-        }
+          if (!response) {
+            if (error) {
+              payload.logger.error(error)
+            }
 
-        req.file = {
-          name: filename,
-          clientUploadContext,
-          data: Buffer.from(await response.arrayBuffer()),
-          mimetype: response.headers.get('Content-Type') || mimeType,
-          size,
+            throw new APIError('Expected response from the upload handler.')
+          }
+
+          req.file = {
+            name: filename,
+            clientUploadContext,
+            data: Buffer.from(await response.arrayBuffer()),
+            // Carry client-supplied dimensions so generateFileData can fall back to them
+            // if the handler returned an empty/redirect body.
+            ...(hasClientDimensions ? { height, width } : {}),
+            mimetype: response.headers.get('Content-Type') || mimeType,
+            size,
+          }
         }
       }
     }

--- a/packages/ui/src/elements/BulkUpload/FormsManager/createFormData.ts
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/createFormData.ts
@@ -5,6 +5,8 @@ import { reduceFieldsToValues } from 'payload/shared'
 
 import type { UploadHandlersContext } from '../../../providers/UploadHandlers/index.js'
 
+import { getImageDimensions } from '../../../utilities/getImageDimensions.js'
+
 export async function createFormData(
   formState: FormState = {},
   overrides: Record<string, any> = {},
@@ -29,12 +31,16 @@ export async function createFormData(
       },
     })
 
+    const { height, width } = await getImageDimensions(file)
+
     file = JSON.stringify({
       clientUploadContext,
       collectionSlug,
       filename,
+      height,
       mimeType: file.type,
       size: file.size,
+      width,
     })
   }
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -39,6 +39,7 @@ import { useTranslation } from '../../providers/Translation/index.js'
 import { useUploadHandlers } from '../../providers/UploadHandlers/index.js'
 import { abortAndIgnore, handleAbortRef } from '../../utilities/abortAndIgnore.js'
 import { requests } from '../../utilities/api.js'
+import { getImageDimensions } from '../../utilities/getImageDimensions.js'
 import {
   BackgroundProcessingContext,
   DocumentFormContext,
@@ -591,12 +592,16 @@ export const Form: React.FC<FormProps> = (props) => {
             },
           })
 
+          const { height, width } = await getImageDimensions(file)
+
           file = JSON.stringify({
             clientUploadContext,
             collectionSlug,
             filename,
+            height,
             mimeType: file.type,
             size: file.size,
+            width,
           })
         }
       }

--- a/packages/ui/src/utilities/getImageDimensions.ts
+++ b/packages/ui/src/utilities/getImageDimensions.ts
@@ -1,0 +1,39 @@
+type ImageDimensions = {
+  height?: number
+  width?: number
+}
+
+/**
+ * Reads the natural pixel dimensions of an image File in the browser.
+ *
+ * Used during client uploads so the server can record dimensions without fetching the
+ * file bytes back. Returns empty dimensions for non-images or when decoding fails, in
+ * which case the server falls back to probing the bytes itself.
+ */
+export async function getImageDimensions(file: File): Promise<ImageDimensions> {
+  if (typeof window === 'undefined' || !file.type?.startsWith('image/')) {
+    return {}
+  }
+
+  const objectURL = URL.createObjectURL(file)
+
+  try {
+    const { height, width } = await new Promise<ImageDimensions>((resolve, reject) => {
+      const image = new Image()
+      image.onload = () => resolve({ height: image.naturalHeight, width: image.naturalWidth })
+      image.onerror = reject
+      image.src = objectURL
+    })
+
+    // Some formats (e.g. SVG without intrinsic size) report 0 — treat as unknown.
+    if (!height || !width) {
+      return {}
+    }
+
+    return { height, width }
+  } catch {
+    return {}
+  } finally {
+    URL.revokeObjectURL(objectURL)
+  }
+}


### PR DESCRIPTION
# Overview

Fixes a 400 crash when uploading an image through a client-upload storage adapter whose `staticHandler` returns a 302 redirect, and lets collections that don't resize record image dimensions without pulling the file bytes back into the server.

During a client upload the file body never transits the server, so core fetches it back from the adapter to probe dimensions. A redirect (empty body) produced a 0-byte buffer that made `image-size` throw `RangeError: Offset is outside the bounds of the DataView`.

## Key Changes

#### Guard dimension probing against missing or unreadable bytes

`getImageSize` now returns `undefined` for empty/missing buffers and catches `image-size` failures, so a redirect or corrupt body degrades to undefined dimensions instead of failing the upload. `generateFileData` tolerates the undefined result.

#### Send client-measured dimensions with the upload

The browser measures the image's natural width and height and includes them in the client-upload payload. `generateFileData` falls back to these when byte probing yields nothing, so dimensions are still recorded for redirect-only adapters.

#### Skip the byte fetch-back when the server needs no bytes

`uploadRequiresFileData` decides whether server-side work (sharp adjustments, animated types, `imageSizes`, crop edits) needs the file. When client dimensions are present and no such work applies, `addDataAndFileToRequest` skips the `staticHandler` fetch-back, so bytes never enter the server for collections that don't resize.

## Design Decisions

Hardening `getImageSize` is the minimal, broadly protective change: no adapter can crash the upload pipeline by returning an empty body. It stands on its own regardless of the dimension-passing work.

The decision of whether bytes are needed lives in core rather than the adapter, because only core knows the collection's resize configuration. `focalPoint` alone does not require bytes, since `createImageSizes` returns early without `imageSizes`. The skip path is conservative: when bytes might be needed, it falls back to the existing fetch-back, so correctness never depends on guessing.

`ProbedImageSize` keeps its required numbers; only `getImageSize`'s return type widens to `| undefined`. The resize machinery always runs with real bytes, so it stays untouched.

## Overall Flow

```mermaid
sequenceDiagram
    participant Browser
    participant Core as addDataAndFileToRequest
    participant Adapter as staticHandler
    participant Gen as generateFileData

    Browser->>Browser: measure naturalWidth/Height
    Browser->>Core: multipart with client-upload JSON (incl. width/height)
    alt dimensions present and no server-side work needed
        Core->>Gen: req.file with empty buffer + dimensions
        Note over Core,Adapter: fetch-back skipped, bytes stay in storage
    else bytes needed (imageSizes / crop / adjustments / animated)
        Core->>Adapter: fetch file back
        Adapter-->>Core: bytes (or redirect, yielding an empty buffer)
        Core->>Gen: req.file with bytes, dimensions carried through
    end
    Gen->>Gen: probe bytes, fall back to client dimensions if unreadable
```
