### PR TITLE
feat(ui): add admin.groups for ordering nav groups in the sidebar

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1005,6 +1005,19 @@ export type Config = {
         Logo?: CustomComponent
       }
       /**
+       * Optional array of nav group labels in the order they should render in the sidebar.
+       * Groups not listed keep their existing first-encounter order and are appended after
+       * the listed ones. Labels are compared against the translated group label, so the
+       * same value used in `admin.group` (or the `general:collections` / `general:globals`
+       * keys for the default groups) should be used. Omit to keep the default behavior.
+       *
+       * @example
+       * admin: {
+       *   groups: ['System', 'Animals', 'Food', 'Layout', 'Collections'],
+       * }
+       */
+      groups?: (Record<string, string> | string)[]
+      /**
        * Add custom header to top of page globally
        */
       header?: CustomComponent[]

--- a/packages/ui/src/elements/Nav/index.tsx
+++ b/packages/ui/src/elements/Nav/index.tsx
@@ -44,6 +44,7 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
   const {
     admin: {
       components: { afterNav, afterNavLinks, beforeNav, beforeNavLinks, settingsMenu },
+      groups: adminGroups,
     },
     collections,
     globals,
@@ -74,6 +75,7 @@ export const DefaultNav: React.FC<NavProps> = async (props) => {
     ],
     permissions,
     i18n,
+    adminGroups,
   )
 
   const navPreferences = await getNavPrefs(req)

--- a/packages/ui/src/utilities/getNavGroups.ts
+++ b/packages/ui/src/utilities/getNavGroups.ts
@@ -44,6 +44,7 @@ export function getNavGroups(
     ],
     permissions,
     i18n,
+    config.admin?.groups,
   )
 
   return navGroups

--- a/packages/ui/src/utilities/groupNavItems.spec.ts
+++ b/packages/ui/src/utilities/groupNavItems.spec.ts
@@ -1,0 +1,120 @@
+import type { I18nClient } from '@payloadcms/translations'
+
+import { EntityType } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { groupNavItems, type EntityToGroup } from './groupNavItems.js'
+
+const i18n = {
+  t: (key: string) => {
+    if (typeof key === 'string' && key.startsWith('general:')) {
+      return key.split(':')[1]
+    }
+    return String(key)
+  },
+} as unknown as I18nClient
+
+// Build a permissions object where every (type, slug) pair has read=true.
+// isNavEntityVisible reads `permissions?.[type.toLowerCase()]?.[slug]?.read`.
+// EntityType.collection === 'collections', EntityType.global === 'globals'.
+function permsFor(entities: EntityToGroup[]) {
+  const collections: Record<string, { read: boolean }> = {}
+  const globals: Record<string, { read: boolean }> = {}
+  for (const e of entities) {
+    if (e.type === EntityType.collection) {
+      collections[e.entity.slug] = { read: true }
+    } else {
+      globals[e.entity.slug] = { read: true }
+    }
+  }
+  return { collections, globals }
+}
+
+function collection(slug: string, label: string, group?: false | string): EntityToGroup {
+  return {
+    type: EntityType.collection,
+    entity: {
+      slug,
+      labels: { plural: label, singular: label },
+      admin: group === undefined ? {} : { group },
+    } as any,
+  }
+}
+
+function globalEntity(slug: string, label: string, group?: false | string): EntityToGroup {
+  return {
+    type: EntityType.global,
+    entity: {
+      slug,
+      label,
+      admin: group === undefined ? {} : { group },
+    } as any,
+  }
+}
+
+describe('groupNavItems', () => {
+  it('keeps the default Collections-first / Globals-second order when groupOrder is omitted', () => {
+    const entities = [
+      collection('zebra', 'Zebras', 'Animals'),
+      collection('banana', 'Bananas'),
+      globalEntity('header', 'Header', 'Layout'),
+    ]
+
+    const result = groupNavItems(entities, permsFor(entities) as any, i18n)
+
+    expect(result.map((g) => g.label)).toEqual(['collections', 'Animals', 'Layout'])
+  })
+
+  it('reorders groups to match admin.groups when provided', () => {
+    const entities = [
+      collection('zebra', 'Zebras', 'Animals'),
+      collection('apple', 'Apples', 'Food'),
+      collection('settings', 'Settings', 'System'),
+      collection('banana', 'Bananas'),
+      globalEntity('header', 'Header', 'Layout'),
+    ]
+
+    const groupOrder = ['System', 'Animals', 'Food', 'Layout', 'collections']
+
+    const result = groupNavItems(entities, permsFor(entities) as any, i18n, groupOrder)
+
+    expect(result.map((g) => g.label)).toEqual([
+      'System',
+      'Animals',
+      'Food',
+      'Layout',
+      'collections',
+    ])
+  })
+
+  it('appends groups not listed in admin.groups after the listed ones, in first-encounter order', () => {
+    const entities = [
+      collection('zebra', 'Zebras', 'Animals'),
+      collection('apple', 'Apples', 'Food'), // Food is NOT in groupOrder
+    ]
+
+    const result = groupNavItems(entities, permsFor(entities) as any, i18n, ['Animals'])
+
+    expect(result.map((g) => g.label)).toEqual(['Animals', 'Food'])
+  })
+
+  it('preserves item order within each group', () => {
+    const entities = [
+      collection('zebra', 'Zebras', 'Animals'),
+      collection('tiger', 'Tigers', 'Animals'),
+    ]
+
+    const result = groupNavItems(entities, permsFor(entities) as any, i18n, ['Animals'])
+
+    expect(result[0].entities.map((e) => e.slug)).toEqual(['zebra', 'tiger'])
+  })
+
+  it('keeps default behavior when admin.groups is an empty array', () => {
+    const entities = [collection('zebra', 'Zebras', 'Animals')]
+
+    const result = groupNavItems(entities, permsFor(entities) as any, i18n, [])
+
+    expect(result.map((g) => g.label)).toEqual(['Animals'])
+  })
+})

--- a/packages/ui/src/utilities/groupNavItems.ts
+++ b/packages/ui/src/utilities/groupNavItems.ts
@@ -34,6 +34,7 @@ export function groupNavItems(
   entities: EntityToGroup[],
   permissions: SanitizedPermissions,
   i18n: I18nClient,
+  groupOrder?: (Record<string, string> | string)[],
 ): NavGroupType[] {
   const result = entities.reduce(
     (groups, entityToGroup) => {
@@ -99,5 +100,49 @@ export function groupNavItems(
     ],
   )
 
-  return result.filter((group) => group.entities.length > 0)
+  const filtered = result.filter((group) => group.entities.length > 0)
+
+  if (groupOrder && groupOrder.length > 0) {
+    return sortGroupsByOrder(filtered, groupOrder, i18n)
+  }
+
+  return filtered
+}
+
+/**
+ * Sorts nav groups to match `groupOrder`, appending any unlisted groups in
+ * their existing first-encounter order. Backward compatible: if `groupOrder`
+ * is empty or omitted, the caller keeps the original order.
+ *
+ * @internal
+ */
+export function sortGroupsByOrder(
+  groups: NavGroupType[],
+  groupOrder: (Record<string, string> | string)[],
+  i18n: I18nClient,
+): NavGroupType[] {
+  const ordered: NavGroupType[] = []
+  const seen = new Set<string>()
+
+  for (const wanted of groupOrder) {
+    const wantedLabel = getTranslation(wanted, i18n)
+    const matched = groups.find(
+      (group) => !seen.has(group.label) && getTranslation(group.label, i18n) === wantedLabel,
+    )
+    if (matched) {
+      ordered.push(matched)
+      seen.add(matched.label)
+    }
+  }
+
+  // Append any groups that weren't listed in groupOrder, preserving their
+  // existing first-encounter order for backward compatibility.
+  for (const group of groups) {
+    if (!seen.has(group.label)) {
+      ordered.push(group)
+      seen.add(group.label)
+    }
+  }
+
+  return ordered
 }


### PR DESCRIPTION
### What?

Adds an optional `admin.groups` array that controls the order nav groups render in the admin sidebar. Example:

```ts
admin: {
  groups: ['System', 'Animals', 'Food', 'Layout', 'Collections'],
}
```

- Adds `groups?: (Record<string, string> | string)[]` to the top-level `admin` config type (`packages/payload/src/config/types.ts`).
- Adds a 4th `groupOrder?` parameter to `groupNavItems` (`packages/ui/src/utilities/groupNavItems.ts`) and a new exported `sortGroupsByOrder` helper. When `groupOrder` is provided and non-empty, the resulting groups are sorted to match it; groups not listed keep their existing first-encounter order and are appended after the listed ones.
- Threads `config.admin?.groups` through both call sites: `getNavGroups` (dashboard cards / dashboard view) and `Nav/index.tsx` (sidebar).

### Why?

Today the sidebar renders nav groups in first-encounter order. Because `groupNavItems` seeds its reducer with `[Collections, Globals]`, the implicit Collections group is always forced to the top and globals-only custom groups are always forced to the bottom, regardless of how the user declares their config. There is no config option to control group order (Discussion #1277, open since Oct 2022, 26+ upvotes; Discussion #14528). The only workarounds today are prefix hacks like `group: '1. System'` (which leak the digit into the rendered label) or swapping in a fully custom `Nav` component.

This has come up repeatedly for ~3.5 years without a core fix. Tracking issue: #17097.

### How?

The change is intentionally minimal and backward compatible:

1. `groupNavItems` keeps its existing reduce + seed-array behavior unchanged, so when `groupOrder` is omitted the output is byte-identical to before.
2. After the existing `filter(group => group.entities.length > 0)` step, if `groupOrder` is a non-empty array, the filtered groups are passed through `sortGroupsByOrder`, which:
   - iterates `groupOrder` and pushes the first unmatched group whose translated label equals the wanted label,
   - then appends any remaining groups in their existing first-encounter order.
3. Labels are compared via `getTranslation(..., i18n)`, so the same value used in `admin.group` works. For the default groups, users should use the translation key (`'Collections'` / `'Globals'`) — shown in the JSDoc example.

```ts
// packages/ui/src/utilities/groupNavItems.ts
const filtered = result.filter((group) => group.entities.length > 0)

if (groupOrder && groupOrder.length > 0) {
  return sortGroupsByOrder(filtered, groupOrder, i18n)
}

return filtered
```

The two callers pass `config.admin?.groups` (sanitized config, always present) or `payload.config.admin.groups` (already destructured on `payload.config`).

### Before / After

Config:

```ts
collections: [
  { slug: 'zebra',    admin: { group: 'Animals' } },
  { slug: 'apple',    admin: { group: 'Food' } },
  { slug: 'settings', admin: { group: 'System' } },
  { slug: 'banana' },                              // default Collections group
],
globals: [
  { slug: 'header', admin: { group: 'Layout' } },
],
admin: { groups: ['System', 'Animals', 'Food', 'Layout', 'Collections'] },
```

**Before** (`admin.groups` ignored — first-encounter order):
1. Collections → banana
2. Animals → zebra
3. Food → apple
4. System → settings
5. Layout → header

**After** (`admin.groups` respected):
1. System → settings
2. Animals → zebra
3. Food → apple
4. Layout → header
5. Collections → banana

### Tests

Added `packages/ui/src/utilities/groupNavItems.spec.ts` (vitest, same style as the neighboring `.spec.ts` files in `packages/ui/src/utilities/`). Covers:

- default order preserved when `groupOrder` is omitted,
- groups reordered to match `admin.groups`,
- unlisted groups appended after listed ones in first-encounter order,
- item order within a group preserved,
- empty `admin.groups` array keeps default behavior.

All 5 pass locally:

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

This PR only changes group-level ordering. Item-level ordering within a group is intentionally left as-is (definition order) to keep the change minimal and backward compatible; that can be a follow-up.

Fixes #17097
