### PR TITLE
fix(ui): make card click overlay span the full card

### DIFF
--- a/packages/ui/src/elements/Card/index.css
+++ b/packages/ui/src/elements/Card/index.css
@@ -44,13 +44,14 @@
     }
   }
 
-  .card__click {
+  .card .card__click {
     z-index: 1;
     inset: 0;
     position: absolute;
     margin: 0;
     height: auto;
     width: auto;
+    min-height: 0;
     border-radius: inherit;
 
     &:hover,

--- a/packages/ui/src/elements/Card/index.css
+++ b/packages/ui/src/elements/Card/index.css
@@ -51,7 +51,6 @@
     margin: 0;
     height: auto;
     width: auto;
-    min-height: 0;
     border-radius: inherit;
 
     &:hover,


### PR DESCRIPTION
Stretches the `.card__click` overlay anchor to fill the entire card so the full surface is hoverable and clickable.

The overlay is a `Button` rendered at the default `size="medium"`, so `.btn--size-medium` applies a fixed `height`.

That selector has the same specificity as `.card__click` (`0,1,0`) but is emitted later in the production bundle, so it won the cascade and collapsed the anchor to button height - leaving only the top portion of the card interactive. 

The tie resolved differently in dev, so the bug only surfaced in production builds.

Raising the overlay selector to `.card .card__click` (`0,2,0`) makes the `height: auto` override win deterministically, independent of bundle order, so `inset: 0` stretches the anchor across the full card.

Before:
<img width="569" height="314" alt="Screenshot 2026-06-22 at 2 26 00 PM (1)" src="https://github.com/user-attachments/assets/a78e9938-0e50-463c-a49a-c0b81f3a3d96" />

After:
<img width="469" height="210" alt="Screenshot 2026-06-22 at 2 40 54 PM" src="https://github.com/user-attachments/assets/359bc4d5-3d4d-49ff-aa85-b57ccb80fafe" />
