### PR TITLE
fix(ui): resolve card aria-label showing [object Object] for localized strings

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -178,6 +178,7 @@ export * from './auth/index.js'
  *
  * By defining the actual shape, we can use simple property access (T['collections'])
  * instead of conditional types throughout the codebase.
+ * (Enhancement: explicit shape definitions)
  */
 export interface PayloadTypesShape {
   auth: Record<string, unknown>

--- a/packages/ui/src/elements/Card/index.tsx
+++ b/packages/ui/src/elements/Card/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import React from 'react'
 import { getTranslation } from '@payloadcms/translations'
+import React from 'react'
 
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Button } from '../Button/index.js'

--- a/packages/ui/src/elements/Card/index.tsx
+++ b/packages/ui/src/elements/Card/index.tsx
@@ -1,17 +1,19 @@
 'use client'
 
 import React from 'react'
+import { getTranslation } from '@payloadcms/translations'
 
+import { useTranslation } from '../../providers/Translation/index.js'
 import { Button } from '../Button/index.js'
 import './index.css'
 
 export type Props = {
   actions?: React.ReactNode
-  buttonAriaLabel?: string
+  buttonAriaLabel?: Record<string, string> | string
   href?: string
   id?: string
   onClick?: () => void
-  title: string
+  title: Record<string, string> | string
   titleAs?: React.ElementType
 }
 
@@ -19,6 +21,7 @@ const baseClass = 'card'
 
 export const Card: React.FC<Props> = (props) => {
   const { id, actions, buttonAriaLabel, href, onClick, title, titleAs } = props
+  const { i18n } = useTranslation()
 
   const classes = [baseClass, id, (onClick || href) && `${baseClass}--has-onclick`]
     .filter(Boolean)
@@ -28,10 +31,10 @@ export const Card: React.FC<Props> = (props) => {
 
   return (
     <div className={classes} id={id}>
-      <Tag className={`${baseClass}__title`}>{title}</Tag>
+      <Tag className={`${baseClass}__title`}>{getTranslation(title as any, i18n)}</Tag>
       {(onClick || href) && (
         <Button
-          aria-label={buttonAriaLabel}
+          aria-label={buttonAriaLabel ? getTranslation(buttonAriaLabel as any, i18n) : undefined}
           buttonStyle="ghost"
           className={`${baseClass}__click`}
           el="link"


### PR DESCRIPTION
## Description

This PR resolves an issue where localized values rendered as `[object Object]` in the `aria-label` attribute of cards within the UI. It correctly unwraps the localized string for accessibility attributes.

Additionally, this PR includes a small documentation update regarding explicit shape definitions.

### Changes
- Fixed localization rendering in Card `aria-label`s.
- Documented explicit shape definitions.
