### PR TITLE
chore: replace hardcoded 1px borders with --stroke-width-small token

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/Collapse/index.css
+++ b/packages/richtext-lexical/src/features/blocks/premade/CodeBlock/Component/Collapse/index.css
@@ -20,7 +20,7 @@
   }
 
   &:focus-visible {
-    outline: 1px solid var(--color-border-brand-strong);
+    outline: var(--stroke-width-small) solid var(--color-border-brand-strong);
     outline-offset: calc(var(--stroke-width-small) / -1);
   }
 }

--- a/packages/ui/src/css/utilities.css
+++ b/packages/ui/src/css/utilities.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   :root {
     --accessibility-focus-color: var(--color-border-selected);
-    --accessibility-outline: 1px solid var(--accessibility-focus-color);
+    --accessibility-outline: var(--stroke-width-small) solid var(--accessibility-focus-color);
     --accessibility-outline-offset: 1px;
   }
 

--- a/packages/ui/src/elements/DatePicker/index.css
+++ b/packages/ui/src/elements/DatePicker/index.css
@@ -373,7 +373,7 @@
   }
 
   .react-datepicker__monthPicker {
-    border-top: 1px solid var(--color-border);
+    border-top: var(--stroke-width-small) solid var(--color-border);
   }
 
   .react-datepicker__month-text {
@@ -413,7 +413,7 @@
     background-color: transparent;
     padding: var(--spacer-2);
     padding-bottom: 0;
-    border-top: 1px solid var(--color-border);
+    border-top: var(--stroke-width-small) solid var(--color-border);
     width: 100%;
     order: 3;
   }
@@ -614,13 +614,13 @@
 
   .react-datepicker__time-container {
     float: right;
-    border-left: 1px solid var(--color-border);
+    border-left: var(--stroke-width-small) solid var(--color-border);
     width: var(--time-column-width);
 
     .react-datepicker__time {
       position: relative;
       background: transparent;
-      border-top: 1px solid var(--color-border);
+      border-top: var(--stroke-width-small) solid var(--color-border);
       border-bottom-right-radius: var(--radius-large);
 
       .react-datepicker__time-box {
@@ -722,7 +722,7 @@
 
   .react-datepicker__today-button {
     background: var(--color-bg-secondary);
-    border-top: 1px solid var(--color-border);
+    border-top: var(--stroke-width-small) solid var(--color-border);
     cursor: pointer;
     text-align: center;
     font-weight: var(--text-body-medium-strong-font-weight);
@@ -894,7 +894,7 @@
 
     .date-time-picker .react-datepicker__time-container {
       width: auto;
-      border-top: 1px solid var(--color-border);
+      border-top: var(--stroke-width-small) solid var(--color-border);
     }
 
     .date-time-picker .react-datepicker__header--time {

--- a/packages/ui/src/elements/DrawerActionHeader/index.css
+++ b/packages/ui/src/elements/DrawerActionHeader/index.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   .drawer-action-header {
     padding: var(--spacer-2-5);
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: var(--stroke-width-small) solid var(--color-border);
   }
 
   .drawer-action-header__content {

--- a/packages/ui/src/elements/Hierarchy/ColumnBrowser/Column/index.css
+++ b/packages/ui/src/elements/Hierarchy/ColumnBrowser/Column/index.css
@@ -5,7 +5,7 @@
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid var(--color-border);
+    border-right: var(--stroke-width-small) solid var(--color-border);
     height: 100%;
     background: var(--color-bg);
   }
@@ -18,7 +18,7 @@
     padding: var(--spacer-1) var(--spacer-3);
     flex-shrink: 0;
     margin-bottom: var(--spacer-2);
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: var(--stroke-width-small) solid var(--color-border);
   }
 
   .hierarchy-column__add-button {

--- a/packages/ui/src/elements/Hierarchy/Drawer/index.css
+++ b/packages/ui/src/elements/Hierarchy/Drawer/index.css
@@ -23,7 +23,7 @@
     justify-content: space-between;
     align-items: center;
     padding: var(--spacer-2) var(--spacer-2-5);
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: var(--stroke-width-small) solid var(--color-border);
     flex-shrink: 0;
   }
 

--- a/packages/ui/src/elements/Nav/index.css
+++ b/packages/ui/src/elements/Nav/index.css
@@ -6,7 +6,7 @@
     flex-shrink: 0;
     height: 100vh;
     width: var(--nav-width);
-    border-right: 1px solid var(--color-border);
+    border-right: var(--stroke-width-small) solid var(--color-border);
     overflow: hidden;
     --nav-padding-inline-start: var(--spacer-2-5);
     --nav-padding-inline-end: var(--spacer-2-5);
@@ -16,7 +16,7 @@
 
   [dir='rtl'] .nav {
     border-right: none;
-    border-left: 1px solid var(--color-border);
+    border-left: var(--stroke-width-small) solid var(--color-border);
   }
 
   .nav__mobile-close {

--- a/packages/ui/src/elements/NavGroup/index.css
+++ b/packages/ui/src/elements/NavGroup/index.css
@@ -6,7 +6,7 @@
 
     & + .nav-group {
       margin-block-start: var(--spacer-2);
-      border-top: 1px solid var(--color-border);
+      border-top: var(--stroke-width-small) solid var(--color-border);
       padding-top: var(--spacer-2-5);
     }
   }

--- a/packages/ui/src/fields/Blocks/BlockSelector/BlockSearch/index.css
+++ b/packages/ui/src/fields/Blocks/BlockSelector/BlockSearch/index.css
@@ -6,7 +6,7 @@
     width: 100%;
     align-items: flex-start;
     padding: var(--spacer-2-5) var(--spacer-3);
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: var(--stroke-width-small) solid var(--color-border);
     z-index: 1;
     background: var(--color-bg);
   }

--- a/packages/ui/src/fields/Blocks/BlockSelector/index.css
+++ b/packages/ui/src/fields/Blocks/BlockSelector/index.css
@@ -10,10 +10,7 @@
     padding: 0;
     list-style: none;
     display: grid;
-    grid-template-columns: repeat(
-      auto-fill,
-      minmax(var(--blocks-drawer-card-min-width), 1fr)
-    );
+    grid-template-columns: repeat(auto-fill, minmax(var(--blocks-drawer-card-min-width), 1fr));
     gap: var(--spacer-3);
   }
 
@@ -59,7 +56,7 @@
   .blocks-drawer__block-group-none {
     order: 1;
     padding-top: var(--spacer-2-5);
-    border-top: 1px solid var(--color-border);
+    border-top: var(--stroke-width-small) solid var(--color-border);
 
     &:only-child {
       padding-top: 0;

--- a/packages/ui/src/fields/Checkbox/index.css
+++ b/packages/ui/src/fields/Checkbox/index.css
@@ -116,7 +116,7 @@
     }
 
     &:has(:focus-visible) .checkbox-input__input {
-      outline: 1px solid var(--color-bg);
+      outline: var(--stroke-width-small) solid var(--color-bg);
       outline-offset: -2px;
     }
   }
@@ -128,7 +128,7 @@
     }
 
     &:has(:focus-visible) .checkbox-input__input {
-      outline: 1px solid var(--color-bg);
+      outline: var(--stroke-width-small) solid var(--color-bg);
       outline-offset: -2px; /* inset offset */
     }
 

--- a/packages/ui/src/fields/Group/index.css
+++ b/packages/ui/src/fields/Group/index.css
@@ -11,7 +11,7 @@
       left: calc(var(--gutter-h) * -1);
       right: calc(var(--gutter-h) * -1);
       height: 0;
-      border-top: 1px solid var(--color-border);
+      border-top: var(--stroke-width-small) solid var(--color-border);
     }
 
     &:first-child {
@@ -33,7 +33,7 @@
       left: calc(var(--spacer-3) * -1);
       right: calc(var(--spacer-3) * -1);
       height: 0;
-      border-top: 1px solid var(--color-border);
+      border-top: var(--stroke-width-small) solid var(--color-border);
     }
 
     &:first-child {
@@ -79,7 +79,7 @@
   }
 
   .group-field--gutter {
-    border-left: 1px solid var(--color-border);
+    border-left: var(--stroke-width-small) solid var(--color-border);
     padding-left: var(--spacer-3);
   }
 

--- a/packages/ui/src/views/Dashboard/Default/ModularDashboard/renderWidget/RenderWidget.tsx
+++ b/packages/ui/src/views/Dashboard/Default/ModularDashboard/renderWidget/RenderWidget.tsx
@@ -62,7 +62,7 @@ export const RenderWidget: React.FC<{
             {
               style: {
                 background: 'var(--theme-error-50)',
-                border: '1px solid var(--theme-error-200)',
+                border: 'var(--stroke-width-small) solid var(--theme-error-200)',
                 borderRadius: '4px',
                 color: 'var(--theme-error-text)',
                 padding: '20px',

--- a/packages/ui/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
+++ b/packages/ui/src/views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.ts
@@ -45,7 +45,7 @@ export const renderWidgetHandler: ServerFunction<
         {
           style: {
             background: 'var(--theme-elevation-50)',
-            border: '1px solid var(--theme-elevation-200)',
+            border: 'var(--stroke-width-small) solid var(--theme-elevation-200)',
             borderRadius: '4px',
             color: 'var(--theme-text)',
             padding: '20px',
@@ -93,7 +93,7 @@ export const renderWidgetHandler: ServerFunction<
         {
           style: {
             background: 'var(--theme-error-50)',
-            border: '1px solid var(--theme-error-200)',
+            border: 'var(--stroke-width-small) solid var(--theme-error-200)',
             borderRadius: '4px',
             color: 'var(--theme-error-text)',
             padding: '20px',

--- a/packages/ui/src/views/HierarchyList/HierarchyTable/SlotTable.css
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/SlotTable.css
@@ -23,7 +23,7 @@
       color: var(--color-text-secondary);
 
       tr {
-        border-top: 1px solid var(--color-border);
+        border-top: var(--stroke-width-small) solid var(--color-border);
 
         &:hover {
           background: var(--color-bg-secondary);
@@ -85,7 +85,7 @@
   .slot-table__tr {
     position: relative;
     line-height: 1;
-    border-top: 1px solid var(--color-border);
+    border-top: var(--stroke-width-small) solid var(--color-border);
   }
 
   .slot-table__tr--clickable {


### PR DESCRIPTION
Replaces hardcoded `1px` border and outline widths with the `--stroke-width-small` token across the `ui` and `richtext-lexical` packages for consistent stroke sizing.

Excludes upload-related components, which are handled in a separate PR #17044 
