### PR TITLE
refactor(ui): drop publishmany and unpublishmany v4 names

### DIFF
--- a/packages/ui/src/elements/PublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/PublishMany/DrawerContent.tsx
@@ -18,12 +18,13 @@ import { parseSearchParams } from '../../utilities/parseSearchParams.js'
 import { ConfirmationModal } from '../ConfirmationModal/index.js'
 
 type PublishManyDrawerContentProps = {
+  collection: PublishManyProps['collection']
   drawerSlug: string
   ids: (number | string)[]
   onSuccess?: () => void
   selectAll: boolean
   where?: Where
-} & PublishManyProps
+}
 
 export function PublishManyDrawerContent(props: PublishManyDrawerContentProps) {
   const {

--- a/packages/ui/src/elements/PublishMany/index.tsx
+++ b/packages/ui/src/elements/PublishMany/index.tsx
@@ -12,45 +12,35 @@ import { PublishManyDrawerContent } from './DrawerContent.js'
 
 export type PublishManyProps = {
   collection: ClientCollectionConfig
-}
-
-export const PublishMany: React.FC<PublishManyProps> = (props) => {
-  const { count, selectAll, selectedIDs, toggleAll } = useSelection()
-
-  return (
-    <PublishMany_v4
-      {...props}
-      count={count}
-      ids={selectedIDs}
-      onSuccess={() => toggleAll()}
-      selectAll={selectAll === SelectAllStatus.AllAvailable}
-    />
-  )
-}
-
-type PublishMany_v4Props = {
-  count: number
-  ids: (number | string)[]
+  count?: number
+  ids?: (number | string)[]
   /**
    * When multiple PublishMany components are rendered on the page, this will differentiate them.
    */
   modalPrefix?: string
   onSuccess?: () => void
-  selectAll: boolean
+  selectAll?: boolean
   where?: Where
-} & PublishManyProps
+}
 
-export const PublishMany_v4: React.FC<PublishMany_v4Props> = (props) => {
+export const PublishMany: React.FC<PublishManyProps> = (props) => {
+  const { count, selectAll, selectedIDs, toggleAll } = useSelection()
+
   const {
     collection,
     collection: { slug, versions } = {},
-    count,
-    ids,
+    count: countFromProps,
+    ids: idsFromProps,
     modalPrefix,
     onSuccess,
-    selectAll,
+    selectAll: selectAllFromProps,
     where,
   } = props
+
+  const resolvedCount = countFromProps ?? count
+  const resolvedIDs = idsFromProps ?? selectedIDs
+  const resolvedOnSuccess = onSuccess ?? (() => toggleAll())
+  const resolvedSelectAll = selectAllFromProps ?? selectAll === SelectAllStatus.AllAvailable
 
   const { permissions } = useAuth()
   const { t } = useTranslation()
@@ -62,7 +52,7 @@ export const PublishMany_v4: React.FC<PublishMany_v4Props> = (props) => {
 
   const drawerSlug = `${modalPrefix ? `${modalPrefix}-` : ''}publish-${slug}`
 
-  if (!versions?.drafts || count === 0 || !hasPermission) {
+  if (!versions?.drafts || resolvedCount === 0 || !hasPermission) {
     return null
   }
 
@@ -79,9 +69,9 @@ export const PublishMany_v4: React.FC<PublishMany_v4Props> = (props) => {
       <PublishManyDrawerContent
         collection={collection}
         drawerSlug={drawerSlug}
-        ids={ids}
-        onSuccess={onSuccess}
-        selectAll={selectAll}
+        ids={resolvedIDs}
+        onSuccess={resolvedOnSuccess}
+        selectAll={resolvedSelectAll}
         where={where}
       />
     </React.Fragment>

--- a/packages/ui/src/elements/PublishMany/index.tsx
+++ b/packages/ui/src/elements/PublishMany/index.tsx
@@ -5,42 +5,34 @@ import { useModal } from '@faceless-ui/modal'
 import React from 'react'
 
 import { useAuth } from '../../providers/Auth/index.js'
-import { SelectAllStatus, useSelection } from '../../providers/Selection/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { ListSelectionButton } from '../ListSelection/index.js'
 import { PublishManyDrawerContent } from './DrawerContent.js'
 
 export type PublishManyProps = {
   collection: ClientCollectionConfig
-  count?: number
-  ids?: (number | string)[]
+  count: number
+  ids: (number | string)[]
   /**
    * When multiple PublishMany components are rendered on the page, this will differentiate them.
    */
   modalPrefix?: string
   onSuccess?: () => void
-  selectAll?: boolean
+  selectAll: boolean
   where?: Where
 }
 
 export const PublishMany: React.FC<PublishManyProps> = (props) => {
-  const { count, selectAll, selectedIDs, toggleAll } = useSelection()
-
   const {
     collection,
     collection: { slug, versions } = {},
-    count: countFromProps,
-    ids: idsFromProps,
+    count,
+    ids,
     modalPrefix,
     onSuccess,
-    selectAll: selectAllFromProps,
+    selectAll,
     where,
   } = props
-
-  const resolvedCount = countFromProps ?? count
-  const resolvedIDs = idsFromProps ?? selectedIDs
-  const resolvedOnSuccess = onSuccess ?? (() => toggleAll())
-  const resolvedSelectAll = selectAllFromProps ?? selectAll === SelectAllStatus.AllAvailable
 
   const { permissions } = useAuth()
   const { t } = useTranslation()
@@ -52,7 +44,7 @@ export const PublishMany: React.FC<PublishManyProps> = (props) => {
 
   const drawerSlug = `${modalPrefix ? `${modalPrefix}-` : ''}publish-${slug}`
 
-  if (!versions?.drafts || resolvedCount === 0 || !hasPermission) {
+  if (!versions?.drafts || count === 0 || !hasPermission) {
     return null
   }
 
@@ -69,9 +61,9 @@ export const PublishMany: React.FC<PublishManyProps> = (props) => {
       <PublishManyDrawerContent
         collection={collection}
         drawerSlug={drawerSlug}
-        ids={resolvedIDs}
-        onSuccess={resolvedOnSuccess}
-        selectAll={resolvedSelectAll}
+        ids={ids}
+        onSuccess={onSuccess}
+        selectAll={selectAll}
         where={where}
       />
     </React.Fragment>

--- a/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
@@ -18,12 +18,13 @@ import { parseSearchParams } from '../../utilities/parseSearchParams.js'
 import { ConfirmationModal } from '../ConfirmationModal/index.js'
 
 type UnpublishManyDrawerContentProps = {
+  collection: UnpublishManyProps['collection']
   drawerSlug: string
   ids: (number | string)[]
   onSuccess?: () => void
   selectAll: boolean
   where?: Where
-} & UnpublishManyProps
+}
 
 export function UnpublishManyDrawerContent(props: UnpublishManyDrawerContentProps) {
   const {

--- a/packages/ui/src/elements/UnpublishMany/index.tsx
+++ b/packages/ui/src/elements/UnpublishMany/index.tsx
@@ -12,45 +12,35 @@ import { UnpublishManyDrawerContent } from './DrawerContent.js'
 
 export type UnpublishManyProps = {
   collection: ClientCollectionConfig
+  count?: number
+  ids?: (number | string)[]
+  /**
+   * When multiple UnpublishMany components are rendered on the page, this will differentiate them.
+   */
+  modalPrefix?: string
+  onSuccess?: () => void
+  selectAll?: boolean
+  where?: Where
 }
 
 export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
   const { count, selectAll, selectedIDs, toggleAll } = useSelection()
 
-  return (
-    <UnpublishMany_v4
-      {...props}
-      count={count}
-      ids={selectedIDs}
-      onSuccess={() => toggleAll()}
-      selectAll={selectAll === SelectAllStatus.AllAvailable}
-    />
-  )
-}
-
-export const UnpublishMany_v4: React.FC<
-  {
-    count: number
-    ids: (number | string)[]
-    /**
-     * When multiple UnpublishMany components are rendered on the page, this will differentiate them.
-     */
-    modalPrefix?: string
-    onSuccess?: () => void
-    selectAll: boolean
-    where?: Where
-  } & UnpublishManyProps
-> = (props) => {
   const {
     collection,
     collection: { slug, versions } = {},
-    count,
-    ids,
+    count: countFromProps,
+    ids: idsFromProps,
     modalPrefix,
     onSuccess,
-    selectAll,
+    selectAll: selectAllFromProps,
     where,
   } = props
+
+  const resolvedCount = countFromProps ?? count
+  const resolvedIDs = idsFromProps ?? selectedIDs
+  const resolvedOnSuccess = onSuccess ?? (() => toggleAll())
+  const resolvedSelectAll = selectAllFromProps ?? selectAll === SelectAllStatus.AllAvailable
 
   const { t } = useTranslation()
   const { permissions } = useAuth()
@@ -61,7 +51,7 @@ export const UnpublishMany_v4: React.FC<
 
   const drawerSlug = `${modalPrefix ? `${modalPrefix}-` : ''}unpublish-${slug}`
 
-  if (!versions?.drafts || count === 0 || !hasPermission) {
+  if (!versions?.drafts || resolvedCount === 0 || !hasPermission) {
     return null
   }
 
@@ -78,9 +68,9 @@ export const UnpublishMany_v4: React.FC<
       <UnpublishManyDrawerContent
         collection={collection}
         drawerSlug={drawerSlug}
-        ids={ids}
-        onSuccess={onSuccess}
-        selectAll={selectAll}
+        ids={resolvedIDs}
+        onSuccess={resolvedOnSuccess}
+        selectAll={resolvedSelectAll}
         where={where}
       />
     </React.Fragment>

--- a/packages/ui/src/elements/UnpublishMany/index.tsx
+++ b/packages/ui/src/elements/UnpublishMany/index.tsx
@@ -5,42 +5,34 @@ import { useModal } from '@faceless-ui/modal'
 import React from 'react'
 
 import { useAuth } from '../../providers/Auth/index.js'
-import { SelectAllStatus, useSelection } from '../../providers/Selection/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { ListSelectionButton } from '../ListSelection/index.js'
 import { UnpublishManyDrawerContent } from './DrawerContent.js'
 
 export type UnpublishManyProps = {
   collection: ClientCollectionConfig
-  count?: number
-  ids?: (number | string)[]
+  count: number
+  ids: (number | string)[]
   /**
    * When multiple UnpublishMany components are rendered on the page, this will differentiate them.
    */
   modalPrefix?: string
   onSuccess?: () => void
-  selectAll?: boolean
+  selectAll: boolean
   where?: Where
 }
 
 export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
-  const { count, selectAll, selectedIDs, toggleAll } = useSelection()
-
   const {
     collection,
     collection: { slug, versions } = {},
-    count: countFromProps,
-    ids: idsFromProps,
+    count,
+    ids,
     modalPrefix,
     onSuccess,
-    selectAll: selectAllFromProps,
+    selectAll,
     where,
   } = props
-
-  const resolvedCount = countFromProps ?? count
-  const resolvedIDs = idsFromProps ?? selectedIDs
-  const resolvedOnSuccess = onSuccess ?? (() => toggleAll())
-  const resolvedSelectAll = selectAllFromProps ?? selectAll === SelectAllStatus.AllAvailable
 
   const { t } = useTranslation()
   const { permissions } = useAuth()
@@ -51,7 +43,7 @@ export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
 
   const drawerSlug = `${modalPrefix ? `${modalPrefix}-` : ''}unpublish-${slug}`
 
-  if (!versions?.drafts || resolvedCount === 0 || !hasPermission) {
+  if (!versions?.drafts || count === 0 || !hasPermission) {
     return null
   }
 
@@ -68,9 +60,9 @@ export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
       <UnpublishManyDrawerContent
         collection={collection}
         drawerSlug={drawerSlug}
-        ids={resolvedIDs}
-        onSuccess={resolvedOnSuccess}
-        selectAll={resolvedSelectAll}
+        ids={ids}
+        onSuccess={onSuccess}
+        selectAll={selectAll}
         where={where}
       />
     </React.Fragment>

--- a/packages/ui/src/views/HierarchyList/DocumentListSelection/index.tsx
+++ b/packages/ui/src/views/HierarchyList/DocumentListSelection/index.tsx
@@ -7,8 +7,8 @@ import { useDocumentDrawer } from '../../../elements/DocumentDrawer/index.js'
 import { EditMany } from '../../../elements/EditMany/index.js'
 import { MoveMany } from '../../../elements/Hierarchy/MoveMany/index.js'
 import { ListSelection_v4, ListSelectionButton } from '../../../elements/ListSelection/index.js'
-import { PublishMany_v4 } from '../../../elements/PublishMany/index.js'
-import { UnpublishMany_v4 } from '../../../elements/UnpublishMany/index.js'
+import { PublishMany } from '../../../elements/PublishMany/index.js'
+import { UnpublishMany } from '../../../elements/UnpublishMany/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useDocumentSelection } from '../../../providers/DocumentSelection/index.js'
 import { useHierarchy } from '../../../providers/Hierarchy/index.js'
@@ -121,7 +121,7 @@ export const DocumentListSelection: React.FC<DocumentListSelectionProps> = ({
                 onSuccess={handleActionSuccess}
                 selectAll={false}
               />
-              <PublishMany_v4
+              <PublishMany
                 collection={collectionConfig}
                 count={ids.length}
                 ids={ids}
@@ -129,7 +129,7 @@ export const DocumentListSelection: React.FC<DocumentListSelectionProps> = ({
                 onSuccess={handleActionSuccess}
                 selectAll={false}
               />
-              <UnpublishMany_v4
+              <UnpublishMany
                 collection={collectionConfig}
                 count={ids.length}
                 ids={ids}

--- a/packages/ui/src/views/List/ListSelection/index.tsx
+++ b/packages/ui/src/views/List/ListSelection/index.tsx
@@ -7,9 +7,9 @@ import React, { Fragment, useCallback } from 'react'
 import { DeleteMany } from '../../../elements/DeleteMany/index.js'
 import { EditMany } from '../../../elements/EditMany/index.js'
 import { ListSelection_v4, ListSelectionButton } from '../../../elements/ListSelection/index.js'
-import { PublishMany_v4 } from '../../../elements/PublishMany/index.js'
+import { PublishMany } from '../../../elements/PublishMany/index.js'
 import { RestoreMany } from '../../../elements/RestoreMany/index.js'
-import { UnpublishMany_v4 } from '../../../elements/UnpublishMany/index.js'
+import { UnpublishMany } from '../../../elements/UnpublishMany/index.js'
 import { useAuth } from '../../../providers/Auth/index.js'
 import { useRouteCache } from '../../../providers/RouteCache/index.js'
 import { useRouter, useSearchParams } from '../../../providers/RouterAdapter/index.js'
@@ -109,7 +109,7 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
               selectAll={selectAll === SelectAllStatus.AllAvailable}
               where={where}
             />
-            <PublishMany_v4
+            <PublishMany
               collection={collectionConfig}
               count={count}
               ids={selectedIDs}
@@ -118,7 +118,7 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
               selectAll={selectAll === SelectAllStatus.AllAvailable}
               where={where}
             />
-            <UnpublishMany_v4
+            <UnpublishMany
               collection={collectionConfig}
               count={count}
               ids={selectedIDs}


### PR DESCRIPTION
Removes the  suffix from the bulk publish/unpublish components in  and updates internal list-selection usage to call  and  directly.

 and  now accept both legacy and v4-style props through a single component surface, so custom components that only pass  continue to work while the list views continue passing explicit selection state.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214557558212719