### PR TITLE
chore: add frozen-lockfile variant of prepare-run-test-against-prod:ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "prepare": "husky && pnpm turbo build --filter @payloadcms/typescript-plugin",
     "prepare-run-test-against-prod": "pnpm bf && rm -rf test/packed && rm -rf test/node_modules && rm -rf app && rm -f test/pnpm-lock.yaml && pnpm run script:pack --all --no-build --dest test/packed && pnpm runts test/setupProd.ts && cd test && pnpm i --ignore-workspace && cd ..",
     "prepare-run-test-against-prod:ci": "rm -rf test/packed && rm -rf test/node_modules && rm -rf app && rm -f test/pnpm-lock.yaml && pnpm run script:pack --all --no-build --dest test/packed && pnpm runts test/setupProd.ts && cd test && pnpm i --ignore-workspace && cd ..",
+    "prepare-run-test-against-prod:ci:frozen": "rm -rf test/packed && rm -rf test/node_modules && rm -rf app && pnpm run script:pack --all --no-build --dest test/packed && pnpm runts test/setupProd.ts && cd test && pnpm i --frozen-lockfile --ignore-workspace && cd ..",
     "publish-prerelease": "pnpm --filter releaser publish-prerelease",
     "reinstall": "pnpm clean:all && pnpm install",
     "release": "pnpm --filter releaser release --tag beta",


### PR DESCRIPTION
## What

Adds `prepare-run-test-against-prod:ci:frozen`, a variant of `prepare-run-test-against-prod:ci` that installs the prod test app with a frozen lockfile.

It is identical to `prepare-run-test-against-prod:ci` except that it does not delete `test/pnpm-lock.yaml` and runs `pnpm i --frozen-lockfile` instead of a plain `pnpm i`. Both still pack the workspace packages, run `test/setupProd.ts`, and install with `--ignore-workspace`.

## Why

The existing `:ci` script deletes the lockfile and installs non-frozen on purpose. As I understand it, that is so the prod test resolves the newest version of every transitive dependency at install time, simulating a real consumer installing published Payload from scratch. That surfaces breakages from upstream dependency updates early, before they reach Payload users, which is valuable for Payload's own CI.

That same behavior is a problem when the install does not go straight to the public npm registry but through a private mirror or proxy (for example a corporate Artifactory). Mirrors sync from npm per package and can briefly lag, so a non-frozen resolution can request a freshly published transitive version that the mirror has not synced yet and fail with `ERR_PNPM_NO_MATCHING_VERSION`. The version exists on npm but not yet on the mirror, and because the resolution always chases the newest, the failure recurs intermittently and is outside the consumer's control.

For that case, being on the bleeding edge is not the goal; reproducibility is. A frozen install against a committed lockfile requests exact, already-mirrored versions, so it never asks the mirror for something it does not have. This variant gives mirror-based consumers (such as Figma's CI, which installs Payload through Artifactory to run the Content API compatibility suite) a deterministic option, without changing the default.

## Notes

- `test/pnpm-lock.yaml` is not committed in this repo, so this script is meant for consumers that generate and commit their own `test/pnpm-lock.yaml`, resolved through their mirror. Generate it once with the existing non-frozen flow, commit it, then use `:frozen` on subsequent runs and refresh it when dependencies change.
- No existing script or default behavior changes; this only adds an opt-in script.
