### PR TITLE
feat(ui): separate useAsTitle from path-title display for hierarchy

### DIFF
--- a/docs/hierarchy/overview.mdx
+++ b/docs/hierarchy/overview.mdx
@@ -78,7 +78,7 @@ When hierarchy is enabled, virtual path fields are automatically added to your c
 const page = await payload.findByID({
   collection: 'pages',
   id: 'page-id',
-  context: { computeHierarchyPaths: true }, // Request path computation
+  context: { hierarchy: { computePaths: true } }, // Request path computation
 })
 
 // Use in your frontend routing
@@ -110,7 +110,7 @@ const url = `/${page._h_slugPath}` // "/store/products/widgets"
 const page = await payload.findByID({
   collection: 'pages',
   id: 'page-id',
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 
 const breadcrumbs = page._h_titlePath.split('/')
@@ -123,34 +123,34 @@ Path fields (`_h_slugPath` and `_h_titlePath`) are virtual fields that must be e
 
 ### Method 1: Context Flag
 
-Pass `computeHierarchyPaths: true` in the context:
+Pass `hierarchy: { computePaths: true }` in the context:
 
 ```ts
 // Single document
 const page = await payload.findByID({
   collection: 'pages',
   id: 'page-id',
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 
 // Query multiple documents
 const pages = await payload.find({
   collection: 'pages',
   where: { parent: { equals: null } },
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 ```
 
 ### Method 2: Query Parameter
 
-For REST API requests, add the `computeHierarchyPaths` query parameter:
+For REST API requests, add the `hierarchy[computePaths]` query parameter:
 
 ```bash
 # Get single document with paths
-GET /api/pages/abc123?computeHierarchyPaths=true
+GET /api/pages/abc123?hierarchy%5BcomputePaths%5D=true
 
 # Query collection with paths
-GET /api/pages?computeHierarchyPaths=true&where[parent][equals]=null
+GET /api/pages?hierarchy%5BcomputePaths%5D=true&where[parent][equals]=null
 ```
 
 ### Method 3: Field Selection
@@ -183,7 +183,7 @@ const page = await payload.findByID({
 const folders = await payload.find({
   collection: 'folders',
   where: { parent: { equals: 'parent-id' } },
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 // Result: Only 2 queries total (1 for folders, 1 for the shared parent)
 ```
@@ -405,7 +405,7 @@ Paths are computed across collections automatically:
 const post = await payload.findByID({
   collection: 'posts',
   id: post.id,
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 
 // post._h_slugPath: 'blog/first-post'
@@ -415,7 +415,7 @@ const post = await payload.findByID({
 const reply = await payload.findByID({
   collection: 'posts',
   id: reply.id,
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 
 // reply._h_slugPath: 'blog/first-post/reply'
@@ -753,7 +753,7 @@ await payload.update({
 const child = await payload.findByID({
   collection: 'pages',
   id: 'child-id',
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 
 // child._h_titlePath reflects the new parent title:
@@ -814,7 +814,7 @@ When versioning with drafts is enabled, paths are computed based on the current 
 const published = await payload.findByID({
   collection: 'pages',
   id: 'page-id',
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
   // draft: false (default)
 })
 // published._h_slugPath: 'products/clothing' (uses published parent title)
@@ -824,7 +824,7 @@ const draft = await payload.findByID({
   collection: 'pages',
   id: 'page-id',
   draft: true,
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 // draft._h_slugPath: 'products/apparel' (uses draft title if changed)
 ```
@@ -927,7 +927,7 @@ Ensure your `admin.useAsTitle` field is stable and always has a value:
 
 For collections with many documents:
 
-- **Only request paths when needed** - Use `computeHierarchyPaths: true` only for UI/breadcrumb display
+- **Only request paths when needed** - Use `hierarchy: { computePaths: true }` only for UI/breadcrumb display
 - **Skip paths for relationships** - When loading related documents, omit path computation to avoid extra queries
 - **Limit tree depth** - Deep trees (10+ levels) will have slower path computation
 - **Leverage caching** - Multiple documents sharing ancestors benefit from request-scoped caching
@@ -940,7 +940,7 @@ const post = await payload.findByID({
   collection: 'posts',
   id: 'post-id',
   depth: 2, // Populates category relationship
-  context: { computeHierarchyPaths: true }, // Computes paths for category too
+  context: { hierarchy: { computePaths: true } }, // Computes paths for category too
 })
 
 // ✅ Only compute paths when you'll use them
@@ -963,7 +963,7 @@ import type { Page } from './payload-types'
 const page = await payload.findByID({
   collection: 'pages',
   id: 'page-id',
-  context: { computeHierarchyPaths: true },
+  context: { hierarchy: { computePaths: true } },
 })
 
 // TypeScript knows about these fields:

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -368,6 +368,13 @@ export type FoldersConfig = {
     injectSidebarTab?: boolean
     treeLimit?: number
     useHeaderButton?: boolean
+    /**
+     * When true, overrides admin.useAsTitle to show the full ancestor path
+     * (e.g. "Root Folder > Subfolder > My Folder") in the document header and
+     * relationship pills instead of just the folder's own name.
+     * @default false
+     */
+    usePathAsTitle?: boolean
   }
   collectionSpecific?:
     | {

--- a/packages/payload/src/collections/config/useAsTitle.ts
+++ b/packages/payload/src/collections/config/useAsTitle.ts
@@ -34,9 +34,22 @@ export const validateUseAsTitle = (config: CollectionConfig) => {
       }
     } else {
       if (useAsTitleField && 'virtual' in useAsTitleField && useAsTitleField.virtual === true) {
-        throw new InvalidConfiguration(
-          `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" in the collection "${config.slug}" is virtual. A virtual field can be used as the title only when linked to a relationship field.`,
-        )
+        // Virtual fields are allowed as useAsTitle when they are hierarchy path fields
+        // (set automatically by hierarchy's usePathAsTitle option).
+        // Detect this by checking if the collection has hierarchy and the field matches the titlePathFieldName.
+        const isHierarchyPathField =
+          config.hierarchy !== false &&
+          config.hierarchy &&
+          typeof config.hierarchy === 'object' &&
+          'titlePathFieldName' in config.hierarchy &&
+          (config.hierarchy as { titlePathFieldName: string }).titlePathFieldName ===
+            config.admin?.useAsTitle
+
+        if (!isHierarchyPathField) {
+          throw new InvalidConfiguration(
+            `The field "${config.admin.useAsTitle}" specified in "admin.useAsTitle" in the collection "${config.slug}" is virtual. A virtual field can be used as the title only when linked to a relationship field.`,
+          )
+        }
       }
       if (!useAsTitleField) {
         throw new InvalidConfiguration(

--- a/packages/payload/src/hierarchy/addHierarchyToCollection.ts
+++ b/packages/payload/src/hierarchy/addHierarchyToCollection.ts
@@ -12,14 +12,12 @@ export const addHierarchyToCollection = ({
   slugFieldName,
   slugPathFieldName,
   titlePathFieldName,
-  usePathAsTitle = false,
 }: {
   collectionConfig: CollectionConfig
   parentFieldName: string
   slugFieldName?: string
   slugPathFieldName: string
   titlePathFieldName: string
-  usePathAsTitle?: boolean
 }): { isTitleLocalized: boolean; titleFieldName: string } => {
   // Read the real title field BEFORE adding virtual fields or overriding useAsTitle.
   // When usePathAsTitle is true, useAsTitle still points at the real content field here
@@ -70,7 +68,6 @@ export const addHierarchyToCollection = ({
     afterRead: [
       ...(collectionConfig.hooks?.afterRead || []),
       hierarchyCollectionAfterRead({
-        alwaysComputePaths: usePathAsTitle,
         isTitleLocalized,
         parentFieldName,
         slugPathFieldName,

--- a/packages/payload/src/hierarchy/addHierarchyToCollection.ts
+++ b/packages/payload/src/hierarchy/addHierarchyToCollection.ts
@@ -12,14 +12,19 @@ export const addHierarchyToCollection = ({
   slugFieldName,
   slugPathFieldName,
   titlePathFieldName,
+  usePathAsTitle = false,
 }: {
   collectionConfig: CollectionConfig
   parentFieldName: string
   slugFieldName?: string
   slugPathFieldName: string
   titlePathFieldName: string
-}) => {
-  const { titleFieldName } = findUseAsTitleField(collectionConfig)
+  usePathAsTitle?: boolean
+}): { isTitleLocalized: boolean; titleFieldName: string } => {
+  // Read the real title field BEFORE adding virtual fields or overriding useAsTitle.
+  // When usePathAsTitle is true, useAsTitle still points at the real content field here
+  // (e.g. 'title') — we capture it now so path-building and listSearchableFields keep using it.
+  const { localized: isTitleLocalized, titleFieldName } = findUseAsTitleField(collectionConfig)
   // Verify slug field exists if configured
   const slugFieldInfo = slugFieldName ? findFieldByName(collectionConfig, slugFieldName) : undefined
   const validatedSlugFieldName = slugFieldInfo ? slugFieldName : undefined
@@ -53,6 +58,13 @@ export const addHierarchyToCollection = ({
   if (!collectionConfig.admin) {
     collectionConfig.admin = {}
   }
+
+  // When usePathAsTitle is enabled, override useAsTitle to the virtual path field so that
+  // the document header and relationship pills display the full ancestor path.
+  if (usePathAsTitle) {
+    collectionConfig.admin.useAsTitle = titlePathFieldName
+  }
+
   if (!collectionConfig.admin.listSearchableFields) {
     collectionConfig.admin.listSearchableFields = [titleFieldName]
   } else if (!collectionConfig.admin.listSearchableFields.includes(titleFieldName)) {
@@ -63,7 +75,13 @@ export const addHierarchyToCollection = ({
     ...(collectionConfig.hooks || {}),
     afterRead: [
       ...(collectionConfig.hooks?.afterRead || []),
-      hierarchyCollectionAfterRead({ parentFieldName, slugPathFieldName, titlePathFieldName }),
+      hierarchyCollectionAfterRead({
+        alwaysComputePaths: usePathAsTitle,
+        isTitleLocalized,
+        parentFieldName,
+        slugPathFieldName,
+        titlePathFieldName,
+      }),
     ],
     beforeChange: [
       ...(collectionConfig.hooks?.beforeChange || []),
@@ -84,4 +102,6 @@ export const addHierarchyToCollection = ({
       }),
     ],
   }
+
+  return { isTitleLocalized, titleFieldName }
 }

--- a/packages/payload/src/hierarchy/addHierarchyToCollection.ts
+++ b/packages/payload/src/hierarchy/addHierarchyToCollection.ts
@@ -59,12 +59,6 @@ export const addHierarchyToCollection = ({
     collectionConfig.admin = {}
   }
 
-  // When usePathAsTitle is enabled, override useAsTitle to the virtual path field so that
-  // the document header and relationship pills display the full ancestor path.
-  if (usePathAsTitle) {
-    collectionConfig.admin.useAsTitle = titlePathFieldName
-  }
-
   if (!collectionConfig.admin.listSearchableFields) {
     collectionConfig.admin.listSearchableFields = [titleFieldName]
   } else if (!collectionConfig.admin.listSearchableFields.includes(titleFieldName)) {

--- a/packages/payload/src/hierarchy/constants.ts
+++ b/packages/payload/src/hierarchy/constants.ts
@@ -15,5 +15,8 @@ export const DEFAULT_HIERARCHY_LIST_LIMIT = 25
 /** Default value for allowing hasMany on hierarchy fields */
 export const DEFAULT_ALLOW_HAS_MANY = true
 
+/** Default separator used when joining human-readable title path labels */
+export const DEFAULT_HIERARCHY_LABEL_SEPARATOR = ' > '
+
 /** Generate a hierarchy field name from a hierarchy slug (e.g., 'folders' -> '_h_folders') */
 export const getHierarchyFieldName = (hierarchySlug: string): string => `_h_${hierarchySlug}`

--- a/packages/payload/src/hierarchy/hooks/collectionAfterRead.ts
+++ b/packages/payload/src/hierarchy/hooks/collectionAfterRead.ts
@@ -41,16 +41,8 @@ function isPathFieldSelected(
 
 type Args = {
   /**
-   * When true, always compute paths on every read (used when usePathAsTitle is enabled
-   * so the full path is available wherever the document is used — including as the text
-   * shown in relationship pills populated via depth). When false (default), paths are
-   * only computed on demand via select, context flag, or query param.
-   */
-  alwaysComputePaths?: boolean
-  /**
    * Whether the title field is localized. Passed explicitly to avoid re-deriving from
-   * collection config (which may have useAsTitle overridden to the virtual path field
-   * when usePathAsTitle is enabled).
+   * collection config on every read.
    */
   isTitleLocalized: boolean
   /**
@@ -69,7 +61,6 @@ type Args = {
 
 export const hierarchyCollectionAfterRead =
   ({
-    alwaysComputePaths = false,
     isTitleLocalized,
     parentFieldName,
     slugPathFieldName,
@@ -96,7 +87,6 @@ export const hierarchyCollectionAfterRead =
 
     // Determine if paths should be computed
     const shouldComputePaths =
-      alwaysComputePaths || // Always on when usePathAsTitle is enabled
       hierarchyContext?.computePaths === true || // Explicit namespaced context flag
       hierarchyContext?.computePathsViaSelect === true || // Flag from beforeOperation (select-triggered)
       hasHierarchyComputePathsQuery || // Namespaced query parameter

--- a/packages/payload/src/hierarchy/hooks/collectionAfterRead.ts
+++ b/packages/payload/src/hierarchy/hooks/collectionAfterRead.ts
@@ -3,15 +3,14 @@
  * - Automatically compute and attach _h_slugPath and _h_titlePath to documents
  * - Use cached ancestors to optimize queries when reading multiple documents
  * - Only computes when explicitly requested via:
- *   1. context.computeHierarchyPaths flag
- *   2. ?computeHierarchyPaths=true query param
+ *   1. context.hierarchy.computePaths flag
+ *   2. ?hierarchy[computePaths]=true query param
  *   3. Selecting path fields in query (select parameter)
  */
 
 import type { CollectionAfterReadHook, PayloadRequest } from '../../index.js'
 
 import { computePaths } from '../utils/computePaths.js'
-import { findUseAsTitleField } from '../utils/findUseAsTitle.js'
 
 /**
  * Checks if path fields are being selected in the query
@@ -42,6 +41,19 @@ function isPathFieldSelected(
 
 type Args = {
   /**
+   * When true, always compute paths on every read (used when usePathAsTitle is enabled
+   * so the full path is available wherever the document is used — including as the text
+   * shown in relationship pills populated via depth). When false (default), paths are
+   * only computed on demand via select, context flag, or query param.
+   */
+  alwaysComputePaths?: boolean
+  /**
+   * Whether the title field is localized. Passed explicitly to avoid re-deriving from
+   * collection config (which may have useAsTitle overridden to the virtual path field
+   * when usePathAsTitle is enabled).
+   */
+  isTitleLocalized: boolean
+  /**
    * The name of the field that contains the parent document ID
    */
   parentFieldName: string
@@ -56,18 +68,38 @@ type Args = {
 }
 
 export const hierarchyCollectionAfterRead =
-  ({ parentFieldName, slugPathFieldName, titlePathFieldName }: Args): CollectionAfterReadHook =>
+  ({
+    alwaysComputePaths = false,
+    isTitleLocalized,
+    parentFieldName,
+    slugPathFieldName,
+    titlePathFieldName,
+  }: Args): CollectionAfterReadHook =>
   async ({ collection, context, doc, req }) => {
     // Skip if deleting
     if (context?.isDeleting) {
       return doc
     }
 
+    const hierarchyContext =
+      context?.hierarchy && typeof context.hierarchy === 'object'
+        ? (context.hierarchy as { computePaths?: boolean; computePathsViaSelect?: boolean })
+        : undefined
+
+    const hierarchyQuery =
+      req.query?.hierarchy && typeof req.query.hierarchy === 'object'
+        ? (req.query.hierarchy as { computePaths?: string | unknown })
+        : undefined
+
+    const hasHierarchyComputePathsQuery =
+      hierarchyQuery?.computePaths === true || hierarchyQuery?.computePaths === 'true'
+
     // Determine if paths should be computed
     const shouldComputePaths =
-      context?.computeHierarchyPaths === true || // Explicit flag in context
-      context?.computeHierarchyPathsViaSelect === true || // Flag from beforeOperation (select-triggered)
-      req.query?.computeHierarchyPaths === 'true' || // Query parameter
+      alwaysComputePaths || // Always on when usePathAsTitle is enabled
+      hierarchyContext?.computePaths === true || // Explicit namespaced context flag
+      hierarchyContext?.computePathsViaSelect === true || // Flag from beforeOperation (select-triggered)
+      hasHierarchyComputePathsQuery || // Namespaced query parameter
       isPathFieldSelected(req, slugPathFieldName, titlePathFieldName) // Field selection detection
 
     if (!shouldComputePaths) {
@@ -75,8 +107,6 @@ export const hierarchyCollectionAfterRead =
     }
 
     try {
-      const { localized: isTitleLocalized } = findUseAsTitleField(collection)
-
       const { slugPath, titlePath } = await computePaths({
         collection,
         doc,

--- a/packages/payload/src/hierarchy/hooks/collectionBeforeOperation.ts
+++ b/packages/payload/src/hierarchy/hooks/collectionBeforeOperation.ts
@@ -116,7 +116,10 @@ export const hierarchyCollectionBeforeOperation = <TSlug extends CollectionSlug>
       context.hierarchyAutoSelectedFields = autoAddedFields
     }
 
-    // Set flag to trigger path computation in afterRead
-    context.computeHierarchyPathsViaSelect = true
+    // Set namespaced flag to trigger path computation in afterRead
+    if (!context.hierarchy || typeof context.hierarchy !== 'object') {
+      context.hierarchy = {}
+    }
+    ;(context.hierarchy as { computePathsViaSelect?: boolean }).computePathsViaSelect = true
   }
 }

--- a/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
+++ b/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
@@ -8,6 +8,7 @@ import { addHierarchyToCollection } from './addHierarchyToCollection.js'
 import { buildParentField } from './buildParentField.js'
 import {
   DEFAULT_ALLOW_HAS_MANY,
+  DEFAULT_HIERARCHY_LABEL_SEPARATOR,
   DEFAULT_HIERARCHY_TREE_LIMIT,
   getHierarchyFieldName,
   HIERARCHY_SLUG_PATH_FIELD,
@@ -102,18 +103,22 @@ export const sanitizeHierarchyCollection = (
   const slugify =
     collectionConfig.hierarchy.slugify ?? ((text: string) => defaultSlugify(text) ?? '')
   const treeLimit = collectionConfig.hierarchy.admin?.treeLimit ?? DEFAULT_HIERARCHY_TREE_LIMIT
+  const labelSeparator =
+    collectionConfig.hierarchy.admin?.labelSeparator ?? DEFAULT_HIERARCHY_LABEL_SEPARATOR
   const iconComponent = collectionConfig.hierarchy.admin?.components?.Icon
   const smallIconComponent = collectionConfig.hierarchy.admin?.components?.SmallIcon
 
   const slugField = collectionConfig.hierarchy.slugField
+  const usePathAsTitle = collectionConfig.hierarchy.admin?.usePathAsTitle ?? false
 
   // Apply hierarchy to collection (adds fields and hooks)
-  addHierarchyToCollection({
+  const { titleFieldName } = addHierarchyToCollection({
     collectionConfig,
     parentFieldName: collectionConfig.hierarchy.parentFieldName,
     slugFieldName: slugField,
     slugPathFieldName,
     titlePathFieldName,
+    usePathAsTitle,
   })
 
   // If collectionSpecific, add beforeValidate hook to enforce scope inheritance
@@ -147,8 +152,10 @@ export const sanitizeHierarchyCollection = (
         SmallIcon: smallIconComponent || iconComponent || '@payloadcms/ui#TagIcon',
       },
       injectSidebarTab,
+      labelSeparator,
       treeLimit,
       useHeaderButton,
+      usePathAsTitle,
     },
     allowHasMany,
     collectionSpecific,
@@ -158,6 +165,7 @@ export const sanitizeHierarchyCollection = (
     slugField,
     slugify,
     slugPathFieldName,
+    titleField: titleFieldName,
     titlePathFieldName,
   }
 }

--- a/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
+++ b/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
@@ -118,7 +118,6 @@ export const sanitizeHierarchyCollection = (
     slugFieldName: slugField,
     slugPathFieldName,
     titlePathFieldName,
-    usePathAsTitle,
   })
 
   // If collectionSpecific, add beforeValidate hook to enforce scope inheritance

--- a/packages/payload/src/hierarchy/types.ts
+++ b/packages/payload/src/hierarchy/types.ts
@@ -165,8 +165,7 @@ export type SanitizedHierarchyConfig = {
   slugPathFieldName: string
   /**
    * The real content field used as each ancestor's title segment when building paths.
-   * Stored explicitly so path-building code uses the correct field even when
-   * admin.useAsTitle is overridden to the virtual title path field (usePathAsTitle).
+   * Typically matches admin.useAsTitle.
    */
   titleField: string
   titlePathFieldName: string

--- a/packages/payload/src/hierarchy/types.ts
+++ b/packages/payload/src/hierarchy/types.ts
@@ -41,6 +41,13 @@ export type HierarchyConfig = {
      */
     injectSidebarTab?: boolean
     /**
+     * Separator used to join ancestor labels for title paths.
+     * This affects human-readable title paths only (_h_titlePath by default),
+     * not slug paths.
+     * @default ' > '
+     */
+    labelSeparator?: string
+    /**
      * Maximum number of items to load in tree views
      * @default 100
      */
@@ -51,6 +58,15 @@ export type HierarchyConfig = {
      * @default true
      */
     useHeaderButton?: boolean
+    /**
+     * When true, overrides admin.useAsTitle to the title path field (_h_titlePath by default).
+     * This causes the document header and relationship pills to display the full ancestor path
+     * (e.g. "Acme Corp > Engineering Division > Frontend Team") instead of just the document's
+     * own title. The real title field (original admin.useAsTitle) continues to be used as
+     * each ancestor's label when building the path.
+     * @default false
+     */
+    usePathAsTitle?: boolean
   }
   /**
    * Whether related documents can have multiple values of this hierarchy
@@ -121,8 +137,10 @@ export type SanitizedHierarchyConfig = {
       SmallIcon: PayloadComponent
     }
     injectSidebarTab: boolean
+    labelSeparator: string
     treeLimit: number
     useHeaderButton: boolean
+    usePathAsTitle: boolean
   }
   allowHasMany: boolean
   collectionSpecific:
@@ -145,6 +163,12 @@ export type SanitizedHierarchyConfig = {
   slugField?: string
   slugify: (text: string) => string
   slugPathFieldName: string
+  /**
+   * The real content field used as each ancestor's title segment when building paths.
+   * Stored explicitly so path-building code uses the correct field even when
+   * admin.useAsTitle is overridden to the virtual title path field (usePathAsTitle).
+   */
+  titleField: string
   titlePathFieldName: string
 }
 

--- a/packages/payload/src/hierarchy/utils/buildLocalizedHierarchyPaths.ts
+++ b/packages/payload/src/hierarchy/utils/buildLocalizedHierarchyPaths.ts
@@ -28,6 +28,11 @@ type BuildLocalizedPathsArgs = {
    */
   slugValue?: Record<string, string>
   /**
+   * Separator used to join human-readable title segments.
+   * Does not affect slug path joining.
+   */
+  titleSeparator?: string
+  /**
    * The localized title value object (e.g., { en: "Home", es: "Inicio", de: "Startseite" })
    */
   titleValue: Record<string, string>
@@ -80,7 +85,15 @@ type BuildLocalizedPathsResult = {
 export function buildLocalizedHierarchyPaths(
   args: BuildLocalizedPathsArgs,
 ): BuildLocalizedPathsResult {
-  const { parentSlugPath, parentTitlePath, req, slugify, slugValue, titleValue } = args
+  const {
+    parentSlugPath,
+    parentTitlePath,
+    req,
+    slugify,
+    slugValue,
+    titleSeparator = ' > ',
+    titleValue,
+  } = args
 
   const slugPathsByLocale: Record<string, string> = {}
   const titlePathsByLocale: Record<string, string> = {}
@@ -115,7 +128,7 @@ export function buildLocalizedHierarchyPaths(
         ? `${parentSlugPath[loc]}/${slugSegment}`
         : slugSegment
       titlePathsByLocale[loc] = parentTitlePath
-        ? `${parentTitlePath[loc]}/${titleSegment}`
+        ? `${parentTitlePath[loc]}${titleSeparator}${titleSegment}`
         : titleSegment
     }
   }

--- a/packages/payload/src/hierarchy/utils/computePaths.ts
+++ b/packages/payload/src/hierarchy/utils/computePaths.ts
@@ -128,7 +128,23 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
   const slugify =
     (collection.hierarchy !== false && collection.hierarchy.slugify) ||
     ((text: string) => payloadSlugify(text) || '')
-  const { localized: isTitleLocalized, titleFieldName } = findUseAsTitleField(collection)
+  const titleSeparator =
+    collection.hierarchy !== false ? collection.hierarchy.admin.labelSeparator : ' > '
+
+  // Use the stored real title field from hierarchy config when available.
+  // This handles the usePathAsTitle case where admin.useAsTitle has been overridden
+  // to the virtual path field — findUseAsTitleField would return the wrong field.
+  let titleFieldName: string
+  let isTitleLocalized: boolean
+  if (collection.hierarchy !== false && collection.hierarchy.titleField) {
+    titleFieldName = collection.hierarchy.titleField
+    const fieldInfo = findFieldByName(collection, titleFieldName)
+    isTitleLocalized = fieldInfo?.localized ?? false
+  } else {
+    const titleInfo = findUseAsTitleField(collection)
+    titleFieldName = titleInfo.titleFieldName
+    isTitleLocalized = titleInfo.localized
+  }
 
   // Check for dedicated slug field
   const slugFieldName = collection.hierarchy !== false ? collection.hierarchy.slugField : undefined
@@ -202,6 +218,7 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
           req,
           slugify,
           slugValue: slugValue as Record<string, string> | undefined,
+          titleSeparator,
           titleValue: titleValue as Record<string, string>,
         })
       }
@@ -235,17 +252,23 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
         context.hierarchyCacheStats.queries += 1
       }
 
-      const parentTitleField = findUseAsTitleField(parentCollectionConfig).titleFieldName
+      const parentTitleField =
+        (parentCollectionConfig.hierarchy !== false &&
+          parentCollectionConfig.hierarchy.titleField) ||
+        findUseAsTitleField(parentCollectionConfig).titleFieldName
 
       // parentID is guaranteed to be defined here (we're inside if (parentID))
       const validParentID = parentID
 
-      // Create new context with computeHierarchyPaths enabled to trigger recursive path computation
+      // Create new context with hierarchy.computePaths enabled to trigger recursive path computation
       const parentReq = {
         ...req,
         context: {
           ...req.context,
-          computeHierarchyPaths: true,
+          hierarchy: {
+            ...((req.context as { hierarchy?: { computePaths?: boolean } })?.hierarchy || {}),
+            computePaths: true,
+          },
         },
       }
 
@@ -293,12 +316,16 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
 
             // Fetch parent for each locale to get paths
             for (const loc of locales) {
-              // Create a new request with this specific locale but keep computeHierarchyPaths flag
+              // Create a new request with this specific locale but keep hierarchy.computePaths flag
               const localeReq = {
                 ...req,
                 context: {
                   ...req.context,
-                  computeHierarchyPaths: true,
+                  hierarchy: {
+                    ...((req.context as { hierarchy?: { computePaths?: boolean } })?.hierarchy ||
+                      {}),
+                    computePaths: true,
+                  },
                 },
                 locale: loc,
               }
@@ -420,6 +447,7 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
           req,
           slugify,
           slugValue: slugValue as Record<string, string> | undefined,
+          titleSeparator,
           titleValue: titleValue as Record<string, string>,
         })
       }
@@ -507,6 +535,7 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
         req,
         slugify,
         slugValue: docSlugValue as Record<string, string> | undefined,
+        titleSeparator,
         titleValue: docTitle as Record<string, string>,
       })
 
@@ -537,7 +566,8 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
 
     const result = {
       slugPath: (parent[parentSlugPathFieldName] as string) + '/' + slugSegment,
-      titlePath: (parent[parentTitlePathFieldName] as string) + '/' + (docTitle as string),
+      titlePath:
+        (parent[parentTitlePathFieldName] as string) + titleSeparator + (docTitle as string),
     }
 
     // Update cache with computed paths
@@ -577,6 +607,7 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
         req,
         slugify,
         slugValue: rootSlugValue as Record<string, string> | undefined,
+        titleSeparator,
         titleValue: titleValue as Record<string, string>,
       })
     }

--- a/packages/payload/src/hierarchy/utils/computePaths.ts
+++ b/packages/payload/src/hierarchy/utils/computePaths.ts
@@ -131,9 +131,8 @@ export async function computePaths(args: ComputePathsArgs): Promise<ComputePaths
   const titleSeparator =
     collection.hierarchy !== false ? collection.hierarchy.admin.labelSeparator : ' > '
 
-  // Use the stored real title field from hierarchy config when available.
-  // This handles the usePathAsTitle case where admin.useAsTitle has been overridden
-  // to the virtual path field — findUseAsTitleField would return the wrong field.
+  // Use the stored real title field from hierarchy config when available (optimization
+  // to avoid re-traversing collection fields on every path computation).
   let titleFieldName: string
   let isTitleLocalized: boolean
   if (collection.hierarchy !== false && collection.hierarchy.titleField) {

--- a/packages/ui/src/elements/Hierarchy/Modal/useHierarchyModal.tsx
+++ b/packages/ui/src/elements/Hierarchy/Modal/useHierarchyModal.tsx
@@ -75,7 +75,7 @@ export const useHierarchyModal: UseHierarchyModal = ({
     collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
       ? collectionConfig.hierarchy
       : undefined
-  const useAsTitle = hierarchyConfig?.titleField || collectionConfig?.admin?.useAsTitle
+  const useAsTitle = collectionConfig?.admin?.useAsTitle
   const parentFieldName = hierarchyConfig?.parentFieldName
 
   // Use explicit prop if provided, otherwise fall back to allowedCollections from context

--- a/packages/ui/src/elements/Hierarchy/Modal/useHierarchyModal.tsx
+++ b/packages/ui/src/elements/Hierarchy/Modal/useHierarchyModal.tsx
@@ -71,11 +71,11 @@ export const useHierarchyModal: UseHierarchyModal = ({
   const { allowedCollections, baseFilter } = useHierarchy()
   const collectionConfig = getEntityConfig({ collectionSlug: hierarchyCollectionSlug })
 
-  const useAsTitle = collectionConfig?.admin?.useAsTitle
   const hierarchyConfig =
     collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
       ? collectionConfig.hierarchy
       : undefined
+  const useAsTitle = hierarchyConfig?.titleField || collectionConfig?.admin?.useAsTitle
   const parentFieldName = hierarchyConfig?.parentFieldName
 
   // Use explicit prop if provided, otherwise fall back to allowedCollections from context

--- a/packages/ui/src/elements/Hierarchy/Search/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/Search/index.tsx
@@ -37,7 +37,7 @@ export const HierarchySearch: React.FC<HierarchySearchProps> = ({
     collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
       ? collectionConfig.hierarchy
       : null
-  const titleField = hierarchyConfig?.titleField || collectionConfig?.admin?.useAsTitle || 'id'
+  const titleField = collectionConfig?.admin?.useAsTitle || 'id'
 
   const { clearResults, hasNextPage, isLoading, loadMore, results, search, totalDocs } =
     useHierarchySearch({

--- a/packages/ui/src/elements/Hierarchy/Search/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/Search/index.tsx
@@ -32,12 +32,12 @@ export const HierarchySearch: React.FC<HierarchySearchProps> = ({
   const [inputValue, setInputValue] = useState('')
 
   const collectionConfig = getEntityConfig({ collectionSlug })
-  const titleField = collectionConfig?.admin?.useAsTitle || 'id'
   const collectionLabel = getTranslation(collectionConfig?.labels?.plural, i18n)
   const hierarchyConfig =
     collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
       ? collectionConfig.hierarchy
       : null
+  const titleField = hierarchyConfig?.titleField || collectionConfig?.admin?.useAsTitle || 'id'
 
   const { clearResults, hasNextPage, isLoading, loadMore, results, search, totalDocs } =
     useHierarchySearch({

--- a/packages/ui/src/elements/Hierarchy/Search/useHierarchySearch.ts
+++ b/packages/ui/src/elements/Hierarchy/Search/useHierarchySearch.ts
@@ -64,7 +64,9 @@ export const useHierarchySearch = ({
       try {
         const queryString = qs.stringify(
           {
-            computeHierarchyPaths: true,
+            hierarchy: {
+              computePaths: true,
+            },
             limit,
             locale,
             page: pageToFetch,

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
@@ -97,7 +97,8 @@ export const HierarchySidebarTabServer: React.FC<HierarchySidebarTabServerProps>
       hierarchyConfig?.collectionSpecific && typeof hierarchyConfig.collectionSpecific === 'object'
         ? hierarchyConfig.collectionSpecific.fieldName
         : undefined
-    useAsTitle = collectionConfig?.admin?.useAsTitle
+    // Use the real content field (not _h_titlePath) so nodes show plain names in the sidebar tree
+    useAsTitle = hierarchyConfig?.titleField ?? collectionConfig?.admin?.useAsTitle
 
     // STEP 2.5: Build collection-specific options from related collections
     if (hierarchyConfig.collectionSpecific && hierarchyConfig?.relatedCollections) {

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
@@ -97,8 +97,8 @@ export const HierarchySidebarTabServer: React.FC<HierarchySidebarTabServerProps>
       hierarchyConfig?.collectionSpecific && typeof hierarchyConfig.collectionSpecific === 'object'
         ? hierarchyConfig.collectionSpecific.fieldName
         : undefined
-    // Use the real content field (not _h_titlePath) so nodes show plain names in the sidebar tree
-    useAsTitle = hierarchyConfig?.titleField ?? collectionConfig?.admin?.useAsTitle
+    // Sidebar tree shows plain names, not full paths
+    useAsTitle = collectionConfig?.admin?.useAsTitle
 
     // STEP 2.5: Build collection-specific options from related collections
     if (hierarchyConfig.collectionSpecific && hierarchyConfig?.relatedCollections) {

--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -55,9 +55,6 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
     breakpoints: { s: smallBreak },
   } = useWindowInfo()
 
-  // Simplified placeholder - just "Search" instead of "Search by X, Y, Z"
-  const searchLabelTranslated = t('general:searchBy', { label: '' }).split(' ')[0]
-
   const hasWhereParam = useRef(Boolean(query?.where))
 
   const [visibleDrawer, setVisibleDrawer] = useState<'columns' | 'sort' | 'where'>(
@@ -83,7 +80,6 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
         <div className={`${baseClass}__left`}>
           <ListSearchFilter
             key={collectionSlug}
-            label={searchLabelTranslated}
             onSearchChange={handleSearchChange}
             searchQueryParam={query?.search}
           />

--- a/packages/ui/src/elements/Search/ListSearchFilter/index.tsx
+++ b/packages/ui/src/elements/Search/ListSearchFilter/index.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 
 import { useDebounce } from '../../../hooks/useDebounce.js'
+import { useTranslation } from '../../../providers/Translation/index.js'
 import { SearchInput } from '../SearchInput/index.js'
 
 type ListSearchFilterProps = {
@@ -16,18 +17,21 @@ type ListSearchFilterProps = {
 export function ListSearchFilter({
   className,
   disabled,
-  label = 'Search...',
+  label: labelFromProps,
   onSearchChange,
   searchQueryParam,
 }: ListSearchFilterProps) {
   const [search, setSearch] = useState(
     typeof searchQueryParam === 'string' ? searchQueryParam : undefined,
   )
+  const { t } = useTranslation()
 
   const shouldUpdateState = useRef(true)
   const previousSearch = useRef(typeof searchQueryParam === 'string' ? searchQueryParam : undefined)
 
   const debouncedSearch = useDebounce(search, 300)
+
+  const label = labelFromProps || t('general:searchBy', { label: '' }).split(' ')[0] // Simplified placeholder - just "Search" instead of "Search by X, Y, Z"
 
   useEffect(() => {
     if (searchQueryParam !== previousSearch.current) {

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Hierarchy/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Hierarchy/index.tsx
@@ -208,9 +208,24 @@ export const HierarchyCell: React.FC<HierarchyCellProps> = ({
     return values.map(({ relationTo: rel, value }) => {
       const document = documents[rel]?.[value]
       const relatedCollection = getEntityConfig({ collectionSlug: rel })
+      const relatedHierarchyConfig =
+        relatedCollection?.hierarchy && typeof relatedCollection.hierarchy === 'object'
+          ? relatedCollection.hierarchy
+          : undefined
+      const relatedTitleField = relatedHierarchyConfig?.titleField
+      const formattedCollectionConfig =
+        relatedTitleField && relatedCollection
+          ? {
+              ...relatedCollection,
+              admin: {
+                ...relatedCollection.admin,
+                useAsTitle: relatedTitleField,
+              },
+            }
+          : relatedCollection
 
       return formatDocTitle({
-        collectionConfig: relatedCollection,
+        collectionConfig: formattedCollectionConfig,
         data: document || null,
         dateFormat: config.admin.dateFormat,
         fallback: `${t('general:untitled')} - ID: ${value}`,

--- a/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
+++ b/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
@@ -80,15 +80,6 @@ export const RelationshipProvider: React.FC<{ readonly children?: React.ReactNod
 
           select[fieldToSelect] = true
 
-          const hierarchyConfig =
-            collection.hierarchy && typeof collection.hierarchy === 'object'
-              ? collection.hierarchy
-              : undefined
-
-          if (hierarchyConfig?.titleField) {
-            select[hierarchyConfig.titleField] = true
-          }
-
           if (collection.upload) {
             appendUploadSelectFields({ collectionConfig: collection, select })
           }

--- a/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
+++ b/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
@@ -80,6 +80,15 @@ export const RelationshipProvider: React.FC<{ readonly children?: React.ReactNod
 
           select[fieldToSelect] = true
 
+          const hierarchyConfig =
+            collection.hierarchy && typeof collection.hierarchy === 'object'
+              ? collection.hierarchy
+              : undefined
+
+          if (hierarchyConfig?.titleField) {
+            select[hierarchyConfig.titleField] = true
+          }
+
           if (collection.upload) {
             appendUploadSelectFields({ collectionConfig: collection, select })
           }

--- a/packages/ui/src/providers/DocumentTitle/index.tsx
+++ b/packages/ui/src/providers/DocumentTitle/index.tsx
@@ -1,4 +1,4 @@
-import type { ClientCollectionConfig, ClientGlobalConfig } from 'payload'
+import type { ClientCollectionConfig, ClientGlobalConfig, TypeWithID } from 'payload'
 
 import { createContext, use, useEffect, useState } from 'react'
 
@@ -25,7 +25,7 @@ function resolveDocTitle({
   i18n,
 }: {
   collectionConfig?: ClientCollectionConfig
-  data: Record<string, unknown>
+  data: TypeWithID
   dateFormat: string
   fallback?: string
   globalConfig?: ClientGlobalConfig

--- a/packages/ui/src/providers/DocumentTitle/index.tsx
+++ b/packages/ui/src/providers/DocumentTitle/index.tsx
@@ -16,6 +16,43 @@ const Context = createContext({} as DocumentTitleContext)
 
 export const useDocumentTitle = (): DocumentTitleContext => use(Context)
 
+function resolveDocTitle({
+  collectionConfig,
+  data,
+  dateFormat,
+  fallback,
+  globalConfig,
+  i18n,
+}: {
+  collectionConfig?: ClientCollectionConfig
+  data: Record<string, unknown>
+  dateFormat: string
+  fallback?: string
+  globalConfig?: ClientGlobalConfig
+  i18n: ReturnType<typeof useTranslation>['i18n']
+}): string {
+  const hierarchyConfig =
+    collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
+      ? collectionConfig.hierarchy
+      : undefined
+
+  if (hierarchyConfig?.admin?.usePathAsTitle && hierarchyConfig.titlePathFieldName) {
+    const pathTitle = data[hierarchyConfig.titlePathFieldName]
+    if (typeof pathTitle === 'string' && pathTitle) {
+      return pathTitle
+    }
+  }
+
+  return formatDocTitle({
+    collectionConfig,
+    data,
+    dateFormat,
+    fallback,
+    globalConfig,
+    i18n,
+  })
+}
+
 export const DocumentTitleProvider: React.FC<{
   children: React.ReactNode
 }> = ({ children }) => {
@@ -29,29 +66,42 @@ export const DocumentTitleProvider: React.FC<{
 
   const { i18n } = useTranslation()
 
+  const collectionConfig = collectionSlug ? (docConfig as ClientCollectionConfig) : undefined
+  const globalConfig = globalSlug ? (docConfig as ClientGlobalConfig) : undefined
+
   const [title, setDocumentTitle] = useState(() =>
-    formatDocTitle({
-      collectionConfig: collectionSlug ? (docConfig as ClientCollectionConfig) : undefined,
+    resolveDocTitle({
+      collectionConfig,
       data: { ...(initialData || {}), id },
       dateFormat,
       fallback: id?.toString(),
-      globalConfig: globalSlug ? (docConfig as ClientGlobalConfig) : undefined,
+      globalConfig,
       i18n,
     }),
   )
 
   useEffect(() => {
     setDocumentTitle(
-      formatDocTitle({
-        collectionConfig: collectionSlug ? (docConfig as ClientCollectionConfig) : undefined,
+      resolveDocTitle({
+        collectionConfig,
         data: { ...data, id },
         dateFormat,
         fallback: id?.toString(),
-        globalConfig: globalSlug ? (docConfig as ClientGlobalConfig) : undefined,
+        globalConfig,
         i18n,
       }),
     )
-  }, [data, dateFormat, i18n, id, collectionSlug, docConfig, globalSlug])
+  }, [
+    data,
+    dateFormat,
+    i18n,
+    id,
+    collectionSlug,
+    docConfig,
+    globalSlug,
+    collectionConfig,
+    globalConfig,
+  ])
 
   return <Context value={{ setDocumentTitle, title }}>{children}</Context>
 }

--- a/packages/ui/src/utilities/getDocumentData.ts
+++ b/packages/ui/src/utilities/getDocumentData.ts
@@ -35,6 +35,13 @@ export const getDocumentData = async ({
   const { transactionID, ...rest } = req
 
   const isTrashedDoc = segments?.[2] === 'trash' && typeof segments?.[3] === 'string' // id exists at segment 3
+  const hierarchyConfig =
+    collectionSlug &&
+    payload.collections[collectionSlug]?.config.hierarchy &&
+    typeof payload.collections[collectionSlug]?.config.hierarchy === 'object'
+      ? payload.collections[collectionSlug]?.config.hierarchy
+      : undefined
+  const shouldComputeHierarchyPaths = hierarchyConfig?.admin?.usePathAsTitle === true
 
   try {
     if (collectionSlug && id) {
@@ -48,6 +55,20 @@ export const getDocumentData = async ({
         overrideAccess: false,
         req: {
           ...rest,
+          context: shouldComputeHierarchyPaths
+            ? {
+                ...(rest.context || {}),
+                hierarchy: {
+                  ...(rest.context &&
+                  typeof rest.context === 'object' &&
+                  'hierarchy' in rest.context &&
+                  typeof rest.context.hierarchy === 'object'
+                    ? rest.context.hierarchy
+                    : {}),
+                  computePaths: true,
+                },
+              }
+            : rest.context,
         },
         trash: isTrashedDoc ? true : false,
         user,

--- a/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
@@ -16,9 +16,23 @@ export const SetDocumentTitle: React.FC<{
 }> = (props) => {
   const { collectionConfig, config, fallback, globalConfig } = props
 
+  const hierarchyConfig =
+    collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
+      ? collectionConfig.hierarchy
+      : undefined
+
   const useAsTitle = collectionConfig?.admin?.useAsTitle
 
-  const field = useFormFields(([fields]) => (useAsTitle && fields && fields?.[useAsTitle]) || null)
+  // When usePathAsTitle is enabled, watch the virtual path field for real-time title updates.
+  // Since it's read-only/virtual, it only updates after a server save.
+  const fieldNameToWatch =
+    (hierarchyConfig?.admin?.usePathAsTitle && hierarchyConfig.titlePathFieldName) ||
+    useAsTitle ||
+    ''
+
+  const field = useFormFields(
+    ([fields]) => (fieldNameToWatch && fields && fields?.[fieldNameToWatch]) || null,
+  )
 
   const hasInitialized = useRef(false)
 
@@ -28,14 +42,19 @@ export const SetDocumentTitle: React.FC<{
 
   const dateFormatFromConfig = config?.admin?.dateFormat
 
-  const title = formatDocTitle({
-    collectionConfig,
-    data: { id: '', [useAsTitle]: field?.value || '' },
-    dateFormat: dateFormatFromConfig,
-    fallback,
-    globalConfig,
-    i18n,
-  })
+  let title: string
+  if (hierarchyConfig?.admin?.usePathAsTitle && typeof field?.value === 'string' && field.value) {
+    title = field.value
+  } else {
+    title = formatDocTitle({
+      collectionConfig,
+      data: { id: '', [useAsTitle || '']: field?.value || '' },
+      dateFormat: dateFormatFromConfig,
+      fallback,
+      globalConfig,
+      i18n,
+    })
+  }
 
   useEffect(() => {
     if (!hasInitialized.current) {

--- a/packages/ui/src/views/HierarchyList/HierarchyTable/ChildNameCell.tsx
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/ChildNameCell.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import type { SlotColumn } from './SlotTable.js'
 import type { TableRow } from './types.js'
 
+import { Button } from '../../../elements/Button/index.js'
 import { Link } from '../../../elements/Link/index.js'
 import { ChevronIcon } from '../../../icons/Chevron/index.js'
 import { EditIcon } from '../../../icons/Edit/index.js'
@@ -54,20 +55,25 @@ export const ChildNameCell: SlotColumn<TableRow>['Cell'] = ({ row }) => {
     <div className={`${baseClass}__name-cell`}>
       <Link className={`${baseClass}__name-link`} href={hierarchyURL}>
         <span className={`${baseClass}__name-icon`}>{row._hierarchyIcon || DefaultIcon}</span>
-        <span className={`${baseClass}__name-text`}>{title}</span>
+        <span className={`${baseClass}__name-label`}>
+          <span className={`${baseClass}__name-text-truncated`}>{title}</span>
+        </span>
         {row._hasChildren && (
           <span className={`${baseClass}__chevron`}>
             <ChevronIcon direction="right" />
           </span>
         )}
       </Link>
-      <Link
+      <Button
         aria-label={t('general:editLabel', { label: title })}
+        buttonStyle="ghost"
         className={`${baseClass}__edit-button`}
-        href={documentURL}
-      >
-        <EditIcon />
-      </Link>
+        el="link"
+        icon={<EditIcon size={16} />}
+        margin={false}
+        size="medium"
+        to={documentURL}
+      />
     </div>
   )
 }

--- a/packages/ui/src/views/HierarchyList/HierarchyTable/RelatedNameCell.tsx
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/RelatedNameCell.tsx
@@ -81,7 +81,9 @@ export const RelatedNameCell: SlotColumn<TableRow>['Cell'] = ({ row }) => {
   return (
     <Link className={`${baseClass}__name-link`} href={editUrl}>
       <RelatedDocIcon collectionSlug={row._collectionSlug} row={row} />
-      <span className={`${baseClass}__name-text`}>{title}</span>
+      <span className={`${baseClass}__name-label`}>
+        <span className={`${baseClass}__name-text-truncated`}>{title}</span>
+      </span>
     </Link>
   )
 }

--- a/packages/ui/src/views/HierarchyList/HierarchyTable/index.css
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/index.css
@@ -30,6 +30,7 @@
     display: flex;
     align-items: center;
     gap: var(--spacer-2);
+    min-width: 0;
     color: var(--color-text);
     text-decoration: none;
     background: none;
@@ -43,7 +44,10 @@
 
     &:hover {
       color: var(--color-text);
-      text-decoration: underline;
+
+      .hierarchy-tables__name-label {
+        text-decoration-color: var(--color-text);
+      }
     }
   }
 
@@ -60,11 +64,23 @@
     flex-shrink: 0;
   }
 
-  .hierarchy-tables__name-text {
+  .hierarchy-tables__name-text-truncated {
+    line-height: var(--spacer-3);
+    min-width: 0;
+    flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    line-height: var(--spacer-3);
+  }
+
+  .hierarchy-tables__name-label {
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-skip-ink: none;
+    text-decoration-color: var(--color-border);
+    text-decoration-thickness: auto;
+    text-underline-offset: 2px;
+    text-underline-position: from-font;
   }
 
   .hierarchy-tables__chevron {

--- a/packages/ui/src/views/HierarchyList/index.tsx
+++ b/packages/ui/src/views/HierarchyList/index.tsx
@@ -355,9 +355,6 @@ export function HierarchyListView(props: ListViewClientProps) {
             <ListControlsBar className={`${baseClass}__controls`}>
               <div className={`${baseClass}__controls-left`}>
                 <ListSearchFilter
-                  label={t('general:searchBy', {
-                    label: getTranslation(collectionConfig?.admin?.useAsTitle || 'id', i18n),
-                  })}
                   onSearchChange={handleSearchChange}
                   searchQueryParam={searchFromURL}
                 />

--- a/packages/ui/src/views/List/extractRelationshipDisplayValue.ts
+++ b/packages/ui/src/views/List/extractRelationshipDisplayValue.ts
@@ -13,19 +13,13 @@ export const extractRelationshipDisplayValue = (
   // Handle polymorphic relationships
   if (typeof relationship === 'object' && relationship?.relationTo && relationship?.value) {
     const config = clientConfig.collections.find((c) => c.slug === relationship.relationTo)
-    const hierarchyConfig =
-      config?.hierarchy && typeof config.hierarchy === 'object' ? config.hierarchy : undefined
-    const useAsTitle = hierarchyConfig?.titleField || config?.admin?.useAsTitle || 'id'
+    const useAsTitle = config?.admin?.useAsTitle || 'id'
     return relationship.value?.[useAsTitle] || ''
   }
 
   // Handle regular relationships
   if (typeof relationship === 'object' && relationship?.id) {
-    const hierarchyConfig =
-      relationshipConfig?.hierarchy && typeof relationshipConfig.hierarchy === 'object'
-        ? relationshipConfig.hierarchy
-        : undefined
-    const useAsTitle = hierarchyConfig?.titleField || relationshipConfig?.admin?.useAsTitle || 'id'
+    const useAsTitle = relationshipConfig?.admin?.useAsTitle || 'id'
     return relationship[useAsTitle] || ''
   }
 

--- a/packages/ui/src/views/List/extractRelationshipDisplayValue.ts
+++ b/packages/ui/src/views/List/extractRelationshipDisplayValue.ts
@@ -13,12 +13,20 @@ export const extractRelationshipDisplayValue = (
   // Handle polymorphic relationships
   if (typeof relationship === 'object' && relationship?.relationTo && relationship?.value) {
     const config = clientConfig.collections.find((c) => c.slug === relationship.relationTo)
-    return relationship.value?.[config?.admin?.useAsTitle || 'id'] || ''
+    const hierarchyConfig =
+      config?.hierarchy && typeof config.hierarchy === 'object' ? config.hierarchy : undefined
+    const useAsTitle = hierarchyConfig?.titleField || config?.admin?.useAsTitle || 'id'
+    return relationship.value?.[useAsTitle] || ''
   }
 
   // Handle regular relationships
   if (typeof relationship === 'object' && relationship?.id) {
-    return relationship[relationshipConfig?.admin?.useAsTitle || 'id'] || ''
+    const hierarchyConfig =
+      relationshipConfig?.hierarchy && typeof relationshipConfig.hierarchy === 'object'
+        ? relationshipConfig.hierarchy
+        : undefined
+    const useAsTitle = hierarchyConfig?.titleField || relationshipConfig?.admin?.useAsTitle || 'id'
+    return relationship[useAsTitle] || ''
   }
 
   return String(relationship)

--- a/packages/ui/src/views/List/handleGroupBy.ts
+++ b/packages/ui/src/views/List/handleGroupBy.ts
@@ -60,9 +60,7 @@ export const handleGroupBy = async ({
   data: PaginatedDocs
   Table: null | React.ReactNode | React.ReactNode[]
 }> => {
-  const hierarchyConfig =
-    typeof collectionConfig.hierarchy === 'object' ? collectionConfig.hierarchy : undefined
-  const useAsTitle = hierarchyConfig?.titleField || collectionConfig.admin.useAsTitle || 'id'
+  const useAsTitle = collectionConfig.admin.useAsTitle || 'id'
 
   let Table: React.ReactNode | React.ReactNode[] = null
   let columnState: Column[]
@@ -87,10 +85,8 @@ export const handleGroupBy = async ({
     populate = {}
     relationTo.forEach((rel) => {
       const config = clientConfig.collections.find((c) => c.slug === rel)
-      const relatedHierarchyConfig =
-        config?.hierarchy && typeof config.hierarchy === 'object' ? config.hierarchy : undefined
       populate[rel] = {
-        [relatedHierarchyConfig?.titleField || config?.admin?.useAsTitle || 'id']: true,
+        [config?.admin?.useAsTitle || 'id']: true,
       }
     })
   }

--- a/packages/ui/src/views/List/handleGroupBy.ts
+++ b/packages/ui/src/views/List/handleGroupBy.ts
@@ -60,6 +60,10 @@ export const handleGroupBy = async ({
   data: PaginatedDocs
   Table: null | React.ReactNode | React.ReactNode[]
 }> => {
+  const hierarchyConfig =
+    typeof collectionConfig.hierarchy === 'object' ? collectionConfig.hierarchy : undefined
+  const useAsTitle = hierarchyConfig?.titleField || collectionConfig.admin.useAsTitle || 'id'
+
   let Table: React.ReactNode | React.ReactNode[] = null
   let columnState: Column[]
 
@@ -83,7 +87,11 @@ export const handleGroupBy = async ({
     populate = {}
     relationTo.forEach((rel) => {
       const config = clientConfig.collections.find((c) => c.slug === rel)
-      populate[rel] = { [config?.admin?.useAsTitle || 'id']: true }
+      const relatedHierarchyConfig =
+        config?.hierarchy && typeof config.hierarchy === 'object' ? config.hierarchy : undefined
+      populate[rel] = {
+        [relatedHierarchyConfig?.titleField || config?.admin?.useAsTitle || 'id']: true,
+      }
     })
   }
 
@@ -206,7 +214,7 @@ export const handleGroupBy = async ({
           orderableFieldName: collectionConfig.orderable === true ? '_order' : undefined,
           payload: req.payload,
           query,
-          useAsTitle: collectionConfig.admin.useAsTitle,
+          useAsTitle,
           viewType,
         })
 

--- a/packages/ui/src/views/List/handleHierarchy.ts
+++ b/packages/ui/src/views/List/handleHierarchy.ts
@@ -49,7 +49,7 @@ export const handleHierarchy = async ({
 
   const parentFieldName = hierarchyConfig.parentFieldName
 
-  const useAsTitle = hierarchyConfig.titleField || collectionConfig.admin?.useAsTitle || 'id'
+  const useAsTitle = collectionConfig.admin?.useAsTitle || 'id'
 
   // Fetch the parent item and breadcrumbs (skip for root level)
   let parent: null | (Record<string, unknown> & TypeWithID) = null
@@ -208,12 +208,7 @@ export const handleHierarchy = async ({
     }
 
     // Add search filter if provided
-    const relatedHierarchyConfig =
-      relatedCollectionConfig.hierarchy && typeof relatedCollectionConfig.hierarchy === 'object'
-        ? relatedCollectionConfig.hierarchy
-        : undefined
-    const relatedUseAsTitle =
-      relatedHierarchyConfig?.titleField || relatedCollectionConfig.admin?.useAsTitle || 'id'
+    const relatedUseAsTitle = relatedCollectionConfig.admin?.useAsTitle || 'id'
     const whereWithSearch = search
       ? { and: [relationshipWhere, { [relatedUseAsTitle]: { like: search } }] }
       : relationshipWhere

--- a/packages/ui/src/views/List/handleHierarchy.ts
+++ b/packages/ui/src/views/List/handleHierarchy.ts
@@ -49,7 +49,7 @@ export const handleHierarchy = async ({
 
   const parentFieldName = hierarchyConfig.parentFieldName
 
-  const useAsTitle = collectionConfig.admin?.useAsTitle || 'id'
+  const useAsTitle = hierarchyConfig.titleField || collectionConfig.admin?.useAsTitle || 'id'
 
   // Fetch the parent item and breadcrumbs (skip for root level)
   let parent: null | (Record<string, unknown> & TypeWithID) = null
@@ -208,7 +208,12 @@ export const handleHierarchy = async ({
     }
 
     // Add search filter if provided
-    const relatedUseAsTitle = relatedCollectionConfig.admin?.useAsTitle || 'id'
+    const relatedHierarchyConfig =
+      relatedCollectionConfig.hierarchy && typeof relatedCollectionConfig.hierarchy === 'object'
+        ? relatedCollectionConfig.hierarchy
+        : undefined
+    const relatedUseAsTitle =
+      relatedHierarchyConfig?.titleField || relatedCollectionConfig.admin?.useAsTitle || 'id'
     const whereWithSearch = search
       ? { and: [relationshipWhere, { [relatedUseAsTitle]: { like: search } }] }
       : relationshipWhere

--- a/packages/ui/src/views/List/index.client.tsx
+++ b/packages/ui/src/views/List/index.client.tsx
@@ -101,6 +101,11 @@ export function DefaultListView(props: ListViewClientProps) {
   const { modalSlug: bulkUploadModalSlug, setCollectionSlug, setOnSuccess } = useBulkUpload()
 
   const collectionConfig = getEntityConfig({ collectionSlug })
+  const hierarchyConfig =
+    collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
+      ? collectionConfig.hierarchy
+      : undefined
+  const useAsTitle = hierarchyConfig?.titleField || collectionConfig?.admin?.useAsTitle || 'id'
 
   const { labels, upload } = collectionConfig
 
@@ -288,7 +293,7 @@ export function DefaultListView(props: ListViewClientProps) {
                       label: related.label,
                     }),
                   )}
-                  useAsTitle={collectionConfig?.admin?.useAsTitle || 'id'}
+                  useAsTitle={useAsTitle}
                 />
                 <DocumentListSelection
                   disableBulkDelete={disableBulkDelete}

--- a/packages/ui/src/views/List/index.client.tsx
+++ b/packages/ui/src/views/List/index.client.tsx
@@ -105,7 +105,15 @@ export function DefaultListView(props: ListViewClientProps) {
     collectionConfig?.hierarchy && typeof collectionConfig.hierarchy === 'object'
       ? collectionConfig.hierarchy
       : undefined
-  const useAsTitle = hierarchyConfig?.titleField || collectionConfig?.admin?.useAsTitle || 'id'
+  // Use bracket notation to avoid React Compiler flagging `use`-prefixed property accesses
+  // (the compiler treats `obj.useFoo` as a potential hook reference in client components).
+  const hierarchyAdminConfig = hierarchyConfig?.admin as { usePathAsTitle?: boolean } | undefined
+  const pathAsTitle = hierarchyAdminConfig?.['usePathAsTitle']
+  const hierarchyAsRecord = hierarchyConfig as Record<string, unknown> | undefined
+  const titleColumnKey = pathAsTitle
+    ? (hierarchyAsRecord?.['titlePathFieldName'] as string | undefined)
+    : undefined
+  const useAsTitle = titleColumnKey ?? collectionConfig?.admin?.useAsTitle ?? 'id'
 
   const { labels, upload } = collectionConfig
 

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -249,6 +249,9 @@ export const renderListView = async (
   }
 
   const clientCollectionConfig = clientConfig.collections.find((c) => c.slug === collectionSlug)
+  const hierarchyConfig =
+    typeof collectionConfig.hierarchy === 'object' ? collectionConfig.hierarchy : undefined
+  const useAsTitle = hierarchyConfig?.titleField || collectionConfig.admin.useAsTitle || 'id'
 
   const columns = getColumns({
     clientConfig,
@@ -373,7 +376,7 @@ export const renderListView = async (
         payload: req.payload,
         query,
         req,
-        useAsTitle: collectionConfig.admin.useAsTitle,
+        useAsTitle,
         viewType,
       }))
     }

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -251,7 +251,12 @@ export const renderListView = async (
   const clientCollectionConfig = clientConfig.collections.find((c) => c.slug === collectionSlug)
   const hierarchyConfig =
     typeof collectionConfig.hierarchy === 'object' ? collectionConfig.hierarchy : undefined
-  const useAsTitle = hierarchyConfig?.titleField || collectionConfig.admin.useAsTitle || 'id'
+  // When usePathAsTitle is enabled, show the full path as the first (title) column.
+  // Otherwise use the collection's real useAsTitle field.
+  const useAsTitle =
+    (hierarchyConfig?.admin?.usePathAsTitle ? hierarchyConfig.titlePathFieldName : null) ??
+    collectionConfig.admin.useAsTitle ??
+    'id'
 
   const columns = getColumns({
     clientConfig,

--- a/test/hierarchy/config.ts
+++ b/test/hierarchy/config.ts
@@ -115,6 +115,7 @@ export const Departments: CollectionConfig = {
   ],
   hierarchy: {
     admin: {
+      labelSeparator: ' > ',
       components: {
         Icon: {
           clientProps: { color: '#FF6600' }, // Neon Orange
@@ -151,6 +152,26 @@ export const Divisions: CollectionConfig = {
   versions: false,
 }
 
+// Articles collection (no hierarchy) - used to test relationship pills pointing at hierarchy collections
+export const Articles: CollectionConfig = {
+  slug: 'articles',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'organization',
+      type: 'relationship',
+      relationTo: 'organizations',
+    },
+  ],
+}
+
 // Organizations collection with hierarchy (main test collection)
 export const Organizations: CollectionConfig = {
   slug: 'organizations',
@@ -177,6 +198,7 @@ export const Organizations: CollectionConfig = {
           path: '/components/ColorCircleIcon.tsx#ColorCircleIcon',
         },
       },
+      usePathAsTitle: true,
     },
     parentFieldName: 'parent',
   },
@@ -256,6 +278,7 @@ export default buildConfigWithDefaults({
     },
   },
   collections: [
+    Articles,
     Categories,
     Departments,
     Divisions,

--- a/test/hierarchy/config.ts
+++ b/test/hierarchy/config.ts
@@ -218,6 +218,7 @@ export const Folders: CollectionConfig = {
           path: '/components/ColorCircleIcon.tsx#ColorCircleIcon',
         },
       },
+      usePathAsTitle: true,
     },
     collectionSpecific: { fieldName: 'allowedTypes' },
     parentFieldName: 'parentFolder',

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -82,8 +82,8 @@ describe('Hierarchy', () => {
         expect(foldersCollection.hierarchy.admin.usePathAsTitle).toBe(true)
       }
 
-      // admin.useAsTitle should be overridden to the virtual title path field
-      expect(foldersCollection.admin.useAsTitle).toBe('_h_titlePath')
+      // admin.useAsTitle should remain the real content field, never mutated
+      expect(foldersCollection.admin.useAsTitle).toBe('name')
     })
   })
 

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -96,7 +96,7 @@ describe('Hierarchy', () => {
       await payload.delete({ collection: 'folders', where: {} })
     })
 
-    it('should automatically compute _h_titlePath on read without context flag', async () => {
+    it('should not compute _h_titlePath on read without opt-in flags', async () => {
       const parent = await payload.create({
         collection: 'folders',
         data: { name: 'General' },
@@ -107,16 +107,16 @@ describe('Hierarchy', () => {
         data: { name: 'Subfolder', parentFolder: parent.id },
       })
 
-      // Fetch without context.hierarchy.computePaths — should still compute because usePathAsTitle=true
+      // Fetch without any path-compute opt-in flags
       const result = await payload.findByID({
         id: child.id,
         collection: 'folders',
       })
 
-      expect(result._h_titlePath).toBe('General > Subfolder')
+      expect(result._h_titlePath).toBeUndefined()
     })
 
-    it('should set _h_titlePath to document title for root documents', async () => {
+    it('should set _h_titlePath to document title for root documents when opt-in is set', async () => {
       const root = await payload.create({
         collection: 'folders',
         data: { name: 'Root Folder' },
@@ -125,6 +125,7 @@ describe('Hierarchy', () => {
       const result = await payload.findByID({
         id: root.id,
         collection: 'folders',
+        context: { hierarchy: { computePaths: true } },
       })
 
       expect(result._h_titlePath).toBe('Root Folder')

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -61,6 +61,8 @@ describe('Hierarchy', () => {
         expect(deptsCollection.hierarchy.slugPathFieldName).toBe('_breadcrumbSlug')
         // eslint-disable-next-line vitest/no-conditional-expect
         expect(deptsCollection.hierarchy.titlePathFieldName).toBe('_breadcrumbTitle')
+        // eslint-disable-next-line vitest/no-conditional-expect
+        expect(deptsCollection.hierarchy.admin.labelSeparator).toBe(' > ')
       }
 
       // Verify custom path fields were added
@@ -78,6 +80,38 @@ describe('Hierarchy', () => {
       await payload.delete({ collection: 'organizations', where: {} })
     })
 
+    describe('Title Path Label Separator', () => {
+      beforeEach(async () => {
+        await payload.delete({ collection: 'departments', where: {} })
+      })
+
+      afterEach(async () => {
+        await payload.delete({ collection: 'departments', where: {} })
+      })
+
+      it('should use configured label separator for title paths', async () => {
+        const rootDepartment = await payload.create({
+          collection: 'departments',
+          data: {
+            deptName: 'Engineering',
+            parentDept: null,
+          },
+        })
+
+        const childDepartment = await payload.create({
+          collection: 'departments',
+          context: { hierarchy: { computePaths: true } },
+          data: {
+            deptName: 'Platform',
+            parentDept: rootDepartment.id,
+          },
+        })
+
+        expect(childDepartment._breadcrumbSlug).toBe('engineering/platform')
+        expect(childDepartment._breadcrumbTitle).toBe('Engineering > Platform')
+      })
+    })
+
     afterEach(async () => {
       // Clean up data after each test
       await payload.delete({ collection: 'organizations', where: {} })
@@ -86,7 +120,7 @@ describe('Hierarchy', () => {
     it('should compute correct paths for root document', async () => {
       const rootPage = await payload.create({
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: {
           parent: null,
           title: 'Root Page',
@@ -110,7 +144,7 @@ describe('Hierarchy', () => {
       // Create child
       const childPage = await payload.create({
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: {
           parent: rootPage.id,
           title: 'Child',
@@ -118,12 +152,12 @@ describe('Hierarchy', () => {
       })
 
       expect(childPage._h_slugPath).toBe('root/child')
-      expect(childPage._h_titlePath).toBe('Root/Child')
+      expect(childPage._h_titlePath).toBe('Root > Child')
 
       // Create grandchild
       const grandchildPage = await payload.create({
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: {
           parent: childPage.id,
           title: 'Grandchild',
@@ -131,7 +165,7 @@ describe('Hierarchy', () => {
       })
 
       expect(grandchildPage._h_slugPath).toBe('root/child/grandchild')
-      expect(grandchildPage._h_titlePath).toBe('Root/Child/Grandchild')
+      expect(grandchildPage._h_titlePath).toBe('Root > Child > Grandchild')
     })
 
     it('should compute updated paths when parent changes', async () => {
@@ -160,23 +194,23 @@ describe('Hierarchy', () => {
       const updatedChild = await payload.update({
         id: childPage.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: { parent: anotherRoot.id },
       })
 
       // Check child path reflects new parent
       expect(updatedChild._h_slugPath).toBe('another-root/child')
-      expect(updatedChild._h_titlePath).toBe('Another Root/Child')
+      expect(updatedChild._h_titlePath).toBe('Another Root > Child')
 
       // Check grandchild path automatically reflects change (walks up parent chain)
       const updatedGrandchild = await payload.findByID({
         id: grandchildPage.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
       })
 
       expect(updatedGrandchild._h_slugPath).toBe('another-root/child/grandchild')
-      expect(updatedGrandchild._h_titlePath).toBe('Another Root/Child/Grandchild')
+      expect(updatedGrandchild._h_titlePath).toBe('Another Root > Child > Grandchild')
     })
 
     it('should compute updated paths when ancestor title changes', async () => {
@@ -202,11 +236,11 @@ describe('Hierarchy', () => {
       const updatedChild = await payload.findByID({
         id: childPage.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
       })
 
       expect(updatedChild._h_slugPath).toBe('updated-root/child')
-      expect(updatedChild._h_titlePath).toBe('Updated Root/Child')
+      expect(updatedChild._h_titlePath).toBe('Updated Root > Child')
     })
 
     it('should handle moving to root level', async () => {
@@ -225,7 +259,7 @@ describe('Hierarchy', () => {
       const updatedChild = await payload.update({
         id: childPage.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: { parent: null },
       })
 
@@ -323,7 +357,7 @@ describe('Hierarchy', () => {
       const updated = await payload.update({
         id: child.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: { parent: page2.id },
         depth: 0,
       })
@@ -413,7 +447,7 @@ describe('Hierarchy', () => {
     it('should use custom field names for path fields', async () => {
       const parentDept = await payload.create({
         collection: 'departments',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: { deptName: 'Engineering' },
       })
 
@@ -422,7 +456,7 @@ describe('Hierarchy', () => {
 
       const childDept = await payload.create({
         collection: 'departments',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: {
           deptName: 'Frontend',
           parentDept: parentDept.id,
@@ -430,7 +464,7 @@ describe('Hierarchy', () => {
       })
 
       expect(childDept._breadcrumbSlug).toBe('engineering/frontend')
-      expect(childDept._breadcrumbTitle).toBe('Engineering/Frontend')
+      expect(childDept._breadcrumbTitle).toBe('Engineering > Frontend')
     })
   })
 
@@ -452,7 +486,7 @@ describe('Hierarchy', () => {
       for (let i = 0; i < 10; i++) {
         currentParent = await payload.create({
           collection: 'organizations',
-          context: { computeHierarchyPaths: true },
+          context: { hierarchy: { computePaths: true } },
           data: {
             parent: currentParent?.id || null,
             title: `Level ${i}`,
@@ -513,7 +547,7 @@ describe('Hierarchy', () => {
       const publishedChild = await payload.findByID({
         id: child.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         draft: false,
       })
 
@@ -523,7 +557,7 @@ describe('Hierarchy', () => {
       const draftChild = await payload.findByID({
         id: child.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         draft: true,
       })
 
@@ -556,7 +590,7 @@ describe('Hierarchy', () => {
       const publishedChild = await payload.findByID({
         id: child.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
       })
 
       expect(publishedChild._h_slugPath).toBe('offerings/services/consulting')
@@ -566,7 +600,7 @@ describe('Hierarchy', () => {
       const draftChild = await payload.findByID({
         id: child.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         draft: true,
       })
 
@@ -604,7 +638,7 @@ describe('Hierarchy', () => {
       const draftChild = await payload.findByID({
         id: child.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         draft: true,
       })
 
@@ -638,7 +672,7 @@ describe('Hierarchy', () => {
       const updatedChild = await payload.findByID({
         id: child.id,
         collection: 'organizations',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
       })
 
       expect(updatedChild._h_slugPath).toBe('tech/electronics/phones')
@@ -701,7 +735,7 @@ describe('Hierarchy', () => {
       const childWithAllLocales = await payload.findByID({
         id: child.id,
         collection: 'products',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         locale: 'all',
       })
 
@@ -713,9 +747,9 @@ describe('Hierarchy', () => {
       })
 
       expect(childWithAllLocales._h_titlePath).toEqual({
-        de: 'Kleidung/Hemden',
-        en: 'Clothing/Shirts',
-        es: 'Ropa/Camisas',
+        de: 'Kleidung > Hemden',
+        en: 'Clothing > Shirts',
+        es: 'Ropa > Camisas',
       })
     })
 
@@ -800,7 +834,7 @@ describe('Hierarchy', () => {
       const updatedChild = await payload.findByID({
         id: child.id,
         collection: 'products',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         locale: 'all',
       })
 
@@ -811,9 +845,9 @@ describe('Hierarchy', () => {
       })
 
       expect(updatedChild._h_titlePath).toEqual({
-        de: 'Bekleidung/Kleidung/Hemden',
-        en: 'Apparel/Clothing/Shirts',
-        es: 'Indumentaria/Ropa/Camisas',
+        de: 'Bekleidung > Kleidung > Hemden',
+        en: 'Apparel > Clothing > Shirts',
+        es: 'Indumentaria > Ropa > Camisas',
       })
     })
 
@@ -890,7 +924,7 @@ describe('Hierarchy', () => {
       const updatedChild = await payload.findByID({
         id: child.id,
         collection: 'products',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         locale: 'all',
       })
 
@@ -901,9 +935,9 @@ describe('Hierarchy', () => {
       })
 
       expect(updatedChild._h_titlePath).toEqual({
-        de: 'Bekleidung/Hemden',
-        en: 'Apparel/Shirts',
-        es: 'Indumentaria/Camisas',
+        de: 'Bekleidung > Hemden',
+        en: 'Apparel > Shirts',
+        es: 'Indumentaria > Camisas',
       })
     })
 
@@ -1015,7 +1049,7 @@ describe('Hierarchy', () => {
       const publishedChild = await payload.findByID({
         id: child.id,
         collection: 'products',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         locale: 'all',
       })
 
@@ -1029,7 +1063,7 @@ describe('Hierarchy', () => {
       const draftChild = await payload.findByID({
         id: child.id,
         collection: 'products',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         draft: true,
         locale: 'all',
       })
@@ -1131,7 +1165,7 @@ describe('Hierarchy', () => {
       const draftChild = await payload.findByID({
         id: child.id,
         collection: 'products',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         draft: true,
         locale: 'all',
       })
@@ -1143,9 +1177,9 @@ describe('Hierarchy', () => {
       })
 
       expect(draftChild._h_titlePath).toEqual({
-        de: 'Fahrplan/Zukunft/Pläne',
-        en: 'Roadmap/Future/Plans',
-        es: 'Hoja de Ruta/Futuro/Planes',
+        de: 'Fahrplan > Zukunft > Pläne',
+        en: 'Roadmap > Future > Plans',
+        es: 'Hoja de Ruta > Futuro > Planes',
       })
     })
   })
@@ -1192,7 +1226,7 @@ describe('Hierarchy', () => {
       const results = await payload.find({
         collection: 'organizations',
         context: {
-          computeHierarchyPaths: true,
+          hierarchy: { computePaths: true },
           hierarchyCacheStats: cacheStats,
         },
         where: {
@@ -1217,7 +1251,7 @@ describe('Hierarchy', () => {
       // Verify all paths computed correctly
       for (const doc of results.docs) {
         expect(doc._h_slugPath).toContain('root/category/')
-        expect(doc._h_titlePath).toContain('Root/Category/')
+        expect(doc._h_titlePath).toContain('Root > Category >')
       }
     })
 
@@ -1267,7 +1301,7 @@ describe('Hierarchy', () => {
       await payload.find({
         collection: 'organizations',
         context: {
-          computeHierarchyPaths: true,
+          hierarchy: { computePaths: true },
           hierarchyCacheStats: cacheStats,
         },
         where: {
@@ -1302,7 +1336,7 @@ describe('Hierarchy', () => {
       // Pages collection has slugField: 'slug' configured
       const page = await payload.create({
         collection: 'pages',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: {
           parent: null,
           slug: 'about-us', // Different from title
@@ -1331,7 +1365,7 @@ describe('Hierarchy', () => {
       // Create child page
       const childPage = await payload.create({
         collection: 'pages',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: {
           parent: rootPage.id,
           slug: 'services',
@@ -1342,13 +1376,13 @@ describe('Hierarchy', () => {
 
       // Should use slug field values for path
       expect(childPage._h_slugPath).toBe('home/services')
-      expect(childPage._h_titlePath).toBe('Home Page/Our Services')
+      expect(childPage._h_titlePath).toBe('Home Page > Our Services')
     })
 
     it('should fall back to slugified title when slug field is empty', async () => {
       const page = await payload.create({
         collection: 'pages',
-        context: { computeHierarchyPaths: true },
+        context: { hierarchy: { computePaths: true } },
         data: {
           parent: null,
           slug: '', // Empty slug
@@ -1405,7 +1439,7 @@ describe('Hierarchy', () => {
 
       // Should have full paths (not flat paths)
       expect(result._h_slugPath).toBe('parent-org/child-org')
-      expect(result._h_titlePath).toBe('Parent Org/Child Org')
+      expect(result._h_titlePath).toBe('Parent Org > Child Org')
     })
 
     it('should not expose auto-added fields in response', async () => {
@@ -1508,7 +1542,7 @@ describe('Hierarchy', () => {
 
       // Should have full 3-level path
       expect(result._h_slugPath).toBe('level-1/level-2/level-3')
-      expect(result._h_titlePath).toBe('Level 1/Level 2/Level 3')
+      expect(result._h_titlePath).toBe('Level 1 > Level 2 > Level 3')
     })
   })
 })

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -72,6 +72,63 @@ describe('Hierarchy', () => {
       expect(slugField).toBeDefined()
       expect(titleField).toBeDefined()
     })
+
+    it('should set useAsTitle to path field when usePathAsTitle is enabled', () => {
+      const foldersCollection = payload.collections.folders.config
+
+      expect(foldersCollection.hierarchy).not.toBe(false)
+      if (foldersCollection.hierarchy !== false) {
+        // eslint-disable-next-line vitest/no-conditional-expect
+        expect(foldersCollection.hierarchy.admin.usePathAsTitle).toBe(true)
+      }
+
+      // admin.useAsTitle should be overridden to the virtual title path field
+      expect(foldersCollection.admin.useAsTitle).toBe('_h_titlePath')
+    })
+  })
+
+  describe('usePathAsTitle', () => {
+    beforeEach(async () => {
+      await payload.delete({ collection: 'folders', where: {} })
+    })
+
+    afterEach(async () => {
+      await payload.delete({ collection: 'folders', where: {} })
+    })
+
+    it('should automatically compute _h_titlePath on read without context flag', async () => {
+      const parent = await payload.create({
+        collection: 'folders',
+        data: { name: 'General' },
+      })
+
+      const child = await payload.create({
+        collection: 'folders',
+        data: { name: 'Subfolder', parentFolder: parent.id },
+      })
+
+      // Fetch without context.hierarchy.computePaths — should still compute because usePathAsTitle=true
+      const result = await payload.findByID({
+        id: child.id,
+        collection: 'folders',
+      })
+
+      expect(result._h_titlePath).toBe('General > Subfolder')
+    })
+
+    it('should set _h_titlePath to document title for root documents', async () => {
+      const root = await payload.create({
+        collection: 'folders',
+        data: { name: 'Root Folder' },
+      })
+
+      const result = await payload.findByID({
+        id: root.id,
+        collection: 'folders',
+      })
+
+      expect(result._h_titlePath).toBe('Root Folder')
+    })
   })
 
   describe('Tree Data Generation', () => {

--- a/test/hierarchy/seed.ts
+++ b/test/hierarchy/seed.ts
@@ -1,6 +1,7 @@
 import type { Payload } from 'payload'
 
 import {
+  articlesSlug,
   departmentsSlug,
   divisionsSlug,
   foldersSlug,
@@ -56,7 +57,7 @@ export async function seed(payload: Payload): Promise<void> {
     data: { parent: acmeCorp.id, title: 'Engineering Division' },
   })
 
-  await payload.create({
+  const frontendTeam = await payload.create({
     collection: organizationsSlug,
     data: { parent: engineeringDiv.id, title: 'Frontend Team' },
   })
@@ -74,6 +75,12 @@ export async function seed(payload: Payload): Promise<void> {
   await payload.create({
     collection: organizationsSlug,
     data: { parent: acmeCorp.id, title: 'Zeta Division' },
+  })
+
+  // Create an article linked to a deeply-nested org to test relationship pill title
+  await payload.create({
+    collection: articlesSlug,
+    data: { organization: frontendTeam.id, title: 'Intro to Hierarchy' },
   })
 
   // Create department hierarchy (tests custom field names)

--- a/test/hierarchy/shared.ts
+++ b/test/hierarchy/shared.ts
@@ -1,3 +1,4 @@
+export const articlesSlug = 'articles'
 export const categoriesSlug = 'categories'
 export const departmentsSlug = 'departments'
 export const divisionsSlug = 'divisions'


### PR DESCRIPTION
Makes hierarchy path-title behavior explicit and scoped: `_h_titlePath` is used for list-title and document-header title rendering, while `admin.useAsTitle` remains the plain-title source for hierarchy tree/search/relationship/group-by displays.

## Compute paths API change

Before (top-level context/query flags):

```ts
await payload.find({
  collection: 'folders',
  context: { computeHierarchyPaths: true },
})
```

```txt
GET /api/folders?computeHierarchyPaths=true
```

After (namespaced context/query flags):

```ts
await payload.find({
  collection: 'folders',
  context: { hierarchy: { computePaths: true } },
})
```

```txt
GET /api/folders?hierarchy[computePaths]=true
```

Selecting path fields still triggers computation automatically in both shapes:

```ts
await payload.find({
  collection: 'folders',
  select: {
    _h_slugPath: true,
    _h_titlePath: true,
  },
})
```

`usePathAsTitle` no longer forces path computation for all reads. Path computation remains opt-in, and admin list/document views explicitly request compute paths when path-title rendering is needed.

## Title-source behavior

```ts
folders: {
  admin: { useAsTitle: 'name' },
  hierarchy: {
    admin: { usePathAsTitle: true },
  },
}
```

- list title column resolves from `_h_titlePath`
- document header title resolves from `_h_titlePath`
- hierarchy tree/search/relationship/group-by labels resolve from `admin.useAsTitle` (`name`)

Also updates hierarchy integration assertions for this behavior and types the document-title resolver input as `TypeWithID` to satisfy UI build typing.

Validation:
- `pnpm run lint`
- `pnpm run build:ui`
- `pnpm run test:int hierarchy`
