### PR TITLE
feat(ui): add medium size variant to form inputs

### DIFF
--- a/app/(payload)/themes/steam.css
+++ b/app/(payload)/themes/steam.css
@@ -140,7 +140,7 @@
   --field-color-upload-border: #2a475e;
 
   /* Field sizing */
-  --field-min-height: 2.25rem;
+  --field-min-height-large: 2.25rem;
   --field-padding-inline: 0.75rem;
   --field-border-radius: 2px;
 

--- a/packages/ui/src/css/forms.css
+++ b/packages/ui/src/css/forms.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   .form-input {
     width: 100%;
-    min-height: var(--field-min-height);
+    min-height: var(--field-min-height-large);
     background: var(--field-color-bg);
     border: var(--stroke-width-small) solid var(--field-color-border);
     border-radius: var(--field-border-radius);
@@ -69,7 +69,7 @@
     background: var(--field-color-bg);
     border: var(--stroke-width-small) solid var(--field-color-border);
     border-radius: var(--field-border-radius);
-    min-height: var(--field-min-height);
+    min-height: var(--field-min-height-large);
     transition-property: box-shadow, background-color;
     transition-duration: 100ms;
     transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
@@ -91,7 +91,6 @@
 
     input.form-input {
       flex: 1 1 0%;
-      width: 0;
       min-width: 0;
       background: transparent;
       border: none;
@@ -111,5 +110,9 @@
     &:focus-within {
       border-color: var(--field-color-border-focus);
     }
+  }
+
+  .field-type[data-size='medium'] {
+    --field-min-height-large: var(--field-min-height-medium);
   }
 }

--- a/packages/ui/src/css/theme.css
+++ b/packages/ui/src/css/theme.css
@@ -10,7 +10,8 @@
 @layer payload-default {
   :root {
     /* Fields — controls text inputs, selects, date pickers, code editors, etc. */
-    --field-min-height: var(--spacer-5);
+    --field-min-height-large: var(--spacer-5);
+    --field-min-height-medium: var(--spacer-4);
     --field-padding-inline: var(--spacer-2);
     --field-border-radius: var(--radius-medium);
 

--- a/packages/ui/src/elements/AddNewRelation/index.css
+++ b/packages/ui/src/elements/AddNewRelation/index.css
@@ -16,7 +16,7 @@
     align-items: center;
     justify-content: center;
     padding-inline: var(--spacer-1);
-    height: var(--field-min-height);
+    height: var(--field-min-height-large);
     margin: 0;
     background: var(--color-bg-secondary);
     border: none;

--- a/packages/ui/src/elements/DatePicker/index.css
+++ b/packages/ui/src/elements/DatePicker/index.css
@@ -827,7 +827,7 @@
     font-weight: var(--text-body-medium-font-weight);
     line-height: var(--text-body-medium-line-height);
     width: 100%;
-    min-height: var(--field-min-height);
+    min-height: var(--field-min-height-large);
     border: var(--stroke-width-small) solid var(--field-color-border);
     border-radius: var(--field-border-radius);
     background: var(--field-color-bg);

--- a/packages/ui/src/elements/DatePicker/index.tsx
+++ b/packages/ui/src/elements/DatePicker/index.tsx
@@ -8,7 +8,7 @@ import { ShimmerEffect } from '../ShimmerEffect/index.js'
 const DatePicker = lazy(() => import('./DatePicker.js'))
 
 export const DatePickerField: React.FC<Props> = (props) => (
-  <Suspense fallback={<ShimmerEffect height="var(--field-min-height)" />}>
+  <Suspense fallback={<ShimmerEffect height="var(--field-min-height-large)" />}>
     <DatePicker {...props} />
   </Suspense>
 )

--- a/packages/ui/src/elements/EditUpload/index.tsx
+++ b/packages/ui/src/elements/EditUpload/index.tsx
@@ -217,6 +217,7 @@ export const EditUpload: React.FC<EditUploadProps> = ({
                       path="cropWidth"
                       prefix="W"
                       readOnly={!imageLoaded}
+                      size="medium"
                       value={Number(cropWidthPx)}
                     />
                     <NumberInput
@@ -225,6 +226,7 @@ export const EditUpload: React.FC<EditUploadProps> = ({
                       path="cropHeight"
                       prefix="H"
                       readOnly={!imageLoaded}
+                      size="medium"
                       value={Number(cropHeightPx)}
                     />
                   </div>
@@ -254,6 +256,7 @@ export const EditUpload: React.FC<EditUploadProps> = ({
                       }
                       path="focalX"
                       prefix="X"
+                      size="medium"
                       suffix="%"
                       value={Math.round(focalPosition.x)}
                     />
@@ -266,6 +269,7 @@ export const EditUpload: React.FC<EditUploadProps> = ({
                       }
                       path="focalY"
                       prefix="Y"
+                      size="medium"
                       suffix="%"
                       value={Math.round(focalPosition.y)}
                     />

--- a/packages/ui/src/elements/LivePreview/Toolbar/SizeInput/index.tsx
+++ b/packages/ui/src/elements/LivePreview/Toolbar/SizeInput/index.tsx
@@ -96,6 +96,7 @@ export const PreviewFrameSizeInput: React.FC<{
       onStep={handleStep}
       path={axis === 'x' ? 'live-preview-width' : 'live-preview-height'}
       prefix={axis === 'x' ? 'W' : 'H'}
+      size="medium"
       step={1}
       value={internalState || 0}
     />

--- a/packages/ui/src/elements/LivePreview/Window/index.css
+++ b/packages/ui/src/elements/LivePreview/Window/index.css
@@ -1,4 +1,10 @@
 @layer payload-default {
+  .collection-edit:has(.live-preview-window--is-expanded) {
+    .document-fields {
+      width: 0;
+    }
+  }
+
   .live-preview-window {
     background-color: var(--color-bg);
     display: none;

--- a/packages/ui/src/elements/ReactSelect/index.css
+++ b/packages/ui/src/elements/ReactSelect/index.css
@@ -7,7 +7,7 @@
     .rs__control {
       position: relative;
       width: 100%;
-      min-height: var(--field-min-height);
+      min-height: var(--field-min-height-large);
       background: var(--field-color-bg);
       border: var(--stroke-width-small) solid var(--field-color-border);
       border-radius: var(--field-border-radius);
@@ -57,7 +57,7 @@
       position: absolute;
       right: var(--spacer-1);
       top: -1px; /* Adjust for border */
-      min-height: var(--field-min-height);
+      min-height: var(--field-min-height-large);
       display: flex;
     }
 

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -276,7 +276,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
   }
 
   if (!hasMounted) {
-    return <ShimmerEffect height="var(--field-min-height)" />
+    return <ShimmerEffect height="var(--field-min-height-large)" />
   }
 
   if (!isCreatable) {

--- a/packages/ui/src/elements/TimezonePicker/index.css
+++ b/packages/ui/src/elements/TimezonePicker/index.css
@@ -6,7 +6,7 @@
     align-items: center;
     position: relative;
 
-    --field-min-height: var(--text-body-medium-line-height);
+    --field-min-height-large: var(--text-body-medium-line-height);
 
     .shimmer-effect {
       max-width: calc(2 * var(--spacer-4));

--- a/packages/ui/src/fields/ConfirmPassword/index.tsx
+++ b/packages/ui/src/fields/ConfirmPassword/index.tsx
@@ -14,10 +14,14 @@ import './index.css'
 export type ConfirmPasswordFieldProps = {
   readonly disabled?: boolean
   readonly path?: string
+  /**
+   * Controls the height of the input. Defaults to `'large'`.
+   */
+  readonly size?: 'large' | 'medium'
 }
 
 export const ConfirmPasswordField: React.FC<ConfirmPasswordFieldProps> = (props) => {
-  const { disabled: disabledFromProps, path = 'confirm-password' } = props
+  const { disabled: disabledFromProps, path = 'confirm-password', size = 'large' } = props
   const { t } = useTranslation()
   const [showPassword, setShowPassword] = useState(false)
 
@@ -45,6 +49,7 @@ export const ConfirmPasswordField: React.FC<ConfirmPasswordFieldProps> = (props)
       ]
         .filter(Boolean)
         .join(' ')}
+      data-size={size}
     >
       <FieldLabel
         htmlFor="field-confirm-password"

--- a/packages/ui/src/fields/Number/Input.tsx
+++ b/packages/ui/src/fields/Number/Input.tsx
@@ -43,6 +43,7 @@ export const NumberInput: React.FC<NumberInputProps> = (props) => {
     readOnly,
     required,
     showError,
+    size = 'large',
     step = 1,
     style,
     suffix,
@@ -67,6 +68,7 @@ export const NumberInput: React.FC<NumberInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-size={size}
       style={style}
     >
       <RenderCustomComponent

--- a/packages/ui/src/fields/Number/types.ts
+++ b/packages/ui/src/fields/Number/types.ts
@@ -36,6 +36,10 @@ export type NumberInputProps = {
   readonly readOnly?: boolean
   readonly required?: boolean
   readonly showError?: boolean
+  /**
+   * Controls the height of the input. Defaults to `'large'`.
+   */
+  readonly size?: 'large' | 'medium'
   readonly step?: number
   readonly style?: React.CSSProperties
   /** Short text affix rendered after the value, e.g. `%`. */

--- a/packages/ui/src/fields/Password/input.tsx
+++ b/packages/ui/src/fields/Password/input.tsx
@@ -38,6 +38,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = (props) => {
     required,
     rtl,
     showError,
+    size = 'large',
     style,
     value,
     width,
@@ -57,6 +58,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-size={size}
       style={{
         ...style,
         width,

--- a/packages/ui/src/fields/Password/types.ts
+++ b/packages/ui/src/fields/Password/types.ts
@@ -56,6 +56,10 @@ export type PasswordInputProps = {
   readonly required?: boolean
   readonly rtl?: boolean
   readonly showError?: boolean
+  /**
+   * Controls the height of the input. Defaults to `'large'`.
+   */
+  readonly size?: 'large' | 'medium'
   readonly style?: React.CSSProperties
   readonly value?: string
   readonly width?: CSSProperties['width']

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -72,6 +72,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
     relationTo,
     required,
     showError,
+    size = 'large',
     sortOptions,
     style,
     value,
@@ -759,6 +760,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-size={size}
       id={`field-${path.replace(/\./g, '__')}`}
       style={style}
     >

--- a/packages/ui/src/fields/Relationship/types.ts
+++ b/packages/ui/src/fields/Relationship/types.ts
@@ -110,6 +110,10 @@ export type RelationshipInputProps = {
   readonly relationTo: string[]
   readonly required?: boolean
   readonly showError?: boolean
+  /**
+   * Controls the height of the input. Defaults to `'large'`.
+   */
+  readonly size?: 'large' | 'medium'
   readonly sortOptions?: Partial<Record<CollectionSlug, string>>
   readonly style?: React.CSSProperties
 } & SharedRelationshipInputProps

--- a/packages/ui/src/fields/Select/Input.tsx
+++ b/packages/ui/src/fields/Select/Input.tsx
@@ -39,6 +39,10 @@ export type SelectInputProps = {
   readonly readOnly?: boolean
   readonly required?: boolean
   readonly showError?: boolean
+  /**
+   * Controls the height of the input. Defaults to `'large'`.
+   */
+  readonly size?: 'large' | 'medium'
   readonly style?: React.CSSProperties
   readonly value?: string | string[]
 }
@@ -67,6 +71,7 @@ export const SelectInput: React.FC<SelectInputProps> = (props) => {
     readOnly,
     required,
     showError,
+    size = 'large',
     style,
     value,
   } = props
@@ -105,6 +110,7 @@ export const SelectInput: React.FC<SelectInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-size={size}
       id={`field-${path.replace(/\./g, '__')}`}
       style={style}
     >

--- a/packages/ui/src/fields/Text/Input.tsx
+++ b/packages/ui/src/fields/Text/Input.tsx
@@ -40,6 +40,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     required,
     rtl,
     showError,
+    size = 'large',
     style,
     value,
     valueToRender,
@@ -109,6 +110,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-size={size}
       style={style}
     >
       <RenderCustomComponent

--- a/packages/ui/src/fields/Text/types.ts
+++ b/packages/ui/src/fields/Text/types.ts
@@ -44,6 +44,10 @@ export type TextInputProps = {
   readonly required?: boolean
   readonly rtl?: boolean
   readonly showError?: boolean
+  /**
+   * Controls the height of the input. Defaults to `'large'`.
+   */
+  readonly size?: 'large' | 'medium'
   readonly style?: React.CSSProperties
   readonly value?: string
   readonly valueToRender?: Option[]

--- a/packages/ui/src/fields/Textarea/Input.tsx
+++ b/packages/ui/src/fields/Textarea/Input.tsx
@@ -33,6 +33,7 @@ export const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
     rows,
     rtl,
     showError,
+    size = 'large',
     style,
     value,
   } = props
@@ -50,6 +51,7 @@ export const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
       ]
         .filter(Boolean)
         .join(' ')}
+      data-size={size}
       style={style}
     >
       <RenderCustomComponent

--- a/packages/ui/src/fields/Textarea/index.css
+++ b/packages/ui/src/fields/Textarea/index.css
@@ -15,7 +15,7 @@
     textarea {
       overflow-y: auto;
       resize: vertical;
-      min-height: calc(var(--field-min-height) * 2);
+      min-height: calc(var(--field-min-height-large) * 2);
       height: auto;
       display: flex;
       field-sizing: content;

--- a/packages/ui/src/fields/Textarea/types.ts
+++ b/packages/ui/src/fields/Textarea/types.ts
@@ -23,6 +23,10 @@ export type TextAreaInputProps = {
   readonly rows?: number
   readonly rtl?: boolean
   readonly showError?: boolean
+  /**
+   * Controls the height of the input. Defaults to `'large'`.
+   */
+  readonly size?: 'large' | 'medium'
   readonly style?: React.CSSProperties
   readonly value?: string
   readonly valueToRender?: string


### PR DESCRIPTION
Adds a `size` prop (`'large' | 'medium'`, default `'large'`) to all form input components and introduces the corresponding `--field-min-height-medium` CSS token (24px / `--spacer-4`).

## What changed

**CSS tokens**

Renames `--field-min-height` → `--field-min-height-large` everywhere and adds `--field-min-height-medium: var(--spacer-4)` to `theme.css`. A single cascade override rule in `forms.css` makes the medium variant work across all descendants:

```css
.field-type[data-size='medium'] {
  --field-min-height-large: var(--field-min-height-medium);
}
```

**Input components**

Adds `size?: 'large' | 'medium'` to the props and types of: `TextInput`, `NumberInput`, `PasswordInput`, `TextareaInput`, `SelectInput`, `RelationshipInput`, `ConfirmPasswordField`. Each component passes `data-size={size}` to its outer `.field-type` wrapper so the CSS token override applies automatically.

**Live preview toolbar**

The W/H dimension inputs in `PreviewFrameSizeInput` now use `size="medium"` to match the compact toolbar design.

**Crop / focal point modal**

All four `NumberInput` instances in `EditUpload` (crop W, crop H, focal X, focal Y) now use `size="medium"`.

**Live preview expanded state**

Hides the document fields panel when the live preview window is fully expanded.