### PR TITLE
fix(deps): resolve high severity audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
       "workerd"
     ],
     "overrides": {
-      "@vercel/blob>undici": "6.24.1",
+      "@types/request>form-data": "^2.5.6",
       "amazon-cognito-identity-js>js-cookie": "^3.0.7",
       "copyfiles": "$copyfiles",
       "cross-env": "$cross-env",

--- a/packages/email-nodemailer/package.json
+++ b/packages/email-nodemailer/package.json
@@ -42,7 +42,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "nodemailer": "^8.0.5"
+    "nodemailer": "^9.0.1"
   },
   "devDependencies": {
     "@types/nodemailer": "^8.0.0",

--- a/packages/payload-cloud/package.json
+++ b/packages/payload-cloud/package.json
@@ -48,7 +48,7 @@
     "@aws-sdk/lib-storage": "^3.614.0",
     "@payloadcms/email-nodemailer": "workspace:*",
     "amazon-cognito-identity-js": "^6.1.2",
-    "nodemailer": "^8.0.5"
+    "nodemailer": "^9.0.1"
   },
   "devDependencies": {
     "@types/nodemailer": "^8.0.0",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -127,7 +127,7 @@
     "sanitize-filename": "1.6.3",
     "ts-essentials": "10.0.3",
     "tsx": "4.22.4",
-    "undici": "7.24.4",
+    "undici": "7.28.0",
     "uuid": "13.0.2",
     "ws": "^8.16.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@vercel/blob>undici': 6.24.1
+  '@types/request>form-data': ^2.5.6
   amazon-cognito-identity-js>js-cookie: ^3.0.7
   copyfiles: 2.4.1
   cross-env: 7.0.3
@@ -548,8 +548,8 @@ importers:
   packages/email-nodemailer:
     dependencies:
       nodemailer:
-        specifier: ^8.0.5
-        version: 8.0.10
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@types/nodemailer':
         specifier: ^8.0.0
@@ -950,8 +950,8 @@ importers:
         specifier: 4.22.4
         version: 4.22.4
       undici:
-        specifier: 7.24.4
-        version: 7.24.4
+        specifier: 7.28.0
+        version: 7.28.0
       uuid:
         specifier: 13.0.2
         version: 13.0.2
@@ -1035,8 +1035,8 @@ importers:
         specifier: ^6.1.2
         version: 6.3.16
       nodemailer:
-        specifier: ^8.0.5
-        version: 8.0.10
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@types/nodemailer':
         specifier: ^8.0.0
@@ -2291,7 +2291,7 @@ importers:
     dependencies:
       recharts:
         specifier: 3.2.1
-        version: 3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1)
+        version: 3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.614.0
@@ -10592,8 +10592,8 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
-  form-data@2.5.5:
-    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+  form-data@2.5.6:
+    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
     engines: {node: '>= 0.12'}
 
   form-data@3.0.4:
@@ -12238,6 +12238,10 @@ packages:
 
   nodemailer@8.0.10:
     resolution: {integrity: sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==}
+    engines: {node: '>=6.0.0'}
+
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   noms@0.0.0:
@@ -14117,6 +14121,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: 5.7.3
@@ -14246,16 +14251,16 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -20938,7 +20943,7 @@ snapshots:
       '@types/caseless': 0.12.5
       '@types/node': 22.19.9
       '@types/tough-cookie': 4.0.5
-      form-data: 2.5.5
+      form-data: 2.5.6
 
   '@types/semver@7.7.1': {}
 
@@ -21238,7 +21243,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 6.24.1
+      undici: 6.27.0
 
   '@vercel/git-hooks@1.0.0': {}
 
@@ -23176,7 +23181,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -23233,7 +23238,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-import-x: 4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
@@ -23295,7 +23300,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.6.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24104,7 +24109,7 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
-  form-data@2.5.5:
+  form-data@2.5.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -24934,7 +24939,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.4
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -26060,6 +26065,8 @@ snapshots:
 
   nodemailer@8.0.10: {}
 
+  nodemailer@9.0.1: {}
+
   noms@0.0.0:
     dependencies:
       inherits: 2.0.4
@@ -26818,7 +26825,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts@3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1):
+  recharts@3.2.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
       clsx: 2.1.1
@@ -26828,7 +26835,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.3.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
@@ -28277,11 +28284,11 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@6.24.1: {}
+  undici@6.27.0: {}
 
   undici@7.18.2: {}
 
-  undici@7.24.4: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/test/storage-s3/client-uploads/int.spec.ts
+++ b/test/storage-s3/client-uploads/int.spec.ts
@@ -61,7 +61,6 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
       method: 'PUT',
       headers: {
         'Content-Type': 'image/png',
-        'Content-Length': String(file.length),
       },
       body: file,
     })
@@ -101,7 +100,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     })
 
     expect(response.status).toBe(200)
-    const { url } = (await response.json()) as any
+    const { url } = await response.json()
     expect(url).toBeDefined()
     expect(url).toContain(getTestBucketName())
     expect(url).toContain('small-file.png')
@@ -113,7 +112,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     })
 
     expect(response.status).toBe(400)
-    const { errors } = (await response.json()) as any
+    const { errors } = await response.json()
     expect(errors).toBeDefined()
     expect(errors[0].message).toContain('Exceeded file size limit')
     expect(errors[0].message).toMatch(/Limit: 10\.0\dMB/)
@@ -126,7 +125,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     })
 
     expect(response.status).toBe(400)
-    const { errors } = (await response.json()) as any
+    const { errors } = await response.json()
     expect(errors).toBeDefined()
     expect(errors[0].message).toContain('Exceeded file size limit')
   })
@@ -137,7 +136,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     })
 
     expect(response.status).toBe(200)
-    const { url } = (await response.json()) as any
+    const { url } = await response.json()
     expect(url).toBeDefined()
   })
 
@@ -161,7 +160,6 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
       method: 'PUT',
       headers: {
         'Content-Type': mimeType,
-        'Content-Length': String(actualFilesize),
       },
       body: file,
     })


### PR DESCRIPTION
# Overview

Backport of #17052 to the `3.x` branch. Resolves the high-severity vulnerabilities reported by `pnpm audit --prod` against the 3.x dependency tree that are fixable at the dependency level.

## Key Changes

**Bump undici to 7.28.0 in packages/payload**

Direct bump within the same major (from 7.24.4). Fixes GHSA-vmh5-mc38-953g / CVE-2026-9697

**Let @vercel/blob's undici resolve to 6.27.0**

Dropping the root pin lets the existing `^6.23.0` range resolve to the patched version. Fixes GHSA-vxpw-j846-p89q

**Bump nodemailer to ^9.0.1 in email-nodemailer and payload-cloud**

Direct bump across the 8 to 9 major. Fixes GHSA-p6gq-j5cr-w38f

**Override @types/request>form-data to ^2.5.6**

Parent-scoped override. Fixes GHSA-hmw2-7cc7-3qxx / CVE-2026-12143

**Drop manual Content-Length headers from the storage-s3 client-upload tests**

undici 7.28.0 rejects a manually-set `Content-Length` on a `fetch` body, so the tests let `fetch` derive it.
