### PR TITLE
fix(ui): adjust header text and icon color only when hovered

### DIFF
--- a/packages/ui/src/elements/SortColumn/index.css
+++ b/packages/ui/src/elements/SortColumn/index.css
@@ -1,6 +1,6 @@
 @layer payload-default {
   .sort-column {
-    display: flex;
+    display: inline-flex;
     gap: var(--spacer-1);
     align-items: center;
   }


### PR DESCRIPTION
Changes `SortColumn` header content to use `inline-flex` so hover styling only affects the text/icon cluster, not the full header cell hit area.

This keeps header color changes scoped to intentional hover on the sort control and prevents visual bleed across the column header.

### Before

https://github.com/user-attachments/assets/55565304-391c-48e5-9cbb-b42bfcd30c2d

### After

https://github.com/user-attachments/assets/7795b5c0-bc34-4bdb-8202-4c3504489bbd

