### PR TITLE
fix(richtext-lexical): preserve hard line breaks on markdown import

### DIFF
--- a/packages/richtext-lexical/src/packages/@lexical/markdown/LexicalMarkdownHardLineBreak.spec.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/LexicalMarkdownHardLineBreak.spec.ts
@@ -1,14 +1,17 @@
 import { createHeadlessEditor } from '@lexical/headless'
+import { LinkNode } from '@lexical/link'
 import { ListItemNode, ListNode } from '@lexical/list'
 import { HeadingNode, QuoteNode } from '@lexical/rich-text'
-import { $getRoot, $isElementNode, $isLineBreakNode } from 'lexical'
+import { $getRoot, $getState, $isElementNode, $isLineBreakNode, $isTextNode } from 'lexical'
 import { describe, expect, it } from 'vitest'
 
 import { $convertFromMarkdownString, $convertToMarkdownString } from './index.js'
-import { normalizeMarkdown } from './MarkdownTransformers.js'
+import { hardLineBreakState, normalizeMarkdown } from './MarkdownTransformers.js'
 
 function createEditor() {
-  return createHeadlessEditor({ nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode] })
+  return createHeadlessEditor({
+    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, LinkNode],
+  })
 }
 
 function importMarkdown(markdown: string): { hasLineBreak: boolean; textContent: string } {
@@ -23,6 +26,38 @@ function importMarkdown(markdown: string): { hasLineBreak: boolean; textContent:
     result = {
       hasLineBreak: firstChild.getChildren().some((child) => $isLineBreakNode(child)),
       textContent: firstChild.getTextContent(),
+    }
+  })
+  return result
+}
+
+// Returns the hard line break marker stored on the first LineBreakNode of the
+// first block, plus the text content of every text node in that block. Used to
+// assert the marker was moved off the text and onto the line break node, even
+// when the trailing whitespace was split into its own text node by an inline
+// transformer (e.g. after bold or a link).
+function getStoredHardLineBreak(markdown: string): {
+  marker: string
+  textNodeTexts: string[]
+} {
+  const editor = createEditor()
+  editor.update(() => $convertFromMarkdownString(markdown), { discrete: true })
+  let result = { marker: '', textNodeTexts: [] as string[] }
+  editor.getEditorState().read(() => {
+    const block = $getRoot().getFirstChild()
+    if (!$isElementNode(block)) {
+      throw new Error('Expected an element block')
+    }
+    const lineBreakNode = block.getChildren().find((child) => $isLineBreakNode(child))
+    if (lineBreakNode === undefined) {
+      throw new Error('Expected a line break node')
+    }
+    result = {
+      marker: $getState(lineBreakNode, hardLineBreakState),
+      textNodeTexts: block
+        .getChildren()
+        .filter($isTextNode)
+        .map((child) => child.getTextContent()),
     }
   })
   return result
@@ -80,6 +115,27 @@ describe('markdown hard line break import', () => {
     expect(hasLineBreak).toBe(true)
     expect(textContent).toBe('foo\nbar')
   })
+
+  it('should store the marker on the line break when the hard break follows formatted text', () => {
+    const { marker, textNodeTexts } = getStoredHardLineBreak('**foo**  \nbar')
+
+    expect(marker).toBe('  ')
+    // The trailing-space marker is split into its own text node by the bold
+    // transformer; it must be moved onto the line break node, not left as text.
+    expect(textNodeTexts).not.toContain('  ')
+  })
+
+  it('should store the exact number of trailing spaces when the hard break follows formatted text', () => {
+    const { marker } = getStoredHardLineBreak('**foo**   \nbar')
+
+    expect(marker).toBe('   ')
+  })
+
+  it('should store the marker on the line break when the hard break follows a link', () => {
+    const { marker } = getStoredHardLineBreak('[foo](https://payloadcms.com)  \nbar')
+
+    expect(marker).toBe('  ')
+  })
 })
 
 describe('markdown hard line break round trip', () => {
@@ -95,5 +151,15 @@ describe('markdown hard line break round trip', () => {
 
   it('should not introduce a hard break for a soft wrap', () => {
     expect(roundTrip(['foo', 'bar'].join('\n'))).toBe('foo bar')
+  })
+
+  it('should round trip a hard break after formatted text', () => {
+    const md = '**foo**  \nbar'
+    expect(roundTrip(md)).toBe(md)
+  })
+
+  it('should round trip a hard break after a link', () => {
+    const md = '[foo](https://payloadcms.com)  \nbar'
+    expect(roundTrip(md)).toBe(md)
   })
 })

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/LexicalMarkdownHardLineBreak.spec.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/LexicalMarkdownHardLineBreak.spec.ts
@@ -1,0 +1,99 @@
+import { createHeadlessEditor } from '@lexical/headless'
+import { ListItemNode, ListNode } from '@lexical/list'
+import { HeadingNode, QuoteNode } from '@lexical/rich-text'
+import { $getRoot, $isElementNode, $isLineBreakNode } from 'lexical'
+import { describe, expect, it } from 'vitest'
+
+import { $convertFromMarkdownString, $convertToMarkdownString } from './index.js'
+import { normalizeMarkdown } from './MarkdownTransformers.js'
+
+function createEditor() {
+  return createHeadlessEditor({ nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode] })
+}
+
+function importMarkdown(markdown: string): { hasLineBreak: boolean; textContent: string } {
+  const editor = createEditor()
+  editor.update(() => $convertFromMarkdownString(markdown), { discrete: true })
+  let result = { hasLineBreak: false, textContent: '' }
+  editor.getEditorState().read(() => {
+    const firstChild = $getRoot().getFirstChild()
+    if (!$isElementNode(firstChild)) {
+      throw new Error('Expected an element block')
+    }
+    result = {
+      hasLineBreak: firstChild.getChildren().some((child) => $isLineBreakNode(child)),
+      textContent: firstChild.getTextContent(),
+    }
+  })
+  return result
+}
+
+function roundTrip(markdown: string): string {
+  const editor = createEditor()
+  editor.update(() => $convertFromMarkdownString(markdown), { discrete: true })
+  let output = ''
+  editor.getEditorState().read(() => {
+    output = $convertToMarkdownString()
+  })
+  return output
+}
+
+describe('markdown hard line break normalization', () => {
+  it('should preserve trailing-space hard breaks when merging adjacent lines', () => {
+    const md = ['foo  ', 'bar'].join('\n')
+    expect(normalizeMarkdown(md, true)).toBe(md)
+  })
+
+  it('should preserve the exact number of trailing spaces', () => {
+    const md = ['foo   ', 'bar'].join('\n')
+    expect(normalizeMarkdown(md, true)).toBe(md)
+  })
+
+  it('should preserve backslash hard breaks when merging adjacent lines', () => {
+    const md = 'foo\\\nbar'
+    expect(normalizeMarkdown(md, true)).toBe(md)
+  })
+
+  it('should still merge a soft break into the previous line', () => {
+    const md = ['foo', 'bar'].join('\n')
+    expect(normalizeMarkdown(md, true)).toBe('foo bar')
+  })
+
+  it('should merge a soft break before a hard-breaking line', () => {
+    const md = ['foo', 'bar  ', 'baz'].join('\n')
+    expect(normalizeMarkdown(md, true)).toBe(['foo bar  ', 'baz'].join('\n'))
+  })
+})
+
+describe('markdown hard line break import', () => {
+  it('should import a trailing-space hard break as a line break node with the marker stripped', () => {
+    const { hasLineBreak, textContent } = importMarkdown(['foo  ', 'bar'].join('\n'))
+
+    expect(hasLineBreak).toBe(true)
+    // The marker is stripped from the text and represented by the line break node.
+    expect(textContent).toBe('foo\nbar')
+  })
+
+  it('should import a backslash hard break as a line break node with the marker stripped', () => {
+    const { hasLineBreak, textContent } = importMarkdown('foo\\\nbar')
+
+    expect(hasLineBreak).toBe(true)
+    expect(textContent).toBe('foo\nbar')
+  })
+})
+
+describe('markdown hard line break round trip', () => {
+  it('should round trip a trailing-space hard break', () => {
+    const md = ['foo  ', 'bar'].join('\n')
+    expect(roundTrip(md)).toBe(md)
+  })
+
+  it('should round trip a backslash hard break', () => {
+    const md = 'foo\\\nbar'
+    expect(roundTrip(md)).toBe(md)
+  })
+
+  it('should not introduce a hard break for a soft wrap', () => {
+    expect(roundTrip(['foo', 'bar'].join('\n'))).toBe('foo bar')
+  })
+})

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
@@ -6,9 +6,16 @@
  *
  */
 
-import type { ElementNode, LexicalNode, TextFormatType, TextNode } from 'lexical'
+import type { ElementNode, LexicalNode, LineBreakNode, TextFormatType, TextNode } from 'lexical'
 
-import { $getRoot, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isTextNode } from 'lexical'
+import {
+  $getRoot,
+  $getState,
+  $isDecoratorNode,
+  $isElementNode,
+  $isLineBreakNode,
+  $isTextNode,
+} from 'lexical'
 
 import type {
   ElementTransformer,
@@ -18,6 +25,7 @@ import type {
   Transformer,
 } from './MarkdownTransformers.js'
 
+import { hardLineBreakState } from './MarkdownTransformers.js'
 import { isEmptyParagraph, transformersByType } from './utils.js'
 
 /**
@@ -161,7 +169,7 @@ function exportChildren(
     }
 
     if ($isLineBreakNode(child)) {
-      output.push('\n')
+      output.push($exportLineBreak(child))
     } else if ($isTextNode(child)) {
       output.push(
         exportTextFormat(
@@ -189,6 +197,13 @@ function exportChildren(
   }
 
   return output.join('')
+}
+
+// Prefixes the newline with the original CommonMark hard line break marker
+// (`\` or trailing spaces) when one was preserved on import, otherwise exports a
+// plain soft line break.
+function $exportLineBreak(node: LineBreakNode): string {
+  return $getState(node, hardLineBreakState) + '\n'
 }
 
 function exportTextFormat(

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
@@ -13,7 +13,6 @@ import { $isListItemNode, $isListNode } from '@lexical/list'
 import { $isQuoteNode } from '@lexical/rich-text'
 import { $findMatchingParent } from '@lexical/utils'
 import {
-  $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
@@ -30,6 +29,7 @@ import type {
 } from './MarkdownTransformers.js'
 
 import { importTextTransformers } from './importTextTransformers.js'
+import { $createMarkdownLineBreakNode } from './MarkdownTransformers.js'
 import { isEmptyParagraph, transformersByType } from './utils.js'
 
 export type TextFormatTransformersIndex = Readonly<{
@@ -231,7 +231,7 @@ function $importBlocks(
 
       if (targetNode != null && targetNode.getTextContentSize() > 0) {
         targetNode.splice(targetNode.getChildrenSize(), 0, [
-          $createLineBreakNode(),
+          $createMarkdownLineBreakNode(targetNode),
           ...elementNode.getChildren(),
         ])
         elementNode.remove()

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownTransformers.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownTransformers.ts
@@ -9,7 +9,14 @@
 
 import type { ListType } from '@lexical/list'
 import type { HeadingTagType } from '@lexical/rich-text'
-import type { ElementNode, Klass, LexicalNode, TextFormatType, TextNode } from 'lexical'
+import type {
+  ElementNode,
+  Klass,
+  LexicalNode,
+  LineBreakNode,
+  TextFormatType,
+  TextNode,
+} from 'lexical'
 
 import {
   $createListItemNode,
@@ -27,7 +34,13 @@ import {
   HeadingNode,
   QuoteNode,
 } from '@lexical/rich-text'
-import { $createLineBreakNode } from 'lexical'
+import {
+  $createLineBreakNode,
+  $isLineBreakNode,
+  $isTextNode,
+  $setState,
+  createState,
+} from 'lexical'
 
 export type Transformer =
   | ElementTransformer
@@ -199,6 +212,106 @@ const TABLE_ROW_DIVIDER_REG_EXP = /^(\| ?:?-*:? ?)+\|\s?$/
 const TAG_START_REGEX = /^[ \t]*<[a-z_][\w-]*(?:\s[^<>]*)?\/?>/i
 const TAG_END_REGEX = /^[ \t]*<\/[a-z_][\w-]*\s*>/i
 
+/**
+ * A CommonMark hard line break marker: either a single backslash (`\`) or two or
+ * more trailing spaces, both placed at the end of a line before the newline.
+ * See https://spec.commonmark.org/0.31.2/#hard-line-breaks
+ */
+export type MarkdownHardLineBreak = string
+
+/**
+ * Stores the original hard line break marker on a `LineBreakNode` so it can be
+ * preserved across a markdown import/export round trip instead of being
+ * collapsed into a soft line break.
+ *
+ * Note: unlike upstream Lexical (which sets `resetOnCopyNode: true`), that option
+ * does not exist in the `lexical` version pinned here (0.41.0), so it is omitted.
+ */
+export const hardLineBreakState = createState('mdHardLineBreak', {
+  parse: (val): MarkdownHardLineBreak => {
+    if (typeof val === 'string' && /^(\\| {2,})$/.test(val)) {
+      return val
+    }
+    return ''
+  },
+})
+
+/**
+ * Detects a CommonMark hard line break marker at the end of a raw line.
+ *
+ * @returns a tuple of `[textWithoutMarker, marker]` when a marker is found, otherwise null.
+ */
+export function parseMarkdownHardLineBreak(line: string): [string, MarkdownHardLineBreak] | null {
+  if (line.endsWith('\\')) {
+    return [line.slice(0, -1), '\\']
+  }
+
+  const spaces = line.match(/^(.*?\S)( {2,})$/)
+  return spaces ? [spaces[1]!, spaces[2]!] : null
+}
+
+function hasNonWhitespaceContentOnLine(children: Array<LexicalNode>, endIndex: number): boolean {
+  for (let i = endIndex - 1; i >= 0; i--) {
+    if ($isLineBreakNode(children[i])) {
+      return false
+    }
+    if (/\S/.test(children[i]!.getTextContent())) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Removes a trailing hard line break marker from the last text node of `previousNode`
+ * (if present) and returns the marker, so it can be carried onto a `LineBreakNode`.
+ */
+function $extractMarkdownHardLineBreakMarker(
+  previousNode: ElementNode,
+): MarkdownHardLineBreak | null {
+  const children = previousNode.getChildren()
+  const lastChildIndex = children.length - 1
+  const lastChild = children[lastChildIndex]
+
+  if (!$isTextNode(lastChild)) {
+    return null
+  }
+
+  const lastText = lastChild.getTextContent()
+  const hardLineBreak = parseMarkdownHardLineBreak(lastText)
+
+  if (hardLineBreak !== null) {
+    const [text, marker] = hardLineBreak
+    lastChild.setTextContent(text)
+    return marker
+  }
+
+  // Trailing whitespace may have been split into its own text node by inline
+  // transformers (e.g. after formatted or linked content). Only treat it as a
+  // hard break when there is preceding non-whitespace content on the same line.
+  if (/^ {2,}$/.test(lastText) && hasNonWhitespaceContentOnLine(children, lastChildIndex)) {
+    lastChild.setTextContent('')
+    return lastText
+  }
+
+  return null
+}
+
+/**
+ * Creates a `LineBreakNode` for a markdown line join, preserving any CommonMark
+ * hard line break marker found at the end of `previousNode` via node state.
+ */
+export function $createMarkdownLineBreakNode(previousNode: ElementNode): LineBreakNode {
+  const lineBreakNode = $createLineBreakNode()
+  const hardLineBreak = $extractMarkdownHardLineBreakMarker(previousNode)
+
+  if (hardLineBreak !== null) {
+    $setState(lineBreakNode, hardLineBreakState, hardLineBreak)
+  }
+
+  return lineBreakNode
+}
+
 const createBlockNode = (
   createNode: (match: Array<string>) => ElementNode,
 ): ElementTransformer['replace'] => {
@@ -333,7 +446,7 @@ export const QUOTE: ElementTransformer = {
       const previousNode = parentNode.getPreviousSibling()
       if ($isQuoteNode(previousNode)) {
         previousNode.splice(previousNode.getChildrenSize(), 0, [
-          $createLineBreakNode(),
+          $createMarkdownLineBreakNode(previousNode),
           ...children,
         ])
         previousNode.select(0, 0)
@@ -445,6 +558,10 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines: boole
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
     const lastLine = sanitizedLines[sanitizedLines.length - 1]
+    // A hard line break marker on the current line only matters if another line follows it.
+    const hardLineBreak = i < lines.length - 1 ? parseMarkdownHardLineBreak(line) : null
+    const lastLineHasHardLineBreak =
+      lastLine !== undefined && parseMarkdownHardLineBreak(lastLine) !== null
 
     // Code blocks of ```single line``` don't toggle the inCodeBlock flag
     if (CODE_SINGLE_LINE_REGEX.test(line)) {
@@ -494,6 +611,8 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines: boole
       CHECK_LIST_REGEX.test(line) ||
       TABLE_ROW_REG_EXP.test(line) ||
       TABLE_ROW_DIVIDER_REG_EXP.test(line) ||
+      // Don't merge the next line into a line that ends with a hard line break marker.
+      lastLineHasHardLineBreak ||
       !shouldMergeAdjacentLines ||
       TAG_START_REGEX.test(line) ||
       TAG_END_REGEX.test(line) ||
@@ -503,7 +622,9 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines: boole
     ) {
       sanitizedLines.push(line)
     } else {
-      sanitizedLines[sanitizedLines.length - 1] = lastLine + ' ' + line.trim()
+      // Preserve a trailing hard line break marker on the merged line so it survives import.
+      sanitizedLines[sanitizedLines.length - 1] =
+        lastLine + ' ' + (hardLineBreak === null ? line.trim() : line.trimStart())
     }
   }
 


### PR DESCRIPTION
## Summary

Markdown imported via `$convertFromMarkdownString` silently dropped CommonMark [hard line breaks](https://spec.commonmark.org/0.31.2/#hard-line-breaks): a line ending in two-or-more trailing spaces or a trailing backslash was merged into the previous line as a soft wrap, losing the intended `<br>`.

This backports the relevant parts of upstream lexical [PR #8402](https://github.com/facebook/lexical/pull/8402) into Payload's forked `@lexical/markdown`. We maintain a fork of `@lexical/markdown` (rather than re-exporting it), and it is pinned to `lexical@0.41.0`, so the upstream fix (shipped in `0.45.0`) is not picked up by a dependency bump alone.

This is the 3.x backport. The equivalent v4 PR is #17060.

### What changed

- **`MarkdownTransformers.ts`**
  - Adds `parseMarkdownHardLineBreak` to detect a trailing `\` or 2+ spaces marker.
  - Adds a `hardLineBreakState` node-state config and `$createMarkdownLineBreakNode`, which strips the marker from the text and stores it on the created `LineBreakNode`.
  - `normalizeMarkdown` no longer merges a following line into a line that ends with a hard break marker, and preserves the marker when merging.
  - The `QUOTE` transformer uses `$createMarkdownLineBreakNode` for multi-line quote joins.
- **`MarkdownImport.ts`** uses `$createMarkdownLineBreakNode` instead of a plain `$createLineBreakNode` when joining adjacent blocks.
- **`MarkdownExport.ts`** re-emits the stored marker (`  \n` or `\\\n`) on export so the value round trips; line breaks without a marker still export as a plain `\n` (unchanged behavior).

### Note on `resetOnCopyNode`

Upstream sets `resetOnCopyNode: true` on the node state. That option does not exist in `lexical@0.41.0` (it was added in `0.42.0`), so it is intentionally omitted here. It only affects copy/paste node duplication and is not required for correct markdown import/export.

## Test plan

- [x] Added `LexicalMarkdownHardLineBreak.spec.ts` covering normalization, import (marker stripped + `LineBreakNode` created), and export round trip for both the trailing-spaces and backslash forms, plus a soft-wrap regression check.
- [x] `vitest --project unit` for the new spec passes (10/10) on this 3.x branch.
- [x] `eslint` + `prettier` clean on changed files.