### PR TITLE
chore(plugin-mcp): use a real MCP client in int tests

### DIFF
--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -96,6 +96,13 @@ export const mcpPlugin = definePlugin<MCPPluginConfig>({
         ...(config.endpoints ?? []),
         // Payload prefixes /api, so the full path is /api/mcp.
         { handler: mcpEndpoint, method: 'post', path: '/mcp' },
+        // Streamable HTTP's optional server=>client GET stream. We don't offer
+        // one, so answer 405 per spec-— clients then skip it cleanly
+        {
+          handler: () => new Response(null, { headers: { Allow: 'POST' }, status: 405 }),
+          method: 'get',
+          path: '/mcp',
+        },
       ],
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1309,7 +1309,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^9.5.0
-        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.25.12)(postcss@8.5.15))
+        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.25.12)(postcss@8.5.15))
       '@sentry/types':
         specifier: ^9.5.0
         version: 9.47.1
@@ -1875,7 +1875,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 4.5.2
-        version: 4.5.2(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.5.2(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       eslint:
         specifier: ^9.16.0
         version: 9.39.2(jiti@2.7.0)
@@ -1896,10 +1896,10 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: 6.0.5
-        version: 6.0.5(typescript@6.0.3)(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.5(typescript@6.0.3)(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   templates/ecommerce:
     dependencies:
@@ -2065,7 +2065,7 @@ importers:
         version: 1.0.0
       '@vitejs/plugin-react':
         specifier: 4.5.2
-        version: 4.5.2(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.5.2(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       eslint:
         specifier: ^9.16.0
         version: 9.39.2(jiti@2.7.0)
@@ -2110,10 +2110,10 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: 6.0.5
-        version: 6.0.5(typescript@6.0.3)(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.5(typescript@6.0.3)(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   templates/website:
     dependencies:
@@ -2240,7 +2240,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 4.5.2
-        version: 4.5.2(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.5.2(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.5.0(postcss@8.5.15)
@@ -2273,16 +2273,16 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: 6.0.5
-        version: 6.0.5(typescript@6.0.3)(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.5(typescript@6.0.3)(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   test:
     dependencies:
       recharts:
         specifier: 3.2.1
-        version: 3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1)
+        version: 3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.614.0
@@ -2302,6 +2302,9 @@ importers:
       '@miniflare/shared':
         specifier: 2.14.4
         version: 2.14.4
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
       '@modelcontextprotocol/server':
         specifier: 2.0.0-alpha.2
         version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
@@ -5508,6 +5511,15 @@ packages:
     resolution: {integrity: sha512-PYn05ET2USfBAeXF6NZfWl0O32KVyE8ncQ/ngysrh3hoIV7l3qGGH7ubeFx+D8VWQ682qYhwGygUzQv2j1tGGg==}
     engines: {node: '>=16.13'}
     deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
+
+  '@modelcontextprotocol/client@2.0.0-alpha.2':
+    resolution: {integrity: sha512-FxlR5QyBPeCDEDPH2Kx20uygmuy9k2jh6ahUeEYtmVfUxboZZlUEUhn6w0XxnbxpkELcT1qyzTXC8Bqh3c8QUA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@modelcontextprotocol/server@2.0.0-alpha.2':
     resolution: {integrity: sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==}
@@ -10318,6 +10330,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -12545,6 +12561,10 @@ packages:
   piscina@4.9.2:
     resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -14369,46 +14389,6 @@ packages:
     resolution: {integrity: sha512-f/WvY6ekHykUF1rWJUAbCU7iS/5QYDIugwpqJA+ttwKbxSbzNlqlE8vZSrsnxNQciUW+z6lvhlXMaEyZn9MSig==}
     peerDependencies:
       vite: '*'
-
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -18065,6 +18045,17 @@ snapshots:
     dependencies:
       '@miniflare/shared': 2.14.4
 
+  '@modelcontextprotocol/client@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+
   '@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
     dependencies:
       zod: 4.3.6
@@ -19753,7 +19744,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.25.12)(postcss@8.5.15))':
+  '@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.25.12)(postcss@8.5.15))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -19766,7 +19757,7 @@ snapshots:
       '@sentry/vercel-edge': 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
       '@sentry/webpack-plugin': 3.6.1(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.25.12)(postcss@8.5.15))
       chalk: 3.0.0
-      next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -21170,7 +21161,7 @@ snapshots:
     transitivePeerDependencies:
       - utf-8-validate
 
-  '@vitejs/plugin-react@4.5.2(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.5.2(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -21178,7 +21169,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.11
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21201,14 +21192,6 @@ snapshots:
       '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.6(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.6(vite@8.0.16(@types/node@24.12.3)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -23649,6 +23632,10 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -26223,6 +26210,8 @@ snapshots:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
 
+  pkce-challenge@5.0.1: {}
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -26581,7 +26570,7 @@ snapshots:
 
   real-require@1.0.0: {}
 
-  recharts@3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1):
+  recharts@3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
       clsx: 2.1.1
@@ -26591,7 +26580,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.3.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
@@ -28228,34 +28217,15 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-tsconfig-paths@6.0.5(typescript@6.0.3)(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-tsconfig-paths@6.0.5(typescript@6.0.3)(vite@8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.12.3)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.1
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.59.0
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.12.3
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      sass: 1.100.0
-      sass-embedded: 1.100.0
-      terser: 5.48.0
-      tsx: 4.22.4
-      yaml: 2.9.0
 
   vite@8.0.16(@types/node@24.12.3)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -28310,37 +28280,6 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
-
-  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.2
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.12.3
-      '@vitest/ui': 4.1.6(vitest@4.1.6)
-      happy-dom: 20.10.1(bufferutil@4.1.0)
-      jsdom: 28.0.0(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/ui@4.1.6)(happy-dom@20.10.1(bufferutil@4.1.0))(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@24.12.3)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:

--- a/test/package.json
+++ b/test/package.json
@@ -31,6 +31,7 @@
     "@date-fns/tz": "1.2.0",
     "@miniflare/d1": "2.14.4",
     "@miniflare/shared": "2.14.4",
+    "@modelcontextprotocol/client": "2.0.0-alpha.2",
     "@modelcontextprotocol/server": "2.0.0-alpha.2",
     "@next/env": "16.2.7",
     "@opennextjs/cloudflare": "1.16.1",

--- a/test/plugin-mcp/helpers/mcpClient.ts
+++ b/test/plugin-mcp/helpers/mcpClient.ts
@@ -1,131 +1,78 @@
+import type { Client } from '@modelcontextprotocol/client'
+
 import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
 
-export type McpToolResultContent = {
-  text: string
-  type: string
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- tool inputSchemas are JSON Schemas with arbitrary nested shapes
-export type McpTool = { description?: string; inputSchema: any; name: string }
-
-export type McpError = { code: number; data?: unknown; message: string }
-
-/**
- * Envelope for a JSON-RPC response from the MCP endpoint. `TResult` narrows
- * the `result` payload per method (e.g. `{ content }` for tool calls, `{ tools }`
- * for tool listings). `result` is non-optional because the helpers below only
- * cover the success path; auth/error responses go through `rawPost`.
- */
-export type McpResponse<TResult = Record<string, unknown>> = {
-  error?: McpError
-  id: number
-  jsonrpc: '2.0'
-  result: TResult
-}
-
-export type McpToolCallResult = {
-  content: McpToolResultContent[]
-}
-
-export type McpListToolsResult = {
-  tools: McpTool[]
-}
-
-async function parseMcpStream<TResult = Record<string, unknown>>(
-  response: Response,
-): Promise<McpResponse<TResult>> {
-  const reader = response.body?.getReader()
-  const decoder = new TextDecoder()
-
-  let streamData = ''
-  while (true) {
-    const { done, value } = (await reader?.read()) || { done: false, value: new Uint8Array() }
-    if (done) {
-      break
-    }
-    streamData += decoder.decode(value, { stream: true })
-  }
-
-  const dataLine = streamData
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith('data:'))
-    .pop()
-
-  const jsonString = dataLine ? dataLine.slice('data:'.length).trim() : streamData.trim()
-  return JSON.parse(jsonString)
-}
+import { connectMcpClient } from './realMcpClient.js'
 
 export type McpClient = {
-  callTool: (args: {
-    apiKey: string
-    args?: Record<string, unknown>
-    id?: number
-    name: string
-  }) => Promise<McpResponse<McpToolCallResult>>
-  listTools: (args: { apiKey: string; id?: number }) => Promise<McpResponse<McpListToolsResult>>
+  /** Disconnects every client opened during the test. */
+  close: () => Promise<void>
+  /** Returns a connected MCP client for the given API key (one per key, reused). */
+  connect: (apiKey: string) => Promise<Client>
+  /** Sends a raw POST to `/mcp` — for the auth/malformed-request tests a real client can't make. */
   rawPost: (args: { apiKey?: string; body: unknown }) => Promise<Response>
-  request: <TResult = Record<string, unknown>>(args: {
-    apiKey: string
-    id?: number
-    method: string
-    params?: Record<string, unknown>
-  }) => Promise<McpResponse<TResult>>
 }
 
 export function createMcpClient(restClient: NextRESTClient): McpClient {
-  const post = async ({ apiKey, body }: { apiKey?: string; body: unknown }): Promise<Response> =>
-    restClient.POST('/mcp', {
-      body: JSON.stringify(body),
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-        'Content-Type': 'application/json',
-      },
-    })
-
-  const request: McpClient['request'] = async ({ apiKey, id = 1, method, params = {} }) => {
-    const response = await post({ apiKey, body: { id, jsonrpc: '2.0', method, params } })
-    return parseMcpStream(response)
-  }
+  // One connected client per API key — the handshake runs once, then reused.
+  const clients = new Map<string, Promise<Client>>()
 
   return {
-    callTool: ({ apiKey, args = {}, id, name }) =>
-      request<McpToolCallResult>({
-        apiKey,
-        id,
-        method: 'tools/call',
-        params: { arguments: args, name },
+    close: async () => {
+      const pending = [...clients.values()]
+      clients.clear()
+      await Promise.all(
+        pending.map(async (client) => {
+          try {
+            await (await client).close()
+          } catch {
+            // Best-effort teardown — a failed handshake leaves nothing to close.
+          }
+        }),
+      )
+    },
+    connect: (apiKey) => {
+      let client = clients.get(apiKey)
+      if (!client) {
+        client = connectMcpClient({ apiKey, restClient })
+        clients.set(apiKey, client)
+      }
+      return client
+    },
+    rawPost: async ({ apiKey, body }) =>
+      restClient.POST('/mcp', {
+        body: JSON.stringify(body),
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+          'Content-Type': 'application/json',
+        },
       }),
-    listTools: ({ apiKey, id }) =>
-      request<McpListToolsResult>({ apiKey, id, method: 'tools/list' }),
-    rawPost: post,
-    request,
   }
 }
 
+/** A tool/call result's content — what `client.callTool()` returns. */
+type ToolResult = { content?: Array<{ text?: string }> }
+
 /**
- * Returns the first text content block from a tool/call response
+ * Returns the first text content block from a tool/call result.
  */
-export function getToolText(response: McpResponse<McpToolCallResult>): string {
-  const text = response.result.content?.[0]?.text
+export function getToolText(result: ToolResult): string {
+  const text = result.content?.[0]?.text
   if (typeof text !== 'string') {
-    throw new Error(`MCP response has no text content: ${JSON.stringify(response, null, 2)}`)
+    throw new Error(`MCP tool result has no text content: ${JSON.stringify(result, null, 2)}`)
   }
   return text
 }
 
 /**
- * Extracts the JSON document block (```json ... ```) from a tool/call response
- * text.
+ * Extracts the JSON document block (```json ... ```) from a tool/call result.
  */
-export function getToolDoc<T = Record<string, unknown>>(
-  response: McpResponse<McpToolCallResult>,
-): T {
-  const text = getToolText(response)
+export function getToolDoc<T = Record<string, unknown>>(result: ToolResult): T {
+  const text = getToolText(result)
   const match = text.match(/```json\n([\s\S]*?)\n```/)
   if (!match) {
-    throw new Error(`MCP response text contained no \`\`\`json block: ${text}`)
+    throw new Error(`MCP tool result text contained no \`\`\`json block: ${text}`)
   }
   return JSON.parse(match[1]!) as T
 }

--- a/test/plugin-mcp/helpers/mcpFixtures.ts
+++ b/test/plugin-mcp/helpers/mcpFixtures.ts
@@ -88,6 +88,8 @@ export const it = base.extend<ScopedFixtures>({
   ],
   // eslint-disable-next-line no-empty-pattern
   mcp: async ({}, use) => {
-    await use(createMcpClient(restClient))
+    const client = createMcpClient(restClient)
+    await use(client)
+    await client.close()
   },
 })

--- a/test/plugin-mcp/helpers/realMcpClient.ts
+++ b/test/plugin-mcp/helpers/realMcpClient.ts
@@ -1,0 +1,33 @@
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client'
+
+import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
+
+/**
+ * Connects a real MCP client and returns it after the initialize handshake.
+ *
+ * The integration tests run Payload in-process with no HTTP server, so the
+ * transport's `fetch` calls the route handlers directly: POSTs to the `/mcp`
+ * POST handler, and the client's optional GET stream to the GET handler (which
+ * answers 405, telling the client there's no server-push stream).
+ */
+export async function connectMcpClient({
+  apiKey,
+  restClient,
+}: {
+  apiKey: string
+  restClient: NextRESTClient
+}): Promise<Client> {
+  const client = new Client({ name: 'plugin-mcp-tests', version: '1.0.0' })
+  const transport = new StreamableHTTPClientTransport(new URL('http://in-process/api/mcp'), {
+    authProvider: { token: () => Promise.resolve(apiKey) },
+    fetch: (_url, init) => {
+      const headers = init?.headers as HeadersInit
+      return (init?.method ?? 'GET').toUpperCase() === 'POST'
+        ? restClient.POST('/mcp', { body: init?.body as string, headers })
+        : restClient.GET('/mcp', { headers })
+    },
+  })
+
+  await client.connect(transport)
+  return client
+}

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -51,7 +51,8 @@ function draft2020Violations(schema: unknown, rootPath: string): string[] {
 describe('@payloadcms/plugin-mcp', () => {
   it('should ping', async ({ mcp }) => {
     const apiKey = await getApiKey()
-    const pingResponse = await mcp.request({ apiKey, method: 'ping' })
+    const client = await mcp.connect(apiKey)
+    const pingResponse = await client.ping()
     expect(pingResponse).toBeDefined()
   })
 
@@ -96,8 +97,9 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      // The MCP endpoint is registered as POST only; a GET should not succeed.
-      expect(response.ok).toBe(false)
+      // MCP is POST-only; the optional GET stream answers 405 (Method Not Allowed)
+      // per the Streamable HTTP spec, so clients skip the server-push stream.
+      expect(response.status).toBe(405)
     })
 
     it('should not allow POST /api/mcp with unauthorized API key', async () => {
@@ -133,7 +135,8 @@ describe('@payloadcms/plugin-mcp', () => {
       const updateOneSpy = vi.spyOn(payload.db, 'updateOne')
 
       try {
-        await mcp.request({ apiKey: doc.apiKey as string, method: 'ping' })
+        const client = await mcp.connect(doc.apiKey as string)
+        await client.ping()
 
         expect(updateOneSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -162,17 +165,15 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('List', () => {
     it('should list tools', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const toolsResponse = await mcp.listTools({ apiKey })
+      const client = await mcp.connect(apiKey)
+      const toolsResponse = await client.listTools()
       expect(toolsResponse).toBeDefined()
-      expect(toolsResponse.id).toBe(1)
-      expect(toolsResponse.jsonrpc).toBe('2.0')
-      expect(toolsResponse.result).toBeDefined()
-      expect(toolsResponse.result.tools).toBeDefined()
-      expect(Array.isArray(toolsResponse.result.tools)).toBe(true)
-      expect(toolsResponse.result.tools.length).toBeGreaterThan(0)
+      expect(toolsResponse.tools).toBeDefined()
+      expect(Array.isArray(toolsResponse.tools)).toBe(true)
+      expect(toolsResponse.tools.length).toBeGreaterThan(0)
 
       const toolsByName: Record<string, any> = Object.fromEntries(
-        toolsResponse.result.tools.map((t: { name: string }) => [t.name, t]),
+        toolsResponse.tools.map((t: { name: string }) => [t.name, t]),
       )
 
       const getConfigInfo = toolsByName['getConfigInfo']
@@ -194,7 +195,7 @@ describe('@payloadcms/plugin-mcp', () => {
         'Rolls a virtual dice with a specified number of sides',
       )
 
-      const createDocumentTools = toolsResponse.result.tools.filter(
+      const createDocumentTools = toolsResponse.tools.filter(
         (tool: { name: string }) => tool.name === 'createDocument',
       )
       expect(createDocumentTools).toHaveLength(1)
@@ -281,7 +282,8 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should return config info', async ({ mcp }) => {
       const apiKey = await getApiKey({ globalFind: true, globalUpdate: true })
-      const response = await mcp.callTool({ apiKey, name: 'getConfigInfo' })
+      const client = await mcp.connect(apiKey)
+      const response = await client.callTool({ arguments: {}, name: 'getConfigInfo' })
       const text = getToolText(response)
 
       expect(text).toContain('Collections:')
@@ -312,7 +314,8 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const response = await mcp.callTool({ apiKey: doc.apiKey as string, name: 'getConfigInfo' })
+      const client = await mcp.connect(doc.apiKey as string)
+      const response = await client.callTool({ arguments: {}, name: 'getConfigInfo' })
       const text = getToolText(response)
 
       expect(text).toContain('posts')
@@ -333,8 +336,9 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const toolsResponse = await mcp.listTools({ apiKey: doc.apiKey as string })
-      const toolNames = toolsResponse.result.tools.map((tool: { name: string }) => tool.name)
+      const client = await mcp.connect(doc.apiKey as string)
+      const toolsResponse = await client.listTools()
+      const toolNames = toolsResponse.tools.map((tool: { name: string }) => tool.name)
 
       expect(toolNames).not.toContain('getConfigInfo')
     })
@@ -343,8 +347,9 @@ describe('@payloadcms/plugin-mcp', () => {
       mcp,
     }) => {
       const apiKey = await getApiKey()
-      const toolsResponse = await mcp.listTools({ apiKey })
-      const tools = toolsResponse.result.tools as Array<{ inputSchema?: object; name: string }>
+      const client = await mcp.connect(apiKey)
+      const toolsResponse = await client.listTools()
+      const tools = toolsResponse.tools as Array<{ inputSchema?: object; name: string }>
 
       // MCP clients validate each input_schema against the strict 2020-12 meta-schema. The SDK's own validator is
       // lenient (it only compiles), so lint for what the meta-schema enforces.
@@ -357,8 +362,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should list tools injected by other plugins via slug and options', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const toolsResponse = await mcp.listTools({ apiKey })
-      const toolNames = toolsResponse.result.tools.map((t: { name: string }) => t.name)
+      const client = await mcp.connect(apiKey)
+      const toolsResponse = await client.listTools()
+      const toolNames = toolsResponse.tools.map((t: { name: string }) => t.name)
 
       // Both plugins inject tools into mcp's options via slug discovery,
       // regardless of whether they are listed before or after mcp in the plugins array
@@ -368,53 +374,47 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should list resources', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const resourcesResponse = await mcp.request({ apiKey, method: 'resources/list' })
+      const client = await mcp.connect(apiKey)
+      const resourcesResponse = await client.listResources()
 
       expect(resourcesResponse).toBeDefined()
-      expect(resourcesResponse.id).toBe(1)
-      expect(resourcesResponse.jsonrpc).toBe('2.0')
-      expect(resourcesResponse.result).toBeDefined()
-      expect(resourcesResponse.result.resources).toBeDefined()
-      expect(resourcesResponse.result.resources).toHaveLength(1)
-      expect(resourcesResponse.result.resources[0].name).toBe('data')
-      expect(resourcesResponse.result.resources[0].title).toBe('Data')
-      expect(resourcesResponse.result.resources[0].uri).toBe('data://app')
-      expect(resourcesResponse.result.resources[0].description).toBe(
+      expect(resourcesResponse.resources).toBeDefined()
+      expect(resourcesResponse.resources).toHaveLength(1)
+      expect(resourcesResponse.resources[0].name).toBe('data')
+      expect(resourcesResponse.resources[0].title).toBe('Data')
+      expect(resourcesResponse.resources[0].uri).toBe('data://app')
+      expect(resourcesResponse.resources[0].description).toBe(
         'Data is a resource that contains special data.',
       )
-      expect(resourcesResponse.result.resources[0].mimeType).toBe('text/plain')
+      expect(resourcesResponse.resources[0].mimeType).toBe('text/plain')
     })
 
     it('should list prompts', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const promptsResponse = await mcp.request({ apiKey, method: 'prompts/list' })
+      const client = await mcp.connect(apiKey)
+      const promptsResponse = await client.listPrompts()
 
       expect(promptsResponse).toBeDefined()
-      expect(promptsResponse.id).toBe(1)
-      expect(promptsResponse.jsonrpc).toBe('2.0')
-      expect(promptsResponse.result).toBeDefined()
-      expect(promptsResponse.result.prompts).toBeDefined()
-      expect(promptsResponse.result.prompts).toHaveLength(1)
-      expect(promptsResponse.result.prompts[0].name).toBe('echo')
-      expect(promptsResponse.result.prompts[0].title).toBe('Echo Prompt')
-      expect(promptsResponse.result.prompts[0].description).toBe(
-        'Creates a prompt to process a message',
-      )
-      expect(promptsResponse.result.prompts[0].arguments).toBeDefined()
-      expect(promptsResponse.result.prompts[0].arguments).toHaveLength(1)
-      expect(promptsResponse.result.prompts[0].arguments[0].name).toBe('message')
-      expect(promptsResponse.result.prompts[0].arguments[0].required).toBe(true)
+      expect(promptsResponse.prompts).toBeDefined()
+      expect(promptsResponse.prompts).toHaveLength(1)
+      expect(promptsResponse.prompts[0].name).toBe('echo')
+      expect(promptsResponse.prompts[0].title).toBe('Echo Prompt')
+      expect(promptsResponse.prompts[0].description).toBe('Creates a prompt to process a message')
+      expect(promptsResponse.prompts[0].arguments).toBeDefined()
+      expect(promptsResponse.prompts[0].arguments).toHaveLength(1)
+      expect(promptsResponse.prompts[0].arguments[0].name).toBe('message')
+      expect(promptsResponse.prompts[0].arguments[0].required).toBe(true)
     })
 
     it('should list globals', async ({ mcp }) => {
       const apiKey = await getApiKey({ globalFind: true, globalUpdate: true })
-      const toolsResponse = await mcp.listTools({ apiKey })
+      const client = await mcp.connect(apiKey)
+      const toolsResponse = await client.listTools()
 
       expect(toolsResponse).toBeDefined()
-      expect(toolsResponse.result).toBeDefined()
-      expect(toolsResponse.result.tools).toBeDefined()
+      expect(toolsResponse.tools).toBeDefined()
 
-      const findGlobalTool = toolsResponse.result.tools.find((t: any) => t.name === 'findGlobal')
+      const findGlobalTool = toolsResponse.tools.find((t: any) => t.name === 'findGlobal')
       expect(findGlobalTool).toBeDefined()
       expect(findGlobalTool.description).toContain('Find any Payload global')
       expect(findGlobalTool.inputSchema.properties.globalSlug.type).toBe('string')
@@ -426,9 +426,7 @@ describe('@payloadcms/plugin-mcp', () => {
         "Optional: define exactly which fields you'd like to return in the response (JSON), e.g., '{\"title\": true}'",
       )
 
-      const updateGlobalTool = toolsResponse.result.tools.find(
-        (t: any) => t.name === 'updateGlobal',
-      )
+      const updateGlobalTool = toolsResponse.tools.find((t: any) => t.name === 'updateGlobal')
       expect(updateGlobalTool).toBeDefined()
       expect(updateGlobalTool.description).toContain('Update any Payload global')
       expect(updateGlobalTool.inputSchema.properties.globalSlug.type).toBe('string')
@@ -445,11 +443,10 @@ describe('@payloadcms/plugin-mcp', () => {
       mcp,
     }) => {
       const apiKey = await getApiKey({ enableUpdate: true })
-      const toolsResponse = await mcp.listTools({ apiKey })
+      const client = await mcp.connect(apiKey)
+      const toolsResponse = await client.listTools()
 
-      const updateToolSchema = toolsResponse.result.tools.find(
-        (t: any) => t.name === 'updateDocument',
-      )
+      const updateToolSchema = toolsResponse.tools.find((t: any) => t.name === 'updateDocument')
       expect(updateToolSchema).toBeDefined()
       expect(updateToolSchema.inputSchema.properties.select).toBeDefined()
       expect(updateToolSchema.inputSchema.properties.select.type).toBe('string')
@@ -462,26 +459,20 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('Prompts', () => {
     it('should get echo prompt', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const promptResponse = await mcp.request({
-        apiKey,
-        method: 'prompts/get',
-        params: {
-          name: 'echo',
-          arguments: {
-            message: 'Hello, world!',
-          },
+      const client = await mcp.connect(apiKey)
+      const promptResponse = await client.getPrompt({
+        name: 'echo',
+        arguments: {
+          message: 'Hello, world!',
         },
       })
 
       expect(promptResponse).toBeDefined()
-      expect(promptResponse.result).toBeDefined()
-      expect(promptResponse.result.messages).toHaveLength(2)
-      expect(promptResponse.result.messages[0].content.type).toBe('text')
-      expect(promptResponse.result.messages[0].content.text).toContain(
-        'This prompt was sent: Hello, world!',
-      )
-      expect(promptResponse.result.messages[1].content.type).toBe('text')
-      expect(promptResponse.result.messages[1].content.text).toContain(
+      expect(promptResponse.messages).toHaveLength(2)
+      expect(promptResponse.messages[0].content.type).toBe('text')
+      expect(promptResponse.messages[0].content.text).toContain('This prompt was sent: Hello, world!')
+      expect(promptResponse.messages[1].content.type).toBe('text')
+      expect(promptResponse.messages[1].content.text).toContain(
         `This prompt was sent by userId: ${userId}`,
       )
 
@@ -505,22 +496,16 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('Resources', () => {
     it('should read the data resource', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const resourceResponse = await mcp.request({
-        apiKey,
-        method: 'resources/read',
-        params: {
-          uri: 'data://app',
-        },
+      const client = await mcp.connect(apiKey)
+      const resourceResponse = await client.readResource({
+        uri: 'data://app',
       })
 
       expect(resourceResponse).toBeDefined()
-      expect(resourceResponse.result).toBeDefined()
-      expect(resourceResponse.result.contents).toHaveLength(2)
-      expect(resourceResponse.result.contents[0].uri).toBe('data://app')
-      expect(resourceResponse.result.contents[0].text).toContain('My special data.')
-      expect(resourceResponse.result.contents[1].text).toContain(
-        `This was requested by user: ${userId}`,
-      )
+      expect(resourceResponse.contents).toHaveLength(2)
+      expect(resourceResponse.contents[0].uri).toBe('data://app')
+      expect(resourceResponse.contents[0].text).toContain('My special data.')
+      expect(resourceResponse.contents[1].text).toContain(`This was requested by user: ${userId}`)
 
       const { docs } = await payload.find({
         collection: 'returned-resources',
@@ -540,22 +525,16 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should read the dataByID resource', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const resourceResponse = await mcp.request({
-        apiKey,
-        method: 'resources/read',
-        params: {
-          uri: 'data://app/1',
-        },
+      const client = await mcp.connect(apiKey)
+      const resourceResponse = await client.readResource({
+        uri: 'data://app/1',
       })
 
       expect(resourceResponse).toBeDefined()
-      expect(resourceResponse.result).toBeDefined()
-      expect(resourceResponse.result.contents).toHaveLength(2)
-      expect(resourceResponse.result.contents[0].uri).toBe('data://app/1')
-      expect(resourceResponse.result.contents[0].text).toContain('My special data for ID: 1')
-      expect(resourceResponse.result.contents[1].text).toContain(
-        `This was requested by user: ${userId}`,
-      )
+      expect(resourceResponse.contents).toHaveLength(2)
+      expect(resourceResponse.contents[0].uri).toBe('data://app/1')
+      expect(resourceResponse.contents[0].text).toContain('My special data for ID: 1')
+      expect(resourceResponse.contents[1].text).toContain(`This was requested by user: ${userId}`)
 
       const { docs } = await payload.find({
         collection: 'returned-resources',
@@ -577,9 +556,9 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('Custom MCP Tools', () => {
     it('should call diceRoll', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           globalSlug: 'site-settings',
           collectionSlug: 'posts',
           sides: 6,
@@ -588,13 +567,12 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(1)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('**Sides:** 6')
-      expect(callResponse.result.content[0].text).toContain('**Result:**')
-      expect(callResponse.result.content[0].text).toContain('🎲 You rolled a **')
-      expect(callResponse.result.content[0].text).toContain('** on a 6-sided die!')
+      expect(callResponse.content).toHaveLength(1)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('**Sides:** 6')
+      expect(callResponse.content[0].text).toContain('**Result:**')
+      expect(callResponse.content[0].text).toContain('🎲 You rolled a **')
+      expect(callResponse.content[0].text).toContain('** on a 6-sided die!')
 
       const { docs } = await payload.find({
         collection: 'rolls',
@@ -616,9 +594,9 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('Collections', () => {
     it('getCollectionSchema returns collection fields for createDocument', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const schemaResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const schemaResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
         },
         name: 'getCollectionSchema',
@@ -632,9 +610,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should call createDocument', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             content: 'Content for test post.',
@@ -645,25 +623,24 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content).toHaveLength(2)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain(
         'Document created successfully in collection "posts"!',
       )
-      expect(callResponse.result.content[0].text).toContain('Created document:')
-      expect(callResponse.result.content[0].text).toContain('```json')
-      expect(callResponse.result.content[0].text).toContain('"title":"Test Post"')
-      expect(callResponse.result.content[0].text).toContain('"content":"Content for test post."')
-      expect(callResponse.result.content[1].type).toBe('text')
-      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.content[0].text).toContain('Created document:')
+      expect(callResponse.content[0].text).toContain('```json')
+      expect(callResponse.content[0].text).toContain('"title":"Test Post"')
+      expect(callResponse.content[0].text).toContain('"content":"Content for test post."')
+      expect(callResponse.content[1].type).toBe('text')
+      expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
     })
 
     it('should call createDocument with select to limit returned fields', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             content: 'Content should be omitted',
@@ -675,31 +652,30 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].text).toContain('"title":"Select Create Post"')
-      expect(callResponse.result.content[0].text).not.toContain('Content should be omitted')
+      expect(callResponse.content[0].text).toContain('"title":"Select Create Post"')
+      expect(callResponse.content[0].text).not.toContain('Content should be omitted')
     })
 
     it('should call getCollectionSchema', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
         },
         name: 'getCollectionSchema',
       })
 
-      expect(callResponse.result.content[0].text).toContain('Schema for collection "posts"')
-      expect(callResponse.result.content[0].text).toContain('"title"')
-      expect(callResponse.result.content[0].text).toContain('"content"')
+      expect(callResponse.content[0].text).toContain('Schema for collection "posts"')
+      expect(callResponse.content[0].text).toContain('"title"')
+      expect(callResponse.content[0].text).toContain('"content"')
     })
 
     it('should call createDocument', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             content: 'Content for generic create.',
@@ -709,11 +685,11 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'createDocument',
       })
 
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content[0].text).toContain(
         'Document created successfully in collection "posts"!',
       )
-      expect(callResponse.result.content[0].text).toContain('"title":"Generic Create Post"')
-      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.content[0].text).toContain('"title":"Generic Create Post"')
+      expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
     })
 
     it('should respect per-collection access for createDocument', async ({ mcp }) => {
@@ -731,16 +707,14 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const toolsResponse = await mcp.listTools({ apiKey: doc.apiKey as string })
-      const createDocument = toolsResponse.result.tools.find(
-        (tool) => tool.name === 'createDocument',
-      )
+      const client = await mcp.connect(doc.apiKey as string)
+      const toolsResponse = await client.listTools()
+      const createDocument = toolsResponse.tools.find((tool) => tool.name === 'createDocument')
       expect(createDocument.inputSchema.properties.collectionSlug.type).toBe('string')
       expect(createDocument.inputSchema.properties.collectionSlug.enum).toBeUndefined()
 
-      const callResponse = await mcp.callTool({
-        apiKey: doc.apiKey as string,
-        args: {
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             content: 'Should not be created',
@@ -750,8 +724,8 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'createDocument',
       })
 
-      expect((callResponse.result as any).isError).toBe(true)
-      expect(callResponse.result.content[0].text).toContain(
+      expect((callResponse as any).isError).toBe(true)
+      expect(callResponse.content[0].text).toContain(
         'MCP access to "createDocument" is not enabled for collection "posts"',
       )
     })
@@ -766,9 +740,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           limit: 1,
           page: 1,
@@ -778,16 +752,15 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('Collection: "posts"')
-      expect(callResponse.result.content[0].text).toContain('Total: 1 documents')
-      expect(callResponse.result.content[0].text).toContain('Page: 1 of 1')
-      expect(callResponse.result.content[0].text).toContain('```json')
-      expect(callResponse.result.content[0].text).toContain('"content":"Content for test post."')
-      expect(callResponse.result.content[1].type).toBe('text')
-      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.content).toHaveLength(2)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('Collection: "posts"')
+      expect(callResponse.content[0].text).toContain('Total: 1 documents')
+      expect(callResponse.content[0].text).toContain('Page: 1 of 1')
+      expect(callResponse.content[0].text).toContain('```json')
+      expect(callResponse.content[0].text).toContain('"content":"Content for test post."')
+      expect(callResponse.content[1].type).toBe('text')
+      expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
     })
 
     it('should call findDocuments with select and return only requested fields', async ({
@@ -802,9 +775,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           limit: 1,
           page: 1,
@@ -815,9 +788,8 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      const responseText: string = callResponse.result.content[0].text
+      expect(callResponse.content).toHaveLength(2)
+      const responseText: string = callResponse.content[0].text
       expect(responseText).toContain('Collection: "posts"')
       expect(responseText).toContain('"title":"Select Test Post (MCP Hook Override)"')
       expect(responseText).not.toContain('"content": "Content that should be omitted"')
@@ -833,9 +805,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           data: {
@@ -846,15 +818,14 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content).toHaveLength(2)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
-      expect(callResponse.result.content[0].text).toContain('Updated document:')
-      expect(callResponse.result.content[0].text).toContain('```json')
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content[0].text).toContain('Updated document:')
+      expect(callResponse.content[0].text).toContain('```json')
+      expect(callResponse.content[0].text).toContain(
         '"content":"Updated content for test post to update."',
       )
     })
@@ -869,9 +840,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           data: {
@@ -882,12 +853,11 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
-      expect(callResponse.result.content[0].text).toContain('"content":null')
+      expect(callResponse.content[0].text).toContain('"content":null')
 
       await payload.delete({ id: post.id, collection: 'posts' })
     })
@@ -901,9 +871,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           data: {
@@ -914,9 +884,8 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
 
@@ -936,9 +905,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           data: {
@@ -951,8 +920,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      const responseText: string = callResponse.result.content[0].text
+      const responseText: string = callResponse.content[0].text
       expect(responseText).toContain('"title":"Select Update Post Edited"')
       expect(responseText).not.toContain('Updated but should be omitted')
       expect(responseText).not.toContain('"content":')
@@ -968,9 +936,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableDelete: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
         },
@@ -978,17 +946,14 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content).toHaveLength(2)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain(
         'Document deleted successfully from collection "posts"!',
       )
-      expect(callResponse.result.content[0].text).toContain('Deleted document:')
-      expect(callResponse.result.content[0].text).toContain('```json')
-      expect(callResponse.result.content[0].text).toContain(
-        '"content":"Content for test post to delete."',
-      )
+      expect(callResponse.content[0].text).toContain('Deleted document:')
+      expect(callResponse.content[0].text).toContain('```json')
+      expect(callResponse.content[0].text).toContain('"content":"Content for test post to delete."')
     })
 
     it('should call updateDocument with object where clause', async ({ mcp }) => {
@@ -1008,9 +973,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             content: 'Updated by object where',
@@ -1026,10 +991,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('Updated: 1 documents')
-      expect(callResponse.result.content[0].text).toContain('"content":"Updated by object where"')
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('Updated: 1 documents')
+      expect(callResponse.content[0].text).toContain('"content":"Updated by object where"')
 
       const untouched = await payload.findByID({ id: excluded.id, collection: 'posts' })
 
@@ -1056,9 +1020,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableDelete: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           where: {
             or: [
@@ -1071,17 +1035,16 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('Deleted: 2 documents')
-      expect(callResponse.result.content[0].text).toContain('Errors: 0')
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('Deleted: 2 documents')
+      expect(callResponse.content[0].text).toContain('Errors: 0')
     })
 
     it('should reject a where clause with an invalid operator', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           where: { title: { equalz: 'whatever' } },
         },
@@ -1089,16 +1052,16 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       // The SDK surfaces schema validation failures as tool error results
-      expect(callResponse.result.isError).toBe(true)
-      expect(callResponse.result.content[0].text).toContain('Input validation error')
-      expect(callResponse.result.content[0].text).toContain('equalz')
+      expect(callResponse.isError).toBe(true)
+      expect(callResponse.content[0].text).toContain('Input validation error')
+      expect(callResponse.content[0].text).toContain('equalz')
     })
 
     it('should handle point fields with object format in createDocument', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             content: 'Testing point field transformation',
@@ -1113,23 +1076,23 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('Document created successfully')
+      expect(callResponse.content).toHaveLength(2)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('Document created successfully')
 
       const createdDoc = getToolDoc(callResponse)
 
       expect(createdDoc.location).toEqual([-74.006, 40.7128])
 
-      expect(callResponse.result.content[1].type).toBe('text')
-      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.content[1].type).toBe('text')
+      expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
 
       await payload.delete({ id: createdDoc.id, collection: 'posts' })
     })
 
     it('should handle point fields with object format in updateDocument', async ({ mcp }) => {
       const apiKey = await getApiKey({ enableUpdate: true })
+      const client = await mcp.connect(apiKey)
 
       const createdPost = await payload.create({
         collection: 'posts',
@@ -1139,9 +1102,8 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
 
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: createdPost.id,
           data: {
@@ -1155,17 +1117,16 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('Document updated successfully')
+      expect(callResponse.content).toHaveLength(2)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('Document updated successfully')
 
       const updatedDoc = getToolDoc(callResponse)
 
       expect(updatedDoc.location).toEqual([-0.1278, 51.5074])
 
-      expect(callResponse.result.content[1].type).toBe('text')
-      expect(callResponse.result.content[1].text).toContain('Override MCP response for Posts!')
+      expect(callResponse.content[1].type).toBe('text')
+      expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
 
       await payload.delete({ id: createdPost.id, collection: 'posts' })
     })
@@ -1200,10 +1161,10 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should create a page with a block', async ({ mcp }) => {
       const apiKey = await getPagesApiKey()
+      const client = await mcp.connect(apiKey)
 
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'pages',
           data: {
             title: 'Hero Page',
@@ -1219,22 +1180,22 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'createDocument',
       })
 
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.isError).toBeFalsy()
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('"title":"Hero Page"')
-      expect(callResponse.result.content[0].text).toContain('"blockType":"hero"')
-      expect(callResponse.result.content[0].text).toContain('"heading":"Welcome to our site"')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.isError).toBeFalsy()
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('"title":"Hero Page"')
+      expect(callResponse.content[0].text).toContain('"blockType":"hero"')
+      expect(callResponse.content[0].text).toContain('"heading":"Welcome to our site"')
 
       createdPageIds.push(getToolDoc(callResponse).id)
     })
 
     it('should create a page with multiple block types', async ({ mcp }) => {
       const apiKey = await getPagesApiKey()
+      const client = await mcp.connect(apiKey)
 
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'pages',
           data: {
             title: 'Multi-block Page',
@@ -1254,12 +1215,12 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'createDocument',
       })
 
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.isError).toBeFalsy()
-      expect(callResponse.result.content[0].text).toContain('"blockType":"hero"')
-      expect(callResponse.result.content[0].text).toContain('"blockType":"textContent"')
-      expect(callResponse.result.content[0].text).toContain('"heading":"Page Hero"')
-      expect(callResponse.result.content[0].text).toContain('"body":"This is the body text."')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.isError).toBeFalsy()
+      expect(callResponse.content[0].text).toContain('"blockType":"hero"')
+      expect(callResponse.content[0].text).toContain('"blockType":"textContent"')
+      expect(callResponse.content[0].text).toContain('"heading":"Page Hero"')
+      expect(callResponse.content[0].text).toContain('"body":"This is the body text."')
 
       createdPageIds.push(getToolDoc(callResponse).id)
     })
@@ -1276,10 +1237,10 @@ describe('@payloadcms/plugin-mcp', () => {
       createdPageIds.push(page.id)
 
       const apiKey = await getPagesApiKey(true)
+      const client = await mcp.connect(apiKey)
 
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'pages',
           id: page.id,
           data: {
@@ -1298,12 +1259,12 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'updateDocument',
       })
 
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.isError).toBeFalsy()
-      expect(callResponse.result.content[0].text).toContain('"blockType":"hero"')
-      expect(callResponse.result.content[0].text).toContain('"heading":"Updated Hero Heading"')
-      expect(callResponse.result.content[0].text).toContain('"blockType":"textContent"')
-      expect(callResponse.result.content[0].text).toContain('"body":"Updated body text."')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.isError).toBeFalsy()
+      expect(callResponse.content[0].text).toContain('"blockType":"hero"')
+      expect(callResponse.content[0].text).toContain('"heading":"Updated Hero Heading"')
+      expect(callResponse.content[0].text).toContain('"blockType":"textContent"')
+      expect(callResponse.content[0].text).toContain('"body":"Updated body text."')
 
       const updatedPage = await payload.findByID({
         collection: 'pages',
@@ -1319,9 +1280,9 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('Virtual Fields', () => {
     it('should not include virtual fields in collection schema', async ({ mcp }) => {
       const apiKey = await getApiKey({ enableUpdate: true })
-      const schemaResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const schemaResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
         },
         name: 'getCollectionSchema',
@@ -1333,9 +1294,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should ignore virtual fields when creating a post via MCP', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             title: 'Virtual Field Create Test',
@@ -1363,9 +1324,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ enableUpdate: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           data: { title: 'Virtual Field Updated Title' },
@@ -1393,9 +1354,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           limit: 1,
           page: 1,
@@ -1405,28 +1366,26 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toHaveLength(2)
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse.content).toHaveLength(2)
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain(
         '"title":"Test Post for Finding (MCP Hook Override)"',
       )
     })
 
     it('should find site-settings global', async ({ mcp }) => {
       const apiKey = await getApiKey({ globalFind: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: { globalSlug: 'site-settings' },
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: { globalSlug: 'site-settings' },
         name: 'findGlobal',
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain('Global "site-settings"')
-      expect(callResponse.result.content[0].text).toContain('```json')
+      expect(callResponse.content).toBeDefined()
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('Global "site-settings"')
+      expect(callResponse.content[0].text).toContain('```json')
     })
 
     it('should find site-settings global with select', async ({ mcp }) => {
@@ -1441,9 +1400,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const apiKey = await getApiKey({ globalFind: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           globalSlug: 'site-settings',
           collectionSlug: 'posts',
           select: '{"siteName": true}',
@@ -1452,10 +1411,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      const responseText: string = callResponse.result.content[0].text
+      expect(callResponse.content).toBeDefined()
+      expect(callResponse.content[0].type).toBe('text')
+      const responseText: string = callResponse.content[0].text
       expect(responseText).toContain('"siteName":"MCP Site"')
       expect(responseText).not.toContain('siteDescription')
       expect(responseText).not.toContain('contactEmail')
@@ -1464,9 +1422,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should update site-settings global', async ({ mcp }) => {
       const apiKey = await getApiKey({ globalFind: true, globalUpdate: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           globalSlug: 'site-settings',
           data: {
             maintenanceMode: false,
@@ -1478,19 +1436,16 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      expect(callResponse.result.content[0].text).toContain(
-        'Global "site-settings" updated successfully',
-      )
+      expect(callResponse.content).toBeDefined()
+      expect(callResponse.content[0].type).toBe('text')
+      expect(callResponse.content[0].text).toContain('Global "site-settings" updated successfully')
     })
 
     it('should update site-settings global with select', async ({ mcp }) => {
       const apiKey = await getApiKey({ globalFind: true, globalUpdate: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           globalSlug: 'site-settings',
           data: {
             maintenanceMode: false,
@@ -1503,10 +1458,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(callResponse).toBeDefined()
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content).toBeDefined()
-      expect(callResponse.result.content[0].type).toBe('text')
-      const responseText: string = callResponse.result.content[0].text
+      expect(callResponse.content).toBeDefined()
+      expect(callResponse.content[0].type).toBe('text')
+      const responseText: string = callResponse.content[0].text
       expect(responseText).toContain('"siteName":"MCP Test Site Select"')
       expect(responseText).not.toContain('siteDescription')
       expect(responseText).not.toContain('maintenanceMode')
@@ -1538,9 +1492,9 @@ describe('@payloadcms/plugin-mcp', () => {
       createdIDs.push(doc.id)
 
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           limit: 1,
           page: 1,
@@ -1549,7 +1503,7 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'findDocuments',
       })
 
-      const responseText: string = callResponse.result.content[0].text
+      const responseText: string = callResponse.content[0].text
       const jsonBlocks = responseText.match(/```json\n[\s\S]*?```/g)
 
       expect(jsonBlocks).toBeTruthy()
@@ -1564,13 +1518,13 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should return minified JSON in global responses', async ({ mcp }) => {
       const apiKey = await getApiKey({ globalFind: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: { globalSlug: 'site-settings' },
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: { globalSlug: 'site-settings' },
         name: 'findGlobal',
       })
 
-      const responseText: string = callResponse.result.content[0].text
+      const responseText: string = callResponse.content[0].text
       const jsonBlocks = responseText.match(/```json\n[\s\S]*?```/g)
 
       expect(jsonBlocks).toBeTruthy()
@@ -1593,16 +1547,16 @@ describe('@payloadcms/plugin-mcp', () => {
       createdIDs.push(doc.id)
 
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: doc.id,
         },
         name: 'findDocuments',
       })
 
-      const responseText: string = callResponse.result.content[0].text
+      const responseText: string = callResponse.content[0].text
       // findByID response format: `Resource from collection "posts":\n${JSON.stringify(doc)}`
       // (no fenced code block — extract the JSON from the second line)
       const jsonPart = responseText.split('\n').slice(1).join('\n')
@@ -1617,12 +1571,13 @@ describe('@payloadcms/plugin-mcp', () => {
   describe('Localization', () => {
     it('should include locale parameters in tool schemas', async ({ mcp }) => {
       const apiKey = await getApiKey({ enableUpdate: true, enableDelete: true })
-      const toolsResponse = await mcp.listTools({ apiKey })
+      const client = await mcp.connect(apiKey)
+      const toolsResponse = await client.listTools()
 
-      expect(toolsResponse.result.tools).toBeDefined()
+      expect(toolsResponse.tools).toBeDefined()
 
       // Check createDocument has locale parameters
-      const createTool = toolsResponse.result.tools.find((t: any) => t.name === 'createDocument')
+      const createTool = toolsResponse.tools.find((t: any) => t.name === 'createDocument')
       expect(createTool).toBeDefined()
       expect(createTool.inputSchema.properties.locale).toBeDefined()
       expect(createTool.inputSchema.properties.locale.type).toBe('string')
@@ -1630,19 +1585,19 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(createTool.inputSchema.properties.fallbackLocale).toBeDefined()
 
       // Check updateDocument has locale parameters
-      const updateTool = toolsResponse.result.tools.find((t: any) => t.name === 'updateDocument')
+      const updateTool = toolsResponse.tools.find((t: any) => t.name === 'updateDocument')
       expect(updateTool).toBeDefined()
       expect(updateTool.inputSchema.properties.locale).toBeDefined()
       expect(updateTool.inputSchema.properties.fallbackLocale).toBeDefined()
 
       // Check findDocuments has locale parameters
-      const findTool = toolsResponse.result.tools.find((t: any) => t.name === 'findDocuments')
+      const findTool = toolsResponse.tools.find((t: any) => t.name === 'findDocuments')
       expect(findTool).toBeDefined()
       expect(findTool.inputSchema.properties.locale).toBeDefined()
       expect(findTool.inputSchema.properties.fallbackLocale).toBeDefined()
 
       // Check deleteDocuments has locale parameters
-      const deleteTool = toolsResponse.result.tools.find((t: any) => t.name === 'deleteDocuments')
+      const deleteTool = toolsResponse.tools.find((t: any) => t.name === 'deleteDocuments')
       expect(deleteTool).toBeDefined()
       expect(deleteTool.inputSchema.properties.locale).toBeDefined()
       expect(deleteTool.inputSchema.properties.fallbackLocale).toBeDefined()
@@ -1650,9 +1605,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should create post with specific locale', async ({ mcp }) => {
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           data: {
             content: 'This is my first post in English',
@@ -1663,12 +1618,10 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'createDocument',
       })
 
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].text).toContain('Document created successfully')
-      expect(callResponse.result.content[0].text).toContain('"title":"Hello World"')
-      expect(callResponse.result.content[0].text).toContain(
-        '"content":"This is my first post in English"',
-      )
+      expect(callResponse).toBeDefined()
+      expect(callResponse.content[0].text).toContain('Document created successfully')
+      expect(callResponse.content[0].text).toContain('"title":"Hello World"')
+      expect(callResponse.content[0].text).toContain('"content":"This is my first post in English"')
     })
 
     it('should update post to add translation', async ({ mcp }) => {
@@ -1683,9 +1636,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       // Update with Spanish translation via MCP
       const apiKey = await getApiKey({ enableUpdate: true })
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: englishPost.id,
           data: {
@@ -1697,10 +1650,10 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'updateDocument',
       })
 
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].text).toContain('Document updated successfully')
-      expect(callResponse.result.content[0].text).toContain('"title":"Título Español"')
-      expect(callResponse.result.content[0].text).toContain('"content":"Contenido Español"')
+      expect(callResponse).toBeDefined()
+      expect(callResponse.content[0].text).toContain('Document updated successfully')
+      expect(callResponse.content[0].text).toContain('"title":"Título Español"')
+      expect(callResponse.content[0].text).toContain('"content":"Contenido Español"')
     })
 
     it('should find post in specific locale', async ({ mcp }) => {
@@ -1725,9 +1678,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       // Find in Spanish via MCP
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           locale: 'es',
@@ -1735,11 +1688,11 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'findDocuments',
       })
 
-      expect(callResponse.result).toBeDefined()
-      expect(callResponse.result.content[0].text).toContain(
+      expect(callResponse).toBeDefined()
+      expect(callResponse.content[0].text).toContain(
         '"title":"Publicación Española (MCP Hook Override)"',
       )
-      expect(callResponse.result.content[0].text).toContain('"content":"Contenido Español"')
+      expect(callResponse.content[0].text).toContain('"content":"Contenido Español"')
     })
 
     it('should find post with locale "all"', async ({ mcp }) => {
@@ -1774,9 +1727,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       // Find with locale: all via MCP
       const apiKey = await getApiKey()
-      const callResponse = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const callResponse = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           locale: 'all',
@@ -1784,8 +1737,8 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'findDocuments',
       })
 
-      expect(callResponse.result).toBeDefined()
-      const responseText = callResponse.result.content[0].text
+      expect(callResponse).toBeDefined()
+      const responseText = callResponse.content[0].text
 
       // Should contain locale objects with all translations
       expect(responseText).toContain('"en":')
@@ -1808,9 +1761,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       // Try to find in French (which doesn't exist)
       const apiKey = await getApiKey()
-      const json = await mcp.callTool({
-        apiKey,
-        args: {
+      const client = await mcp.connect(apiKey)
+      const json = await client.callTool({
+        arguments: {
           collectionSlug: 'posts',
           id: post.id,
           locale: 'fr',
@@ -1819,14 +1772,11 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       expect(json).toBeDefined()
-      expect(json.result).toBeDefined()
-      expect(json.result.content).toBeDefined()
-      expect(json.result.content[0].type).toBe('text')
+      expect(json.content).toBeDefined()
+      expect(json.content[0].type).toBe('text')
       // Should fallback to English (with default value for content)
-      expect(json.result.content[0].text).toContain(
-        '"title":"English Only Title (MCP Hook Override)"',
-      )
-      expect(json.result.content[0].text).toContain('"content":"Hello World."')
+      expect(json.content[0].text).toContain('"title":"English Only Title (MCP Hook Override)"')
+      expect(json.content[0].text).toContain('"content":"Hello World."')
     })
   })
 
@@ -1857,9 +1807,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
     describe('Schema validation', () => {
       const getFieldTypeInputProps = async (mcp: any, apiKey: string) => {
-        const schemaResponse = await mcp.callTool({
-          apiKey,
-          args: { collectionSlug: 'field-types' },
+        const client = await mcp.connect(apiKey)
+        const schemaResponse = await client.callTool({
+          arguments: { collectionSlug: 'field-types' },
           name: 'getCollectionSchema',
         })
 
@@ -1967,9 +1917,9 @@ describe('@payloadcms/plugin-mcp', () => {
         mcp,
       }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Hello MCP',
@@ -1982,10 +1932,10 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
-        expect(callResponse.result.content[0].type).toBe('text')
-        expect(callResponse.result.content[0].text).toContain(
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
+        expect(callResponse.content[0].type).toBe('text')
+        expect(callResponse.content[0].text).toContain(
           'Document created successfully in collection "field-types"!',
         )
 
@@ -2004,9 +1954,9 @@ describe('@payloadcms/plugin-mcp', () => {
         mcp,
       }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               numberField: 'not a number',
@@ -2015,20 +1965,20 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result.isError).toBe(true)
-        expect(callResponse.result.content[0].text).toContain('Use this schema for data')
-        expect(callResponse.result.content[0].text).toContain('"numberField"')
+        expect(callResponse.isError).toBe(true)
+        expect(callResponse.content[0].text).toContain('Use this schema for data')
+        expect(callResponse.content[0].text).toContain('"numberField"')
         expect(
-          (callResponse.result as any).structuredContent.schema.properties.numberField,
+          (callResponse as any).structuredContent.schema.properties.numberField,
         ).toBeDefined()
       })
 
       it('should create document with date, code, and json fields', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
+        const client = await mcp.connect(apiKey)
         const testDate = '2024-01-15T10:30:00.000Z'
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Date/Code/JSON test',
@@ -2040,8 +1990,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2054,9 +2004,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should create document with select field', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Select test',
@@ -2066,8 +2016,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2078,9 +2028,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should create document with radio field', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Radio test',
@@ -2090,8 +2040,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2102,9 +2052,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should create document with group field (nested object)', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Group test',
@@ -2117,8 +2067,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2131,9 +2081,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should create document with collapsible children at top level', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Collapsible test',
@@ -2143,8 +2093,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2156,9 +2106,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should create document with row children at top level', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Row test',
@@ -2168,8 +2118,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2183,9 +2133,9 @@ describe('@payloadcms/plugin-mcp', () => {
         mcp,
       }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Tabs test',
@@ -2198,8 +2148,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2215,9 +2165,9 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should create document with array field', async ({ mcp }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'Array test',
@@ -2230,8 +2180,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2252,20 +2202,20 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey()
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             where: { textField: { equals: 'Findable doc' } },
           },
           name: 'findDocuments',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
-        expect(callResponse.result.content[0].text).toContain('Collection: "field-types"')
-        expect(callResponse.result.content[0].text).toContain('"textField":"Findable doc"')
-        expect(callResponse.result.content[0].text).toContain('"numberField":7')
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
+        expect(callResponse.content[0].text).toContain('Collection: "field-types"')
+        expect(callResponse.content[0].text).toContain('"textField":"Findable doc"')
+        expect(callResponse.content[0].text).toContain('"numberField":7')
       })
     })
 
@@ -2281,9 +2231,9 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey(true, false)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             id: created.id,
             data: {
@@ -2296,9 +2246,9 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'updateDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
-        expect(callResponse.result.content[0].text).toContain(
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
+        expect(callResponse.content[0].text).toContain(
           'Document updated successfully in collection "field-types"!',
         )
 
@@ -2321,9 +2271,9 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey(true, false)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             id: created.id,
             data: {
@@ -2333,11 +2283,11 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'updateDocument',
         })
 
-        expect(callResponse.result.isError).toBe(true)
-        expect(callResponse.result.content[0].text).toContain('Use this schema for data')
-        expect(callResponse.result.content[0].text).toContain('"numberField"')
+        expect(callResponse.isError).toBe(true)
+        expect(callResponse.content[0].text).toContain('Use this schema for data')
+        expect(callResponse.content[0].text).toContain('"numberField"')
         expect(
-          (callResponse.result as any).structuredContent.schema.properties.numberField,
+          (callResponse as any).structuredContent.schema.properties.numberField,
         ).toBeDefined()
       })
 
@@ -2354,9 +2304,9 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey(true, false)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             id: created.id,
             data: {
@@ -2366,8 +2316,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'updateDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2385,9 +2335,9 @@ describe('@payloadcms/plugin-mcp', () => {
         createdFieldTypeIds.push(created.id)
 
         const apiKey = await getFieldTypesApiKey(true, false)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             id: created.id,
             data: {
@@ -2401,8 +2351,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'updateDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 
@@ -2417,11 +2367,11 @@ describe('@payloadcms/plugin-mcp', () => {
         mcp,
       }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
+        const client = await mcp.connect(apiKey)
 
         // Create a doc without passing any `uiField` value (it has no stored data)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'UI field safety test',
@@ -2430,9 +2380,9 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
-        expect(callResponse.result.content[0].text).toContain('Document created successfully')
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
+        expect(callResponse.content[0].text).toContain('Document created successfully')
 
         const doc = getToolDoc(callResponse)
 
@@ -2446,9 +2396,9 @@ describe('@payloadcms/plugin-mcp', () => {
         mcp,
       }) => {
         const apiKey = await getFieldTypesApiKey(false, true)
-        const callResponse = await mcp.callTool({
-          apiKey,
-          args: {
+        const client = await mcp.connect(apiKey)
+        const callResponse = await client.callTool({
+          arguments: {
             collectionSlug: 'field-types',
             data: {
               textField: 'All layout fields test',
@@ -2462,8 +2412,8 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'createDocument',
         })
 
-        expect(callResponse.result).toBeDefined()
-        expect(callResponse.result.isError).toBeFalsy()
+        expect(callResponse).toBeDefined()
+        expect(callResponse.isError).toBeFalsy()
 
         const doc = getToolDoc(callResponse)
 


### PR DESCRIPTION
Our mcp int tests used to build http requests and parse the responses by hand. They now use a real MCP client (`@modelcontextprotocol/client`, the same version the server is built on), so they go through the real protocol.

Tests now call the client's own methods directly (`client.callTool`, `client.getPrompt`, `client.listTools`, …). Since the tests run Payload in-process with no HTTP server, the client's `fetch` is pointed directly at the `/mcp` route handlers.

This PR also fixes a small detail: MCP's Streamable HTTP has an optional GET stream for server => client messages. We don't offer one, so `GET /mcp` now answers `405` (per spec) instead of `404`.

See https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server

> The server MUST either return Content-Type: text/event-stream in response to this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server does not offer an SSE stream at this endpoint.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215721320412768