### PR TITLE
feat(cpa): default to canary, rename version flag

### DIFF
--- a/packages/create-payload-app/package.json
+++ b/packages/create-payload-app/package.json
@@ -55,7 +55,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "pack-template-files": "node --no-deprecation --import @swc-node/register/esm-register src/scripts/pack-template-files.ts",
-    "test": "jest",
+    "test": "vitest --run",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -16,7 +16,10 @@ import type {
 
 import { tryInitRepoAndCommit } from '../utils/git.js'
 import { debug, error, info, warning } from '../utils/log.js'
-import { resolvePackageVersion } from '../utils/resolvePackageVersion.js'
+import {
+  DEFAULT_PAYLOAD_VERSION_TAG,
+  resolvePackageVersion,
+} from '../utils/resolvePackageVersion.js'
 import { configurePayloadConfig } from './configure-payload-config.js'
 import { configurePluginProject } from './configure-plugin-project.js'
 import { downloadExample } from './download-example.js'
@@ -131,14 +134,14 @@ export async function createProject(
     })
   }
 
-  const versionOrTag = cliArgs['--version'] ?? 'latest'
+  const versionOrTag = cliArgs['--payload-version'] ?? DEFAULT_PAYLOAD_VERSION_TAG
 
   const spinner = p.spinner()
   spinner.start(`Resolving Payload version (${versionOrTag})...`)
 
   const payloadVersion = await resolvePackageVersion({
     packageName: 'payload',
-    versionOrTag: cliArgs['--version'],
+    versionOrTag,
   })
 
   spinner.stop(`Using Payload version ${payloadVersion}`)

--- a/packages/create-payload-app/src/lib/init-next.ts
+++ b/packages/create-payload-app/src/lib/init-next.ts
@@ -14,7 +14,10 @@ import type { CliArgs, DbType, NextAppDetails, NextConfigType, PackageManager } 
 import { copyRecursiveSync } from '../utils/copy-recursive-sync.js'
 import { debug as origDebug, warning } from '../utils/log.js'
 import { moveMessage } from '../utils/messages.js'
-import { resolvePackageVersion } from '../utils/resolvePackageVersion.js'
+import {
+  DEFAULT_PAYLOAD_VERSION_TAG,
+  resolvePackageVersion,
+} from '../utils/resolvePackageVersion.js'
 import { installPackages } from './install-packages.js'
 import { wrapNextConfig } from './wrap-next-config.js'
 
@@ -30,7 +33,7 @@ type InitNextArgs = {
   packageManager: PackageManager
   projectDir: string
   useDistFiles?: boolean
-} & Pick<CliArgs, '--debug' | '--version'>
+} & Pick<CliArgs, '--debug' | '--payload-version'>
 
 type InitNextResult =
   | { isSrcDir: boolean; nextAppDir?: string; reason: string; success: false }
@@ -94,7 +97,7 @@ export async function initNext(args: InitNextArgs): Promise<InitNextResult> {
     dbType,
     packageManager,
     projectDir,
-    versionOrTag: args['--version'],
+    versionOrTag: args['--payload-version'] ?? DEFAULT_PAYLOAD_VERSION_TAG,
   })
   if (!installSuccess) {
     installSpinner.stop('Failed to install dependencies', 1)

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -28,7 +28,10 @@ import {
   successfulNextInit,
   successMessage,
 } from './utils/messages.js'
-import { resolvePackageVersion } from './utils/resolvePackageVersion.js'
+import {
+  DEFAULT_PAYLOAD_VERSION_TAG,
+  resolvePackageVersion,
+} from './utils/resolvePackageVersion.js'
 
 export class Main {
   args: CliArgs
@@ -46,9 +49,9 @@ export class Main {
         '--help': Boolean,
         '--local-template': String,
         '--name': String,
+        '--payload-version': String, // Install a specific Payload version or npm dist-tag (e.g. 3.40.0 or canary; default: canary)
         '--secret': String,
         '--template': String,
-        '--version': String, // Install a specific Payload version or npm dist-tag (e.g. 3.40.0 or canary; default: latest)
 
         // Next.js
         '--init-next': Boolean, // TODO: Is this needed if we detect if inside Next.js project?
@@ -95,7 +98,7 @@ export class Main {
       const LATEST_VERSION = await resolvePackageVersion({
         debug: debugFlag,
         packageName: 'payload',
-        versionOrTag: this.args['--version'],
+        versionOrTag: this.args['--payload-version'] ?? DEFAULT_PAYLOAD_VERSION_TAG,
       })
 
       if (this.args['--help']) {
@@ -138,7 +141,7 @@ export class Main {
         if (!p.isCancel(shouldUpdate) && shouldUpdate) {
           const { message, success: updateSuccess } = await updatePayloadInProject(
             nextAppDetails,
-            this.args['--version'],
+            this.args['--payload-version'] ?? DEFAULT_PAYLOAD_VERSION_TAG,
           )
           if (updateSuccess) {
             info(message)

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -21,13 +21,13 @@ export interface Args extends arg.Spec {
   '--no-agent': BooleanConstructor
   '--no-deps': BooleanConstructor
   '--no-git': BooleanConstructor
+  '--payload-version': StringConstructor
   '--secret': StringConstructor
   '--template': StringConstructor
   '--use-bun': BooleanConstructor
   '--use-npm': BooleanConstructor
   '--use-pnpm': BooleanConstructor
   '--use-yarn': BooleanConstructor
-  '--version': StringConstructor
 
   // Aliases
 

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -48,7 +48,7 @@ export function helpMessage(): void {
       --use-pnpm                    Use pnpm to install dependencies
       --use-bun                     Use bun to install dependencies (experimental)
       --no-deps                     Do not install any dependencies
-      --version {underline value}               Install a specific Payload version or npm dist-tag (default: latest)
+      --payload-version {underline value}       Install a specific Payload version or npm dist-tag (default: canary)
       -h                            Show help
 `)
 }

--- a/packages/create-payload-app/src/utils/resolvePackageVersion.spec.ts
+++ b/packages/create-payload-app/src/utils/resolvePackageVersion.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { resolvePackageVersion } from './resolvePackageVersion.js'
+import { DEFAULT_PAYLOAD_VERSION_TAG, resolvePackageVersion } from './resolvePackageVersion.js'
 
 const mockRegistry = ({
   distTags,
@@ -57,5 +57,11 @@ describe('resolvePackageVersion', () => {
     await expect(
       resolvePackageVersion({ packageName: 'payload', versionOrTag: 'nope' }),
     ).rejects.toThrow('No version or tag "nope" found for package: payload')
+  })
+})
+
+describe('DEFAULT_PAYLOAD_VERSION_TAG', () => {
+  it('should export DEFAULT_PAYLOAD_VERSION_TAG as "canary"', () => {
+    expect(DEFAULT_PAYLOAD_VERSION_TAG).toBe('canary')
   })
 })

--- a/packages/create-payload-app/src/utils/resolvePackageVersion.ts
+++ b/packages/create-payload-app/src/utils/resolvePackageVersion.ts
@@ -1,4 +1,10 @@
 /**
+ * Default npm dist-tag used by the create-payload-app CLI when no
+ * `--payload-version` is provided. The CLI scaffolds against canary by default.
+ */
+export const DEFAULT_PAYLOAD_VERSION_TAG = 'canary'
+
+/**
  * Resolves a package version from either an npm dist-tag (e.g. `canary`) or an
  * explicit version number (e.g. `3.40.0`).
  *

--- a/packages/create-payload-app/vitest.config.ts
+++ b/packages/create-payload-app/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+  },
+})


### PR DESCRIPTION
# Overview

`create-payload-app` now scaffolds against the `canary` npm dist-tag by default, and the `--version` flag is renamed to `--payload-version`.

Usage:

```bash
# Before
npx create-payload-app my-app --version canary

# After (canary is now the default)
npx create-payload-app my-app
npx create-payload-app my-app --payload-version 3.40.0

# After canary release
npx create-payload-app@canary my-app
```

## Key Changes

- Default to the `canary` dist-tag
- Rename `--version` to `--payload-version`
