### PR TITLE
fix(ui): resolve localized label for card button aria-label and title (#17069)

### DIFF
--- a/packages/ui/src/widgets/CollectionCards/index.tsx
+++ b/packages/ui/src/widgets/CollectionCards/index.tsx
@@ -103,7 +103,7 @@ export async function CollectionCards(props: WidgetServerProps) {
                             ) : hasCreatePermission && type === EntityType.collection ? (
                               <Button
                                 aria-label={t('general:createNewLabel', {
-                                  label,
+                                  label: getTranslation(label, i18n),
                                 })}
                                 buttonStyle="ghost"
                                 el="link"


### PR DESCRIPTION
Fixes #17069

## What
On the admin dashboard, each collection card's "create new" button rendered `aria-label="[object Object] neu erstellen"` (and the same in `title`) when the collection used a localized label object, e.g. `{ en: 'Pages', de: 'Seiten' }`.

## Why
`packages/ui/src/widgets/CollectionCards/index.tsx` passed the raw `label` object straight into the i18n interpolation:

```ts
aria-label={t('general:createNewLabel', { label })}
```

The `createNewLabel` strings are interpolation templates (`Create new {{label}}` / `{{label}} neu erstellen`), so the localized object gets string-coerced to `[object Object]`. Payload's `Button` also copies `aria-label` into `title` (`packages/ui/src/elements/Button/index.tsx`), so both attributes were affected.

## Fix
Resolve the label to a string for the active locale with the existing `getTranslation` helper before interpolating — matching every other `createNewLabel` call site (ListCreateNewDocButton, QueryPresetBar, Hierarchy/Tree, RelationshipTable, views/List) and the card's own `title`/`buttonAriaLabel`, which already use `getTranslation(label, i18n)`:

```ts
aria-label={t('general:createNewLabel', { label: getTranslation(label, i18n) })}
```

## Verification
- `getTranslation` resolves a `Record<string, string>` label to `label[i18n.language]` (with fallback), returning a plain string — verified against `packages/translations/src/utilities/getTranslation.ts`.
- `label` is typed `StaticLabel`, which `getTranslation` accepts and narrows to `string`; the change is type-consistent with the 5 other call sites.
- One-line, behavior-preserving change scoped to the affected button.
