### PR TITLE
fix(ui): restore first-column padding and horizontal scroll in condensed relationship table

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.css
+++ b/packages/ui/src/elements/RelationshipTable/index.css
@@ -41,11 +41,10 @@
     background: var(--color-bg);
     border: var(--stroke-width-small) solid var(--color-border);
     border-radius: var(--radius-medium);
-    overflow: hidden;
+    overflow: auto;
 
     table {
       width: 100%;
-      overflow: auto;
     }
 
     &:not(.table--appearance-condensed) table {

--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -131,6 +131,8 @@
   /* Condensed appearance */
   .table--appearance-condensed {
     border-radius: var(--radius-medium);
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-color) transparent;
 
     table {
       border-collapse: collapse;

--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -200,16 +200,19 @@
         padding: 0;
       }
 
-      > :is(a, button) {
+      > :is(a, button, .drawer-link) {
         display: flex;
         align-items: center;
         width: 100%;
         padding: 0 var(--spacer-2-5);
         min-height: var(--spacer-5);
+      }
+
+      > :is(a, button) {
         cursor: pointer;
       }
 
-      &:first-child > :is(a, button) {
+      &:first-child > :is(a, button, .drawer-link) {
         padding-inline-start: var(--spacer-2-5);
       }
     }


### PR DESCRIPTION
Fixes two visual issues with the condensed relationship/join table.

The linked first column renders `DrawerLink` as a `div.drawer-link` (its inner `DefaultCell` uses `link={false}`), but the `td.cell--linked` rule resets cell padding to `0` and only re-applies it to a direct `> a`/`button` child. Since the child is a `div`, the inline padding was never restored and the first cell sat flush against the table edge. The `.drawer-link` element is now included in the padding selectors, with `cursor: pointer` kept scoped to actual `a`/`button` elements.

`.relationship-table .table` also used `overflow: hidden` to clip its rounded corners, which suppressed the horizontal scrollbar. Inside a narrow drawer, columns wider than the available space were clipped with no way to scroll. Switching to `overflow: auto` preserves the rounded-corner clipping while restoring horizontal scrolling, matching the base `.table` behavior.

### Before:
<img width="885" height="248" alt="Screenshot 2026-06-29 at 6 01 07 PM" src="https://github.com/user-attachments/assets/748e8bb1-3731-4018-a5ce-ff5083f2f060" />

<img width="674" height="879" alt="Screenshot 2026-06-29 at 6 11 50 PM" src="https://github.com/user-attachments/assets/068beafc-86bb-4247-9e86-aae4b11c73d6" />

### After:
<img width="910" height="220" alt="Screenshot 2026-06-29 at 6 04 52 PM" src="https://github.com/user-attachments/assets/3620b5e6-6065-4a80-bc2b-6e40ae3767c9" />

<img width="1295" height="308" alt="Screenshot 2026-06-30 at 10 32 38 AM" src="https://github.com/user-attachments/assets/e8d8d4a2-9cc6-467b-a367-4b8bff2dcd2e" />

<img width="909" height="804" alt="Screenshot 2026-06-30 at 10 33 40 AM" src="https://github.com/user-attachments/assets/b3745c98-d510-4558-b4b9-0a99e59273f1" />
