### PR TITLE
fix(ui): translate Dialog close button aria-label

### DIFF
--- a/packages/ui/src/elements/Dialog/DialogHeader/index.tsx
+++ b/packages/ui/src/elements/Dialog/DialogHeader/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react'
 
+import { useTranslation } from '../../../providers/Translation/index.js'
 import { XIcon } from '../../../icons/X/index.js'
 import { Button } from '../../Button/index.js'
 import { useModal } from '../../Modal/index.js'
@@ -17,6 +18,7 @@ export type DialogHeaderProps = {
 export const DialogHeader: React.FC<DialogHeaderProps> = ({ children, showClose, title }) => {
   const { slug, isConfirming } = useDialogContext()
   const { closeModal } = useModal()
+  const { t } = useTranslation()
 
   if (!title && !children && !showClose) {
     return null
@@ -32,7 +34,7 @@ export const DialogHeader: React.FC<DialogHeaderProps> = ({ children, showClose,
       {children ? <div className={`${baseClass}__header-extras`}>{children}</div> : null}
       {showClose ? (
         <Button
-          aria-label="Close"
+          aria-label={t('general:close')}
           buttonStyle="ghost"
           disabled={isConfirming}
           icon={<XIcon />}


### PR DESCRIPTION
## What?

The close button in `DialogHeader` had a hardcoded `aria-label="Close"` string. The translation key `general:close` already exists in the translations package — it just wasn't being used here.

## How?

- Import `useTranslation` from the Translation provider
- Use `t('general:close')` for the close button's `aria-label`