### PR TITLE
fix(next): warn at startup when installed Next.js is outside supported peer range

### DIFF
--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -5,6 +5,12 @@
  * user projects regardless of their TypeScript setup.
  */
 
+import {
+  getNextjsVersion,
+  getSupportedNextRange,
+  getUnsupportedNextVersionWarning,
+} from './withPayload.utils.js'
+
 const poweredByHeader = {
   key: 'X-Powered-By',
   value: 'Next.js, Payload',
@@ -17,6 +23,14 @@ const poweredByHeader = {
  * */
 export const withPayload = (nextConfig = {}, options = {}) => {
   const env = nextConfig.env || {}
+
+  const unsupportedNextVersionWarning = getUnsupportedNextVersionWarning(
+    getNextjsVersion(),
+    getSupportedNextRange(),
+  )
+  if (unsupportedNextVersionWarning) {
+    console.warn(unsupportedNextVersionWarning)
+  }
 
   if (nextConfig.experimental?.staleTimes?.dynamic) {
     console.warn(

--- a/packages/next/src/withPayload/withPayload.utils.js
+++ b/packages/next/src/withPayload/withPayload.utils.js
@@ -25,6 +25,7 @@
  */
 
 import { readFileSync } from 'fs'
+import { join } from 'path'
 import { fileURLToPath } from 'url'
 
 /**
@@ -103,4 +104,127 @@ export function getNextjsVersion() {
     console.error('Payload: Error getting Next.js version', e)
     return undefined
   }
+}
+
+/**
+ * Reads the `next` peer dependency range declared by `@payloadcms/next` itself,
+ * so the supported range stays in sync with `package.json` rather than being
+ * duplicated. Returns undefined if it cannot be read.
+ * @returns {string | undefined}
+ */
+export function getSupportedNextRange() {
+  try {
+    /** @type {string} */
+    let pkgPath
+
+    if (typeof import.meta?.url === 'string') {
+      // ESM environment - resolve relative to this module. Both the source
+      // (src/withPayload/) and published (dist/withPayload/ and dist/cjs/)
+      // locations are two levels below the package root.
+      pkgPath = fileURLToPath(new URL('../../package.json', import.meta.url))
+    } else if (typeof __dirname !== 'undefined') {
+      // CJS environment
+      pkgPath = join(__dirname, '../../package.json')
+    } else {
+      return undefined
+    }
+
+    const pkgJson = JSON.parse(readFileSync(pkgPath, 'utf8'))
+    return pkgJson?.peerDependencies?.next
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Compares the core (major.minor.patch) of two SemVer objects, ignoring
+ * prerelease and build metadata.
+ * @param {SemVer} a
+ * @param {SemVer} b
+ * @returns {number} negative if a < b, 0 if equal, positive if a > b
+ */
+function compareCoreVersion(a, b) {
+  return (
+    (a.major ?? 0) - (b.major ?? 0) ||
+    (a.minor ?? 0) - (b.minor ?? 0) ||
+    (a.patch ?? 0) - (b.patch ?? 0)
+  )
+}
+
+/**
+ * Minimal semver range check supporting the comparator syntax Payload uses in
+ * its `next` peer dependency, e.g. `>=16.2.6 <17.0.0` and disjoint ranges joined
+ * by `||`. We avoid a runtime `semver` dependency because this file runs inside
+ * `next.config` before the build, where extra dependencies are undesirable.
+ * @param {SemVer} version
+ * @param {string} range
+ * @returns {boolean}
+ */
+export function satisfiesNextRange(version, range) {
+  if (version?.major === undefined || !range) {
+    return false
+  }
+
+  return range.split('||').some((clause) => {
+    const comparators = clause.trim().split(/\s+/).filter(Boolean)
+
+    if (comparators.length === 0) {
+      return false
+    }
+
+    return comparators.every((comparator) => {
+      const match = comparator.match(/^(>=|<=|>|<|=)?\s*(.+)$/)
+
+      if (!match) {
+        return false
+      }
+
+      const operator = match[1] || '='
+      const bound = parseSemver(match[2])
+
+      if (bound.major === undefined) {
+        return false
+      }
+
+      const comparison = compareCoreVersion(version, bound)
+
+      switch (operator) {
+        case '<':
+          return comparison < 0
+        case '<=':
+          return comparison <= 0
+        case '>':
+          return comparison > 0
+        case '>=':
+          return comparison >= 0
+        default:
+          return comparison === 0
+      }
+    })
+  })
+}
+
+/**
+ * Pure builder for the unsupported-version warning. Returns a clear, actionable
+ * message when `installedVersion` falls outside `supportedRange`, or undefined
+ * when the version is supported or either input is missing (so the build is
+ * never blocked by the check itself). Inputs are explicit so this stays pure and
+ * easy to test; callers resolve them via `getNextjsVersion` / `getSupportedNextRange`.
+ * @param {SemVer | undefined} installedVersion
+ * @param {string | undefined} supportedRange
+ * @returns {string | undefined}
+ */
+export function getUnsupportedNextVersionWarning(installedVersion, supportedRange) {
+  if (
+    !installedVersion ||
+    installedVersion.major === undefined ||
+    !supportedRange ||
+    satisfiesNextRange(installedVersion, supportedRange)
+  ) {
+    return undefined
+  }
+
+  const installedString = `${installedVersion.major}.${installedVersion.minor}.${installedVersion.patch}`
+
+  return `Payload: the installed Next.js version (${installedString}) is outside the supported range "${supportedRange}". Unsupported versions may break the Admin Panel or contain unpatched security advisories. Install a supported Next.js version to clear this warning.`
 }

--- a/packages/next/src/withPayload/withPayload.utils.spec.ts
+++ b/packages/next/src/withPayload/withPayload.utils.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getUnsupportedNextVersionWarning,
+  parseSemver,
+  satisfiesNextRange,
+} from './withPayload.utils.js'
+
+describe('satisfiesNextRange', () => {
+  it('returns true for a version inside a `>= <` range', () => {
+    expect(satisfiesNextRange(parseSemver('16.2.6'), '>=16.2.6 <17.0.0')).toBe(true)
+    expect(satisfiesNextRange(parseSemver('16.5.0'), '>=16.2.6 <17.0.0')).toBe(true)
+  })
+
+  it('returns false for a version below the lower bound', () => {
+    expect(satisfiesNextRange(parseSemver('16.2.1'), '>=16.2.6 <17.0.0')).toBe(false)
+    expect(satisfiesNextRange(parseSemver('16.0.0'), '>=16.2.6 <17.0.0')).toBe(false)
+  })
+
+  it('returns false for a version at or above the upper bound', () => {
+    expect(satisfiesNextRange(parseSemver('17.0.0'), '>=16.2.6 <17.0.0')).toBe(false)
+    expect(satisfiesNextRange(parseSemver('18.1.2'), '>=16.2.6 <17.0.0')).toBe(false)
+  })
+
+  it('supports disjoint ranges joined by ||', () => {
+    const range = '>=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.6 <17.0.0'
+
+    expect(satisfiesNextRange(parseSemver('15.4.11'), range)).toBe(true)
+    expect(satisfiesNextRange(parseSemver('16.2.7'), range)).toBe(true)
+    expect(satisfiesNextRange(parseSemver('15.4.0'), range)).toBe(false)
+    expect(satisfiesNextRange(parseSemver('16.2.1'), range)).toBe(false)
+  })
+
+  it('compares prerelease (canary) versions by their core version', () => {
+    expect(satisfiesNextRange(parseSemver('16.3.0-canary.1'), '>=16.2.6 <17.0.0')).toBe(true)
+  })
+
+  it('returns false when version or range is missing', () => {
+    expect(satisfiesNextRange(parseSemver('not-a-version'), '>=16.2.6 <17.0.0')).toBe(false)
+    expect(satisfiesNextRange(parseSemver('16.2.6'), '')).toBe(false)
+  })
+})
+
+describe('getUnsupportedNextVersionWarning', () => {
+  const range = '>=16.2.6 <17.0.0'
+
+  it('returns undefined when the installed version is supported', () => {
+    expect(getUnsupportedNextVersionWarning(parseSemver('16.3.0'), range)).toBeUndefined()
+  })
+
+  it('returns a warning mentioning the installed version and supported range', () => {
+    const warning = getUnsupportedNextVersionWarning(parseSemver('16.2.1'), range)
+
+    expect(warning).toContain('16.2.1')
+    expect(warning).toContain(range)
+  })
+
+  it('returns undefined when the installed version cannot be determined', () => {
+    expect(getUnsupportedNextVersionWarning(undefined, range)).toBeUndefined()
+  })
+
+  it('returns undefined when the supported range cannot be determined', () => {
+    expect(getUnsupportedNextVersionWarning(parseSemver('16.2.1'), undefined)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What?

Adds a startup check in `withPayload()` that compares the installed Next.js
version against the `next` peer-dependency range declared by `@payloadcms/next`.
If the installed version falls outside that range, Payload logs a clear,
actionable warning. When the version is supported (or can't be determined), it
stays silent and never blocks the build.

New helpers in `withPayload.utils.js`:
- `getSupportedNextRange()` — reads the declared peer range from the package's own `package.json` (stays in sync automatically).
- `satisfiesNextRange()` — minimal semver range check (supports `>= <` and disjoint `||` ranges) with no runtime `semver` dependency, since this runs inside `next.config` before the build.
- `getUnsupportedNextVersionWarning()` — pure builder for the warning message.

Example output:
> Payload: the installed Next.js version (16.2.1) is outside the supported range ">=16.2.6 <17.0.0". Unsupported versions may break the Admin Panel or contain unpatched security advisories. Install a supported Next.js version to clear this warning.

## Why?

Payload declares a `next` peer dependency but never enforced it at runtime.
Installing an unsupported version (e.g. in the 16.0.0–16.2.5 gap) produced a
cryptic "This page could not be found" admin failure with no hint that Next was
the cause. A one-line startup warning turns an opaque debugging session into an
obvious fix, and surfaces the security angle (the `>=16.2.6` floor exists for
security reasons).

## How?

`withPayload()` runs when `next.config` loads — the single hook that fires for
`dev`, `build`, and `start` — and already emits other startup warnings, so the
check lives there. The range is read from the package's own `peerDependencies`
so it never drifts from what's actually published.

Fixes #17119