### PR TITLE
fix(ui): hide upload panel on create when hideFileInputOnCreate is set

### DIFF
--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -682,7 +682,8 @@ export function DefaultEditView({
     />
   ) : undefined
 
-  const shouldRenderUploadPanel = Boolean(upload)
+  const shouldRenderUploadPanel =
+    Boolean(upload) && !(operation === 'create' && upload.hideFileInputOnCreate)
   const shouldScrollFieldsOnly = shouldRenderUploadPanel
 
   return (


### PR DESCRIPTION
Hides the upload panel in the create view when a collection sets `upload.hideFileInputOnCreate`, so upload collections that generate their file server-side don't render an empty `FileManager` panel.

The import-export plugin's exports collection is an upload collection with `hideFileInputOnCreate` enabled, so its export drawer showed an empty upload panel and the two-column layout. `shouldRenderUploadPanel` now accounts for this. The panel still renders when editing a saved document.

### Before
<img width="1214" height="824" alt="Screenshot 2026-06-29 at 12 06 05 PM" src="https://github.com/user-attachments/assets/b89cf168-5e60-475f-94eb-c7306e975e07" />


### After
<img width="1496" height="769" alt="Screenshot 2026-06-29 at 12 06 26 PM" src="https://github.com/user-attachments/assets/9305c32e-9a1f-44c5-b45f-36fd4cf75317" />
