### PR TITLE
fix(richtext-lexical): order=0 being sorted to the end of the toolbar

### DIFF
--- a/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
@@ -185,11 +185,11 @@ export const sanitizeClientFeatures = (
 
   // Sort sanitized.toolbarInline.groups by order property
   sanitized.toolbarInline.groups.sort((a, b) => {
-    if (a.order && b.order) {
+    if (a.order != null && b.order != null) {
       return a.order - b.order
-    } else if (a.order) {
+    } else if (a.order != null) {
       return -1
-    } else if (b.order) {
+    } else if (b.order != null) {
       return 1
     } else {
       return 0
@@ -197,11 +197,11 @@ export const sanitizeClientFeatures = (
   })
   // Sort sanitized.toolbarFixed.groups by order property
   sanitized.toolbarFixed.groups.sort((a, b) => {
-    if (a.order && b.order) {
+    if (a.order != null && b.order != null) {
       return a.order - b.order
-    } else if (a.order) {
+    } else if (a.order != null) {
       return -1
-    } else if (b.order) {
+    } else if (b.order != null) {
       return 1
     } else {
       return 0
@@ -211,11 +211,11 @@ export const sanitizeClientFeatures = (
   // Sort sanitized.toolbarInline.groups.[group].entries by order property
   for (const group of sanitized.toolbarInline.groups) {
     group.items.sort((a, b) => {
-      if (a.order && b.order) {
+      if (a.order != null && b.order != null) {
         return a.order - b.order
-      } else if (a.order) {
+      } else if (a.order != null) {
         return -1
-      } else if (b.order) {
+      } else if (b.order != null) {
         return 1
       } else {
         return 0
@@ -226,11 +226,11 @@ export const sanitizeClientFeatures = (
   // Sort sanitized.toolbarFixed.groups.[group].entries by order property
   for (const group of sanitized.toolbarFixed.groups) {
     group.items.sort((a, b) => {
-      if (a.order && b.order) {
+      if (a.order != null && b.order != null) {
         return a.order - b.order
-      } else if (a.order) {
+      } else if (a.order != null) {
         return -1
-      } else if (b.order) {
+      } else if (b.order != null) {
         return 1
       } else {
         return 0


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change
-->
### What?
The following lexical editor `features.BlocksFeature` config:

```javascript
		BlocksFeature({
			blocks: [
				BoxBlockConfig,
				MediaImageBlockConfig,
				MediaVideoBlockConfig,
				CardImageBlockConfig,
				FloatClearBlockConfig,
				EmbedBlockConfig,
			],
			// ...
		})
```

...currently results in a mis-sorted dropdown:

<img width="230" height="266" alt="Dropdown" src="https://github.com/user-attachments/assets/959133c6-3823-4462-9858-dfebaef7e1a1" />

...where my custom "BoxBlockConfig" is at the end.

### Why?

Because the sorting component does not consider false-y orders valid, the item with the index 0 is incorrectly sorted to the end.

### How?

Switching to an explicit non-null check keeps the defensiveness while fixing this:

<img width="206" height="262" alt="Fixed Dropdown" src="https://github.com/user-attachments/assets/2694e551-84a7-4748-9cb4-d7c629aaf1cf" />