### PR TITLE
fix(plugin-mcp): omit body on GET/HEAD and fix schema fallback partial()

### DIFF
--- a/packages/plugin-mcp/src/mcp/createRequest.spec.ts
+++ b/packages/plugin-mcp/src/mcp/createRequest.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { createRequestFromPayloadRequest } from './createRequest.js'
+
+describe('createRequestFromPayloadRequest', () => {
+  it('does not pass a body for GET requests', () => {
+    const request = createRequestFromPayloadRequest({
+      body: 'should-not-be-sent',
+      headers: new Headers(),
+      method: 'GET',
+      url: 'http://localhost:3000/api/mcp',
+    } as Parameters<typeof createRequestFromPayloadRequest>[0])
+
+    expect(request.method).toBe('GET')
+    expect(request.body).toBeNull()
+  })
+
+  it('does not pass a body for HEAD requests', () => {
+    const request = createRequestFromPayloadRequest({
+      body: 'should-not-be-sent',
+      headers: new Headers(),
+      method: 'HEAD',
+      url: 'http://localhost:3000/api/mcp',
+    } as Parameters<typeof createRequestFromPayloadRequest>[0])
+
+    expect(request.method).toBe('HEAD')
+    expect(request.body).toBeNull()
+  })
+
+  it('passes body and duplex for POST requests', () => {
+    const body = JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 })
+
+    const request = createRequestFromPayloadRequest({
+      body,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      method: 'POST',
+      url: 'http://localhost:3000/api/mcp',
+    } as Parameters<typeof createRequestFromPayloadRequest>[0])
+
+    expect(request.method).toBe('POST')
+    expect(request.body).not.toBeNull()
+  })
+})

--- a/packages/plugin-mcp/src/mcp/createRequest.ts
+++ b/packages/plugin-mcp/src/mcp/createRequest.ts
@@ -4,9 +4,11 @@ export const createRequestFromPayloadRequest = (req: PayloadRequest) => {
   if (!req.url) {
     throw new AuthenticationError()
   }
+
+  const noBody = req.method === 'GET' || req.method === 'HEAD'
+
   return new Request(req.url, {
-    body: req.body,
-    duplex: 'half',
+    ...(noBody ? {} : { body: req.body, duplex: 'half' }),
     headers: req.headers,
     method: req.method,
   } as { duplex: 'half' } & RequestInit)

--- a/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.spec.ts
+++ b/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+vi.mock('json-schema-to-zod', () => ({
+  jsonSchemaToZod: () => {
+    throw new Error('schema too complex')
+  },
+}))
+
+describe('convertCollectionSchemaToZod', () => {
+  it('returns a schema that supports partial() when conversion fails', async () => {
+    const { convertCollectionSchemaToZod } = await import('./convertCollectionSchemaToZod.js')
+
+    const converted = convertCollectionSchemaToZod({
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+      },
+      required: ['title'],
+    })
+
+    expect(() => converted.partial().shape).not.toThrow()
+    expect(converted.partial()).toBeInstanceOf(z.ZodObject)
+  })
+})

--- a/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.ts
+++ b/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.ts
@@ -47,6 +47,6 @@ export const convertCollectionSchemaToZod = (schema: JSONSchema4) => {
       `[plugin-mcp] Schema conversion failed, using permissive fallback:`,
       error instanceof Error ? error.message : error,
     )
-    return z.record(z.any())
+    return z.object({})
   }
 }


### PR DESCRIPTION
fixes #17125

### What?
Fixes two MCP plugin bugs:
1. GET/HEAD requests no longer pass a `body` when constructing the `Request` object
2. Schema conversion fallback returns `z.object({})` instead of `z.record(z.any())` so `.partial()` works in update tools
### Why?
- MCP uses GET for the SSE stream; passing a body causes `Request with GET/HEAD method cannot have body` (500)
- When `jsonSchemaToZod` fails on complex schemas, the fallback `z.record()` crashes update tools that call `.partial()`
### How?
- `createRequest.ts`: conditionally omit `body`/`duplex` for GET and HEAD
- `convertCollectionSchemaToZod.ts`: use `z.object({})` as permissive fallback
- Added unit tests for both fixes


