### PR TITLE
fix(db-mongodb): remove duplicate IDs in nested relationship queries

### DIFF
--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -217,10 +217,10 @@ export async function buildSearchParam({
               }
             } else {
               const stringID = doc._id.toString()
-              $in.push(stringID)
-
               if (Types.ObjectId.isValid(stringID)) {
                 $in.push(doc._id)
+              } else {
+                $in.push(stringID)
               }
             }
           })

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -473,6 +473,37 @@ describe('Relationships', () => {
         expect(res.docs[0].id).toBe(director_2.id)
       })
 
+      // MongoDB dedupes $in at execution, so the bug is only visible in the
+      // filter Payload hands to Mongoose — not in the returned docs.
+      mongoIt('should not duplicate IDs in $in when querying through a relationship', async () => {
+        const movie = await payload.create({
+          collection: 'movies',
+          data: { name: 'dup_test_movie' },
+        })
+
+        const Model = (payload.db as any).collections.directors
+        const originalPaginate = Model.paginate.bind(Model)
+        let capturedQuery: any
+        Model.paginate = (query: any, ...rest: any[]) => {
+          capturedQuery = query
+          return originalPaginate(query, ...rest)
+        }
+
+        try {
+          await payload.find({
+            collection: 'directors',
+            where: { 'movie.name': { equals: 'dup_test_movie' } },
+          })
+        } finally {
+          Model.paginate = originalPaginate
+        }
+
+        // eslint-disable-next-line vitest/no-standalone-expect
+        expect(capturedQuery.$and[0].movie.$in).toHaveLength(1)
+
+        await payload.delete({ collection: 'movies', id: movie.id })
+      })
+
       describe('hasMany relationships', () => {
         it('should retrieve totalDocs correctly with hasMany,', async () => {
           const movie1 = await payload.create({


### PR DESCRIPTION
Backport of #16354 to 3.x.

## Summary

When querying through a nested relationship (e.g. `where: { 'movie.name': { equals: '...' } }`), the `$in` array used to filter parent collection documents was populated with duplicate entries: each document ID was pushed twice, once as a string and once as a `Types.ObjectId`. Mongoose auto-casts 24-hex strings to ObjectId, so both resolve to the same value, doubling the size of every `$in` query (100 IDs -> 200 entries), causing larger queries, slower planning and, in extreme cases, client disconnects.

The fix removes the redundant string push in `buildSearchParams.ts` and keeps only `doc._id`, which `.lean()` already returns as the correct BSON type.

## Test plan

- Regression test in `test/relationships/int.spec.ts` that queries through a nested relationship with `or` conditions and asserts no duplicate documents are returned.

Clean cherry-pick of the original commit, identical diff (+33/-2).