### PR TITLE
feat: auto-discover import map across framework adapters

### DIFF
--- a/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/resolveImportMapFilePath.ts
@@ -11,12 +11,20 @@ async function pathOrFileExists(path: string): Promise<boolean> {
 }
 
 /**
- * Default directory patterns for Next.js import map resolution.
- * Other framework adapters can provide their own patterns via `candidateDirectories`.
+ * Default directory patterns for import map resolution, covering the supported
+ * framework conventions. Directories are probed in order and the first existing
+ * one wins; the conventions are mutually exclusive in practice, so a Next.js app
+ * never matches the TanStack patterns and vice versa.
+ *
+ * Adapters with a bespoke layout can still bypass this via `candidateDirectories`.
  */
 const defaultCandidateDirectories = (rootDir: string, adminRoute: string): string[] => [
+  // Next.js App Router: `(payload)` route group nested under the admin route
   path.resolve(rootDir, `app/(payload)${adminRoute}/`),
   path.resolve(rootDir, `src/app/(payload)${adminRoute}/`),
+  // TanStack Start: `_payload` pathless route folder at the app root
+  path.resolve(rootDir, `app/_payload/`),
+  path.resolve(rootDir, `src/app/_payload/`),
 ]
 
 /**

--- a/packages/tanstack-start/src/utilities/importMap.server.ts
+++ b/packages/tanstack-start/src/utilities/importMap.server.ts
@@ -1,12 +1,11 @@
 import path from 'node:path'
 
 /**
- * Returns the default output path for the generated import map file
- * in a TanStack Start project.
- *
- * TanStack Start projects typically use `src/` as the source root,
- * so the import map is placed there.
+ * Returns the default output path for the generated import map file in a
+ * TanStack Start project. Matches the `app/_payload/` convention that Payload's
+ * import map auto-discovery probes, so the file is found without a custom
+ * `admin.importMap.importMapFile` override.
  */
 export function getImportMapOutputPath(rootDir?: string): string {
-  return path.resolve(rootDir || process.cwd(), 'src', 'payload-import-map.ts')
+  return path.resolve(rootDir || process.cwd(), 'app', '_payload', 'importMap.js')
 }

--- a/test/initDevAndTest.ts
+++ b/test/initDevAndTest.ts
@@ -63,8 +63,9 @@ export async function initDevAndTest(
   const config: SanitizedConfig = await (await import(configUrl)).default
 
   if (framework === 'tanstack-start') {
-    process.env.ROOT_DIR = path.resolve(dirname, 'app-tanstack')
-    config.admin.importMap.importMapFile = importMapPath
+    // ROOT_DIR drives import map auto-discovery; point it at the app that owns the
+    // generated importMap so the `app/_payload/` convention resolves on its own.
+    process.env.ROOT_DIR = tanstackAppDir
   } else {
     process.env.ROOT_DIR = getNextRootDir(testSuiteArg).rootDir
   }


### PR DESCRIPTION
Allows the generated importMap.js file to be discoverable within TanStack Start directory conventions. This way we no longer need a custom `admin.importMap.importMapFile` override.

Previously, we only probed the Next.js App Router layout — `app/(payload)/*`. TanStack Start, however, places its generated map at `app/_payload/*`.

Now `defaultCandidateDirectories` also probes the `_payload` convention:

```ts
// Next.js App Router: `(payload)` route group nested under the admin route
path.resolve(rootDir, `app/(payload)${adminRoute}/`),
path.resolve(rootDir, `src/app/(payload)${adminRoute}/`),

// TanStack Start: `_payload` pathless route folder at the app root
path.resolve(rootDir, `app/_payload/`),
path.resolve(rootDir, `src/app/_payload/`),
```