### PR TITLE
feat(ui): underline linked cell anchors on hover across list views

### DIFF
--- a/packages/ui/src/elements/Table/OrderableRow.tsx
+++ b/packages/ui/src/elements/Table/OrderableRow.tsx
@@ -38,7 +38,12 @@ export const OrderableRow = ({
       }
 
       return (
-        <td className={`cell-${accessor}`} key={colIndex}>
+        <td
+          className={[`cell-${accessor}`, col.isLinkedColumn && 'cell--linked']
+            .filter(Boolean)
+            .join(' ')}
+          key={colIndex}
+        >
           {cell}
         </td>
       )

--- a/packages/ui/src/views/List/index.css
+++ b/packages/ui/src/views/List/index.css
@@ -20,8 +20,12 @@
     overflow: auto;
   }
 
-  .collection-list .table table td.cell--linked > a:hover {
-    text-decoration: underline;
+  .collection-list .table table td.cell--linked > a {
+    text-decoration: underline dotted var(--color-text-disabled);
+
+    &:hover {
+      text-decoration-color: currentColor;
+    }
   }
 
   .collection-list .table table [class^='cell']:not(.cell--linked) > p,

--- a/packages/ui/src/views/List/index.css
+++ b/packages/ui/src/views/List/index.css
@@ -20,6 +20,10 @@
     overflow: auto;
   }
 
+  .collection-list .table table td.cell--linked > a:hover {
+    text-decoration: underline;
+  }
+
   .collection-list .table table [class^='cell']:not(.cell--linked) > p,
   .collection-list .table table [class^='cell']:not(.cell--linked) > span,
   .collection-list .table table [class^='cell']:not(.cell--linked) > a {

--- a/packages/ui/src/views/List/index.css
+++ b/packages/ui/src/views/List/index.css
@@ -31,7 +31,7 @@
     text-underline-position: from-font;
 
     &:hover {
-      text-decoration-color: currentColor;
+      text-decoration-color: var(--color-text);
     }
   }
 

--- a/packages/ui/src/views/List/index.css
+++ b/packages/ui/src/views/List/index.css
@@ -21,7 +21,14 @@
   }
 
   .collection-list .table table td.cell--linked > a {
-    text-decoration: underline dotted var(--color-text-disabled);
+    font-weight: var(--text-body-medium-strong-font-weight);
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-skip-ink: none;
+    text-decoration-color: var(--color-border);
+    text-decoration-thickness: auto;
+    text-underline-offset: 2px;
+    text-underline-position: from-font;
 
     &:hover {
       text-decoration-color: currentColor;

--- a/packages/ui/src/views/Versions/index.css
+++ b/packages/ui/src/views/Versions/index.css
@@ -55,7 +55,14 @@
   }
 
   .versions .table td.cell--linked > a {
-    text-decoration: underline dotted var(--color-text-disabled);
+    font-weight: var(--text-body-medium-strong-font-weight);
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-skip-ink: none;
+    text-decoration-color: var(--color-border);
+    text-decoration-thickness: auto;
+    text-underline-offset: 2px;
+    text-underline-position: from-font;
 
     &:hover {
       text-decoration-color: currentColor;

--- a/packages/ui/src/views/Versions/index.css
+++ b/packages/ui/src/views/Versions/index.css
@@ -54,8 +54,12 @@
     width: 100%;
   }
 
-  .versions .table td.cell--linked > a:hover {
-    text-decoration: underline;
+  .versions .table td.cell--linked > a {
+    text-decoration: underline dotted var(--color-text-disabled);
+
+    &:hover {
+      text-decoration-color: currentColor;
+    }
   }
 
   .versions .paginator {

--- a/packages/ui/src/views/Versions/index.css
+++ b/packages/ui/src/views/Versions/index.css
@@ -54,6 +54,10 @@
     width: 100%;
   }
 
+  .versions .table td.cell--linked > a:hover {
+    text-decoration: underline;
+  }
+
   .versions .paginator {
     margin-bottom: 0;
   }

--- a/packages/ui/src/views/Versions/index.css
+++ b/packages/ui/src/views/Versions/index.css
@@ -65,7 +65,7 @@
     text-underline-position: from-font;
 
     &:hover {
-      text-decoration-color: currentColor;
+      text-decoration-color: var(--color-text);
     }
   }
 


### PR DESCRIPTION
Underlines the primary linked cell anchor on hover in the collection list, orderable list, and versions list views, giving the clickable document link a consistent hover affordance.

The hover rule is scoped to `.cell--linked > a:hover` within each view container (`.collection-list` and `.versions`), so only the row's document link gets the underline.

`OrderableRow` previously never tagged its linked column with `cell--linked`, so orderable lists missed both the full-cell anchor padding treatment and the hover affordance that the standard `Table` already had. It now adds `cell--linked` when `col.isLinkedColumn` is set, bringing orderable lists in line with the regular list view.

### Before

https://github.com/user-attachments/assets/0769692e-d191-4abb-bc09-bb652a82be5d


### After

https://github.com/user-attachments/assets/89252e45-5eae-4170-a046-afb4ec345fcb
