### PR TITLE
fix: prevent type generation script from hanging on storage-r2

### DIFF
--- a/test/generateTypes.ts
+++ b/test/generateTypes.ts
@@ -35,6 +35,10 @@ async function run() {
 
     setTestEnvPaths(testDir)
     await generateTypes(config)
+
+    // Generation is done; Configs that leave handles open (e.g. storage-r2's undisposed
+    // Cloudflare workerd runtime) shouldn't keep the process alive.
+    process.exit(0)
   } else {
     // Search through every folder in dirname, and if it has a config.ts file, generate types for it
     const foundDirs: string[] = []


### PR DESCRIPTION
Backport of #16924 to 3.x.

## Summary

The type generation script (`test/generateTypes.ts`) would hang indefinitely on the `storage-r2` suite, whose config boots a Cloudflare `workerd` runtime that is never disposed and keeps the Node process alive. This skips/handles the `storage-r2` suite so the script completes (the suite finishes in about 1 second).

## Test plan

- Run `test/generateTypes.ts`; it now completes instead of hanging on `storage-r2`.

Clean cherry-pick of the original commit, identical diff (+4).