### PR TITLE
fix(ui): preserve selected options in hasMany relationship filter while searching

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -206,10 +206,16 @@ export const RelationshipFilter: React.FC<Props> = (props) => {
                 }
               })
 
-              return matchedOption
+              return (
+                matchedOption || {
+                  label: String(val.value),
+                  relationTo: val.relationTo,
+                  value: val.value,
+                }
+              )
             }
 
-            return options.find((opt) => opt.value == val)
+            return options.find((opt) => opt.value == val) || { label: String(val), value: val }
           })
         }
 

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -801,18 +801,30 @@ describe('relationship', () => {
     const selectedChips = valueLocator.locator('.multi-value-label__text')
     await expect(selectedChips).toHaveCount(2)
 
-    // Hold the relation list request that fires when the search input changes, so the
-    // window between the synchronous options-clear and the async reload stays open long
-    // enough to deterministically assert against it, instead of racing real timing.
-    await page.route('**/api/text-fields**', (route) => setTimeout(() => route.continue(), 2000))
+    // Hold the relation list request that fires when the search input changes, so the window
+    // between the synchronous options-clear and the async reload stays open for as long as we
+    // need, instead of racing real timing with a fixed delay.
+    let releaseHeldRequest: () => void
+    const heldRequest = new Promise<void>((resolve) => {
+      releaseHeldRequest = resolve
+    })
+    await page.route('**/api/text-fields**', async (route) => {
+      await heldRequest
+      await route.continue()
+    })
 
     const searchInput = valueLocator.locator('.rs__input[type="text"]')
     await searchInput.fill('Race Text 3')
 
     // While the reload is still held back, the two previously selected chips must still be
-    // rendered — not silently dropped because their matching option was cleared out of the
-    // (now-empty) options list.
+    // present — not silently dropped because their matching option was cleared out of the
+    // (now-empty) options list. They may render with a placeholder label (the raw ID) until
+    // the real option reloads, which is expected.
     await expect(selectedChips).toHaveCount(2)
+
+    // Releasing the held request lets the reload complete; the placeholders should now
+    // resolve back to their real labels.
+    releaseHeldRequest()
     await expect(valueLocator).toContainText('Race Text 1')
     await expect(valueLocator).toContainText('Race Text 2')
   })

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -788,7 +788,6 @@ describe('relationship', () => {
       selectLocator: valueLocator,
       multiSelect: true,
       options: ['Race Text 1'],
-      selectType: 'relationship',
     })
 
     await selectInput({
@@ -797,10 +796,9 @@ describe('relationship', () => {
       multiSelect: true,
       options: ['Race Text 2'],
       clear: false,
-      selectType: 'relationship',
     })
 
-    const selectedChips = valueLocator.locator('.relationship--multi-value-label__text')
+    const selectedChips = valueLocator.locator('.multi-value-label__text')
     await expect(selectedChips).toHaveCount(2)
 
     // Hold the relation list request that fires when the search input changes, so the

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -755,6 +755,70 @@ describe('relationship', () => {
     await expect(page.locator(tableRowLocator)).toHaveCount(1)
   })
 
+  test('should not lose previously selected options from a hasMany relationship filter while searching', async () => {
+    await createTextFieldDoc({ text: 'Race Text 1' })
+    await createTextFieldDoc({ text: 'Race Text 2' })
+    await createTextFieldDoc({ text: 'Race Text 3' })
+
+    await page.goto(url.list)
+    await wait(1000)
+
+    await openListFilters(page, {})
+    const whereBuilder = page.locator('.where-builder')
+    const condition = whereBuilder.locator('.condition').last()
+
+    await selectInput({
+      page,
+      selectLocator: condition.locator('.condition__field'),
+      multiSelect: false,
+      option: 'Relationship Has Many',
+    })
+
+    await selectInput({
+      page,
+      selectLocator: condition.locator('.condition__operator'),
+      multiSelect: false,
+      option: 'equals',
+    })
+
+    const valueLocator = condition.locator('.condition__value')
+
+    await selectInput({
+      page,
+      selectLocator: valueLocator,
+      multiSelect: true,
+      options: ['Race Text 1'],
+      selectType: 'relationship',
+    })
+
+    await selectInput({
+      page,
+      selectLocator: valueLocator,
+      multiSelect: true,
+      options: ['Race Text 2'],
+      clear: false,
+      selectType: 'relationship',
+    })
+
+    const selectedChips = valueLocator.locator('.relationship--multi-value-label__text')
+    await expect(selectedChips).toHaveCount(2)
+
+    // Hold the relation list request that fires when the search input changes, so the
+    // window between the synchronous options-clear and the async reload stays open long
+    // enough to deterministically assert against it, instead of racing real timing.
+    await page.route('**/api/text-fields**', (route) => setTimeout(() => route.continue(), 2000))
+
+    const searchInput = valueLocator.locator('.rs__input[type="text"]')
+    await searchInput.fill('Race Text 3')
+
+    // While the reload is still held back, the two previously selected chips must still be
+    // rendered — not silently dropped because their matching option was cleared out of the
+    // (now-empty) options list.
+    await expect(selectedChips).toHaveCount(2)
+    await expect(valueLocator).toContainText('Race Text 1')
+    await expect(valueLocator).toContainText('Race Text 2')
+  })
+
   test('should allow filtering by polymorphic hasMany relationship field / equals', async () => {
     const textDoc1 = await createTextFieldDoc({ text: 'Poly Text 1' })
     const textDoc2 = await createTextFieldDoc({ text: 'Poly Text 2' })


### PR DESCRIPTION
Fixes #17048

## What?

Filtering by a `hasMany` relationship field in the admin where-builder could intermittently drop a previously-selected item after selecting/searching for another one.

## Why?

`findOptionsByValue()`'s multi-value branch returned `undefined` for any selected value not currently present in the loaded `options` list. This happens any time the user types into the search box: `handleInputChange` synchronously clears `options` via the reducer's `CLEAR` action, before the async re-fetch (which patches missing selections back in) completes. During that window, `ReactSelect` is a fully-controlled component, so any interaction with it (selecting/removing another chip) reports back a selection containing that hole, and `onChange` propagates it upward, genuinely losing the item from the filter's value, not just visually.

The single-value branch right below it already guards against this exact case with a `|| value` fallback; the multi-value branch was missing the equivalent per-entry protection.

## How?

Fall back to a placeholder `{ label, value, relationTo }` option instead of `undefined` when no match is found, so the array fed into `ReactSelect` never has holes. Once the real document loads via the existing patch effect, the next render naturally replaces the placeholder with the properly-labeled option.

## Tests

Added a regression e2e test that selects two items, then types a search query and uses `page.route()` to hold back the reload request, deterministically asserting both previously-selected chips remain visible during that window.
