### PR TITLE
fix(db-*): make deleteByID idempotent under concurrent deletes

### DIFF
--- a/packages/drizzle/src/deleteOne.ts
+++ b/packages/drizzle/src/deleteOne.ts
@@ -1,11 +1,11 @@
+import type { SQL } from 'drizzle-orm'
 import type { DeleteOne } from 'payload'
 
 import { eq } from 'drizzle-orm'
 import toSnakeCase from 'to-snake-case'
 
-import type { DrizzleAdapter } from './types.js'
+import type { DrizzleAdapter, TransactionPg, TransactionSQLite } from './types.js'
 
-import { buildFindManyArgs } from './find/buildFindManyArgs.js'
 import { buildQuery } from './queries/buildQuery.js'
 import { selectDistinct } from './queries/selectDistinct.js'
 import { transform } from './transform/read/index.js'
@@ -15,13 +15,12 @@ import { markWrite } from './utilities/readAfterWrite.js'
 
 export const deleteOne: DeleteOne = async function deleteOne(
   this: DrizzleAdapter,
-  { collection: collectionSlug, req, returning, select, where: whereArg },
+  { collection: collectionSlug, req, returning, where: whereArg },
 ) {
   const collection = this.payload.collections[collectionSlug].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
-
-  let docToDelete: Record<string, unknown>
+  const table = this.tables[tableName]
 
   const { joins, selectFields, where } = buildQuery({
     adapter: this,
@@ -33,58 +32,64 @@ export const deleteOne: DeleteOne = async function deleteOne(
 
   const db = getPrimaryDb(this, await getTransaction(this, req))
 
-  const selectDistinctResult = await selectDistinct({
-    adapter: this,
-    db,
-    joins,
-    query: ({ query }) => query.limit(1),
-    selectFields,
-    tableName,
-    where,
-  })
+  let whereToDelete: SQL = where
 
-  if (selectDistinctResult?.[0]?.id) {
-    docToDelete = await db.query[tableName].findFirst({
-      where: eq(this.tables[tableName].id, selectDistinctResult[0].id),
-    })
-  } else {
-    const findManyArgs = buildFindManyArgs({
+  if (joins?.length) {
+    const selectDistinctResult = await selectDistinct({
       adapter: this,
-      depth: 0,
-      fields: collection.flattenedFields,
-      joinQuery: false,
-      select,
+      db,
+      joins,
+      query: ({ query }) => query.limit(1),
+      selectFields,
       tableName,
+      where,
     })
 
-    findManyArgs.where = where
+    if (!selectDistinctResult?.[0]?.id) {
+      return null
+    }
 
-    docToDelete = await db.query[tableName].findFirst(findManyArgs)
+    whereToDelete = eq(table.id, selectDistinctResult[0].id)
   }
 
-  if (!docToDelete) {
+  if (returning === false) {
+    await this.deleteWhere({
+      db,
+      tableName,
+      where: whereToDelete,
+    })
+
+    markWrite(this)
+
     return null
   }
 
-  const result =
-    returning === false
-      ? null
-      : transform({
-          adapter: this,
-          config: this.payload.config,
-          data: docToDelete,
-          fields: collection.flattenedFields,
-          joinQuery: false,
-          tableName,
-        })
+  let deletedRows: Record<string, unknown>[]
 
-  await this.deleteWhere({
-    db,
-    tableName,
-    where: eq(this.tables[tableName].id, docToDelete.id),
-  })
+  if (this.name === 'postgres') {
+    deletedRows = (await (db as TransactionPg)
+      .delete(table)
+      .where(whereToDelete)
+      .returning()) as Record<string, unknown>[]
+  } else {
+    deletedRows = (await (db as TransactionSQLite)
+      .delete(table)
+      .where(whereToDelete)
+      .returning()) as Record<string, unknown>[]
+  }
+
+  if (!deletedRows.length) {
+    return null
+  }
 
   markWrite(this)
 
-  return result
+  return transform({
+    adapter: this,
+    config: this.payload.config,
+    data: deletedRows[0],
+    fields: collection.flattenedFields,
+    joinQuery: false,
+    tableName,
+  })
 }

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -102,10 +102,6 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
       }
     }
 
-    // /////////////////////////////////////
-    // Retrieve document
-    // /////////////////////////////////////
-
     let where = combineQueries({ id: { equals: id } }, accessResults)
 
     // Exclude trashed documents when trash: false
@@ -114,20 +110,6 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
       trash,
       where,
     })
-
-    const docToDelete = await req.payload.db.findOne({
-      collection: collectionConfig.slug,
-      locale: req.locale!,
-      req,
-      where,
-    })
-
-    if (!docToDelete && !hasWhereAccess) {
-      throw new NotFound(req.t)
-    }
-    if (!docToDelete && hasWhereAccess) {
-      throw new Forbidden(req.t)
-    }
 
     // /////////////////////////////////////
     // Handle potentially locked documents
@@ -141,39 +123,6 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
       req,
     })
 
-    await deleteAssociatedFiles({
-      collectionConfig,
-      config,
-      doc: docToDelete!,
-      overrideDelete: true,
-      req,
-    })
-
-    // /////////////////////////////////////
-    // Delete versions
-    // /////////////////////////////////////
-
-    if (collectionConfig.versions) {
-      await deleteCollectionVersions({
-        id,
-        slug: collectionConfig.slug,
-        payload,
-        req,
-      })
-    }
-
-    // /////////////////////////////////////
-    // Delete scheduled posts
-    // /////////////////////////////////////
-    if (hasScheduledPublishEnabled(collectionConfig)) {
-      await deleteScheduledPublishJobs({
-        id,
-        slug: collectionConfig.slug,
-        payload,
-        req,
-      })
-    }
-
     const select = sanitizeSelect({
       fields: collectionConfig.flattenedFields,
       select: resolveSelect({
@@ -185,15 +134,81 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
     })
 
     // /////////////////////////////////////
-    // Delete document
+    // Delete document (atomic at the adapter level)
     // /////////////////////////////////////
 
     let result: DataFromCollectionSlug<TSlug> = await req.payload.db.deleteOne({
       collection: collectionConfig.slug,
       req,
       select,
-      where: { id: { equals: id } },
+      where,
     })
+
+    let wasAlreadyDeleted = false
+
+    if (!result) {
+      if (hasWhereAccess) {
+        throw new Forbidden(req.t)
+      }
+
+      if (collectionConfig.trash && !trash) {
+        const trashedDoc = await req.payload.db.findOne({
+          collection: collectionConfig.slug,
+          locale: req.locale!,
+          req,
+          where: combineQueries(
+            {
+              id: { equals: id },
+              deletedAt: { exists: true },
+            },
+            accessResults,
+          ),
+        })
+
+        if (trashedDoc) {
+          throw new NotFound(req.t)
+        }
+      }
+
+      // Atomic deleteOne returned no row — the document was already removed by a concurrent delete
+      wasAlreadyDeleted = true
+      result = { id } as DataFromCollectionSlug<TSlug>
+    }
+
+    if (!wasAlreadyDeleted) {
+      await deleteAssociatedFiles({
+        collectionConfig,
+        config,
+        doc: result,
+        overrideDelete: true,
+        req,
+      })
+
+      // /////////////////////////////////////
+      // Delete versions
+      // /////////////////////////////////////
+
+      if (collectionConfig.versions) {
+        await deleteCollectionVersions({
+          id,
+          slug: collectionConfig.slug,
+          payload,
+          req,
+        })
+      }
+
+      // /////////////////////////////////////
+      // Delete scheduled posts
+      // /////////////////////////////////////
+      if (hasScheduledPublishEnabled(collectionConfig)) {
+        await deleteScheduledPublishJobs({
+          id,
+          slug: collectionConfig.slug,
+          payload,
+          req,
+        })
+      }
+    }
 
     // /////////////////////////////////////
     // Add collection property for auth collections
@@ -255,7 +270,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
     // afterDelete - Collection
     // /////////////////////////////////////
 
-    if (collectionConfig.hooks?.afterDelete?.length) {
+    if (collectionConfig.hooks?.afterDelete?.length && !wasAlreadyDeleted) {
       for (const hook of collectionConfig.hooks.afterDelete) {
         result =
           (await hook({

--- a/test/collections-rest/collections/ConcurrentDelete/index.ts
+++ b/test/collections-rest/collections/ConcurrentDelete/index.ts
@@ -1,0 +1,52 @@
+import type { CollectionConfig } from 'payload'
+
+export const concurrentDeleteSlug = 'concurrent-delete'
+
+let deleteCompletion: null | Promise<void> = null
+let resolveDeleteCompletion: (() => void) | null = null
+let deleteOrder = 0
+
+export const resetConcurrentDeleteState = (): void => {
+  deleteCompletion = null
+  resolveDeleteCompletion = null
+  deleteOrder = 0
+}
+
+export const ConcurrentDeleteCollection: CollectionConfig = {
+  slug: concurrentDeleteSlug,
+  access: {
+    create: () => true,
+    delete: () => true,
+    read: () => true,
+    update: () => true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  hooks: {
+    afterDelete: [
+      () => {
+        resolveDeleteCompletion?.()
+      },
+    ],
+    beforeDelete: [
+      async () => {
+        const order = deleteOrder++
+
+        if (order === 0) {
+          deleteCompletion = new Promise((resolve) => {
+            resolveDeleteCompletion = resolve
+          })
+
+          return
+        }
+
+        await deleteCompletion!
+      },
+    ],
+  },
+  versions: false,
+}

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -6,6 +6,7 @@ import { APIError, type CollectionConfig, type Endpoint } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
+import { ConcurrentDeleteCollection } from './collections/ConcurrentDelete/index.js'
 import { LargeDocuments } from './collections/LargeDocuments.js'
 
 export interface Relation {
@@ -302,6 +303,7 @@ export default buildConfigWithDefaults({
       versions: false,
     },
     LargeDocuments,
+    ConcurrentDeleteCollection,
   ],
   bodyParser: {
     limits: {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -13,6 +13,10 @@ import type { Post } from './payload-types.js'
 
 import { getFormDataSize } from '../__helpers/shared/getFormDataSize.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import {
+  concurrentDeleteSlug,
+  resetConcurrentDeleteState,
+} from './collections/ConcurrentDelete/index.js'
 import { largeDocumentsCollectionSlug } from './collections/LargeDocuments.js'
 import {
   customIdNumberSlug,
@@ -541,6 +545,67 @@ describe('collections-rest', () => {
 
       expect(response.status).toEqual(200)
       expect(doc.id).toEqual(id)
+    })
+
+    describe('concurrent deleteByID', () => {
+      beforeEach(() => {
+        resetConcurrentDeleteState()
+      })
+
+      it('should be idempotent when deleting the same document concurrently via local API', async () => {
+        const doc = await payload.create({
+          collection: concurrentDeleteSlug,
+          data: {
+            title: 'concurrent delete test',
+          },
+        })
+
+        const results = await Promise.all([
+          payload.delete({ collection: concurrentDeleteSlug, id: doc.id }),
+          payload.delete({ collection: concurrentDeleteSlug, id: doc.id }),
+        ])
+
+        expect(results).toHaveLength(2)
+        results.forEach((result) => {
+          expect(result.id).toEqual(doc.id)
+        })
+
+        const remaining = await payload.find({
+          collection: concurrentDeleteSlug,
+          where: { id: { equals: doc.id } },
+        })
+
+        expect(remaining.totalDocs).toEqual(0)
+      })
+
+      it('should be idempotent when deleting the same document concurrently via REST API', async () => {
+        const { doc } = await restClient
+          .POST(`/${concurrentDeleteSlug}`, {
+            body: JSON.stringify({ title: 'concurrent delete test' }),
+          })
+          .then((res) => res.json())
+
+        const [response1, response2] = await Promise.all([
+          restClient.DELETE(`/${concurrentDeleteSlug}/${doc.id}`),
+          restClient.DELETE(`/${concurrentDeleteSlug}/${doc.id}`),
+        ])
+
+        expect(response1.status).toEqual(200)
+        expect(response2.status).toEqual(200)
+
+        const { doc: deletedDoc1 } = await response1.json()
+        const { doc: deletedDoc2 } = await response2.json()
+
+        expect(deletedDoc1.id).toEqual(doc.id)
+        expect(deletedDoc2.id).toEqual(doc.id)
+
+        const remaining = await payload.find({
+          collection: concurrentDeleteSlug,
+          where: { id: { equals: doc.id } },
+        })
+
+        expect(remaining.totalDocs).toEqual(0)
+      })
     })
 
     it('should include metadata', async () => {

--- a/test/collections-rest/payload-types.ts
+++ b/test/collections-rest/payload-types.ts
@@ -78,6 +78,7 @@ export interface Config {
     'disabled-bulk-edit-docs': DisabledBulkEditDoc;
     'disabled-bulk-delete-docs': DisabledBulkDeleteDoc;
     'large-documents': LargeDocument;
+    'concurrent-delete': ConcurrentDelete;
     users: User;
     'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
@@ -98,6 +99,7 @@ export interface Config {
     'disabled-bulk-edit-docs': DisabledBulkEditDocsSelect<false> | DisabledBulkEditDocsSelect<true>;
     'disabled-bulk-delete-docs': DisabledBulkDeleteDocsSelect<false> | DisabledBulkDeleteDocsSelect<true>;
     'large-documents': LargeDocumentsSelect<false> | LargeDocumentsSelect<true>;
+    'concurrent-delete': ConcurrentDeleteSelect<false> | ConcurrentDeleteSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -296,6 +298,16 @@ export interface LargeDocument {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "concurrent-delete".
+ */
+export interface ConcurrentDelete {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -411,6 +423,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'large-documents';
         value: string | LargeDocument;
+      } | null)
+    | ({
+        relationTo: 'concurrent-delete';
+        value: string | ConcurrentDelete;
       } | null)
     | ({
         relationTo: 'users';
@@ -588,6 +604,15 @@ export interface LargeDocumentsSelect<T extends boolean = true> {
         text?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "concurrent-delete_select".
+ */
+export interface ConcurrentDeleteSelect<T extends boolean = true> {
+  title?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?

Fixes a race condition where concurrent `deleteByID` requests for the same document could throw `NotFound` (404), even though the delete should succeed or be idempotent.

Changes:
- **`deleteByIDOperation`** — removes the upfront `findOne` before delete; calls atomic `deleteOne` first, then runs cleanup from the returned document
- **Drizzle `deleteOne`** — replaces `findFirst` + `deleteWhere` with a single `DELETE … RETURNING *`
- **Tests** — adds concurrent delete coverage in `test/collections-rest` (local API + REST)

### Why?

`deleteByIDOperation` used a check-then-act pattern:

1. `findOne` to load the document
2. cleanup (files, versions, scheduled jobs)
3. `deleteOne` to remove the row

If two requests deleted the same ID at the same time, the slower one could fail at step 1 with `NotFound` after the faster request had already deleted the document. The Drizzle adapter had a similar two-step pattern (`findFirst` then `deleteWhere`).

MongoDB already used atomic `findOneAndDelete`; the main issue was the extra `findOne` in the operation layer.

### How?

**Operation layer (`deleteByIDOperation`):**
- Build the full `where` clause (ID + access + trash filters) and call `deleteOne` immediately
- If a document is returned, run cleanup and hooks as before
- If `deleteOne` returns nothing and the doc isn’t a soft-deleted record (with `trash: false`), treat it as already deleted: return `{ id }`, skip cleanup and `afterDelete`
- Soft-deleted documents with `trash: false` still return `404`

**Drizzle adapter (`deleteOne`):**
- Use one atomic `DELETE … RETURNING *` instead of read-then-delete
- For queries with joins, resolve the ID via `selectDistinct`, then delete by ID with `RETURNING`

**MongoDB adapter:**
- No code changes; it already uses `findOneAndDelete`. The operation-layer fix applies to MongoDB as well.

Fixes #17133