### PR TITLE
ci: backport test service image pinning to ghcr on 3.x

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -85,7 +85,10 @@ runs:
       if: inputs.database == 'supabase'
       uses: supabase/setup-cli@v1
       with:
-        version: latest
+        # Pinned instead of `latest` to skip setup-cli's GitHub API release lookup,
+        # which flakes on shared CI runners with "rate limit exceeded" (unauthenticated
+        # 60 req/hr limit). A fixed version short-circuits that call entirely.
+        version: 2.104.0
 
     - name: Initialize Supabase
       if: inputs.database == 'supabase'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
               - 'templates/**'
             needs_tests:
               - '.github/workflows/main.yml'
+              - '.github/actions/start-services/**'
               - 'packages/**'
               - 'test/**'
               - 'pnpm-lock.yaml'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -184,7 +184,7 @@ services:
   # ── Azure Storage (Azurite emulator) ────────────────────────
   azure-storage:
     profiles: [all, storage]
-    image: mcr.microsoft.com/azure-storage/azurite:latest
+    image: ghcr.io/payloadcms/azurite:3.35.0
     platform: linux/amd64
     restart: always
     command: 'azurite --loose --blobHost 0.0.0.0 --tableHost 0.0.0.0 --queueHost 0.0.0.0 --skipApiVersionCheck'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -82,7 +82,7 @@ services:
   # Connection: mongodb://payload:payload@localhost:27018/payload?authSource=admin&directConnection=true&replicaSet=rs0
   mongodb:
     profiles: [all, mongodb]
-    image: mongodb/mongodb-community-server:8.2-ubi9
+    image: ghcr.io/payloadcms/mongodb-community-server:8.2.9-ubi9
     container_name: mongodb-payload-test
     ports:
       - '27018:27017'
@@ -115,7 +115,7 @@ services:
   # mongot - MongoDB Community Search for $search and $vectorSearch
   mongot:
     profiles: [all, mongodb]
-    image: mongodb/mongodb-community-search:latest
+    image: ghcr.io/payloadcms/mongodb-community-search:1.67.1
     container_name: mongot-payload-test
     depends_on:
       mongodb:
@@ -144,7 +144,7 @@ services:
   # Connection: mongodb://localhost:27019/payload?directConnection=true&replicaSet=mongodb-atlas-local
   mongodb-atlas:
     profiles: [all, mongodb-atlas]
-    image: mongodb/mongodb-atlas-local:latest
+    image: ghcr.io/payloadcms/mongodb-atlas-local:8.2.4
     container_name: mongodb-atlas-payload-test
     hostname: mongodb-atlas-local
     ports:
@@ -166,7 +166,7 @@ services:
   # ── LocalStack (S3 emulator) ────────────────────────────────
   localstack:
     profiles: [all, storage]
-    image: localstack/localstack:4.14.0
+    image: ghcr.io/payloadcms/localstack:4.14.0
     container_name: localstack_demo
     ports:
       - '4563-4599:4563-4599'
@@ -198,7 +198,7 @@ services:
   # ── Google Cloud Storage (fake-gcs-server) ──────────────────
   google-cloud-storage:
     profiles: [all, storage]
-    image: fsouza/fake-gcs-server
+    image: ghcr.io/payloadcms/fake-gcs-server:1.54.0
     restart: always
     command:
       [


### PR DESCRIPTION
`mongot-payload-test` is going unhealthy during `start-services` on `3.x` before E2E tests run, which blocks setup; this backport removes the floating/externally rate-limited image pulls in that path by pinning the affected test-service images to `ghcr.io/payloadcms/*` and pinning Supabase CLI.

Backported from `main`:
- [`0318f87928`](https://github.com/payloadcms/payload/commit/0318f87928fde5950f1d5478c99dad52b55786d7) (`ci: pull test service images from GHCR instead of Docker Hub`)
- [`b3e877c3da`](https://github.com/payloadcms/payload/commit/b3e877c3dafba64c150a688982359af4379eccbd) (`ci: avoid registry rate limits for supabase cli and azurite image`)

Manual port note:
- `0318f87928` conflicted because `3.x` does not include the `redis` service block present on `main`; only the overlapping image-pin changes for existing `3.x` services were applied.

Related context: #17152 (blocked by the same infra-wide CI failure pattern).
