### PR TITLE
docs: fix spelling typos in comments and JSDoc

### DIFF
--- a/packages/payload/src/admin/functions/index.ts
+++ b/packages/payload/src/admin/functions/index.ts
@@ -73,7 +73,7 @@ export type ServerFunctionHandler = (
      *    },
      *   }))
      *
-     *   // Do someting with the result
+     *   // Do something with the result
      *  }
      *
      *  void call()

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -270,7 +270,7 @@ export interface IncomingAuthType {
    */
   removeTokenFromResponses?: true
   /**
-   * Advanced - an array of custom authentification strategies to extend this collection's authentication with.
+   * Advanced - an array of custom authentication strategies to extend this collection's authentication with.
    * @link https://payloadcms.com/docs/authentication/custom-strategies
    */
   strategies?: AuthStrategy[]

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -145,7 +145,7 @@ export const findByIDOperation = async <
       req,
     })
 
-    // execute only if there's a custom ID and potentially overwriten access on id
+    // execute only if there's a custom ID and potentially overwritten access on id
     if (req.payload.collections[collectionConfig.slug]!.customIDType) {
       await validateQueryPaths({
         collectionConfig,

--- a/packages/payload/src/globals/endpoints/findOne.ts
+++ b/packages/payload/src/globals/endpoints/findOne.ts
@@ -17,7 +17,7 @@ export const findOneHandler: PayloadHandler = async (req) => {
     ? data.flattenLocales
     : searchParams.has('flattenLocales')
       ? searchParams.get('flattenLocales') === 'true'
-      : // flattenLocales should be undfined if not provided, so that the default (true) is applied in the operation
+      : // flattenLocales should be undefined if not provided, so that the default (true) is applied in the operation
         undefined
 
   const result = await findOneOperation({

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -274,7 +274,7 @@ export type TransformDataWithSelect<
     ? Data
     : // START Handle types when they aren't generated
       // For example in any package in this repository outside of tests / plugins
-      // This stil gives us autocomplete when using include select mode, i.e select: {title :true} returns type {title: any, id: string | number}
+      // This still gives us autocomplete when using include select mode, i.e select: {title :true} returns type {title: any, id: string | number}
       string extends keyof Omit<Data, 'id'>
       ? Select extends SelectIncludeType
         ? {

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -145,7 +145,7 @@ export type UploadConfig = {
    * Allow restricted file types known to be problematic.
    * - If set to `true`, it will allow all file types.
    * - If set to `false`, it will not allow file types and extensions known to be problematic.
-   * - This setting is overriden by the `mimeTypes` option.
+   * - This setting is overridden by the `mimeTypes` option.
    * @default false
    */
   allowRestrictedFileTypes?: boolean

--- a/packages/payload/src/utilities/flattenTopLevelFields.spec.ts
+++ b/packages/payload/src/utilities/flattenTopLevelFields.spec.ts
@@ -572,7 +572,7 @@ describe('flattenFields', () => {
       },
     ]
 
-    it('should hoist named group fields inside unamed tabs when moveSubFieldsToTop is true', () => {
+    it('should hoist named group fields inside unnamed tabs when moveSubFieldsToTop is true', () => {
       const unnamedTabWithNamedGroup: ClientField[] = [
         {
           type: 'tabs',

--- a/packages/payload/src/utilities/flattenTopLevelFields.ts
+++ b/packages/payload/src/utilities/flattenTopLevelFields.ts
@@ -122,7 +122,7 @@ export function flattenTopLevelFields<TField extends ClientField | Field>(
         )
       } else {
         if (fieldAffectsData(field)) {
-          // Hoisting diabled - keep as top level field
+          // Hoisting disabled - keep as top level field
           acc.push(field as FlattenedField<TField>)
         } else {
           acc.push(...flattenTopLevelFields(field.fields as TField[], options))

--- a/packages/plugin-ecommerce/src/collections/addresses/defaultCountries.ts
+++ b/packages/plugin-ecommerce/src/collections/addresses/defaultCountries.ts
@@ -2,7 +2,7 @@ import type { CountryType } from '../../types/index.js'
 
 /**
  * Default list of countries supported for forms and payments.
- * This can be overriden or reused in other parts of the application.
+ * This can be overridden or reused in other parts of the application.
  *
  * The label is the human-readable name of the country, and the value is the ISO 3166-1 alpha-2 code.
  */

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -86,7 +86,7 @@ export type S3StorageOptions = {
    */
   enabled?: boolean
   /**
-   * Use pre-signed URLs for files downloading. Can be overriden per-collection.
+   * Use pre-signed URLs for files downloading. Can be overridden per-collection.
    */
   signedDownloads?: SignedDownloadsConfig
   /**

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -1275,7 +1275,7 @@ describe('Localization', () => {
           // eslint-disable-next-line vitest/no-conditional-expect
           expect(docWithoutFallback.items).toStrictEqual(null)
         } else {
-          // TODO: build out compatability with SQL databases
+          // TODO: build out compatibility with SQL databases
           // Currently SQL databases always fallback since the localized values are joined in.
           // The join only has 2 states, undefined or the localized value of the requested locale.
           // If the localized value is not in the DB, there is no way to know if the value should fallback or not so we fallback if fallbackLocale is truthy.


### PR DESCRIPTION
Fixes a batch of genuine spelling typos in code comments, JSDoc, and one test title. **Comment/JSDoc-only — no behavioral impact.**

`overriden` → `overridden`:
- `packages/payload/src/uploads/types.ts` (mimeTypes JSDoc)
- `packages/plugin-ecommerce/src/collections/addresses/defaultCountries.ts`
- `packages/storage-s3/src/index.ts` (`signedDownloads` JSDoc)

Other comment/JSDoc typos:
- `someting` → `something` (`packages/payload/src/admin/functions/index.ts`)
- `authentification` → `authentication` (`packages/payload/src/auth/types.ts`)
- `overwriten` → `overwritten` (`packages/payload/src/collections/operations/findByID.ts`)
- `undfined` → `undefined` (`packages/payload/src/globals/endpoints/findOne.ts`)
- `stil` → `still` (`packages/payload/src/types/index.ts`)
- `diabled` → `disabled` (`packages/payload/src/utilities/flattenTopLevelFields.ts`)
- `compatability` → `compatibility` (`test/localization/int.spec.ts`)
- `unamed` → `unnamed` (`test`/`flattenTopLevelFields.spec.ts` test title)