### PR TITLE
fix(ui): combobox entries not spanning full popup width

### DIFF
--- a/packages/ui/src/elements/Combobox/index.css
+++ b/packages/ui/src/elements/Combobox/index.css
@@ -48,5 +48,6 @@
 
   .combobox__entry {
     cursor: pointer;
+    display: flex;
   }
 }


### PR DESCRIPTION
### What

The hover/active highlight on Combobox entries (e.g. the code block language selector in the Lexical rich text field) did not span the full width of the popup.

### Why

The `<button>` rendered by `PopupList.Button` defaults to `fit-content` width. Its wrapper `.combobox__entry` was a plain block `div`, so nothing stretched the button to fill the popup. (In `DocumentControls` the button is a direct flex child, so `align-items: stretch` already handled this.)

### Fix

Added `display: flex` to `.combobox__entry` so the button becomes a flex item and its existing `flex: 1` rule stretches it to full width.

#### Before
<img width="357" height="397" alt="Screenshot 2026-06-11 at 1 59 30 PM" src="https://github.com/user-attachments/assets/10fe5ddc-38a5-48fd-82db-188dba13e8d0" />

#### After
<img width="327" height="433" alt="Screenshot 2026-06-11 at 3 32 57 PM" src="https://github.com/user-attachments/assets/9305b38e-7c0c-404b-bd99-6899d641ae20" />
