### PR TITLE
fix(ui,next): resolve globals copy and versions config lookup bugs

### DIFF
--- a/packages/next/src/views/Version/fetchVersions.ts
+++ b/packages/next/src/views/Version/fetchVersions.ts
@@ -167,7 +167,7 @@ export const fetchLatestVersion = async <TVersionData extends object = object>({
   const entityConfig = collectionSlug
     ? req.payload.collections[collectionSlug]?.config
     : globalSlug
-      ? req.payload.globals[globalSlug]?.config
+      ? req.payload.config.globals.find((g) => g.slug === globalSlug)
       : undefined
 
   // Only query by _status if drafts are enabled (since _status field only exists with drafts)

--- a/packages/ui/src/utilities/copyDataFromLocale.ts
+++ b/packages/ui/src/utilities/copyDataFromLocale.ts
@@ -235,7 +235,7 @@ export const copyDataFromLocale = async (args: CopyDataFromLocaleArgs) => {
     overrideData = false,
     req: {
       payload,
-      payload: { collections, globals },
+      payload: { collections },
       user,
     },
     req,
@@ -298,7 +298,7 @@ export const copyDataFromLocale = async (args: CopyDataFromLocaleArgs) => {
   }
 
   const fields = globalSlug
-    ? globals[globalSlug].config.fields
+    ? payload.config.globals.find((g) => g.slug === globalSlug)?.fields
     : collections[collectionSlug].config.fields
 
   const fromLocaleDataWithoutID = fromLocaleData.value

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -467,6 +467,16 @@ export default buildConfigWithDefaults({
           type: 'text',
         },
       ],
+      slug: 'global-copy-test',
+    },
+    {
+      fields: [
+        {
+          name: 'text',
+          localized: true,
+          type: 'text',
+        },
+      ],
       slug: globalWithDraftsSlug,
       versions: {
         drafts: {

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -216,8 +216,8 @@ describe('Localization', () => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
-          locale: portugueseLocale,
           fallbackLocale: 'none',
+          locale: portugueseLocale,
         })
 
         expect(localizedFallback.title).not.toBeDefined()
@@ -429,8 +429,8 @@ describe('Localization', () => {
               localizedAccentPostOne = await payload.create({
                 collection,
                 data: {
-                  title: 'non accent post',
                   localizedDescription: 'something',
+                  title: 'non accent post',
                 },
                 locale: englishLocale,
               })
@@ -438,8 +438,8 @@ describe('Localization', () => {
               localizedAccentPostTwo = await payload.create({
                 collection,
                 data: {
-                  title: 'accent post',
                   localizedDescription: 'veterinarian',
+                  title: 'accent post',
                 },
                 locale: englishLocale,
               })
@@ -448,8 +448,8 @@ describe('Localization', () => {
                 id: localizedAccentPostOne.id,
                 collection,
                 data: {
-                  title: 'non accent post',
                   localizedDescription: 'valami',
+                  title: 'non accent post',
                 },
                 locale: hungarianLocale,
               })
@@ -458,8 +458,8 @@ describe('Localization', () => {
                 id: localizedAccentPostTwo.id,
                 collection,
                 data: {
-                  title: 'accent post',
                   localizedDescription: 'állatorvos',
+                  title: 'accent post',
                 },
                 locale: hungarianLocale,
               })
@@ -468,13 +468,13 @@ describe('Localization', () => {
             it('should sort alphabetically even with accented letters', async () => {
               const sortByDescriptionQuery = await payload.find({
                 collection,
+                locale: hungarianLocale,
                 sort: 'description',
                 where: {
                   title: {
                     like: 'accent',
                   },
                 },
-                locale: hungarianLocale,
               })
 
               expect(sortByDescriptionQuery.docs[0].id).toEqual(localizedAccentPostTwo.id)
@@ -489,8 +489,8 @@ describe('Localization', () => {
         const document = await payload.create({
           collection: localizedDateFieldsSlug,
           data: {
-            localizedDate: new Date().toISOString(),
             date: new Date().toISOString(),
+            localizedDate: new Date().toISOString(),
           },
         })
         expect(document.localizedDate).toBeTruthy()
@@ -500,8 +500,8 @@ describe('Localization', () => {
         const document = await payload.create({
           collection: localizedDateFieldsSlug,
           data: {
-            localizedDate: new Date().toISOString(),
             date: new Date().toISOString(),
+            localizedDate: new Date().toISOString(),
           },
         })
 
@@ -619,9 +619,9 @@ describe('Localization', () => {
           const post = await payload.create({ collection: 'localized-sort', data: { title: en } })
           const es = randomWordsSpanish[i]
           await payload.update({
+            id: post.id,
             collection: 'localized-sort',
             data: { title: es },
-            id: post.id,
             locale: 'es',
           })
 
@@ -659,9 +659,9 @@ describe('Localization', () => {
         // Fetch sorted words in Spanish (ascending)
         const { docs: randomWordsEsAsc } = await payload.find({
           collection: localizedSortSlug,
+          locale: 'es',
           sort: 'title',
           where: q,
-          locale: 'es',
         })
 
         randomWordsEsAsc.forEach((doc, i) => {
@@ -671,9 +671,9 @@ describe('Localization', () => {
         // Fetch sorted words in Spanish (descending)
         const { docs: randomWordsEsDesc } = await payload.find({
           collection: localizedSortSlug,
+          locale: 'es',
           sort: '-title',
           where: q,
-          locale: 'es',
         })
 
         randomWordsEsDesc.forEach((doc, i) => {
@@ -1465,14 +1465,26 @@ describe('Localization', () => {
         const doc = await payload.create({
           collection: withRequiredLocalizedFields,
           data: {
+            myTab: {
+              group: {
+                nestedArray2: [
+                  {
+                    nestedText: 'hello',
+                  },
+                  {
+                    nestedText: 'goodbye',
+                  },
+                ],
+                nestedText: 'hello',
+              },
+              text: 'hello',
+            },
             nav: {
               layout: [
                 {
                   blockType: 'text',
-                  text: englishText,
                   nestedArray: [
                     {
-                      text: 'hello',
                       l2: [
                         {
                           l3: [
@@ -1486,9 +1498,9 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'hello',
                     },
                     {
-                      text: 'goodbye',
                       l2: [
                         {
                           l3: [
@@ -1502,24 +1514,12 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'goodbye',
                     },
                   ],
+                  text: englishText,
                 },
               ],
-            },
-            myTab: {
-              text: 'hello',
-              group: {
-                nestedText: 'hello',
-                nestedArray2: [
-                  {
-                    nestedText: 'hello',
-                  },
-                  {
-                    nestedText: 'goodbye',
-                  },
-                ],
-              },
             },
             title: 'hello',
           },
@@ -1530,14 +1530,26 @@ describe('Localization', () => {
           id: doc.id,
           collection: withRequiredLocalizedFields,
           data: {
+            myTab: {
+              group: {
+                nestedArray2: [
+                  {
+                    nestedText: 'hola',
+                  },
+                  {
+                    nestedText: 'adios',
+                  },
+                ],
+                nestedText: 'hola',
+              },
+              text: 'hola',
+            },
             nav: {
               layout: [
                 {
                   blockType: 'text',
-                  text: spanishText,
                   nestedArray: [
                     {
-                      text: 'hola',
                       l2: [
                         {
                           l3: [
@@ -1551,9 +1563,9 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'hola',
                     },
                     {
-                      text: 'adios',
                       l2: [
                         {
                           l3: [
@@ -1567,26 +1579,14 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'adios',
                     },
                   ],
+                  text: spanishText,
                 },
               ],
             },
             title: 'hello',
-            myTab: {
-              text: 'hola',
-              group: {
-                nestedText: 'hola',
-                nestedArray2: [
-                  {
-                    nestedText: 'hola',
-                  },
-                  {
-                    nestedText: 'adios',
-                  },
-                ],
-              },
-            },
           },
           locale: spanishLocale,
         })
@@ -1622,8 +1622,8 @@ describe('Localization', () => {
         const post = await payload.create({
           collection,
           data: {
-            title: englishTitle,
             description: 'keep me',
+            title: englishTitle,
           },
         })
 
@@ -1669,25 +1669,25 @@ describe('Localization', () => {
         expect(result.groupLocalized?.title).toBe('hello en')
 
         await payload.update({
-          collection: groupSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: groupSlug,
           data: {
             groupLocalized: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.groupLocalized.title).toBe('hello en')
@@ -1697,36 +1697,36 @@ describe('Localization', () => {
       it('should properly create/update/read localized field inside of group', async () => {
         const result = await payload.create({
           collection: groupSlug,
-          locale: englishLocale,
           data: {
             group: {
               title: 'hello en',
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.group.title).toBe('hello en')
 
         await payload.update({
-          collection: groupSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: groupSlug,
           data: {
             group: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.group.title).toBe('hello en')
@@ -1736,54 +1736,54 @@ describe('Localization', () => {
       it('should properly create/update/read deep localized field inside of group', async () => {
         const result = await payload.create({
           collection: groupSlug,
-          locale: englishLocale,
           data: {
             deep: {
+              array: [{ title: 'hello en' }],
               blocks: [
                 {
                   blockType: 'first',
                   title: 'hello en',
                 },
               ],
-              array: [{ title: 'hello en' }],
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.deep.array[0].title).toBe('hello en')
 
         await payload.update({
-          collection: groupSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: groupSlug,
           data: {
             deep: {
-              blocks: [
-                {
-                  blockType: 'first',
-                  title: 'hello es',
-                  id: result.deep.blocks[0].id,
-                },
-              ],
               array: [
                 {
                   id: result.deep.array[0].id,
                   title: 'hello es',
                 },
               ],
+              blocks: [
+                {
+                  id: result.deep.blocks[0].id,
+                  blockType: 'first',
+                  title: 'hello es',
+                },
+              ],
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.deep.array[0].title).toBe('hello en')
@@ -1806,6 +1806,7 @@ describe('Localization', () => {
         expect(doc.groupLocalizedRow.text).toBe('hello world')
 
         const docES = await payload.update({
+          id: doc.id,
           collection: 'groups',
           data: {
             groupLocalizedRow: {
@@ -1813,16 +1814,15 @@ describe('Localization', () => {
             },
           },
           locale: 'es',
-          id: doc.id,
         })
 
         expect(docES.groupLocalizedRow.text).toBe('hola world or something')
 
         // check if docES didnt break EN
-        const docEN = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'en' })
+        const docEN = await payload.findByID({ id: doc.id, collection: 'groups', locale: 'en' })
         expect(docEN.groupLocalizedRow.text).toBe('hello world')
 
-        const all = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'all' })
+        const all = await payload.findByID({ id: doc.id, collection: 'groups', locale: 'all' })
 
         expect(all.groupLocalizedRow.en.text).toBe('hello world')
         expect(all.groupLocalizedRow.es.text).toBe('hola world or something')
@@ -1831,10 +1831,10 @@ describe('Localization', () => {
       it('should not crash on empty localized tab', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tabLocalized: {},
           },
+          locale: englishLocale,
         })
 
         expect(result).toBeTruthy()
@@ -1843,37 +1843,37 @@ describe('Localization', () => {
       it('should properly create/update/read array field inside localized tab field', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tabLocalized: {
               title: 'hello en',
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.tabLocalized?.title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             tabLocalized: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
 
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.tabLocalized.title).toBe('hello en')
@@ -1883,7 +1883,6 @@ describe('Localization', () => {
       it('should properly create/update/read localized tab field', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tabLocalized: {
               array: [
@@ -1893,31 +1892,32 @@ describe('Localization', () => {
               ],
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.tabLocalized.array[0].title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             tabLocalized: {
               array: [{ title: 'hello es' }],
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
 
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.tabLocalized.array[0].title).toBe('hello en')
@@ -1927,36 +1927,36 @@ describe('Localization', () => {
       it('should properly create/update/read localized field inside of tab', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tab: {
               title: 'hello en',
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.tab.title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             tab: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.tab.title).toBe('hello en')
@@ -1966,54 +1966,54 @@ describe('Localization', () => {
       it('should properly create/update/read deep localized field inside of tab', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             deep: {
+              array: [{ title: 'hello en' }],
               blocks: [
                 {
                   blockType: 'first',
                   title: 'hello en',
                 },
               ],
-              array: [{ title: 'hello en' }],
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.deep.array[0].title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             deep: {
-              blocks: [
-                {
-                  blockType: 'first',
-                  title: 'hello es',
-                  id: result.deep.blocks[0].id,
-                },
-              ],
               array: [
                 {
                   id: result.deep.array[0].id,
                   title: 'hello es',
                 },
               ],
+              blocks: [
+                {
+                  id: result.deep.blocks[0].id,
+                  blockType: 'first',
+                  title: 'hello es',
+                },
+              ],
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.deep.array[0].title).toBe('hello en')
@@ -2025,7 +2025,6 @@ describe('Localization', () => {
       it('should properly isolate locales for a group inside a localized tab', async () => {
         const docEs = await payload.create({
           collection: tabSlug,
-          locale: spanishLocale,
           data: {
             tabLocalized: {
               group: {
@@ -2033,12 +2032,12 @@ describe('Localization', () => {
               },
             },
           },
+          locale: spanishLocale,
         })
 
         await payload.update({
-          collection: tabSlug,
-          locale: englishLocale,
           id: docEs.id,
+          collection: tabSlug,
           data: {
             tabLocalized: {
               group: {
@@ -2046,18 +2045,19 @@ describe('Localization', () => {
               },
             },
           },
+          locale: englishLocale,
         })
 
         const readEn = await payload.findByID({
+          id: docEs.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: docEs.id,
         })
 
         const readEs = await payload.findByID({
+          id: docEs.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: docEs.id,
         })
 
         expect(readEn.tabLocalized.group.heading).toBe('English heading')
@@ -2086,7 +2086,6 @@ describe('Localization', () => {
           data: {
             content: [
               {
-                blockType: 'blockInsideBlock',
                 array: [
                   {
                     link: {
@@ -2099,6 +2098,7 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'blockInsideBlock',
                 content: [
                   {
                     blockType: 'textBlock',
@@ -2113,18 +2113,16 @@ describe('Localization', () => {
         id = doc.id
 
         const retrievedInEN = await payload.findByID({
-          collection: 'blocks-fields',
           id,
+          collection: 'blocks-fields',
         })
 
         await payload.update({
-          collection: 'blocks-fields',
           id,
-          locale: 'es',
+          collection: 'blocks-fields',
           data: {
             content: [
               {
-                blockType: 'blockInsideBlock',
                 array: [
                   {
                     link: {
@@ -2137,6 +2135,7 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'blockInsideBlock',
                 content: [
                   {
                     blockType: 'textBlock',
@@ -2146,11 +2145,12 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'es',
         })
 
         const retrieved = await payload.findByID({
-          collection: 'blocks-fields',
           id,
+          collection: 'blocks-fields',
           locale: 'all',
         })
 
@@ -2185,26 +2185,26 @@ describe('Localization', () => {
           {
             blockName: '1',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc.id,
             myGroup: {
               text: 'hello in english 1',
             },
+            relationWithinBlock: randomDoc.id,
           },
           {
             blockName: '2',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc.id,
             myGroup: {
               text: 'hello in english 2',
             },
+            relationWithinBlock: randomDoc.id,
           },
           {
             blockName: '3',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc.id,
             myGroup: {
               text: 'hello in english 3',
             },
+            relationWithinBlock: randomDoc.id,
           },
         ]
 
@@ -2212,33 +2212,31 @@ describe('Localization', () => {
           {
             blockName: '1',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc2.id,
             myGroup: {
               text: 'hello in spanish 1',
             },
+            relationWithinBlock: randomDoc2.id,
           },
           {
             blockName: '2',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc2.id,
             myGroup: {
               text: 'hello in spanish 2',
             },
+            relationWithinBlock: randomDoc2.id,
           },
           {
             blockName: '3',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc2.id,
             myGroup: {
               text: 'hello in spanish 3',
             },
+            relationWithinBlock: randomDoc2.id,
           },
         ]
 
         const createdEnDoc = await payload.create({
           collection: 'nested-arrays',
-          locale: 'en',
-          depth: 0,
           data: {
             arrayWithBlocks: [
               {
@@ -2246,13 +2244,13 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'en',
         })
 
         const updatedEsDoc = await payload.update({
-          collection: 'nested-arrays',
           id: createdEnDoc.id,
-          depth: 0,
-          locale: 'es',
+          collection: 'nested-arrays',
           data: {
             arrayWithBlocks: [
               {
@@ -2260,6 +2258,8 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         const esArrayBlocks = updatedEsDoc.arrayWithBlocks[0].blocksWithinArray
@@ -2280,8 +2280,8 @@ describe('Localization', () => {
         const enDoc2 = await payload.findByID({
           id: createdEnDoc.id,
           collection: 'nested-arrays',
-          locale: 'en',
           depth: 0,
+          locale: 'en',
         })
         removeId(enDoc2.arrayWithBlocks[0].blocksWithinArray)
         expect(enDoc2.arrayWithBlocks[0].blocksWithinArray).toEqual(blocksWithinArrayEN)
@@ -2303,8 +2303,6 @@ describe('Localization', () => {
 
         const createdEnDoc = await payload.create({
           collection: 'nested-arrays',
-          locale: 'en',
-          depth: 0,
           data: {
             arrayWithLocalizedRelation: [
               {
@@ -2312,13 +2310,13 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'en',
         })
 
         const updatedEsDoc = await payload.update({
-          collection: 'nested-arrays',
           id: createdEnDoc.id,
-          depth: 0,
-          locale: 'es',
+          collection: 'nested-arrays',
           data: {
             arrayWithLocalizedRelation: [
               {
@@ -2327,6 +2325,8 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         expect(updatedEsDoc.arrayWithLocalizedRelation).toHaveLength(1)
@@ -2339,8 +2339,8 @@ describe('Localization', () => {
         const enDoc2 = await payload.findByID({
           id: createdEnDoc.id,
           collection: 'nested-arrays',
-          locale: 'en',
           depth: 0,
+          locale: 'en',
         })
         expect(enDoc2.arrayWithLocalizedRelation).toHaveLength(1)
         expect(enDoc2.arrayWithLocalizedRelation[0].localizedRelation).toBe(randomTextDoc.id)
@@ -2351,7 +2351,6 @@ describe('Localization', () => {
       it('should update localized block', async () => {
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             content: [
               {
@@ -2365,6 +2364,7 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const updated = await payload.update({
@@ -2378,16 +2378,16 @@ describe('Localization', () => {
                 // since the parent is localized, and the primary key in the block table
                 // consists only of the ID. That's why it's removed in `copyToLocale`.
                 // id: doc.content?.[0]?.id,
-                blockName: null,
                 array: [],
+                blockName: null,
                 blockType: 'blockInsideBlock',
                 content: [
                   {
                     // Same as above.
                     // id: doc.content?.[0]?.content?.[0]?.id,
-                    text: 'some-text',
                     blockName: null,
                     blockType: 'textBlock',
+                    text: 'some-text',
                   },
                 ],
               },
@@ -2404,7 +2404,6 @@ describe('Localization', () => {
       it('update specific locale should not erease the others in blocks and arrays', async () => {
         const doc = await payload.create({
           collection: 'nested',
-          locale: 'en',
           data: {
             blocks: [
               {
@@ -2419,6 +2418,7 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         expect(doc.blocks?.[0]?.someText).toBe('some-block-text-en')
@@ -2442,7 +2442,6 @@ describe('Localization', () => {
         const updatedDoc = await payload.update({
           id: doc.id,
           collection: 'nested',
-          locale: 'es',
           data: {
             blocks: [
               {
@@ -2459,6 +2458,7 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'es',
         })
 
         expect(updatedDoc.blocks?.[0]?.someText).toBe('some-block-text-es')
@@ -2484,12 +2484,12 @@ describe('Localization', () => {
       it('update specific locale should not erease the others in simple fields', async () => {
         const doc = await payload.create({
           collection: 'localized-posts',
-          locale: 'en',
           data: {
-            title: 'some-localized-title',
             description: 'some-not-localized-description',
             localizedDescription: 'some-localized-description',
+            title: 'some-localized-title',
           },
+          locale: 'en',
         })
 
         expect(doc.title).toBe('some-localized-title')
@@ -2511,12 +2511,12 @@ describe('Localization', () => {
         const updatedDoc = await payload.update({
           id: doc.id,
           collection: 'localized-posts',
-          locale: 'es',
           data: {
-            title: 'some-localized-title-es',
             description: 'some-not-localized-description-es',
             localizedDescription: 'some-localized-description-es',
+            title: 'some-localized-title-es',
           },
+          locale: 'es',
         })
 
         expect(updatedDoc.title).toBe('some-localized-title-es')
@@ -2556,11 +2556,6 @@ describe('Localization', () => {
           data: {
             array: [
               {
-                relation: {
-                  value: randomDoc.id,
-                  relationTo: 'localized-posts',
-                },
-                hasManyRelation: [randomDoc.id, randomDoc2.id],
                 hasManyPolyRelation: [
                   {
                     relationTo: 'localized-posts',
@@ -2571,26 +2566,25 @@ describe('Localization', () => {
                     value: randomDoc2.id,
                   },
                 ],
+                hasManyRelation: [randomDoc.id, randomDoc2.id],
                 number: [1, 2],
-                text: ['hello', 'goodbye'],
+                relation: {
+                  relationTo: 'localized-posts',
+                  value: randomDoc.id,
+                },
                 select: ['one'],
+                text: ['hello', 'goodbye'],
               },
             ],
           },
         })
 
         await payload.update({
-          collection: 'nested-field-tables',
           id: newDoc.id,
-          locale: 'es',
+          collection: 'nested-field-tables',
           data: {
             array: [
               {
-                relation: {
-                  value: randomDoc2.id,
-                  relationTo: 'localized-posts',
-                },
-                hasManyRelation: [randomDoc2.id, randomDoc.id],
                 hasManyPolyRelation: [
                   {
                     relationTo: 'localized-posts',
@@ -2601,17 +2595,23 @@ describe('Localization', () => {
                     value: randomDoc.id,
                   },
                 ],
+                hasManyRelation: [randomDoc2.id, randomDoc.id],
+                number: [3, 4],
+                relation: {
+                  relationTo: 'localized-posts',
+                  value: randomDoc2.id,
+                },
                 select: ['two', 'three'],
                 text: ['hola', 'adios'],
-                number: [3, 4],
               },
             ],
           },
+          locale: 'es',
         })
 
         const retrieved = await payload.findByID({
-          collection: 'nested-field-tables',
           id: newDoc.id,
+          collection: 'nested-field-tables',
           depth: 0,
           locale: 'all',
         })
@@ -2623,12 +2623,12 @@ describe('Localization', () => {
         expect(retrieved.array.es[0].hasManyRelation).toEqual([randomDoc2.id, randomDoc.id])
 
         expect(retrieved.array.en[0].hasManyPolyRelation).toEqual([
-          { value: randomDoc.id, relationTo: 'localized-posts' },
-          { value: randomDoc2.id, relationTo: 'localized-posts' },
+          { relationTo: 'localized-posts', value: randomDoc.id },
+          { relationTo: 'localized-posts', value: randomDoc2.id },
         ])
         expect(retrieved.array.es[0].hasManyPolyRelation).toEqual([
-          { value: randomDoc2.id, relationTo: 'localized-posts' },
-          { value: randomDoc.id, relationTo: 'localized-posts' },
+          { relationTo: 'localized-posts', value: randomDoc2.id },
+          { relationTo: 'localized-posts', value: randomDoc.id },
         ])
 
         expect(retrieved.array.en[0].number).toEqual([1, 2])
@@ -2657,7 +2657,6 @@ describe('Localization', () => {
 
         const docEn = await payload.create({
           collection: 'nested-field-tables',
-          depth: 0,
           data: {
             blocks: [
               {
@@ -2698,6 +2697,7 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
         })
 
         expect(docEn.blocks[0].nestedBlocks[0].relation.value).toBe(randomDoc.id)
@@ -2706,8 +2706,6 @@ describe('Localization', () => {
 
         const docEs = await payload.update({
           id: docEn.id,
-          depth: 0,
-          locale: 'es',
           collection: 'nested-field-tables',
           data: {
             blocks: [
@@ -2749,6 +2747,8 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         expect(docEs.blocks[0].nestedBlocks[0].relation.value).toBe(randomDoc2.id)
@@ -2756,10 +2756,10 @@ describe('Localization', () => {
         expect(docEs.blocks[2].nestedBlocks[0].relation.value).toBe(randomDoc2.id)
 
         const docAll = await payload.findByID({
-          collection: 'nested-field-tables',
           id: docEn.id,
-          locale: 'all',
+          collection: 'nested-field-tables',
           depth: 0,
+          locale: 'all',
         })
 
         expect(docAll.blocks.en[0].nestedBlocks[0].relation.value).toBe(randomDoc.id)
@@ -2787,11 +2787,9 @@ describe('Localization', () => {
 
         const docEn = await payload.create({
           collection: 'nested-field-tables',
-          depth: 0,
           data: {
             blocks: [
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2800,9 +2798,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2811,9 +2809,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2822,9 +2820,11 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
             ],
           },
+          depth: 0,
         })
 
         expect(docEn.blocks[0].array[0].relation.value).toBe(randomDoc.id)
@@ -2833,13 +2833,10 @@ describe('Localization', () => {
 
         const docEs = await payload.update({
           id: docEn.id,
-          depth: 0,
-          locale: 'es',
           collection: 'nested-field-tables',
           data: {
             blocks: [
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2848,9 +2845,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2859,9 +2856,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2870,9 +2867,12 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         expect(docEs.blocks[0].array[0].relation.value).toBe(randomDoc2.id)
@@ -2880,10 +2880,10 @@ describe('Localization', () => {
         expect(docEs.blocks[2].array[0].relation.value).toBe(randomDoc2.id)
 
         const docAll = await payload.findByID({
-          collection: 'nested-field-tables',
           id: docEn.id,
-          locale: 'all',
+          collection: 'nested-field-tables',
           depth: 0,
+          locale: 'all',
         })
 
         expect(docAll.blocks.en[0].array[0].relation.value).toBe(randomDoc.id)
@@ -2900,35 +2900,35 @@ describe('Localization', () => {
       it('localized with unique should work for each locale', async () => {
         await payload.create({
           collection: 'localized-posts',
+          data: {
+            unique: 'text',
+          },
           locale: 'ar',
-          data: {
-            unique: 'text',
-          },
         })
 
         await payload.create({
           collection: 'localized-posts',
+          data: {
+            unique: 'text',
+          },
           locale: 'en',
-          data: {
-            unique: 'text',
-          },
         })
 
         await payload.create({
           collection: 'localized-posts',
-          locale: 'es',
           data: {
             unique: 'text',
           },
+          locale: 'es',
         })
 
         await expect(
           payload.create({
             collection: 'localized-posts',
-            locale: 'en',
             data: {
               unique: 'text',
             },
+            locale: 'en',
           }),
         ).rejects.toBeTruthy()
       })
@@ -2938,19 +2938,19 @@ describe('Localization', () => {
 
         await payload.create({
           collection: localizedPostsSlug,
-          locale: 'en',
           data: {
             unique: uniqueValue,
           },
+          locale: 'en',
         })
 
         try {
           await payload.create({
             collection: localizedPostsSlug,
-            locale: 'en',
             data: {
               unique: uniqueValue,
             },
+            locale: 'en',
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
@@ -2973,27 +2973,27 @@ describe('Localization', () => {
 
         await payload.create({
           collection: withRequiredLocalizedFields,
-          locale: 'en',
           data: {
-            title: 'Test title 1',
-            seoTitle: uniqueValue,
             nav: {
               layout: blockData,
             },
+            seoTitle: uniqueValue,
+            title: 'Test title 1',
           },
+          locale: 'en',
         })
 
         try {
           await payload.create({
             collection: withRequiredLocalizedFields,
-            locale: 'en',
             data: {
-              title: 'Test title 2',
-              seoTitle: uniqueValue,
               nav: {
                 layout: blockData,
               },
+              seoTitle: uniqueValue,
+              title: 'Test title 2',
             },
+            locale: 'en',
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
@@ -3032,23 +3032,23 @@ describe('Localization', () => {
         const doc = await payload.create({
           collection: 'localized-posts',
           data: {
-            title: 'Hello',
             group: {
               children: 'Children',
             },
-            unique: 'unique-field',
             localizedCheckbox: true,
+            title: 'Hello',
+            unique: 'unique-field',
           },
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'localized-posts',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'localized-posts',
         })) as LocalizedPost
 
         expect(res.title).toBe('Hello')
@@ -3063,7 +3063,6 @@ describe('Localization', () => {
         // and that's where the bug occurs.
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             content: [
               {
@@ -3077,16 +3076,17 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
         })) as BlocksField
 
         expect(res.content?.[0]?.content?.[0]?.text).toBe('some-text')
@@ -3098,7 +3098,6 @@ describe('Localization', () => {
         // and that's where the bug occurs.
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             tabContent: [
               {
@@ -3107,15 +3106,16 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'pt',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
         })) as BlocksField
 
         expect(res.tabContent?.[0]?.text).toBe('some-text')
@@ -3124,7 +3124,6 @@ describe('Localization', () => {
       it('should copy localized nested to arrays', async () => {
         const doc = await payload.create({
           collection: 'nested',
-          locale: 'en',
           data: {
             topLevelArray: [
               {
@@ -3133,16 +3132,17 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'nested',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'nested',
         })) as Nested
 
         expect(res.topLevelArray?.[0]?.localizedText).toBe('some-localized-text')
@@ -3162,7 +3162,6 @@ describe('Localization', () => {
       it('should copy localized arrays', async () => {
         const doc = await payload.create({
           collection: 'nested',
-          locale: 'en',
           data: {
             topLevelArrayLocalized: [
               {
@@ -3170,16 +3169,17 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'nested',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'nested',
         })) as Nested
 
         expect(res.topLevelArrayLocalized?.[0]?.text).toBe('some-text')
@@ -3201,38 +3201,38 @@ describe('Localization', () => {
         // Create a document with content in en locale
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
-            title: 'English Title',
             content: [
               {
                 blockType: 'blockInsideBlock',
-                text: 'English block text',
                 content: [
                   {
                     blockType: 'textBlock',
                     text: 'Nested English text',
                   },
                 ],
+                text: 'English block text',
               },
             ],
+            title: 'English Title',
           },
+          locale: 'en',
         })
 
         // Add content to Spanish locale separately
         await payload.update({
-          collection: 'blocks-fields',
           id: doc.id,
-          locale: 'es',
+          collection: 'blocks-fields',
           data: {
-            title: 'Spanish Title',
             content: [
               {
                 blockType: 'blockInsideBlock',
                 text: 'Spanish block text',
               },
             ],
+            title: 'Spanish Title',
           },
+          locale: 'es',
         })
 
         // Verify initial state - English data should exist
@@ -3249,12 +3249,12 @@ describe('Localization', () => {
         const req = await createLocalReq({ user }, payload)
 
         await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
+          overrideData: true,
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
-          overrideData: true,
         })
 
         // CRITICAL: Verify English data is NOT lost after copy operation
@@ -3272,8 +3272,8 @@ describe('Localization', () => {
         const esDocAfter = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'es',
           draft: true,
+          locale: 'es',
         })
 
         expect(esDocAfter.title).toBe('English Title')
@@ -3284,25 +3284,25 @@ describe('Localization', () => {
         // Create a document with draft content
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
-          draft: true,
           data: {
-            title: 'Draft English Title',
             content: [
               {
                 blockType: 'blockInsideBlock',
                 text: 'Draft block text',
               },
             ],
+            title: 'Draft English Title',
           },
+          draft: true,
+          locale: 'en',
         })
 
         // Verify draft exists
         const draftBefore = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: true,
+          locale: 'en',
         })
 
         expect(draftBefore.title).toBe('Draft English Title')
@@ -3311,19 +3311,19 @@ describe('Localization', () => {
         const req = await createLocalReq({ user }, payload)
 
         await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
         })
 
         // Verify the source draft is not lost
         const draftAfter = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: true,
+          locale: 'en',
         })
 
         expect(draftAfter.title).toBe('Draft English Title')
@@ -3334,35 +3334,35 @@ describe('Localization', () => {
         // Create published doc in en
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             title: 'Published EN',
           },
+          locale: 'en',
         })
 
         // Create draft with different content
         await payload.update({
-          collection: 'blocks-fields',
           id: doc.id,
-          locale: 'en',
-          draft: true,
+          collection: 'blocks-fields',
           data: {
             title: 'Draft EN',
           },
+          draft: true,
+          locale: 'en',
         })
 
         // Verify both published and draft exist with different content
         const enPublishedBefore = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: false,
+          locale: 'en',
         })
         const enDraftBefore = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: true,
+          locale: 'en',
         })
 
         expect(enPublishedBefore.title).toBe('Published EN')
@@ -3372,23 +3372,52 @@ describe('Localization', () => {
         const req = await createLocalReq({ user }, payload)
 
         await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
+          overrideData: true,
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
-          overrideData: true,
         })
 
         // Verify published content in source locale is NOT overwritten
         const enPublishedAfter = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: false,
+          locale: 'en',
         })
 
         expect(enPublishedAfter.title).toBe('Published EN')
+      })
+
+      it('should copy global data to another locale', async () => {
+        // Set some initial data on global-copy-test in 'en'
+        await payload.updateGlobal({
+          slug: 'global-copy-test',
+          data: {
+            text: 'Global text en',
+          },
+          locale: 'en',
+        })
+
+        const req = await createLocalReq({ user }, payload)
+
+        await copyDataFromLocaleHandler({
+          fromLocale: 'en',
+          globalSlug: 'global-copy-test',
+          overrideData: true,
+          req,
+          toLocale: 'es',
+        })
+
+        const esGlobal = await payload.findGlobal({
+          slug: 'global-copy-test',
+          fallbackLocale: 'none',
+          locale: 'es',
+        })
+
+        expect(esGlobal.text).toBe('Global text en')
       })
     })
 
@@ -3399,8 +3428,8 @@ describe('Localization', () => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
-              locale: portugueseLocale,
               fallbackLocale: [spanishLocale, englishLocale],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3411,8 +3440,8 @@ describe('Localization', () => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar', spanishLocale],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3423,8 +3452,8 @@ describe('Localization', () => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar'],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3436,8 +3465,8 @@ describe('Localization', () => {
           it('should allow fallback locale to be an array', async () => {
             const result = await payload.findGlobal({
               slug: global,
-              locale: portugueseLocale,
               fallbackLocale: [spanishLocale, englishLocale],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3447,8 +3476,8 @@ describe('Localization', () => {
           it('should pass over fallback locales until it finds one that exists', async () => {
             const result = await payload.findGlobal({
               slug: global,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', spanishLocale],
+              locale: portugueseLocale,
             })
             expect(result).toBeDefined()
             expect(result.text).toBe(spanishTitle)
@@ -3457,8 +3486,8 @@ describe('Localization', () => {
           it('should return undefined if no fallback locales exist', async () => {
             const result = await payload.findGlobal({
               slug: global,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar'],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3552,7 +3581,7 @@ describe('Localization', () => {
             const { data } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['es', 'en'] },
+                query: { fallbackLocale: ['es', 'en'], locale: 'pt' },
               })
               .then((res) => res.json())
             console.log(data)
@@ -3572,7 +3601,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar', 'es'] },
+                query: { fallbackLocale: ['hu', 'ar', 'es'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3591,7 +3620,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar'] },
+                query: { fallbackLocale: ['hu', 'ar'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3610,7 +3639,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['es', 'en'] },
+                query: { fallbackLocale: ['es', 'en'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3627,7 +3656,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar', 'es'] },
+                query: { fallbackLocale: ['hu', 'ar', 'es'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3644,7 +3673,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar'] },
+                query: { fallbackLocale: ['hu', 'ar'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3735,8 +3764,8 @@ describe('Localization', () => {
         const fallbackDoc = await payload.findByID({
           id: post1.id,
           collection,
-          locale: portugueseLocale,
           fallbackLocale: englishLocale,
+          locale: portugueseLocale,
         })
 
         expect(fallbackDoc.title).toBe(englishTitle)
@@ -3756,8 +3785,8 @@ describe('Localization', () => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
-          locale: portugueseLocale,
           fallbackLocale: false,
+          locale: portugueseLocale,
         })
 
         expect(localizedFallback.title).not.toBeDefined()
@@ -3773,8 +3802,8 @@ describe('Localization', () => {
         })
 
         await payload.update({
-          collection: allFieldsLocalizedSlug,
           id: originalPost.id,
+          collection: allFieldsLocalizedSlug,
           data: {
             selfRelation: originalPost.id,
           },
@@ -3782,19 +3811,19 @@ describe('Localization', () => {
         })
 
         const spanishPostWithEnglishFallback = await payload.findByID({
-          collection: allFieldsLocalizedSlug,
           id: originalPost.id,
-          locale: 'es',
+          collection: allFieldsLocalizedSlug,
           fallbackLocale: 'en',
+          locale: 'es',
         })
 
         expect(spanishPostWithEnglishFallback.text).toBe('Post EN')
 
         const spanishPostWithNoFallback = await payload.findByID({
-          collection: allFieldsLocalizedSlug,
           id: originalPost.id,
-          locale: 'es',
+          collection: allFieldsLocalizedSlug,
           fallbackLocale: false,
+          locale: 'es',
         })
 
         expect(spanishPostWithNoFallback?.selfRelation?.text).toBeUndefined()
@@ -3823,11 +3852,7 @@ describe('Localization', () => {
       const doc = await payload.create({
         collection: allFieldsLocalizedSlug,
         data: {
-          t1: {
-            t2: {
-              text: 'EN Deep Text',
-            },
-          },
+          _status: 'draft',
           g1: {
             g2: {
               g2a1: [{ text: 'EN Deep 1' }, { text: 'EN Deep 2' }],
@@ -3852,15 +3877,19 @@ describe('Localization', () => {
           },
           number: 100,
           select: 'option1',
+          t1: {
+            t2: {
+              text: 'EN Deep Text',
+            },
+          },
           text: 'English text',
-          _status: 'draft',
         },
         locale: 'en',
       })
 
       const allLocalesDoc = await payload.findByID({
-        collection: allFieldsLocalizedSlug,
         id: doc.id,
+        collection: allFieldsLocalizedSlug,
         locale: 'all',
       })
 
@@ -3923,12 +3952,12 @@ describe('Localization', () => {
       const doc = await payload.create({
         collection: noLocalizedFieldsCollectionSlug,
         data: {
-          text: 'title',
           group: {
             en: {
               text: 'some text',
             },
           },
+          text: 'title',
         },
       })
 
@@ -3957,16 +3986,16 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata EN',
               _status: 'published',
+              text: 'Localized Metadata EN',
             },
             locale: defaultLocale,
           })
 
           const esDoc = await payload.findByID({
-            locale: spanishLocale,
             id: doc.id,
             collection: allFieldsLocalizedSlug,
+            locale: spanishLocale,
           })
 
           expect(esDoc._status).toContain('draft')
@@ -3976,17 +4005,17 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata EN',
               _status: 'published',
+              text: 'Localized Metadata EN',
             },
             locale: defaultLocale,
             publishAllLocales: true,
           })
 
           const esDoc = await payload.findByID({
-            locale: spanishLocale,
             id: doc.id,
             collection: allFieldsLocalizedSlug,
+            locale: spanishLocale,
           })
 
           expect(esDoc._status).toContain('published')
@@ -4002,61 +4031,61 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'english draft 1',
               _status: 'draft',
+              text: 'english draft 1',
             },
             draft: true,
             locale: defaultLocale,
           })
           // update english published 1
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'english published 1',
               _status: 'published',
+              text: 'english published 1',
             },
             locale: defaultLocale,
           })
 
           // create spanish draft 1
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'spanish draft 1',
               _status: 'draft',
+              text: 'spanish draft 1',
             },
             draft: true,
             locale: spanishLocale,
           })
           // update spanish published 1
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'spanish published 1',
               _status: 'published',
+              text: 'spanish published 1',
             },
             locale: spanishLocale,
           })
           // update spanish draft 2
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'spanish draft 2',
               _status: 'draft',
+              text: 'spanish draft 2',
             },
             draft: true,
             locale: spanishLocale,
           })
 
           const publishedDoc = await payload.findByID({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
-            locale: 'all',
+            collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(publishedDoc._status!.en).toBe('published')
@@ -4065,8 +4094,8 @@ describe('Localization', () => {
           expect(publishedDoc.text!.es).toBe('spanish published 1')
 
           const latestVersionDoc = await payload.findByID({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             draft: true,
             locale: 'all',
           })
@@ -4081,25 +4110,25 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata EN',
               _status: 'published',
+              text: 'Localized Metadata EN',
             },
             locale: defaultLocale,
           })
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata ES',
               _status: 'draft',
+              text: 'Localized Metadata ES',
             },
             draft: true,
             locale: spanishLocale,
           })
 
           const esPublished = await payload.find({
-            locale: spanishLocale,
             collection: allFieldsLocalizedSlug,
+            locale: spanishLocale,
             where: {
               and: [
                 {
@@ -4118,9 +4147,9 @@ describe('Localization', () => {
           expect(esPublished.totalDocs).toBe(0)
 
           const esDraft = await payload.find({
-            locale: spanishLocale,
             collection: allFieldsLocalizedSlug,
             draft: true,
+            locale: spanishLocale,
             where: {
               and: [
                 {
@@ -4141,9 +4170,9 @@ describe('Localization', () => {
           expect(esDraft.docs[0]!.text).toBe('Localized Metadata ES')
 
           const enPublished = await payload.find({
-            locale: defaultLocale,
             collection: allFieldsLocalizedSlug,
             draft: true,
+            locale: defaultLocale,
             where: {
               and: [
                 {
@@ -4169,38 +4198,38 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: defaultLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             draft: true,
             locale: defaultLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'es published',
               _status: 'published',
+              text: 'es published',
             },
             locale: spanishLocale,
           })
 
           const mainDocument = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.es).toBe('published')
@@ -4209,10 +4238,10 @@ describe('Localization', () => {
           expect(mainDocument.text!.en).toBe('en published')
 
           const latestVersion = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: true,
+            locale: 'all',
           })
 
           expect(latestVersion._status!.es).toBe('published')
@@ -4225,38 +4254,38 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             locale: defaultLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'es draft',
               _status: 'draft',
+              text: 'es draft',
             },
             locale: spanishLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: 'en',
             publishAllLocales: true,
           })
 
           const mainDocument = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.en).toBe('published')
@@ -4265,17 +4294,17 @@ describe('Localization', () => {
           expect(mainDocument.text!.es).toBe('es draft')
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
-            unpublishAllLocales: true,
+            collection: allFieldsLocalizedSlug,
             data: {},
+            unpublishAllLocales: true,
           })
 
           const unpublishedDocument = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(unpublishedDocument._status!.en).toBe('draft')
@@ -4294,8 +4323,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'english draft 1',
               _status: 'draft',
+              text: 'english draft 1',
             },
             draft: true,
             locale: defaultLocale,
@@ -4304,8 +4333,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'english published 1',
               _status: 'published',
+              text: 'english published 1',
             },
             locale: defaultLocale,
           })
@@ -4314,8 +4343,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'spanish draft 1',
               _status: 'draft',
+              text: 'spanish draft 1',
             },
             draft: true,
             locale: spanishLocale,
@@ -4324,8 +4353,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'spanish published 1',
               _status: 'published',
+              text: 'spanish published 1',
             },
             locale: spanishLocale,
           })
@@ -4333,8 +4362,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'spanish draft 2',
               _status: 'draft',
+              text: 'spanish draft 2',
             },
             draft: true,
             locale: spanishLocale,
@@ -4342,8 +4371,8 @@ describe('Localization', () => {
 
           const publishedDoc = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(publishedDoc._status!.en).toBe('published')
@@ -4369,8 +4398,8 @@ describe('Localization', () => {
           const doc = await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: defaultLocale,
           })
@@ -4378,8 +4407,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             draft: true,
             locale: defaultLocale,
@@ -4388,16 +4417,16 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'es published',
               _status: 'published',
+              text: 'es published',
             },
             locale: spanishLocale,
           })
 
           const mainDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.es).toBe('published')
@@ -4407,8 +4436,8 @@ describe('Localization', () => {
 
           const latestVersion = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: true,
+            locale: 'all',
           })
 
           expect(latestVersion._status!.es).toBe('published')
@@ -4421,8 +4450,8 @@ describe('Localization', () => {
           const doc = await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             locale: defaultLocale,
           })
@@ -4430,8 +4459,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'es draft',
               _status: 'draft',
+              text: 'es draft',
             },
             locale: spanishLocale,
           })
@@ -4439,8 +4468,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: defaultLocale,
             publishAllLocales: true,
@@ -4448,8 +4477,8 @@ describe('Localization', () => {
 
           const mainDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.en).toBe('published')
@@ -4459,14 +4488,14 @@ describe('Localization', () => {
 
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
-            unpublishAllLocales: true,
             data: {},
+            unpublishAllLocales: true,
           })
 
           const unpublishedDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(unpublishedDocument._status!.en).toBe('draft')
@@ -4529,8 +4558,8 @@ describe('Localization', () => {
         const localizedFallback: any = await payload.findByID({
           id: allFieldsPostWithLocalizedData.id,
           collection: allFieldsLocalizedSlug,
-          locale: portugueseLocale,
           fallbackLocale: 'none',
+          locale: portugueseLocale,
         })
 
         expect(localizedFallback.text).not.toBeDefined()

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -271,8 +271,8 @@ describe('Localization', () => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
-          locale: portugueseLocale,
           fallbackLocale: 'none',
+          locale: portugueseLocale,
         })
 
         expect(localizedFallback.title).not.toBeDefined()
@@ -484,8 +484,8 @@ describe('Localization', () => {
               localizedAccentPostOne = await payload.create({
                 collection,
                 data: {
-                  title: 'non accent post',
                   localizedDescription: 'something',
+                  title: 'non accent post',
                 },
                 locale: englishLocale,
               })
@@ -493,8 +493,8 @@ describe('Localization', () => {
               localizedAccentPostTwo = await payload.create({
                 collection,
                 data: {
-                  title: 'accent post',
                   localizedDescription: 'veterinarian',
+                  title: 'accent post',
                 },
                 locale: englishLocale,
               })
@@ -503,8 +503,8 @@ describe('Localization', () => {
                 id: localizedAccentPostOne.id,
                 collection,
                 data: {
-                  title: 'non accent post',
                   localizedDescription: 'valami',
+                  title: 'non accent post',
                 },
                 locale: hungarianLocale,
               })
@@ -513,8 +513,8 @@ describe('Localization', () => {
                 id: localizedAccentPostTwo.id,
                 collection,
                 data: {
-                  title: 'accent post',
                   localizedDescription: 'állatorvos',
+                  title: 'accent post',
                 },
                 locale: hungarianLocale,
               })
@@ -523,13 +523,13 @@ describe('Localization', () => {
             it('should sort alphabetically even with accented letters', async () => {
               const sortByDescriptionQuery = await payload.find({
                 collection,
+                locale: hungarianLocale,
                 sort: 'description',
                 where: {
                   title: {
                     like: 'accent',
                   },
                 },
-                locale: hungarianLocale,
               })
 
               expect(sortByDescriptionQuery.docs[0].id).toEqual(localizedAccentPostTwo.id)
@@ -544,8 +544,8 @@ describe('Localization', () => {
         const document = await payload.create({
           collection: localizedDateFieldsSlug,
           data: {
-            localizedDate: new Date().toISOString(),
             date: new Date().toISOString(),
+            localizedDate: new Date().toISOString(),
           },
         })
         expect(document.localizedDate).toBeTruthy()
@@ -555,8 +555,8 @@ describe('Localization', () => {
         const document = await payload.create({
           collection: localizedDateFieldsSlug,
           data: {
-            localizedDate: new Date().toISOString(),
             date: new Date().toISOString(),
+            localizedDate: new Date().toISOString(),
           },
         })
 
@@ -674,9 +674,9 @@ describe('Localization', () => {
           const post = await payload.create({ collection: 'localized-sort', data: { title: en } })
           const es = randomWordsSpanish[i]
           await payload.update({
+            id: post.id,
             collection: 'localized-sort',
             data: { title: es },
-            id: post.id,
             locale: 'es',
           })
 
@@ -714,9 +714,9 @@ describe('Localization', () => {
         // Fetch sorted words in Spanish (ascending)
         const { docs: randomWordsEsAsc } = await payload.find({
           collection: localizedSortSlug,
+          locale: 'es',
           sort: 'title',
           where: q,
-          locale: 'es',
         })
 
         randomWordsEsAsc.forEach((doc, i) => {
@@ -726,9 +726,9 @@ describe('Localization', () => {
         // Fetch sorted words in Spanish (descending)
         const { docs: randomWordsEsDesc } = await payload.find({
           collection: localizedSortSlug,
+          locale: 'es',
           sort: '-title',
           where: q,
-          locale: 'es',
         })
 
         randomWordsEsDesc.forEach((doc, i) => {
@@ -1520,14 +1520,26 @@ describe('Localization', () => {
         const doc = await payload.create({
           collection: withRequiredLocalizedFields,
           data: {
+            myTab: {
+              group: {
+                nestedArray2: [
+                  {
+                    nestedText: 'hello',
+                  },
+                  {
+                    nestedText: 'goodbye',
+                  },
+                ],
+                nestedText: 'hello',
+              },
+              text: 'hello',
+            },
             nav: {
               layout: [
                 {
                   blockType: 'text',
-                  text: englishText,
                   nestedArray: [
                     {
-                      text: 'hello',
                       l2: [
                         {
                           l3: [
@@ -1541,9 +1553,9 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'hello',
                     },
                     {
-                      text: 'goodbye',
                       l2: [
                         {
                           l3: [
@@ -1557,24 +1569,12 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'goodbye',
                     },
                   ],
+                  text: englishText,
                 },
               ],
-            },
-            myTab: {
-              text: 'hello',
-              group: {
-                nestedText: 'hello',
-                nestedArray2: [
-                  {
-                    nestedText: 'hello',
-                  },
-                  {
-                    nestedText: 'goodbye',
-                  },
-                ],
-              },
             },
             title: 'hello',
           },
@@ -1585,14 +1585,26 @@ describe('Localization', () => {
           id: doc.id,
           collection: withRequiredLocalizedFields,
           data: {
+            myTab: {
+              group: {
+                nestedArray2: [
+                  {
+                    nestedText: 'hola',
+                  },
+                  {
+                    nestedText: 'adios',
+                  },
+                ],
+                nestedText: 'hola',
+              },
+              text: 'hola',
+            },
             nav: {
               layout: [
                 {
                   blockType: 'text',
-                  text: spanishText,
                   nestedArray: [
                     {
-                      text: 'hola',
                       l2: [
                         {
                           l3: [
@@ -1606,9 +1618,9 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'hola',
                     },
                     {
-                      text: 'adios',
                       l2: [
                         {
                           l3: [
@@ -1622,26 +1634,14 @@ describe('Localization', () => {
                           ],
                         },
                       ],
+                      text: 'adios',
                     },
                   ],
+                  text: spanishText,
                 },
               ],
             },
             title: 'hello',
-            myTab: {
-              text: 'hola',
-              group: {
-                nestedText: 'hola',
-                nestedArray2: [
-                  {
-                    nestedText: 'hola',
-                  },
-                  {
-                    nestedText: 'adios',
-                  },
-                ],
-              },
-            },
           },
           locale: spanishLocale,
         })
@@ -1677,8 +1677,8 @@ describe('Localization', () => {
         const post = await payload.create({
           collection,
           data: {
-            title: englishTitle,
             description: 'keep me',
+            title: englishTitle,
           },
         })
 
@@ -1724,25 +1724,25 @@ describe('Localization', () => {
         expect(result.groupLocalized?.title).toBe('hello en')
 
         await payload.update({
-          collection: groupSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: groupSlug,
           data: {
             groupLocalized: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.groupLocalized.title).toBe('hello en')
@@ -1752,36 +1752,36 @@ describe('Localization', () => {
       it('should properly create/update/read localized field inside of group', async () => {
         const result = await payload.create({
           collection: groupSlug,
-          locale: englishLocale,
           data: {
             group: {
               title: 'hello en',
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.group.title).toBe('hello en')
 
         await payload.update({
-          collection: groupSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: groupSlug,
           data: {
             group: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.group.title).toBe('hello en')
@@ -1791,54 +1791,54 @@ describe('Localization', () => {
       it('should properly create/update/read deep localized field inside of group', async () => {
         const result = await payload.create({
           collection: groupSlug,
-          locale: englishLocale,
           data: {
             deep: {
+              array: [{ title: 'hello en' }],
               blocks: [
                 {
                   blockType: 'first',
                   title: 'hello en',
                 },
               ],
-              array: [{ title: 'hello en' }],
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.deep.array[0].title).toBe('hello en')
 
         await payload.update({
-          collection: groupSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: groupSlug,
           data: {
             deep: {
-              blocks: [
-                {
-                  blockType: 'first',
-                  title: 'hello es',
-                  id: result.deep.blocks[0].id,
-                },
-              ],
               array: [
                 {
                   id: result.deep.array[0].id,
                   title: 'hello es',
                 },
               ],
+              blocks: [
+                {
+                  id: result.deep.blocks[0].id,
+                  blockType: 'first',
+                  title: 'hello es',
+                },
+              ],
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: groupSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.deep.array[0].title).toBe('hello en')
@@ -1861,6 +1861,7 @@ describe('Localization', () => {
         expect(doc.groupLocalizedRow.text).toBe('hello world')
 
         const docES = await payload.update({
+          id: doc.id,
           collection: 'groups',
           data: {
             groupLocalizedRow: {
@@ -1868,16 +1869,15 @@ describe('Localization', () => {
             },
           },
           locale: 'es',
-          id: doc.id,
         })
 
         expect(docES.groupLocalizedRow.text).toBe('hola world or something')
 
         // check if docES didnt break EN
-        const docEN = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'en' })
+        const docEN = await payload.findByID({ id: doc.id, collection: 'groups', locale: 'en' })
         expect(docEN.groupLocalizedRow.text).toBe('hello world')
 
-        const all = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'all' })
+        const all = await payload.findByID({ id: doc.id, collection: 'groups', locale: 'all' })
 
         expect(all.groupLocalizedRow.en.text).toBe('hello world')
         expect(all.groupLocalizedRow.es.text).toBe('hola world or something')
@@ -1886,10 +1886,10 @@ describe('Localization', () => {
       it('should not crash on empty localized tab', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tabLocalized: {},
           },
+          locale: englishLocale,
         })
 
         expect(result).toBeTruthy()
@@ -1898,37 +1898,37 @@ describe('Localization', () => {
       it('should properly create/update/read array field inside localized tab field', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tabLocalized: {
               title: 'hello en',
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.tabLocalized?.title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             tabLocalized: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
 
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.tabLocalized.title).toBe('hello en')
@@ -1938,7 +1938,6 @@ describe('Localization', () => {
       it('should properly create/update/read localized tab field', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tabLocalized: {
               array: [
@@ -1948,31 +1947,32 @@ describe('Localization', () => {
               ],
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.tabLocalized.array[0].title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             tabLocalized: {
               array: [{ title: 'hello es' }],
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
 
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.tabLocalized.array[0].title).toBe('hello en')
@@ -1982,36 +1982,36 @@ describe('Localization', () => {
       it('should properly create/update/read localized field inside of tab', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             tab: {
               title: 'hello en',
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.tab.title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             tab: {
               title: 'hello es',
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.tab.title).toBe('hello en')
@@ -2021,54 +2021,54 @@ describe('Localization', () => {
       it('should properly create/update/read deep localized field inside of tab', async () => {
         const result = await payload.create({
           collection: tabSlug,
-          locale: englishLocale,
           data: {
             deep: {
+              array: [{ title: 'hello en' }],
               blocks: [
                 {
                   blockType: 'first',
                   title: 'hello en',
                 },
               ],
-              array: [{ title: 'hello en' }],
             },
           },
+          locale: englishLocale,
         })
 
         expect(result.deep.array[0].title).toBe('hello en')
 
         await payload.update({
-          collection: tabSlug,
-          locale: spanishLocale,
           id: result.id,
+          collection: tabSlug,
           data: {
             deep: {
-              blocks: [
-                {
-                  blockType: 'first',
-                  title: 'hello es',
-                  id: result.deep.blocks[0].id,
-                },
-              ],
               array: [
                 {
                   id: result.deep.array[0].id,
                   title: 'hello es',
                 },
               ],
+              blocks: [
+                {
+                  id: result.deep.blocks[0].id,
+                  blockType: 'first',
+                  title: 'hello es',
+                },
+              ],
             },
           },
+          locale: spanishLocale,
         })
 
         const docEn = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: result.id,
         })
         const docEs = await payload.findByID({
+          id: result.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: result.id,
         })
 
         expect(docEn.deep.array[0].title).toBe('hello en')
@@ -2080,7 +2080,6 @@ describe('Localization', () => {
       it('should properly isolate locales for a group inside a localized tab', async () => {
         const docEs = await payload.create({
           collection: tabSlug,
-          locale: spanishLocale,
           data: {
             tabLocalized: {
               group: {
@@ -2088,12 +2087,12 @@ describe('Localization', () => {
               },
             },
           },
+          locale: spanishLocale,
         })
 
         await payload.update({
-          collection: tabSlug,
-          locale: englishLocale,
           id: docEs.id,
+          collection: tabSlug,
           data: {
             tabLocalized: {
               group: {
@@ -2101,18 +2100,19 @@ describe('Localization', () => {
               },
             },
           },
+          locale: englishLocale,
         })
 
         const readEn = await payload.findByID({
+          id: docEs.id,
           collection: tabSlug,
           locale: englishLocale,
-          id: docEs.id,
         })
 
         const readEs = await payload.findByID({
+          id: docEs.id,
           collection: tabSlug,
           locale: spanishLocale,
-          id: docEs.id,
         })
 
         expect(readEn.tabLocalized.group.heading).toBe('English heading')
@@ -2141,7 +2141,6 @@ describe('Localization', () => {
           data: {
             content: [
               {
-                blockType: 'blockInsideBlock',
                 array: [
                   {
                     link: {
@@ -2154,6 +2153,7 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'blockInsideBlock',
                 content: [
                   {
                     blockType: 'textBlock',
@@ -2168,18 +2168,16 @@ describe('Localization', () => {
         id = doc.id
 
         const retrievedInEN = await payload.findByID({
-          collection: 'blocks-fields',
           id,
+          collection: 'blocks-fields',
         })
 
         await payload.update({
-          collection: 'blocks-fields',
           id,
-          locale: 'es',
+          collection: 'blocks-fields',
           data: {
             content: [
               {
-                blockType: 'blockInsideBlock',
                 array: [
                   {
                     link: {
@@ -2192,6 +2190,7 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'blockInsideBlock',
                 content: [
                   {
                     blockType: 'textBlock',
@@ -2201,11 +2200,12 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'es',
         })
 
         const retrieved = await payload.findByID({
-          collection: 'blocks-fields',
           id,
+          collection: 'blocks-fields',
           locale: 'all',
         })
 
@@ -2240,26 +2240,26 @@ describe('Localization', () => {
           {
             blockName: '1',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc.id,
             myGroup: {
               text: 'hello in english 1',
             },
+            relationWithinBlock: randomDoc.id,
           },
           {
             blockName: '2',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc.id,
             myGroup: {
               text: 'hello in english 2',
             },
+            relationWithinBlock: randomDoc.id,
           },
           {
             blockName: '3',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc.id,
             myGroup: {
               text: 'hello in english 3',
             },
+            relationWithinBlock: randomDoc.id,
           },
         ]
 
@@ -2267,33 +2267,31 @@ describe('Localization', () => {
           {
             blockName: '1',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc2.id,
             myGroup: {
               text: 'hello in spanish 1',
             },
+            relationWithinBlock: randomDoc2.id,
           },
           {
             blockName: '2',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc2.id,
             myGroup: {
               text: 'hello in spanish 2',
             },
+            relationWithinBlock: randomDoc2.id,
           },
           {
             blockName: '3',
             blockType: 'someBlock',
-            relationWithinBlock: randomDoc2.id,
             myGroup: {
               text: 'hello in spanish 3',
             },
+            relationWithinBlock: randomDoc2.id,
           },
         ]
 
         const createdEnDoc = await payload.create({
           collection: 'nested-arrays',
-          locale: 'en',
-          depth: 0,
           data: {
             arrayWithBlocks: [
               {
@@ -2301,13 +2299,13 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'en',
         })
 
         const updatedEsDoc = await payload.update({
-          collection: 'nested-arrays',
           id: createdEnDoc.id,
-          depth: 0,
-          locale: 'es',
+          collection: 'nested-arrays',
           data: {
             arrayWithBlocks: [
               {
@@ -2315,6 +2313,8 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         const esArrayBlocks = updatedEsDoc.arrayWithBlocks[0].blocksWithinArray
@@ -2335,8 +2335,8 @@ describe('Localization', () => {
         const enDoc2 = await payload.findByID({
           id: createdEnDoc.id,
           collection: 'nested-arrays',
-          locale: 'en',
           depth: 0,
+          locale: 'en',
         })
         removeId(enDoc2.arrayWithBlocks[0].blocksWithinArray)
         expect(enDoc2.arrayWithBlocks[0].blocksWithinArray).toEqual(blocksWithinArrayEN)
@@ -2358,8 +2358,6 @@ describe('Localization', () => {
 
         const createdEnDoc = await payload.create({
           collection: 'nested-arrays',
-          locale: 'en',
-          depth: 0,
           data: {
             arrayWithLocalizedRelation: [
               {
@@ -2367,13 +2365,13 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'en',
         })
 
         const updatedEsDoc = await payload.update({
-          collection: 'nested-arrays',
           id: createdEnDoc.id,
-          depth: 0,
-          locale: 'es',
+          collection: 'nested-arrays',
           data: {
             arrayWithLocalizedRelation: [
               {
@@ -2382,6 +2380,8 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         expect(updatedEsDoc.arrayWithLocalizedRelation).toHaveLength(1)
@@ -2394,8 +2394,8 @@ describe('Localization', () => {
         const enDoc2 = await payload.findByID({
           id: createdEnDoc.id,
           collection: 'nested-arrays',
-          locale: 'en',
           depth: 0,
+          locale: 'en',
         })
         expect(enDoc2.arrayWithLocalizedRelation).toHaveLength(1)
         expect(enDoc2.arrayWithLocalizedRelation[0].localizedRelation).toBe(randomTextDoc.id)
@@ -2406,7 +2406,6 @@ describe('Localization', () => {
       it('should update localized block', async () => {
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             content: [
               {
@@ -2420,6 +2419,7 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const updated = await payload.update({
@@ -2433,16 +2433,16 @@ describe('Localization', () => {
                 // since the parent is localized, and the primary key in the block table
                 // consists only of the ID. That's why it's removed in `copyToLocale`.
                 // id: doc.content?.[0]?.id,
-                blockName: null,
                 array: [],
+                blockName: null,
                 blockType: 'blockInsideBlock',
                 content: [
                   {
                     // Same as above.
                     // id: doc.content?.[0]?.content?.[0]?.id,
-                    text: 'some-text',
                     blockName: null,
                     blockType: 'textBlock',
+                    text: 'some-text',
                   },
                 ],
               },
@@ -2459,7 +2459,6 @@ describe('Localization', () => {
       it('update specific locale should not erease the others in blocks and arrays', async () => {
         const doc = await payload.create({
           collection: 'nested',
-          locale: 'en',
           data: {
             blocks: [
               {
@@ -2474,6 +2473,7 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         expect(doc.blocks?.[0]?.someText).toBe('some-block-text-en')
@@ -2497,7 +2497,6 @@ describe('Localization', () => {
         const updatedDoc = await payload.update({
           id: doc.id,
           collection: 'nested',
-          locale: 'es',
           data: {
             blocks: [
               {
@@ -2514,6 +2513,7 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'es',
         })
 
         expect(updatedDoc.blocks?.[0]?.someText).toBe('some-block-text-es')
@@ -2539,12 +2539,12 @@ describe('Localization', () => {
       it('update specific locale should not erease the others in simple fields', async () => {
         const doc = await payload.create({
           collection: 'localized-posts',
-          locale: 'en',
           data: {
-            title: 'some-localized-title',
             description: 'some-not-localized-description',
             localizedDescription: 'some-localized-description',
+            title: 'some-localized-title',
           },
+          locale: 'en',
         })
 
         expect(doc.title).toBe('some-localized-title')
@@ -2566,12 +2566,12 @@ describe('Localization', () => {
         const updatedDoc = await payload.update({
           id: doc.id,
           collection: 'localized-posts',
-          locale: 'es',
           data: {
-            title: 'some-localized-title-es',
             description: 'some-not-localized-description-es',
             localizedDescription: 'some-localized-description-es',
+            title: 'some-localized-title-es',
           },
+          locale: 'es',
         })
 
         expect(updatedDoc.title).toBe('some-localized-title-es')
@@ -2611,11 +2611,6 @@ describe('Localization', () => {
           data: {
             array: [
               {
-                relation: {
-                  value: randomDoc.id,
-                  relationTo: 'localized-posts',
-                },
-                hasManyRelation: [randomDoc.id, randomDoc2.id],
                 hasManyPolyRelation: [
                   {
                     relationTo: 'localized-posts',
@@ -2626,26 +2621,25 @@ describe('Localization', () => {
                     value: randomDoc2.id,
                   },
                 ],
+                hasManyRelation: [randomDoc.id, randomDoc2.id],
                 number: [1, 2],
-                text: ['hello', 'goodbye'],
+                relation: {
+                  relationTo: 'localized-posts',
+                  value: randomDoc.id,
+                },
                 select: ['one'],
+                text: ['hello', 'goodbye'],
               },
             ],
           },
         })
 
         await payload.update({
-          collection: 'nested-field-tables',
           id: newDoc.id,
-          locale: 'es',
+          collection: 'nested-field-tables',
           data: {
             array: [
               {
-                relation: {
-                  value: randomDoc2.id,
-                  relationTo: 'localized-posts',
-                },
-                hasManyRelation: [randomDoc2.id, randomDoc.id],
                 hasManyPolyRelation: [
                   {
                     relationTo: 'localized-posts',
@@ -2656,17 +2650,23 @@ describe('Localization', () => {
                     value: randomDoc.id,
                   },
                 ],
+                hasManyRelation: [randomDoc2.id, randomDoc.id],
+                number: [3, 4],
+                relation: {
+                  relationTo: 'localized-posts',
+                  value: randomDoc2.id,
+                },
                 select: ['two', 'three'],
                 text: ['hola', 'adios'],
-                number: [3, 4],
               },
             ],
           },
+          locale: 'es',
         })
 
         const retrieved = await payload.findByID({
-          collection: 'nested-field-tables',
           id: newDoc.id,
+          collection: 'nested-field-tables',
           depth: 0,
           locale: 'all',
         })
@@ -2678,12 +2678,12 @@ describe('Localization', () => {
         expect(retrieved.array.es[0].hasManyRelation).toEqual([randomDoc2.id, randomDoc.id])
 
         expect(retrieved.array.en[0].hasManyPolyRelation).toEqual([
-          { value: randomDoc.id, relationTo: 'localized-posts' },
-          { value: randomDoc2.id, relationTo: 'localized-posts' },
+          { relationTo: 'localized-posts', value: randomDoc.id },
+          { relationTo: 'localized-posts', value: randomDoc2.id },
         ])
         expect(retrieved.array.es[0].hasManyPolyRelation).toEqual([
-          { value: randomDoc2.id, relationTo: 'localized-posts' },
-          { value: randomDoc.id, relationTo: 'localized-posts' },
+          { relationTo: 'localized-posts', value: randomDoc2.id },
+          { relationTo: 'localized-posts', value: randomDoc.id },
         ])
 
         expect(retrieved.array.en[0].number).toEqual([1, 2])
@@ -2712,7 +2712,6 @@ describe('Localization', () => {
 
         const docEn = await payload.create({
           collection: 'nested-field-tables',
-          depth: 0,
           data: {
             blocks: [
               {
@@ -2753,6 +2752,7 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
         })
 
         expect(docEn.blocks[0].nestedBlocks[0].relation.value).toBe(randomDoc.id)
@@ -2761,8 +2761,6 @@ describe('Localization', () => {
 
         const docEs = await payload.update({
           id: docEn.id,
-          depth: 0,
-          locale: 'es',
           collection: 'nested-field-tables',
           data: {
             blocks: [
@@ -2804,6 +2802,8 @@ describe('Localization', () => {
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         expect(docEs.blocks[0].nestedBlocks[0].relation.value).toBe(randomDoc2.id)
@@ -2811,10 +2811,10 @@ describe('Localization', () => {
         expect(docEs.blocks[2].nestedBlocks[0].relation.value).toBe(randomDoc2.id)
 
         const docAll = await payload.findByID({
-          collection: 'nested-field-tables',
           id: docEn.id,
-          locale: 'all',
+          collection: 'nested-field-tables',
           depth: 0,
+          locale: 'all',
         })
 
         expect(docAll.blocks.en[0].nestedBlocks[0].relation.value).toBe(randomDoc.id)
@@ -2842,11 +2842,9 @@ describe('Localization', () => {
 
         const docEn = await payload.create({
           collection: 'nested-field-tables',
-          depth: 0,
           data: {
             blocks: [
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2855,9 +2853,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2866,9 +2864,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2877,9 +2875,11 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
             ],
           },
+          depth: 0,
         })
 
         expect(docEn.blocks[0].array[0].relation.value).toBe(randomDoc.id)
@@ -2888,13 +2888,10 @@ describe('Localization', () => {
 
         const docEs = await payload.update({
           id: docEn.id,
-          depth: 0,
-          locale: 'es',
           collection: 'nested-field-tables',
           data: {
             blocks: [
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2903,9 +2900,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2914,9 +2911,9 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
               {
-                blockType: 'block',
                 array: [
                   {
                     relation: {
@@ -2925,9 +2922,12 @@ describe('Localization', () => {
                     },
                   },
                 ],
+                blockType: 'block',
               },
             ],
           },
+          depth: 0,
+          locale: 'es',
         })
 
         expect(docEs.blocks[0].array[0].relation.value).toBe(randomDoc2.id)
@@ -2935,10 +2935,10 @@ describe('Localization', () => {
         expect(docEs.blocks[2].array[0].relation.value).toBe(randomDoc2.id)
 
         const docAll = await payload.findByID({
-          collection: 'nested-field-tables',
           id: docEn.id,
-          locale: 'all',
+          collection: 'nested-field-tables',
           depth: 0,
+          locale: 'all',
         })
 
         expect(docAll.blocks.en[0].array[0].relation.value).toBe(randomDoc.id)
@@ -2955,35 +2955,35 @@ describe('Localization', () => {
       it('localized with unique should work for each locale', async () => {
         await payload.create({
           collection: 'localized-posts',
+          data: {
+            unique: 'text',
+          },
           locale: 'ar',
-          data: {
-            unique: 'text',
-          },
         })
 
         await payload.create({
           collection: 'localized-posts',
+          data: {
+            unique: 'text',
+          },
           locale: 'en',
-          data: {
-            unique: 'text',
-          },
         })
 
         await payload.create({
           collection: 'localized-posts',
-          locale: 'es',
           data: {
             unique: 'text',
           },
+          locale: 'es',
         })
 
         await expect(
           payload.create({
             collection: 'localized-posts',
-            locale: 'en',
             data: {
               unique: 'text',
             },
+            locale: 'en',
           }),
         ).rejects.toBeTruthy()
       })
@@ -2993,19 +2993,19 @@ describe('Localization', () => {
 
         await payload.create({
           collection: localizedPostsSlug,
-          locale: 'en',
           data: {
             unique: uniqueValue,
           },
+          locale: 'en',
         })
 
         try {
           await payload.create({
             collection: localizedPostsSlug,
-            locale: 'en',
             data: {
               unique: uniqueValue,
             },
+            locale: 'en',
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
@@ -3028,27 +3028,27 @@ describe('Localization', () => {
 
         await payload.create({
           collection: withRequiredLocalizedFields,
-          locale: 'en',
           data: {
-            title: 'Test title 1',
-            seoTitle: uniqueValue,
             nav: {
               layout: blockData,
             },
+            seoTitle: uniqueValue,
+            title: 'Test title 1',
           },
+          locale: 'en',
         })
 
         try {
           await payload.create({
             collection: withRequiredLocalizedFields,
-            locale: 'en',
             data: {
-              title: 'Test title 2',
-              seoTitle: uniqueValue,
               nav: {
                 layout: blockData,
               },
+              seoTitle: uniqueValue,
+              title: 'Test title 2',
             },
+            locale: 'en',
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
@@ -3095,23 +3095,23 @@ describe('Localization', () => {
         const doc = await payload.create({
           collection: 'localized-posts',
           data: {
-            title: 'Hello',
             group: {
               children: 'Children',
             },
-            unique: 'unique-field',
             localizedCheckbox: true,
+            title: 'Hello',
+            unique: 'unique-field',
           },
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'localized-posts',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'localized-posts',
         })) as LocalizedPost
 
         expect(res.title).toBe('Hello')
@@ -3126,7 +3126,6 @@ describe('Localization', () => {
         // and that's where the bug occurs.
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             content: [
               {
@@ -3140,16 +3139,17 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
         })) as BlocksField
 
         expect(res.content?.[0]?.content?.[0]?.text).toBe('some-text')
@@ -3161,7 +3161,6 @@ describe('Localization', () => {
         // and that's where the bug occurs.
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             tabContent: [
               {
@@ -3170,15 +3169,16 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'pt',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
         })) as BlocksField
 
         expect(res.tabContent?.[0]?.text).toBe('some-text')
@@ -3187,7 +3187,6 @@ describe('Localization', () => {
       it('should copy localized nested to arrays', async () => {
         const doc = await payload.create({
           collection: 'nested',
-          locale: 'en',
           data: {
             topLevelArray: [
               {
@@ -3196,16 +3195,17 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'nested',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'nested',
         })) as Nested
 
         expect(res.topLevelArray?.[0]?.localizedText).toBe('some-localized-text')
@@ -3225,7 +3225,6 @@ describe('Localization', () => {
       it('should copy localized arrays', async () => {
         const doc = await payload.create({
           collection: 'nested',
-          locale: 'en',
           data: {
             topLevelArrayLocalized: [
               {
@@ -3233,16 +3232,17 @@ describe('Localization', () => {
               },
             ],
           },
+          locale: 'en',
         })
 
         const req = await createLocalReq({ user }, payload)
 
         const res = (await copyDataFromLocaleHandler({
+          collectionSlug: 'nested',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'nested',
         })) as Nested
 
         expect(res.topLevelArrayLocalized?.[0]?.text).toBe('some-text')
@@ -3295,38 +3295,38 @@ describe('Localization', () => {
         // Create a document with content in en locale
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
-            title: 'English Title',
             content: [
               {
                 blockType: 'blockInsideBlock',
-                text: 'English block text',
                 content: [
                   {
                     blockType: 'textBlock',
                     text: 'Nested English text',
                   },
                 ],
+                text: 'English block text',
               },
             ],
+            title: 'English Title',
           },
+          locale: 'en',
         })
 
         // Add content to Spanish locale separately
         await payload.update({
-          collection: 'blocks-fields',
           id: doc.id,
-          locale: 'es',
+          collection: 'blocks-fields',
           data: {
-            title: 'Spanish Title',
             content: [
               {
                 blockType: 'blockInsideBlock',
                 text: 'Spanish block text',
               },
             ],
+            title: 'Spanish Title',
           },
+          locale: 'es',
         })
 
         // Verify initial state - English data should exist
@@ -3343,12 +3343,12 @@ describe('Localization', () => {
         const req = await createLocalReq({ user }, payload)
 
         await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
+          overrideData: true,
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
-          overrideData: true,
         })
 
         // CRITICAL: Verify English data is NOT lost after copy operation
@@ -3366,8 +3366,8 @@ describe('Localization', () => {
         const esDocAfter = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'es',
           draft: true,
+          locale: 'es',
         })
 
         expect(esDocAfter.title).toBe('English Title')
@@ -3378,25 +3378,25 @@ describe('Localization', () => {
         // Create a document with draft content
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
-          draft: true,
           data: {
-            title: 'Draft English Title',
             content: [
               {
                 blockType: 'blockInsideBlock',
                 text: 'Draft block text',
               },
             ],
+            title: 'Draft English Title',
           },
+          draft: true,
+          locale: 'en',
         })
 
         // Verify draft exists
         const draftBefore = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: true,
+          locale: 'en',
         })
 
         expect(draftBefore.title).toBe('Draft English Title')
@@ -3405,19 +3405,19 @@ describe('Localization', () => {
         const req = await createLocalReq({ user }, payload)
 
         await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
         })
 
         // Verify the source draft is not lost
         const draftAfter = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: true,
+          locale: 'en',
         })
 
         expect(draftAfter.title).toBe('Draft English Title')
@@ -3428,35 +3428,35 @@ describe('Localization', () => {
         // Create published doc in en
         const doc = await payload.create({
           collection: 'blocks-fields',
-          locale: 'en',
           data: {
             title: 'Published EN',
           },
+          locale: 'en',
         })
 
         // Create draft with different content
         await payload.update({
-          collection: 'blocks-fields',
           id: doc.id,
-          locale: 'en',
-          draft: true,
+          collection: 'blocks-fields',
           data: {
             title: 'Draft EN',
           },
+          draft: true,
+          locale: 'en',
         })
 
         // Verify both published and draft exist with different content
         const enPublishedBefore = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: false,
+          locale: 'en',
         })
         const enDraftBefore = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: true,
+          locale: 'en',
         })
 
         expect(enPublishedBefore.title).toBe('Published EN')
@@ -3466,23 +3466,52 @@ describe('Localization', () => {
         const req = await createLocalReq({ user }, payload)
 
         await copyDataFromLocaleHandler({
+          collectionSlug: 'blocks-fields',
+          docID: doc.id,
           fromLocale: 'en',
+          overrideData: true,
           req,
           toLocale: 'es',
-          docID: doc.id,
-          collectionSlug: 'blocks-fields',
-          overrideData: true,
         })
 
         // Verify published content in source locale is NOT overwritten
         const enPublishedAfter = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
-          locale: 'en',
           draft: false,
+          locale: 'en',
         })
 
         expect(enPublishedAfter.title).toBe('Published EN')
+      })
+
+      it('should copy global data to another locale', async () => {
+        // Set some initial data on global-copy-test in 'en'
+        await payload.updateGlobal({
+          slug: 'global-copy-test',
+          data: {
+            text: 'Global text en',
+          },
+          locale: 'en',
+        })
+
+        const req = await createLocalReq({ user }, payload)
+
+        await copyDataFromLocaleHandler({
+          fromLocale: 'en',
+          globalSlug: 'global-copy-test',
+          overrideData: true,
+          req,
+          toLocale: 'es',
+        })
+
+        const esGlobal = await payload.findGlobal({
+          slug: 'global-copy-test',
+          fallbackLocale: 'none',
+          locale: 'es',
+        })
+
+        expect(esGlobal.text).toBe('Global text en')
       })
     })
 
@@ -3493,8 +3522,8 @@ describe('Localization', () => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
-              locale: portugueseLocale,
               fallbackLocale: [spanishLocale, englishLocale],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3505,8 +3534,8 @@ describe('Localization', () => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar', spanishLocale],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3517,8 +3546,8 @@ describe('Localization', () => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar'],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3530,8 +3559,8 @@ describe('Localization', () => {
           it('should allow fallback locale to be an array', async () => {
             const result = await payload.findGlobal({
               slug: global,
-              locale: portugueseLocale,
               fallbackLocale: [spanishLocale, englishLocale],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3541,8 +3570,8 @@ describe('Localization', () => {
           it('should pass over fallback locales until it finds one that exists', async () => {
             const result = await payload.findGlobal({
               slug: global,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', spanishLocale],
+              locale: portugueseLocale,
             })
             expect(result).toBeDefined()
             expect(result.text).toBe(spanishTitle)
@@ -3551,8 +3580,8 @@ describe('Localization', () => {
           it('should return undefined if no fallback locales exist', async () => {
             const result = await payload.findGlobal({
               slug: global,
-              locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar'],
+              locale: portugueseLocale,
             })
 
             expect(result).toBeDefined()
@@ -3646,7 +3675,7 @@ describe('Localization', () => {
             const { data } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['es', 'en'] },
+                query: { fallbackLocale: ['es', 'en'], locale: 'pt' },
               })
               .then((res) => res.json())
             console.log(data)
@@ -3666,7 +3695,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar', 'es'] },
+                query: { fallbackLocale: ['hu', 'ar', 'es'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3685,7 +3714,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar'] },
+                query: { fallbackLocale: ['hu', 'ar'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3704,7 +3733,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['es', 'en'] },
+                query: { fallbackLocale: ['es', 'en'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3721,7 +3750,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar', 'es'] },
+                query: { fallbackLocale: ['hu', 'ar', 'es'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3738,7 +3767,7 @@ describe('Localization', () => {
             const { data: queryResult } = await restClient
               .GRAPHQL_POST({
                 body: JSON.stringify({ query }),
-                query: { locale: 'pt', fallbackLocale: ['hu', 'ar'] },
+                query: { fallbackLocale: ['hu', 'ar'], locale: 'pt' },
               })
               .then((res) => res.json())
 
@@ -3829,8 +3858,8 @@ describe('Localization', () => {
         const fallbackDoc = await payload.findByID({
           id: post1.id,
           collection,
-          locale: portugueseLocale,
           fallbackLocale: englishLocale,
+          locale: portugueseLocale,
         })
 
         expect(fallbackDoc.title).toBe(englishTitle)
@@ -3850,8 +3879,8 @@ describe('Localization', () => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
-          locale: portugueseLocale,
           fallbackLocale: false,
+          locale: portugueseLocale,
         })
 
         expect(localizedFallback.title).not.toBeDefined()
@@ -3867,8 +3896,8 @@ describe('Localization', () => {
         })
 
         await payload.update({
-          collection: allFieldsLocalizedSlug,
           id: originalPost.id,
+          collection: allFieldsLocalizedSlug,
           data: {
             selfRelation: originalPost.id,
           },
@@ -3876,19 +3905,19 @@ describe('Localization', () => {
         })
 
         const spanishPostWithEnglishFallback = await payload.findByID({
-          collection: allFieldsLocalizedSlug,
           id: originalPost.id,
-          locale: 'es',
+          collection: allFieldsLocalizedSlug,
           fallbackLocale: 'en',
+          locale: 'es',
         })
 
         expect(spanishPostWithEnglishFallback.text).toBe('Post EN')
 
         const spanishPostWithNoFallback = await payload.findByID({
-          collection: allFieldsLocalizedSlug,
           id: originalPost.id,
-          locale: 'es',
+          collection: allFieldsLocalizedSlug,
           fallbackLocale: false,
+          locale: 'es',
         })
 
         expect(spanishPostWithNoFallback?.selfRelation?.text).toBeUndefined()
@@ -3917,11 +3946,7 @@ describe('Localization', () => {
       const doc = await payload.create({
         collection: allFieldsLocalizedSlug,
         data: {
-          t1: {
-            t2: {
-              text: 'EN Deep Text',
-            },
-          },
+          _status: 'draft',
           g1: {
             g2: {
               g2a1: [{ text: 'EN Deep 1' }, { text: 'EN Deep 2' }],
@@ -3946,15 +3971,19 @@ describe('Localization', () => {
           },
           number: 100,
           select: 'option1',
+          t1: {
+            t2: {
+              text: 'EN Deep Text',
+            },
+          },
           text: 'English text',
-          _status: 'draft',
         },
         locale: 'en',
       })
 
       const allLocalesDoc = await payload.findByID({
-        collection: allFieldsLocalizedSlug,
         id: doc.id,
+        collection: allFieldsLocalizedSlug,
         locale: 'all',
       })
 
@@ -4017,12 +4046,12 @@ describe('Localization', () => {
       const doc = await payload.create({
         collection: noLocalizedFieldsCollectionSlug,
         data: {
-          text: 'title',
           group: {
             en: {
               text: 'some text',
             },
           },
+          text: 'title',
         },
       })
 
@@ -4051,16 +4080,16 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata EN',
               _status: 'published',
+              text: 'Localized Metadata EN',
             },
             locale: defaultLocale,
           })
 
           const esDoc = await payload.findByID({
-            locale: spanishLocale,
             id: doc.id,
             collection: allFieldsLocalizedSlug,
+            locale: spanishLocale,
           })
 
           expect(esDoc._status).toContain('draft')
@@ -4070,17 +4099,17 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata EN',
               _status: 'published',
+              text: 'Localized Metadata EN',
             },
             locale: defaultLocale,
             publishAllLocales: true,
           })
 
           const esDoc = await payload.findByID({
-            locale: spanishLocale,
             id: doc.id,
             collection: allFieldsLocalizedSlug,
+            locale: spanishLocale,
           })
 
           expect(esDoc._status).toContain('published')
@@ -4096,61 +4125,61 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'english draft 1',
               _status: 'draft',
+              text: 'english draft 1',
             },
             draft: true,
             locale: defaultLocale,
           })
           // update english published 1
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'english published 1',
               _status: 'published',
+              text: 'english published 1',
             },
             locale: defaultLocale,
           })
 
           // create spanish draft 1
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'spanish draft 1',
               _status: 'draft',
+              text: 'spanish draft 1',
             },
             draft: true,
             locale: spanishLocale,
           })
           // update spanish published 1
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'spanish published 1',
               _status: 'published',
+              text: 'spanish published 1',
             },
             locale: spanishLocale,
           })
           // update spanish draft 2
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'spanish draft 2',
               _status: 'draft',
+              text: 'spanish draft 2',
             },
             draft: true,
             locale: spanishLocale,
           })
 
           const publishedDoc = await payload.findByID({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
-            locale: 'all',
+            collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(publishedDoc._status!.en).toBe('published')
@@ -4159,8 +4188,8 @@ describe('Localization', () => {
           expect(publishedDoc.text!.es).toBe('spanish published 1')
 
           const latestVersionDoc = await payload.findByID({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             draft: true,
             locale: 'all',
           })
@@ -4175,25 +4204,25 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata EN',
               _status: 'published',
+              text: 'Localized Metadata EN',
             },
             locale: defaultLocale,
           })
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'Localized Metadata ES',
               _status: 'draft',
+              text: 'Localized Metadata ES',
             },
             draft: true,
             locale: spanishLocale,
           })
 
           const esPublished = await payload.find({
-            locale: spanishLocale,
             collection: allFieldsLocalizedSlug,
+            locale: spanishLocale,
             where: {
               and: [
                 {
@@ -4212,9 +4241,9 @@ describe('Localization', () => {
           expect(esPublished.totalDocs).toBe(0)
 
           const esDraft = await payload.find({
-            locale: spanishLocale,
             collection: allFieldsLocalizedSlug,
             draft: true,
+            locale: spanishLocale,
             where: {
               and: [
                 {
@@ -4235,9 +4264,9 @@ describe('Localization', () => {
           expect(esDraft.docs[0]!.text).toBe('Localized Metadata ES')
 
           const enPublished = await payload.find({
-            locale: defaultLocale,
             collection: allFieldsLocalizedSlug,
             draft: true,
+            locale: defaultLocale,
             where: {
               and: [
                 {
@@ -4263,38 +4292,38 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: defaultLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             draft: true,
             locale: defaultLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'es published',
               _status: 'published',
+              text: 'es published',
             },
             locale: spanishLocale,
           })
 
           const mainDocument = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.es).toBe('published')
@@ -4303,10 +4332,10 @@ describe('Localization', () => {
           expect(mainDocument.text!.en).toBe('en published')
 
           const latestVersion = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: true,
+            locale: 'all',
           })
 
           expect(latestVersion._status!.es).toBe('published')
@@ -4319,38 +4348,38 @@ describe('Localization', () => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             locale: defaultLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'es draft',
               _status: 'draft',
+              text: 'es draft',
             },
             locale: spanishLocale,
           })
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
+            collection: allFieldsLocalizedSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: 'en',
             publishAllLocales: true,
           })
 
           const mainDocument = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.en).toBe('published')
@@ -4359,17 +4388,17 @@ describe('Localization', () => {
           expect(mainDocument.text!.es).toBe('es draft')
 
           await payload.update({
-            collection: allFieldsLocalizedSlug,
             id: doc.id,
-            unpublishAllLocales: true,
+            collection: allFieldsLocalizedSlug,
             data: {},
+            unpublishAllLocales: true,
           })
 
           const unpublishedDocument = await payload.findByID({
-            locale: 'all',
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            locale: 'all',
           })
 
           expect(unpublishedDocument._status!.en).toBe('draft')
@@ -4388,8 +4417,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'english draft 1',
               _status: 'draft',
+              text: 'english draft 1',
             },
             draft: true,
             locale: defaultLocale,
@@ -4398,8 +4427,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'english published 1',
               _status: 'published',
+              text: 'english published 1',
             },
             locale: defaultLocale,
           })
@@ -4408,8 +4437,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'spanish draft 1',
               _status: 'draft',
+              text: 'spanish draft 1',
             },
             draft: true,
             locale: spanishLocale,
@@ -4418,8 +4447,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'spanish published 1',
               _status: 'published',
+              text: 'spanish published 1',
             },
             locale: spanishLocale,
           })
@@ -4427,8 +4456,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'spanish draft 2',
               _status: 'draft',
+              text: 'spanish draft 2',
             },
             draft: true,
             locale: spanishLocale,
@@ -4436,8 +4465,8 @@ describe('Localization', () => {
 
           const publishedDoc = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(publishedDoc._status!.en).toBe('published')
@@ -4463,8 +4492,8 @@ describe('Localization', () => {
           const doc = await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: defaultLocale,
           })
@@ -4472,8 +4501,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             draft: true,
             locale: defaultLocale,
@@ -4482,16 +4511,16 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'es published',
               _status: 'published',
+              text: 'es published',
             },
             locale: spanishLocale,
           })
 
           const mainDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.es).toBe('published')
@@ -4501,8 +4530,8 @@ describe('Localization', () => {
 
           const latestVersion = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: true,
+            locale: 'all',
           })
 
           expect(latestVersion._status!.es).toBe('published')
@@ -4515,8 +4544,8 @@ describe('Localization', () => {
           const doc = await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en draft',
               _status: 'draft',
+              text: 'en draft',
             },
             locale: defaultLocale,
           })
@@ -4524,8 +4553,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'es draft',
               _status: 'draft',
+              text: 'es draft',
             },
             locale: spanishLocale,
           })
@@ -4533,8 +4562,8 @@ describe('Localization', () => {
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
-              text: 'en published',
               _status: 'published',
+              text: 'en published',
             },
             locale: defaultLocale,
             publishAllLocales: true,
@@ -4542,8 +4571,8 @@ describe('Localization', () => {
 
           const mainDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(mainDocument._status!.en).toBe('published')
@@ -4553,14 +4582,14 @@ describe('Localization', () => {
 
           await payload.updateGlobal({
             slug: globalWithDraftsSlug,
-            unpublishAllLocales: true,
             data: {},
+            unpublishAllLocales: true,
           })
 
           const unpublishedDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
-            locale: 'all',
             draft: false,
+            locale: 'all',
           })
 
           expect(unpublishedDocument._status!.en).toBe('draft')
@@ -4623,8 +4652,8 @@ describe('Localization', () => {
         const localizedFallback: any = await payload.findByID({
           id: allFieldsPostWithLocalizedData.id,
           collection: allFieldsLocalizedSlug,
-          locale: portugueseLocale,
           fallbackLocale: 'none',
+          locale: portugueseLocale,
         })
 
         expect(localizedFallback.text).not.toBeDefined()

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -11,7 +11,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { AutosaveMultiSelectPost, DraftPost } from './payload-types.js'
-
+// eslint-disable-next-line payload/no-relative-monorepo-imports
+import { fetchLatestVersion } from '../../packages/next/src/views/Version/fetchVersions.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
 import { cloudStorageDeletedFilenames } from './collections/DraftsWithUploadCloudStorage.js'
@@ -32,6 +33,7 @@ import {
   draftWithUploadCollectionSlug,
   localizedCollectionSlug,
   localizedGlobalSlug,
+  simpleDraftGlobalSlug,
   versionCollectionSlug,
 } from './slugs.js'
 
@@ -561,34 +563,34 @@ describe('Versions', () => {
         const originalDoc = await payload.create({
           collection: draftCollectionSlug,
           data: {
+            _status: 'published',
             description: 'Original description',
             title: 'Original Title',
-            _status: 'published',
           },
           draft: false,
         })
 
         const duplicatedDoc = await payload.create({
-          duplicateFromID: originalDoc.id,
           collection: draftCollectionSlug,
           data: {
             _status: 'draft',
           },
           draft: true,
+          duplicateFromID: originalDoc.id,
         })
 
         expect(duplicatedDoc._status).toBe('draft')
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+        await payload.delete({ id: originalDoc.id, collection: draftCollectionSlug })
+        await payload.delete({ id: duplicatedDoc.id, collection: draftCollectionSlug })
       })
 
       it('should duplicate a draft document with empty required fields via local API', async () => {
         const originalDoc = await payload.create({
           collection: draftCollectionSlug,
           data: {
-            title: 'Draft with partial data',
             _status: 'draft',
+            title: 'Draft with partial data',
           },
           draft: true,
         })
@@ -604,16 +606,16 @@ describe('Versions', () => {
         expect(duplicatedDoc.id).not.toEqual(originalDoc.id)
         expect(duplicatedDoc.title).toContain('Draft with partial data')
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+        await payload.delete({ id: originalDoc.id, collection: draftCollectionSlug })
+        await payload.delete({ id: duplicatedDoc.id, collection: draftCollectionSlug })
       })
 
       it('should duplicate a draft document with empty required fields via REST API without explicit draft param', async () => {
         const originalDoc = await payload.create({
           collection: draftCollectionSlug,
           data: {
-            title: 'REST draft partial',
             _status: 'draft',
+            title: 'REST draft partial',
           },
           draft: true,
         })
@@ -633,8 +635,8 @@ describe('Versions', () => {
         expect(doc._status).toBe('draft')
         expect(doc.id).not.toEqual(originalDoc.id)
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
+        await payload.delete({ id: originalDoc.id, collection: draftCollectionSlug })
+        await payload.delete({ id: doc.id, collection: draftCollectionSlug })
       })
     })
 
@@ -745,7 +747,7 @@ describe('Versions', () => {
         })
 
         for (let i = 0; i < 100; i++) {
-          await payload.update({ collection: draftCollectionSlug, id: doc.id, data: {} })
+          await payload.update({ id: doc.id, collection: draftCollectionSlug, data: {} })
         }
         const res = await payload.findVersions({
           collection: draftCollectionSlug,
@@ -1302,7 +1304,7 @@ describe('Versions', () => {
 
         expect(updateManyResult.docs).toHaveLength(0)
         expect(updateManyResult.errors).toStrictEqual([
-          { id: doc.id, message: 'The following field is invalid: Group > Title', isPublic: true },
+          { id: doc.id, isPublic: true, message: 'The following field is invalid: Group > Title' },
         ])
       })
 
@@ -1606,7 +1608,7 @@ describe('Versions', () => {
         expect(afterVersions.docs).toHaveLength(initialCount)
         expect(afterVersions.docs[0].version._status).toBe('draft')
 
-        await cleanupGlobal({ payload, globalSlug: draftGlobalSlug })
+        await cleanupGlobal({ globalSlug: draftGlobalSlug, payload })
       })
 
       it('should update main table _status to draft when unpublishing', async () => {
@@ -1656,7 +1658,7 @@ describe('Versions', () => {
 
         expect(unpublished._status).toBe('draft')
 
-        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
+        await payload.delete({ id: doc.id, collection: draftCollectionSlug })
       })
 
       it('should unpublish a global with localized required fields from a non-default locale', async () => {
@@ -1676,7 +1678,7 @@ describe('Versions', () => {
 
         expect(unpublished._status).toBe('draft')
 
-        await cleanupGlobal({ payload, globalSlug: draftGlobalSlug })
+        await cleanupGlobal({ globalSlug: draftGlobalSlug, payload })
       })
     })
 
@@ -1912,7 +1914,7 @@ describe('Versions', () => {
       it('should fall back to creating a new version when updateVersion fails due to a concurrent write', async () => {
         const doc = await payload.create({
           collection: autosaveCollectionSlug,
-          data: { title: 'original', _status: 'draft' },
+          data: { _status: 'draft', title: 'original' },
           draft: true,
         })
 
@@ -1961,7 +1963,7 @@ describe('Versions', () => {
       it('should propagate the error when createVersion also fails', async () => {
         const doc = await payload.create({
           collection: autosaveCollectionSlug,
-          data: { title: 'original', _status: 'draft' },
+          data: { _status: 'draft', title: 'original' },
           draft: true,
         })
 
@@ -3292,11 +3294,11 @@ describe('Versions', () => {
 
         const updated = await payload.updateGlobal({
           slug: draftGlobalSlug,
+          autosave: true,
           data: {
             title: 'updated title',
           },
           draft: true,
-          autosave: true,
         })
 
         const createdUpdatedAt = new Date(created.updatedAt)
@@ -4371,8 +4373,8 @@ describe('Versions', () => {
           data: {
             blocks: [
               {
-                blockType: 'block',
                 array: [],
+                blockType: 'block',
               },
             ],
             text: 'English with blocks',
@@ -4389,8 +4391,8 @@ describe('Versions', () => {
             _status: 'published',
             blocks: [
               {
-                blockType: 'block',
                 array: [],
+                blockType: 'block',
               },
             ],
             text: 'English published with blocks',
@@ -4619,6 +4621,44 @@ describe('Versions', () => {
         const latestVersion = versions[0].version
         expect(latestVersion.title.es).toBeFalsy()
         expect(latestVersion.title.en).toStrictEqual('New eng')
+      })
+    })
+
+    describe('fetchLatestVersion', () => {
+      it('should retrieve the latest published version of a global', async () => {
+        // 1. Create a published version of a global
+        await payload.updateGlobal({
+          slug: simpleDraftGlobalSlug,
+          data: {
+            _status: 'published',
+            title: 'Published Global Title',
+          },
+          draft: false,
+        })
+
+        // 2. Create a draft version of the global (newer than published)
+        await payload.updateGlobal({
+          slug: simpleDraftGlobalSlug,
+          data: {
+            _status: 'draft',
+            title: 'Draft Global Title',
+          },
+          draft: true,
+        })
+
+        const req = await createLocalReq({ user }, payload)
+
+        // 3. Call fetchLatestVersion requesting 'published' version
+        const latestPublished = await fetchLatestVersion({
+          globalSlug: simpleDraftGlobalSlug,
+          req,
+          status: 'published',
+          user,
+        })
+
+        // 4. Assert that the returned version is the published one, NOT the newer draft one!
+        expect(latestPublished).toBeDefined()
+        expect(latestPublished.version.title).toBe('Published Global Title')
       })
     })
   })

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -14,7 +14,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { AutosaveMultiSelectPost, DraftPost } from './payload-types.js'
-
+// eslint-disable-next-line payload/no-relative-monorepo-imports
+import { fetchLatestVersion } from '../../packages/next/src/views/Version/fetchVersions.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
 import { cloudStorageDeletedFilenames } from './collections/DraftsWithUploadCloudStorage.js'
@@ -35,6 +36,7 @@ import {
   draftWithUploadCollectionSlug,
   localizedCollectionSlug,
   localizedGlobalSlug,
+  simpleDraftGlobalSlug,
   versionCollectionSlug,
 } from './slugs.js'
 
@@ -564,34 +566,34 @@ describe('Versions', () => {
         const originalDoc = await payload.create({
           collection: draftCollectionSlug,
           data: {
+            _status: 'published',
             description: 'Original description',
             title: 'Original Title',
-            _status: 'published',
           },
           draft: false,
         })
 
         const duplicatedDoc = await payload.create({
-          duplicateFromID: originalDoc.id,
           collection: draftCollectionSlug,
           data: {
             _status: 'draft',
           },
           draft: true,
+          duplicateFromID: originalDoc.id,
         })
 
         expect(duplicatedDoc._status).toBe('draft')
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+        await payload.delete({ id: originalDoc.id, collection: draftCollectionSlug })
+        await payload.delete({ id: duplicatedDoc.id, collection: draftCollectionSlug })
       })
 
       it('should duplicate a draft document with empty required fields via local API', async () => {
         const originalDoc = await payload.create({
           collection: draftCollectionSlug,
           data: {
-            title: 'Draft with partial data',
             _status: 'draft',
+            title: 'Draft with partial data',
           },
           draft: true,
         })
@@ -607,16 +609,16 @@ describe('Versions', () => {
         expect(duplicatedDoc.id).not.toEqual(originalDoc.id)
         expect(duplicatedDoc.title).toContain('Draft with partial data')
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+        await payload.delete({ id: originalDoc.id, collection: draftCollectionSlug })
+        await payload.delete({ id: duplicatedDoc.id, collection: draftCollectionSlug })
       })
 
       it('should duplicate a draft document with empty required fields via REST API without explicit draft param', async () => {
         const originalDoc = await payload.create({
           collection: draftCollectionSlug,
           data: {
-            title: 'REST draft partial',
             _status: 'draft',
+            title: 'REST draft partial',
           },
           draft: true,
         })
@@ -636,8 +638,8 @@ describe('Versions', () => {
         expect(doc._status).toBe('draft')
         expect(doc.id).not.toEqual(originalDoc.id)
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
+        await payload.delete({ id: originalDoc.id, collection: draftCollectionSlug })
+        await payload.delete({ id: doc.id, collection: draftCollectionSlug })
       })
     })
 
@@ -748,7 +750,7 @@ describe('Versions', () => {
         })
 
         for (let i = 0; i < 100; i++) {
-          await payload.update({ collection: draftCollectionSlug, id: doc.id, data: {} })
+          await payload.update({ id: doc.id, collection: draftCollectionSlug, data: {} })
         }
         const res = await payload.findVersions({
           collection: draftCollectionSlug,
@@ -1305,7 +1307,7 @@ describe('Versions', () => {
 
         expect(updateManyResult.docs).toHaveLength(0)
         expect(updateManyResult.errors).toStrictEqual([
-          { id: doc.id, message: 'The following field is invalid: Group > Title', isPublic: true },
+          { id: doc.id, isPublic: true, message: 'The following field is invalid: Group > Title' },
         ])
       })
 
@@ -1609,7 +1611,7 @@ describe('Versions', () => {
         expect(afterVersions.docs).toHaveLength(initialCount)
         expect(afterVersions.docs[0].version._status).toBe('draft')
 
-        await cleanupGlobal({ payload, globalSlug: draftGlobalSlug })
+        await cleanupGlobal({ globalSlug: draftGlobalSlug, payload })
       })
 
       it('should update main table _status to draft when unpublishing', async () => {
@@ -1659,7 +1661,7 @@ describe('Versions', () => {
 
         expect(unpublished._status).toBe('draft')
 
-        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
+        await payload.delete({ id: doc.id, collection: draftCollectionSlug })
       })
 
       it('should unpublish a global with localized required fields from a non-default locale', async () => {
@@ -1679,7 +1681,7 @@ describe('Versions', () => {
 
         expect(unpublished._status).toBe('draft')
 
-        await cleanupGlobal({ payload, globalSlug: draftGlobalSlug })
+        await cleanupGlobal({ globalSlug: draftGlobalSlug, payload })
       })
     })
 
@@ -1915,7 +1917,7 @@ describe('Versions', () => {
       it('should fall back to creating a new version when updateVersion fails due to a concurrent write', async () => {
         const doc = await payload.create({
           collection: autosaveCollectionSlug,
-          data: { title: 'original', _status: 'draft' },
+          data: { _status: 'draft', title: 'original' },
           draft: true,
         })
 
@@ -1964,7 +1966,7 @@ describe('Versions', () => {
       it('should propagate the error when createVersion also fails', async () => {
         const doc = await payload.create({
           collection: autosaveCollectionSlug,
-          data: { title: 'original', _status: 'draft' },
+          data: { _status: 'draft', title: 'original' },
           draft: true,
         })
 
@@ -3295,11 +3297,11 @@ describe('Versions', () => {
 
         const updated = await payload.updateGlobal({
           slug: draftGlobalSlug,
+          autosave: true,
           data: {
             title: 'updated title',
           },
           draft: true,
-          autosave: true,
         })
 
         const createdUpdatedAt = new Date(created.updatedAt)
@@ -4449,8 +4451,8 @@ describe('Versions', () => {
           data: {
             blocks: [
               {
-                blockType: 'block',
                 array: [],
+                blockType: 'block',
               },
             ],
             text: 'English with blocks',
@@ -4467,8 +4469,8 @@ describe('Versions', () => {
             _status: 'published',
             blocks: [
               {
-                blockType: 'block',
                 array: [],
+                blockType: 'block',
               },
             ],
             text: 'English published with blocks',
@@ -4697,6 +4699,44 @@ describe('Versions', () => {
         const latestVersion = versions[0].version
         expect(latestVersion.title.es).toBeFalsy()
         expect(latestVersion.title.en).toStrictEqual('New eng')
+      })
+    })
+
+    describe('fetchLatestVersion', () => {
+      it('should retrieve the latest published version of a global', async () => {
+        // 1. Create a published version of a global
+        await payload.updateGlobal({
+          slug: simpleDraftGlobalSlug,
+          data: {
+            _status: 'published',
+            title: 'Published Global Title',
+          },
+          draft: false,
+        })
+
+        // 2. Create a draft version of the global (newer than published)
+        await payload.updateGlobal({
+          slug: simpleDraftGlobalSlug,
+          data: {
+            _status: 'draft',
+            title: 'Draft Global Title',
+          },
+          draft: true,
+        })
+
+        const req = await createLocalReq({ user }, payload)
+
+        // 3. Call fetchLatestVersion requesting 'published' version
+        const latestPublished = await fetchLatestVersion({
+          globalSlug: simpleDraftGlobalSlug,
+          req,
+          status: 'published',
+          user,
+        })
+
+        // 4. Assert that the returned version is the published one, NOT the newer draft one!
+        expect(latestPublished).toBeDefined()
+        expect(latestPublished.version.title).toBe('Published Global Title')
       })
     })
   })


### PR DESCRIPTION
### What?

This PR fixes two bugs in Payload CMS related to how global configurations are looked up in the Admin UI and the Next.js views:
1. A crash (`TypeError`) when copying localized data from one locale to another on a Global.
2. A silent bug where draft/version queries for globals did not detect that versions were enabled, leading to incorrect
  queries (returning draft content when published was expected).

### Why?

1. In `copyDataFromLocale.ts`, the code looked up global fields using `globals[globalSlug].config.fields`. However, `payload.globals` only contains the database model instances or initial states and is not keyed by slug with configurations, leading to a crash.
2. In `fetchVersions.ts`, the logic checked if versions were enabled on the entity using `req.payload.globals[globalSlug]?.config`. Because `req.payload.globals` is not structured this way, the configuration returned `undefined` (falsy). As a result, the code incorrectly assumed drafts/versions were disabled for all globals, causing version queries to bypass status-based filtering.

### How?

1. Modified `packages/ui/src/utilities/copyDataFromLocale.ts` to retrieve the global configuration correctly using `payload.config.globals.find((g) => g.slug === globalSlug)?.fields`.
2. Modified `packages/next/src/views/Version/fetchVersions.ts` to locate the global configuration via `req.payload.config.globals.find((g) => g.slug === globalSlug)`.
3. Added a new integration test `should copy global data to another locale` in `test/localization/int.spec.ts` (using a new test global `global-copy-test`) to prevent regressions on copy-locale operations for globals.
4. Added a new integration test `should retrieve the latest published version of a global` in `test/versions/int.spec.ts`
  using `simpleDraftGlobalSlug` to ensure version querying fetches correct published drafts on globals.

Fixes #16747
