### PR TITLE
fix(ui): avoid eager root fetch per hierarchy cell in list view

### DIFF
--- a/packages/ui/src/elements/Table/DefaultCell/fields/Hierarchy/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Hierarchy/index.tsx
@@ -79,6 +79,28 @@ export const HierarchyCell: React.FC<HierarchyCellProps> = ({
     Icon: drawerIcon,
   })
 
+  // Lazy-mount the drawer so its column browser doesn't eagerly fetch root items
+  // for every cell in the list view. Only mount once the user opens it.
+  const [hasMountedDrawer, setHasMountedDrawer] = useState(false)
+  const shouldOpenAfterMountRef = useRef(false)
+
+  const handleOpenDrawer = useCallback(() => {
+    if (hasMountedDrawer) {
+      openDrawer()
+      return
+    }
+    shouldOpenAfterMountRef.current = true
+    setHasMountedDrawer(true)
+  }, [hasMountedDrawer, openDrawer])
+
+  // Open the drawer once it has mounted (state update from handleOpenDrawer).
+  useEffect(() => {
+    if (hasMountedDrawer && shouldOpenAfterMountRef.current) {
+      shouldOpenAfterMountRef.current = false
+      openDrawer()
+    }
+  }, [hasMountedDrawer, openDrawer])
+
   // Fetch relationship data when visible
   useEffect(() => {
     // Reset tracking if data changed
@@ -210,12 +232,12 @@ export const HierarchyCell: React.FC<HierarchyCellProps> = ({
         icon={displayIcon}
         iconPosition="left"
         margin={false}
-        onClick={openDrawer}
+        onClick={handleOpenDrawer}
         size="medium"
       >
         {isLoading ? `${t('general:loading')}...` : displayText}
       </Button>
-      {hierarchyCollectionSlug && (
+      {hierarchyCollectionSlug && hasMountedDrawer && (
         <HierarchyDrawer
           hasMany={hasMany}
           initialSelections={initialSelections}


### PR DESCRIPTION
Lazy-mounts the hierarchy/tag selection drawer inside `HierarchyCell` so it only renders after the user opens it.

Previously every hierarchy cell in a list view unconditionally rendered its `HierarchyDrawer`. Because `@faceless-ui/modal` keeps modal children mounted while closed, each cell's `HierarchyColumnBrowser` ran its mount-time root load (`GET /api/<collection>?where[parentFieldName][exists]=false&sort=<useAsTitle>&limit=<treeLimit>`). This produced one redundant request per row before any drawer was ever opened.

The cell now tracks a `hasMountedDrawer` flag, mounts the drawer on first click, and opens it via an effect once mounted. Subsequent opens reuse the mounted drawer.