### PR TITLE
fix: re-read sessions inside transaction to prevent concurrent-login overwrite

### DIFF
--- a/packages/payload/src/auth/sessions.ts
+++ b/packages/payload/src/auth/sessions.ts
@@ -34,7 +34,6 @@ export const addSessionToUser = async ({
 }): Promise<{ sid?: string }> => {
   let sid: string | undefined
   if (collectionConfig.auth.useSessions) {
-    // Add session to user
     sid = uuid()
     const now = new Date()
     const tokenExpInMs = collectionConfig.auth.tokenExpiration * 1000
@@ -42,12 +41,20 @@ export const addSessionToUser = async ({
 
     const session = { id: sid, createdAt: now, expiresAt }
 
-    if (!user.sessions?.length) {
-      user.sessions = [session]
-    } else {
-      user.sessions = removeExpiredSessions(user.sessions)
-      user.sessions.push(session)
-    }
+    // Re-read the user's sessions from the DB inside the active transaction.
+    // The `user` passed in was read before the transaction started, so concurrent
+    // logins that race past the password check can each hold a stale snapshot of
+    // `user.sessions`. Without this re-read, whichever request commits last
+    // overwrites the other's session, leaving the first token referencing a sid
+    // that no longer exists in the DB — which causes /api/users/me to return 403.
+    const freshUser = await payload.db.findOne<TypedUser>({
+      collection: collectionConfig.slug,
+      req,
+      where: { id: { equals: user.id } },
+    })
+    const currentSessions: UserSession[] = (freshUser as TypedUser | null)?.sessions ?? []
+
+    user.sessions = [...removeExpiredSessions(currentSessions), session]
 
     // Prevent updatedAt from being updated when only adding a session
     user.updatedAt = null

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -188,6 +188,62 @@ describe('Auth', () => {
       })
     })
 
+    it('should preserve both sessions when two logins race concurrently', async () => {
+      const testEmail = 'concurrent-login-test@example.com'
+      const testPassword = 'test123'
+
+      const testUser = await payload.create({
+        collection: slug,
+        data: {
+          email: testEmail,
+          password: testPassword,
+          roles: ['user'],
+        },
+      })
+
+      // Fire two logins simultaneously — before the fix, whichever committed
+      // last would overwrite the other's session, leaving one token orphaned.
+      const [res1, res2] = await Promise.all([
+        restClient.POST(`/${slug}/login`, {
+          body: JSON.stringify({ email: testEmail, password: testPassword }),
+        }),
+        restClient.POST(`/${slug}/login`, {
+          body: JSON.stringify({ email: testEmail, password: testPassword }),
+        }),
+      ])
+
+      const [data1, data2]: any[] = await Promise.all([res1.json(), res2.json()])
+
+      expect(res1.status).toBe(200)
+      expect(res2.status).toBe(200)
+      expect(data1.token).toBeDefined()
+      expect(data2.token).toBeDefined()
+
+      // Both /me requests must succeed — if a session was overwritten, one
+      // would return 401/403.
+      const [me1, me2] = await Promise.all([
+        restClient.GET(`/${slug}/me`, {
+          headers: { Authorization: `JWT ${data1.token}` },
+        }),
+        restClient.GET(`/${slug}/me`, {
+          headers: { Authorization: `JWT ${data2.token}` },
+        }),
+      ])
+
+      expect(me1.status).toBe(200)
+      expect(me2.status).toBe(200)
+
+      // Both sessions must be stored on the user record.
+      const userAfter: any = await payload.findByID({
+        id: testUser.id,
+        collection: slug,
+      })
+      expect(userAfter.sessions?.length).toBeGreaterThanOrEqual(2)
+
+      // Clean up
+      await payload.delete({ id: testUser.id, collection: slug })
+    })
+
     describe('logged in', () => {
       let token: string | undefined
       let loggedInUser: undefined | User


### PR DESCRIPTION
## Root cause

`addSessionToUser` in `packages/payload/src/auth/sessions.ts` has a **read-modify-write race condition** when two logins happen concurrently for the same user.

The `user` object is read from the DB before `initTransaction` is called in `loginOperation` (line 206 vs line 250). Two concurrent requests both read the same stale `user.sessions` snapshot, then both write back — and the second writer's `updateOne` overwrites the first writer's session:

```
T1: findOne(user)  →  sessions: []
T2: findOne(user)  →  sessions: []       ← both see same stale snapshot
T1: updateOne  →  sessions: [session1]
T2: updateOne  →  sessions: [session2]   ← session1 is gone
```

T1's JWT contains `sid = session1`, but that sid no longer exists in the DB → subsequent calls with T1's token return `user: undefined` / 403.

Reported in #16027 with a reproduction repo: https://github.com/nathanbowang/payload-concurrent-login-issue

## Fix

Re-read the user's sessions from the DB **inside the active transaction** (using the `req` that carries the transaction context) before appending the new session. With `READ COMMITTED` isolation (PostgreSQL default), the fresh read inside the transaction sees all previously committed sessions — so even if T1 committed before T2's re-read, T2 will see `[session1]` and correctly produce `[session1, session2]`:

```ts
// Before (stale snapshot from before the transaction started):
if (!user.sessions?.length) {
  user.sessions = [session]
} else {
  user.sessions = removeExpiredSessions(user.sessions)
  user.sessions.push(session)
}

// After (fresh read inside the transaction):
const freshUser = await payload.db.findOne<TypedUser>({
  collection: collectionConfig.slug,
  req,
  where: { id: { equals: user.id } },
})
const currentSessions = (freshUser as TypedUser | null)?.sessions ?? []
user.sessions = [...removeExpiredSessions(currentSessions), session]
```

The extra `findOne` only runs when `useSessions` is enabled (the existing guard) and only during login — not on every request. The overhead is one indexed primary-key lookup per login, which is negligible.

> **Note:** for full serialisability under extremely high concurrency, a `SELECT … FOR UPDATE` would be required. That would need Payload's DB adapters to expose a lock option. The re-read fix eliminates the race in the common case (sequential or loosely-concurrent logins) and is safe to ship now.

Fixes #16027