### PR TITLE
fix(ui): prevent tooltip overflow in drawers

### DIFF
--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -17,7 +17,6 @@ import { useDocumentDrawer } from '../DocumentDrawer/index.js'
 import { Popup } from '../Popup/index.js'
 import * as PopupList from '../Popup/PopupButtonList/index.js'
 import './index.css'
-import { Tooltip } from '../Tooltip/index.js'
 
 const baseClass = 'relationship-add-new'
 
@@ -43,7 +42,6 @@ export const AddNewRelation: React.FC<Props> = ({
 
   const [popupOpen, setPopupOpen] = useState(false)
   const { i18n, t } = useTranslation()
-  const [showTooltip, setShowTooltip] = useState(false)
 
   const [DocumentDrawer, DocumentDrawerToggler, { isDrawerOpen, toggleDrawer }] = useDocumentDrawer(
     {
@@ -90,10 +88,6 @@ export const AddNewRelation: React.FC<Props> = ({
     },
     [collectionConfig, hasMany, onChange, value],
   )
-
-  const onPopupToggle = useCallback((state) => {
-    setPopupOpen(state)
-  }, [])
 
   useEffect(() => {
     if (permissions) {
@@ -152,19 +146,9 @@ export const AddNewRelation: React.FC<Props> = ({
             ]
               .filter(Boolean)
               .join(' ')}
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
+            tooltip={ButtonFromProps ? undefined : label}
           >
-            {ButtonFromProps ? (
-              ButtonFromProps
-            ) : (
-              <Fragment>
-                <Tooltip className={`${baseClass}__tooltip`} show={showTooltip}>
-                  {label}
-                </Tooltip>
-                <PlusIcon />
-              </Fragment>
-            )}
+            {ButtonFromProps ? ButtonFromProps : <PlusIcon />}
           </DocumentDrawerToggler>
           <DocumentDrawer onSave={onSave} />
         </Fragment>
@@ -174,7 +158,8 @@ export const AddNewRelation: React.FC<Props> = ({
           <Popup
             buttonType="custom"
             horizontalAlign="right"
-            onToggleOpen={onPopupToggle}
+            onToggleClose={() => setPopupOpen(false)}
+            onToggleOpen={() => setPopupOpen(true)}
             render={({ close: closePopup }) => (
               <PopupList.ButtonGroup>
                 {relatedCollections.map((relatedCollection) => {
@@ -203,6 +188,7 @@ export const AddNewRelation: React.FC<Props> = ({
                 {...buttonProps}
                 buttonStyle="pill"
                 selected={active}
+                tooltip={popupOpen ? '' : t('fields:addNew')}
               >
                 <PlusIcon />
               </Button>

--- a/packages/ui/src/elements/Button/index.css
+++ b/packages/ui/src/elements/Button/index.css
@@ -156,6 +156,14 @@
     border-color: var(--color-border-selected-strong);
   }
 
+  /* Selected state - pill buttons */
+  .btn.btn--style-pill.btn--selected,
+  .btn.btn--style-pill.btn--selected:hover,
+  .btn.btn--style-pill.btn--selected:active {
+    background-color: var(--color-bg-selected);
+    color: var(--color-text-selected);
+  }
+
   /* Icon */
 
   .btn__icon {

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -42,6 +42,7 @@ export type DocumentTogglerProps = {
   readonly extraButtonProps?: Record<string, any>
   readonly onClick?: () => void
   readonly operation: Operation
+  readonly tooltip?: string
 } & Readonly<HTMLAttributes<HTMLButtonElement>>
 
 export type UseDocumentDrawerContext = {

--- a/packages/ui/src/elements/Drawer/index.css
+++ b/packages/ui/src/elements/Drawer/index.css
@@ -44,7 +44,8 @@
   .drawer__content-children {
     position: relative;
     z-index: 1;
-    overflow: auto;
+    overflow-x: clip;
+    overflow-y: auto;
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/packages/ui/src/elements/Drawer/types.ts
+++ b/packages/ui/src/elements/Drawer/types.ts
@@ -24,4 +24,5 @@ export type TogglerProps = {
   disabled?: boolean
   extraButtonProps?: Record<string, any>
   slug: string
+  tooltip?: string
 } & HTMLAttributes<HTMLButtonElement>

--- a/packages/ui/src/elements/Tooltip/index.css
+++ b/packages/ui/src/elements/Tooltip/index.css
@@ -95,7 +95,11 @@
 
   .tooltip--position-top {
     top: 0;
-    transform: translate3d(var(--tooltip-x), calc(-100% - var(--caret-height) - var(--caret-offset) + 1px), 0);
+    transform: translate3d(
+      var(--tooltip-x),
+      calc(-100% - var(--caret-height) - var(--caret-offset) + 1px),
+      0
+    );
 
     .tooltip__caret {
       --color-border: var(--ramp-grey-700);
@@ -109,7 +113,11 @@
 
   .tooltip--position-bottom {
     top: 100%;
-    transform: translate3d(var(--tooltip-x), calc(var(--caret-height) + var(--caret-offset) - 1px), 0);
+    transform: translate3d(
+      var(--tooltip-x),
+      calc(var(--caret-height) + var(--caret-offset) - 1px),
+      0
+    );
 
     .tooltip__caret {
       bottom: calc(100% - 0.5px);

--- a/packages/ui/src/elements/Tooltip/index.css
+++ b/packages/ui/src/elements/Tooltip/index.css
@@ -5,12 +5,15 @@
     --caret-offset: 4px;
     --caret-border-color: var(--color-border);
     --tooltip-x: -50%;
+    --tooltip-caret-x: 0px;
+    --tooltip-max-width: none;
 
     opacity: 0;
     background-color: var(--color-bg-tooltip);
     position: absolute;
     z-index: 3;
     left: 50%;
+    max-width: var(--tooltip-max-width);
     padding: var(--spacer-1);
     color: var(--color-text-ontooltip);
     font-family: var(--text-body-medium-font-family);
@@ -46,6 +49,11 @@
     @media (max-width: 768px) {
       display: none;
     }
+  }
+
+  .tooltip--wrap {
+    white-space: normal;
+    overflow-wrap: break-word;
   }
 
   .tooltip__caret {
@@ -95,13 +103,13 @@
     }
 
     &.tooltip--caret-center .tooltip__caret {
-      transform: translateX(-50%);
+      transform: translateX(calc(-50% + var(--tooltip-caret-x)));
     }
   }
 
   .tooltip--position-bottom {
     top: 100%;
-    transform: translate3d(-50%, calc(var(--caret-height) + var(--caret-offset) - 1px), 0);
+    transform: translate3d(var(--tooltip-x), calc(var(--caret-height) + var(--caret-offset) - 1px), 0);
 
     .tooltip__caret {
       bottom: calc(100% - 0.5px);
@@ -109,7 +117,7 @@
     }
 
     &.tooltip--caret-center .tooltip__caret {
-      transform: translateX(-50%) rotate(180deg);
+      transform: translateX(calc(-50% + var(--tooltip-caret-x))) rotate(180deg);
     }
 
     &.tooltip--caret-right .tooltip__caret {

--- a/packages/ui/src/elements/Tooltip/index.tsx
+++ b/packages/ui/src/elements/Tooltip/index.tsx
@@ -1,8 +1,29 @@
 'use client'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 
 import { useIntersect } from '../../hooks/useIntersect.js'
 import './index.css'
+
+const EDGE_GUTTER = 8
+
+const getClipBoundary = (el: HTMLElement | null): DOMRect | null => {
+  let current = el?.parentElement || null
+
+  while (current) {
+    const { overflowX } = window.getComputedStyle(current)
+    if (
+      overflowX === 'auto' ||
+      overflowX === 'clip' ||
+      overflowX === 'hidden' ||
+      overflowX === 'scroll'
+    ) {
+      return current.getBoundingClientRect()
+    }
+    current = current.parentElement
+  }
+
+  return null
+}
 
 export type Props = {
   alignCaret?: 'center' | 'left' | 'right'
@@ -52,8 +73,10 @@ export const Tooltip: React.FC<Props> = (props) => {
 
   const [show, setShow] = React.useState(showFromProps)
   const [position, setPosition] = React.useState<'bottom' | 'left' | 'right' | 'top'>('top')
+  const [shiftX, setShiftX] = useState(0)
+  const [maxWidth, setMaxWidth] = useState<null | number>(null)
 
-  const [ref, intersectionEntry] = useIntersect(
+  const [ref, intersectionEntry, node] = useIntersect(
     {
       root: boundingRef?.current || null,
       rootMargin: '-145px 0px 0px 100px',
@@ -88,6 +111,60 @@ export const Tooltip: React.FC<Props> = (props) => {
     setPosition(intersectionEntry?.isIntersecting ? 'top' : 'bottom')
   }, [intersectionEntry, staticPositioning])
 
+  // Keep a horizontally-centered tooltip (top/bottom) inside its boundary by
+  // shifting it inward by exactly the amount it would overflow. The hidden
+  // measuring aside (`node`) provides the natural, unshifted geometry.
+  const computeShift = useCallback(() => {
+    const usesHorizontalCenter =
+      (positionFromProps || position) === 'top' || (positionFromProps || position) === 'bottom'
+
+    if (staticPositioning || !node || !usesHorizontalCenter) {
+      setShiftX(0)
+      setMaxWidth(null)
+      return
+    }
+
+    const rect = node.getBoundingClientRect()
+    const boundary =
+      boundingRef?.current?.getBoundingClientRect() ?? getClipBoundary(node) ?? undefined
+    const leftEdge = (boundary?.left ?? 0) + EDGE_GUTTER
+    const rightEdge = (boundary?.right ?? window.innerWidth) - EDGE_GUTTER
+    const available = rightEdge - leftEdge
+
+    // When the tooltip can't fit even at full boundary width, cap it so it wraps.
+    const nextMaxWidth = rect.width > available ? available : null
+    setMaxWidth(nextMaxWidth)
+
+    // Compute the shift against the clamped box, kept centered on the anchor.
+    const center = rect.left + rect.width / 2
+    const effectiveWidth = nextMaxWidth ?? rect.width
+    const effectiveLeft = center - effectiveWidth / 2
+    const effectiveRight = center + effectiveWidth / 2
+
+    let shift = 0
+    if (effectiveRight > rightEdge) {
+      shift = rightEdge - effectiveRight
+    }
+    if (effectiveLeft + shift < leftEdge) {
+      shift = leftEdge - effectiveLeft
+    }
+
+    setShiftX(shift)
+  }, [boundingRef, node, position, positionFromProps, staticPositioning])
+
+  useLayoutEffect(() => {
+    if (!show) {
+      return
+    }
+
+    computeShift()
+    window.addEventListener('resize', computeShift)
+
+    return () => {
+      window.removeEventListener('resize', computeShift)
+    }
+  }, [show, computeShift])
+
   // The first aside is always on top. The purpose of that is that it can reliably be used for the interaction observer (as it's not moving around), to calculate the position of the actual tooltip.
   return (
     <React.Fragment>
@@ -109,11 +186,23 @@ export const Tooltip: React.FC<Props> = (props) => {
           'tooltip',
           className,
           show && 'tooltip--show',
+          maxWidth && 'tooltip--wrap',
           `tooltip--caret-${alignCaret}`,
           `tooltip--position-${positionFromProps || position}`,
         ]
           .filter(Boolean)
           .join(' ')}
+        style={
+          {
+            ...(maxWidth ? { '--tooltip-max-width': `${maxWidth}px` } : {}),
+            ...(shiftX
+              ? {
+                  '--tooltip-caret-x': `${-shiftX}px`,
+                  '--tooltip-x': `calc(-50% + ${shiftX}px)`,
+                }
+              : {}),
+          } as React.CSSProperties
+        }
       >
         <TooltipCaret />
         <div className="tooltip-content">{children}</div>

--- a/packages/ui/src/elements/Tooltip/index.tsx
+++ b/packages/ui/src/elements/Tooltip/index.tsx
@@ -4,7 +4,8 @@ import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import { useIntersect } from '../../hooks/useIntersect.js'
 import './index.css'
 
-const EDGE_GUTTER = 8
+// Breathing room (px) between a shifted tooltip and its clipping edge. Maps to `--spacer-1`.
+const EDGE_GUTTER = 4
 
 const getClipBoundary = (el: HTMLElement | null): DOMRect | null => {
   let current = el?.parentElement || null


### PR DESCRIPTION
Keeps tooltips inside their nearest clipping container instead of overflowing the drawer or viewport.

A horizontally-centered tooltip rendered near the right edge of a drawer (e.g. the relationship "Add new" button) previously extended past the drawer edge, causing a rogue horizontal scrollbar. The `Tooltip` only handled vertical collisions (`top`/`bottom` flip via `IntersectionObserver`) and had no horizontal logic.

`Tooltip` now measures the hidden positioning `aside` with `getBoundingClientRect` and shifts the visible tooltip inward by exactly the amount it would overflow, moving the caret the opposite amount so it keeps pointing at the trigger. The boundary is resolved as the explicit `boundingRef`, else the nearest ancestor that clips overflow (`overflow-x` of `auto`/`clip`/`hidden`/`scroll`), else the viewport.

When a tooltip is wider than its boundary even at full width, it caps `max-width` to the boundary and wraps (`tooltip--wrap`) rather than clipping.

`.drawer__content-children` uses `overflow-x: clip; overflow-y: auto` so the drawer never produces a horizontal scrollbar while still scrolling vertically.

Related:

- `AddNewRelation` now uses `Button`'s built-in `tooltip` prop instead of a manually wired `Tooltip` and `onMouseEnter`/`onMouseLeave` handlers, which were silently dropped because `Button` does not forward arbitrary props. This also adds the tooltip to the polymorphic (multi-collection) `+` button. `tooltip` is threaded through `DocumentTogglerProps` and `TogglerProps`.
- Adds a `selected` style for `pill` buttons (`--color-bg-selected` / `--color-text-selected`), matching `ghost` and `secondary`.

### Before

https://github.com/user-attachments/assets/c9c59138-aee6-46d8-8dfa-aab667fe6ba5

### After

https://github.com/user-attachments/assets/1a6e7c19-1cfd-45c4-b191-407d278909d0