### PR TITLE
fix(translations): add Icelandic translations for redirect plugin

### DIFF
--- a/packages/plugin-redirects/src/translations/index.ts
+++ b/packages/plugin-redirects/src/translations/index.ts
@@ -3,6 +3,7 @@ import type { GenericTranslationsObject, NestedKeysStripped } from '@payloadcms/
 import { en } from './languages/en.js'
 import { es } from './languages/es.js'
 import { fr } from './languages/fr.js'
+import { is } from './languages/is.js'
 import { ja } from './languages/ja.js'
 import { pt } from './languages/pt.js'
 import { sv } from './languages/sv.js'
@@ -11,9 +12,10 @@ export const translations = {
   en,
   es,
   fr,
+  is,
   ja,
   pt,
-  sv
+  sv,
 }
 
 export type RedirectsTranslations = GenericTranslationsObject

--- a/packages/plugin-redirects/src/translations/languages/is.ts
+++ b/packages/plugin-redirects/src/translations/languages/is.ts
@@ -1,0 +1,13 @@
+import type { GenericTranslationsObject } from '@payloadcms/translations'
+
+export const is: GenericTranslationsObject = {
+  $schema: '../translation-schema.json',
+  'plugin-redirects': {
+    customUrl: 'Sérsniðin slóð',
+    documentToRedirect: 'Færsla til að vísa á',
+    fromUrl: 'Frá slóð',
+    internalLink: 'Innri hlekkur',
+    redirectType: 'Tegund tilvísunar',
+    toUrlType: 'Tegund hlekks',
+  },
+}


### PR DESCRIPTION
### What?
Adds missing Icelandic translations for redirect plugin

### Why?
So users with is locale active don't see i18n keys like `plugin-redirects:fromUrl`
