### PR TITLE
fix(graphql): preserve hasMany relationship order in populated results

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -704,15 +704,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
 
               if (result) {
                 if (isRelatedToManyCollections) {
-                  results.push({
+                  results[i] = {
                     relationTo: collectionSlug,
                     value: {
                       ...result,
                       collection: collectionSlug,
                     },
-                  })
+                  }
                 } else {
-                  results.push(result)
+                  results[i] = result
                 }
               }
             }
@@ -725,7 +725,10 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           }
 
           await Promise.all(resultPromises)
-          return results
+          // Assigned by index above so the populated order matches the stored
+          // order regardless of which dataloader promise settles first. Filter
+          // out holes left by skipped (invalid collection / missing) entries.
+          return results.filter((result) => result !== undefined)
         }
 
         let id = value
@@ -1123,15 +1126,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
 
               if (result) {
                 if (isRelatedToManyCollections) {
-                  results.push({
+                  results[i] = {
                     relationTo: collectionSlug,
                     value: {
                       ...result,
                       collection: collectionSlug,
                     },
-                  })
+                  }
                 } else {
-                  results.push(result)
+                  results[i] = result
                 }
               }
             }
@@ -1144,7 +1147,10 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           }
 
           await Promise.all(resultPromises)
-          return results
+          // Assigned by index above so the populated order matches the stored
+          // order regardless of which dataloader promise settles first. Filter
+          // out holes left by skipped (invalid collection / missing) entries.
+          return results.filter((result) => result !== undefined)
         }
 
         let id = value

--- a/test/graphql/config.ts
+++ b/test/graphql/config.ts
@@ -33,6 +33,17 @@ export default buildConfigWithDefaults({
           },
         },
         {
+          type: 'relationship',
+          name: 'singleRelation',
+          relationTo: 'posts',
+        },
+        {
+          type: 'relationship',
+          name: 'manyRelations',
+          hasMany: true,
+          relationTo: 'posts',
+        },
+        {
           name: 'contentBlockField',
           type: 'blocks',
           blocks: [ContentBlock],

--- a/test/graphql/int.spec.ts
+++ b/test/graphql/int.spec.ts
@@ -268,5 +268,43 @@ query {
 
       expect(afterDelete.errors).toBeUndefined()
     })
+
+    it('should preserve hasMany relationship order when a single relationship to the same collection is queried first', async () => {
+      const postA = await payload.create({ collection: 'posts', data: { title: 'A' } })
+      const postB = await payload.create({ collection: 'posts', data: { title: 'B' } })
+      const postC = await payload.create({ collection: 'posts', data: { title: 'C' } })
+
+      const parent = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'parent',
+          manyRelations: [postA.id, postB.id, postC.id],
+          singleRelation: postA.id,
+        },
+      })
+
+      const query = `query {
+        Post(id: ${idToString(parent.id, payload)}) {
+          singleRelation {
+            title
+          }
+          manyRelations {
+            title
+          }
+        }
+      }`
+
+      const response = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        .then((res) => res.json())
+
+      expect(response.errors).toBeUndefined()
+      expect(response.data.Post.manyRelations.map((doc) => doc.title)).toStrictEqual(['A', 'B', 'C'])
+
+      await payload.delete({
+        collection: 'posts',
+        where: { id: { in: [parent.id, postA.id, postB.id, postC.id] } },
+      })
+    })
   })
 })


### PR DESCRIPTION
### What?
hasMany relationship and upload fields could return populated documents in the wrong order when a single relationship to the same collection was queried before the array field in the same request.

### Why?
The populate promises run in parallel via Promise.all and were pushed onto the results array in resolution order, not input order. When a sibling single relationship warms the per-request dataloader cache for a shared document, that document settles out of order, so e.g. [A, B, C] comes back as [B, C, A].

### How?
Assign each populated doc to its source index (results[i] = ...) instead of pushing, then filter out the holes left by skipped entries, so the returned list always matches the stored order regardless of which promise settles first. Applied to both the relationship and upload resolvers. Added an int test that reproduces the reorder.

Fixes #14956
