### PR TITLE
fix: field visibility on create-first-user screen

### DIFF
--- a/packages/ui/src/views/CreateFirstUser/index.tsx
+++ b/packages/ui/src/views/CreateFirstUser/index.tsx
@@ -52,7 +52,7 @@ export async function CreateFirstUserView({ initPageResult }: AdminViewServerPro
   const baseFields: SanitizedFieldsPermissions = Object.fromEntries(
     collectionConfig.fields
       .filter((f): f is { name: string } & typeof f => 'name' in f && typeof f.name === 'string')
-      .map((f) => [f.name, { create: true, read: true, update: true }]),
+      .map((f) => [f.name, { create: true }]),
   )
 
   // In create-first-user we should always allow all fields


### PR DESCRIPTION
Fields with \ccess.read: false\ were still shown on the create-first-user screen because field permissions were granted \ead: true\ and \update: true\ for all fields unconditionally.

**Fix:** Set base field permissions to \{ create: true }\ only, so that per-field access controls are respected. The \docPermissionsForForm\ at the document level already grants \create: true\, \ead: true\, \update: true\, so the document is fully accessible — only field-level read/update restrictions are preserved.