### PR TITLE
fix(ui): render admin.components.providers under client-layout adapters

### DIFF
--- a/packages/plugin-import-export/src/components/ImportPreview/index.tsx
+++ b/packages/plugin-import-export/src/components/ImportPreview/index.tsx
@@ -114,7 +114,7 @@ export const ImportPreview: React.FC = () => {
           if (fileField?.value && fileField.value instanceof File) {
             // File is being uploaded, read its contents
             const arrayBuffer = await fileField.value.arrayBuffer()
-            const base64 = Buffer.from(arrayBuffer).toString('base64')
+            const base64 = arrayBufferToBase64(arrayBuffer)
             fileData = base64
           } else if (url) {
             // File has been saved, fetch from URL
@@ -123,7 +123,7 @@ export const ImportPreview: React.FC = () => {
               throw new Error('Failed to fetch file')
             }
             const arrayBuffer = await response.arrayBuffer()
-            const base64 = Buffer.from(arrayBuffer).toString('base64')
+            const base64 = arrayBufferToBase64(arrayBuffer)
             fileData = base64
           }
 
@@ -648,4 +648,20 @@ export const ImportPreview: React.FC = () => {
       )}
     </div>
   )
+}
+
+/**
+ * Encodes an ArrayBuffer as base64 using browser-native APIs. `Buffer` is a Node
+ * global that Next.js polyfills in the browser, but Vite-based adapters (e.g.
+ * TanStack Start) do not, so this client component must avoid it.
+ */
+function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(arrayBuffer)
+  let binary = ''
+  // Chunk to stay within argument-count limits of String.fromCharCode for large files.
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+  }
+  return btoa(binary)
 }

--- a/packages/ui/src/views/Root/index.tsx
+++ b/packages/ui/src/views/Root/index.tsx
@@ -20,6 +20,7 @@ import React from 'react'
 import { RenderServerComponent } from '../../elements/RenderServerComponent/index.js'
 // eslint-disable-next-line payload/no-imports-from-exports-dir -- Server component must reference exports/client bundle for proper client boundary in prod builds
 import { PageConfigProvider } from '../../exports/client/index.js'
+import { NestProviders } from '../../layouts/Root/NestProviders.js'
 import { DefaultTemplate } from '../../templates/Default/index.js'
 import { MinimalTemplate } from '../../templates/Minimal/index.js'
 import { getClientConfig } from '../../utilities/getClientConfig.js'
@@ -49,6 +50,15 @@ export type RenderRootArgs = {
   params: Promise<{ segments: string[] }>
   /** Framework redirect implementation (e.g. next/navigation redirect). Called before req is available. */
   redirect: (url: string) => never
+  /**
+   * Wrap the rendered admin view with the config's `admin.components.providers`
+   * (via {@link NestProviders}). Next.js renders these in its server layout
+   * (`@payloadcms/ui` `RootLayout`), so it leaves this `false`. Adapters whose
+   * root layout runs on the client (e.g. TanStack Start) can't resolve provider
+   * components from the import map there, so they opt in here to nest them
+   * around the server-rendered view instead.
+   */
+  renderCustomProviders?: boolean
   searchParams: Promise<{ [key: string]: string | string[] }>
 }
 
@@ -60,6 +70,7 @@ export const renderRoot = async ({
   notFound,
   params: paramsPromise,
   redirect,
+  renderCustomProviders = false,
   searchParams: searchParamsPromise,
 }: RenderRootArgs) => {
   const config = await configPromise
@@ -336,7 +347,9 @@ export const renderRoot = async ({
     } satisfies AdminViewServerPropsOnly,
   })
 
-  return (
+  const customProviders = config.admin?.components?.providers
+
+  const tree = (
     <PageConfigProvider config={clientConfig}>
       {!templateType && <React.Fragment>{RenderedView}</React.Fragment>}
       {templateType === 'minimal' && (
@@ -370,4 +383,24 @@ export const renderRoot = async ({
       )}
     </PageConfigProvider>
   )
+
+  if (renderCustomProviders && Array.isArray(customProviders) && customProviders.length > 0) {
+    return (
+      <NestProviders
+        importMap={importMap}
+        providers={customProviders}
+        serverProps={{
+          i18n: req.i18n,
+          payload: req.payload,
+          permissions,
+          server: req.server,
+          user: req.user,
+        }}
+      >
+        {tree}
+      </NestProviders>
+    )
+  }
+
+  return tree
 }

--- a/tanstack-app/src/functions/adminPageRSC.functions.tsx
+++ b/tanstack-app/src/functions/adminPageRSC.functions.tsx
@@ -98,7 +98,12 @@ const toAdminPageMetadata = (meta: MetaConfig): AdminPageMetadata => {
   return {
     description: typeof meta.description === 'string' ? meta.description : undefined,
     icons: icons?.length ? icons : undefined,
-    keywords: typeof keywords === 'string' ? keywords : Array.isArray(keywords) ? keywords.join(', ') : undefined,
+    keywords:
+      typeof keywords === 'string'
+        ? keywords
+        : Array.isArray(keywords)
+          ? keywords.join(', ')
+          : undefined,
     openGraph: og
       ? {
           description: typeof og.description === 'string' ? og.description : undefined,
@@ -215,6 +220,11 @@ export const loadAdminPageRSC = createServerFn({ method: 'GET' })
         notFound,
         params: Promise.resolve({ segments }),
         redirect,
+        // The TanStack root layout renders on the client and can't resolve the
+        // config's `admin.components.providers` from the import map, so nest them
+        // around the server-rendered view here (Next does this in its server
+        // layout instead).
+        renderCustomProviders: true,
         searchParams: Promise.resolve(searchParams),
       })
 


### PR DESCRIPTION
## Fix: custom `admin.components.providers` not rendered under TanStack Start (+ `Buffer` in a client component)

### Root cause

The TanStack adapter's root layout (`packages/tanstack-start/src/layouts/Root/index.tsx`) renders `<RootProvider>{children}` but — unlike the shared `@payloadcms/ui` `RootLayout` (`packages/ui/src/layouts/Root/index.tsx`) — **never renders `NestProviders`**. As a result, no config-registered `admin.components.providers` are ever mounted under TanStack.

The TanStack root layout runs on the **client**, so it can't resolve provider components from the import map there. The providers therefore have to be nested **server-side**, around the RSC-rendered view.

Concrete symptom (with `plugin-import-export` installed): every list view crashes with `TypeError: setCollection is not a function`, because `ExportListMenuItem` / `ImportListMenuItem` call `useImportExport()`, which returns the empty `createContext({})` default when `ImportExportProvider` never renders.

A second, independent bug in the same suite: `ImportPreview` (a `'use client'` component) used Node's `Buffer.from(arrayBuffer).toString('base64')`. Next's webpack auto-polyfills `Buffer` in the browser; Vite does not → `ReferenceError: Buffer is not defined`.

### Fix (3 files, +57/−3)

1. **`packages/ui/src/views/Root/index.tsx`** — add an **opt-in** `renderCustomProviders?: boolean` (default `false`) to the shared `renderRoot`. When enabled, it wraps the view tree in the existing `NestProviders`, reusing the **same** serverProps Next's `RootLayout` already passes (`i18n`, `payload`, `permissions`, `server`, `user`) and the same `providers.length > 0` guard. Next leaves it `false` (it nests providers in its server layout), so **its behavior is unchanged** — when `false`, `renderRoot` returns the verbatim prior tree.
2. **`tanstack-app/src/functions/adminPageRSC.functions.tsx`** — pass `renderCustomProviders: true`.
3. **`packages/plugin-import-export/.../ImportPreview/index.tsx`** — replace `Buffer` with a browser-native `arrayBufferToBase64` helper (`btoa` + chunked `String.fromCharCode`), which works under both adapters.

DRY note: this reuses Next's existing `NestProviders` rather than forking provider-nesting logic into the adapter.

### Validation

- ✅ **TanStack** `plugin-import-export` e2e: **45/45**, run **twice** (deterministic). The `setCollection` crash is gone.
- ✅ **Next** `plugin-import-export` e2e: **45/45** (no regression — the shared `renderRoot` change is gated behind the opt-in flag).
- ✅ Direct source comparison: the new `NestProviders` serverProps are byte-identical to Next's `RootLayout`.
- ✅ `0` new lint errors/warnings on the 3 changed files.
- _(MongoDB + LocalStack S3 mock running for the import-export suite.)_

### Caveats / scope

- **Generalization to other provider plugins is mechanism-level, not independently e2e-greened.** `NestProviders` in `renderRoot` is plugin-agnostic, so any registered provider should now render under TanStack. I could not green a second suite end-to-end through the harness: `plugin-multi-tenant`'s e2e uses a _manual_ quick-login `BeforeLogin` panel and gets stuck at the auto-login→dashboard poll — upstream of, and unrelated to, `admin.components.providers` (providers don't render on the login page). Its admin login _does_ render cleanly under TanStack (no provider crash, no console error).
- The `Buffer` fix is a general lesson worth enforcing repo-wide: **client components must not use Node globals** — they only worked by accident under Next's polyfilling.
