### PR TITLE
fix(drizzle): use table alias when sorting joined drafts by a localized field

### DIFF
--- a/packages/drizzle/src/queries/buildOrderBy.ts
+++ b/packages/drizzle/src/queries/buildOrderBy.ts
@@ -78,6 +78,7 @@ export const buildOrderBy = ({
     try {
       const { columnName: sortTableColumnName, table: sortTable } = getTableColumnFromPath({
         adapter,
+        aliasTable,
         collectionPath: sortProperty,
         fields,
         joins,

--- a/test/localization/localizeStatus.config.ts
+++ b/test/localization/localizeStatus.config.ts
@@ -52,6 +52,24 @@ export default buildConfigWithDefaults({
       // Explicitly disabled — migration should skip collections without versions
       versions: false,
     },
+    // Joined draft collection sorted by a localized field (`_status`) — repros #15248.
+    {
+      slug: 'joinOrgs',
+      fields: [
+        { name: 'title', type: 'text', localized: true },
+        { name: 'repos', type: 'join', collection: 'joinRepos', on: 'org' },
+      ],
+      versions: { drafts: true },
+    },
+    {
+      slug: 'joinRepos',
+      defaultSort: ['_status', '-updatedAt'],
+      fields: [
+        { name: 'org', type: 'relationship', relationTo: 'joinOrgs' },
+        { name: 'title', type: 'text', localized: true },
+      ],
+      versions: { drafts: true },
+    },
   ],
   localization: {
     defaultLocale: 'en',

--- a/test/localization/localizeStatus.int.spec.ts
+++ b/test/localization/localizeStatus.int.spec.ts
@@ -8,7 +8,7 @@ import { sql as drizzleSql } from 'drizzle-orm'
 import { Types } from 'mongoose'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 
@@ -26,6 +26,43 @@ describe('localizeStatus migration', () => {
     if (payload?.db && typeof payload.db.destroy === 'function') {
       await payload.db.destroy()
     }
+  })
+
+  describe('querying a joined localized draft collection', () => {
+    const createdOrgIDs: Array<number | string> = []
+
+    afterEach(async () => {
+      for (const id of createdOrgIDs) {
+        await payload.delete({ id, collection: 'joinOrgs' })
+      }
+      createdOrgIDs.length = 0
+    })
+
+    // Used to throw `invalid reference to FROM-clause entry for table "_r_v"` on Postgres
+    // because the join subquery's ORDER BY referenced the un-aliased version table.
+    it('should not throw when the joined collection sorts by a localized field', async () => {
+      const org = await payload.create({
+        collection: 'joinOrgs',
+        data: { title: 'Acme' },
+        locale: 'en',
+      })
+      createdOrgIDs.push(org.id)
+
+      await payload.create({
+        collection: 'joinRepos',
+        data: { org: org.id, title: 'repo-a' },
+        locale: 'en',
+      })
+
+      const result = await payload.find({
+        collection: 'joinOrgs',
+        draft: true,
+        locale: 'en',
+      })
+
+      expect(result.docs).toHaveLength(1)
+      expect(result.docs[0]?.repos?.docs).toHaveLength(1)
+    })
   })
 
   describe.skipIf(process.env.PAYLOAD_DATABASE !== 'postgres')('PostgreSQL', () => {

--- a/test/localization/localizeStatus.int.spec.ts
+++ b/test/localization/localizeStatus.int.spec.ts
@@ -28,42 +28,47 @@ describe('localizeStatus migration', () => {
     }
   })
 
-  describe('querying a joined localized draft collection', () => {
-    const createdOrgIDs: Array<number | string> = []
+  // SQL-adapter only: the bug is a Postgres FROM-clause error in the join ORDER BY, which
+  // cannot occur on MongoDB (no SQL join subquery there).
+  describe.skipIf(process.env.PAYLOAD_DATABASE === 'mongodb')(
+    'querying a joined localized draft collection',
+    () => {
+      const createdOrgIDs: Array<number | string> = []
 
-    afterEach(async () => {
-      for (const id of createdOrgIDs) {
-        await payload.delete({ id, collection: 'joinOrgs' })
-      }
-      createdOrgIDs.length = 0
-    })
-
-    // Used to throw `invalid reference to FROM-clause entry for table "_r_v"` on Postgres
-    // because the join subquery's ORDER BY referenced the un-aliased version table.
-    it('should not throw when the joined collection sorts by a localized field', async () => {
-      const org = await payload.create({
-        collection: 'joinOrgs',
-        data: { title: 'Acme' },
-        locale: 'en',
-      })
-      createdOrgIDs.push(org.id)
-
-      await payload.create({
-        collection: 'joinRepos',
-        data: { org: org.id, title: 'repo-a' },
-        locale: 'en',
+      afterEach(async () => {
+        for (const id of createdOrgIDs) {
+          await payload.delete({ id, collection: 'joinOrgs' })
+        }
+        createdOrgIDs.length = 0
       })
 
-      const result = await payload.find({
-        collection: 'joinOrgs',
-        draft: true,
-        locale: 'en',
-      })
+      // Used to throw `invalid reference to FROM-clause entry for table "_r_v"` on Postgres
+      // because the join subquery's ORDER BY referenced the un-aliased version table.
+      it('should not throw when the joined collection sorts by a localized field', async () => {
+        const org = await payload.create({
+          collection: 'joinOrgs',
+          data: { title: 'Acme' },
+          locale: 'en',
+        })
+        createdOrgIDs.push(org.id)
 
-      expect(result.docs).toHaveLength(1)
-      expect(result.docs[0]?.repos?.docs).toHaveLength(1)
-    })
-  })
+        await payload.create({
+          collection: 'joinRepos',
+          data: { org: org.id, title: 'repo-a' },
+          locale: 'en',
+        })
+
+        const result = await payload.find({
+          collection: 'joinOrgs',
+          draft: true,
+          locale: 'en',
+        })
+
+        expect(result.docs).toHaveLength(1)
+        expect(result.docs[0]?.repos?.docs).toHaveLength(1)
+      })
+    },
+  )
 
   describe.skipIf(process.env.PAYLOAD_DATABASE !== 'postgres')('PostgreSQL', () => {
     // Reset both test collections to their pre-migration database shape before every


### PR DESCRIPTION
### What?

Fixes invalid SQL (`invalid reference to FROM-clause entry for table "_r_v"`) when querying a collection that joins a localized draft collection whose default sort is a localized field (for example `_status` when `localizeStatus` is on), with a locale set. Postgres-specific.

### Why?

`buildOrderBy` runs against the join subquery's aliased version table, but it called `getTableColumnFromPath` without passing `aliasTable`. The `where` builder (`parseParams`) already passes it. For a localized sort column, `getTableColumnFromPath` builds the locales JOIN condition from `(aliasTable || adapter.tables[tableName]).id`; with `aliasTable` omitted it referenced the canonical, un-aliased version table, which isn't in the subquery's FROM clause - so Postgres rejected the query.

### How?

Pass `aliasTable` into the `getTableColumnFromPath` call in `buildOrderBy`, matching `parseParams`. The locales JOIN now references the aliased version table that's actually in scope.

Added an integration test in the `localizeStatus` suite (a join onto a draft collection sorted by `_status`) that fails on Postgres before the change and passes after.

Fixes #15248