### PR TITLE
fix(ui): clear submitted state when adding a new block/array row

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -695,8 +695,11 @@ export const Form: React.FC<FormProps> = (props) => {
       })
 
       setModified(true)
+      // Adding a new row means the user hasn't submitted this state yet — clear the
+      // submitted flag so new required fields don't immediately show validation errors.
+      setSubmitted(false)
     },
-    [dispatchFields, getDataByPath, setModified],
+    [dispatchFields, getDataByPath, setModified, setSubmitted],
   )
 
   const moveFieldRow: FormContextType['moveFieldRow'] = useCallback(


### PR DESCRIPTION
## What

Fixes #17186

When `addFieldRow` is called (user adds a new blocks/array row), the form's `submitted` state is now reset to `false`.

## Why

`showError` for any field is computed as:

```ts
const showError = valid === false && submitted
```

When a form is submitted with validation errors (e.g. publishing with empty required fields), `submitted` is set to `true`. Previously, `addFieldRow` only called `setModified(true)`, leaving `submitted` as `true`. This caused newly added rows to immediately display validation errors on their empty required fields — before the user had any chance to interact with them or re-submit the form.

Resetting `submitted` to `false` when a row is added correctly reflects the semantic state: the user has modified the form and has not yet attempted to submit the new state.

## Steps to reproduce

1. Open any document with a blocks or array field in the admin UI.
2. Add a row and leave one or more required fields empty.
3. Click **Publish** (or **Save**) — validation errors appear as expected.
4. Without changing anything, click **Add Block** to add another row.

**Before this fix:** the new row's required fields immediately show validation errors.
**After this fix:** no errors appear on the new row until the user attempts to submit again.
