### PR TITLE
fix(ui): list relationship cell shows (Untitled) for draft-only titles

### DIFF
--- a/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
+++ b/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
@@ -67,6 +67,7 @@ export const RelationshipProvider: React.FC<{ readonly children?: React.ReactNod
           const select: SelectType = {}
 
           params.append('depth', '0')
+          params.append('draft', 'true')
           params.append('limit', '250')
 
           const collection = collections.find((c) => c.slug === slug)

--- a/test/fields-relationship/collections/Versions/index.ts
+++ b/test/fields-relationship/collections/Versions/index.ts
@@ -4,6 +4,9 @@ import { collection1Slug, versionedRelationshipFieldSlug } from '../../slugs.js'
 
 export const Versions: CollectionConfig = {
   slug: versionedRelationshipFieldSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
   fields: [
     {
       name: 'title',
@@ -15,6 +18,11 @@ export const Versions: CollectionConfig = {
       type: 'relationship',
       relationTo: [collection1Slug],
       hasMany: true,
+    },
+    {
+      name: 'relatedVersionedDoc',
+      type: 'relationship',
+      relationTo: versionedRelationshipFieldSlug,
     },
   ],
   versions: {

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -770,6 +770,43 @@ describe('Relationship Field', () => {
     await expect(page.locator(tableRowLocator)).toHaveCount(1)
   })
 
+  test('should show draft-only title for related doc in list view cell', async () => {
+    // Create a related doc whose title only lives in a draft. The main collection
+    // row is created empty and the title is then saved as a draft, so the published
+    // row has no title. This reproduces the list cell rendering "(Untitled)".
+    const draftRelated = await payload.create({
+      collection: versionedRelationshipFieldSlug,
+      data: {
+        title: '',
+      },
+      draft: true,
+    })
+
+    await payload.update({
+      collection: versionedRelationshipFieldSlug,
+      id: draftRelated.id,
+      data: {
+        title: 'Draft Only Title',
+      },
+      draft: true,
+    })
+
+    // Create the doc that holds the relationship to the draft-only related doc.
+    await createVersionedRelationshipFieldDoc('Parent doc', undefined, {
+      relatedVersionedDoc: draftRelated.id,
+    })
+
+    await page.goto(versionedRelationshipFieldURL.list)
+    await wait(300)
+
+    const relationshipCell = page
+      .locator(tableRowLocator, { hasText: 'Parent doc' })
+      .locator('.cell-relatedVersionedDoc')
+
+    await expect(relationshipCell).toContainText('Draft Only Title')
+    await expect(relationshipCell).not.toContainText('Untitled - ID')
+  })
+
   describe('existing relationships', () => {
     test('should highlight existing relationship', async () => {
       await page.goto(url.edit(docWithExistingRelations.id))

--- a/test/fields-relationship/payload-types.ts
+++ b/test/fields-relationship/payload-types.ts
@@ -403,6 +403,7 @@ export interface VersionedRelationshipField {
         value: string | Collection1;
       }[]
     | null;
+  relatedVersionedDoc?: (string | null) | VersionedRelationshipField;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -767,6 +768,7 @@ export interface MixedMediaSelect<T extends boolean = true> {
 export interface VersionedRelationshipFieldSelect<T extends boolean = true> {
   title?: T;
   relationshipField?: T;
+  relatedVersionedDoc?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;


### PR DESCRIPTION
## What

Fixes #16977

The list view relationship/upload cell loads related docs through `RelationshipProvider`, which requested `GET /api/<slug>?depth=0&select[<useAsTitle>]=true` with **no** `draft` parameter, so Payload returned the published/main-collection row.

Because draft-only edits are written only to the versions table (the main row is updated only on first create and on publish), the list cell read a stale/empty title and rendered "(Untitled)", while the edit-view relationship field (which loads options with `draft: true`) rendered the real title. This is especially visible with autosave.

This PR requests the related docs with `draft=true` in `RelationshipProvider`, matching the edit-view relationship field, so the list column shows the same title.

## How

- Append `draft=true` to the request made by `packages/ui/src/elements/Table/RelationshipProvider/index.tsx`.

## Tests

Added an e2e test in `test/fields-relationship/e2e.spec.ts` (`should show draft-only title for related doc in list view cell`) that:

1. Creates a related doc whose title only exists in a draft (empty main row, then the title saved as a draft).
2. Creates a doc that holds a relationship to it.
3. Asserts the list view relationship cell shows the draft title.

Without the fix the test fails because the cell renders "(Untitled)":

```
Error: expect(locator).toContainText(expected) failed

Locator: locator('table > tbody > tr').filter({ hasText: 'Parent doc' }).locator('.cell-relatedVersionedDoc')
Expected substring: "Draft Only Title"
Received string:    "Untitled - ID: 6a2bf2bf93581c5a92f6c4f1"
Timeout: 6000ms
```

The dev server log for that failing run confirms the root cause: the request omits the `draft` param.

```
GET /api/versioned-relationship-field?depth=0&limit=250&locale=en&where[id][in]=... 200
```

With the fix applied the request includes `draft=true` and the test passes.

## Notes

A companion PR targets `3.x` with the same fix.
