### PR TITLE
fix(ui): normalize description spacing for radio and rich text fields

### DIFF
--- a/packages/richtext-lexical/src/field/index.css
+++ b/packages/richtext-lexical/src/field/index.css
@@ -35,10 +35,9 @@
   .rich-text-lexical__wrap {
     width: 100%;
     position: relative;
-
-    > .field-description {
-      margin-top: var(--spacer-2);
-    }
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacer-2);
   }
 
   .rich-text-lexical--read-only {

--- a/packages/richtext-lexical/src/utilities/fieldsDrawer/index.css
+++ b/packages/richtext-lexical/src/utilities/fieldsDrawer/index.css
@@ -9,8 +9,4 @@
       padding: var(--spacer-3);
     }
   }
-
-  .fields-drawer .radio-group .field-description {
-    margin-top: var(--spacer-2);
-  }
 }

--- a/packages/ui/src/fields/RadioGroup/index.css
+++ b/packages/ui/src/fields/RadioGroup/index.css
@@ -4,6 +4,12 @@
     flex-direction: column;
     gap: var(--spacer-2);
 
+    .field-type__wrap {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacer-2);
+    }
+
     .tooltip:not([aria-hidden='true']) {
       right: auto;
       position: static;

--- a/test/v4/collections/Radio/index.ts
+++ b/test/v4/collections/Radio/index.ts
@@ -9,6 +9,9 @@ const RadioFields: CollectionConfig = {
       name: 'contentType',
       type: 'radio',
       label: 'Content Type',
+      admin: {
+        description: 'Choose the type of content this entry represents.',
+      },
       options: [
         { label: 'Article', value: 'article' },
         { label: 'Video', value: 'video' },
@@ -20,6 +23,9 @@ const RadioFields: CollectionConfig = {
       type: 'radio',
       label: 'Content Type (Required)',
       required: true,
+      admin: {
+        description: 'Choose the type of content this required field represents.',
+      },
       options: [
         { label: 'Article', value: 'article' },
         { label: 'Video', value: 'video' },
@@ -33,6 +39,7 @@ const RadioFields: CollectionConfig = {
       defaultValue: 'video',
       admin: {
         disabled: true,
+        description: 'This disabled radio field still renders its description text.',
       },
       options: [
         { label: 'Article', value: 'article' },
@@ -47,6 +54,7 @@ const RadioFields: CollectionConfig = {
       defaultValue: 'podcast',
       admin: {
         readOnly: true,
+        description: 'This read-only radio field should keep consistent description spacing.',
       },
       options: [
         { label: 'Article', value: 'article' },
@@ -60,6 +68,7 @@ const RadioFields: CollectionConfig = {
       label: 'Content Type (Vertical)',
       admin: {
         layout: 'vertical',
+        description: 'Vertical radio options should match field description spacing.',
       },
       options: [
         { label: 'Article', value: 'article' },
@@ -74,6 +83,7 @@ const RadioFields: CollectionConfig = {
       required: true,
       admin: {
         layout: 'vertical',
+        description: 'Required vertical radio field with description text.',
       },
       options: [
         { label: 'Article', value: 'article' },
@@ -89,6 +99,7 @@ const RadioFields: CollectionConfig = {
       admin: {
         layout: 'vertical',
         disabled: true,
+        description: 'Disabled vertical radio field with description text.',
       },
       options: [
         { label: 'Article', value: 'article' },
@@ -104,6 +115,7 @@ const RadioFields: CollectionConfig = {
       admin: {
         layout: 'vertical',
         readOnly: true,
+        description: 'Read-only vertical radio field with description text.',
       },
       options: [
         { label: 'Article', value: 'article' },

--- a/test/v4/collections/RichText/index.ts
+++ b/test/v4/collections/RichText/index.ts
@@ -83,6 +83,9 @@ const RichTextFields: CollectionConfig = {
     {
       name: 'table',
       type: 'richText',
+      admin: {
+        description: 'Rich text table field used to validate description spacing.',
+      },
       editor: lexicalEditor({
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
@@ -94,6 +97,9 @@ const RichTextFields: CollectionConfig = {
     {
       name: 'code',
       type: 'richText',
+      admin: {
+        description: 'Rich text code block field used to validate description spacing.',
+      },
       editor: lexicalEditor({
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
@@ -107,6 +113,9 @@ const RichTextFields: CollectionConfig = {
     {
       name: 'typography',
       type: 'richText',
+      admin: {
+        description: 'Rich text typography field used to validate description spacing.',
+      },
       editor: lexicalEditor({
         features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
       }),
@@ -114,6 +123,9 @@ const RichTextFields: CollectionConfig = {
     {
       name: 'lists',
       type: 'richText',
+      admin: {
+        description: 'Rich text list field used to validate description spacing.',
+      },
       editor: lexicalEditor({
         features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
       }),


### PR DESCRIPTION
Normalizes admin field description spacing for `radio` and Lexical `richText` fields so it matches other fields.

Adds `admin.description` values to the v4 `Radio` and `RichText` test collections so this spacing is visible in test coverage.

## Radio Field

### Before
<img width="471" height="612" alt="CleanShot 2026-06-17 at 11 41 39" src="https://github.com/user-attachments/assets/90972fec-4ba9-4d50-9598-20fd255e067e" />

### After
<img width="454" height="647" alt="CleanShot 2026-06-17 at 11 41 46" src="https://github.com/user-attachments/assets/6daf2a59-01d5-4351-80c8-10d1bf4b8ef5" />


## Rich Text Field

### Before
<img width="384" height="193" alt="CleanShot 2026-06-17 at 11 43 20" src="https://github.com/user-attachments/assets/53a2e810-29b5-44ad-95cd-b4fcb0b93dfb" />

### After
<img width="372" height="200" alt="CleanShot 2026-06-17 at 11 43 28" src="https://github.com/user-attachments/assets/dd5f575f-c4dc-4923-879b-01705b97eb52" />
