### PR TITLE
fix(ui): render custom logout button in user menu

### DIFF
--- a/packages/ui/src/elements/AppHeader/index.tsx
+++ b/packages/ui/src/elements/AppHeader/index.tsx
@@ -23,9 +23,10 @@ const baseClass = 'app-header'
 
 type Props = {
   CustomAvatar?: React.ReactNode
+  CustomLogoutButton?: React.ReactNode
   settingsItemGroups?: UserMenuSettingsGroup[]
 }
-export function AppHeader({ CustomAvatar, settingsItemGroups }: Props) {
+export function AppHeader({ CustomAvatar, CustomLogoutButton, settingsItemGroups }: Props) {
   const { t } = useTranslation()
   const locale = useLocale()
 
@@ -123,7 +124,11 @@ export function AppHeader({ CustomAvatar, settingsItemGroups }: Props) {
                 )}
               />
             )}
-            <UserMenu CustomAvatar={CustomAvatar} settingsItemGroups={settingsItemGroups} />
+            <UserMenu
+              CustomAvatar={CustomAvatar}
+              CustomLogoutButton={CustomLogoutButton}
+              settingsItemGroups={settingsItemGroups}
+            />
           </div>
         </div>
       </div>

--- a/packages/ui/src/elements/UserMenu/index.tsx
+++ b/packages/ui/src/elements/UserMenu/index.tsx
@@ -23,10 +23,15 @@ const baseClass = 'user-menu'
 
 type UserMenuProps = {
   CustomAvatar?: React.ReactNode
+  CustomLogoutButton?: React.ReactNode
   settingsItemGroups?: UserMenuSettingsGroup[]
 }
 
-export const UserMenu: React.FC<UserMenuProps> = ({ CustomAvatar, settingsItemGroups = [] }) => {
+export const UserMenu: React.FC<UserMenuProps> = ({
+  CustomAvatar,
+  CustomLogoutButton,
+  settingsItemGroups = [],
+}) => {
   const { user } = useAuth()
   const { languageOptions, t } = useTranslation()
   const {
@@ -171,9 +176,11 @@ export const UserMenu: React.FC<UserMenuProps> = ({ CustomAvatar, settingsItemGr
 
           {/* Account actions */}
           <PopupList.MenuItem>
-            <PopupList.Button href={logoutHref} icon={<LogOutIcon />}>
-              {t('authentication:logOut')}
-            </PopupList.Button>
+            {CustomLogoutButton ?? (
+              <PopupList.Button href={logoutHref} icon={<LogOutIcon />}>
+                {t('authentication:logOut')}
+              </PopupList.Button>
+            )}
           </PopupList.MenuItem>
         </>
       )}

--- a/packages/ui/src/templates/Default/index.tsx
+++ b/packages/ui/src/templates/Default/index.tsx
@@ -206,6 +206,16 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
                         })
                       : undefined
                   }
+                  CustomLogoutButton={
+                    components?.logout?.Button
+                      ? RenderServerComponent({
+                          clientProps,
+                          Component: components.logout.Button,
+                          importMap: payload.importMap,
+                          serverProps,
+                        })
+                      : undefined
+                  }
                   settingsItemGroups={settingsItemGroups}
                 />
                 {children}

--- a/test/admin/components/Logout/index.tsx
+++ b/test/admin/components/Logout/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { LogOutIcon, useConfig } from '@payloadcms/ui'
+import { LogOutIcon, PopupList, useConfig } from '@payloadcms/ui'
 import React from 'react'
 
 export const Logout: React.FC = () => {
@@ -14,11 +14,10 @@ export const Logout: React.FC = () => {
   } = useConfig()
 
   return (
-    <a
-      href={`${admin}${logoutRoute}#custom`}
-      style={{ alignItems: 'center', display: 'flex', gap: 8 }}
-    >
-      <LogOutIcon /> Custom Logout
+    <a aria-label="Custom Logout" href={`${admin}${logoutRoute}#custom`}>
+      <PopupList.Button className="logout-button" icon={<LogOutIcon />}>
+        Custom Logout
+      </PopupList.Button>
     </a>
   )
 }

--- a/test/admin/components/Logout/index.tsx
+++ b/test/admin/components/Logout/index.tsx
@@ -14,8 +14,11 @@ export const Logout: React.FC = () => {
   } = useConfig()
 
   return (
-    <a href={`${admin}${logoutRoute}#custom`}>
-      <LogOutIcon />
+    <a
+      href={`${admin}${logoutRoute}#custom`}
+      style={{ alignItems: 'center', display: 'flex', gap: 8 }}
+    >
+      <LogOutIcon /> Custom Logout
     </a>
   )
 }

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -415,6 +415,17 @@ describe('General', () => {
           .click()
         await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
       })
+
+      test('should render custom logout button from admin.components.logout.Button', async () => {
+        await page.goto(postsUrl.admin)
+
+        // Logout lives inside the user menu popup
+        await page.locator('button[aria-label="Account"]').click()
+
+        // The custom Logout component (admin.components.logout.Button) renders an
+        // anchor ending in `#custom`, replacing the default logout button.
+        await expect(page.locator('a[href$="/custom-logout#custom"]')).toBeVisible()
+      })
     })
   })
 


### PR DESCRIPTION
## What?

Restores support for the `admin.components.logout.Button` override in v4 by rendering it inside the new `UserMenu` popup, with a fallback to the default logout button when none is configured.

<img width="219" height="215" alt="image" src="https://github.com/user-attachments/assets/4cc9f572-5de4-47ed-819f-0e9a63307a09" />


## Why?

#16950 redesigned the user menu and moved logout out of the nav controls into the `UserMenu` popup. In doing so, the old render site in `DefaultNav` (`RenderServerComponent({ Component: logout?.Button, Fallback: Logout })`) was removed and not reintroduced. The new `UserMenu` renders a hardcoded logout link instead.

As a result, `admin.components.logout.Button` is still declared in the config types and still added to the import map (`iterateConfig.ts`), but is no longer rendered anywhere. Any custom logout button silently stopped appearing in v4. This also breaks integrations that depend on it, such as the OAuth2 plugin, where a custom logout button is the supported way to log out of the IdP session.

This regression went uncaught because, although the admin test suite configures `admin.components.logout.Button`, no test asserted that the custom button actually rendered.

## How?

- Resolve `admin.components.logout.Button` server-side in `DefaultTemplate` (the same way `CustomAvatar` is resolved) and pass it through `AppHeader` to `UserMenu`.
- In `UserMenu`, render the resolved custom button in the account actions area, falling back to the default logout button when it is not provided.
- Add an e2e assertion in the admin suite that the configured custom logout button renders inside the user menu popup.

## Notes

The admin test app already wires `admin.components.logout.Button` to a custom component (`test/admin/components/Logout`). The new e2e test opens the user menu and asserts that custom button is visible, which would have caught this regression.