### PR TITLE
feat(plugin-search): adopt v4 design tokens and restyle reindex button

### DIFF
--- a/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
@@ -4,6 +4,10 @@ import { CopyToClipboard, Link, useConfig, useField } from '@payloadcms/ui'
 import { formatAdminURL } from 'payload/shared'
 import React from 'react'
 
+import './index.css'
+
+const baseClass = 'link-to-doc'
+
 export const LinkToDocClient: React.FC = () => {
   const { config } = useConfig()
 
@@ -27,25 +31,12 @@ export const LinkToDocClient: React.FC = () => {
   })
 
   return (
-    <div style={{ marginBottom: 'var(--spacing-field, 1rem)' }}>
+    <div className={baseClass}>
       <div>
-        <span
-          className="label"
-          style={{
-            color: '#9A9A9A',
-          }}
-        >
-          Doc URL
-        </span>
+        <span className={`label ${baseClass}__label`}>Doc URL</span>
         <CopyToClipboard value={href} />
       </div>
-      <div
-        style={{
-          fontWeight: '600',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-        }}
-      >
+      <div className={`${baseClass}__url`}>
         <Link href={href} rel="noopener noreferrer" target="_blank">
           {href}
         </Link>

--- a/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CopyToClipboard, Link, useConfig, useField } from '@payloadcms/ui'
+import { CopyToClipboard, FieldLabel, Link, useConfig, useField } from '@payloadcms/ui'
 import { formatAdminURL } from 'payload/shared'
 import React from 'react'
 
@@ -32,8 +32,8 @@ export const LinkToDocClient: React.FC = () => {
 
   return (
     <div className={baseClass}>
-      <div>
-        <span className={`label ${baseClass}__label`}>Doc URL</span>
+      <div className={`${baseClass}__header`}>
+        <FieldLabel htmlFor={baseClass} label="Doc URL" />
         <CopyToClipboard value={href} />
       </div>
       <div className={`${baseClass}__url`}>

--- a/packages/plugin-search/src/Search/ui/LinkToDoc/index.css
+++ b/packages/plugin-search/src/Search/ui/LinkToDoc/index.css
@@ -1,0 +1,15 @@
+@layer payload-default {
+  .link-to-doc {
+    margin-bottom: var(--spacing-field);
+  }
+
+  .link-to-doc__label {
+    color: var(--color-text-secondary);
+  }
+
+  .link-to-doc__url {
+    overflow: hidden;
+    font-weight: 600;
+    text-overflow: ellipsis;
+  }
+}

--- a/packages/plugin-search/src/Search/ui/LinkToDoc/index.css
+++ b/packages/plugin-search/src/Search/ui/LinkToDoc/index.css
@@ -3,13 +3,24 @@
     margin-bottom: var(--spacing-field);
   }
 
-  .link-to-doc__label {
-    color: var(--color-text-secondary);
+  .link-to-doc__header {
+    display: flex;
+    align-items: center;
+    width: fit-content;
+    gap: var(--spacer-1);
   }
 
   .link-to-doc__url {
     overflow: hidden;
     font-weight: 600;
     text-overflow: ellipsis;
+  }
+
+  .link-to-doc__url a {
+    color: var(--color-text-secondary);
+
+    &:hover {
+      color: var(--color-text);
+    }
   }
 }

--- a/packages/plugin-search/src/Search/ui/ReindexButton/ReindexButtonLabel/index.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/ReindexButtonLabel/index.tsx
@@ -1,11 +1,34 @@
 import { Button, ChevronIcon, useTranslation } from '@payloadcms/ui'
+import React from 'react'
 
-export const ReindexButtonLabel = () => {
+type ReindexButtonLabelProps = {
+  readonly active?: boolean
+  readonly 'aria-expanded'?: boolean
+  readonly 'aria-haspopup'?: true
+  readonly onClick?: React.MouseEventHandler
+  readonly onKeyDown?: React.KeyboardEventHandler
+}
+
+export const ReindexButtonLabel: React.FC<ReindexButtonLabelProps> = ({
+  active,
+  onClick,
+  onKeyDown,
+  ...ariaProps
+}) => {
   const {
     i18n: { t },
   } = useTranslation()
   return (
-    <Button buttonStyle="pill" icon="chevron" iconPosition="right" size="medium">
+    <Button
+      buttonStyle="secondary"
+      extraButtonProps={{ onKeyDown }}
+      icon={<ChevronIcon direction={active ? 'up' : 'down'} size={16} />}
+      iconPosition="right"
+      onClick={onClick}
+      selected={active}
+      size="medium"
+      {...ariaProps}
+    >
       {t('general:reindex')}
     </Button>
   )

--- a/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
@@ -125,7 +125,6 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
   return (
     <div>
       <Popup
-        button={<ReindexButtonLabel />}
         render={({ close }) => (
           <PopupList.ButtonGroup>
             {searchCollections.map((collectionSlug) => (
@@ -141,6 +140,7 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
             </PopupList.Button>
           </PopupList.ButtonGroup>
         )}
+        renderButton={(buttonProps) => <ReindexButtonLabel {...buttonProps} />}
         showScrollbar
         size="large"
         verticalAlign="bottom"


### PR DESCRIPTION
Aligns the `plugin-search` admin components with the v4 design system and resolves a hydration error on the search list view.

`LinkToDoc` moves its inline styles into a dedicated stylesheet scoped to `@layer payload-default`, using design tokens (`--color-text-secondary`, `--spacing-field`) in place of a hardcoded `#9A9A9A` color and a `var(--spacing-field, 1rem)` fallback.

The `ReindexButton` trigger adopts the `Localizer` button styling (`buttonStyle="secondary"`) so its background and border match the rest of the app header, and its chevron flips between `down` and `up` as the popup opens and closes.

## Hydration fix

The reindex trigger rendered a `<button>` inside a `<button>`:

1. `Popup` defaults to `buttonType="default"`, which wraps its `button` prop in a `<button>`.
2. The `button` prop was `ReindexButtonLabel`, which renders a `Button`, itself a `<button>`.

Switching `Popup` to `renderButton` resolves it. The popup passes its trigger handlers (`onClick`, `onKeyDown`, aria props) straight to `ReindexButtonLabel`'s `Button` instead of wrapping it:

```tsx
<Popup
  renderButton={(buttonProps) => <ReindexButtonLabel {...buttonProps} />}
  render={({ close }) => (
    // popup list
  )}
/>
```

The public `LinkToDoc` and `ReindexButton` exports keep their existing signatures, so the change is non-breaking.

### Before
<img width="235" height="43" alt="Screenshot 2026-06-29 at 3 28 29 PM" src="https://github.com/user-attachments/assets/9f28d506-2b0a-4443-b5ce-5b7deb6e7284" />
<img width="237" height="236" alt="Screenshot 2026-06-29 at 3 28 36 PM" src="https://github.com/user-attachments/assets/94d2497d-000a-40a8-a9ad-c44883f81d58" />

### After
<img width="262" height="63" alt="Screenshot 2026-06-29 at 2 50 11 PM" src="https://github.com/user-attachments/assets/b3105086-bce8-477d-9b79-933c7956b415" />
<img width="257" height="278" alt="Screenshot 2026-06-29 at 2 50 03 PM" src="https://github.com/user-attachments/assets/5b52a480-f712-40e9-ad06-5f29960d8d70" />


https://github.com/user-attachments/assets/8d91d49f-7d9d-427e-9ddd-cbb09fb3341e

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215289866044373