### PR TITLE
fix(ui): ignore the IME composition Enter in SearchInput

### DIFF
--- a/packages/ui/src/elements/Search/SearchInput/index.tsx
+++ b/packages/ui/src/elements/Search/SearchInput/index.tsx
@@ -37,7 +37,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter' && value.length > 0) {
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing && value.length > 0) {
         onSearch(value)
       }
     },


### PR DESCRIPTION
### What?

The shared `SearchInput` (`packages/ui/src/elements/Search/SearchInput`) runs `onSearch` on any `Enter` keydown while the field has a value. It doesn't check whether that `Enter` is the one that confirms an in-progress IME composition.

When you type with an IME (Japanese, Chinese, Korean, etc.), the first `Enter` after typing commits the candidate text rather than submitting. Right now that confirmation `Enter` also fires a search, so the search runs with the half-finished text and you have to search a second time. `SearchInput` backs the list-view search/filter, the block selector search, and the hierarchy search, so this shows up in a few places in the admin.

### Why?

The codebase already handles this for its other commit-on-Enter input. `packages/ui/src/fields/Text/Input.tsx` only reacts to `Enter`/`Tab`/`Escape` when `!event.nativeEvent.isComposing`, so the composition-commit key is correctly ignored there. `SearchInput` is just missing the same check, so the two inputs behave differently for IME users.

### How?

Add the same `!e.nativeEvent.isComposing` guard before calling `onSearch`. For input without an IME `isComposing` is always `false`, so search-on-Enter works exactly as before; this only skips the extra submit on the key that commits a composition.

I checked the change against the repo's Prettier config and esbuild locally. I didn't add a unit test because jsdom doesn't fire real composition events (`isComposing` stays `false` there), so an int test can't reproduce the keystroke. Happy to add a Playwright e2e if you'd prefer one.
