### PR TITLE
fix(storage-s3): support S3 client uploads over 5 GiB via multipart

### DIFF
--- a/packages/payload/src/utilities/addDataAndFileToRequest.spec.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.spec.ts
@@ -46,4 +46,62 @@ describe('addDataAndFileToRequest', () => {
     expect(req.file?.name).toBe('hello.txt')
     expect(req.file?.mimetype).toBe('text/plain')
   })
+
+  it('should avoid buffering oversized remote upload handler responses', async () => {
+    const collectionSlug = 'media'
+    const oversizedBytes = 0x80000000
+    const fileMeta = JSON.stringify({
+      clientUploadContext: { source: 'test' },
+      collectionSlug,
+      filename: 'remote-file.txt',
+      mimeType: 'text/plain',
+      size: oversizedBytes,
+    })
+
+    const formData = new FormData()
+    formData.append('file', fileMeta)
+
+    const request = new Request('http://localhost/api/upload', {
+      body: formData,
+      method: 'POST',
+    })
+
+    const req = {
+      body: request.body,
+      headers: request.headers,
+      method: request.method,
+      payload: {
+        collections: {
+          [collectionSlug]: {
+            config: {
+              upload: {
+                handlers: [
+                  async () =>
+                    new Response(Buffer.from('hello from remote handler'), {
+                      headers: {
+                        'Content-Type': 'text/plain',
+                      },
+                    }),
+                ],
+              },
+            },
+          },
+        },
+        config: {
+          bodyParser: {},
+          upload: {},
+        },
+        logger: {
+          error: () => {},
+        },
+      },
+    } as unknown as PayloadRequest
+
+    await addDataAndFileToRequest(req)
+
+    expect(req.file).toBeDefined()
+    expect(req.file?.size).toBe(oversizedBytes)
+    expect(req.file?.data.length).toBe(0)
+    expect(req.file?.mimetype).toBe('text/plain')
+  })
 })

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -3,6 +3,8 @@ import type { PayloadRequest } from '../types/index.js'
 import { APIError } from '../errors/APIError.js'
 import { processMultipartFormdata } from '../uploads/fetchAPI-multipart/index.js'
 
+const MAX_SAFE_BUFFER_LENGTH = 0x7fffffff
+
 type AddDataAndFileToRequest = (req: PayloadRequest) => Promise<void>
 
 /**
@@ -102,12 +104,21 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
           throw new APIError('Expected response from the upload handler.')
         }
 
+        const parsedSize = Number(size)
+        const normalizedSize = Number.isFinite(parsedSize) && parsedSize >= 0 ? parsedSize : 0
+
+        let data = Buffer.alloc(0)
+        // Node cannot allocate buffers larger than 2^31 - 1 bytes, so avoid materializing oversized remote uploads in memory.
+        if (normalizedSize > 0 && normalizedSize <= MAX_SAFE_BUFFER_LENGTH) {
+          data = Buffer.from(await response.arrayBuffer())
+        }
+
         req.file = {
           name: filename,
           clientUploadContext,
-          data: Buffer.from(await response.arrayBuffer()),
+          data,
           mimetype: response.headers.get('Content-Type') || mimeType,
-          size,
+          size: normalizedSize,
         }
       }
     }

--- a/packages/storage-s3/README.md
+++ b/packages/storage-s3/README.md
@@ -18,6 +18,31 @@ pnpm add @payloadcms/storage-s3
 - When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client. You must allow CORS PUT method for the bucket to your website.
 - Configure `signedDownloads` (either globally of per-collection in `collections`) to use [presigned URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) for files downloading. This can improve performance for large files (like videos) while still respecting your access control. Additionally, with `signedDownloads.shouldUseSignedURL` you can specify a condition whether Payload should use a presigned URL, if you want to use this feature only for specific files.
 
+### Client uploads and file size limits
+
+When `clientUploads` is enabled, files are uploaded directly from the browser to S3. This bypasses server/Vercel request-body size limits, but **Payload still enforces** `upload.limits.fileSize` from your Payload config on the signed-URL endpoints (both single-part and multipart).
+
+Raise the global limit to match your largest expected upload:
+
+```ts
+export default buildConfig({
+  upload: {
+    limits: {
+      fileSize: 7 * 1024 * 1024 * 1024, // 7 GiB in bytes
+    },
+  },
+  // ...
+})
+```
+
+To disable the signer-side cap entirely, set `fileSize: Infinity` (treated as no limit by the S3 adapter).
+
+**Multipart routing:** The client uses a single presigned `PutObject` URL for files up to **5 GiB** (the S3 single-request limit). Files **larger than 5 GiB** automatically use S3 multipart upload (`initiateMultipart` → part uploads → `completeMultipart`). Multipart does not bypass `upload.limits.fileSize`—you must raise that limit for large files regardless of upload method.
+
+For debugging multipart uploads, set `PAYLOAD_UPLOAD_DEBUG=true`.
+
+When developing in the Payload monorepo, `pnpm run dev storage-s3/client-uploads` uses a config with no signer cap. Integration tests that assert the 10 MB limit use `config-limit-tests.ts` instead. You can swap configs at dev time with `pnpm run dev storage-s3/client-uploads#config-limit-tests.ts`.
+
 ```ts
 import { s3Storage } from '@payloadcms/storage-s3'
 import { Media } from './collections/Media'

--- a/packages/storage-s3/src/client/S3ClientUploadHandler.ts
+++ b/packages/storage-s3/src/client/S3ClientUploadHandler.ts
@@ -2,6 +2,318 @@
 import { createClientUploadHandler } from '@payloadcms/plugin-cloud-storage/client'
 import { formatAdminURL } from 'payload/shared'
 
+import type {
+  MultipartRequestByAction,
+  MultipartResponseByAction,
+  SignedURLRequest,
+} from '../types.js'
+
+import {
+  DEFAULT_MULTIPART_PART_SIZE,
+  FIVE_GIB_BYTES,
+  MAX_PART_RETRIES,
+  MULTIPART_CONCURRENCY,
+  multipartAction,
+  RETRY_BASE_MS,
+} from '../constants.js'
+
+type CompleteMultipartRequest = MultipartRequestByAction[typeof multipartAction.completeMultipart]
+type GenerateSignedURLRequest = MultipartRequestByAction[typeof multipartAction.generateSignedURL]
+type InitiateMultipartRequest = MultipartRequestByAction[typeof multipartAction.initiateMultipart]
+type SignMultipartPartRequest = MultipartRequestByAction[typeof multipartAction.signMultipartPart]
+
+type AbortMultipartResponse = MultipartResponseByAction[typeof multipartAction.abortMultipart]
+type GenerateSignedURLResponse = MultipartResponseByAction[typeof multipartAction.generateSignedURL]
+type InitiateMultipartResponse = MultipartResponseByAction[typeof multipartAction.initiateMultipart]
+type SignMultipartPartResponse = MultipartResponseByAction[typeof multipartAction.signMultipartPart]
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+const formatResponseErrors = (errors: unknown) => {
+  if (!Array.isArray(errors)) {
+    return 'Upload request failed.'
+  }
+
+  return errors.reduce((acc, err) => {
+    const errorMessage =
+      err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
+        ? err.message
+        : 'Unknown error'
+
+    return `${acc ? `${acc}, ` : ''}${errorMessage}`
+  }, '')
+}
+
+const parseJSONOrThrow = async <T>(response: Response): Promise<T> => {
+  const data = (await response.json()) as { errors?: unknown } & T
+
+  if (!response.ok) {
+    throw new Error(formatResponseErrors(data?.errors))
+  }
+
+  return data
+}
+
+type PostToSigner = <T>(body: SignedURLRequest) => Promise<T>
+
+const createPostToSigner = ({ endpointRoute }: { endpointRoute: string }): PostToSigner => {
+  return async <T>(body: SignedURLRequest) => {
+    const response = await fetch(endpointRoute, {
+      body: JSON.stringify(body),
+      credentials: 'include',
+      method: 'POST',
+    })
+
+    return parseJSONOrThrow<T>(response)
+  }
+}
+
+const updateFilenameIfNeeded = ({
+  sanitizedFilename,
+  updateFilename,
+  uploadedFilename,
+}: {
+  sanitizedFilename?: string
+  updateFilename: (filename: string) => void
+  uploadedFilename: string
+}) => {
+  if (sanitizedFilename && sanitizedFilename !== uploadedFilename) {
+    updateFilename(sanitizedFilename)
+  }
+}
+
+const uploadSinglePart = async ({
+  file,
+  postToSigner,
+  signerRequest,
+  updateFilename,
+}: {
+  file: File
+  postToSigner: PostToSigner
+  signerRequest: GenerateSignedURLRequest
+  updateFilename: (filename: string) => void
+}) => {
+  const response = await postToSigner<GenerateSignedURLResponse>(signerRequest)
+
+  updateFilenameIfNeeded({
+    sanitizedFilename: response.filename,
+    updateFilename,
+    uploadedFilename: file.name,
+  })
+
+  await fetch(response.url, {
+    body: file,
+    headers: { 'Content-Length': file.size.toString(), 'Content-Type': file.type },
+    method: 'PUT',
+  })
+
+  return { prefix: response.docPrefix }
+}
+
+const signMultipartPart = async ({
+  collectionSlug,
+  key,
+  partNumber,
+  postToSigner,
+  uploadId,
+}: {
+  collectionSlug: string
+  key: string
+  partNumber: number
+  postToSigner: PostToSigner
+  uploadId: string
+}) => {
+  const request: SignMultipartPartRequest = {
+    action: multipartAction.signMultipartPart,
+    collectionSlug,
+    key,
+    partNumber,
+    uploadId,
+  }
+
+  return postToSigner<SignMultipartPartResponse>(request)
+}
+
+const uploadPartWithRetry = async ({
+  collectionSlug,
+  completedParts,
+  file,
+  key,
+  partNumber,
+  partSize,
+  postToSigner,
+  uploadId,
+}: {
+  collectionSlug: string
+  completedParts: { ETag: string; PartNumber: number }[]
+  file: File
+  key: string
+  partNumber: number
+  partSize: number
+  postToSigner: PostToSigner
+  uploadId: string
+}) => {
+  let attempt = 0
+
+  while (attempt <= MAX_PART_RETRIES) {
+    try {
+      const start = (partNumber - 1) * partSize
+      const end = Math.min(start + partSize, file.size)
+      const blob = file.slice(start, end)
+      const { url } = await signMultipartPart({
+        collectionSlug,
+        key,
+        partNumber,
+        postToSigner,
+        uploadId,
+      })
+
+      const uploadPartResponse = await fetch(url, {
+        body: blob,
+        method: 'PUT',
+      })
+
+      if (!uploadPartResponse.ok) {
+        throw new Error(`Upload part ${partNumber} failed with status ${uploadPartResponse.status}`)
+      }
+
+      const etag = uploadPartResponse.headers.get('etag')
+      if (!etag) {
+        throw new Error(`Upload part ${partNumber} did not return an ETag.`)
+      }
+
+      completedParts.push({
+        ETag: etag,
+        PartNumber: partNumber,
+      })
+
+      return
+    } catch (error) {
+      if (attempt === MAX_PART_RETRIES) {
+        throw error
+      }
+
+      const backoff = RETRY_BASE_MS * Math.pow(2, attempt)
+      await sleep(backoff)
+      attempt += 1
+    }
+  }
+}
+
+const completeMultipartUpload = async ({
+  collectionSlug,
+  key,
+  parts,
+  postToSigner,
+  uploadId,
+}: {
+  collectionSlug: string
+  key: string
+  parts: CompleteMultipartRequest['parts']
+  postToSigner: PostToSigner
+  uploadId: string
+}) => {
+  const request: CompleteMultipartRequest = {
+    action: multipartAction.completeMultipart,
+    collectionSlug,
+    key,
+    parts,
+    uploadId,
+  }
+
+  await postToSigner(request)
+}
+
+const abortMultipartUpload = async ({
+  collectionSlug,
+  key,
+  postToSigner,
+  uploadId,
+}: {
+  collectionSlug: string
+  key: string
+  postToSigner: PostToSigner
+  uploadId: string
+}) => {
+  await postToSigner<AbortMultipartResponse>({
+    action: multipartAction.abortMultipart,
+    collectionSlug,
+    key,
+    uploadId,
+  }).catch(() => undefined)
+}
+
+const uploadMultipart = async ({
+  collectionSlug,
+  file,
+  postToSigner,
+  signerRequest,
+  updateFilename,
+}: {
+  collectionSlug: string
+  file: File
+  postToSigner: PostToSigner
+  signerRequest: InitiateMultipartRequest
+  updateFilename: (filename: string) => void
+}) => {
+  const { docPrefix, filename, key, partCount, partSize, uploadId } =
+    await postToSigner<InitiateMultipartResponse>(signerRequest)
+
+  updateFilenameIfNeeded({
+    sanitizedFilename: filename,
+    updateFilename,
+    uploadedFilename: file.name,
+  })
+
+  const completedParts: CompleteMultipartRequest['parts'] = []
+  let nextPartNumber = 1
+
+  const worker = async () => {
+    while (nextPartNumber <= partCount) {
+      const partNumber = nextPartNumber
+      nextPartNumber += 1
+      await uploadPartWithRetry({
+        collectionSlug,
+        completedParts,
+        file,
+        key,
+        partNumber,
+        partSize,
+        postToSigner,
+        uploadId,
+      })
+    }
+  }
+
+  const workers: Promise<void>[] = []
+  for (let index = 0; index < Math.min(MULTIPART_CONCURRENCY, partCount); index++) {
+    workers.push(worker())
+  }
+
+  try {
+    await Promise.all(workers)
+    await completeMultipartUpload({
+      collectionSlug,
+      key,
+      parts: completedParts,
+      postToSigner,
+      uploadId,
+    })
+
+    return {
+      prefix: docPrefix,
+    }
+  } catch (error) {
+    await abortMultipartUpload({
+      collectionSlug,
+      key,
+      postToSigner,
+      uploadId,
+    })
+    throw error
+  }
+}
+
 export const S3ClientUploadHandler = createClientUploadHandler({
   handler: async ({
     apiRoute,
@@ -17,50 +329,37 @@ export const S3ClientUploadHandler = createClientUploadHandler({
       path: serverHandlerPath,
       serverURL,
     })
+    const postToSigner = createPostToSigner({ endpointRoute })
+    const baseRequest = {
+      collectionSlug,
+      docPrefix,
+      filename: file.name,
+      filesize: file.size,
+      mimeType: file.type,
+    }
 
-    // get the signed URL from the server
-    const response = await fetch(endpointRoute, {
-      body: JSON.stringify({
-        collectionSlug,
-        docPrefix,
-        filename: file.name,
-        filesize: file.size,
-        mimeType: file.type,
-      }),
-      credentials: 'include',
-      method: 'POST',
+    if (file.size <= FIVE_GIB_BYTES) {
+      return uploadSinglePart({
+        file,
+        postToSigner,
+        signerRequest: {
+          action: multipartAction.generateSignedURL,
+          ...baseRequest,
+        },
+        updateFilename,
+      })
+    }
+
+    return uploadMultipart({
+      collectionSlug,
+      file,
+      postToSigner,
+      signerRequest: {
+        action: multipartAction.initiateMultipart,
+        ...baseRequest,
+        partSize: DEFAULT_MULTIPART_PART_SIZE,
+      },
+      updateFilename,
     })
-
-    if (!response.ok) {
-      const { errors } = (await response.json()) as {
-        errors: { message: string }[]
-      }
-
-      throw new Error(errors.reduce((acc, err) => `${acc ? `${acc}, ` : ''}${err.message}`, ''))
-    }
-
-    const {
-      docPrefix: sanitizedDocPrefix,
-      filename: sanitizedFilename,
-      url,
-    } = (await response.json()) as {
-      docPrefix: string
-      filename?: string
-      url: string
-    }
-
-    if (sanitizedFilename && sanitizedFilename !== file.name) {
-      updateFilename(sanitizedFilename)
-    }
-
-    // upload the file directly to S3 using the signed URL
-    await fetch(url, {
-      body: file,
-      headers: { 'Content-Length': file.size.toString(), 'Content-Type': file.type },
-      method: 'PUT',
-    })
-
-    // return the docPrefix so the client can update the field value accordingly
-    return { prefix: sanitizedDocPrefix }
   },
 })

--- a/packages/storage-s3/src/constants.ts
+++ b/packages/storage-s3/src/constants.ts
@@ -1,0 +1,16 @@
+export const FIVE_GIB_BYTES = 5 * 1024 * 1024 * 1024
+export const DEFAULT_MULTIPART_PART_SIZE = 64 * 1024 * 1024
+export const MIN_MULTIPART_PART_SIZE = 5 * 1024 * 1024
+export const MULTIPART_CONCURRENCY = 4
+export const MAX_PART_RETRIES = 3
+export const RETRY_BASE_MS = 500
+export const MAX_MULTIPART_PARTS = 10000
+export const MAX_SIGNED_URL_EXPIRY = 60 * 60
+
+export const multipartAction = {
+  abortMultipart: 'abortMultipart',
+  completeMultipart: 'completeMultipart',
+  generateSignedURL: 'generateSignedURL',
+  initiateMultipart: 'initiateMultipart',
+  signMultipartPart: 'signMultipartPart',
+} as const

--- a/packages/storage-s3/src/generateSignedURL.ts
+++ b/packages/storage-s3/src/generateSignedURL.ts
@@ -502,6 +502,8 @@ export const getGenerateSignedURLHandler = ({
 
     const body = (await req.json()) as {
       collectionSlug?: unknown
+    } & {
+      partSize?: number
     } & Partial<MultipartCreateFields> &
       Partial<SignedURLRequest>
     const action = body.action || multipartAction.generateSignedURL

--- a/packages/storage-s3/src/generateSignedURL.ts
+++ b/packages/storage-s3/src/generateSignedURL.ts
@@ -115,15 +115,19 @@ const ensureValidFilesize = ({
 }
 
 const enforceFilesizeLimit = ({
+  action,
   filesize,
   filesizeLimit,
 }: {
+  action?: string
   filesize: number
   filesizeLimit: number | undefined
 }) => {
   if (filesizeLimit && filesize > filesizeLimit) {
+    const prefix = action ? `${action}: ` : ''
+
     throw new APIError(
-      `Exceeded file size limit. Limit: ${bytesToMB(filesizeLimit).toFixed(2)}MB, got: ${bytesToMB(filesize).toFixed(2)}MB`,
+      `${prefix}Exceeded file size limit. Limit: ${bytesToMB(filesizeLimit).toFixed(2)}MB, got: ${bytesToMB(filesize).toFixed(2)}MB`,
       400,
     )
   }
@@ -174,7 +178,7 @@ const buildSignableHeaders = ({
   const signableHeaders = new Set<string>()
 
   if (filesizeLimit) {
-    enforceFilesizeLimit({ filesize, filesizeLimit })
+    enforceFilesizeLimit({ action: 'generateSignedURL', filesize, filesizeLimit })
     signableHeaders.add('content-length')
   }
 
@@ -202,7 +206,7 @@ const initiateMultipartUpload = async ({
     filesize: body.filesize,
     message: 'A valid filesize is required to initiate multipart upload.',
   })
-  enforceFilesizeLimit({ filesize, filesizeLimit })
+  enforceFilesizeLimit({ action: 'initiateMultipart', filesize, filesizeLimit })
 
   const requestedPartSize = Number.isFinite(body.partSize)
     ? Math.trunc(body.partSize as number)
@@ -447,7 +451,7 @@ const generateSinglePartSignedURL = async ({
     filesize: body.filesize,
     message: 'A valid filesize is required for signed URL generation.',
   })
-  enforceFilesizeLimit({ filesize, filesizeLimit })
+  enforceFilesizeLimit({ action: 'generateSignedURL', filesize, filesizeLimit })
 
   if (filesize > FIVE_GIB_BYTES) {
     throw new APIError('Single-request S3 upload is limited to 5 GiB. Use multipart upload.', 400)

--- a/packages/storage-s3/src/generateSignedURL.ts
+++ b/packages/storage-s3/src/generateSignedURL.ts
@@ -2,15 +2,69 @@ import type { S3 } from '@aws-sdk/client-s3'
 import type { ClientUploadsAccess } from '@payloadcms/plugin-cloud-storage/types'
 import type { PayloadHandler } from 'payload'
 
-import { PutObjectCommand } from '@aws-sdk/client-s3'
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  PutObjectCommand,
+  UploadPartCommand,
+} from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { resolveSignedURLKey } from '@payloadcms/plugin-cloud-storage/utilities'
 import { APIError, Forbidden } from 'payload'
 
 import type { S3StorageOptions } from './index.js'
+import type {
+  MultipartCreateFields,
+  MultipartRequestByAction,
+  MultipartResponseByAction,
+  SignedURLRequest,
+  SignedURLResponse,
+} from './types.js'
+
+import {
+  DEFAULT_MULTIPART_PART_SIZE,
+  FIVE_GIB_BYTES,
+  MAX_MULTIPART_PARTS,
+  MAX_SIGNED_URL_EXPIRY,
+  MIN_MULTIPART_PART_SIZE,
+  multipartAction,
+} from './constants.js'
+
+type AbortMultipartRequest = MultipartRequestByAction[typeof multipartAction.abortMultipart]
+type CompleteMultipartRequest = MultipartRequestByAction[typeof multipartAction.completeMultipart]
+type GenerateSignedURLRequest = MultipartRequestByAction[typeof multipartAction.generateSignedURL]
+type InitiateMultipartRequest = MultipartRequestByAction[typeof multipartAction.initiateMultipart]
+type SignMultipartPartRequest = MultipartRequestByAction[typeof multipartAction.signMultipartPart]
+
+type AbortMultipartResponse = MultipartResponseByAction[typeof multipartAction.abortMultipart]
+type CompleteMultipartResponse = MultipartResponseByAction[typeof multipartAction.completeMultipart]
+type GenerateSignedURLResponse = MultipartResponseByAction[typeof multipartAction.generateSignedURL]
+type InitiateMultipartResponse = MultipartResponseByAction[typeof multipartAction.initiateMultipart]
+type SignMultipartPartResponse = MultipartResponseByAction[typeof multipartAction.signMultipartPart]
 
 const bytesToMB = (bytes: number) => {
   return bytes / 1024 / 1024
+}
+
+const isDebugUpload = () =>
+  process.env.NODE_ENV !== 'production' || process.env.PAYLOAD_UPLOAD_DEBUG === 'true'
+
+const debugUploadLog = ({
+  data,
+  msg,
+  req,
+}: {
+  data?: Record<string, unknown>
+  msg: string
+  req: Parameters<PayloadHandler>[0]
+}) => {
+  if (isDebugUpload()) {
+    req.payload.logger.info({
+      ...data,
+      msg: `[storage-s3 multipart] ${msg}`,
+    })
+  }
 }
 
 interface Args {
@@ -23,6 +77,409 @@ interface Args {
 }
 
 const defaultAccess: Args['access'] = ({ req }) => !!req.user
+
+type UploadKeyContext = {
+  fileKey: string
+  sanitizedDocPrefix: string | undefined
+  sanitizedFilename: string | undefined
+}
+
+const ensureValidCollectionSlug = ({
+  body,
+}: {
+  body: { collectionSlug?: unknown } & Partial<SignedURLRequest>
+}) => {
+  if (typeof body.collectionSlug !== 'string' || body.collectionSlug.length === 0) {
+    throw new APIError('A valid collectionSlug is required for upload URL generation.', 400)
+  }
+
+  return body.collectionSlug
+}
+
+const ensureValidFilesize = ({
+  allowZero = false,
+  filesize,
+  message,
+}: {
+  allowZero?: boolean
+  filesize: unknown
+  message: string
+}) => {
+  const minSize = allowZero ? 0 : 1
+
+  if (!Number.isFinite(filesize) || (filesize as number) < minSize) {
+    throw new APIError(message, 400)
+  }
+
+  return filesize as number
+}
+
+const enforceFilesizeLimit = ({
+  filesize,
+  filesizeLimit,
+}: {
+  filesize: number
+  filesizeLimit: number | undefined
+}) => {
+  if (filesizeLimit && filesize > filesizeLimit) {
+    throw new APIError(
+      `Exceeded file size limit. Limit: ${bytesToMB(filesizeLimit).toFixed(2)}MB, got: ${bytesToMB(filesize).toFixed(2)}MB`,
+      400,
+    )
+  }
+}
+
+const resolveUploadKeyContext = async ({
+  collectionPrefix,
+  collectionSlug,
+  docPrefix,
+  filename,
+  req,
+  useCompositePrefixes,
+}: {
+  collectionPrefix: string
+  collectionSlug: string
+  docPrefix?: string
+  filename: unknown
+  req: Parameters<PayloadHandler>[0]
+  useCompositePrefixes: boolean
+}): Promise<UploadKeyContext> => {
+  if (typeof filename !== 'string' || filename.length === 0) {
+    throw new APIError('A valid filename is required for upload URL generation.', 400)
+  }
+
+  const { fileKey, sanitizedDocPrefix, sanitizedFilename } = await resolveSignedURLKey({
+    collectionPrefix,
+    collectionSlug,
+    docPrefix,
+    filename,
+    req,
+    useCompositePrefixes,
+  })
+
+  return {
+    fileKey,
+    sanitizedDocPrefix,
+    sanitizedFilename,
+  }
+}
+
+const buildSignableHeaders = ({
+  filesize,
+  filesizeLimit,
+}: {
+  filesize: number
+  filesizeLimit: number | undefined
+}) => {
+  const signableHeaders = new Set<string>()
+
+  if (filesizeLimit) {
+    enforceFilesizeLimit({ filesize, filesizeLimit })
+    signableHeaders.add('content-length')
+  }
+
+  return signableHeaders
+}
+
+const initiateMultipartUpload = async ({
+  acl,
+  body,
+  bucket,
+  filesizeLimit,
+  getStorageClient,
+  keyContext,
+  req,
+}: {
+  acl: 'private' | 'public-read' | undefined
+  body: InitiateMultipartRequest
+  bucket: string
+  filesizeLimit: number | undefined
+  getStorageClient: () => S3
+  keyContext: UploadKeyContext
+  req: Parameters<PayloadHandler>[0]
+}): Promise<InitiateMultipartResponse> => {
+  const filesize = ensureValidFilesize({
+    filesize: body.filesize,
+    message: 'A valid filesize is required to initiate multipart upload.',
+  })
+  enforceFilesizeLimit({ filesize, filesizeLimit })
+
+  const requestedPartSize = Number.isFinite(body.partSize)
+    ? Math.trunc(body.partSize as number)
+    : DEFAULT_MULTIPART_PART_SIZE
+  const partSize = Math.max(MIN_MULTIPART_PART_SIZE, requestedPartSize)
+  const partCount = Math.ceil(filesize / partSize)
+
+  if (partCount > MAX_MULTIPART_PARTS) {
+    throw new APIError(
+      `Multipart upload would exceed S3 limit of ${MAX_MULTIPART_PARTS} parts. Increase part size and retry.`,
+      400,
+    )
+  }
+
+  const result = await getStorageClient().send(
+    new CreateMultipartUploadCommand({
+      ACL: acl,
+      Bucket: bucket,
+      ContentType: body.mimeType,
+      Key: keyContext.fileKey,
+    }),
+  )
+
+  if (!result.UploadId) {
+    throw new APIError('Failed to create multipart upload session.', 500)
+  }
+
+  debugUploadLog({
+    data: {
+      collectionSlug: body.collectionSlug,
+      fileKey: keyContext.fileKey,
+      filesize,
+      partCount,
+      partSize,
+      uploadId: result.UploadId,
+    },
+    msg: 'initiate',
+    req,
+  })
+
+  return {
+    action: multipartAction.initiateMultipart,
+    docPrefix: keyContext.sanitizedDocPrefix,
+    filename: keyContext.sanitizedFilename,
+    key: keyContext.fileKey,
+    ok: true,
+    partCount,
+    partSize,
+    uploadId: result.UploadId,
+  }
+}
+
+const signMultipartPartURL = async ({
+  body,
+  bucket,
+  getStorageClient,
+}: {
+  body: SignMultipartPartRequest
+  bucket: string
+  getStorageClient: () => S3
+}): Promise<SignMultipartPartResponse> => {
+  if (
+    !body.key ||
+    !body.uploadId ||
+    !Number.isInteger(body.partNumber) ||
+    body.partNumber < 1 ||
+    body.partNumber > MAX_MULTIPART_PARTS
+  ) {
+    throw new APIError(
+      'key, uploadId, and a valid partNumber are required to sign multipart part uploads.',
+      400,
+    )
+  }
+
+  const url = await getSignedUrl(
+    getStorageClient(),
+    new UploadPartCommand({
+      Body: undefined,
+      Bucket: bucket,
+      Key: body.key,
+      PartNumber: body.partNumber,
+      UploadId: body.uploadId,
+    }),
+    {
+      expiresIn: MAX_SIGNED_URL_EXPIRY,
+    },
+  )
+
+  return {
+    action: multipartAction.signMultipartPart,
+    key: body.key,
+    ok: true,
+    partNumber: body.partNumber,
+    uploadId: body.uploadId,
+    url,
+  }
+}
+
+const normalizeCompletedParts = ({
+  parts,
+}: {
+  parts: CompleteMultipartRequest['parts']
+}): CompleteMultipartRequest['parts'] => {
+  return parts
+    .map((part) => {
+      const partNumber = Number(part.PartNumber)
+
+      if (!Number.isInteger(partNumber) || partNumber < 1 || !part.ETag) {
+        throw new APIError('Invalid multipart part descriptor received during complete.', 400)
+      }
+
+      return {
+        ETag: part.ETag,
+        PartNumber: partNumber,
+      }
+    })
+    .sort((a, b) => a.PartNumber - b.PartNumber)
+}
+
+const completeMultipartUpload = async ({
+  body,
+  bucket,
+  getStorageClient,
+  req,
+}: {
+  body: CompleteMultipartRequest
+  bucket: string
+  getStorageClient: () => S3
+  req: Parameters<PayloadHandler>[0]
+}): Promise<CompleteMultipartResponse> => {
+  if (!body.key || !body.uploadId || !Array.isArray(body.parts) || body.parts.length === 0) {
+    throw new APIError(
+      'key, uploadId, and at least one completed part are required to complete multipart upload.',
+      400,
+    )
+  }
+
+  const normalizedParts = normalizeCompletedParts({ parts: body.parts })
+
+  await getStorageClient().send(
+    new CompleteMultipartUploadCommand({
+      Bucket: bucket,
+      Key: body.key,
+      MultipartUpload: {
+        Parts: normalizedParts,
+      },
+      UploadId: body.uploadId,
+    }),
+  )
+
+  debugUploadLog({
+    data: {
+      collectionSlug: body.collectionSlug,
+      key: body.key,
+      partCount: normalizedParts.length,
+      uploadId: body.uploadId,
+    },
+    msg: 'complete',
+    req,
+  })
+
+  return {
+    action: multipartAction.completeMultipart,
+    key: body.key,
+    ok: true,
+    partCount: normalizedParts.length,
+    uploadId: body.uploadId,
+  }
+}
+
+const abortMultipartUpload = async ({
+  body,
+  bucket,
+  getStorageClient,
+  req,
+}: {
+  body: AbortMultipartRequest
+  bucket: string
+  getStorageClient: () => S3
+  req: Parameters<PayloadHandler>[0]
+}): Promise<AbortMultipartResponse> => {
+  try {
+    await getStorageClient().send(
+      new AbortMultipartUploadCommand({
+        Bucket: bucket,
+        Key: body.key,
+        UploadId: body.uploadId,
+      }),
+    )
+    debugUploadLog({
+      data: {
+        collectionSlug: body.collectionSlug,
+        key: body.key,
+        uploadId: body.uploadId,
+      },
+      msg: 'abort',
+      req,
+    })
+  } catch (err) {
+    debugUploadLog({
+      data: {
+        collectionSlug: body.collectionSlug,
+        key: body.key,
+        uploadId: body.uploadId,
+      },
+      msg: 'abort-failed',
+      req,
+    })
+    req.payload.logger.error({
+      err,
+      key: body.key,
+      msg: '[storage-s3 multipart] abort failed',
+      uploadId: body.uploadId,
+    })
+  }
+
+  return {
+    action: multipartAction.abortMultipart,
+    key: body.key,
+    ok: true,
+    uploadId: body.uploadId,
+  }
+}
+
+const generateSinglePartSignedURL = async ({
+  acl,
+  body,
+  bucket,
+  filesizeLimit,
+  getStorageClient,
+  keyContext,
+}: {
+  acl: 'private' | 'public-read' | undefined
+  body: GenerateSignedURLRequest
+  bucket: string
+  filesizeLimit: number | undefined
+  getStorageClient: () => S3
+  keyContext: UploadKeyContext
+}): Promise<GenerateSignedURLResponse> => {
+  const filesize = ensureValidFilesize({
+    allowZero: true,
+    filesize: body.filesize,
+    message: 'A valid filesize is required for signed URL generation.',
+  })
+  enforceFilesizeLimit({ filesize, filesizeLimit })
+
+  if (filesize > FIVE_GIB_BYTES) {
+    throw new APIError('Single-request S3 upload is limited to 5 GiB. Use multipart upload.', 400)
+  }
+
+  const signableHeaders = buildSignableHeaders({
+    filesize,
+    filesizeLimit,
+  })
+
+  const url = await getSignedUrl(
+    getStorageClient(),
+    new PutObjectCommand({
+      ACL: acl,
+      Bucket: bucket,
+      ContentLength: filesizeLimit ? Math.min(filesize, filesizeLimit) : undefined,
+      ContentType: body.mimeType,
+      Key: keyContext.fileKey,
+    }),
+    {
+      expiresIn: 600,
+      signableHeaders,
+    },
+  )
+
+  return {
+    action: multipartAction.generateSignedURL,
+    docPrefix: keyContext.sanitizedDocPrefix,
+    filename: keyContext.sanitizedFilename,
+    url,
+  }
+}
 
 export const getGenerateSignedURLHandler = ({
   access = defaultAccess,
@@ -43,13 +500,12 @@ export const getGenerateSignedURLHandler = ({
       filesizeLimit = undefined
     }
 
-    const { collectionSlug, docPrefix, filename, filesize, mimeType } = (await req.json()) as {
-      collectionSlug: string
-      docPrefix?: string
-      filename: string
-      filesize: number
-      mimeType: string
-    }
+    const body = (await req.json()) as {
+      collectionSlug?: unknown
+    } & Partial<MultipartCreateFields> &
+      Partial<SignedURLRequest>
+    const action = body.action || multipartAction.generateSignedURL
+    const collectionSlug = ensureValidCollectionSlug({ body })
 
     const collectionS3Config = collections[collectionSlug]
     if (!collectionS3Config) {
@@ -63,48 +519,85 @@ export const getGenerateSignedURLHandler = ({
       throw new Forbidden()
     }
 
-    const { fileKey, sanitizedDocPrefix, sanitizedFilename } = await resolveSignedURLKey({
+    if (action === multipartAction.signMultipartPart) {
+      return Response.json(
+        await signMultipartPartURL({
+          body: body as SignMultipartPartRequest,
+          bucket,
+          getStorageClient,
+        }),
+      )
+    }
+
+    if (action === multipartAction.completeMultipart) {
+      return Response.json(
+        await completeMultipartUpload({
+          body: body as CompleteMultipartRequest,
+          bucket,
+          getStorageClient,
+          req,
+        }),
+      )
+    }
+
+    if (action === multipartAction.abortMultipart) {
+      return Response.json(
+        await abortMultipartUpload({
+          body: body as AbortMultipartRequest,
+          bucket,
+          getStorageClient,
+          req,
+        }),
+      )
+    }
+
+    const keyContext = await resolveUploadKeyContext({
       collectionPrefix,
       collectionSlug,
-      docPrefix,
-      filename,
+      docPrefix: body.docPrefix,
+      filename: body.filename,
       req,
       useCompositePrefixes,
     })
 
-    const signableHeaders = new Set<string>()
-
-    if (filesizeLimit) {
-      if (filesize > filesizeLimit) {
-        throw new APIError(
-          `Exceeded file size limit. Limit: ${bytesToMB(filesizeLimit).toFixed(2)}MB, got: ${bytesToMB(filesize).toFixed(2)}MB`,
-          400,
-        )
-      }
-
-      // Still force S3 to validate
-      signableHeaders.add('content-length')
+    if (action === multipartAction.initiateMultipart) {
+      return Response.json(
+        await initiateMultipartUpload({
+          acl,
+          body: {
+            action,
+            collectionSlug,
+            docPrefix: body.docPrefix,
+            filename: body.filename as string,
+            filesize: body.filesize as number,
+            mimeType: body.mimeType as string,
+            partSize: body.partSize,
+          },
+          bucket,
+          filesizeLimit,
+          getStorageClient,
+          keyContext,
+          req,
+        }),
+      )
     }
 
-    const url = await getSignedUrl(
-      getStorageClient(),
-      new PutObjectCommand({
-        ACL: acl,
-        Bucket: bucket,
-        ContentLength: filesizeLimit ? Math.min(filesize, filesizeLimit) : undefined,
-        ContentType: mimeType,
-        Key: fileKey,
-      }),
-      {
-        expiresIn: 600,
-        signableHeaders,
+    const response: SignedURLResponse = await generateSinglePartSignedURL({
+      acl,
+      body: {
+        action: multipartAction.generateSignedURL,
+        collectionSlug,
+        docPrefix: body.docPrefix,
+        filename: body.filename as string,
+        filesize: body.filesize as number,
+        mimeType: body.mimeType as string,
       },
-    )
-
-    return Response.json({
-      docPrefix: sanitizedDocPrefix,
-      filename: sanitizedFilename,
-      url,
+      bucket,
+      filesizeLimit,
+      getStorageClient,
+      keyContext,
     })
+
+    return Response.json(response)
   }
 }

--- a/packages/storage-s3/src/types.ts
+++ b/packages/storage-s3/src/types.ts
@@ -1,0 +1,113 @@
+import type { multipartAction } from './constants.js'
+
+export type MultipartAction = (typeof multipartAction)[keyof typeof multipartAction]
+
+type SharedUploadFields = {
+  collectionSlug: string
+}
+
+type SharedCreateFields = {
+  docPrefix?: string
+  filename: string
+  filesize: number
+  mimeType: string
+} & SharedUploadFields
+
+export type MultipartCreateFields = SharedCreateFields
+
+export type MultipartPartDescriptor = {
+  ETag: string
+  PartNumber: number
+}
+
+export type MultipartRequestByAction = {
+  [multipartAction.abortMultipart]: {
+    action: typeof multipartAction.abortMultipart
+    key: string
+    uploadId: string
+  } & SharedUploadFields
+  [multipartAction.completeMultipart]: {
+    action: typeof multipartAction.completeMultipart
+    key: string
+    parts: MultipartPartDescriptor[]
+    uploadId: string
+  } & SharedUploadFields
+  [multipartAction.generateSignedURL]: {
+    action?: typeof multipartAction.generateSignedURL
+  } & SharedCreateFields
+  [multipartAction.initiateMultipart]: {
+    action: typeof multipartAction.initiateMultipart
+    partSize?: number
+  } & SharedCreateFields
+  [multipartAction.signMultipartPart]: {
+    action: typeof multipartAction.signMultipartPart
+    key: string
+    partNumber: number
+    uploadId: string
+  } & SharedUploadFields
+}
+
+export type GenerateSignedURLRequest =
+  MultipartRequestByAction[typeof multipartAction.generateSignedURL]
+export type InitiateMultipartRequest =
+  MultipartRequestByAction[typeof multipartAction.initiateMultipart]
+export type SignMultipartPartRequest =
+  MultipartRequestByAction[typeof multipartAction.signMultipartPart]
+export type CompleteMultipartRequest =
+  MultipartRequestByAction[typeof multipartAction.completeMultipart]
+export type AbortMultipartRequest = MultipartRequestByAction[typeof multipartAction.abortMultipart]
+
+export type SignedURLRequest = MultipartRequestByAction[MultipartAction]
+
+export type MultipartResponseByAction = {
+  [multipartAction.abortMultipart]: {
+    action: typeof multipartAction.abortMultipart
+    key: string
+    ok: true
+    uploadId: string
+  }
+  [multipartAction.completeMultipart]: {
+    action: typeof multipartAction.completeMultipart
+    key: string
+    ok: true
+    partCount: number
+    uploadId: string
+  }
+  [multipartAction.generateSignedURL]: {
+    action: typeof multipartAction.generateSignedURL
+    docPrefix: string | undefined
+    filename?: string
+    url: string
+  }
+  [multipartAction.initiateMultipart]: {
+    action: typeof multipartAction.initiateMultipart
+    docPrefix: string | undefined
+    filename?: string
+    key: string
+    ok: true
+    partCount: number
+    partSize: number
+    uploadId: string
+  }
+  [multipartAction.signMultipartPart]: {
+    action: typeof multipartAction.signMultipartPart
+    key: string
+    ok: true
+    partNumber: number
+    uploadId: string
+    url: string
+  }
+}
+
+export type GenerateSignedURLResponse =
+  MultipartResponseByAction[typeof multipartAction.generateSignedURL]
+export type InitiateMultipartResponse =
+  MultipartResponseByAction[typeof multipartAction.initiateMultipart]
+export type SignMultipartPartResponse =
+  MultipartResponseByAction[typeof multipartAction.signMultipartPart]
+export type CompleteMultipartResponse =
+  MultipartResponseByAction[typeof multipartAction.completeMultipart]
+export type AbortMultipartResponse =
+  MultipartResponseByAction[typeof multipartAction.abortMultipart]
+
+export type SignedURLResponse = MultipartResponseByAction[MultipartAction]

--- a/test/storage-s3/client-uploads/config-limit-tests.ts
+++ b/test/storage-s3/client-uploads/config-limit-tests.ts
@@ -59,8 +59,7 @@ export default buildConfigWithDefaults({
   ],
   upload: {
     limits: {
-      // Default dev config: no signer-side cap. Size-limit tests use config-limit-tests.ts instead.
-      fileSize: Infinity,
+      fileSize: 10 * 1024 * 1024, // 10 MB — used by int.spec.ts size-limit tests only
     },
   },
   typescript: {

--- a/test/storage-s3/client-uploads/int.spec.ts
+++ b/test/storage-s3/client-uploads/int.spec.ts
@@ -41,7 +41,12 @@ const signedURLBody = (
 
 describe('@payloadcms/storage-s3 clientUploads', () => {
   beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+    ;({ payload, restClient } = await initPayloadInt(
+      dirname,
+      undefined,
+      true,
+      'config-limit-tests.ts',
+    ))
 
     await createTestBucket()
     await clearTestBucket()
@@ -216,6 +221,25 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
       expect(response.status).toBe(400)
       const { errors } = (await response.json()) as any
       expect(errors[0].message).toContain('valid filesize is required to initiate multipart upload')
+    })
+
+    it('should reject multipart initiate when file exceeds upload.limits.fileSize', async () => {
+      const response = await restClient.POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'initiateMultipart',
+          collectionSlug: 'media',
+          filename: 'large-multipart.png',
+          filesize: MB(11),
+          mimeType: 'image/png',
+        }),
+      })
+
+      expect(response.status).toBe(400)
+      const { errors } = (await response.json()) as any
+      expect(errors).toBeDefined()
+      expect(errors[0].message).toContain('initiateMultipart: Exceeded file size limit')
+      expect(errors[0].message).toMatch(/Limit: 10\.0\dMB/)
+      expect(errors[0].message).toMatch(/got: 11\.0\dMB/)
     })
 
     it('should reject multipart part signing for invalid part number', async () => {

--- a/test/storage-s3/client-uploads/int.spec.ts
+++ b/test/storage-s3/client-uploads/int.spec.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 
+import * as AWS from '@aws-sdk/client-s3'
 import { readFileSync } from 'fs'
 import path from 'path'
 import { assert } from 'ts-essentials'
@@ -175,6 +176,250 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
 
     expect(uploadResponse.ok).toBe(false)
     expect(uploadResponse.status).toBe(403)
+  })
+
+  describe('multipart actions', () => {
+    it('should initiate multipart upload and return a stable response shape', async () => {
+      const response = await restClient.POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'initiateMultipart',
+          collectionSlug: 'media',
+          filename: 'multipart-initiate.png',
+          filesize: MB(6),
+          mimeType: 'image/png',
+          partSize: MB(5),
+        }),
+      })
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+
+      expect(body.action).toBe('initiateMultipart')
+      expect(body.ok).toBe(true)
+      expect(body.key).toContain('multipart-initiate.png')
+      expect(body.partCount).toBe(2)
+      expect(body.partSize).toBe(MB(5))
+      expect(body.uploadId).toBeDefined()
+    })
+
+    it('should reject multipart initiate for invalid filesize', async () => {
+      const response = await restClient.POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'initiateMultipart',
+          collectionSlug: 'media',
+          filename: 'invalid-size.png',
+          filesize: 0,
+          mimeType: 'image/png',
+        }),
+      })
+
+      expect(response.status).toBe(400)
+      const { errors } = (await response.json()) as any
+      expect(errors[0].message).toContain('valid filesize is required to initiate multipart upload')
+    })
+
+    it('should reject multipart part signing for invalid part number', async () => {
+      const response = await restClient.POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'signMultipartPart',
+          collectionSlug: 'media',
+          key: 'fake-key',
+          partNumber: 0,
+          uploadId: 'fake-upload-id',
+        }),
+      })
+
+      expect(response.status).toBe(400)
+      const { errors } = (await response.json()) as any
+      expect(errors[0].message).toContain('valid partNumber')
+    })
+
+    it('should complete multipart upload and normalize unsorted parts', async () => {
+      const initiate = await restClient
+        .POST(signedURLEndpoint, {
+          body: JSON.stringify({
+            action: 'initiateMultipart',
+            collectionSlug: 'media',
+            filename: 'multipart-complete.png',
+            filesize: MB(6),
+            mimeType: 'image/png',
+            partSize: MB(5),
+          }),
+        })
+        .then((res) =>
+          res.json<{
+            action: string
+            key: string
+            partCount: number
+            uploadId: string
+          }>(),
+        )
+
+      const partUploadResults: { ETag: string; PartNumber: number }[] = []
+
+      for (let partNumber = 1; partNumber <= initiate.partCount; partNumber++) {
+        const partSign = await restClient
+          .POST(signedURLEndpoint, {
+            body: JSON.stringify({
+              action: 'signMultipartPart',
+              collectionSlug: 'media',
+              key: initiate.key,
+              partNumber,
+              uploadId: initiate.uploadId,
+            }),
+          })
+          .then((res) => res.json<{ url: string }>())
+
+        const chunk = Buffer.alloc(MB(5), partNumber)
+        const uploadResponse = await fetch(partSign.url, {
+          body: chunk,
+          method: 'PUT',
+        })
+
+        expect(uploadResponse.ok).toBe(true)
+        const etag = uploadResponse.headers.get('etag')
+        expect(etag).toBeDefined()
+        partUploadResults.push({
+          ETag: etag!,
+          PartNumber: partNumber,
+        })
+      }
+
+      const reversedParts = [...partUploadResults].reverse()
+      const complete = await restClient
+        .POST(signedURLEndpoint, {
+          body: JSON.stringify({
+            action: 'completeMultipart',
+            collectionSlug: 'media',
+            key: initiate.key,
+            parts: reversedParts,
+            uploadId: initiate.uploadId,
+          }),
+        })
+        .then((res) =>
+          res.json<{
+            action: string
+            key: string
+            ok: boolean
+            partCount: number
+            uploadId: string
+          }>(),
+        )
+
+      expect(complete.action).toBe('completeMultipart')
+      expect(complete.ok).toBe(true)
+      expect(complete.partCount).toBe(initiate.partCount)
+      expect(complete.key).toBe(initiate.key)
+      expect(complete.uploadId).toBe(initiate.uploadId)
+    })
+
+    it('should allow cleanup via abort after multipart completion failure', async () => {
+      const initiate = await restClient
+        .POST(signedURLEndpoint, {
+          body: JSON.stringify({
+            action: 'initiateMultipart',
+            collectionSlug: 'media',
+            filename: 'multipart-failure-cleanup.png',
+            filesize: MB(6),
+            mimeType: 'image/png',
+            partSize: MB(5),
+          }),
+        })
+        .then((res) =>
+          res.json<{
+            key: string
+            uploadId: string
+          }>(),
+        )
+
+      const failedComplete = await restClient.POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'completeMultipart',
+          collectionSlug: 'media',
+          key: initiate.key,
+          parts: [],
+          uploadId: initiate.uploadId,
+        }),
+      })
+
+      expect(failedComplete.status).toBe(400)
+
+      await restClient.POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'abortMultipart',
+          collectionSlug: 'media',
+          key: initiate.key,
+          uploadId: initiate.uploadId,
+        }),
+      })
+
+      const multipartUploads = await getAWSClient().send(
+        new AWS.ListMultipartUploadsCommand({
+          Bucket: getTestBucketName(),
+          Prefix: initiate.key,
+        }),
+      )
+
+      const matchedUpload = multipartUploads.Uploads?.find(
+        (upload) => upload.Key === initiate.key && upload.UploadId === initiate.uploadId,
+      )
+      expect(matchedUpload).toBeUndefined()
+    })
+
+    it('should abort multipart upload and remove pending upload', async () => {
+      const initiate = await restClient
+        .POST(signedURLEndpoint, {
+          body: JSON.stringify({
+            action: 'initiateMultipart',
+            collectionSlug: 'media',
+            filename: 'multipart-abort.png',
+            filesize: MB(6),
+            mimeType: 'image/png',
+            partSize: MB(5),
+          }),
+        })
+        .then((res) =>
+          res.json<{
+            key: string
+            uploadId: string
+          }>(),
+        )
+
+      const abortResponse = await restClient
+        .POST(signedURLEndpoint, {
+          body: JSON.stringify({
+            action: 'abortMultipart',
+            collectionSlug: 'media',
+            key: initiate.key,
+            uploadId: initiate.uploadId,
+          }),
+        })
+        .then((res) =>
+          res.json<{
+            action: string
+            key: string
+            ok: boolean
+            uploadId: string
+          }>(),
+        )
+
+      expect(abortResponse.action).toBe('abortMultipart')
+      expect(abortResponse.ok).toBe(true)
+      expect(abortResponse.key).toBe(initiate.key)
+      expect(abortResponse.uploadId).toBe(initiate.uploadId)
+
+      const multipartUploads = await getAWSClient().send(
+        new AWS.ListMultipartUploadsCommand({
+          Bucket: getTestBucketName(),
+          Prefix: initiate.key,
+        }),
+      )
+
+      const matchedUpload = multipartUploads.Uploads?.find(
+        (upload) => upload.Key === initiate.key && upload.UploadId === initiate.uploadId,
+      )
+      expect(matchedUpload).toBeUndefined()
+    })
   })
 
   describe('filename handling', () => {

--- a/test/storage-s3/client-uploads/large-limit.int.spec.ts
+++ b/test/storage-s3/client-uploads/large-limit.int.spec.ts
@@ -1,0 +1,111 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
+
+import { FIVE_GIB_BYTES } from '../../../packages/storage-s3/src/constants.js'
+import { initPayloadInt } from '../../__helpers/shared/initPayloadInt.js'
+import { clearTestBucket, createTestBucket, MB } from '../test-utils.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+const signedURLEndpoint = '/storage-s3-generate-signed-url'
+
+let restClient: NextRESTClient
+let payload: Payload
+
+describe('@payloadcms/storage-s3 clientUploads with raised file size limit', () => {
+  beforeAll(async () => {
+    ;({ payload, restClient } = await initPayloadInt(dirname))
+
+    await createTestBucket()
+    await clearTestBucket()
+  })
+
+  it('should initiate multipart upload for files larger than 5 GiB when upload.limits.fileSize allows it', async () => {
+    const filesize = FIVE_GIB_BYTES + MB(1)
+
+    const response = await restClient.POST(signedURLEndpoint, {
+      body: JSON.stringify({
+        action: 'initiateMultipart',
+        collectionSlug: 'media',
+        filename: 'large-multipart-initiate.bin',
+        filesize,
+        mimeType: 'application/octet-stream',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+
+    expect(body.action).toBe('initiateMultipart')
+    expect(body.ok).toBe(true)
+    expect(body.key).toContain('large-multipart-initiate.bin')
+    expect(body.partCount).toBeGreaterThan(1)
+    expect(body.uploadId).toBeDefined()
+  })
+
+  it('should sign and upload the first multipart part for files larger than 5 GiB', async () => {
+    const filesize = FIVE_GIB_BYTES + MB(1)
+
+    const initiate = await restClient
+      .POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'initiateMultipart',
+          collectionSlug: 'media',
+          filename: 'large-multipart-part.bin',
+          filesize,
+          mimeType: 'application/octet-stream',
+        }),
+      })
+      .then((res) =>
+        res.json<{
+          key: string
+          partSize: number
+          uploadId: string
+        }>(),
+      )
+
+    const partSign = await restClient
+      .POST(signedURLEndpoint, {
+        body: JSON.stringify({
+          action: 'signMultipartPart',
+          collectionSlug: 'media',
+          key: initiate.key,
+          partNumber: 1,
+          uploadId: initiate.uploadId,
+        }),
+      })
+      .then((res) => res.json<{ url: string }>())
+
+    const chunk = Buffer.alloc(initiate.partSize, 1)
+    const uploadResponse = await fetch(partSign.url, {
+      body: chunk,
+      method: 'PUT',
+    })
+
+    expect(uploadResponse.ok).toBe(true)
+    expect(uploadResponse.headers.get('etag')).toBeDefined()
+
+    await restClient.POST(signedURLEndpoint, {
+      body: JSON.stringify({
+        action: 'abortMultipart',
+        collectionSlug: 'media',
+        key: initiate.key,
+        uploadId: initiate.uploadId,
+      }),
+    })
+  })
+
+  afterEach(async () => {
+    await clearTestBucket()
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+})

--- a/test/storage-s3/payload-types.ts
+++ b/test/storage-s3/payload-types.ts
@@ -100,6 +100,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -594,6 +597,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
## Which branch?
Targets **`main`** (Payload v4).

## What?
Fixes S3 **client uploads** failing for files larger than **5 GiB**.
AWS S3 limits single `PutObject` uploads to 5 GiB. This PR ensures the S3 client upload handler automatically switches to **multipart upload** for larger files, and documents the related Payload config requirements.

## Why?
With `clientUploads: true`, files upload directly from the browser to S3. That bypasses server/Vercel body-size limits, but two constraints still apply:
1. **S3 single-request limit (5 GiB)** — files above this cannot use a single presigned `PutObject` URL.
2. **Payload `upload.limits.fileSize`** — the signed-URL signer still enforces this limit for both single-part and multipart flows.
Without multipart routing and clear configuration guidance, large client uploads fail (e.g. `Exceeded file size limit` on `initiateMultipart` or `generateSignedURL`).

## How?
  ### Client (`S3ClientUploadHandler`)
  - Files **≤ 5 GiB** → existing single-part flow (`generateSignedURL` → S3 `PUT`)
  - Files **> 5 GiB** → multipart flow:
    - `initiateMultipart`
    - concurrent part uploads with retry
    - `completeMultipart` (with `abortMultipart` on failure)
    
  ### Server (`generateSignedURL` handler)
  - Adds multipart signer actions: `initiateMultipart`, `signMultipartPart`, `completeMultipart`, `abortMultipart`
  - Rejects single-part signed URLs above 5 GiB with a clear error directing callers to multipart
  - Treats `upload.limits.fileSize: Infinity` as no signer-side cap
  - Prefixes size-limit errors with the action name (e.g. `initiateMultipart: Exceeded file size limit`) for easier debugging
  
### Docs & tests
- Documents client upload limits, the 5 GiB threshold, and `upload.limits.fileSize` in `packages/storage-s3/README.md`
- Integration tests cover multipart initiate/complete/abort and related edge cases in `test/storage-s3/client-uploads/`

### User-facing config requirement
Users uploading large files must raise the global limit to match their largest expected file:
```ts
export default buildConfig({
  upload: {
    limits: {
      fileSize: 7 * 1024 * 1024 * 1024, // e.g. 7 GiB
      // or Infinity to disable the signer-side cap
    },
  },
})

