### PR TITLE
test: add coverage for autosave redirects

### DIFF
--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -488,6 +488,24 @@ describe('Versions', () => {
       await expect(drawer.locator('.id-label')).toBeVisible()
     })
 
+    test('collection - autosave - should redirect from create to edit URL after first save', async () => {
+      await page.goto(autosaveURL.create)
+      await expect.poll(() => page.url()).toContain('/create')
+
+      await page.locator('#field-title').fill('autosave redirect title')
+      await waitForAutoSaveToRunAndComplete(page)
+
+      await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).not.toContain('/create')
+
+      const editURLPattern = new RegExp(`/collections/${autosaveCollectionSlug}/[^/]+$`)
+      await expect
+        .poll(() => new URL(page.url()).pathname, { timeout: POLL_TOPASS_TIMEOUT })
+        .toMatch(editURLPattern)
+
+      // value should persist across the redirect, confirming it's the same doc
+      await expect(page.locator('#field-title')).toHaveValue('autosave redirect title')
+    })
+
     test('collection - should autosave using proper depth', async () => {
       const { id: postID } = await payload.create({
         collection: postCollectionSlug,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -490,7 +490,6 @@ describe('Versions', () => {
 
     test('collection - autosave - should redirect from create to edit URL after first save', async () => {
       await page.goto(autosaveURL.create)
-      await expect.poll(() => page.url()).toContain('/create')
 
       await page.locator('#field-title').fill('autosave redirect title')
       await waitForAutoSaveToRunAndComplete(page)

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -202,6 +202,7 @@ export interface Config {
   locale: 'en' | 'es' | 'de';
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
   };
   user: User;
   jobs: {
@@ -1737,6 +1738,52 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection:
+      | 'disable-publish'
+      | 'posts'
+      | 'autosave-posts'
+      | 'autosave-with-draft-button-posts'
+      | 'autosave-multi-select-posts'
+      | 'autosave-with-validate-posts'
+      | 'draft-posts'
+      | 'drafts-no-read-versions'
+      | 'draft-with-max-posts'
+      | 'draft-posts-with-change-hook'
+      | 'drafts-with-custom-unpublish'
+      | 'draft-with-validate-posts'
+      | 'error-on-unpublish'
+      | 'localized-posts'
+      | 'version-posts'
+      | 'custom-ids'
+      | 'diff'
+      | 'text'
+      | 'draft-with-upload'
+      | 'draft-with-upload-cloud-storage'
+      | 'media'
+      | 'media2'
+      | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Adds e2e coverage asserting that creating an autosave-enabled document successfully redirects from `/:collection/create` to `/:collection/:id` after the first save, as expected. This behavior already works, but was untested and susceptible to regression, e.g. in the TanStack Start adapter.