### PR TITLE
fix(ui): translate SidebarToggle tooltip label

### DIFF
--- a/packages/ui/src/elements/SidebarToggle/index.tsx
+++ b/packages/ui/src/elements/SidebarToggle/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useState } from 'react'
 
+import { useTranslation } from '../../providers/Translation/index.js'
 import { SidebarIcon } from '../../icons/Sidebar/index.js'
 import { Tooltip } from '../Tooltip/index.js'
 import './index.css'
@@ -11,9 +12,9 @@ export const SidebarToggle: React.FC<{
   readonly isActive?: boolean
 }> = ({ isActive = false }) => {
   const [showTooltip, setShowTooltip] = useState(false)
+  const { t } = useTranslation()
 
-  // TODO: translations
-  const label = isActive ? 'Hide Sidebar' : 'Show Sidebar'
+  const label = isActive ? t('general:hideSidebar') : t('general:showSidebar')
 
   return (
     <div


### PR DESCRIPTION
## What?

Replace hardcoded English strings in `SidebarToggle` with the translation system.

## Why?

The tooltip label was using hardcoded `'Hide Sidebar'` / `'Show Sidebar'` strings with a `// TODO: translations` comment. The translation keys `general:hideSidebar` and `general:showSidebar` already exist in the translations package — they just weren't being used.

## How?

- Import `useTranslation` from the Translation provider
- Call `t('general:hideSidebar')` / `t('general:showSidebar')` for the tooltip label
- Remove the TODO comment