### PR TITLE
fix(ui): translate DiffCollapser expand/collapse aria-label

### DIFF
--- a/packages/ui/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.tsx
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.tsx
@@ -104,7 +104,7 @@ export const DiffCollapser: React.FC<Props> = ({
     <div className={baseClass}>
       <FieldDiffLabel>
         <button
-          aria-label={isCollapsed ? 'Expand' : 'Collapse'}
+          aria-label={isCollapsed ? t('general:expand') : t('general:collapse')}
           className={`${baseClass}__toggle-button`}
           onClick={() => setIsCollapsed(!isCollapsed)}
           type="button"


### PR DESCRIPTION
## What?

The expand/collapse toggle button in `DiffCollapser` used hardcoded English strings `'Expand'` and `'Collapse'` for its `aria-label`. The translation keys `general:expand` and `general:collapse` already exist, and `useTranslation` was already imported and `t` already in scope — the strings just weren't being used.

## How?

```tsx
aria-label={isCollapsed ? t('general:expand') : t('general:collapse')}