### PR TITLE
fix(drizzle): lazy load drizzle-kit to prevent production bundling

### DIFF
--- a/packages/drizzle/src/postgres/requireDrizzleKit.ts
+++ b/packages/drizzle/src/postgres/requireDrizzleKit.ts
@@ -1,10 +1,8 @@
-import { createRequire } from 'module'
-
 import type { RequireDrizzleKit } from '../types.js'
 
-const require = createRequire(import.meta.url)
-
 export const requireDrizzleKit: RequireDrizzleKit = () => {
+  const { createRequire } = require('module')
+  const require = createRequire(import.meta.url)
   const {
     generateDrizzleJson,
     generateMigration,

--- a/packages/drizzle/src/sqlite/requireDrizzleKit.ts
+++ b/packages/drizzle/src/sqlite/requireDrizzleKit.ts
@@ -1,10 +1,8 @@
-import { createRequire } from 'module'
-
 import type { RequireDrizzleKit } from '../types.js'
 
-const require = createRequire(import.meta.url)
-
 export const requireDrizzleKit: RequireDrizzleKit = () => {
+  const { createRequire } = require('module')
+  const require = createRequire(import.meta.url)
   const {
     generateSQLiteDrizzleJson,
     generateSQLiteMigration,


### PR DESCRIPTION
drizzle-kit/api was being required at module load time, causing it to be included in production bundle for OpenNext Cloudflare and other edge runtimes.

Moves the require() inside the function so it's only loaded when actually needed (during migrations/schema push). Also fixes the same issue in postgres adapter.

Closes #16470