### PR TITLE
fix(ui): make linked table cells fully clickable in drawers

### DIFF
--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -49,16 +49,30 @@
     }
 
     /* Linked cells: move padding to the anchor/button for full-cell clickability */
-    .cell--linked {
+    td.cell--linked {
       padding: 0;
+
+      &:first-child,
+      &:last-child {
+        padding: 0;
+      }
 
       > :is(a, button) {
         display: flex;
         align-items: center;
+        width: 100%;
         padding: var(--spacer-2) var(--spacer-2-5);
         min-height: calc(var(--spacer-4) * 2);
         cursor: pointer;
       }
+
+      &:first-child > :is(a, button) {
+        padding-inline-start: var(--gutter-h);
+      }
+    }
+
+    .drawer & td.cell--linked:first-child > :is(a, button) {
+      padding-inline-start: var(--spacer-3);
     }
 
     #heading-_select,
@@ -178,10 +192,18 @@
     }
 
     /* Linked cells: move padding to the anchor/button for full-cell clickability */
-    .cell--linked {
+    td.cell--linked {
       padding: 0;
 
+      &:first-child,
+      &:last-child {
+        padding: 0;
+      }
+
       > :is(a, button) {
+        display: flex;
+        align-items: center;
+        width: 100%;
         padding: 0 var(--spacer-2-5);
         min-height: var(--spacer-5);
         cursor: pointer;

--- a/packages/ui/src/views/Versions/index.css
+++ b/packages/ui/src/views/Versions/index.css
@@ -37,10 +37,6 @@
     overflow: auto;
   }
 
-  .versions .table th:first-child {
-    padding-inline-start: var(--gutter-h);
-  }
-
   .versions .table td:first-child:not(.cell--linked) {
     padding-inline-start: var(--gutter-h);
   }


### PR DESCRIPTION
Makes the linked cell in drawer-rendered tables fill the entire `<td>`, matching the list view where the whole cell is clickable rather than just the text.

In drawer tables the linked column is the first cell, since drawers have no row-select checkbox column. The `td:first-child` padding rules - in particular the drawer variant `.drawer .table td:first-child` (specificity `(0,3,1)`) - overrode `.cell--linked { padding: 0 }` (specificity `(0,2,0)`), leaving padding on the `<td>` that the inner element did not cover. Drawer linked cells also render a `<button>` (with an `onSelect` handler) instead of an `<a>`, and a button with `width: auto` only sizes to its text, so only the text was clickable.

The fix scopes the linked-cell rules to `td.cell--linked` with explicit `:first-child` / `:last-child` padding resets so they win over the cell padding rules, adds `width: 100%` to the inner `<a>`/`<button>` so buttons stretch like anchors, and moves the first-cell gutter onto the inner element so text alignment is unchanged.

Before:

The drawer linked cell renders a `<button>` sized to its text — only the text is clickable.

After:

The `<button>` fills the full cell (width and height) with `cursor: pointer`, matching the list view `<a>` behavior.
