### PR TITLE
fix(graphql): register distinct block types when collections share a block slug

### DIFF
--- a/packages/graphql/src/schema/blocks.spec.ts
+++ b/packages/graphql/src/schema/blocks.spec.ts
@@ -1,0 +1,71 @@
+import type { Config } from 'payload'
+
+import { isObjectType, type GraphQLObjectType } from 'graphql'
+import { sanitizeConfig } from 'payload'
+import { describe, expect, it } from 'vitest'
+
+import { configToSchema } from '../index.js'
+
+describe('configToSchema - blocks', () => {
+  it('builds distinct GraphQL types for inline blocks that share a slug across collections', async () => {
+    // Two collections each define an inline block with the SAME slug ('text') but a
+    // different interfaceName and different fields. The GraphQL schema builder must
+    // register both object types, not reuse the first one for the second collection.
+    // @ts-expect-error - intentionally minimal config for a unit test of the schema builder
+    const config: Config = {
+      db: { defaultIDType: 'text' },
+      collections: [
+        {
+          slug: 'a',
+          fields: [
+            {
+              name: 'items',
+              type: 'blocks',
+              blocks: [
+                {
+                  slug: 'text',
+                  fields: [{ name: 'showOnA', type: 'text' }],
+                  interfaceName: 'ABlockText',
+                },
+              ],
+            },
+          ],
+          timestamps: false,
+          versions: false,
+        },
+        {
+          slug: 'b',
+          fields: [
+            {
+              name: 'items',
+              type: 'blocks',
+              blocks: [
+                {
+                  slug: 'text',
+                  fields: [{ name: 'showOnB', type: 'text' }],
+                  interfaceName: 'BBlockText',
+                },
+              ],
+            },
+          ],
+          timestamps: false,
+          versions: false,
+        },
+      ],
+    }
+
+    const sanitizedConfig = await sanitizeConfig(config)
+    const { schema } = configToSchema(sanitizedConfig)
+
+    const aType = schema.getType('ABlockText')
+    const bType = schema.getType('BBlockText')
+
+    expect(isObjectType(aType)).toBe(true)
+    expect((aType as GraphQLObjectType).getFields()).toHaveProperty('showOnA')
+
+    // Before the fix, collection B's 'text' block reused collection A's cached type
+    // (keyed by slug), so BBlockText was never registered and showOnB was unqueryable.
+    expect(isObjectType(bType)).toBe(true)
+    expect((bType as GraphQLObjectType).getFields()).toHaveProperty('showOnB')
+  })
+})

--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -165,16 +165,29 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
     parentIsLocalized,
     parentName,
   }) => {
+    // Per-field map of block slug -> GraphQL type, used by the union's `resolveType`.
+    // Block slugs are unique within a single blocks field, but not across collections,
+    // so resolution must not rely on the shared `graphqlResult.types.blockTypes` cache,
+    // which is keyed by the globally-unique GraphQL type name.
+    const blockTypesBySlug: Record<string, GraphQLObjectType<any, any>> = {}
+
     const blockTypes: GraphQLObjectType<any, any>[] = field.blocks.reduce((acc, _block) => {
-      const blockSlug = typeof _block === 'string' ? _block : _block.slug
-      if (!graphqlResult.types.blockTypes[blockSlug]) {
-        // TODO: iterate over blocks mapped to block slug in v4, or pass through payload.blocks
-        const block =
-          typeof _block === 'string' ? config.blocks.find((b) => b.slug === _block) : _block
+      // TODO: iterate over blocks mapped to block slug in v4, or pass through payload.blocks
+      const block =
+        typeof _block === 'string' ? config.blocks.find((b) => b.slug === _block) : _block
 
-        const interfaceName =
-          block?.interfaceName || block?.graphQL?.singularName || toWords(block.slug, true)
+      if (!block) {
+        return acc
+      }
 
+      const interfaceName =
+        block.interfaceName || block.graphQL?.singularName || toWords(block.slug, true)
+
+      // Cache by the GraphQL type name, not the slug. Two different collections can each
+      // define an inline block that shares a slug but has a different interfaceName and
+      // fields; keying by slug made the second reuse the first's type. Type names are
+      // globally unique, so the interfaceName is the correct, collision-free key.
+      if (!graphqlResult.types.blockTypes[interfaceName]) {
         const objectType = buildObjectType({
           name: interfaceName,
           config,
@@ -197,12 +210,14 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
             ...objectType.extensions,
             blockSlug: block.slug,
           }
-          graphqlResult.types.blockTypes[block.slug] = objectType
+          graphqlResult.types.blockTypes[interfaceName] = objectType
         }
       }
 
-      if (graphqlResult.types.blockTypes[blockSlug]) {
-        acc.push(graphqlResult.types.blockTypes[blockSlug])
+      const objectType = graphqlResult.types.blockTypes[interfaceName]
+      if (objectType) {
+        acc.push(objectType)
+        blockTypesBySlug[block.slug] = objectType
       }
 
       return acc
@@ -218,7 +233,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       new GraphQLNonNull(
         new GraphQLUnionType({
           name: fullName,
-          resolveType: (data) => graphqlResult.types.blockTypes[data.blockType].name,
+          resolveType: (data) => blockTypesBySlug[data.blockType].name,
           types: blockTypes,
         }),
       ),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,12 @@ export default defineConfig({
         // Vite 8 / oxc reads `jsx: preserve` from the workspace tsconfig (needed by Next.js)
         // and refuses to transform JSX. Set jsx explicitly here so oxc transforms it.
         // Project vite options are NOT inherited from the root config.
+        resolve: {
+          alias: [
+            { find: /^graphql\/(.*)/, replacement: graphqlDir + '/$1' },
+            { find: /^graphql$/, replacement: path.join(graphqlDir, 'index.js') },
+          ],
+        },
         oxc: {
           jsx: {
             runtime: 'automatic',


### PR DESCRIPTION
### What?

When two collections each define an inline block that shares a slug but has a different `interfaceName` and different fields, the GraphQL schema builder registered only the first block's type and reused it for the second collection. Queries against the second collection's block union returned the wrong shape, and selecting that block's own fields failed with `Cannot query field "X" on type "<other-collection-block>"`.

### Why?

In `packages/graphql/src/schema/fieldToSchemaMap.ts`, block object types are cached in `graphqlResult.types.blockTypes`, keyed by `block.slug`. That cache is shared across every collection, so a second block with the same slug hit the cache and reused the first block's type, ignoring its different `interfaceName`. `payload generate:types` already handles the same config correctly, so the bug was isolated to the GraphQL schema builder.

### How?

Key the cache by `interfaceName` (the GraphQL type name, which is globally unique) instead of the slug, so two blocks that share a slug but have different interface names each get their own type. The union's `resolveType` now resolves the concrete type from a per-field slug map, since slugs are unique within a single blocks field but not across collections.

Added a unit test in `packages/graphql/src/schema/blocks.spec.ts` that builds a schema from two collections sharing a block slug and asserts both block types are registered with their own fields. Building a real schema needs `graphql` resolved to a single instance, so I added the same alias the `int` project already uses to the `unit` vitest project. Happy to move the test into the integration suite instead if you'd prefer that over the config change.

Fixes #16769
