### PR TITLE
fix(deps): override transitive js-cookie to ^3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     ],
     "overrides": {
       "@vercel/blob>undici": "6.24.1",
+      "amazon-cognito-identity-js>js-cookie": "^3.0.7",
       "copyfiles": "$copyfiles",
       "cross-env": "$cross-env",
       "dotenv": "$dotenv",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@vercel/blob>undici': 6.24.1
+  amazon-cognito-identity-js>js-cookie: ^3.0.7
   copyfiles: 2.4.1
   cross-env: 10.1.0
   dotenv: 16.4.7
@@ -11317,8 +11318,8 @@ packages:
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -21589,7 +21590,7 @@ snapshots:
       buffer: 4.9.2
       fast-base64-decode: 1.0.0
       isomorphic-unfetch: 3.1.0
-      js-cookie: 2.2.1
+      js-cookie: 3.0.8
     transitivePeerDependencies:
       - encoding
 
@@ -24745,7 +24746,7 @@ snapshots:
 
   js-base64@3.7.8: {}
 
-  js-cookie@2.2.1: {}
+  js-cookie@3.0.8: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## Summary

- Adds a scoped `pnpm` override forcing the transitive `js-cookie` dependency to `^3.0.7` (resolves to `3.0.8`), removing the version flagged by CVE-2026-46625.
- `js-cookie` is pulled in transitively via `amazon-cognito-identity-js`, a dependency of `@payloadcms/payload-cloud`.
- 3.x backport: #17000.

## Context

[CVE-2026-46625](https://www.cve.org/CVERecord?id=CVE-2026-46625) ([GHSA-qjx8-664m-686j](https://github.com/js-cookie/js-cookie/security/advisories/GHSA-qjx8-664m-686j), CVSS 7.5) is a prototype-pollution cookie-attribute injection affecting `js-cookie <= 3.0.5`, fixed in `3.0.7`.

`amazon-cognito-identity-js@6.3.16` still pins `js-cookie@2.2.1` and is in maintenance mode (AWS recommends migrating to Amplify v6), so an upstream bump is unlikely in the near term. A scoped override is the lowest-risk way to clear the advisory.

This forces `js-cookie` to a major version outside `amazon-cognito-identity-js`'s declared range (one AWS has not tested cognito against), so it is worth noting at release time. It is safe here: `js-cookie@3.0.8` still ships a CommonJS (`require`) entry and declares no `engines` constraint, and cognito's only `js-cookie` consumer is the browser `CookieStorage` class, which `payload-cloud` never uses (see below).

### Real-world impact: the vulnerable path is not reachable in `payload-cloud`

This override is defense-in-depth / dependency hygiene rather than a fix for a reachable bug:

- The vulnerable `assign()` helper only runs via `Cookies.set()` / `Cookies.remove()`, which in `amazon-cognito-identity-js` are only called by its browser `CookieStorage` class.
- `payload-cloud` never instantiates `CookieStorage`; it passes no `Storage`, so the default in-memory storage is used and `js-cookie` is never exercised.
- Usage is server-side only (no `document.cookie`), and nothing passes attacker-controlled JSON into a `Cookies.set(...)` attributes argument.
- `js-cookie@2.2.1` appears exactly once in the lockfile, solely under `amazon-cognito-identity-js`.

So practical exploitability through this package is effectively nil; the change keeps the dependency tree clean and satisfies vulnerability scanners.

## Changes

- `package.json`: add `"amazon-cognito-identity-js>js-cookie": "^3.0.7"` to `pnpm.overrides`.
- `pnpm-lock.yaml`: `js-cookie` now resolves to `3.0.8`; `2.2.1` removed.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds (matches CI install behavior).
- [x] Only `js-cookie@3.0.8` present in the dependency tree (`2.2.1` gone).
- [ ] CI green.