### PR TITLE
feat: add GitHub Copilot agent support and Next.js agent rules to create-payload-app

### DIFF
--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -33,6 +33,12 @@ import { getAgentChoice } from './select-agent.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
+const NEXTJS_AGENT_RULES = `<!-- BEGIN:nextjs-agent-rules -->
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` before writing any code. Heed deprecation notices.
+<!-- END:nextjs-agent-rules -->`
+
 async function createOrFindProjectDir(projectDir: string): Promise<void> {
   const pathExists = await fse.pathExists(projectDir)
   if (!pathExists) {
@@ -183,13 +189,19 @@ export async function createProject(
         projectDir,
       })
 
-      const { configFile, skillsDir } = getAgentChoice(agentType)
+      const { configFile, heading, skillsDir } = getAgentChoice(agentType)
       const skillPath = `${skillsDir}/payload`
-      const configContent =
-        configFile === 'CLAUDE.md'
-          ? `# Claude Code\n\nThis project uses the Payload CMS skill at \`${skillPath}/\`.\nStart with \`${skillPath}/SKILL.md\` for a quick reference, then see \`${skillPath}/reference/\` for detailed docs.\n`
-          : `# Agents\n\nThis project uses the Payload CMS skill at \`${skillPath}/\`.\nStart with \`${skillPath}/SKILL.md\` for a quick reference, then see \`${skillPath}/reference/\` for detailed docs.\n`
-      await fse.writeFile(path.resolve(projectDir, configFile), configContent)
+      const configContent = [
+        heading,
+        '',
+        `This project uses the Payload CMS skill at \`${skillPath}/\`.`,
+        `Start with \`${skillPath}/SKILL.md\` for a quick reference, then see \`${skillPath}/reference/\` for detailed docs.`,
+        '',
+        NEXTJS_AGENT_RULES,
+        '',
+      ].join('\n')
+      // outputFile creates intermediate directories (e.g. .github/) automatically
+      await fse.outputFile(path.resolve(projectDir, configFile), configContent)
     } catch (err) {
       if (cliArgs['--debug'] && err instanceof Error) {
         debug(`Failed to download skill: ${err.message}`)

--- a/packages/create-payload-app/src/lib/select-agent.ts
+++ b/packages/create-payload-app/src/lib/select-agent.ts
@@ -4,16 +4,43 @@ import type { AgentType, CliArgs } from '../types.js'
 
 type AgentChoice = {
   /** File to write at project root pointing agents to the skill */
-  configFile: 'AGENTS.md' | 'CLAUDE.md'
+  configFile: string
+  /** Heading to use at the top of the generated config file */
+  heading: string
   label: string
   skillsDir: string
   value: AgentType
 }
 
 export const agentChoices: AgentChoice[] = [
-  { configFile: 'CLAUDE.md', label: 'Claude Code', skillsDir: '.claude/skills', value: 'claude' },
-  { configFile: 'AGENTS.md', label: 'Codex', skillsDir: '.agents/skills', value: 'codex' },
-  { configFile: 'AGENTS.md', label: 'Cursor', skillsDir: '.agents/skills', value: 'cursor' },
+  {
+    configFile: 'CLAUDE.md',
+    heading: '# Claude Code',
+    label: 'Claude Code',
+    skillsDir: '.claude/skills',
+    value: 'claude',
+  },
+  {
+    configFile: 'AGENTS.md',
+    heading: '# Agents',
+    label: 'Codex',
+    skillsDir: '.agents/skills',
+    value: 'codex',
+  },
+  {
+    configFile: 'AGENTS.md',
+    heading: '# Agents',
+    label: 'Cursor',
+    skillsDir: '.agents/skills',
+    value: 'cursor',
+  },
+  {
+    configFile: '.github/copilot-instructions.md',
+    heading: '# GitHub Copilot',
+    label: 'GitHub Copilot',
+    skillsDir: '.github/skills',
+    value: 'github-copilot',
+  },
 ]
 
 const validAgentValues = agentChoices.map((c) => c.value)

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -96,4 +96,4 @@ export type NextConfigType = 'cjs' | 'esm' | 'ts'
 
 export type StorageAdapterType = (typeof ALL_STORAGE_ADAPTERS)[number]
 
-export type AgentType = 'claude' | 'codex' | 'cursor'
+export type AgentType = 'claude' | 'codex' | 'cursor' | 'github-copilot'


### PR DESCRIPTION
Adds `github-copilot` as a supported coding agent option in `create-payload-app`, and appends a Next.js version-awareness block to all generated agent config files.

**GitHub Copilot support**

When the user selects GitHub Copilot during project creation (or passes `--agent github-copilot`), the CLI now writes `.github/copilot-instructions.md` (using `fse.outputFile` so the `.github/` directory is created automatically) and downloads the Payload skill to `.github/skills/payload/`.

**Next.js agent rules block**

All generated agent config files (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`) now include:

```
<!-- BEGIN:nextjs-agent-rules -->
# This is NOT the Next.js you know

This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
<!-- END:nextjs-agent-rules -->
```

This mirrors the pattern used in the Next.js repo itself, where `AGENTS.md` and `CLAUDE.md` carry the same version-awareness notice to prevent agents from applying stale training-data assumptions.

**Refactor**

Adds a `heading` field to `AgentChoice` so the config file heading is co-located with the rest of the agent metadata, removing the `configFile === 'CLAUDE.md'` conditional that was previously spread across `create-project.ts`.