### PR TITLE
fix(drizzle): `select` `hasMany` nested 2+ array levels crash

### DIFF
--- a/packages/drizzle/src/upsertRow/insertArrays.ts
+++ b/packages/drizzle/src/upsertRow/insertArrays.ts
@@ -120,6 +120,7 @@ export const insertArrays = async ({
         arrays: row.arrays,
         db,
         parentRows: insertedRows,
+        uuidMap,
       })
     }
   }

--- a/test/versions/collections/NestedArraySelect.ts
+++ b/test/versions/collections/NestedArraySelect.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from 'payload'
+
+import { nestedArraySelectCollectionSlug } from '../slugs.js'
+
+const NestedArraySelect: CollectionConfig = {
+  slug: nestedArraySelectCollectionSlug,
+  fields: [
+    {
+      name: 'outer',
+      type: 'array',
+      fields: [
+        {
+          name: 'inner',
+          type: 'array',
+          fields: [
+            {
+              name: 'days',
+              type: 'select',
+              hasMany: true,
+              options: ['monday', 'tuesday', 'wednesday'],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  versions: {
+    drafts: true,
+  },
+}
+
+export default NestedArraySelect

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -26,6 +26,7 @@ import ErrorOnUnpublish from './collections/ErrorOnUnpublish.js'
 import LocalizedPosts from './collections/Localized.js'
 import { Media } from './collections/Media.js'
 import { Media2 } from './collections/Media2.js'
+import NestedArraySelect from './collections/NestedArraySelect.js'
 import Posts from './collections/Posts.js'
 import { TextCollection } from './collections/Text.js'
 import VersionPosts from './collections/Versions.js'
@@ -56,6 +57,7 @@ export default buildConfigWithDefaults({
     AutosavePosts,
     AutosaveWithDraftButtonPosts,
     AutosaveWithMultiSelectPosts,
+    NestedArraySelect,
     AutosaveWithDraftValidate,
     DraftPosts,
     DraftsNoReadVersions,

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -31,6 +31,7 @@ import {
   draftWithUploadCloudStorageCollectionSlug,
   draftWithUploadCollectionSlug,
   localizedCollectionSlug,
+  nestedArraySelectCollectionSlug,
   localizedGlobalSlug,
   versionCollectionSlug,
 } from './slugs.js'
@@ -1272,6 +1273,29 @@ describe('Versions', () => {
 
         await cleanupDocuments({
           collectionSlugs: [autosaveWithMultiSelectCollectionSlug],
+          payload,
+        })
+      })
+
+      it('should save draft with hasMany select nested two array levels deep', async () => {
+        const doc = await payload.create({
+          collection: nestedArraySelectCollectionSlug,
+          data: {},
+        })
+
+        const updated = await payload.update({
+          id: doc.id,
+          collection: nestedArraySelectCollectionSlug,
+          data: {
+            outer: [{ inner: [{ days: ['monday'] }] }],
+          },
+          draft: true,
+        })
+
+        expect(updated.outer?.[0]?.inner?.[0]?.days).toEqual(['monday'])
+
+        await cleanupDocuments({
+          collectionSlugs: [nestedArraySelectCollectionSlug],
           payload,
         })
       })

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -1,6 +1,8 @@
 export const autosaveCollectionSlug = 'autosave-posts'
 export const autosaveWithMultiSelectCollectionSlug = 'autosave-multi-select-posts'
 
+export const nestedArraySelectCollectionSlug = 'nested-array-select'
+
 export const autosaveWithDraftButtonSlug = 'autosave-with-draft-button-posts'
 
 export const autosaveWithDraftValidateSlug = 'autosave-with-validate-posts'
@@ -36,6 +38,7 @@ export const textCollectionSlug = 'text'
 export const collectionSlugs = [
   autosaveCollectionSlug,
   autosaveWithMultiSelectCollectionSlug,
+  nestedArraySelectCollectionSlug,
   draftCollectionSlug,
   draftWithChangeHookCollectionSlug,
   postCollectionSlug,


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/17142