### PR TITLE
chore(skills): encourage versions, slugField, and sidebar guidance in payload skill

### DIFF
--- a/tools/claude-plugin/skills/payload/SKILL.md
+++ b/tools/claude-plugin/skills/payload/SKILL.md
@@ -80,22 +80,47 @@ export default buildConfig({
 
 ## Essential Patterns
 
+### Defaults & Conventions
+
+Apply these defaults when modeling content unless there's a clear reason not to:
+
+- **Enable drafts/versions by default:** `versions: { drafts: true }`. This is the
+  recommended starting point for any content collection. It auto-injects a
+  `_status` field (`draft` / `published` / `changed`) — **don't add your own
+  `status` field**, it's redundant. Only skip versions for collections that have
+  no publish/draft lifecycle (e.g. internal join tables, settings).
+- **Use `slugField()` for all slugs** instead of hand-rolling
+  `{ name: 'slug', type: 'text', unique: true }`. It auto-generates the slug from
+  the title, adds a regenerate toggle, and handles uniqueness/indexing for you.
+  It defaults to generating from a `title` field — if the collection has no
+  `title`, pass the source field: `slugField({ useAsSlug: 'name' })`.
+- **`position: 'sidebar'` is for short, at-a-glance fields** — status, category,
+  author, publish date. Avoid it for long fields that need horizontal space to be
+  usable (description, rich text content, long text). Those belong in the main
+  document area.
+
 ### Basic Collection
 
 ```ts
 import type { CollectionConfig } from 'payload'
+import { slugField } from 'payload'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
   admin: {
     useAsTitle: 'title',
-    defaultColumns: ['title', 'author', 'status', 'createdAt'],
+    // _status (from versions.drafts) shows the draft/published state — no custom status field needed
+    defaultColumns: ['title', 'author', '_status', 'createdAt'],
+  },
+  versions: {
+    drafts: true,
   },
   fields: [
     { name: 'title', type: 'text', required: true },
-    { name: 'slug', type: 'text', unique: true, index: true },
-    { name: 'content', type: 'richText' },
-    { name: 'author', type: 'relationship', relationTo: 'users' },
+    slugField(), // auto-generates from `title`, unique + indexed, sidebar position
+    { name: 'content', type: 'richText' }, // long field — stays in the main area, not the sidebar
+    // short, at-a-glance field — good sidebar candidate
+    { name: 'author', type: 'relationship', relationTo: 'users', admin: { position: 'sidebar' } },
   ],
   timestamps: true,
 }
@@ -115,8 +140,11 @@ For more collection patterns (auth, upload, drafts, live preview), see [COLLECTI
 // Rich text
 { name: 'content', type: 'richText', required: true }
 
-// Select
-{ name: 'status', type: 'select', options: ['draft', 'published'], defaultValue: 'draft' }
+// Slug — use the helper instead of a hand-rolled text field
+slugField()
+
+// Select (for genuine taxonomy — NOT publish state; use versions.drafts + _status for that)
+{ name: 'category', type: 'select', options: ['news', 'tutorial', 'opinion'] }
 
 // Upload
 { name: 'image', type: 'upload', relationTo: 'media' }
@@ -418,6 +446,14 @@ import type { Post, User } from '@/payload-types'
 10. **Point fields** are not supported in SQLite
 
 ## Best Practices
+
+### Content Modeling
+
+- Enable `versions: { drafts: true }` by default on content collections; rely on the
+  auto-injected `_status` field rather than adding a custom `status` field
+- Use `slugField()` for slugs instead of hand-rolling a unique text field
+- Reserve `position: 'sidebar'` for short, at-a-glance fields (status, category,
+  author, date); keep long fields (description, rich text) in the main area
 
 ### Security
 

--- a/tools/claude-plugin/skills/payload/reference/ACCESS-CONTROL.md
+++ b/tools/claude-plugin/skills/payload/reference/ACCESS-CONTROL.md
@@ -85,7 +85,6 @@ export const Posts: CollectionConfig = {
   },
   fields: [
     { name: 'title', type: 'text' },
-    { name: 'status', type: 'select', options: ['draft', 'published'] },
     { name: 'author', type: 'relationship', relationTo: 'users' },
   ],
 }

--- a/tools/claude-plugin/skills/payload/reference/COLLECTIONS.md
+++ b/tools/claude-plugin/skills/payload/reference/COLLECTIONS.md
@@ -6,6 +6,7 @@ Complete reference for collection configurations and patterns.
 
 ```ts
 import type { CollectionConfig } from 'payload'
+import { slugField } from 'payload'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
@@ -15,10 +16,15 @@ export const Posts: CollectionConfig = {
   },
   admin: {
     useAsTitle: 'title',
-    defaultColumns: ['title', 'author', 'status', 'createdAt'],
+    // _status comes from versions.drafts below — no custom status field needed
+    defaultColumns: ['title', 'author', '_status', 'createdAt'],
     group: 'Content', // Organize in admin sidebar
     description: 'Blog posts and articles',
     listSearchableFields: ['title', 'slug'],
+  },
+  // Enable drafts by default — auto-injects the _status field (draft/published/changed)
+  versions: {
+    drafts: true,
   },
   fields: [
     {
@@ -27,24 +33,17 @@ export const Posts: CollectionConfig = {
       required: true,
       index: true,
     },
-    {
-      name: 'slug',
-      type: 'text',
-      unique: true,
-      index: true,
-      admin: { position: 'sidebar' },
-    },
-    {
-      name: 'status',
-      type: 'select',
-      options: ['draft', 'published'],
-      defaultValue: 'draft',
-    },
+    slugField(), // unique + indexed, sidebar position — don't hand-roll a slug text field
   ],
   defaultSort: '-createdAt',
   timestamps: true,
 }
 ```
+
+> Don't add a custom `status` select for publish state — enabling
+> `versions: { drafts: true }` injects a managed `_status` field
+> (`draft` / `published` / `changed`) that the admin UI and Draft Preview already
+> understand. Use it in `defaultColumns` and access control directly.
 
 ## Auth Collection
 
@@ -129,6 +128,7 @@ Enable real-time content preview during editing.
 
 ```ts
 import type { CollectionConfig } from 'payload'
+import { slugField } from 'payload'
 
 const generatePreviewPath = ({
   slug,
@@ -164,10 +164,7 @@ export const Pages: CollectionConfig = {
         req,
       }),
   },
-  fields: [
-    { name: 'title', type: 'text' },
-    { name: 'slug', type: 'text' },
-  ],
+  fields: [{ name: 'title', type: 'text' }, slugField()],
 }
 ```
 

--- a/tools/claude-plugin/skills/payload/reference/FIELDS.md
+++ b/tools/claude-plugin/skills/payload/reference/FIELDS.md
@@ -26,9 +26,19 @@ const textField: TextField = {
 }
 ```
 
+> **When to use `position: 'sidebar'`:** Reserve the sidebar for short fields that
+> give quick insight into the content — status, category, author, publish date,
+> slug. Avoid it for fields that need horizontal space to be useful, like a
+> description, rich text content, or long text — those belong in the main document
+> area. (`title` above is shown in the sidebar only to demonstrate the option.)
+
 ### Slug Field Helper
 
-Built-in helper for auto-generating slugs:
+Built-in helper for auto-generating slugs. **Use this for all slugs** instead of
+hand-rolling a `{ name: 'slug', type: 'text', unique: true }` field — it
+auto-generates the slug from the title, adds a regenerate toggle, and handles
+uniqueness and indexing. Call it with no args when the collection has a `title`
+field — the slug is generated from `title` by default:
 
 ```ts
 import { slugField } from 'payload'
@@ -38,19 +48,35 @@ export const Pages: CollectionConfig = {
   slug: 'pages',
   fields: [
     { name: 'title', type: 'text', required: true },
-    slugField({
-      name: 'slug', // defaults to 'slug'
-      useAsSlug: 'title', // defaults to 'title'
-      checkboxName: 'generateSlug', // defaults to 'generateSlug'
-      localized: true,
-      required: true,
-      overrides: (defaultField) => {
-        // Customize the generated fields if needed
-        return defaultField
-      },
-    }),
+    slugField(), // name: 'slug', useAsSlug: 'title', required, unique, position: 'sidebar'
   ],
 }
+```
+
+`useAsSlug` defaults to `'title'`, so if the collection has **no `title` field**,
+you must pass the source field explicitly — otherwise the slug generates from a
+field that doesn't exist:
+
+```ts
+// Collection keyed on `name` instead of `title`
+fields: [{ name: 'name', type: 'text', required: true }, slugField({ useAsSlug: 'name' })]
+```
+
+Override defaults when needed (`overrides` receives the generated `RowField`):
+
+```ts
+slugField({
+  name: 'slug', // defaults to 'slug'
+  useAsSlug: 'title', // defaults to 'title'
+  checkboxName: 'generateSlug', // defaults to 'generateSlug'
+  localized: true,
+  required: true, // defaults to true
+  position: 'sidebar', // default; the slug is a short field well-suited to the sidebar
+  overrides: (field) => {
+    field.fields[1].label = 'Custom Slug Label'
+    return field
+  },
+})
 ```
 
 ## Rich Text (Lexical)
@@ -264,14 +290,17 @@ const blocksField: BlocksField = {
 ```ts
 import type { SelectField } from 'payload'
 
+// Use select for genuine taxonomy. For publish state, enable versions.drafts
+// and rely on the auto-injected _status field instead of a custom select.
 const selectField: SelectField = {
-  name: 'status',
+  name: 'priority',
   type: 'select',
   options: [
-    { label: 'Draft', value: 'draft' },
-    { label: 'Published', value: 'published' },
+    { label: 'Low', value: 'low' },
+    { label: 'Medium', value: 'medium' },
+    { label: 'High', value: 'high' },
   ],
-  defaultValue: 'draft',
+  defaultValue: 'medium',
   required: true,
 }
 


### PR DESCRIPTION
# Overview

Updates the `payload` skill with guidance on versions, `slugField()`, and `position: 'sidebar'`.

## Key Changes

#### Encourage drafts/versions by default

`versions: { drafts: true }` is now the default for content collections across `SKILL.md` and the collections reference. Examples rely on the auto-injected `_status` field and drop hand-rolled `status` selects.

#### Default to `slugField()` for slugs

All slug examples use the `slugField()` helper instead of a hand-rolled `{ name: 'slug', type: 'text', unique: true }` field, with a note that the helper generates from `title` by default and needs `slugField({ useAsSlug: 'name' })` when there is no `title` field.

#### Add `position: 'sidebar'` guidance

New guidance on sidebar placement: short, at-a-glance fields (status, category, author, date) belong there; long fields (description, rich text) stay in the main document area.

#### Consistency sweep

Removed remaining anti-pattern examples across `FIELDS.md`, `COLLECTIONS.md`, and `ACCESS-CONTROL.md` (custom publish-state selects, hand-rolled slugs) so the reference docs match the new defaults.
