### PR TITLE
fix: resolve extensionless imports in generate:types

### DIFF
--- a/packages/graphql/bin.js
+++ b/packages/graphql/bin.js
@@ -23,10 +23,10 @@ if (disableTranspile) {
 
   if (!useSwc) {
     const start = async () => {
-      // Use tsx
-      let tsImport = (await import('tsx/esm/api')).tsImport
+      const { register } = await import('tsx/esm/api')
+      register()
 
-      const { bin } = await tsImport('./dist/bin/index.js', url)
+      const { bin } = await import('./dist/bin/index.js')
       await bin()
     }
 

--- a/packages/graphql/eslint.config.js
+++ b/packages/graphql/eslint.config.js
@@ -1,0 +1,22 @@
+import { rootEslintConfig, rootParserOptions } from '../../eslint.config.js'
+
+/** @typedef {import('eslint').Linter.Config} Config */
+
+/** @type {Config[]} */
+export const index = [
+  ...rootEslintConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        ...rootParserOptions,
+        tsconfigRootDir: import.meta.dirname,
+        projectService: {
+          // See comment in packages/eslint-config/index.mjs
+          allowDefaultProject: ['bin.js'],
+        },
+      },
+    },
+  },
+]
+
+export default index

--- a/packages/payload/bin.js
+++ b/packages/payload/bin.js
@@ -23,10 +23,14 @@ if (disableTranspile) {
 
   if (!useSwc) {
     const start = async () => {
-      // Use tsx
-      let tsImport = (await import('tsx/esm/api')).tsImport
+      // Use global tsx registration so nested extensionless imports in the
+      // project's payload.config.ts resolve correctly (e.g. ./collections/Users).
+      // tsImport() only scopes resolution to the entry file and does not
+      // propagate to nested imports the way `node --import tsx/esm` does.
+      const { register } = await import('tsx/esm/api')
+      register()
 
-      const { bin } = await tsImport('./dist/bin/index.js', url)
+      const { bin } = await import('./dist/bin/index.js')
       await bin()
     }
 

--- a/packages/payload/src/bin/generateTypesExtensionlessImports.spec.ts
+++ b/packages/payload/src/bin/generateTypesExtensionlessImports.spec.ts
@@ -1,0 +1,44 @@
+import execa from 'execa'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+const repoRoot = path.resolve(dirname, '../../../../')
+const fixtureDir = path.resolve(repoRoot, 'test/generate-types-extensionless')
+const outputFile = path.resolve(fixtureDir, 'payload-types.ts')
+const payloadBin = path.resolve(dirname, '../../bin.js')
+
+describe('payload generate:types CLI', () => {
+  afterEach(() => {
+    if (fs.existsSync(outputFile)) {
+      fs.unlinkSync(outputFile)
+    }
+  })
+
+  it('should resolve extensionless collection imports from payload.config.ts', async () => {
+    const { exitCode, stderr, stdout } = await execa(
+      process.execPath,
+      [payloadBin, 'generate:types'],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          DATABASE_URL: process.env.DATABASE_URL || 'mongodb://127.0.0.1:27017/payload',
+          PAYLOAD_CONFIG_PATH: path.resolve(fixtureDir, 'payload.config.ts'),
+          PAYLOAD_SECRET: 'test',
+        },
+        reject: false,
+      },
+    )
+
+    expect(exitCode, [stderr, stdout].filter(Boolean).join('\n')).toBe(0)
+    expect(fs.existsSync(outputFile)).toBe(true)
+
+    const generated = fs.readFileSync(outputFile, 'utf8')
+    expect(generated).toContain('export interface User')
+  }, 60000)
+})

--- a/packages/plugin-mcp/bin.js
+++ b/packages/plugin-mcp/bin.js
@@ -10,14 +10,7 @@
  * `--disable-transpile` if your config is already JS (or you've registered your
  * own loader).
  */
-import path from 'path'
-import { fileURLToPath, pathToFileURL } from 'url'
-
 const disableTranspile = process.argv.includes('--disable-transpile')
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-const baseURL = pathToFileURL(dirname).toString() + '/'
 
 const start = async () => {
   if (disableTranspile) {
@@ -27,8 +20,10 @@ const start = async () => {
     return
   }
 
-  const { tsImport } = await import('tsx/esm/api')
-  const { runMcpStdio } = await tsImport('./dist/stdio.js', baseURL)
+  const { register } = await import('tsx/esm/api')
+  register()
+
+  const { runMcpStdio } = await import('./dist/stdio.js')
   await runMcpStdio()
 }
 

--- a/test/generate-types-extensionless/.gitignore
+++ b/test/generate-types-extensionless/.gitignore
@@ -1,0 +1,1 @@
+payload-types.ts

--- a/test/generate-types-extensionless/collections/Users.ts
+++ b/test/generate-types-extensionless/collections/Users.ts
@@ -1,0 +1,8 @@
+import type { CollectionConfig } from 'payload'
+
+export const Users: CollectionConfig = {
+  slug: 'users',
+  auth: true,
+  fields: [],
+  versions: false,
+}

--- a/test/generate-types-extensionless/payload.config.ts
+++ b/test/generate-types-extensionless/payload.config.ts
@@ -1,0 +1,23 @@
+import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import path from 'path'
+import { buildConfig } from 'payload'
+import { fileURLToPath } from 'url'
+
+import { Users } from './collections/Users'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+export default buildConfig({
+  admin: {
+    user: Users.slug,
+  },
+  collections: [Users],
+  db: mongooseAdapter({
+    url: process.env.DATABASE_URL || 'mongodb://127.0.0.1:27017/payload',
+  }),
+  secret: process.env.PAYLOAD_SECRET || 'test',
+  typescript: {
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  },
+})

--- a/test/generate-types-extensionless/tsconfig.json
+++ b/test/generate-types-extensionless/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}


### PR DESCRIPTION
Fixes #16734

## Which branch should this PR target?
main — This is a bug fix in the v4 codebase. The same issue affects v3 users who run create-payload-app with extensionless collection imports.
What?
Fixes pnpm payload generate:types failing when payload.config.ts imports collections using extensionless paths (e.g. import { Users } from './collections/Users'), which is the layout create-payload-app scaffolds.

## Before: 
CLI fails with ERR_MODULE_NOT_FOUND for ./collections/Users.

## After: 
generate:types loads the config, resolves nested extensionless imports, and writes payload-types.ts successfully.

## Why?
packages/payload/bin.js used tsx/esm/api's tsImport(), which only scopes TypeScript resolution to the entry file. Nested extensionless imports in the user's payload.config.ts are not resolved the same way as with node --import tsx/esm (global registration).

Users following the default scaffold could not regenerate types after adding new collections.

## How?
Replaced scoped tsImport() with global tsx registration via register() from tsx/esm/api before dynamically importing the bin script.
Applied the same change in packages/graphql/bin.js and packages/plugin-mcp/bin.js for consistency.
Added packages/graphql/eslint.config.js so graphql/bin.js passes lint-staged (same pattern as packages/payload).
Added a unit test (packages/payload/src/bin/generateTypesExtensionlessImports.spec.ts) with a fixture at test/generate-types-extensionless/ that mirrors the scaffolded config layout.

## Test plan

 pnpm run build:payload

 pnpm run test:unit -- packages/payload/src/bin/generateTypesExtensionlessImports.spec.ts

 Manual: PAYLOAD_CONFIG_PATH=... node packages/payload/bin.js generate:types succeeds with extensionless imports
