### PR TITLE
fix(ui): show dot menu when editMenuItems exist regardless of create/delete permission

### DIFF
--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -198,7 +198,8 @@ export const DocumentControls: React.FC<{
 
   const showDotMenu = Boolean(
     !disableActions &&
-      ((collectionConfig && id && (hasCreatePermission || hasDeletePermission)) ||
+      (EditMenuItems ||
+        (collectionConfig && id && (hasCreatePermission || hasDeletePermission)) ||
         (globalConfig && (globalHasDraftsEnabled || localization))),
   )
   const collectionAutosaveEnabled = hasAutosaveEnabled(collectionConfig)

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -425,7 +425,7 @@ export const DocumentControls: React.FC<{
                   )}
                 </React.Fragment>
               )}
-              {hasDeletePermission && (
+              {hasDeletePermission && id && (
                 <DeleteDocument
                   buttonId="action-delete"
                   collectionSlug={collectionConfig?.slug}


### PR DESCRIPTION
Fixes #16975

## What?

`editMenuItems` defined on a collection were silently hidden when both `create` and `delete` permissions were denied, because the three-dot menu's visibility (`showDotMenu`) was gated entirely on those permissions.

## Why?

Custom `editMenuItems` represent arbitrary business logic unrelated to CRUD operations. A collection that blocks creation (e.g. webhook-only) and deletion (e.g. audit trail) should still expose custom actions like "Resend confirmation email".

## How?

Added `EditMenuItems` as an additional condition in `showDotMenu` so the popup renders whenever custom items are present, regardless of create/delete access.