### PR TITLE
fix: reuploading file on Save draft resets main doc _status to draft

### DIFF
--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -121,7 +121,7 @@ export const updateDocument = async <
       !isSavingDraft,
   )
 
-  if (isSavingDraft) {
+  if (isSavingDraft && !id) {
     data._status = 'draft'
   }
 


### PR DESCRIPTION
For an upload-enabled collection with drafts enabled, replacing a published file and saving as a draft incorrectly overwrites the main collection document's _status from 'published' to 'draft'.

The bug was in \collections/operations/utilities/update.ts\ where \data._status = 'draft'\ was set unconditionally when \isSavingDraft\ was true, even when updating an existing published document.

Fix by only setting \_status = 'draft'\ for new documents (when id is undefined). For existing documents, the main doc should remain published while a draft version is created.

Closes #16633