### PR TITLE
fix(ui): respect admin.condition on row fields

### DIFF
--- a/packages/payload/src/admin/fields/Row.ts
+++ b/packages/payload/src/admin/fields/Row.ts
@@ -22,9 +22,9 @@ import type {
 
 type RowFieldClientWithoutType = MarkOptional<RowFieldClient, 'type'>
 
-type RowFieldBaseClientProps = Omit<FieldPaths, 'path'> & Pick<ClientComponentProps, 'forceRender'>
+type RowFieldBaseClientProps = FieldPaths & Pick<ClientComponentProps, 'forceRender'>
 
-export type RowFieldClientProps = Omit<ClientFieldBase<RowFieldClientWithoutType>, 'path'> &
+export type RowFieldClientProps = ClientFieldBase<RowFieldClientWithoutType> &
   RowFieldBaseClientProps
 
 export type RowFieldServerProps = ServerFieldBase<RowField, RowFieldClientWithoutType>

--- a/packages/payload/src/admin/forms/Field.ts
+++ b/packages/payload/src/admin/forms/Field.ts
@@ -63,10 +63,8 @@ export type FieldPaths = {
    * Nested fields will have a path that includes the parent field names
    * if they are nested within a group, array, block or named tab.
    *
-   * Collapsibles and unnamed tabs will have arbitrary paths
+   * Collapsibles, rows and unnamed tabs will have arbitrary paths
    * that look like _index-0, _index-1, etc.
-   *
-   * Row fields will not have a path.
    *
    * @example 'parentGroupField.childTextField'
    *

--- a/packages/ui/src/forms/RenderFields/RenderField.tsx
+++ b/packages/ui/src/forms/RenderFields/RenderField.tsx
@@ -125,7 +125,7 @@ export function RenderField({
       return <RichTextField {...baseFieldProps} field={clientFieldConfig} path={path} />
 
     case 'row':
-      return <RowField {...iterableFieldProps} field={clientFieldConfig} />
+      return <RowField {...iterableFieldProps} field={clientFieldConfig} path={path} />
 
     case 'select':
       return <SelectField {...baseFieldProps} field={clientFieldConfig} path={path} />

--- a/test/fields/collections/ConditionalLogic/e2e.spec.ts
+++ b/test/fields/collections/ConditionalLogic/e2e.spec.ts
@@ -289,6 +289,15 @@ describe('Conditional Logic', () => {
     await expect(fieldWithOperationCondition).toBeHidden()
   })
 
+  test('should hide row field UI when admin.condition is false', async () => {
+    await page.goto(url.create)
+
+    await toggleConditionAndCheckField(
+      'label[for=field-toggleField]',
+      'label[for=field-rowFieldWithCondition]',
+    )
+  })
+
   test('should hide entire tabs field UI when admin.condition is false', async () => {
     await page.goto(url.create)
 

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -32,6 +32,18 @@ const ConditionalLogic: CollectionConfig = {
       },
     },
     {
+      type: 'row',
+      admin: {
+        condition: ({ toggleField }) => Boolean(toggleField),
+      },
+      fields: [
+        {
+          name: 'rowFieldWithCondition',
+          type: 'text',
+        },
+      ],
+    },
+    {
       name: 'fieldWithOperationCondition',
       type: 'text',
       admin: {


### PR DESCRIPTION
Same as https://github.com/payloadcms/payload/pull/16954, applied to 4.x.

Rows aren't respecting their admin.condition property.

This is because `path` was never forwarded to the row field, so its `withCondition` wrapper looked up `passesCondition` at an undefined path. The row fields never become hidden no matter what the `admin.condition` evaluates to.

## Before

https://github.com/user-attachments/assets/3b859409-16ba-42c8-91ad-f82fca01ccd9

## After

https://github.com/user-attachments/assets/30cd5edc-f32c-447f-b74a-0cd95d13af2c