### PR TITLE
fix(ui): don't crash admin render on unparseable custom component route path

### DIFF
--- a/packages/ui/src/utilities/isPathMatchingRoute.spec.ts
+++ b/packages/ui/src/utilities/isPathMatchingRoute.spec.ts
@@ -181,4 +181,26 @@ describe('isPathMatchingRoute', () => {
       ).toBe(false)
     })
   })
+
+  describe('paths that path-to-regexp cannot parse — regression for #15241', () => {
+    it('should not throw on a trailing bare colon', () => {
+      expect(() =>
+        isPathMatchingRoute({ currentRoute: '/admin/foo', path: '/foo/:' }),
+      ).not.toThrow()
+    })
+
+    it('should not throw on consecutive colons', () => {
+      expect(() =>
+        isPathMatchingRoute({ currentRoute: '/admin/foo', path: '/foo::bar' }),
+      ).not.toThrow()
+    })
+
+    it('should not match an unrelated route against an unparseable path', () => {
+      expect(isPathMatchingRoute({ currentRoute: '/dashboard', path: '/foo/:' })).toBe(false)
+    })
+
+    it('should fall back to literal equality for an unparseable path when exact', () => {
+      expect(isPathMatchingRoute({ currentRoute: '/foo/:', exact: true, path: '/foo/:' })).toBe(true)
+    })
+  })
 })

--- a/packages/ui/src/utilities/isPathMatchingRoute.ts
+++ b/packages/ui/src/utilities/isPathMatchingRoute.ts
@@ -19,12 +19,21 @@ export const isPathMatchingRoute = ({
 
   const keys = []
 
-  const regex = pathToRegexp(viewPath, keys, {
-    sensitive,
-    strict,
-  })
+  // A view path that is not a valid path-to-regexp pattern (e.g. a stray ":")
+  // makes pathToRegexp throw, which would crash the whole admin render since
+  // this runs inside route-matching `.find` callbacks. Treat an unparseable
+  // pattern as a literal string and fall back to plain comparison.
+  let match: null | RegExpExecArray = null
 
-  const match = regex.exec(currentRoute)
+  try {
+    match = pathToRegexp(viewPath, keys, {
+      sensitive,
+      strict,
+    }).exec(currentRoute)
+  } catch {
+    match = null
+  }
+
   const viewRoute = match?.[0] || viewPath
 
   if (exact) {


### PR DESCRIPTION
### What?

When a custom admin component's route path can't be parsed by `path-to-regexp` (for example a path containing a stray `:`), `isPathMatchingRoute` threw an uncaught `TypeError: Missing parameter name at N`. Because this runs inside the `.find()` callbacks that match custom-component routes, the throw crashed the entire admin server render. This change catches the parse error and falls back to a literal path comparison.

### Why?

This is the root cause behind #15241: with `@payloadcms/plugin-multi-tenant`, any custom admin component (`views`, `afterNavLinks`, `beforeNavLinks`, ...) could surface a route path that `path-to-regexp` 6.3.0 rejects, and a single bad pattern took down the whole panel with `TypeError: Missing parameter name at 5`. A pattern that can't be compiled should simply not match, not crash route matching for every page.

### How?

Wrapped the `pathToRegexp(...).exec(...)` call in `isPathMatchingRoute` in a `try/catch`. On a parse error, `match` is `null`, so the existing fallback (`viewRoute = viewPath`) does a plain literal comparison: strict equality when `exact`, and the existing segment-boundary `startsWith` check otherwise. Because the fallback compares against the full literal pattern, it can't produce greedy false-positive matches. Added regression tests covering the previously-throwing inputs.

Fixes #15241