### PR TITLE
feat(cpa): detect nub package manager

### DIFF
--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -57,6 +57,8 @@ async function installDeps(args: {
     installCmd = 'pnpm install'
   } else if (packageManager === 'bun') {
     installCmd = 'bun install'
+  } else if (packageManager === 'nub') {
+    installCmd = 'nub install'
   }
 
   await ensurePnpmBuildApprovals({ packageManager, projectDir })

--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -49,6 +49,10 @@ function getEnvironmentPackageManager(): PackageManager {
     return 'bun'
   }
 
+  if (userAgent.startsWith('nub')) {
+    return 'nub'
+  }
+
   return 'npm'
 }
 

--- a/packages/create-payload-app/src/lib/install-packages.ts
+++ b/packages/create-payload-app/src/lib/install-packages.ts
@@ -16,6 +16,7 @@ export async function installPackages(args: {
 
   switch (packageManager) {
     case 'bun':
+    case 'nub':
     case 'pnpm':
     case 'yarn': {
       if (packageManager === 'bun') {

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -72,7 +72,7 @@ interface Template {
   type: ProjectTemplate['type']
 }
 
-export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
+export type PackageManager = 'bun' | 'npm' | 'nub' | 'pnpm' | 'yarn'
 
 export type DbType = (typeof ALL_DATABASE_ADAPTERS)[number]
 

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -65,7 +65,7 @@ export function successMessage(projectDir: string, packageManager: PackageManage
 ${header('Launch Application:')}
 
   - cd ./${relativePath}
-  - ${packageManager === 'npm' ? 'npm run' : packageManager === 'nub' ? 'nub run' : packageManager} dev or follow directions in README.md
+  - ${['npm', 'nub'].includes(packageManager) ? `${packageManager} run` : packageManager} dev or follow directions in README.md
 
 ${header('Documentation:')}
 

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -65,7 +65,7 @@ export function successMessage(projectDir: string, packageManager: PackageManage
 ${header('Launch Application:')}
 
   - cd ./${relativePath}
-  - ${packageManager === 'npm' ? 'npm run' : packageManager} dev or follow directions in README.md
+  - ${packageManager === 'npm' ? 'npm run' : packageManager === 'nub' ? 'nub run' : packageManager} dev or follow directions in README.md
 
 ${header('Documentation:')}
 


### PR DESCRIPTION
When invoked through nub, create-payload-app falls back to npm — and where the install command is built it would run npm against a nub project. `getEnvironmentPackageManager` reads `npm_config_user_agent`, matching `yarn`/`pnpm`/`bun` and defaulting to npm; [nub](https://nubjs.com) advertises `nub/<version>`, so it isn't matched.

nub is a Rust CLI with a pnpm-compatible command grammar. This adds `nub` to the `PackageManager` type and the user-agent detection, and completes the command paths it flows into: `installCmd` (`nub install`), the `installPackages` switch (`nub add …`, which otherwise silently no-ops on an unmatched manager), and the "next steps" hint. nub uses an explicit `run`, so the hint prints `nub run dev`. The lockfile branch is intentionally left untouched — detection stays on the user agent.
