### PR TITLE
fix(ui): resolve card aria-label showing [object Object] for localized labels

### DIFF
--- a/packages/ui/src/widgets/CollectionCards/index.tsx
+++ b/packages/ui/src/widgets/CollectionCards/index.tsx
@@ -103,7 +103,7 @@ export async function CollectionCards(props: WidgetServerProps) {
                             ) : hasCreatePermission && type === EntityType.collection ? (
                               <Button
                                 aria-label={t('general:createNewLabel', {
-                                  label,
+                                  label: title,
                                 })}
                                 buttonStyle="ghost"
                                 el="link"


### PR DESCRIPTION
### What?

The `createNewLabel` aria-label on collection card buttons displays `[object Object]` instead of the localized collection name when collection labels are defined as multilingual objects (e.g., `{ en: 'Pages', de: 'Seiten' }`).

### Why?

Line 106 in `CollectionCards/index.tsx` passes the raw `label` object directly to the `t()` translation function. Since `label` is an object (not a string), JavaScript coerces it to `[object Object]`. The other translation calls in the same file (`showAllLabel` on line 50, `editLabel` on line 68-69) already resolve the label correctly — this one was missed.

### How?

Changed `label` to `label: title` on line 106, where `title` is already resolved via `getTranslation(label, i18n)` on line 48. One-line change, consistent with the existing pattern in the same file.

Fixes #17069