### PR TITLE
fix(plugin-multi-tenant): prevent form reset when tenant create fails validation

### DIFF
--- a/packages/plugin-multi-tenant/src/components/WatchTenantCollection/index.tsx
+++ b/packages/plugin-multi-tenant/src/components/WatchTenantCollection/index.tsx
@@ -44,7 +44,7 @@ export const WatchTenantCollection = () => {
   }, [id, titleField?.initialValue])
 
   React.useEffect(() => {
-    if (operation === 'create' && submitted) {
+    if (operation === 'create' && submitted && id) {
       void syncTenants()
     }
   }, [operation, submitted, syncTenants, id])


### PR DESCRIPTION
## What?

When creating a document in the tenants collection, a client-side validation failure caused the entire form to wipe its values.

## Why?

`WatchTenantCollection` watches `submitted` and calls `syncTenants()` whenever `operation === 'create' && submitted`. But `submitted` becomes `true` on any submit attempt — including failed validation — not only on a successful save. The resulting `syncTenants()` call triggered a state cascade that called `router.refresh()`, which reset the form to its empty initial state.

## How?

Added an `id` guard to the effect:

```tsx
if (operation === 'create' && submitted && id) {
```
Fixes #16953