### PR TITLE
fix: S3 upload silent skip when select projects out mimeType/filename

### DIFF
--- a/packages/plugin-cloud-storage/src/utilities/getIncomingFiles.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getIncomingFiles.ts
@@ -21,21 +21,26 @@ export function getIncomingFiles({
 
   let files: File[] = []
 
-  if (file && data.filename && data.mimeType) {
+  const effectiveFilename = data.filename ?? file?.name
+  const effectiveMimeType = data.mimeType ?? file?.mimetype
+
+  if (file && effectiveFilename && effectiveMimeType) {
     const mainFile: File = {
       buffer: file.data,
-      filename: data.filename,
+      clientUploadContext: file.clientUploadContext,
+      filename: effectiveFilename,
       filesize: file.size,
-      mimeType: data.mimeType,
+      mimeType: effectiveMimeType,
       tempFilePath: file.tempFilePath,
       uploadReference: file.uploadReference,
     }
 
     files = [mainFile]
 
-    if (data?.sizes) {
-      Object.entries(data.sizes).forEach(([key, resizedFileData]) => {
-        if (payloadUploadSizes?.[key] && resizedFileData.mimeType) {
+    const sizes = data?.sizes ?? payloadUploadSizes
+    if (sizes) {
+      Object.entries(sizes).forEach(([key, resizedFileData]) => {
+        if (payloadUploadSizes?.[key] && resizedFileData?.mimeType) {
           files = files.concat([
             {
               buffer: payloadUploadSizes[key],

--- a/packages/plugin-cloud-storage/src/utilities/getIncomingFiles.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getIncomingFiles.ts
@@ -21,21 +21,25 @@ export function getIncomingFiles({
 
   let files: File[] = []
 
-  if (file && data.filename && data.mimeType) {
+  const effectiveFilename = data.filename ?? file?.name
+  const effectiveMimeType = data.mimeType ?? file?.mimetype
+
+  if (file && effectiveFilename && effectiveMimeType) {
     const mainFile: File = {
       buffer: file.data,
       clientUploadContext: file.clientUploadContext,
-      filename: data.filename,
+      filename: effectiveFilename,
       filesize: file.size,
-      mimeType: data.mimeType,
+      mimeType: effectiveMimeType,
       tempFilePath: file.tempFilePath,
     }
 
     files = [mainFile]
 
-    if (data?.sizes) {
-      Object.entries(data.sizes).forEach(([key, resizedFileData]) => {
-        if (payloadUploadSizes?.[key] && resizedFileData.mimeType) {
+    const sizes = data?.sizes ?? payloadUploadSizes
+    if (sizes) {
+      Object.entries(sizes).forEach(([key, resizedFileData]) => {
+        if (payloadUploadSizes?.[key] && resizedFileData?.mimeType) {
           files = files.concat([
             {
               buffer: payloadUploadSizes[key],


### PR DESCRIPTION
When a POST request uses \?select[...]\ to project mimeType/filename out of the response doc, the cloud-storage plugin silently skips uploading to S3.

Fix by falling back to req.file properties when data.filename/data.mimeType are undefined due to select projection. Also handle sizes fallback using payloadUploadSizes when data.sizes is missing.

Closes #16670