### PR TITLE
fix(ui): show loading state for document updated-at timestamp

### DIFF
--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -267,18 +267,22 @@ export const DocumentControls: React.FC<{
                   )}
               </Fragment>
             )}
-            {collectionConfig?.timestamps && (isEditing || isAccountView) && relativeTime && (
-              <li
-                className={`${baseClass}__list-item ${baseClass}__value-wrap`}
-                title={updatedAt || createdAt || undefined}
-              >
-                <p className={`${baseClass}__value`}>
-                  {t(isTrashed ? 'general:deletedAgo' : 'general:updatedAgo', {
-                    distance: relativeTime,
-                  })}
-                </p>
-              </li>
-            )}
+            {collectionConfig?.timestamps &&
+              (isEditing || isAccountView) &&
+              (data?.updatedAt || data?.createdAt) && (
+                <li
+                  className={`${baseClass}__list-item ${baseClass}__value-wrap`}
+                  title={updatedAt || createdAt || undefined}
+                >
+                  <p className={`${baseClass}__value`}>
+                    {relativeTime
+                      ? t(isTrashed ? 'general:deletedAgo' : 'general:updatedAgo', {
+                          distance: relativeTime,
+                        })
+                      : `${t('general:loading')}...`}
+                  </p>
+                </li>
+              )}
           </ul>
         </div>
       )}

--- a/packages/ui/src/elements/DocumentDrawer/DrawerHeader/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerHeader/index.tsx
@@ -119,7 +119,9 @@ export const DocumentDrawerHeader: React.FC<{
     }
   }, [updatedAt, createdAt, i18n, dateFormat])
 
-  const showUpdatedAt = Boolean(collectionConfig?.timestamps && isEditing && relativeTime)
+  const showUpdatedAt = Boolean(
+    collectionConfig?.timestamps && isEditing && (updatedAt || createdAt),
+  )
 
   const handleOnClose = useCallback(() => {
     if (isModified) {
@@ -172,9 +174,11 @@ export const DocumentDrawerHeader: React.FC<{
               className={`${documentDrawerBaseClass}__updated-at`}
               title={formattedUpdatedAt || formattedCreatedAt || undefined}
             >
-              {t(isTrashed ? 'general:deletedAgo' : 'general:updatedAgo', {
-                distance: relativeTime,
-              })}
+              {relativeTime
+                ? t(isTrashed ? 'general:deletedAgo' : 'general:updatedAgo', {
+                    distance: relativeTime,
+                  })
+                : `${t('general:loading')}...`}
             </span>
           ) : null}
           {showAutosave ? (

--- a/packages/ui/src/utilities/formatDocTitle/formatDateTitle.ts
+++ b/packages/ui/src/utilities/formatDocTitle/formatDateTitle.ts
@@ -39,7 +39,5 @@ type FormatTimeToNowArgs = {
 
 export const formatTimeToNow = ({ date, i18n }: FormatTimeToNowArgs): string => {
   const theDate = typeof date === 'string' ? new Date(date) : date
-  return i18n?.dateFNS
-    ? formatDistanceToNow(theDate, { locale: i18n.dateFNS })
-    : `${i18n.t('general:loading')}...`
+  return i18n?.dateFNS ? formatDistanceToNow(theDate, { locale: i18n.dateFNS }) : ''
 }


### PR DESCRIPTION
Fixes the "Updated loading... ago" flash that appeared in the document controls and drawer header while the `date-fns` locale was still loading.

`formatTimeToNow` was returning `` `${i18n.t('general:loading')}...` `` (a truthy string) when `i18n.dateFNS` wasn't available yet. Both `DocumentControls` and `DrawerHeader` guard the timestamp element on that string being truthy, so the element rendered immediately with `"loading..."` interpolated into the translation string — producing `"Updated loading... ago"`.

The fix changes `formatTimeToNow` to return `''` when the locale isn't ready, and shifts the render sites to check for actual date data (`data?.updatedAt || data?.createdAt`) instead. While the locale loads, the element renders with `"loading..."` as a standalone label; once the locale resolves, it switches to the real relative time.

### Before
<img width="463" height="138" alt="CleanShot 2026-06-12 at 00 37 56" src="https://github.com/user-attachments/assets/b4753c3d-4043-42b9-a709-f2f9a308e460" />


### After
<img width="458" height="127" alt="CleanShot 2026-06-12 at 00 38 08" src="https://github.com/user-attachments/assets/446fbd5b-6c82-4205-ab8c-85b02783c101" />
