### PR TITLE
test: adapt MCP plugin codegen eval to generic CRUD tools

### DIFF
--- a/test/evals/datasets/plugins/official/codegen.ts
+++ b/test/evals/datasets/plugins/official/codegen.ts
@@ -51,9 +51,9 @@ export const pluginsOfficialCodegenDataset: CodegenEvalCase[] = [
   },
   {
     input:
-      'Add the MCP plugin from "@payloadcms/plugin-mcp" to the config. Enable find and create operations for the "posts" collection, and set its description to "Blog posts for content creation".',
+      'Add the MCP plugin from "@payloadcms/plugin-mcp" to the config. For the "posts" collection, set its description to "Blog posts for content creation" and disable the delete operation.',
     expected:
-      'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { find: true, create: true }, description: "Blog posts for content creation" } } }) added to plugins array',
+      'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { delete: false }, description: "Blog posts for content creation" } } }) added to plugins array',
     category: 'plugins',
     fixturePath: 'plugins/official/codegen/mcp',
   },


### PR DESCRIPTION
## What

Updates the `plugins/official/codegen/mcp` eval case so its expected
shape matches the current `@payloadcms/plugin-mcp` API.

## Why

This is a follow-up to the same kind of alignment done in #16896, but for
a newer breaking change.

- In #16896 the eval was updated from `{ enabled: { find, create } }` to
  `{ tools: { find, create } }` after the plugin refactor.
- #16962 (`feat(plugin-mcp)!: use generic CRUD tools`) then changed the
  model again: collections are now **opt-out**. Built-in CRUD tools
  (`find`, `create`, `update`, `delete`, `getCollectionSchema`) are enabled
  by default and accept `false` (to disable) or an override object, **not**
  `true`.

As a result, the previous expected output (`tools: { find: true, create: true }`)
is no longer valid v4, and the rubric was penalizing the agent for
generating correct, current code.

## Change

Rewrites the single MCP case to the opt-out model, mirroring the canonical
example in `docs/plugins/mcp.mdx` (configure a description and disable a
built-in tool with `delete: false`):

```ts
mcpPlugin({
  collections: {
    posts: {
      tools: { delete: false },
      description: "Blog posts for content creation",
    },
  },
})
```

The `input` prompt is updated accordingly, since "enable find and create"
no longer maps to a positive config under the opt-out model.

## Context

- #16896 - previous eval alignment (`enabled` -> `tools`)
- #16962 - breaking change this PR adapts to (generic CRUD tools / opt-out)