### PR TITLE
fix(richtext-*): re-enable toolbar buttons after failed save

### DIFF
--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -259,7 +259,11 @@ const RichTextField: React.FC<LoadedSlateFieldProps> = (props) => {
           const isDisabling = clickState === 'disabled'
           child.setAttribute('tabIndex', isDisabling ? '-1' : '0')
           if (isButton) {
-            child.setAttribute('disabled', isDisabling ? 'disabled' : null)
+            if (isDisabling) {
+              child.setAttribute('disabled', 'disabled')
+            } else {
+              child.removeAttribute('disabled')
+            }
           }
         })
     }


### PR DESCRIPTION
### What?

Re-enables the Slate rich text editor toolbar buttons after a failed save. When a save fails validation, every toolbar button, built-in and custom, on the edit view is disabled until a hard reload. 

### Why?

While the form is processing, the field is disabled and `setClickableState` disables the toolbar buttons. When processing ends it is re-enabled:

```ts
child.setAttribute('disabled', isDisabling ? 'disabled' : null)
```

`setAttribute` stringifies, so the enable case sets `disabled="null"` instead of removing the attribute. `disabled` is a boolean attribute, so its presence alone keeps the button disabled. On a failed save the user stays on the edit view, so the toolbar is left disabled until a reload. A successful save navigates away, which is why it only shows up on failures.

### How?

Remove the attribute on the enable path instead of setting it to `null`:

```ts
if (isDisabling) {
  child.setAttribute('disabled', 'disabled')
} else {
  child.removeAttribute('disabled')
}
```

The change is contained to the Slate toolbar. `setClickableState` exists only in this file, and nothing in the repo reads the `disabled` attribute, so nothing depended on the old value.
