### PR TITLE
fix(drizzle): preserve failing sub-table on unique-constraint ValidationError

### DIFF
--- a/packages/drizzle/src/upsertRow/handleUpsertError.spec.ts
+++ b/packages/drizzle/src/upsertRow/handleUpsertError.spec.ts
@@ -1,0 +1,49 @@
+import { ValidationError } from 'payload'
+import { describe, expect, it } from 'vitest'
+
+import type { DrizzleAdapter } from '../types.js'
+
+import { handleUpsertError } from './handleUpsertError.js'
+
+const adapter = { fieldConstraints: {} } as unknown as DrizzleAdapter
+
+describe('handleUpsertError', () => {
+  it('preserves the failing sub-table name on the ValidationError', () => {
+    const pgError = {
+      code: '23505',
+      constraint: 'ultrasonic_avail_country_pkey',
+      detail: 'Key (id)=(6a27e2a63f4b64567370f595) already exists.',
+    }
+
+    let thrown: unknown
+    try {
+      handleUpsertError({
+        adapter,
+        collectionSlug: 'ultrasonic',
+        error: pgError,
+        tableName: 'ultrasonic_avail_country',
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(ValidationError)
+    const validationError = thrown as ValidationError
+    const fieldError = validationError.data.errors[0]!
+    expect(fieldError.path).toBe('id')
+    expect(fieldError.tableName).toBe('ultrasonic_avail_country')
+  })
+
+  it('re-throws non unique-constraint errors unchanged', () => {
+    const otherError = new Error('some other db error')
+
+    expect(() =>
+      handleUpsertError({
+        adapter,
+        collectionSlug: 'ultrasonic',
+        error: otherError,
+        tableName: 'ultrasonic_avail_country',
+      }),
+    ).toThrow(otherError)
+  })
+})

--- a/packages/drizzle/src/upsertRow/handleUpsertError.ts
+++ b/packages/drizzle/src/upsertRow/handleUpsertError.ts
@@ -81,6 +81,10 @@ export const handleUpsertError = ({
           {
             message: req?.t ? req.t('error:valueMustBeUnique') : 'Value must be unique',
             path: fieldName,
+            // Preserve the failing sub-table so `afterError` hooks can resolve the
+            // affected array/block field. Doing this here is safe because it does not
+            // touch how rows are inserted (the cause of the data loss in PR #15754).
+            tableName,
           },
         ],
         global: globalSlug,

--- a/packages/drizzle/src/upsertRow/handleUpsertError.ts
+++ b/packages/drizzle/src/upsertRow/handleUpsertError.ts
@@ -81,9 +81,6 @@ export const handleUpsertError = ({
           {
             message: req?.t ? req.t('error:valueMustBeUnique') : 'Value must be unique',
             path: fieldName,
-            // Preserve the failing sub-table so `afterError` hooks can resolve the
-            // affected array/block field. Doing this here is safe because it does not
-            // touch how rows are inserted (the cause of the data loss in PR #15754).
             tableName,
           },
         ],

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -16,13 +16,6 @@ export type ValidationFieldError = {
   // The error message to display for this field
   message: string
   path: string
-  /**
-   * For database-level unique-constraint errors raised on an array/block sub-table,
-   * the name of the failing sub-table (e.g. `posts_my_array`). The dotted field path
-   * cannot be resolved safely at insert time, so this is exposed so that `afterError`
-   * hooks can map the failure back to a collection field/block and build a clearer
-   * message for the editor.
-   */
   tableName?: string
 }
 

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -16,6 +16,14 @@ export type ValidationFieldError = {
   // The error message to display for this field
   message: string
   path: string
+  /**
+   * For database-level unique-constraint errors raised on an array/block sub-table,
+   * the name of the failing sub-table (e.g. `posts_my_array`). The dotted field path
+   * cannot be resolved safely at insert time, so this is exposed so that `afterError`
+   * hooks can map the failure back to a collection field/block and build a clearer
+   * message for the editor.
+   */
+  tableName?: string
 }
 
 export class ValidationError extends APIError<{


### PR DESCRIPTION
## What?

When a database-level unique-constraint violation (Postgres `23505` / SQLite `SQLITE_CONSTRAINT_UNIQUE`) is raised on an array/block **sub-table** and converted into a `ValidationError` in `handleUpsertError`, only the bare column name (typically `id`) was preserved. The failing sub-table name and original constraint detail were discarded.

As a result:
- Editors see an unhelpful "The following field is invalid: id", with no indication of which array/block row or collection field is affected.
- `afterError` hooks cannot enrich the message, because by the time they run `ValidationError.data` only contains `path: "id"`.

Closes #16965.

## How?

`handleUpsertError` already receives the failing `tableName`. This PR adds an optional `tableName` to `ValidationFieldError` and populates it when throwing the constraint `ValidationError`, so `afterError` hooks can map the failure back to a collection field/block.

The dotted field path is intentionally **not** resolved at insert time. The previous attempt (#15754) did that by switching from a batch insert to per-row inserts to recover a per-row block path, and it was closed by its author because it caused data loss. This change is purely diagnostic and does **not** touch how rows are inserted.

## Notes

- This is the error-message half of the array-id problem. The underlying id reuse (#14574, bulk update / #13783) is tracked and fixed separately.

## Tests

- Adds `handleUpsertError.spec.ts` (unit): asserts a `23505` on an array sub-table throws a `ValidationError` carrying `tableName`, and that non-constraint errors are re-thrown unchanged.