### PR TITLE
feat(ui): add "Clear" action to Array and Blocks fields

### DIFF
--- a/packages/ui/src/elements/ClearRows/index.tsx
+++ b/packages/ui/src/elements/ClearRows/index.tsx
@@ -1,0 +1,21 @@
+'use client'
+import React from 'react'
+
+import { useTranslation } from '../../providers/Translation/index.js'
+import { Button } from '../Button/index.js'
+
+export type ClearRowsProps = {
+  onClick: () => void
+}
+
+export const ClearRows: React.FC<ClearRowsProps> = ({ onClick }) => {
+  const { t } = useTranslation()
+
+  return (
+    <li>
+      <Button buttonStyle="ghost" onClick={onClick}>
+        {t('general:clear')}
+      </Button>
+    </li>
+  )
+}

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -13,6 +13,7 @@ import type { ClipboardPasteData } from '../../elements/ClipboardAction/types.js
 
 import { Banner } from '../../elements/Banner/index.js'
 import { Button } from '../../elements/Button/index.js'
+import { ClearRows } from '../../elements/ClearRows/index.js'
 import { clipboardCopy, clipboardPaste } from '../../elements/ClipboardAction/clipboardUtilities.js'
 import { ClipboardAction } from '../../elements/ClipboardAction/index.js'
 import {
@@ -181,6 +182,12 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
     },
     [removeFieldRow, path],
   )
+
+  const clearRows = useCallback(() => {
+    dispatchFields({ type: 'CLEAR_ROWS', path })
+    setDocFieldPreferences(path, { collapsed: [] })
+    setModified(true)
+  }, [dispatchFields, path, setDocFieldPreferences, setModified])
 
   const moveRow = useCallback(
     (moveFromIndex: number, moveToIndex: number) => {
@@ -369,6 +376,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
                 </li>
               </Fragment>
             )}
+            {rows?.length > 0 && !readOnly && !disabled && <ClearRows onClick={clearRows} />}
             <li>
               <ClipboardAction
                 allowCopy={rows?.length > 0}

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -9,6 +9,7 @@ import type { ClipboardPasteData } from '../../elements/ClipboardAction/types.js
 
 import { Banner } from '../../elements/Banner/index.js'
 import { Button } from '../../elements/Button/index.js'
+import { ClearRows } from '../../elements/ClearRows/index.js'
 import { clipboardCopy, clipboardPaste } from '../../elements/ClipboardAction/clipboardUtilities.js'
 import { ClipboardAction } from '../../elements/ClipboardAction/index.js'
 import {
@@ -203,6 +204,12 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
     [path, removeFieldRow],
   )
 
+  const clearRows = useCallback(() => {
+    dispatchFields({ type: 'CLEAR_ROWS', path })
+    setDocFieldPreferences(path, { collapsed: [] })
+    setModified(true)
+  }, [dispatchFields, path, setDocFieldPreferences, setModified])
+
   const moveRow = useCallback(
     (moveFromIndex: number, moveToIndex: number) => {
       moveFieldRow({ moveFromIndex, moveToIndex, path })
@@ -377,6 +384,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
                 </li>
               </Fragment>
             )}
+            {rows.length > 0 && !readOnly && !disabled && <ClearRows onClick={clearRows} />}
             <li>
               <ClipboardAction
                 allowCopy={rows?.length > 0}

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -132,6 +132,28 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
     }
 
     /**
+     * Clears all rows from an array or blocks field at once.
+     * `separateRows` strips every `${path}.*` subfield key into the discarded `rows` array, so
+     * nested subfields at any depth are removed automatically - we simply don't re-flatten them.
+     */
+    case 'CLEAR_ROWS': {
+      const { path } = action
+      const { remainingFields } = separateRows(path, state)
+
+      const newState: FormState = {
+        ...remainingFields,
+        [path]: {
+          ...state[path],
+          disableFormData: false,
+          rows: [],
+          value: 0,
+        },
+      }
+
+      return newState
+    }
+
+    /**
      * Duplicates a row in an array or blocks field.
      * It needs to manipulate two distinct parts of the form state:
      *   - The `rows` property of the parent field, e.g. `array.rows`, `blocks.rows`, etc.

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -220,6 +220,11 @@ export type DUPLICATE_ROW = {
   type: 'DUPLICATE_ROW'
 }
 
+export type CLEAR_ROWS = {
+  path: string
+  type: 'CLEAR_ROWS'
+}
+
 export type MOVE_ROW = {
   moveFromIndex: number
   moveToIndex: number
@@ -247,6 +252,7 @@ export type SET_ALL_ROWS_COLLAPSED = {
 export type FieldAction =
   | ADD_ROW
   | ADD_SERVER_ERRORS
+  | CLEAR_ROWS
   | DUPLICATE_ROW
   | MERGE_SERVER_STATE
   | MODIFY_CONDITION

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -323,6 +323,96 @@ describe('Array', () => {
         assertGroupText3,
       )
     })
+
+    test('should clear all rows at once', async () => {
+      await loadCreatePage()
+      await scrollEntirePage(page)
+
+      await addArrayRow(page, { fieldName: 'potentiallyEmptyArray' })
+      await addArrayRow(page, { fieldName: 'potentiallyEmptyArray' })
+      await addArrayRow(page, { fieldName: 'potentiallyEmptyArray' })
+
+      const rows = page.locator('#field-potentiallyEmptyArray .array-field__row')
+      await expect(rows).toHaveCount(3)
+
+      await page
+        .locator('#field-potentiallyEmptyArray .array-field__header-actions')
+        .first()
+        .getByRole('button', { name: 'Clear', exact: true })
+        .click()
+
+      await expect(rows).toHaveCount(0)
+
+      // The empty state persists after saving
+      await saveDocAndAssert(page)
+      await expect(rows).toHaveCount(0)
+    })
+
+    test('should clear rows including their nested arrays', async () => {
+      await loadCreatePage()
+      await scrollEntirePage(page)
+
+      await addArrayRow(page, { fieldName: 'potentiallyEmptyArray' })
+      await addArrayRow(page, { fieldName: 'potentiallyEmptyArray__0__array' })
+      await page.locator('#field-potentiallyEmptyArray__0__array__0__text').fill('nested')
+
+      await page
+        .locator('#field-potentiallyEmptyArray .array-field__header-actions')
+        .first()
+        .getByRole('button', { name: 'Clear', exact: true })
+        .click()
+
+      await expect(page.locator('#field-potentiallyEmptyArray .array-field__row')).toHaveCount(0)
+      await expect(page.locator('#field-potentiallyEmptyArray__0__array__0__text')).toBeHidden()
+
+      await saveDocAndAssert(page)
+      await expect(page.locator('#field-potentiallyEmptyArray .array-field__row')).toHaveCount(0)
+    })
+
+    test('should not show the clear button when there are no rows', async () => {
+      await loadCreatePage()
+      await scrollEntirePage(page)
+
+      // potentiallyEmptyArray starts with no rows
+      await expect(
+        page
+          .locator('#field-potentiallyEmptyArray .array-field__header-actions')
+          .getByRole('button', { name: 'Clear', exact: true }),
+      ).toHaveCount(0)
+    })
+
+    test('should not show the clear button on a read-only array', async () => {
+      await loadCreatePage()
+      await scrollEntirePage(page)
+
+      // readOnly has default rows but is not editable
+      await expect(
+        page
+          .locator('#field-readOnly .array-field__header-actions')
+          .getByRole('button', { name: 'Clear', exact: true }),
+      ).toHaveCount(0)
+    })
+
+    test('should restore cleared rows on reload without saving', async () => {
+      await loadCreatePage()
+      await scrollEntirePage(page)
+
+      // `items` has a default value of two rows
+      const rows = page.locator('#field-items .array-field__row')
+      await expect(rows).toHaveCount(2)
+
+      await page
+        .locator('#field-items .array-field__header-actions')
+        .first()
+        .getByRole('button', { name: 'Clear', exact: true })
+        .click()
+
+      await expect(rows).toHaveCount(0)
+
+      // Reloading without saving discards the change and restores the default rows
+      await page.reload()
+      await expect(page.locator('#field-items .array-field__row')).toHaveCount(2)
+    })
   })
 
   // TODO: re-enable this test

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -419,6 +419,50 @@ describe('Block fields', () => {
         ).toHaveValue('REPLACED BLOCK')
       })
     })
+
+    test('should clear all blocks at once', async () => {
+      await page.goto(url.create)
+      await expect(page.locator('.shimmer-effect')).toHaveCount(0)
+      await scrollEntirePage(page)
+
+      // The `blocks` field is seeded with default blocks
+      const rows = page.locator('[id^="blocks-row-"]')
+      expect(await rows.count()).toBeGreaterThan(0)
+
+      await page
+        .locator('#field-blocks .blocks-field__header-actions')
+        .first()
+        .getByRole('button', { name: 'Clear', exact: true })
+        .click()
+
+      await expect(rows).toHaveCount(0)
+    })
+
+    test('should not show the clear button when there are no blocks', async () => {
+      await page.goto(url.create)
+      await expect(page.locator('.shimmer-effect')).toHaveCount(0)
+      await scrollEntirePage(page)
+
+      // customBlocks starts with no rows
+      await expect(
+        page
+          .locator('#field-customBlocks .blocks-field__header-actions')
+          .getByRole('button', { name: 'Clear', exact: true }),
+      ).toHaveCount(0)
+    })
+
+    test('should not show the clear button on a read-only blocks field', async () => {
+      await page.goto(url.create)
+      await expect(page.locator('.shimmer-effect')).toHaveCount(0)
+      await scrollEntirePage(page)
+
+      // readOnly has a default block but is not editable
+      await expect(
+        page
+          .locator('#field-readOnly .blocks-field__header-actions')
+          .getByRole('button', { name: 'Clear', exact: true }),
+      ).toHaveCount(0)
+    })
   })
 
   describe('sortable blocks', () => {


### PR DESCRIPTION
Adds a dedicated "Clear" button to Array and Blocks field headers, allowing users to quickly remove all rows or blocks with a single click. This significantly improves the user experience for clearing fields that previously required manual, row-by-row deletion.

The "Clear" button is contextually displayed only when the field contains rows, is not read-only, and is not disabled. The action efficiently clears all field data, including nested subfields, via a new `CLEAR_ROWS` action in the form reducer.
