### PR TITLE
test: more flexible eval verification api

### DIFF
--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -14,8 +14,8 @@ Three orthogonal knobs select what runs (defaults: direct LLM, skill on):
 
 `EVAL_MODEL` is interpreted per runner, and overrides only the **runner** (the LLM scorer keeps its own default):
 
-- `llm` — a key from `models.ts` (e.g. `anthropic:claude-sonnet-4-6`, `openai:gpt-5.2`). Unset → key-based default (OpenAI when `OPENAI_API_KEY` is set, else Anthropic).
-- `claude-code` — a bare `claude --model` name (e.g. `claude-opus-4-6`). Unset → `claude-opus-4-6`.
+- `llm` — a key from `models.ts` (e.g. `anthropic:claude-sonnet-4-6`, `openai:gpt-5.2`). Unset -> key-based default (OpenAI when `OPENAI_API_KEY` is set, else Anthropic).
+- `claude-code` — a bare `claude --model` name (e.g. `claude-opus-4-6`). Unset -> `claude-opus-4-6`.
 
 The skill is delivered per harness: system-prompt injection for `llm`, embedded in the workdir's `.claude/skills/` for `claude-code`.
 
@@ -36,7 +36,7 @@ If neither works, the runner fails with the exact fix (set `ANTHROPIC_API_KEY` o
 ## Running
 
 `pnpm test:eval` is a single launcher ([cli.ts](cli.ts)). With no flags it shows
-an interactive picker (runner → skill → suite → model); pass flags to skip the
+an interactive picker (runner -> skill -> suite -> model); pass flags to skip the
 prompts:
 
 ```bash
@@ -70,8 +70,19 @@ setting `EVAL_RUNNER` / `EVAL_SKILL` / `EVAL_MODEL` directly works too.
 See `~/.claude/plans/2026-05-06_ai-evals-agent-runners_agent-eval-runners/2-DESIGN.md`
 for the agent-runner design and rationale.
 
-Every dataset row has a `verify` object. `verify.type: 'scorer'` runs the
-normal codegen pipeline, optional structural assertions, and the LLM scorer.
-`verify.type: 'runtime'` runs the same codegen pipeline, boots the generated
-config, and calls `verify.check` against the database. It skips only the LLM
-scorer.
+Every dataset row has a `verify` object. `verify.assertions` runs deterministic
+structural checks. `verify.runtime` boots the generated config and calls
+`verify.runtime.check` against the database. `verify.scorer` runs the LLM
+scorer. Cases can combine these checks as needed.
+
+```text
+agent generates config
+-> TypeScript check
+-> structural assertions, if configured
+-> runtime check, if configured
+-> scorer, if configured
+```
+
+TypeScript, assertion, or runtime failures stop the case early. Runtime failures
+score `0` when a scorer is configured. If runtime passes and a scorer exists,
+the case continues to the scorer and uses the scorer score.

--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -70,19 +70,113 @@ setting `EVAL_RUNNER` / `EVAL_SKILL` / `EVAL_MODEL` directly works too.
 See `~/.claude/plans/2026-05-06_ai-evals-agent-runners_agent-eval-runners/2-DESIGN.md`
 for the agent-runner design and rationale.
 
-Every dataset row has a `verify` object. `verify.assertions` runs deterministic
-structural checks. `verify.runtime` boots the generated config and calls
-`verify.runtime.check` against the database. `verify.scorer` runs the LLM
-scorer. Cases can combine these checks as needed.
+Every dataset row gives the model one starter config and one task. The runner
+asks the model to return a complete edited `payload.config.ts`, then verifies it.
 
 ```text
 agent generates config
 -> TypeScript check
--> structural assertions, if configured
--> runtime check, if configured
--> scorer, if configured
+-> verify() runs
+-> config can check the imported generated config without booting Payload
+-> ast can check the TypeScript parser's source-level summary
+-> payload.* can boot the generated config and inspect real database state
+-> score(...) can ask the LLM scorer for a score
 ```
 
-TypeScript, assertion, or runtime failures stop the case early. Runtime failures
-score `0` when a scorer is configured. If runtime passes and a scorer exists,
-the case continues to the scorer and uses the scorer score.
+TypeScript and `expect` failures stop the case early and score `0`. If `verify`
+returns `await score(...)`, that scorer result becomes the final result. If
+`verify` passes without calling `score`, the case passes deterministically.
+
+## Writing Evals
+
+Add cases to one of the files in `datasets/`. A case has:
+
+- `category` - dashboard grouping.
+- `configPath` - folder under `fixtures/` that contains the starter
+  `payload.config.ts` the model edits.
+- `input` - the task prompt given to the model.
+- `verify` - the check that runs after the generated config typechecks.
+
+Simple scorer-only case:
+
+```ts
+{
+  category: 'config',
+  configPath: 'config/codegen/cors-serverurl',
+  input: 'Allow CORS from "https://myapp.com" and set serverURL.',
+  verify: async ({ score }) => {
+    return await score('cors contains "https://myapp.com" and serverURL is set correctly')
+  },
+}
+```
+
+Deterministic config checks use `config`. This imports the generated config but
+does not boot Payload or connect to the database. Field schemas are flattened by
+Payload schema path, so nested fields use keys like `seo.metaTitle` and block
+fields use keys like `layout.hero.heading`:
+
+```ts
+{
+  category: 'collections',
+  configPath: 'collections/codegen/posts-title-content',
+  input: 'Add a posts collection with title and content fields.',
+  verify: async ({
+    config: {
+      collections: { posts },
+    },
+    expect,
+    score,
+  }) => {
+    expect(posts).toBeDefined()
+    expect(posts?.fields.title).toMatchObject({ required: true, type: 'text' })
+    expect(posts?.fields.content).toMatchObject({ type: 'richText' })
+
+    return await score('posts collection has title text and content richText fields')
+  },
+}
+```
+
+The TypeScript parser is still available as `ast` for source-level checks
+that should not import/execute the generated config:
+
+```ts
+verify: ({ ast, expect }) => {
+  expect(ast.collections.some((collection) => collection.slug === 'posts')).toBe(true)
+}
+```
+
+Runtime checks use `payload`. The first `payload.*` call lazily boots the
+generated config with a real Payload Local API. If `payload` is never used,
+nothing boots. Runtime evals run in an isolated Payload boot with a freshly
+dropped database, so cases should assert the final state and leave cleanup to
+the harness.
+
+```ts
+{
+  category: 'collections',
+  configPath: 'collections/runtime/simple-post',
+  input: 'Add an onInit hook that creates a seeded post.',
+  verify: async ({ expect, payload }) => {
+    const { docs } = await payload.find({
+      collection: 'posts',
+      where: { title: { equals: 'Seeded by runtime eval' } },
+    })
+
+    expect(docs).toHaveLength(1)
+  },
+}
+```
+
+You can combine runtime and scorer checks. Runtime failure stops the case with
+score `0`; runtime success continues to the scorer:
+
+```text
+agent generates config
+-> TypeScript check
+-> verify()
+-> expect(payload result).toHaveLength(1)
+-> return await score('expected outcome', payload result)
+```
+
+Use this when a case needs both facts: "does the generated config boot and write
+the right data?" and "how complete was the result overall?"

--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -56,7 +56,7 @@ setting `EVAL_RUNNER` / `EVAL_SKILL` / `EVAL_MODEL` directly works too.
 
 ## Required env vars
 
-- `OPENAI_API_KEY` **or** `ANTHROPIC_API_KEY` — at least one is required for **all** runs. Both the runner and the LLM scorer default to OpenAI models when `OPENAI_API_KEY` is set, and otherwise fall back to Anthropic (`claude-sonnet-4-6` runner, `claude-haiku-4-5` scorer).
+- `OPENAI_API_KEY` **or** `ANTHROPIC_API_KEY` — at least one is required. Both the runner and the LLM scorer default to OpenAI models when `OPENAI_API_KEY` is set, and otherwise fall back to Anthropic (`claude-sonnet-4-6` runner, `claude-haiku-4-5` scorer).
 - The `claude-code` runner uses `ANTHROPIC_API_KEY` by default; if that's rejected (e.g. an org OAuth pin), it automatically falls back to a one-time login into an isolated sandbox config dir (see Variants above).
 
 ## Optional env knobs
@@ -69,3 +69,9 @@ setting `EVAL_RUNNER` / `EVAL_SKILL` / `EVAL_MODEL` directly works too.
 
 See `~/.claude/plans/2026-05-06_ai-evals-agent-runners_agent-eval-runners/2-DESIGN.md`
 for the agent-runner design and rationale.
+
+Every dataset row has a `verify` object. `verify.type: 'scorer'` runs the
+normal codegen pipeline, optional structural assertions, and the LLM scorer.
+`verify.type: 'runtime'` runs the same codegen pipeline, boots the generated
+config, and calls `verify.check` against the database. It skips only the LLM
+scorer.

--- a/test/evals/cli.ts
+++ b/test/evals/cli.ts
@@ -77,6 +77,9 @@ function parseArgs(argv: string[]): ParsedArgs {
   const out: ParsedArgs = { noCache: false }
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
+    if (!arg) {
+      continue
+    }
     if (arg === '-t') {
       out.testPattern = argv[++i]
       continue

--- a/test/evals/components/EvalDashboard/index.tsx
+++ b/test/evals/components/EvalDashboard/index.tsx
@@ -34,7 +34,7 @@ const codegenFixtureByQuestion: Record<string, string> = (() => {
     pluginsOfficialCodegenDataset,
   ]) {
     for (const c of ds) {
-      map[c.input] = c.fixturePath
+      map[c.input] = c.configPath
     }
   }
   return map
@@ -144,11 +144,11 @@ async function buildCodegenHtml(entries: EvalEntry[]): Promise<Record<string, Re
         const modified = e.result.answer ?? ''
         let starter = e.result.starterContent
         if (!starter) {
-          const fixturePath = e.result.fixturePath ?? codegenFixtureByQuestion[e.result.question]
-          if (fixturePath) {
+          const configPath = e.result.configPath ?? codegenFixtureByQuestion[e.result.question]
+          if (configPath) {
             try {
               starter = readFileSync(
-                path.join(fixturesDir, fixturePath, 'payload.config.ts'),
+                path.join(fixturesDir, configPath, 'payload.config.ts'),
                 'utf-8',
               )
             } catch {

--- a/test/evals/datasets/collections/codegen.ts
+++ b/test/evals/datasets/collections/codegen.ts
@@ -7,15 +7,16 @@ export const collectionsCodegenDataset: EvalCase[] = [
     input:
       'Add a "posts" collection with a required text field "title" and a richText field "content". Export it as a named TypeScript constant and add it to the config.',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'posts', kind: 'collectionExists' },
         { slug: 'posts', field: 'title', fieldType: 'text', kind: 'fieldExists' },
         { slug: 'posts', field: 'title', kind: 'fieldOption', option: 'required', value: true },
         { slug: 'posts', field: 'content', fieldType: 'richText', kind: 'fieldExists' },
       ],
-      expected:
-        'CollectionConfig with slug "posts" added to collections, fields array with a text field named title with required: true, and a richText field named content',
+      scorer: {
+        expected:
+          'CollectionConfig with slug "posts" added to collections, fields array with a text field named title with required: true, and a richText field named content',
+      },
     },
   },
   {
@@ -24,7 +25,6 @@ export const collectionsCodegenDataset: EvalCase[] = [
     input:
       'Add a "categories" collection with a text field "name" and a relationship field "posts" that relates to the "posts" collection with hasMany: true.',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'categories', kind: 'collectionExists' },
         { slug: 'categories', field: 'name', fieldType: 'text', kind: 'fieldExists' },
@@ -36,10 +36,18 @@ export const collectionsCodegenDataset: EvalCase[] = [
           option: 'relationTo',
           value: 'posts',
         },
-        { slug: 'categories', field: 'posts', kind: 'fieldOption', option: 'hasMany', value: true },
+        {
+          slug: 'categories',
+          field: 'posts',
+          kind: 'fieldOption',
+          option: 'hasMany',
+          value: true,
+        },
       ],
-      expected:
-        'CollectionConfig with slug "categories" added to collections, text field named name, relationship field named posts with relationTo: "posts" and hasMany: true',
+      scorer: {
+        expected:
+          'CollectionConfig with slug "categories" added to collections, text field named name, relationship field named posts with relationTo: "posts" and hasMany: true',
+      },
     },
   },
   {
@@ -48,7 +56,6 @@ export const collectionsCodegenDataset: EvalCase[] = [
     input:
       'Add a "media" collection with access control that allows anyone to read but requires authentication for create, update, and delete operations.',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'media', kind: 'collectionExists' },
         { slug: 'media', kind: 'collectionAccess', operation: 'read' },
@@ -56,8 +63,10 @@ export const collectionsCodegenDataset: EvalCase[] = [
         { slug: 'media', kind: 'collectionAccess', operation: 'update' },
         { slug: 'media', kind: 'collectionAccess', operation: 'delete' },
       ],
-      expected:
-        'CollectionConfig with slug "media" added to collections, access object with a read function returning true unconditionally, and create/update/delete functions that check req.user',
+      scorer: {
+        expected:
+          'CollectionConfig with slug "media" added to collections, access object with a read function returning true unconditionally, and create/update/delete functions that check req.user',
+      },
     },
   },
   {
@@ -66,7 +75,6 @@ export const collectionsCodegenDataset: EvalCase[] = [
     input:
       'Add a "comments" collection with a required textarea field "body", a required relationship to "posts" named "post", and a required relationship to "users" named "author".',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'comments', kind: 'collectionExists' },
         { slug: 'comments', field: 'body', fieldType: 'textarea', kind: 'fieldExists' },
@@ -88,10 +96,18 @@ export const collectionsCodegenDataset: EvalCase[] = [
           option: 'relationTo',
           value: 'users',
         },
-        { slug: 'comments', field: 'author', kind: 'fieldOption', option: 'required', value: true },
+        {
+          slug: 'comments',
+          field: 'author',
+          kind: 'fieldOption',
+          option: 'required',
+          value: true,
+        },
       ],
-      expected:
-        'CollectionConfig with slug "comments" added to collections, textarea field named body, relationship field post with relationTo: "posts" and required: true, relationship field author with relationTo: "users" and required: true',
+      scorer: {
+        expected:
+          'CollectionConfig with slug "comments" added to collections, textarea field named body, relationship field post with relationTo: "posts" and required: true, relationship field author with relationTo: "users" and required: true',
+      },
     },
   },
   {
@@ -100,13 +116,14 @@ export const collectionsCodegenDataset: EvalCase[] = [
     input:
       'Add a beforeChange hook to the posts collection that sets the "updatedBy" field to the currently authenticated user\'s ID (req.user.id) before every save.',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'posts', kind: 'collectionExists' },
         { slug: 'posts', hook: 'beforeChange', kind: 'collectionHook' },
       ],
-      expected:
-        'hooks.beforeChange array with an async function, sets data.updatedBy from req.user?.id or req.user.id, returns data',
+      scorer: {
+        expected:
+          'hooks.beforeChange array with an async function, sets data.updatedBy from req.user?.id or req.user.id, returns data',
+      },
     },
   },
   {
@@ -115,7 +132,6 @@ export const collectionsCodegenDataset: EvalCase[] = [
     input:
       'Add a users collection with first and last name, then add a virtual field, called "fullName", which combines the first + last in an afterRead hook to populate the value',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'users', kind: 'collectionExists' },
         { slug: 'users', field: 'firstName', fieldType: 'text', kind: 'fieldExists' },
@@ -124,8 +140,10 @@ export const collectionsCodegenDataset: EvalCase[] = [
         { slug: 'users', field: 'fullName', kind: 'fieldOption', option: 'virtual', value: true },
         { slug: 'users', field: 'fullName', hook: 'afterRead', kind: 'fieldHook' },
       ],
-      expected:
-        'CollectionConfig with slug "users" added to collections, text fields named firstName and lastName, text field fullName with virtual: true and a field-level hooks.afterRead array whose function receives ({ siblingData }) and returns `${siblingData.firstName} ${siblingData.lastName}`',
+      scorer: {
+        expected:
+          'CollectionConfig with slug "users" added to collections, text fields named firstName and lastName, text field fullName with virtual: true and a field-level hooks.afterRead array whose function receives ({ siblingData }) and returns `${siblingData.firstName} ${siblingData.lastName}`',
+      },
     },
   },
   {
@@ -134,18 +152,19 @@ export const collectionsCodegenDataset: EvalCase[] = [
     input:
       'Add an onInit hook that uses the Payload Local API to create a post titled "Seeded by runtime eval".',
     verify: {
-      type: 'runtime',
-      check: async ({ payload }) => {
-        const seededTitle = 'Seeded by runtime eval'
+      runtime: {
+        check: async ({ payload }) => {
+          const seededTitle = 'Seeded by runtime eval'
 
-        const { docs } = await payload.find({
-          collection: 'posts',
-          where: { title: { equals: seededTitle } },
-        })
+          const { docs } = await payload.find({
+            collection: 'posts',
+            where: { title: { equals: seededTitle } },
+          })
 
-        await payload.delete({ collection: 'posts', where: { title: { equals: seededTitle } } })
+          await payload.delete({ collection: 'posts', where: { title: { equals: seededTitle } } })
 
-        return docs.length === 1 ? [] : [`expected 1 seeded post, found ${docs.length}`]
+          return docs.length === 1 ? [] : [`expected 1 seeded post, found ${docs.length}`]
+        },
       },
     },
   },

--- a/test/evals/datasets/collections/codegen.ts
+++ b/test/evals/datasets/collections/codegen.ts
@@ -1,22 +1,23 @@
 import type { EvalCase } from '../../types.js'
-
 export const collectionsCodegenDataset: EvalCase[] = [
   {
     category: 'collections',
     configPath: 'collections/codegen/posts-title-content',
     input:
       'Add a "posts" collection with a required text field "title" and a richText field "content". Export it as a named TypeScript constant and add it to the config.',
-    verify: {
-      assertions: [
-        { slug: 'posts', kind: 'collectionExists' },
-        { slug: 'posts', field: 'title', fieldType: 'text', kind: 'fieldExists' },
-        { slug: 'posts', field: 'title', kind: 'fieldOption', option: 'required', value: true },
-        { slug: 'posts', field: 'content', fieldType: 'richText', kind: 'fieldExists' },
-      ],
-      scorer: {
-        expected:
-          'CollectionConfig with slug "posts" added to collections, fields array with a text field named title with required: true, and a richText field named content',
+    verify: ({
+      config: {
+        collections: { posts },
       },
+      expect,
+      score,
+    }) => {
+      expect(posts).toBeDefined()
+      expect(posts?.fields.title).toMatchObject({ type: 'text', required: true })
+      expect(posts?.fields.content).toMatchObject({ type: 'richText' })
+      return score(
+        'CollectionConfig with slug "posts" added to collections, fields array with a text field named title with required: true, and a richText field named content',
+      )
     },
   },
   {
@@ -24,30 +25,23 @@ export const collectionsCodegenDataset: EvalCase[] = [
     configPath: 'collections/codegen/categories-relationship',
     input:
       'Add a "categories" collection with a text field "name" and a relationship field "posts" that relates to the "posts" collection with hasMany: true.',
-    verify: {
-      assertions: [
-        { slug: 'categories', kind: 'collectionExists' },
-        { slug: 'categories', field: 'name', fieldType: 'text', kind: 'fieldExists' },
-        { slug: 'categories', field: 'posts', fieldType: 'relationship', kind: 'fieldExists' },
-        {
-          slug: 'categories',
-          field: 'posts',
-          kind: 'fieldOption',
-          option: 'relationTo',
-          value: 'posts',
-        },
-        {
-          slug: 'categories',
-          field: 'posts',
-          kind: 'fieldOption',
-          option: 'hasMany',
-          value: true,
-        },
-      ],
-      scorer: {
-        expected:
-          'CollectionConfig with slug "categories" added to collections, text field named name, relationship field named posts with relationTo: "posts" and hasMany: true',
+    verify: ({
+      config: {
+        collections: { categories },
       },
+      expect,
+      score,
+    }) => {
+      expect(categories).toBeDefined()
+      expect(categories?.fields.name).toMatchObject({ type: 'text' })
+      expect(categories?.fields.posts).toMatchObject({
+        type: 'relationship',
+        hasMany: true,
+        relationTo: 'posts',
+      })
+      return score(
+        'CollectionConfig with slug "categories" added to collections, text field named name, relationship field named posts with relationTo: "posts" and hasMany: true',
+      )
     },
   },
   {
@@ -55,18 +49,21 @@ export const collectionsCodegenDataset: EvalCase[] = [
     configPath: 'collections/codegen/media-access-control',
     input:
       'Add a "media" collection with access control that allows anyone to read but requires authentication for create, update, and delete operations.',
-    verify: {
-      assertions: [
-        { slug: 'media', kind: 'collectionExists' },
-        { slug: 'media', kind: 'collectionAccess', operation: 'read' },
-        { slug: 'media', kind: 'collectionAccess', operation: 'create' },
-        { slug: 'media', kind: 'collectionAccess', operation: 'update' },
-        { slug: 'media', kind: 'collectionAccess', operation: 'delete' },
-      ],
-      scorer: {
-        expected:
-          'CollectionConfig with slug "media" added to collections, access object with a read function returning true unconditionally, and create/update/delete functions that check req.user',
+    verify: ({
+      config: {
+        collections: { media },
       },
+      expect,
+      score,
+    }) => {
+      expect(media).toBeDefined()
+      expect(media?.access?.read).toBeDefined()
+      expect(media?.access?.create).toBeDefined()
+      expect(media?.access?.update).toBeDefined()
+      expect(media?.access?.delete).toBeDefined()
+      return score(
+        'CollectionConfig with slug "media" added to collections, access object with a read function returning true unconditionally, and create/update/delete functions that check req.user',
+      )
     },
   },
   {
@@ -74,40 +71,28 @@ export const collectionsCodegenDataset: EvalCase[] = [
     configPath: 'collections/codegen/comments-relationships',
     input:
       'Add a "comments" collection with a required textarea field "body", a required relationship to "posts" named "post", and a required relationship to "users" named "author".',
-    verify: {
-      assertions: [
-        { slug: 'comments', kind: 'collectionExists' },
-        { slug: 'comments', field: 'body', fieldType: 'textarea', kind: 'fieldExists' },
-        { slug: 'comments', field: 'body', kind: 'fieldOption', option: 'required', value: true },
-        { slug: 'comments', field: 'post', fieldType: 'relationship', kind: 'fieldExists' },
-        {
-          slug: 'comments',
-          field: 'post',
-          kind: 'fieldOption',
-          option: 'relationTo',
-          value: 'posts',
-        },
-        { slug: 'comments', field: 'post', kind: 'fieldOption', option: 'required', value: true },
-        { slug: 'comments', field: 'author', fieldType: 'relationship', kind: 'fieldExists' },
-        {
-          slug: 'comments',
-          field: 'author',
-          kind: 'fieldOption',
-          option: 'relationTo',
-          value: 'users',
-        },
-        {
-          slug: 'comments',
-          field: 'author',
-          kind: 'fieldOption',
-          option: 'required',
-          value: true,
-        },
-      ],
-      scorer: {
-        expected:
-          'CollectionConfig with slug "comments" added to collections, textarea field named body, relationship field post with relationTo: "posts" and required: true, relationship field author with relationTo: "users" and required: true',
+    verify: ({
+      config: {
+        collections: { comments },
       },
+      expect,
+      score,
+    }) => {
+      expect(comments).toBeDefined()
+      expect(comments?.fields.body).toMatchObject({ type: 'textarea', required: true })
+      expect(comments?.fields.post).toMatchObject({
+        type: 'relationship',
+        relationTo: 'posts',
+        required: true,
+      })
+      expect(comments?.fields.author).toMatchObject({
+        type: 'relationship',
+        relationTo: 'users',
+        required: true,
+      })
+      return score(
+        'CollectionConfig with slug "comments" added to collections, textarea field named body, relationship field post with relationTo: "posts" and required: true, relationship field author with relationTo: "users" and required: true',
+      )
     },
   },
   {
@@ -115,15 +100,18 @@ export const collectionsCodegenDataset: EvalCase[] = [
     configPath: 'collections/codegen/beforechange-hook',
     input:
       'Add a beforeChange hook to the posts collection that sets the "updatedBy" field to the currently authenticated user\'s ID (req.user.id) before every save.',
-    verify: {
-      assertions: [
-        { slug: 'posts', kind: 'collectionExists' },
-        { slug: 'posts', hook: 'beforeChange', kind: 'collectionHook' },
-      ],
-      scorer: {
-        expected:
-          'hooks.beforeChange array with an async function, sets data.updatedBy from req.user?.id or req.user.id, returns data',
+    verify: ({
+      config: {
+        collections: { posts },
       },
+      expect,
+      score,
+    }) => {
+      expect(posts).toBeDefined()
+      expect(posts?.hooks?.beforeChange).toBeDefined()
+      return score(
+        'hooks.beforeChange array with an async function, sets data.updatedBy from req.user?.id or req.user.id, returns data',
+      )
     },
   },
   {
@@ -131,19 +119,21 @@ export const collectionsCodegenDataset: EvalCase[] = [
     configPath: 'collections/codegen/virtual-field',
     input:
       'Add a users collection with first and last name, then add a virtual field, called "fullName", which combines the first + last in an afterRead hook to populate the value',
-    verify: {
-      assertions: [
-        { slug: 'users', kind: 'collectionExists' },
-        { slug: 'users', field: 'firstName', fieldType: 'text', kind: 'fieldExists' },
-        { slug: 'users', field: 'lastName', fieldType: 'text', kind: 'fieldExists' },
-        { slug: 'users', field: 'fullName', fieldType: 'text', kind: 'fieldExists' },
-        { slug: 'users', field: 'fullName', kind: 'fieldOption', option: 'virtual', value: true },
-        { slug: 'users', field: 'fullName', hook: 'afterRead', kind: 'fieldHook' },
-      ],
-      scorer: {
-        expected:
-          'CollectionConfig with slug "users" added to collections, text fields named firstName and lastName, text field fullName with virtual: true and a field-level hooks.afterRead array whose function receives ({ siblingData }) and returns `${siblingData.firstName} ${siblingData.lastName}`',
+    verify: ({
+      config: {
+        collections: { users },
       },
+      expect,
+      score,
+    }) => {
+      expect(users).toBeDefined()
+      expect(users?.fields.firstName).toMatchObject({ type: 'text' })
+      expect(users?.fields.lastName).toMatchObject({ type: 'text' })
+      expect(users?.fields.fullName).toMatchObject({ type: 'text', virtual: true })
+      expect(users?.fields.fullName).toHaveProperty('hooks.afterRead')
+      return score(
+        'CollectionConfig with slug "users" added to collections, text fields named firstName and lastName, text field fullName with virtual: true and a field-level hooks.afterRead array whose function receives ({ siblingData }) and returns `${siblingData.firstName} ${siblingData.lastName}`',
+      )
     },
   },
   {
@@ -151,21 +141,13 @@ export const collectionsCodegenDataset: EvalCase[] = [
     configPath: 'collections/runtime/simple-post',
     input:
       'Add an onInit hook that uses the Payload Local API to create a post titled "Seeded by runtime eval".',
-    verify: {
-      runtime: {
-        check: async ({ payload }) => {
-          const seededTitle = 'Seeded by runtime eval'
-
-          const { docs } = await payload.find({
-            collection: 'posts',
-            where: { title: { equals: seededTitle } },
-          })
-
-          await payload.delete({ collection: 'posts', where: { title: { equals: seededTitle } } })
-
-          return docs.length === 1 ? [] : [`expected 1 seeded post, found ${docs.length}`]
-        },
-      },
+    verify: async ({ expect, payload }) => {
+      const seededTitle = 'Seeded by runtime eval'
+      const { docs } = await payload.find({
+        collection: 'posts',
+        where: { title: { equals: seededTitle } },
+      })
+      expect(docs).toHaveLength(1)
     },
   },
 ]

--- a/test/evals/datasets/collections/codegen.ts
+++ b/test/evals/datasets/collections/codegen.ts
@@ -1,113 +1,152 @@
-import type { CodegenEvalCase } from '../../types.js'
+import type { EvalCase } from '../../types.js'
 
-export const collectionsCodegenDataset: CodegenEvalCase[] = [
+export const collectionsCodegenDataset: EvalCase[] = [
   {
+    category: 'collections',
+    configPath: 'collections/codegen/posts-title-content',
     input:
       'Add a "posts" collection with a required text field "title" and a richText field "content". Export it as a named TypeScript constant and add it to the config.',
-    expected:
-      'CollectionConfig with slug "posts" added to collections, fields array with a text field named title with required: true, and a richText field named content',
-    category: 'collections',
-    fixturePath: 'collections/codegen/posts-title-content',
-    assertions: [
-      { kind: 'collectionExists', slug: 'posts' },
-      { field: 'title', fieldType: 'text', kind: 'fieldExists', slug: 'posts' },
-      { field: 'title', kind: 'fieldOption', option: 'required', slug: 'posts', value: true },
-      { field: 'content', fieldType: 'richText', kind: 'fieldExists', slug: 'posts' },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'posts', kind: 'collectionExists' },
+        { slug: 'posts', field: 'title', fieldType: 'text', kind: 'fieldExists' },
+        { slug: 'posts', field: 'title', kind: 'fieldOption', option: 'required', value: true },
+        { slug: 'posts', field: 'content', fieldType: 'richText', kind: 'fieldExists' },
+      ],
+      expected:
+        'CollectionConfig with slug "posts" added to collections, fields array with a text field named title with required: true, and a richText field named content',
+    },
   },
   {
+    category: 'collections',
+    configPath: 'collections/codegen/categories-relationship',
     input:
       'Add a "categories" collection with a text field "name" and a relationship field "posts" that relates to the "posts" collection with hasMany: true.',
-    expected:
-      'CollectionConfig with slug "categories" added to collections, text field named name, relationship field named posts with relationTo: "posts" and hasMany: true',
-    category: 'collections',
-    fixturePath: 'collections/codegen/categories-relationship',
-    assertions: [
-      { kind: 'collectionExists', slug: 'categories' },
-      { field: 'name', fieldType: 'text', kind: 'fieldExists', slug: 'categories' },
-      { field: 'posts', fieldType: 'relationship', kind: 'fieldExists', slug: 'categories' },
-      {
-        field: 'posts',
-        kind: 'fieldOption',
-        option: 'relationTo',
-        slug: 'categories',
-        value: 'posts',
-      },
-      { field: 'posts', kind: 'fieldOption', option: 'hasMany', slug: 'categories', value: true },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'categories', kind: 'collectionExists' },
+        { slug: 'categories', field: 'name', fieldType: 'text', kind: 'fieldExists' },
+        { slug: 'categories', field: 'posts', fieldType: 'relationship', kind: 'fieldExists' },
+        {
+          slug: 'categories',
+          field: 'posts',
+          kind: 'fieldOption',
+          option: 'relationTo',
+          value: 'posts',
+        },
+        { slug: 'categories', field: 'posts', kind: 'fieldOption', option: 'hasMany', value: true },
+      ],
+      expected:
+        'CollectionConfig with slug "categories" added to collections, text field named name, relationship field named posts with relationTo: "posts" and hasMany: true',
+    },
   },
   {
+    category: 'collections',
+    configPath: 'collections/codegen/media-access-control',
     input:
       'Add a "media" collection with access control that allows anyone to read but requires authentication for create, update, and delete operations.',
-    expected:
-      'CollectionConfig with slug "media" added to collections, access object with a read function returning true unconditionally, and create/update/delete functions that check req.user',
-    category: 'collections',
-    fixturePath: 'collections/codegen/media-access-control',
-    assertions: [
-      { kind: 'collectionExists', slug: 'media' },
-      { kind: 'collectionAccess', operation: 'read', slug: 'media' },
-      { kind: 'collectionAccess', operation: 'create', slug: 'media' },
-      { kind: 'collectionAccess', operation: 'update', slug: 'media' },
-      { kind: 'collectionAccess', operation: 'delete', slug: 'media' },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'media', kind: 'collectionExists' },
+        { slug: 'media', kind: 'collectionAccess', operation: 'read' },
+        { slug: 'media', kind: 'collectionAccess', operation: 'create' },
+        { slug: 'media', kind: 'collectionAccess', operation: 'update' },
+        { slug: 'media', kind: 'collectionAccess', operation: 'delete' },
+      ],
+      expected:
+        'CollectionConfig with slug "media" added to collections, access object with a read function returning true unconditionally, and create/update/delete functions that check req.user',
+    },
   },
   {
+    category: 'collections',
+    configPath: 'collections/codegen/comments-relationships',
     input:
       'Add a "comments" collection with a required textarea field "body", a required relationship to "posts" named "post", and a required relationship to "users" named "author".',
-    expected:
-      'CollectionConfig with slug "comments" added to collections, textarea field named body, relationship field post with relationTo: "posts" and required: true, relationship field author with relationTo: "users" and required: true',
-    category: 'collections',
-    fixturePath: 'collections/codegen/comments-relationships',
-    assertions: [
-      { kind: 'collectionExists', slug: 'comments' },
-      { field: 'body', fieldType: 'textarea', kind: 'fieldExists', slug: 'comments' },
-      { field: 'body', kind: 'fieldOption', option: 'required', slug: 'comments', value: true },
-      { field: 'post', fieldType: 'relationship', kind: 'fieldExists', slug: 'comments' },
-      {
-        field: 'post',
-        kind: 'fieldOption',
-        option: 'relationTo',
-        slug: 'comments',
-        value: 'posts',
-      },
-      { field: 'post', kind: 'fieldOption', option: 'required', slug: 'comments', value: true },
-      { field: 'author', fieldType: 'relationship', kind: 'fieldExists', slug: 'comments' },
-      {
-        field: 'author',
-        kind: 'fieldOption',
-        option: 'relationTo',
-        slug: 'comments',
-        value: 'users',
-      },
-      { field: 'author', kind: 'fieldOption', option: 'required', slug: 'comments', value: true },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'comments', kind: 'collectionExists' },
+        { slug: 'comments', field: 'body', fieldType: 'textarea', kind: 'fieldExists' },
+        { slug: 'comments', field: 'body', kind: 'fieldOption', option: 'required', value: true },
+        { slug: 'comments', field: 'post', fieldType: 'relationship', kind: 'fieldExists' },
+        {
+          slug: 'comments',
+          field: 'post',
+          kind: 'fieldOption',
+          option: 'relationTo',
+          value: 'posts',
+        },
+        { slug: 'comments', field: 'post', kind: 'fieldOption', option: 'required', value: true },
+        { slug: 'comments', field: 'author', fieldType: 'relationship', kind: 'fieldExists' },
+        {
+          slug: 'comments',
+          field: 'author',
+          kind: 'fieldOption',
+          option: 'relationTo',
+          value: 'users',
+        },
+        { slug: 'comments', field: 'author', kind: 'fieldOption', option: 'required', value: true },
+      ],
+      expected:
+        'CollectionConfig with slug "comments" added to collections, textarea field named body, relationship field post with relationTo: "posts" and required: true, relationship field author with relationTo: "users" and required: true',
+    },
   },
   {
+    category: 'collections',
+    configPath: 'collections/codegen/beforechange-hook',
     input:
       'Add a beforeChange hook to the posts collection that sets the "updatedBy" field to the currently authenticated user\'s ID (req.user.id) before every save.',
-    expected:
-      'hooks.beforeChange array with an async function, sets data.updatedBy from req.user?.id or req.user.id, returns data',
-    category: 'collections',
-    fixturePath: 'collections/codegen/beforechange-hook',
-    assertions: [
-      { kind: 'collectionExists', slug: 'posts' },
-      { hook: 'beforeChange', kind: 'collectionHook', slug: 'posts' },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'posts', kind: 'collectionExists' },
+        { slug: 'posts', hook: 'beforeChange', kind: 'collectionHook' },
+      ],
+      expected:
+        'hooks.beforeChange array with an async function, sets data.updatedBy from req.user?.id or req.user.id, returns data',
+    },
   },
   {
+    category: 'collections',
+    configPath: 'collections/codegen/virtual-field',
     input:
       'Add a users collection with first and last name, then add a virtual field, called "fullName", which combines the first + last in an afterRead hook to populate the value',
-    expected:
-      'CollectionConfig with slug "users" added to collections, text fields named firstName and lastName, text field fullName with virtual: true and a field-level hooks.afterRead array whose function receives ({ siblingData }) and returns `${siblingData.firstName} ${siblingData.lastName}`',
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'users', kind: 'collectionExists' },
+        { slug: 'users', field: 'firstName', fieldType: 'text', kind: 'fieldExists' },
+        { slug: 'users', field: 'lastName', fieldType: 'text', kind: 'fieldExists' },
+        { slug: 'users', field: 'fullName', fieldType: 'text', kind: 'fieldExists' },
+        { slug: 'users', field: 'fullName', kind: 'fieldOption', option: 'virtual', value: true },
+        { slug: 'users', field: 'fullName', hook: 'afterRead', kind: 'fieldHook' },
+      ],
+      expected:
+        'CollectionConfig with slug "users" added to collections, text fields named firstName and lastName, text field fullName with virtual: true and a field-level hooks.afterRead array whose function receives ({ siblingData }) and returns `${siblingData.firstName} ${siblingData.lastName}`',
+    },
+  },
+  {
     category: 'collections',
-    fixturePath: 'collections/codegen/virtual-field',
-    assertions: [
-      { kind: 'collectionExists', slug: 'users' },
-      { field: 'firstName', fieldType: 'text', kind: 'fieldExists', slug: 'users' },
-      { field: 'lastName', fieldType: 'text', kind: 'fieldExists', slug: 'users' },
-      { field: 'fullName', fieldType: 'text', kind: 'fieldExists', slug: 'users' },
-      { field: 'fullName', kind: 'fieldOption', option: 'virtual', slug: 'users', value: true },
-      { field: 'fullName', hook: 'afterRead', kind: 'fieldHook', slug: 'users' },
-    ],
+    configPath: 'collections/runtime/simple-post',
+    input:
+      'Add an onInit hook that uses the Payload Local API to create a post titled "Seeded by runtime eval".',
+    verify: {
+      type: 'runtime',
+      check: async ({ payload }) => {
+        const seededTitle = 'Seeded by runtime eval'
+
+        const { docs } = await payload.find({
+          collection: 'posts',
+          where: { title: { equals: seededTitle } },
+        })
+
+        await payload.delete({ collection: 'posts', where: { title: { equals: seededTitle } } })
+
+        return docs.length === 1 ? [] : [`expected 1 seeded post, found ${docs.length}`]
+      },
+    },
   },
 ]

--- a/test/evals/datasets/config/codegen.ts
+++ b/test/evals/datasets/config/codegen.ts
@@ -1,36 +1,48 @@
-import type { CodegenEvalCase } from '../../types.js'
+import type { EvalCase } from '../../types.js'
 
-export const configCodegenDataset: CodegenEvalCase[] = [
+export const configCodegenDataset: EvalCase[] = [
   {
+    category: 'config',
+    configPath: 'config/codegen/admin-components',
     input:
       'Configure the admin panel to use a custom Logo component imported from "@/components/Logo" and set the admin meta titleSuffix to " | My CMS".',
-    expected:
-      'admin.components.graphics.Logo set to the Logo component from "@/components/Logo" (or similar import), admin.meta.titleSuffix set to " | My CMS"',
-    category: 'config',
-    fixturePath: 'config/codegen/admin-components',
+    verify: {
+      type: 'scorer',
+      expected:
+        'admin.components.graphics.Logo set to the Logo component from "@/components/Logo" (or similar import), admin.meta.titleSuffix set to " | My CMS"',
+    },
   },
   {
+    category: 'config',
+    configPath: 'config/codegen/cors-serverurl',
     input:
       'Configure the Payload config to allow CORS from "https://myapp.com" and "https://staging.myapp.com", and set serverURL to "https://api.myapp.com".',
-    expected:
-      'cors property as an array containing "https://myapp.com" and "https://staging.myapp.com", serverURL set to "https://api.myapp.com"',
-    category: 'config',
-    fixturePath: 'config/codegen/cors-serverurl',
+    verify: {
+      type: 'scorer',
+      expected:
+        'cors property as an array containing "https://myapp.com" and "https://staging.myapp.com", serverURL set to "https://api.myapp.com"',
+    },
   },
   {
+    category: 'config',
+    configPath: 'config/codegen/oninit-admin-user',
     input:
       'Add an onInit hook that creates a default admin user with email "admin@example.com" and role "admin" if no users exist yet in the "users" collection.',
-    expected:
-      'onInit async function receiving payload, uses payload.find or payload.count on users collection, conditionally calls payload.create with email "admin@example.com" only when no users exist',
-    category: 'config',
-    fixturePath: 'config/codegen/oninit-admin-user',
+    verify: {
+      type: 'scorer',
+      expected:
+        'onInit async function receiving payload, uses payload.find or payload.count on users collection, conditionally calls payload.create with email "admin@example.com" only when no users exist',
+    },
   },
   {
+    category: 'config',
+    configPath: 'config/codegen/localization',
     input:
       'Configure Payload localization with two locales: "en" (English) as the default and "fr" (French). Set fallback to the default locale.',
-    expected:
-      'localization config with locales array containing en and fr locale entries, defaultLocale: "en", fallback: true',
-    category: 'config',
-    fixturePath: 'config/codegen/localization',
+    verify: {
+      type: 'scorer',
+      expected:
+        'localization config with locales array containing en and fr locale entries, defaultLocale: "en", fallback: true',
+    },
   },
 ]

--- a/test/evals/datasets/config/codegen.ts
+++ b/test/evals/datasets/config/codegen.ts
@@ -1,52 +1,43 @@
 import type { EvalCase } from '../../types.js'
-
 export const configCodegenDataset: EvalCase[] = [
   {
     category: 'config',
     configPath: 'config/codegen/admin-components',
     input:
       'Configure the admin panel to use a custom Logo component imported from "@/components/Logo" and set the admin meta titleSuffix to " | My CMS".',
-    verify: {
-      scorer: {
-        expected:
-          'admin.components.graphics.Logo set to the Logo component from "@/components/Logo" (or similar import), admin.meta.titleSuffix set to " | My CMS"',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'admin.components.graphics.Logo set to the Logo component from "@/components/Logo" (or similar import), admin.meta.titleSuffix set to " | My CMS"',
+      ),
   },
   {
     category: 'config',
     configPath: 'config/codegen/cors-serverurl',
     input:
       'Configure the Payload config to allow CORS from "https://myapp.com" and "https://staging.myapp.com", and set serverURL to "https://api.myapp.com".',
-    verify: {
-      scorer: {
-        expected:
-          'cors property as an array containing "https://myapp.com" and "https://staging.myapp.com", serverURL set to "https://api.myapp.com"',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'cors property as an array containing "https://myapp.com" and "https://staging.myapp.com", serverURL set to "https://api.myapp.com"',
+      ),
   },
   {
     category: 'config',
     configPath: 'config/codegen/oninit-admin-user',
     input:
       'Add an onInit hook that creates a default admin user with email "admin@example.com" and role "admin" if no users exist yet in the "users" collection.',
-    verify: {
-      scorer: {
-        expected:
-          'onInit async function receiving payload, uses payload.find or payload.count on users collection, conditionally calls payload.create with email "admin@example.com" only when no users exist',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'onInit async function receiving payload, uses payload.find or payload.count on users collection, conditionally calls payload.create with email "admin@example.com" only when no users exist',
+      ),
   },
   {
     category: 'config',
     configPath: 'config/codegen/localization',
     input:
       'Configure Payload localization with two locales: "en" (English) as the default and "fr" (French). Set fallback to the default locale.',
-    verify: {
-      scorer: {
-        expected:
-          'localization config with locales array containing en and fr locale entries, defaultLocale: "en", fallback: true',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'localization config with locales array containing en and fr locale entries, defaultLocale: "en", fallback: true',
+      ),
   },
 ]

--- a/test/evals/datasets/config/codegen.ts
+++ b/test/evals/datasets/config/codegen.ts
@@ -7,9 +7,10 @@ export const configCodegenDataset: EvalCase[] = [
     input:
       'Configure the admin panel to use a custom Logo component imported from "@/components/Logo" and set the admin meta titleSuffix to " | My CMS".',
     verify: {
-      type: 'scorer',
-      expected:
-        'admin.components.graphics.Logo set to the Logo component from "@/components/Logo" (or similar import), admin.meta.titleSuffix set to " | My CMS"',
+      scorer: {
+        expected:
+          'admin.components.graphics.Logo set to the Logo component from "@/components/Logo" (or similar import), admin.meta.titleSuffix set to " | My CMS"',
+      },
     },
   },
   {
@@ -18,9 +19,10 @@ export const configCodegenDataset: EvalCase[] = [
     input:
       'Configure the Payload config to allow CORS from "https://myapp.com" and "https://staging.myapp.com", and set serverURL to "https://api.myapp.com".',
     verify: {
-      type: 'scorer',
-      expected:
-        'cors property as an array containing "https://myapp.com" and "https://staging.myapp.com", serverURL set to "https://api.myapp.com"',
+      scorer: {
+        expected:
+          'cors property as an array containing "https://myapp.com" and "https://staging.myapp.com", serverURL set to "https://api.myapp.com"',
+      },
     },
   },
   {
@@ -29,9 +31,10 @@ export const configCodegenDataset: EvalCase[] = [
     input:
       'Add an onInit hook that creates a default admin user with email "admin@example.com" and role "admin" if no users exist yet in the "users" collection.',
     verify: {
-      type: 'scorer',
-      expected:
-        'onInit async function receiving payload, uses payload.find or payload.count on users collection, conditionally calls payload.create with email "admin@example.com" only when no users exist',
+      scorer: {
+        expected:
+          'onInit async function receiving payload, uses payload.find or payload.count on users collection, conditionally calls payload.create with email "admin@example.com" only when no users exist',
+      },
     },
   },
   {
@@ -40,9 +43,10 @@ export const configCodegenDataset: EvalCase[] = [
     input:
       'Configure Payload localization with two locales: "en" (English) as the default and "fr" (French). Set fallback to the default locale.',
     verify: {
-      type: 'scorer',
-      expected:
-        'localization config with locales array containing en and fr locale entries, defaultLocale: "en", fallback: true',
+      scorer: {
+        expected:
+          'localization config with locales array containing en and fr locale entries, defaultLocale: "en", fallback: true',
+      },
     },
   },
 ]

--- a/test/evals/datasets/fields/codegen.ts
+++ b/test/evals/datasets/fields/codegen.ts
@@ -1,28 +1,26 @@
 import type { EvalCase } from '../../types.js'
-
 export const fieldsCodegenDataset: EvalCase[] = [
   {
     category: 'fields',
     configPath: 'fields/codegen/select-status',
     input:
       'Add a required select field named "status" to the posts collection with three options: "draft", "published", and "archived". The field should default to "draft".',
-    verify: {
-      assertions: [
-        { slug: 'posts', field: 'status', fieldType: 'select', kind: 'fieldExists' },
-        { slug: 'posts', field: 'status', kind: 'fieldOption', option: 'required', value: true },
-        {
-          slug: 'posts',
-          field: 'status',
-          kind: 'fieldOption',
-          option: 'defaultValue',
-          value: 'draft',
-        },
-        { slug: 'posts', field: 'status', kind: 'fieldOption', option: 'options' },
-      ],
-      scorer: {
-        expected:
-          'select field with name "status", required: true, defaultValue: "draft", options array containing objects with label and value for draft, published, and archived',
+    verify: ({
+      config: {
+        collections: { posts },
       },
+      expect,
+      score,
+    }) => {
+      expect(posts?.fields.status).toMatchObject({
+        type: 'select',
+        defaultValue: 'draft',
+        required: true,
+      })
+      expect(posts?.fields.status).toHaveProperty('options')
+      return score(
+        'select field with name "status", required: true, defaultValue: "draft", options array containing objects with label and value for draft, published, and archived',
+      )
     },
   },
   {
@@ -30,36 +28,19 @@ export const fieldsCodegenDataset: EvalCase[] = [
     configPath: 'fields/codegen/array-images',
     input:
       'Add an array field named "images" to the posts collection where each item has a required text field "url" and an optional text field "alt".',
-    verify: {
-      assertions: [
-        { slug: 'posts', field: 'images', fieldType: 'array', kind: 'fieldExists' },
-        {
-          slug: 'posts',
-          field: 'url',
-          fieldType: 'text',
-          kind: 'fieldExists',
-          parentField: 'images',
-        },
-        {
-          slug: 'posts',
-          field: 'url',
-          kind: 'fieldOption',
-          option: 'required',
-          parentField: 'images',
-          value: true,
-        },
-        {
-          slug: 'posts',
-          field: 'alt',
-          fieldType: 'text',
-          kind: 'fieldExists',
-          parentField: 'images',
-        },
-      ],
-      scorer: {
-        expected:
-          'array field with name "images", fields array containing a text field named url with required: true, and a text field named alt',
+    verify: ({
+      config: {
+        collections: { posts },
       },
+      expect,
+      score,
+    }) => {
+      expect(posts?.fields.images).toMatchObject({ type: 'array' })
+      expect(posts?.fields['images.url']).toMatchObject({ type: 'text', required: true })
+      expect(posts?.fields['images.alt']).toMatchObject({ type: 'text' })
+      return score(
+        'array field with name "images", fields array containing a text field named url with required: true, and a text field named alt',
+      )
     },
   },
   {
@@ -67,44 +48,22 @@ export const fieldsCodegenDataset: EvalCase[] = [
     configPath: 'fields/codegen/group-seo',
     input:
       'Add a group field named "seo" to the posts collection containing a text field "metaTitle" with maxLength 60 and a textarea field "metaDescription" with maxLength 160.',
-    verify: {
-      assertions: [
-        { slug: 'posts', field: 'seo', fieldType: 'group', kind: 'fieldExists' },
-        {
-          slug: 'posts',
-          field: 'metaTitle',
-          fieldType: 'text',
-          kind: 'fieldExists',
-          parentField: 'seo',
-        },
-        {
-          slug: 'posts',
-          field: 'metaTitle',
-          kind: 'fieldOption',
-          option: 'maxLength',
-          parentField: 'seo',
-          value: 60,
-        },
-        {
-          slug: 'posts',
-          field: 'metaDescription',
-          fieldType: 'textarea',
-          kind: 'fieldExists',
-          parentField: 'seo',
-        },
-        {
-          slug: 'posts',
-          field: 'metaDescription',
-          kind: 'fieldOption',
-          option: 'maxLength',
-          parentField: 'seo',
-          value: 160,
-        },
-      ],
-      scorer: {
-        expected:
-          'group field with name "seo", fields array with a text field named metaTitle with maxLength: 60, and a textarea field named metaDescription with maxLength: 160',
+    verify: ({
+      config: {
+        collections: { posts },
       },
+      expect,
+      score,
+    }) => {
+      expect(posts?.fields.seo).toMatchObject({ type: 'group' })
+      expect(posts?.fields['seo.metaTitle']).toMatchObject({ type: 'text', maxLength: 60 })
+      expect(posts?.fields['seo.metaDescription']).toMatchObject({
+        type: 'textarea',
+        maxLength: 160,
+      })
+      return score(
+        'group field with name "seo", fields array with a text field named metaTitle with maxLength: 60, and a textarea field named metaDescription with maxLength: 160',
+      )
     },
   },
   {
@@ -112,22 +71,20 @@ export const fieldsCodegenDataset: EvalCase[] = [
     configPath: 'fields/codegen/number-price',
     input:
       'Add a required number field named "price" to the products collection that only accepts values between 0 and 99999.99.',
-    verify: {
-      assertions: [
-        { slug: 'products', field: 'price', fieldType: 'number', kind: 'fieldExists' },
-        {
-          slug: 'products',
-          field: 'price',
-          kind: 'fieldOption',
-          option: 'required',
-          value: true,
-        },
-        { slug: 'products', field: 'price', kind: 'fieldOption', option: 'min', value: 0 },
-        { slug: 'products', field: 'price', kind: 'fieldOption', option: 'max', value: 99999.99 },
-      ],
-      scorer: {
-        expected: 'number field with name "price", required: true, min: 0, max: 99999.99',
+    verify: ({
+      config: {
+        collections: { products },
       },
+      expect,
+      score,
+    }) => {
+      expect(products?.fields.price).toMatchObject({
+        type: 'number',
+        max: 99999.99,
+        min: 0,
+        required: true,
+      })
+      return score('number field with name "price", required: true, min: 0, max: 99999.99')
     },
   },
   {
@@ -135,38 +92,20 @@ export const fieldsCodegenDataset: EvalCase[] = [
     configPath: 'fields/codegen/blocks-layout',
     input:
       'Add a blocks field named "layout" to the pages collection that accepts two block types: a "hero" block with a "heading" text field, and a "cta" block with a "buttonLabel" text field and a "buttonUrl" text field.',
-    verify: {
-      assertions: [
-        { slug: 'pages', field: 'layout', fieldType: 'blocks', kind: 'fieldExists' },
-        {
-          slug: 'pages',
-          blockSlug: 'hero',
-          field: 'layout',
-          fieldType: 'text',
-          kind: 'blockField',
-          subfield: 'heading',
-        },
-        {
-          slug: 'pages',
-          blockSlug: 'cta',
-          field: 'layout',
-          fieldType: 'text',
-          kind: 'blockField',
-          subfield: 'buttonLabel',
-        },
-        {
-          slug: 'pages',
-          blockSlug: 'cta',
-          field: 'layout',
-          fieldType: 'text',
-          kind: 'blockField',
-          subfield: 'buttonUrl',
-        },
-      ],
-      scorer: {
-        expected:
-          'blocks field with name "layout", blocks array with two block configs: one with slug "hero" containing a text field named heading, one with slug "cta" containing text fields buttonLabel and buttonUrl',
+    verify: ({
+      config: {
+        collections: { pages },
       },
+      expect,
+      score,
+    }) => {
+      expect(pages?.fields.layout).toMatchObject({ type: 'blocks' })
+      expect(pages?.fields['layout.hero.heading']).toMatchObject({ type: 'text' })
+      expect(pages?.fields['layout.cta.buttonLabel']).toMatchObject({ type: 'text' })
+      expect(pages?.fields['layout.cta.buttonUrl']).toMatchObject({ type: 'text' })
+      return score(
+        'blocks field with name "layout", blocks array with two block configs: one with slug "hero" containing a text field named heading, one with slug "cta" containing text fields buttonLabel and buttonUrl',
+      )
     },
   },
   {
@@ -174,22 +113,21 @@ export const fieldsCodegenDataset: EvalCase[] = [
     configPath: 'fields/codegen/checkbox-ispublished',
     input:
       'Add a checkbox field named "isPublished" to the posts collection that defaults to false and shows the admin description "Check to make this post visible to the public".',
-    verify: {
-      assertions: [
-        { slug: 'posts', field: 'isPublished', fieldType: 'checkbox', kind: 'fieldExists' },
-        {
-          slug: 'posts',
-          field: 'isPublished',
-          kind: 'fieldOption',
-          option: 'defaultValue',
-          value: false,
-        },
-        { slug: 'posts', field: 'isPublished', kind: 'fieldOption', option: 'admin' },
-      ],
-      scorer: {
-        expected:
-          'checkbox field with name "isPublished", defaultValue: false, admin.description set to "Check to make this post visible to the public"',
+    verify: ({
+      config: {
+        collections: { posts },
       },
+      expect,
+      score,
+    }) => {
+      expect(posts?.fields.isPublished).toMatchObject({
+        type: 'checkbox',
+        defaultValue: false,
+      })
+      expect(posts?.fields.isPublished).toHaveProperty('admin')
+      return score(
+        'checkbox field with name "isPublished", defaultValue: false, admin.description set to "Check to make this post visible to the public"',
+      )
     },
   },
 ]

--- a/test/evals/datasets/fields/codegen.ts
+++ b/test/evals/datasets/fields/codegen.ts
@@ -1,165 +1,183 @@
-import type { CodegenEvalCase } from '../../types.js'
+import type { EvalCase } from '../../types.js'
 
-export const fieldsCodegenDataset: CodegenEvalCase[] = [
+export const fieldsCodegenDataset: EvalCase[] = [
   {
+    category: 'fields',
+    configPath: 'fields/codegen/select-status',
     input:
       'Add a required select field named "status" to the posts collection with three options: "draft", "published", and "archived". The field should default to "draft".',
-    expected:
-      'select field with name "status", required: true, defaultValue: "draft", options array containing objects with label and value for draft, published, and archived',
-    category: 'fields',
-    fixturePath: 'fields/codegen/select-status',
-    assertions: [
-      { field: 'status', fieldType: 'select', kind: 'fieldExists', slug: 'posts' },
-      { field: 'status', kind: 'fieldOption', option: 'required', slug: 'posts', value: true },
-      {
-        field: 'status',
-        kind: 'fieldOption',
-        option: 'defaultValue',
-        slug: 'posts',
-        value: 'draft',
-      },
-      { field: 'status', kind: 'fieldOption', option: 'options', slug: 'posts' },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'posts', field: 'status', fieldType: 'select', kind: 'fieldExists' },
+        { slug: 'posts', field: 'status', kind: 'fieldOption', option: 'required', value: true },
+        {
+          slug: 'posts',
+          field: 'status',
+          kind: 'fieldOption',
+          option: 'defaultValue',
+          value: 'draft',
+        },
+        { slug: 'posts', field: 'status', kind: 'fieldOption', option: 'options' },
+      ],
+      expected:
+        'select field with name "status", required: true, defaultValue: "draft", options array containing objects with label and value for draft, published, and archived',
+    },
   },
   {
+    category: 'fields',
+    configPath: 'fields/codegen/array-images',
     input:
       'Add an array field named "images" to the posts collection where each item has a required text field "url" and an optional text field "alt".',
-    expected:
-      'array field with name "images", fields array containing a text field named url with required: true, and a text field named alt',
-    category: 'fields',
-    fixturePath: 'fields/codegen/array-images',
-    assertions: [
-      { field: 'images', fieldType: 'array', kind: 'fieldExists', slug: 'posts' },
-      {
-        field: 'url',
-        fieldType: 'text',
-        kind: 'fieldExists',
-        parentField: 'images',
-        slug: 'posts',
-      },
-      {
-        field: 'url',
-        kind: 'fieldOption',
-        option: 'required',
-        parentField: 'images',
-        slug: 'posts',
-        value: true,
-      },
-      {
-        field: 'alt',
-        fieldType: 'text',
-        kind: 'fieldExists',
-        parentField: 'images',
-        slug: 'posts',
-      },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'posts', field: 'images', fieldType: 'array', kind: 'fieldExists' },
+        {
+          slug: 'posts',
+          field: 'url',
+          fieldType: 'text',
+          kind: 'fieldExists',
+          parentField: 'images',
+        },
+        {
+          slug: 'posts',
+          field: 'url',
+          kind: 'fieldOption',
+          option: 'required',
+          parentField: 'images',
+          value: true,
+        },
+        {
+          slug: 'posts',
+          field: 'alt',
+          fieldType: 'text',
+          kind: 'fieldExists',
+          parentField: 'images',
+        },
+      ],
+      expected:
+        'array field with name "images", fields array containing a text field named url with required: true, and a text field named alt',
+    },
   },
   {
+    category: 'fields',
+    configPath: 'fields/codegen/group-seo',
     input:
       'Add a group field named "seo" to the posts collection containing a text field "metaTitle" with maxLength 60 and a textarea field "metaDescription" with maxLength 160.',
-    expected:
-      'group field with name "seo", fields array with a text field named metaTitle with maxLength: 60, and a textarea field named metaDescription with maxLength: 160',
-    category: 'fields',
-    fixturePath: 'fields/codegen/group-seo',
-    assertions: [
-      { field: 'seo', fieldType: 'group', kind: 'fieldExists', slug: 'posts' },
-      {
-        field: 'metaTitle',
-        fieldType: 'text',
-        kind: 'fieldExists',
-        parentField: 'seo',
-        slug: 'posts',
-      },
-      {
-        field: 'metaTitle',
-        kind: 'fieldOption',
-        option: 'maxLength',
-        parentField: 'seo',
-        slug: 'posts',
-        value: 60,
-      },
-      {
-        field: 'metaDescription',
-        fieldType: 'textarea',
-        kind: 'fieldExists',
-        parentField: 'seo',
-        slug: 'posts',
-      },
-      {
-        field: 'metaDescription',
-        kind: 'fieldOption',
-        option: 'maxLength',
-        parentField: 'seo',
-        slug: 'posts',
-        value: 160,
-      },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'posts', field: 'seo', fieldType: 'group', kind: 'fieldExists' },
+        {
+          slug: 'posts',
+          field: 'metaTitle',
+          fieldType: 'text',
+          kind: 'fieldExists',
+          parentField: 'seo',
+        },
+        {
+          slug: 'posts',
+          field: 'metaTitle',
+          kind: 'fieldOption',
+          option: 'maxLength',
+          parentField: 'seo',
+          value: 60,
+        },
+        {
+          slug: 'posts',
+          field: 'metaDescription',
+          fieldType: 'textarea',
+          kind: 'fieldExists',
+          parentField: 'seo',
+        },
+        {
+          slug: 'posts',
+          field: 'metaDescription',
+          kind: 'fieldOption',
+          option: 'maxLength',
+          parentField: 'seo',
+          value: 160,
+        },
+      ],
+      expected:
+        'group field with name "seo", fields array with a text field named metaTitle with maxLength: 60, and a textarea field named metaDescription with maxLength: 160',
+    },
   },
   {
+    category: 'fields',
+    configPath: 'fields/codegen/number-price',
     input:
       'Add a required number field named "price" to the products collection that only accepts values between 0 and 99999.99.',
-    expected: 'number field with name "price", required: true, min: 0, max: 99999.99',
-    category: 'fields',
-    fixturePath: 'fields/codegen/number-price',
-    assertions: [
-      { field: 'price', fieldType: 'number', kind: 'fieldExists', slug: 'products' },
-      { field: 'price', kind: 'fieldOption', option: 'required', slug: 'products', value: true },
-      { field: 'price', kind: 'fieldOption', option: 'min', slug: 'products', value: 0 },
-      { field: 'price', kind: 'fieldOption', option: 'max', slug: 'products', value: 99999.99 },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'products', field: 'price', fieldType: 'number', kind: 'fieldExists' },
+        { slug: 'products', field: 'price', kind: 'fieldOption', option: 'required', value: true },
+        { slug: 'products', field: 'price', kind: 'fieldOption', option: 'min', value: 0 },
+        { slug: 'products', field: 'price', kind: 'fieldOption', option: 'max', value: 99999.99 },
+      ],
+      expected: 'number field with name "price", required: true, min: 0, max: 99999.99',
+    },
   },
   {
+    category: 'fields',
+    configPath: 'fields/codegen/blocks-layout',
     input:
       'Add a blocks field named "layout" to the pages collection that accepts two block types: a "hero" block with a "heading" text field, and a "cta" block with a "buttonLabel" text field and a "buttonUrl" text field.',
-    expected:
-      'blocks field with name "layout", blocks array with two block configs: one with slug "hero" containing a text field named heading, one with slug "cta" containing text fields buttonLabel and buttonUrl',
-    category: 'fields',
-    fixturePath: 'fields/codegen/blocks-layout',
-    assertions: [
-      { field: 'layout', fieldType: 'blocks', kind: 'fieldExists', slug: 'pages' },
-      {
-        blockSlug: 'hero',
-        field: 'layout',
-        fieldType: 'text',
-        kind: 'blockField',
-        slug: 'pages',
-        subfield: 'heading',
-      },
-      {
-        blockSlug: 'cta',
-        field: 'layout',
-        fieldType: 'text',
-        kind: 'blockField',
-        slug: 'pages',
-        subfield: 'buttonLabel',
-      },
-      {
-        blockSlug: 'cta',
-        field: 'layout',
-        fieldType: 'text',
-        kind: 'blockField',
-        slug: 'pages',
-        subfield: 'buttonUrl',
-      },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'pages', field: 'layout', fieldType: 'blocks', kind: 'fieldExists' },
+        {
+          slug: 'pages',
+          blockSlug: 'hero',
+          field: 'layout',
+          fieldType: 'text',
+          kind: 'blockField',
+          subfield: 'heading',
+        },
+        {
+          slug: 'pages',
+          blockSlug: 'cta',
+          field: 'layout',
+          fieldType: 'text',
+          kind: 'blockField',
+          subfield: 'buttonLabel',
+        },
+        {
+          slug: 'pages',
+          blockSlug: 'cta',
+          field: 'layout',
+          fieldType: 'text',
+          kind: 'blockField',
+          subfield: 'buttonUrl',
+        },
+      ],
+      expected:
+        'blocks field with name "layout", blocks array with two block configs: one with slug "hero" containing a text field named heading, one with slug "cta" containing text fields buttonLabel and buttonUrl',
+    },
   },
   {
+    category: 'fields',
+    configPath: 'fields/codegen/checkbox-ispublished',
     input:
       'Add a checkbox field named "isPublished" to the posts collection that defaults to false and shows the admin description "Check to make this post visible to the public".',
-    expected:
-      'checkbox field with name "isPublished", defaultValue: false, admin.description set to "Check to make this post visible to the public"',
-    category: 'fields',
-    fixturePath: 'fields/codegen/checkbox-ispublished',
-    assertions: [
-      { field: 'isPublished', fieldType: 'checkbox', kind: 'fieldExists', slug: 'posts' },
-      {
-        field: 'isPublished',
-        kind: 'fieldOption',
-        option: 'defaultValue',
-        slug: 'posts',
-        value: false,
-      },
-      { field: 'isPublished', kind: 'fieldOption', option: 'admin', slug: 'posts' },
-    ],
+    verify: {
+      type: 'scorer',
+      assertions: [
+        { slug: 'posts', field: 'isPublished', fieldType: 'checkbox', kind: 'fieldExists' },
+        {
+          slug: 'posts',
+          field: 'isPublished',
+          kind: 'fieldOption',
+          option: 'defaultValue',
+          value: false,
+        },
+        { slug: 'posts', field: 'isPublished', kind: 'fieldOption', option: 'admin' },
+      ],
+      expected:
+        'checkbox field with name "isPublished", defaultValue: false, admin.description set to "Check to make this post visible to the public"',
+    },
   },
 ]

--- a/test/evals/datasets/fields/codegen.ts
+++ b/test/evals/datasets/fields/codegen.ts
@@ -7,7 +7,6 @@ export const fieldsCodegenDataset: EvalCase[] = [
     input:
       'Add a required select field named "status" to the posts collection with three options: "draft", "published", and "archived". The field should default to "draft".',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'posts', field: 'status', fieldType: 'select', kind: 'fieldExists' },
         { slug: 'posts', field: 'status', kind: 'fieldOption', option: 'required', value: true },
@@ -20,8 +19,10 @@ export const fieldsCodegenDataset: EvalCase[] = [
         },
         { slug: 'posts', field: 'status', kind: 'fieldOption', option: 'options' },
       ],
-      expected:
-        'select field with name "status", required: true, defaultValue: "draft", options array containing objects with label and value for draft, published, and archived',
+      scorer: {
+        expected:
+          'select field with name "status", required: true, defaultValue: "draft", options array containing objects with label and value for draft, published, and archived',
+      },
     },
   },
   {
@@ -30,7 +31,6 @@ export const fieldsCodegenDataset: EvalCase[] = [
     input:
       'Add an array field named "images" to the posts collection where each item has a required text field "url" and an optional text field "alt".',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'posts', field: 'images', fieldType: 'array', kind: 'fieldExists' },
         {
@@ -56,8 +56,10 @@ export const fieldsCodegenDataset: EvalCase[] = [
           parentField: 'images',
         },
       ],
-      expected:
-        'array field with name "images", fields array containing a text field named url with required: true, and a text field named alt',
+      scorer: {
+        expected:
+          'array field with name "images", fields array containing a text field named url with required: true, and a text field named alt',
+      },
     },
   },
   {
@@ -66,7 +68,6 @@ export const fieldsCodegenDataset: EvalCase[] = [
     input:
       'Add a group field named "seo" to the posts collection containing a text field "metaTitle" with maxLength 60 and a textarea field "metaDescription" with maxLength 160.',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'posts', field: 'seo', fieldType: 'group', kind: 'fieldExists' },
         {
@@ -100,8 +101,10 @@ export const fieldsCodegenDataset: EvalCase[] = [
           value: 160,
         },
       ],
-      expected:
-        'group field with name "seo", fields array with a text field named metaTitle with maxLength: 60, and a textarea field named metaDescription with maxLength: 160',
+      scorer: {
+        expected:
+          'group field with name "seo", fields array with a text field named metaTitle with maxLength: 60, and a textarea field named metaDescription with maxLength: 160',
+      },
     },
   },
   {
@@ -110,14 +113,21 @@ export const fieldsCodegenDataset: EvalCase[] = [
     input:
       'Add a required number field named "price" to the products collection that only accepts values between 0 and 99999.99.',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'products', field: 'price', fieldType: 'number', kind: 'fieldExists' },
-        { slug: 'products', field: 'price', kind: 'fieldOption', option: 'required', value: true },
+        {
+          slug: 'products',
+          field: 'price',
+          kind: 'fieldOption',
+          option: 'required',
+          value: true,
+        },
         { slug: 'products', field: 'price', kind: 'fieldOption', option: 'min', value: 0 },
         { slug: 'products', field: 'price', kind: 'fieldOption', option: 'max', value: 99999.99 },
       ],
-      expected: 'number field with name "price", required: true, min: 0, max: 99999.99',
+      scorer: {
+        expected: 'number field with name "price", required: true, min: 0, max: 99999.99',
+      },
     },
   },
   {
@@ -126,7 +136,6 @@ export const fieldsCodegenDataset: EvalCase[] = [
     input:
       'Add a blocks field named "layout" to the pages collection that accepts two block types: a "hero" block with a "heading" text field, and a "cta" block with a "buttonLabel" text field and a "buttonUrl" text field.',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'pages', field: 'layout', fieldType: 'blocks', kind: 'fieldExists' },
         {
@@ -154,8 +163,10 @@ export const fieldsCodegenDataset: EvalCase[] = [
           subfield: 'buttonUrl',
         },
       ],
-      expected:
-        'blocks field with name "layout", blocks array with two block configs: one with slug "hero" containing a text field named heading, one with slug "cta" containing text fields buttonLabel and buttonUrl',
+      scorer: {
+        expected:
+          'blocks field with name "layout", blocks array with two block configs: one with slug "hero" containing a text field named heading, one with slug "cta" containing text fields buttonLabel and buttonUrl',
+      },
     },
   },
   {
@@ -164,7 +175,6 @@ export const fieldsCodegenDataset: EvalCase[] = [
     input:
       'Add a checkbox field named "isPublished" to the posts collection that defaults to false and shows the admin description "Check to make this post visible to the public".',
     verify: {
-      type: 'scorer',
       assertions: [
         { slug: 'posts', field: 'isPublished', fieldType: 'checkbox', kind: 'fieldExists' },
         {
@@ -176,8 +186,10 @@ export const fieldsCodegenDataset: EvalCase[] = [
         },
         { slug: 'posts', field: 'isPublished', kind: 'fieldOption', option: 'admin' },
       ],
-      expected:
-        'checkbox field with name "isPublished", defaultValue: false, admin.description set to "Check to make this post visible to the public"',
+      scorer: {
+        expected:
+          'checkbox field with name "isPublished", defaultValue: false, admin.description set to "Check to make this post visible to the public"',
+      },
     },
   },
 ]

--- a/test/evals/datasets/negative/codegen.ts
+++ b/test/evals/datasets/negative/codegen.ts
@@ -12,9 +12,10 @@ export const negativeCorrectionCodegenDataset: EvalCase[] = [
     input:
       'This config has a bug in the access control. Fix the read access function so it returns a proper boolean instead of a string.',
     verify: {
-      type: 'scorer',
-      expected:
-        'access.read returns a boolean (e.g. Boolean(req.user) or true) instead of the string "yes"/"no"',
+      scorer: {
+        expected:
+          'access.read returns a boolean (e.g. Boolean(req.user) or true) instead of the string "yes"/"no"',
+      },
     },
   },
   {
@@ -23,9 +24,10 @@ export const negativeCorrectionCodegenDataset: EvalCase[] = [
     input:
       'This config has a bug in the beforeChange hook. Fix it so the hook correctly returns the data object after mutation.',
     verify: {
-      type: 'scorer',
-      expected:
-        'beforeChange hook adds a return statement returning the data object after setting data.updatedAt',
+      scorer: {
+        expected:
+          'beforeChange hook adds a return statement returning the data object after setting data.updatedAt',
+      },
     },
   },
   {
@@ -34,8 +36,9 @@ export const negativeCorrectionCodegenDataset: EvalCase[] = [
     input:
       "This config has an invalid field type. Fix the title field so it uses a valid Payload field type ('text') instead of the invalid one.",
     verify: {
-      type: 'scorer',
-      expected: "title field type changed from 'not-a-real-type' to 'text'",
+      scorer: {
+        expected: "title field type changed from 'not-a-real-type' to 'text'",
+      },
     },
   },
 ]
@@ -52,9 +55,10 @@ export const negativeInvalidInstructionDataset: EvalCase[] = [
     input:
       "Change the type of the title field from 'text' to 'not-a-real-type'. This is an intentional negative test to verify the evaluation pipeline correctly catches TypeScript type errors.",
     verify: {
-      type: 'scorer',
-      expected:
-        "TypeScript compilation error — 'not-a-real-type' is not a valid Payload field type and must be rejected by tsc",
+      scorer: {
+        expected:
+          "TypeScript compilation error — 'not-a-real-type' is not a valid Payload field type and must be rejected by tsc",
+      },
     },
   },
 ]

--- a/test/evals/datasets/negative/codegen.ts
+++ b/test/evals/datasets/negative/codegen.ts
@@ -1,5 +1,4 @@
 import type { EvalCase } from '../../types.js'
-
 /**
  * Correction cases: the LLM receives a broken fixture as its starter config and
  * must fix the error. tsc validation passing confirms the fix is valid TypeScript.
@@ -11,38 +10,29 @@ export const negativeCorrectionCodegenDataset: EvalCase[] = [
     configPath: 'negative/codegen/invalid-access-return',
     input:
       'This config has a bug in the access control. Fix the read access function so it returns a proper boolean instead of a string.',
-    verify: {
-      scorer: {
-        expected:
-          'access.read returns a boolean (e.g. Boolean(req.user) or true) instead of the string "yes"/"no"',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'access.read returns a boolean (e.g. Boolean(req.user) or true) instead of the string "yes"/"no"',
+      ),
   },
   {
     category: 'negative',
     configPath: 'negative/codegen/missing-beforechange-return',
     input:
       'This config has a bug in the beforeChange hook. Fix it so the hook correctly returns the data object after mutation.',
-    verify: {
-      scorer: {
-        expected:
-          'beforeChange hook adds a return statement returning the data object after setting data.updatedAt',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'beforeChange hook adds a return statement returning the data object after setting data.updatedAt',
+      ),
   },
   {
     category: 'negative',
     configPath: 'negative/codegen/invalid-field-type',
     input:
       "This config has an invalid field type. Fix the title field so it uses a valid Payload field type ('text') instead of the invalid one.",
-    verify: {
-      scorer: {
-        expected: "title field type changed from 'not-a-real-type' to 'text'",
-      },
-    },
+    verify: ({ score }) => score("title field type changed from 'not-a-real-type' to 'text'"),
   },
 ]
-
 /**
  * Invalid-instruction case: the LLM is explicitly told to introduce a TypeScript error.
  * Used to verify the eval pipeline correctly catches type failures.
@@ -54,11 +44,9 @@ export const negativeInvalidInstructionDataset: EvalCase[] = [
     configPath: 'negative/codegen/invalid-field-type',
     input:
       "Change the type of the title field from 'text' to 'not-a-real-type'. This is an intentional negative test to verify the evaluation pipeline correctly catches TypeScript type errors.",
-    verify: {
-      scorer: {
-        expected:
-          "TypeScript compilation error — 'not-a-real-type' is not a valid Payload field type and must be rejected by tsc",
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        "TypeScript compilation error — 'not-a-real-type' is not a valid Payload field type and must be rejected by tsc",
+      ),
   },
 ]

--- a/test/evals/datasets/negative/codegen.ts
+++ b/test/evals/datasets/negative/codegen.ts
@@ -1,33 +1,42 @@
-import type { CodegenEvalCase } from '../../types.js'
+import type { EvalCase } from '../../types.js'
 
 /**
  * Correction cases: the LLM receives a broken fixture as its starter config and
  * must fix the error. tsc validation passing confirms the fix is valid TypeScript.
  * Expects >= 70% accuracy.
  */
-export const negativeCorrectionCodegenDataset: CodegenEvalCase[] = [
+export const negativeCorrectionCodegenDataset: EvalCase[] = [
   {
+    category: 'negative',
+    configPath: 'negative/codegen/invalid-access-return',
     input:
       'This config has a bug in the access control. Fix the read access function so it returns a proper boolean instead of a string.',
-    expected:
-      'access.read returns a boolean (e.g. Boolean(req.user) or true) instead of the string "yes"/"no"',
-    category: 'negative',
-    fixturePath: 'negative/codegen/invalid-access-return',
+    verify: {
+      type: 'scorer',
+      expected:
+        'access.read returns a boolean (e.g. Boolean(req.user) or true) instead of the string "yes"/"no"',
+    },
   },
   {
+    category: 'negative',
+    configPath: 'negative/codegen/missing-beforechange-return',
     input:
       'This config has a bug in the beforeChange hook. Fix it so the hook correctly returns the data object after mutation.',
-    expected:
-      'beforeChange hook adds a return statement returning the data object after setting data.updatedAt',
-    category: 'negative',
-    fixturePath: 'negative/codegen/missing-beforechange-return',
+    verify: {
+      type: 'scorer',
+      expected:
+        'beforeChange hook adds a return statement returning the data object after setting data.updatedAt',
+    },
   },
   {
+    category: 'negative',
+    configPath: 'negative/codegen/invalid-field-type',
     input:
       "This config has an invalid field type. Fix the title field so it uses a valid Payload field type ('text') instead of the invalid one.",
-    expected: "title field type changed from 'not-a-real-type' to 'text'",
-    category: 'negative',
-    fixturePath: 'negative/codegen/invalid-field-type',
+    verify: {
+      type: 'scorer',
+      expected: "title field type changed from 'not-a-real-type' to 'text'",
+    },
   },
 ]
 
@@ -36,13 +45,16 @@ export const negativeCorrectionCodegenDataset: CodegenEvalCase[] = [
  * Used to verify the eval pipeline correctly catches type failures.
  * Expects < 70% accuracy (the test passes when the LLM obeys and tsc fails).
  */
-export const negativeInvalidInstructionDataset: CodegenEvalCase[] = [
+export const negativeInvalidInstructionDataset: EvalCase[] = [
   {
+    category: 'negative',
+    configPath: 'negative/codegen/invalid-field-type',
     input:
       "Change the type of the title field from 'text' to 'not-a-real-type'. This is an intentional negative test to verify the evaluation pipeline correctly catches TypeScript type errors.",
-    expected:
-      "TypeScript compilation error — 'not-a-real-type' is not a valid Payload field type and must be rejected by tsc",
-    category: 'negative',
-    fixturePath: 'negative/codegen/invalid-field-type',
+    verify: {
+      type: 'scorer',
+      expected:
+        "TypeScript compilation error — 'not-a-real-type' is not a valid Payload field type and must be rejected by tsc",
+    },
   },
 ]

--- a/test/evals/datasets/plugins/codegen.ts
+++ b/test/evals/datasets/plugins/codegen.ts
@@ -7,9 +7,10 @@ export const pluginsCodegenDataset: EvalCase[] = [
     input:
       'Implement the withTimestamps plugin so that it adds a "publishedAt" date field to every collection in the config.',
     verify: {
-      type: 'scorer',
-      expected:
-        'withTimestamps maps over config.collections spreading each collection with a new date field named publishedAt appended to the fields array; imports Config and/or Plugin from "payload"',
+      scorer: {
+        expected:
+          'withTimestamps maps over config.collections spreading each collection with a new date field named publishedAt appended to the fields array; imports Config and/or Plugin from "payload"',
+      },
     },
   },
   {
@@ -18,9 +19,10 @@ export const pluginsCodegenDataset: EvalCase[] = [
     input:
       'Implement the withFeature plugin factory so that when options.enabled is false it returns the config unchanged, and when true it adds a "feature" text field to every collection.',
     verify: {
-      type: 'scorer',
-      expected:
-        'withFeature returns the incomingConfig early when !options.enabled; otherwise maps over collections spreading each with a text field named "feature" appended to fields',
+      scorer: {
+        expected:
+          'withFeature returns the incomingConfig early when !options.enabled; otherwise maps over collections spreading each with a text field named "feature" appended to fields',
+      },
     },
   },
   {
@@ -29,9 +31,10 @@ export const pluginsCodegenDataset: EvalCase[] = [
     input:
       'Implement the withInitLogging plugin so that it extends onInit to log "Plugin initialized" using payload.logger.info after any existing onInit has run.',
     verify: {
-      type: 'scorer',
-      expected:
-        'withInitLogging assigns config.onInit to an async function, conditionally awaits incomingConfig.onInit(payload) if it exists, then calls payload.logger.info("Plugin initialized")',
+      scorer: {
+        expected:
+          'withInitLogging assigns config.onInit to an async function, conditionally awaits incomingConfig.onInit(payload) if it exists, then calls payload.logger.info("Plugin initialized")',
+      },
     },
   },
   {
@@ -40,9 +43,10 @@ export const pluginsCodegenDataset: EvalCase[] = [
     input:
       'Implement the withTenancy plugin so that it adds a "tenant" relationship field pointing to the "tenants" collection to every collection that has auth enabled.',
     verify: {
-      type: 'scorer',
-      expected:
-        'withTenancy filters or maps over incomingConfig.collections; for collections with a truthy auth property, spreads the collection and appends a relationship field named "tenant" with relationTo: "tenants"',
+      scorer: {
+        expected:
+          'withTenancy filters or maps over incomingConfig.collections; for collections with a truthy auth property, spreads the collection and appends a relationship field named "tenant" with relationTo: "tenants"',
+      },
     },
   },
 ]

--- a/test/evals/datasets/plugins/codegen.ts
+++ b/test/evals/datasets/plugins/codegen.ts
@@ -1,36 +1,48 @@
-import type { CodegenEvalCase } from '../../types.js'
+import type { EvalCase } from '../../types.js'
 
-export const pluginsCodegenDataset: CodegenEvalCase[] = [
+export const pluginsCodegenDataset: EvalCase[] = [
   {
+    category: 'plugins',
+    configPath: 'plugins/codegen/with-timestamps',
     input:
       'Implement the withTimestamps plugin so that it adds a "publishedAt" date field to every collection in the config.',
-    expected:
-      'withTimestamps maps over config.collections spreading each collection with a new date field named publishedAt appended to the fields array; imports Config and/or Plugin from "payload"',
-    category: 'plugins',
-    fixturePath: 'plugins/codegen/with-timestamps',
+    verify: {
+      type: 'scorer',
+      expected:
+        'withTimestamps maps over config.collections spreading each collection with a new date field named publishedAt appended to the fields array; imports Config and/or Plugin from "payload"',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/codegen/enabled-option',
     input:
       'Implement the withFeature plugin factory so that when options.enabled is false it returns the config unchanged, and when true it adds a "feature" text field to every collection.',
-    expected:
-      'withFeature returns the incomingConfig early when !options.enabled; otherwise maps over collections spreading each with a text field named "feature" appended to fields',
-    category: 'plugins',
-    fixturePath: 'plugins/codegen/enabled-option',
+    verify: {
+      type: 'scorer',
+      expected:
+        'withFeature returns the incomingConfig early when !options.enabled; otherwise maps over collections spreading each with a text field named "feature" appended to fields',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/codegen/oninit-logging',
     input:
       'Implement the withInitLogging plugin so that it extends onInit to log "Plugin initialized" using payload.logger.info after any existing onInit has run.',
-    expected:
-      'withInitLogging assigns config.onInit to an async function, conditionally awaits incomingConfig.onInit(payload) if it exists, then calls payload.logger.info("Plugin initialized")',
-    category: 'plugins',
-    fixturePath: 'plugins/codegen/oninit-logging',
+    verify: {
+      type: 'scorer',
+      expected:
+        'withInitLogging assigns config.onInit to an async function, conditionally awaits incomingConfig.onInit(payload) if it exists, then calls payload.logger.info("Plugin initialized")',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/codegen/tenant-relationship',
     input:
       'Implement the withTenancy plugin so that it adds a "tenant" relationship field pointing to the "tenants" collection to every collection that has auth enabled.',
-    expected:
-      'withTenancy filters or maps over incomingConfig.collections; for collections with a truthy auth property, spreads the collection and appends a relationship field named "tenant" with relationTo: "tenants"',
-    category: 'plugins',
-    fixturePath: 'plugins/codegen/tenant-relationship',
+    verify: {
+      type: 'scorer',
+      expected:
+        'withTenancy filters or maps over incomingConfig.collections; for collections with a truthy auth property, spreads the collection and appends a relationship field named "tenant" with relationTo: "tenants"',
+    },
   },
 ]

--- a/test/evals/datasets/plugins/codegen.ts
+++ b/test/evals/datasets/plugins/codegen.ts
@@ -1,52 +1,43 @@
 import type { EvalCase } from '../../types.js'
-
 export const pluginsCodegenDataset: EvalCase[] = [
   {
     category: 'plugins',
     configPath: 'plugins/codegen/with-timestamps',
     input:
       'Implement the withTimestamps plugin so that it adds a "publishedAt" date field to every collection in the config.',
-    verify: {
-      scorer: {
-        expected:
-          'withTimestamps maps over config.collections spreading each collection with a new date field named publishedAt appended to the fields array; imports Config and/or Plugin from "payload"',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'withTimestamps maps over config.collections spreading each collection with a new date field named publishedAt appended to the fields array; imports Config and/or Plugin from "payload"',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/codegen/enabled-option',
     input:
       'Implement the withFeature plugin factory so that when options.enabled is false it returns the config unchanged, and when true it adds a "feature" text field to every collection.',
-    verify: {
-      scorer: {
-        expected:
-          'withFeature returns the incomingConfig early when !options.enabled; otherwise maps over collections spreading each with a text field named "feature" appended to fields',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'withFeature returns the incomingConfig early when !options.enabled; otherwise maps over collections spreading each with a text field named "feature" appended to fields',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/codegen/oninit-logging',
     input:
       'Implement the withInitLogging plugin so that it extends onInit to log "Plugin initialized" using payload.logger.info after any existing onInit has run.',
-    verify: {
-      scorer: {
-        expected:
-          'withInitLogging assigns config.onInit to an async function, conditionally awaits incomingConfig.onInit(payload) if it exists, then calls payload.logger.info("Plugin initialized")',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'withInitLogging assigns config.onInit to an async function, conditionally awaits incomingConfig.onInit(payload) if it exists, then calls payload.logger.info("Plugin initialized")',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/codegen/tenant-relationship',
     input:
       'Implement the withTenancy plugin so that it adds a "tenant" relationship field pointing to the "tenants" collection to every collection that has auth enabled.',
-    verify: {
-      scorer: {
-        expected:
-          'withTenancy filters or maps over incomingConfig.collections; for collections with a truthy auth property, spreads the collection and appends a relationship field named "tenant" with relationTo: "tenants"',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'withTenancy filters or maps over incomingConfig.collections; for collections with a truthy auth property, spreads the collection and appends a relationship field named "tenant" with relationTo: "tenants"',
+      ),
   },
 ]

--- a/test/evals/datasets/plugins/official/codegen.ts
+++ b/test/evals/datasets/plugins/official/codegen.ts
@@ -1,136 +1,113 @@
 import type { EvalCase } from '../../../types.js'
-
 export const pluginsOfficialCodegenDataset: EvalCase[] = [
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/seo',
     input:
       'Add the SEO plugin from "@payloadcms/plugin-seo" to the config. Configure it with a generateTitle function that returns the document title followed by " | Acme".',
-    verify: {
-      scorer: {
-        expected:
-          'named import { seoPlugin } from "@payloadcms/plugin-seo", seoPlugin({ generateTitle }) added to plugins array, generateTitle returns a string with the doc title and " | Acme"',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { seoPlugin } from "@payloadcms/plugin-seo", seoPlugin({ generateTitle }) added to plugins array, generateTitle returns a string with the doc title and " | Acme"',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/redirects',
     input:
       'Add the Redirects plugin from "@payloadcms/plugin-redirects" to the config. Configure it to apply to the "pages" and "posts" collections.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { redirectsPlugin } from "@payloadcms/plugin-redirects", redirectsPlugin({ collections: ["pages", "posts"] }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { redirectsPlugin } from "@payloadcms/plugin-redirects", redirectsPlugin({ collections: ["pages", "posts"] }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/nested-docs',
     input:
       'Add the Nested Docs plugin from "@payloadcms/plugin-nested-docs" to the config for the "pages" collection, generating breadcrumbs with a label from the "title" field.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { nestedDocsPlugin } from "@payloadcms/plugin-nested-docs", nestedDocsPlugin({ collections: ["pages"], generateLabel: (_, doc) => doc.title }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { nestedDocsPlugin } from "@payloadcms/plugin-nested-docs", nestedDocsPlugin({ collections: ["pages"], generateLabel: (_, doc) => doc.title }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/search',
     input:
       'Add the Search plugin from "@payloadcms/plugin-search" to the config, indexing the "posts" and "pages" collections.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { searchPlugin } from "@payloadcms/plugin-search", searchPlugin({ collections: ["posts", "pages"] }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { searchPlugin } from "@payloadcms/plugin-search", searchPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/form-builder',
     input:
       'Add the Form Builder plugin from "@payloadcms/plugin-form-builder" to the config with a redirectRelationships option pointing to the "pages" collection.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { formBuilderPlugin } from "@payloadcms/plugin-form-builder", formBuilderPlugin({ redirectRelationships: ["pages"] }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { formBuilderPlugin } from "@payloadcms/plugin-form-builder", formBuilderPlugin({ redirectRelationships: ["pages"] }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/sentry',
     input:
       'Add the Sentry plugin from "@payloadcms/plugin-sentry" to the config. The plugin accepts a Sentry instance via the Sentry option and optional captureErrors array via options.captureErrors.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { sentryPlugin } from "@payloadcms/plugin-sentry", sentryPlugin({ Sentry }) added to plugins array where Sentry is a Sentry instance import',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { sentryPlugin } from "@payloadcms/plugin-sentry", sentryPlugin({ Sentry }) added to plugins array where Sentry is a Sentry instance import',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/mcp',
     input:
       'Add the MCP plugin from "@payloadcms/plugin-mcp" to the config. For the "posts" collection, set its description to "Blog posts for content creation" and disable the delete operation.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { delete: false }, description: "Blog posts for content creation" } } }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { delete: false }, description: "Blog posts for content creation" } } }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/multi-tenant',
     input:
       'Add the Multi-Tenant plugin from "@payloadcms/plugin-multi-tenant" to the config. Enable it for the "pages" collection with default options, and mark "posts" as a global (one document per tenant).',
-    verify: {
-      scorer: {
-        expected:
-          'named import { multiTenantPlugin } from "@payloadcms/plugin-multi-tenant", multiTenantPlugin({ collections: { pages: {}, posts: { isGlobal: true } } }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { multiTenantPlugin } from "@payloadcms/plugin-multi-tenant", multiTenantPlugin({ collections: { pages: {}, posts: { isGlobal: true } } }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/stripe',
     input:
       'Add the Stripe plugin from "@payloadcms/plugin-stripe" to the config using the STRIPE_SECRET_KEY environment variable. Also enable the REST proxy endpoint.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { stripePlugin } from "@payloadcms/plugin-stripe", stripePlugin({ stripeSecretKey: process.env.STRIPE_SECRET_KEY, rest: true }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { stripePlugin } from "@payloadcms/plugin-stripe", stripePlugin({ stripeSecretKey: process.env.STRIPE_SECRET_KEY, rest: true }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/import-export',
     input:
       'Add the Import/Export plugin from "@payloadcms/plugin-import-export" to the config, enabling it for the "posts" and "pages" collections.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { importExportPlugin } from "@payloadcms/plugin-import-export", importExportPlugin({ collections: ["posts", "pages"] }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { importExportPlugin } from "@payloadcms/plugin-import-export", importExportPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+      ),
   },
   {
     category: 'plugins',
     configPath: 'plugins/official/codegen/ecommerce',
     input:
       'Add the Ecommerce plugin from "@payloadcms/plugin-ecommerce" to the config. Use the "users" collection as the customer collection and provide stub access functions (each returns true) for all required access keys: adminOnlyFieldAccess, adminOrPublishedStatus, isAdmin, isAuthenticated, isCustomer, and isDocumentOwner.',
-    verify: {
-      scorer: {
-        expected:
-          'named import { ecommercePlugin } from "@payloadcms/plugin-ecommerce", ecommercePlugin({ access: { adminOnlyFieldAccess: () => true, adminOrPublishedStatus: () => true, isAdmin: () => true, isAuthenticated: () => true, isCustomer: () => true, isDocumentOwner: () => true }, customers: { slug: "users" } }) added to plugins array',
-      },
-    },
+    verify: ({ score }) =>
+      score(
+        'named import { ecommercePlugin } from "@payloadcms/plugin-ecommerce", ecommercePlugin({ access: { adminOnlyFieldAccess: () => true, adminOrPublishedStatus: () => true, isAdmin: () => true, isAuthenticated: () => true, isCustomer: () => true, isDocumentOwner: () => true }, customers: { slug: "users" } }) added to plugins array',
+      ),
   },
 ]

--- a/test/evals/datasets/plugins/official/codegen.ts
+++ b/test/evals/datasets/plugins/official/codegen.ts
@@ -7,9 +7,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the SEO plugin from "@payloadcms/plugin-seo" to the config. Configure it with a generateTitle function that returns the document title followed by " | Acme".',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { seoPlugin } from "@payloadcms/plugin-seo", seoPlugin({ generateTitle }) added to plugins array, generateTitle returns a string with the doc title and " | Acme"',
+      scorer: {
+        expected:
+          'named import { seoPlugin } from "@payloadcms/plugin-seo", seoPlugin({ generateTitle }) added to plugins array, generateTitle returns a string with the doc title and " | Acme"',
+      },
     },
   },
   {
@@ -18,9 +19,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Redirects plugin from "@payloadcms/plugin-redirects" to the config. Configure it to apply to the "pages" and "posts" collections.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { redirectsPlugin } from "@payloadcms/plugin-redirects", redirectsPlugin({ collections: ["pages", "posts"] }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { redirectsPlugin } from "@payloadcms/plugin-redirects", redirectsPlugin({ collections: ["pages", "posts"] }) added to plugins array',
+      },
     },
   },
   {
@@ -29,9 +31,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Nested Docs plugin from "@payloadcms/plugin-nested-docs" to the config for the "pages" collection, generating breadcrumbs with a label from the "title" field.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { nestedDocsPlugin } from "@payloadcms/plugin-nested-docs", nestedDocsPlugin({ collections: ["pages"], generateLabel: (_, doc) => doc.title }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { nestedDocsPlugin } from "@payloadcms/plugin-nested-docs", nestedDocsPlugin({ collections: ["pages"], generateLabel: (_, doc) => doc.title }) added to plugins array',
+      },
     },
   },
   {
@@ -40,9 +43,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Search plugin from "@payloadcms/plugin-search" to the config, indexing the "posts" and "pages" collections.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { searchPlugin } from "@payloadcms/plugin-search", searchPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { searchPlugin } from "@payloadcms/plugin-search", searchPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+      },
     },
   },
   {
@@ -51,9 +55,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Form Builder plugin from "@payloadcms/plugin-form-builder" to the config with a redirectRelationships option pointing to the "pages" collection.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { formBuilderPlugin } from "@payloadcms/plugin-form-builder", formBuilderPlugin({ redirectRelationships: ["pages"] }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { formBuilderPlugin } from "@payloadcms/plugin-form-builder", formBuilderPlugin({ redirectRelationships: ["pages"] }) added to plugins array',
+      },
     },
   },
   {
@@ -62,9 +67,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Sentry plugin from "@payloadcms/plugin-sentry" to the config. The plugin accepts a Sentry instance via the Sentry option and optional captureErrors array via options.captureErrors.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { sentryPlugin } from "@payloadcms/plugin-sentry", sentryPlugin({ Sentry }) added to plugins array where Sentry is a Sentry instance import',
+      scorer: {
+        expected:
+          'named import { sentryPlugin } from "@payloadcms/plugin-sentry", sentryPlugin({ Sentry }) added to plugins array where Sentry is a Sentry instance import',
+      },
     },
   },
   {
@@ -73,9 +79,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the MCP plugin from "@payloadcms/plugin-mcp" to the config. For the "posts" collection, set its description to "Blog posts for content creation" and disable the delete operation.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { delete: false }, description: "Blog posts for content creation" } } }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { delete: false }, description: "Blog posts for content creation" } } }) added to plugins array',
+      },
     },
   },
   {
@@ -84,9 +91,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Multi-Tenant plugin from "@payloadcms/plugin-multi-tenant" to the config. Enable it for the "pages" collection with default options, and mark "posts" as a global (one document per tenant).',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { multiTenantPlugin } from "@payloadcms/plugin-multi-tenant", multiTenantPlugin({ collections: { pages: {}, posts: { isGlobal: true } } }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { multiTenantPlugin } from "@payloadcms/plugin-multi-tenant", multiTenantPlugin({ collections: { pages: {}, posts: { isGlobal: true } } }) added to plugins array',
+      },
     },
   },
   {
@@ -95,9 +103,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Stripe plugin from "@payloadcms/plugin-stripe" to the config using the STRIPE_SECRET_KEY environment variable. Also enable the REST proxy endpoint.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { stripePlugin } from "@payloadcms/plugin-stripe", stripePlugin({ stripeSecretKey: process.env.STRIPE_SECRET_KEY, rest: true }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { stripePlugin } from "@payloadcms/plugin-stripe", stripePlugin({ stripeSecretKey: process.env.STRIPE_SECRET_KEY, rest: true }) added to plugins array',
+      },
     },
   },
   {
@@ -106,9 +115,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Import/Export plugin from "@payloadcms/plugin-import-export" to the config, enabling it for the "posts" and "pages" collections.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { importExportPlugin } from "@payloadcms/plugin-import-export", importExportPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { importExportPlugin } from "@payloadcms/plugin-import-export", importExportPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+      },
     },
   },
   {
@@ -117,9 +127,10 @@ export const pluginsOfficialCodegenDataset: EvalCase[] = [
     input:
       'Add the Ecommerce plugin from "@payloadcms/plugin-ecommerce" to the config. Use the "users" collection as the customer collection and provide stub access functions (each returns true) for all required access keys: adminOnlyFieldAccess, adminOrPublishedStatus, isAdmin, isAuthenticated, isCustomer, and isDocumentOwner.',
     verify: {
-      type: 'scorer',
-      expected:
-        'named import { ecommercePlugin } from "@payloadcms/plugin-ecommerce", ecommercePlugin({ access: { adminOnlyFieldAccess: () => true, adminOrPublishedStatus: () => true, isAdmin: () => true, isAuthenticated: () => true, isCustomer: () => true, isDocumentOwner: () => true }, customers: { slug: "users" } }) added to plugins array',
+      scorer: {
+        expected:
+          'named import { ecommercePlugin } from "@payloadcms/plugin-ecommerce", ecommercePlugin({ access: { adminOnlyFieldAccess: () => true, adminOrPublishedStatus: () => true, isAdmin: () => true, isAuthenticated: () => true, isCustomer: () => true, isDocumentOwner: () => true }, customers: { slug: "users" } }) added to plugins array',
+      },
     },
   },
 ]

--- a/test/evals/datasets/plugins/official/codegen.ts
+++ b/test/evals/datasets/plugins/official/codegen.ts
@@ -1,92 +1,125 @@
-import type { CodegenEvalCase } from '../../../types.js'
+import type { EvalCase } from '../../../types.js'
 
-export const pluginsOfficialCodegenDataset: CodegenEvalCase[] = [
+export const pluginsOfficialCodegenDataset: EvalCase[] = [
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/seo',
     input:
       'Add the SEO plugin from "@payloadcms/plugin-seo" to the config. Configure it with a generateTitle function that returns the document title followed by " | Acme".',
-    expected:
-      'named import { seoPlugin } from "@payloadcms/plugin-seo", seoPlugin({ generateTitle }) added to plugins array, generateTitle returns a string with the doc title and " | Acme"',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/seo',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { seoPlugin } from "@payloadcms/plugin-seo", seoPlugin({ generateTitle }) added to plugins array, generateTitle returns a string with the doc title and " | Acme"',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/redirects',
     input:
       'Add the Redirects plugin from "@payloadcms/plugin-redirects" to the config. Configure it to apply to the "pages" and "posts" collections.',
-    expected:
-      'named import { redirectsPlugin } from "@payloadcms/plugin-redirects", redirectsPlugin({ collections: ["pages", "posts"] }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/redirects',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { redirectsPlugin } from "@payloadcms/plugin-redirects", redirectsPlugin({ collections: ["pages", "posts"] }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/nested-docs',
     input:
       'Add the Nested Docs plugin from "@payloadcms/plugin-nested-docs" to the config for the "pages" collection, generating breadcrumbs with a label from the "title" field.',
-    expected:
-      'named import { nestedDocsPlugin } from "@payloadcms/plugin-nested-docs", nestedDocsPlugin({ collections: ["pages"], generateLabel: (_, doc) => doc.title }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/nested-docs',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { nestedDocsPlugin } from "@payloadcms/plugin-nested-docs", nestedDocsPlugin({ collections: ["pages"], generateLabel: (_, doc) => doc.title }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/search',
     input:
       'Add the Search plugin from "@payloadcms/plugin-search" to the config, indexing the "posts" and "pages" collections.',
-    expected:
-      'named import { searchPlugin } from "@payloadcms/plugin-search", searchPlugin({ collections: ["posts", "pages"] }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/search',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { searchPlugin } from "@payloadcms/plugin-search", searchPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/form-builder',
     input:
       'Add the Form Builder plugin from "@payloadcms/plugin-form-builder" to the config with a redirectRelationships option pointing to the "pages" collection.',
-    expected:
-      'named import { formBuilderPlugin } from "@payloadcms/plugin-form-builder", formBuilderPlugin({ redirectRelationships: ["pages"] }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/form-builder',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { formBuilderPlugin } from "@payloadcms/plugin-form-builder", formBuilderPlugin({ redirectRelationships: ["pages"] }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/sentry',
     input:
       'Add the Sentry plugin from "@payloadcms/plugin-sentry" to the config. The plugin accepts a Sentry instance via the Sentry option and optional captureErrors array via options.captureErrors.',
-    expected:
-      'named import { sentryPlugin } from "@payloadcms/plugin-sentry", sentryPlugin({ Sentry }) added to plugins array where Sentry is a Sentry instance import',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/sentry',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { sentryPlugin } from "@payloadcms/plugin-sentry", sentryPlugin({ Sentry }) added to plugins array where Sentry is a Sentry instance import',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/mcp',
     input:
       'Add the MCP plugin from "@payloadcms/plugin-mcp" to the config. For the "posts" collection, set its description to "Blog posts for content creation" and disable the delete operation.',
-    expected:
-      'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { delete: false }, description: "Blog posts for content creation" } } }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/mcp',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { mcpPlugin } from "@payloadcms/plugin-mcp", mcpPlugin({ collections: { posts: { tools: { delete: false }, description: "Blog posts for content creation" } } }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/multi-tenant',
     input:
       'Add the Multi-Tenant plugin from "@payloadcms/plugin-multi-tenant" to the config. Enable it for the "pages" collection with default options, and mark "posts" as a global (one document per tenant).',
-    expected:
-      'named import { multiTenantPlugin } from "@payloadcms/plugin-multi-tenant", multiTenantPlugin({ collections: { pages: {}, posts: { isGlobal: true } } }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/multi-tenant',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { multiTenantPlugin } from "@payloadcms/plugin-multi-tenant", multiTenantPlugin({ collections: { pages: {}, posts: { isGlobal: true } } }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/stripe',
     input:
       'Add the Stripe plugin from "@payloadcms/plugin-stripe" to the config using the STRIPE_SECRET_KEY environment variable. Also enable the REST proxy endpoint.',
-    expected:
-      'named import { stripePlugin } from "@payloadcms/plugin-stripe", stripePlugin({ stripeSecretKey: process.env.STRIPE_SECRET_KEY, rest: true }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/stripe',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { stripePlugin } from "@payloadcms/plugin-stripe", stripePlugin({ stripeSecretKey: process.env.STRIPE_SECRET_KEY, rest: true }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/import-export',
     input:
       'Add the Import/Export plugin from "@payloadcms/plugin-import-export" to the config, enabling it for the "posts" and "pages" collections.',
-    expected:
-      'named import { importExportPlugin } from "@payloadcms/plugin-import-export", importExportPlugin({ collections: ["posts", "pages"] }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/import-export',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { importExportPlugin } from "@payloadcms/plugin-import-export", importExportPlugin({ collections: ["posts", "pages"] }) added to plugins array',
+    },
   },
   {
+    category: 'plugins',
+    configPath: 'plugins/official/codegen/ecommerce',
     input:
       'Add the Ecommerce plugin from "@payloadcms/plugin-ecommerce" to the config. Use the "users" collection as the customer collection and provide stub access functions (each returns true) for all required access keys: adminOnlyFieldAccess, adminOrPublishedStatus, isAdmin, isAuthenticated, isCustomer, and isDocumentOwner.',
-    expected:
-      'named import { ecommercePlugin } from "@payloadcms/plugin-ecommerce", ecommercePlugin({ access: { adminOnlyFieldAccess: () => true, adminOrPublishedStatus: () => true, isAdmin: () => true, isAuthenticated: () => true, isCustomer: () => true, isDocumentOwner: () => true }, customers: { slug: "users" } }) added to plugins array',
-    category: 'plugins',
-    fixturePath: 'plugins/official/codegen/ecommerce',
+    verify: {
+      type: 'scorer',
+      expected:
+        'named import { ecommercePlugin } from "@payloadcms/plugin-ecommerce", ecommercePlugin({ access: { adminOnlyFieldAccess: () => true, adminOrPublishedStatus: () => true, isAdmin: () => true, isAuthenticated: () => true, isCustomer: () => true, isDocumentOwner: () => true }, customers: { slug: "users" } }) added to plugins array',
+    },
   },
 ]

--- a/test/evals/evalConfig.ts
+++ b/test/evals/evalConfig.ts
@@ -1,0 +1,179 @@
+import type {
+  Field,
+  FieldSchemaMap,
+  SanitizedCollectionConfig,
+  SanitizedConfig,
+  SanitizedGlobalConfig,
+} from 'payload'
+
+import { initI18n } from '@payloadcms/translations'
+
+// eslint-disable-next-line payload/no-relative-monorepo-imports
+import { buildFieldSchemaMap } from '../../packages/ui/src/utilities/buildFieldSchemaMap/index.js'
+
+const missingValue = Symbol('missing eval config value')
+
+export type EvalFields = Record<string, Field>
+
+export type EvalCollectionConfig = {
+  fields: EvalFields
+} & Omit<SanitizedCollectionConfig, 'fields'>
+
+export type EvalGlobalConfig = {
+  fields: EvalFields
+} & Omit<SanitizedGlobalConfig, 'fields'>
+
+export type EvalConfig = {
+  collections: Record<string, EvalCollectionConfig>
+  globals: Record<string, EvalGlobalConfig>
+  raw: SanitizedConfig
+}
+
+type MissingValue = {
+  readonly [missingValue]: true
+}
+
+const missingProxy = new Proxy(Object.create(null) as MissingValue, {
+  get(_target, prop) {
+    if (prop === missingValue) {
+      return true
+    }
+    if (prop === 'then') {
+      return undefined
+    }
+    if (prop === Symbol.toStringTag) {
+      return 'MissingEvalConfigValue'
+    }
+    return missingProxy
+  },
+})
+
+const safeObjectCache = new WeakMap<object, unknown>()
+
+export const isMissingEvalConfigValue = (value: unknown): value is MissingValue =>
+  Boolean(value && typeof value === 'object' && (value as MissingValue)[missingValue])
+
+export const unwrapEvalConfigValue = <T>(value: T): T | undefined =>
+  isMissingEvalConfigValue(value) ? undefined : value
+
+export async function buildEvalConfig(config: SanitizedConfig): Promise<EvalConfig> {
+  const i18n = await initI18n({
+    config: config.i18n,
+    context: 'client',
+    language: 'en',
+  })
+
+  const collections: Record<string, EvalCollectionConfig> = {}
+  for (const collection of config.collections) {
+    const { fieldSchemaMap } = buildFieldSchemaMap({
+      collectionSlug: collection.slug,
+      config,
+      i18n,
+    })
+    const { fields: _fields, ...collectionConfig } = collection
+
+    collections[collection.slug] = safeObject({
+      ...collectionConfig,
+      fields: safeRecord(fieldSchemaMapToFields(fieldSchemaMap, collection.slug)),
+    }) as EvalCollectionConfig
+  }
+
+  const globals: Record<string, EvalGlobalConfig> = {}
+  for (const global of config.globals) {
+    const { fieldSchemaMap } = buildFieldSchemaMap({
+      config,
+      globalSlug: global.slug,
+      i18n,
+    })
+    const { fields: _fields, ...globalConfig } = global
+
+    globals[global.slug] = safeObject({
+      ...globalConfig,
+      fields: safeRecord(fieldSchemaMapToFields(fieldSchemaMap, global.slug)),
+    }) as EvalGlobalConfig
+  }
+
+  return safeObject({
+    collections: safeRecord(collections),
+    globals: safeRecord(globals),
+    raw: config,
+  }) as EvalConfig
+}
+
+export function missingEvalConfig(): EvalConfig {
+  return safeObject({
+    collections: safeRecord({}),
+    globals: safeRecord({}),
+    raw: missingProxy,
+  }) as unknown as EvalConfig
+}
+
+function fieldSchemaMapToFields(fieldSchemaMap: FieldSchemaMap, entitySlug: string): EvalFields {
+  const fields: EvalFields = {}
+
+  for (const [schemaPath, entry] of fieldSchemaMap.entries()) {
+    if (schemaPath === entitySlug || !isField(entry)) {
+      continue
+    }
+
+    const fieldPath = schemaPath.startsWith(`${entitySlug}.`)
+      ? schemaPath.slice(entitySlug.length + 1)
+      : schemaPath
+
+    fields[fieldPath] = safeValue(entry) as Field
+  }
+
+  return fields
+}
+
+function isField(
+  entry: FieldSchemaMap extends Map<string, infer Value> ? Value : never,
+): entry is Field {
+  return Boolean(entry && typeof entry === 'object' && 'type' in entry)
+}
+
+function safeRecord<T extends Record<string, unknown>>(record: T): T {
+  return safeObject(record)
+}
+
+function safeValue(value: unknown): unknown {
+  if (value === undefined) {
+    return missingProxy
+  }
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+  if (value instanceof Date || value instanceof Map || value instanceof Set) {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.map(safeValue)
+  }
+
+  return safeObject(value)
+}
+
+function safeObject<T extends object>(object: T): T {
+  const cached = safeObjectCache.get(object)
+  if (cached) {
+    return cached as T
+  }
+
+  const proxy = new Proxy(object, {
+    get(target, prop, receiver) {
+      if (prop === missingValue) {
+        return false
+      }
+      if (prop === 'then') {
+        return undefined
+      }
+      if (Reflect.has(target, prop)) {
+        return safeValue(Reflect.get(target, prop, receiver))
+      }
+      return missingProxy
+    },
+  })
+
+  safeObjectCache.set(object, proxy)
+  return proxy
+}

--- a/test/evals/fixtures/collections/runtime/simple-post/payload.config.ts
+++ b/test/evals/fixtures/collections/runtime/simple-post/payload.config.ts
@@ -1,0 +1,26 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { buildConfigWithDefaults } from '../../../../../buildConfigWithDefaults.js'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
+/** A tiny real Payload config the runtime eval boots in-memory. */
+export default buildConfigWithDefaults({
+  admin: {
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+  },
+  collections: [
+    {
+      slug: 'posts',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+})

--- a/test/evals/fixtures/collections/runtime/simple-post/payload.config.ts
+++ b/test/evals/fixtures/collections/runtime/simple-post/payload.config.ts
@@ -1,12 +1,16 @@
+import { mongooseAdapter } from '@payloadcms/db-mongodb'
 import path from 'path'
+import { buildConfig } from 'payload'
 import { fileURLToPath } from 'url'
 
-import { buildConfigWithDefaults } from '../../../../../buildConfigWithDefaults.js'
-
 const dirname = path.dirname(fileURLToPath(import.meta.url))
+const databaseURL =
+  process.env.MONGODB_URL ||
+  process.env.DATABASE_URL ||
+  'mongodb://payload:payload@localhost:27018/payload?authSource=admin&directConnection=true&replicaSet=rs0'
 
-/** A tiny real Payload config the runtime eval boots in-memory. */
-export default buildConfigWithDefaults({
+/** A tiny real Payload config the runtime eval boots against the test database. */
+export default buildConfig({
   admin: {
     importMap: {
       baseDir: path.resolve(dirname),
@@ -21,6 +25,12 @@ export default buildConfigWithDefaults({
           type: 'text',
         },
       ],
+      versions: false,
     },
   ],
+  db: mongooseAdapter({
+    ensureIndexes: true,
+    url: databaseURL,
+  }),
+  secret: 'eval-runtime',
 })

--- a/test/evals/fixtures/db-mongodb-stub.ts
+++ b/test/evals/fixtures/db-mongodb-stub.ts
@@ -1,0 +1,3 @@
+import { stubAdapter } from './db-stub.js'
+
+export const mongooseAdapter = (..._args: unknown[]) => stubAdapter

--- a/test/evals/fixtures/tsconfig.json
+++ b/test/evals/fixtures/tsconfig.json
@@ -11,9 +11,11 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "lib": ["ES2022"],
+    "types": ["node"],
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "paths": {
+      "@payloadcms/db-mongodb": ["./db-mongodb-stub.ts"],
       "@/*": ["./*"]
     }
   }

--- a/test/evals/runCodegenDataset.ts
+++ b/test/evals/runCodegenDataset.ts
@@ -1,13 +1,25 @@
+/* eslint-disable no-console -- eval runner reports case progress and summaries */
+
 import type { Payload } from 'payload'
 
 import { randomUUID } from 'node:crypto'
 import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import ts from 'typescript'
+import { expect as vitestExpect } from 'vitest'
 
-import type { EvalCase, EvalResult, RunCodegenDatasetOptions } from './types.js'
+import type {
+  ConfigChangeScorerResult,
+  EvalCase,
+  EvalExpect,
+  EvalResult,
+  EvalUsage,
+  RunCodegenDatasetOptions,
+  TokenUsage,
+} from './types.js'
 
-import { evaluateAssertions } from './assertions/index.js'
+import { parseConfig } from './assertions/parseConfig.js'
 import {
   codegenKey,
   getCachedResult,
@@ -15,23 +27,32 @@ import {
   pruneStaleEntries,
   setCachedResult,
 } from './cache.js'
+import { buildEvalConfig, missingEvalConfig, unwrapEvalConfigValue } from './evalConfig.js'
 import { DEFAULT_RUNNER_MODEL, DEFAULT_SCORER_MODEL } from './models.js'
 import { getAgentVersion } from './runner/claudeCode.js'
 import { runCodegenEval } from './runner/index.js'
-import { scoreConfigChange } from './scorer/index.js'
+import { scoreConfigChange, scoreEvidence } from './scorer/index.js'
 import { accuracySummary, writeFailedCodegenAssertion } from './utils/index.js'
 import { validateConfigTypes } from './validate.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const fixturesDir = path.join(__dirname, 'fixtures')
+let runtimeVerifyLock: Promise<void> = Promise.resolve()
+
+class VerifyFailure extends Error {
+  assertionErrors?: string[]
+}
 
 /**
  * Runs the full codegen pipeline for a single eval case:
  *   1. LLM modifies the per-case starter payload.config.ts
  *   2. TypeScript compiler validates the result (hard check)
- *   3. `verify` decides whether to run runtime checks, the LLM scorer, or both.
+ *   3. `verify` performs deterministic config checks, runtime checks, scorer
+ *      checks, or any combination of those through one readable function.
  *
- * Results are cached by a hash of the inputs. Pass label for logging context.
+ * Results are cached by a hash of the inputs and verifier source. Runtime
+ * cases are intentionally not served from cache because their point is booting
+ * the generated config.
  */
 export async function runCodegenCase(
   testCase: EvalCase,
@@ -71,25 +92,19 @@ export async function runCodegenCase(
       ? r.modelId === resolvedModelId && r.systemPromptKey === systemPromptKey
       : r.modelId === resolvedModelId && r.skillInstall === skillInstall)
 
-  const runtime = testCase.verify.runtime
-  const scorer = testCase.verify.scorer
-  const shouldCache = Boolean(scorer && !runtime)
-  const key =
-    scorer && shouldCache
-      ? codegenKey({
-          expected: scorer.expected,
-          fixtureContent: starterConfig,
-          input: testCase.input,
-          modelId: resolvedModelId,
-          runnerKind: kind,
-          skillInstall: kind === 'claude-code' ? skillInstall : undefined,
-          systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
-        })
-      : undefined
+  const key = codegenKey({
+    expected: testCase.verify.toString(),
+    fixtureContent: starterConfig,
+    input: testCase.input,
+    modelId: resolvedModelId,
+    runnerKind: kind,
+    skillInstall: kind === 'claude-code' ? skillInstall : undefined,
+    systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+  })
 
   const bypassCache = isCacheBypassed()
-  const cached = key && !bypassCache ? getCachedResult(key) : null
-  if (cached) {
+  const cached = !bypassCache ? getCachedResult(key) : null
+  if (cached && cached.runtimeUsed !== true) {
     const cachedScore = cached.score != null ? `  score: ${cached.score.toFixed(2)}` : ''
     console.log(`[${cached.category}] ${cached.pass ? '✓ PASS' : '✗ FAIL'} (cached)${cachedScore}`)
     console.log(`  Task: ${cached.question}`)
@@ -108,6 +123,22 @@ export async function runCodegenCase(
   const agentExitCode = runnerOutput.agentExitCode
   const transcript = runnerOutput.transcript
 
+  const commonResult = {
+    agentExitCode,
+    agentLog,
+    answer: modifiedConfig,
+    category: testCase.category,
+    confidence,
+    configPath: testCase.configPath,
+    modelId: resolvedModelId,
+    question: testCase.input,
+    runnerKind: kind,
+    skillInstall: kind === 'claude-code' ? skillInstall : undefined,
+    starterContent: starterConfig,
+    systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+    transcript,
+  } satisfies Partial<EvalResult>
+
   const { errors: tscErrors, valid } = await validateConfigTypes(
     modifiedConfig,
     testCase.configPath,
@@ -115,48 +146,16 @@ export async function runCodegenCase(
 
   if (!valid) {
     const result: EvalResult = {
-      agentExitCode,
-      agentLog,
-      answer: modifiedConfig,
-      category: testCase.category,
-      confidence,
-      configPath: testCase.configPath,
-      modelId: resolvedModelId,
+      ...commonResult,
       pass: false,
-      question: testCase.input,
       reasoning: `TypeScript compilation failed:\n${tscErrors.join('\n')}`,
-      runnerKind: kind,
-      score: scorer ? 0 : undefined,
-      skillInstall: kind === 'claude-code' ? skillInstall : undefined,
-      starterContent: starterConfig,
-      systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
-      transcript,
+      score: 0,
       tscErrors,
-      usage: {
-        runner: runnerUsage,
-        total: {
-          cachedInputTokens: runnerUsage.cachedInputTokens,
-          inputTokens: runnerUsage.inputTokens,
-          outputTokens: runnerUsage.outputTokens,
-          totalTokens: runnerUsage.totalTokens,
-        },
-      },
+      usage: runnerOnlyUsage(runnerUsage),
     }
-    if (key) {
-      setCachedResult(key, result)
-      pruneStaleEntries(key, isSameLogicalCase)
-    }
-    writeFailedCodegenAssertion({
-      category: testCase.category,
-      confidence,
-      configPath: testCase.configPath,
-      label,
-      modifiedConfig,
-      question: testCase.input,
-      reasoning: result.reasoning,
-      starterConfig,
-      tscErrors,
-    })
+    setCachedResult(key, result)
+    pruneStaleEntries(key, isSameLogicalCase)
+    writeFailure({ label, modifiedConfig, result, starterConfig })
     console.log(`[${result.category}] ✗ FAIL [TSC]  ${testCase.configPath}`)
     for (const err of tscErrors) {
       console.log(`  TSC: ${err}`)
@@ -164,218 +163,406 @@ export async function runCodegenCase(
     return result
   }
 
-  const assertionErrors = evaluateAssertions(modifiedConfig, testCase.verify.assertions ?? [])
+  const ast = parseConfig(modifiedConfig)
+  let evalConfig = missingEvalConfig()
 
-  if (assertionErrors.length > 0) {
-    const result: EvalResult = {
-      agentExitCode,
-      agentLog,
-      answer: modifiedConfig,
-      assertionErrors,
-      category: testCase.category,
-      confidence,
-      configPath: testCase.configPath,
-      modelId: resolvedModelId,
-      pass: false,
-      question: testCase.input,
-      reasoning: `Structural assertions failed:\n${assertionErrors.join('\n')}`,
-      runnerKind: kind,
-      score: scorer ? 0 : undefined,
-      skillInstall: kind === 'claude-code' ? skillInstall : undefined,
-      starterContent: starterConfig,
-      systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
-      transcript,
-      usage: {
-        runner: runnerUsage,
-        total: {
-          cachedInputTokens: runnerUsage.cachedInputTokens,
-          inputTokens: runnerUsage.inputTokens,
-          outputTokens: runnerUsage.outputTokens,
-          totalTokens: runnerUsage.totalTokens,
-        },
-      },
-    }
-    if (key) {
+  if (verifyUsesArg(testCase.verify, 'config')) {
+    try {
+      evalConfig = await importGeneratedEvalConfig(testCase, modifiedConfig)
+    } catch (error) {
+      const result: EvalResult = {
+        ...commonResult,
+        pass: false,
+        reasoning: `Generated config import failed:\n${formatError(error)}`,
+        score: 0,
+        usage: runnerOnlyUsage(runnerUsage),
+      }
       setCachedResult(key, result)
       pruneStaleEntries(key, isSameLogicalCase)
-    }
-    writeFailedCodegenAssertion({
-      category: testCase.category,
-      confidence,
-      configPath: testCase.configPath,
-      label,
-      modifiedConfig,
-      question: testCase.input,
-      reasoning: result.reasoning,
-      starterConfig,
-    })
-    console.log(`[${result.category}] ✗ FAIL [ASSERT]  ${testCase.configPath}`)
-    for (const err of assertionErrors) {
-      console.log(`  ASSERT: ${err}`)
-    }
-    return result
-  }
-
-  if (runtime) {
-    const problems = await runRuntimeVerification(testCase, modifiedConfig)
-    const pass = problems.length === 0
-    const result: EvalResult = {
-      agentExitCode,
-      agentLog,
-      answer: modifiedConfig,
-      category: testCase.category,
-      confidence,
-      configPath: testCase.configPath,
-      modelId: resolvedModelId,
-      pass,
-      question: testCase.input,
-      reasoning: pass ? 'Runtime verification passed' : problems.join('\n'),
-      runnerKind: kind,
-      score: !pass && scorer ? 0 : undefined,
-      skillInstall: kind === 'claude-code' ? skillInstall : undefined,
-      starterContent: starterConfig,
-      systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
-      transcript,
-      usage: {
-        runner: runnerUsage,
-        total: {
-          cachedInputTokens: runnerUsage.cachedInputTokens,
-          inputTokens: runnerUsage.inputTokens,
-          outputTokens: runnerUsage.outputTokens,
-          totalTokens: runnerUsage.totalTokens,
-        },
-      },
-    }
-
-    const status = pass ? '✓ PASS' : '✗ FAIL'
-    console.log(`[${result.category}] ${status} [RUNTIME]  ${testCase.configPath}`)
-    if (!pass) {
-      writeFailedCodegenAssertion({
-        category: testCase.category,
-        confidence,
-        configPath: testCase.configPath,
-        label,
-        modifiedConfig,
-        question: testCase.input,
-        reasoning: result.reasoning,
-        starterConfig,
-      })
+      writeFailure({ label, modifiedConfig, result, starterConfig })
+      console.log(`[${result.category}] ✗ FAIL [IMPORT]  ${testCase.configPath}`)
       console.log(`  Reason: ${result.reasoning}`)
       return result
     }
-
-    if (!scorer) {
-      return result
-    }
   }
 
-  if (!scorer) {
-    throw new Error(`Eval case has no verifier: ${testCase.configPath}`)
+  const lazyPayload = createLazyPayload(testCase, modifiedConfig)
+  let scorerResult: ConfigChangeScorerResult | undefined
+
+  const score = async (expected: string, evidence?: unknown): Promise<ConfigChangeScorerResult> => {
+    scorerResult =
+      evidence === undefined
+        ? await scoreConfigChange(testCase.input, expected, starterConfig, modifiedConfig, {
+            model: scorerModel,
+          })
+        : await scoreEvidence(testCase.input, expected, evidence, { model: scorerModel })
+
+    return scorerResult
   }
 
-  const {
-    changeDescription,
-    completeness,
-    correctness,
-    pass,
-    reasoning,
-    score,
-    usage: scorerUsage,
-  } = await scoreConfigChange(testCase.input, scorer.expected, starterConfig, modifiedConfig, {
-    model: scorerModel,
-  })
-
-  const result: EvalResult = {
-    agentExitCode,
-    agentLog,
-    answer: modifiedConfig,
-    category: testCase.category,
-    changeDescription,
-    completeness,
-    confidence,
-    configPath: testCase.configPath,
-    correctness,
-    modelId: resolvedModelId,
-    pass,
-    question: testCase.input,
-    reasoning,
-    runnerKind: kind,
-    score,
-    skillInstall: kind === 'claude-code' ? skillInstall : undefined,
-    starterContent: starterConfig,
-    systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
-    transcript,
-    usage: {
-      runner: runnerUsage,
-      scorer: scorerUsage,
-      total: {
-        cachedInputTokens: runnerUsage.cachedInputTokens + scorerUsage.cachedInputTokens,
-        inputTokens: runnerUsage.inputTokens + scorerUsage.inputTokens,
-        outputTokens: runnerUsage.outputTokens + scorerUsage.outputTokens,
-        totalTokens: runnerUsage.totalTokens + scorerUsage.totalTokens,
-      },
-    },
-  }
-
-  if (key) {
-    setCachedResult(key, result)
-    pruneStaleEntries(key, isSameLogicalCase)
-  }
-
-  if (!pass) {
-    writeFailedCodegenAssertion({
-      category: testCase.category,
-      changeDescription,
-      confidence,
-      configPath: testCase.configPath,
-      label,
-      modifiedConfig,
-      question: testCase.input,
-      reasoning,
-      starterConfig,
+  try {
+    const verifyResult = await testCase.verify({
+      ast,
+      config: evalConfig,
+      expect: createEvalExpect(),
+      payload: lazyPayload.payload,
+      score,
+      source: modifiedConfig,
     })
-  }
+    const resolvedScore = verifyResult ?? scorerResult
+    const result: EvalResult = resolvedScore
+      ? {
+          ...commonResult,
+          changeDescription: resolvedScore.changeDescription,
+          completeness: resolvedScore.completeness,
+          correctness: resolvedScore.correctness,
+          pass: resolvedScore.pass,
+          reasoning: resolvedScore.reasoning,
+          runtimeUsed: lazyPayload.didBoot(),
+          score: resolvedScore.score,
+          usage: usageWithScorer(runnerUsage, resolvedScore.usage),
+        }
+      : {
+          ...commonResult,
+          pass: true,
+          reasoning: lazyPayload.didBoot() ? 'Runtime verification passed' : 'Verification passed',
+          runtimeUsed: lazyPayload.didBoot(),
+          usage: runnerOnlyUsage(runnerUsage),
+        }
 
-  const status = pass ? '✓ PASS' : '✗ FAIL'
-  console.log(
-    `[${result.category}] ${status}  score: ${score.toFixed(2)}  (correctness: ${correctness.toFixed(2)} · completeness: ${completeness.toFixed(2)})`,
-  )
-  console.log(`  Task: ${result.question}`)
-  if (changeDescription) {
-    console.log(`  Change: ${changeDescription}`)
-  }
-  if (!pass) {
-    console.log(`  Reason: ${reasoning}`)
-  }
+    if (!result.runtimeUsed) {
+      setCachedResult(key, result)
+      pruneStaleEntries(key, isSameLogicalCase)
+    }
 
-  return result
+    if (!result.pass) {
+      writeFailure({ label, modifiedConfig, result, starterConfig })
+    }
+
+    logResult(result)
+    return result
+  } catch (error) {
+    const verifyError = normalizeVerifyError(error)
+    const result: EvalResult = {
+      ...commonResult,
+      assertionErrors: verifyError.assertionErrors,
+      pass: false,
+      reasoning: verifyError.message,
+      runtimeUsed: lazyPayload.didBoot(),
+      score: 0,
+      usage: runnerOnlyUsage(runnerUsage),
+    }
+
+    if (!result.runtimeUsed) {
+      setCachedResult(key, result)
+      pruneStaleEntries(key, isSameLogicalCase)
+    }
+
+    writeFailure({ label, modifiedConfig, result, starterConfig })
+    console.log(`[${result.category}] ✗ FAIL [VERIFY]  ${testCase.configPath}`)
+    console.log(`  Reason: ${result.reasoning}`)
+    return result
+  } finally {
+    await lazyPayload.cleanup()
+  }
 }
 
-async function runRuntimeVerification(
+function createEvalExpect(): EvalExpect {
+  const evalExpect = ((actual: unknown, message?: string) =>
+    vitestExpect(unwrapEvalConfigValue(actual), message)) as EvalExpect
+
+  Object.assign(evalExpect, vitestExpect)
+
+  return evalExpect
+}
+
+async function importGeneratedEvalConfig(
   testCase: EvalCase,
   modifiedConfig: string,
-): Promise<string[]> {
-  if (!testCase.verify.runtime) {
-    throw new Error(`Runtime verifier received case without runtime check: ${testCase.configPath}`)
+): Promise<Awaited<ReturnType<typeof buildEvalConfig>>> {
+  const configDir = path.resolve(fixturesDir, testCase.configPath)
+  const configFile = `payload.generated.${randomUUID()}.config.ts`
+  const configFilePath = path.join(configDir, configFile)
+
+  writeFileSync(configFilePath, modifiedConfig, 'utf-8')
+
+  try {
+    const imported = (await import(pathToFileURL(configFilePath).href)) as {
+      default: unknown
+    }
+    const generatedConfig = await imported.default
+    return buildEvalConfig(generatedConfig as Parameters<typeof buildEvalConfig>[0])
+  } finally {
+    rmSync(configFilePath, { force: true })
+  }
+}
+
+function verifyUsesArg(verify: EvalCase['verify'], argName: string): boolean {
+  const source = `const verify = ${verify.toString()}`
+  const sourceFile = parseConfigSource(source)
+  const statement = sourceFile.statements[0]
+  if (!statement || !ts.isVariableStatement(statement)) {
+    return false
   }
 
+  const initializer = statement.declarationList.declarations[0]?.initializer
+  if (!initializer || !isArrowOrFunctionExpression(initializer)) {
+    return false
+  }
+
+  const firstParam = initializer.parameters[0]?.name
+  if (!firstParam) {
+    return false
+  }
+
+  if (bindingIncludesName(firstParam, argName)) {
+    return true
+  }
+
+  return ts.isIdentifier(firstParam)
+    ? bodyReadsProperty(initializer.body, firstParam.text, argName)
+    : false
+}
+
+function bindingIncludesName(binding: ts.BindingName, name: string): boolean {
+  if ('text' in binding) {
+    return binding.text === name
+  }
+
+  return binding.elements.some((element) => {
+    if (ts.isOmittedExpression(element)) {
+      return false
+    }
+    const propertyName = element.propertyName
+    if (propertyName && 'text' in propertyName && propertyName.text === name) {
+      return true
+    }
+    return bindingIncludesName(element.name, name)
+  })
+}
+
+function parseConfigSource(source: string): ts.SourceFile {
+  return ts.createSourceFile('verify.ts', source, ts.ScriptTarget.Latest, true)
+}
+
+function bodyReadsProperty(body: ts.ConciseBody, objectName: string, propName: string): boolean {
+  let found = false
+
+  const visit = (node: ts.Node): void => {
+    if (found) {
+      return
+    }
+
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === objectName &&
+      node.name.text === propName
+    ) {
+      found = true
+      return
+    }
+
+    if (
+      ts.isElementAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === objectName &&
+      ts.isStringLiteral(node.argumentExpression) &&
+      node.argumentExpression.text === propName
+    ) {
+      found = true
+      return
+    }
+
+    node.forEachChild(visit)
+  }
+
+  visit(body)
+  return found
+}
+
+function isArrowOrFunctionExpression(
+  node: ts.Node,
+): node is ts.ArrowFunction | ts.FunctionExpression {
+  return ts.isArrowFunction(node) || ts.isFunctionExpression(node)
+}
+
+function createLazyPayload(
+  testCase: EvalCase,
+  modifiedConfig: string,
+): {
+  cleanup: () => Promise<void>
+  didBoot: () => boolean
+  payload: Payload
+} {
   let payload: Payload | undefined
+  let payloadPromise: Promise<Payload> | undefined
+  let releaseRuntime: (() => void) | undefined
   const configDir = path.resolve(fixturesDir, testCase.configPath)
   const configFile = `payload.generated.${randomUUID()}.config.ts`
   const configFilePath = path.join(configDir, configFile)
   const suiteName = path.join('evals', 'fixtures', testCase.configPath)
 
-  writeFileSync(configFilePath, modifiedConfig, 'utf-8')
+  const getPayload = async () => {
+    if (!payloadPromise) {
+      payloadPromise = (async () => {
+        releaseRuntime = await acquireRuntimeVerifyLock()
+        writeFileSync(configFilePath, modifiedConfig, 'utf-8')
 
-  try {
-    const { initPayloadInt } = await import('../__helpers/shared/initPayloadInt.js')
+        const previousDropDatabase = process.env.PAYLOAD_DROP_DATABASE
+        process.env.PAYLOAD_DROP_DATABASE = 'true'
 
-    payload = (await initPayloadInt(configDir, suiteName, undefined, configFile)).payload
+        try {
+          const { initPayloadInt } = await import('../__helpers/shared/initPayloadInt.js')
+          payload = (await initPayloadInt(configDir, suiteName, undefined, configFile)).payload
+          return payload
+        } finally {
+          if (previousDropDatabase === undefined) {
+            delete process.env.PAYLOAD_DROP_DATABASE
+          } else {
+            process.env.PAYLOAD_DROP_DATABASE = previousDropDatabase
+          }
+        }
+      })()
+    }
 
-    return await testCase.verify.runtime.check({ payload })
-  } finally {
-    await payload?.destroy()
-    rmSync(configFilePath, { force: true })
+    return payloadPromise
+  }
+
+  const lazy = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'then') {
+          return undefined
+        }
+
+        return async (...args: unknown[]) => {
+          const realPayload = await getPayload()
+          const value = realPayload[prop as keyof Payload]
+
+          if (typeof value === 'function') {
+            return Reflect.apply(value as (...args: unknown[]) => unknown, realPayload, args)
+          }
+
+          return value
+        }
+      },
+    },
+  ) as Payload
+
+  return {
+    cleanup: async () => {
+      try {
+        await payloadPromise?.catch(() => undefined)
+        await payload?.destroy()
+      } finally {
+        rmSync(configFilePath, { force: true })
+        releaseRuntime?.()
+        releaseRuntime = undefined
+      }
+    },
+    didBoot: () => Boolean(payloadPromise),
+    payload: lazy,
+  }
+}
+
+async function acquireRuntimeVerifyLock(): Promise<() => void> {
+  let release!: () => void
+  const previous = runtimeVerifyLock
+
+  runtimeVerifyLock = previous.then(
+    () =>
+      new Promise<void>((resolve) => {
+        release = resolve
+      }),
+  )
+
+  await previous
+  return release
+}
+
+function normalizeVerifyError(error: unknown): VerifyFailure {
+  if (error instanceof VerifyFailure) {
+    return error
+  }
+
+  const normalized = new VerifyFailure(formatError(error))
+  return normalized
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function runnerOnlyUsage(runnerUsage: TokenUsage): EvalUsage {
+  return {
+    runner: runnerUsage,
+    total: {
+      cachedInputTokens: runnerUsage.cachedInputTokens,
+      inputTokens: runnerUsage.inputTokens,
+      outputTokens: runnerUsage.outputTokens,
+      totalTokens: runnerUsage.totalTokens,
+    },
+  }
+}
+
+function usageWithScorer(runnerUsage: TokenUsage, scorerUsage: TokenUsage): EvalUsage {
+  return {
+    runner: runnerUsage,
+    scorer: scorerUsage,
+    total: {
+      cachedInputTokens: runnerUsage.cachedInputTokens + scorerUsage.cachedInputTokens,
+      inputTokens: runnerUsage.inputTokens + scorerUsage.inputTokens,
+      outputTokens: runnerUsage.outputTokens + scorerUsage.outputTokens,
+      totalTokens: runnerUsage.totalTokens + scorerUsage.totalTokens,
+    },
+  }
+}
+
+function writeFailure({
+  label,
+  modifiedConfig,
+  result,
+  starterConfig,
+}: {
+  label: string
+  modifiedConfig: string
+  result: EvalResult
+  starterConfig: string
+}) {
+  writeFailedCodegenAssertion({
+    category: result.category,
+    changeDescription: result.changeDescription,
+    confidence: result.confidence,
+    configPath: result.configPath,
+    label,
+    modifiedConfig,
+    question: result.question,
+    reasoning: result.reasoning,
+    starterConfig,
+    tscErrors: result.tscErrors,
+  })
+}
+
+function logResult(result: EvalResult) {
+  const status = result.pass ? '✓ PASS' : '✗ FAIL'
+  const mode = result.runtimeUsed ? ' [RUNTIME]' : ''
+
+  if (result.score == null) {
+    console.log(`[${result.category}] ${status}${mode}  ${result.configPath}`)
+  } else {
+    console.log(
+      `[${result.category}] ${status}${mode}  score: ${result.score.toFixed(2)}  (correctness: ${result.correctness?.toFixed(2)} · completeness: ${result.completeness?.toFixed(2)})`,
+    )
+  }
+
+  console.log(`  Task: ${result.question}`)
+  if (result.changeDescription) {
+    console.log(`  Change: ${result.changeDescription}`)
+  }
+  if (!result.pass) {
+    console.log(`  Reason: ${result.reasoning}`)
   }
 }
 

--- a/test/evals/runCodegenDataset.ts
+++ b/test/evals/runCodegenDataset.ts
@@ -1,8 +1,11 @@
-import { readFileSync } from 'node:fs'
+import type { Payload } from 'payload'
+
+import { randomUUID } from 'node:crypto'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import type { CodegenEvalCase, EvalResult, RunCodegenDatasetOptions } from './types.js'
+import type { EvalCase, EvalResult, RunCodegenDatasetOptions } from './types.js'
 
 import { evaluateAssertions } from './assertions/index.js'
 import {
@@ -26,12 +29,13 @@ const fixturesDir = path.join(__dirname, 'fixtures')
  * Runs the full codegen pipeline for a single eval case:
  *   1. LLM modifies the per-case starter payload.config.ts
  *   2. TypeScript compiler validates the result (hard check)
- *   3. LLM scorer compares before/after and names the precise change (soft check)
+ *   3. `verify.type` decides whether to run the LLM scorer or boot the
+ *      generated config and check real DB state.
  *
  * Results are cached by a hash of the inputs. Pass label for logging context.
  */
 export async function runCodegenCase(
-  testCase: CodegenEvalCase,
+  testCase: EvalCase,
   label: string,
   options: RunCodegenDatasetOptions = {},
 ): Promise<EvalResult> {
@@ -56,30 +60,33 @@ export async function runCodegenCase(
       : llmModelId
 
   const starterConfig = readFileSync(
-    path.join(fixturesDir, testCase.fixturePath, 'payload.config.ts'),
+    path.join(fixturesDir, testCase.configPath, 'payload.config.ts'),
     'utf-8',
   )
 
   const isSameLogicalCase = (r: EvalResult): boolean =>
     r.question === testCase.input &&
-    r.fixturePath === testCase.fixturePath &&
+    r.configPath === testCase.configPath &&
     (r.runnerKind ?? 'llm') === kind &&
     (kind === 'llm'
       ? r.modelId === resolvedModelId && r.systemPromptKey === systemPromptKey
       : r.modelId === resolvedModelId && r.skillInstall === skillInstall)
 
-  const key = codegenKey({
-    expected: testCase.expected,
-    fixtureContent: starterConfig,
-    input: testCase.input,
-    modelId: resolvedModelId,
-    runnerKind: kind,
-    skillInstall: kind === 'claude-code' ? skillInstall : undefined,
-    systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
-  })
+  const key =
+    testCase.verify.type === 'scorer'
+      ? codegenKey({
+          expected: testCase.verify.expected,
+          fixtureContent: starterConfig,
+          input: testCase.input,
+          modelId: resolvedModelId,
+          runnerKind: kind,
+          skillInstall: kind === 'claude-code' ? skillInstall : undefined,
+          systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+        })
+      : undefined
 
   const bypassCache = isCacheBypassed()
-  const cached = !bypassCache && getCachedResult(key)
+  const cached = key && !bypassCache ? getCachedResult(key) : null
   if (cached) {
     const cachedScore = cached.score != null ? `  score: ${cached.score.toFixed(2)}` : ''
     console.log(`[${cached.category}] ${cached.pass ? '✓ PASS' : '✗ FAIL'} (cached)${cachedScore}`)
@@ -101,10 +108,8 @@ export async function runCodegenCase(
 
   const { errors: tscErrors, valid } = await validateConfigTypes(
     modifiedConfig,
-    testCase.fixturePath,
+    testCase.configPath,
   )
-
-  const assertionErrors = valid ? evaluateAssertions(modifiedConfig, testCase.assertions ?? []) : []
 
   if (!valid) {
     const result: EvalResult = {
@@ -113,7 +118,7 @@ export async function runCodegenCase(
       answer: modifiedConfig,
       category: testCase.category,
       confidence,
-      fixturePath: testCase.fixturePath,
+      configPath: testCase.configPath,
       modelId: resolvedModelId,
       pass: false,
       question: testCase.input,
@@ -134,12 +139,14 @@ export async function runCodegenCase(
         },
       },
     }
-    setCachedResult(key, result)
-    pruneStaleEntries(key, isSameLogicalCase)
+    if (key) {
+      setCachedResult(key, result)
+      pruneStaleEntries(key, isSameLogicalCase)
+    }
     writeFailedCodegenAssertion({
       category: testCase.category,
       confidence,
-      fixturePath: testCase.fixturePath,
+      configPath: testCase.configPath,
       label,
       modifiedConfig,
       question: testCase.input,
@@ -147,12 +154,63 @@ export async function runCodegenCase(
       starterConfig,
       tscErrors,
     })
-    console.log(`[${result.category}] ✗ FAIL [TSC]  ${testCase.fixturePath}`)
+    console.log(`[${result.category}] ✗ FAIL [TSC]  ${testCase.configPath}`)
     for (const err of tscErrors) {
       console.log(`  TSC: ${err}`)
     }
     return result
   }
+
+  if (testCase.verify.type === 'runtime') {
+    const problems = await runRuntimeVerification(testCase, modifiedConfig)
+    const pass = problems.length === 0
+    const result: EvalResult = {
+      agentExitCode,
+      agentLog,
+      answer: modifiedConfig,
+      category: testCase.category,
+      confidence,
+      configPath: testCase.configPath,
+      modelId: resolvedModelId,
+      pass,
+      question: testCase.input,
+      reasoning: pass ? 'Runtime verification passed' : problems.join('\n'),
+      runnerKind: kind,
+      skillInstall: kind === 'claude-code' ? skillInstall : undefined,
+      starterContent: starterConfig,
+      systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+      transcript,
+      usage: {
+        runner: runnerUsage,
+        total: {
+          cachedInputTokens: runnerUsage.cachedInputTokens,
+          inputTokens: runnerUsage.inputTokens,
+          outputTokens: runnerUsage.outputTokens,
+          totalTokens: runnerUsage.totalTokens,
+        },
+      },
+    }
+
+    const status = pass ? '✓ PASS' : '✗ FAIL'
+    console.log(`[${result.category}] ${status} [RUNTIME]  ${testCase.configPath}`)
+    if (!pass) {
+      writeFailedCodegenAssertion({
+        category: testCase.category,
+        confidence,
+        configPath: testCase.configPath,
+        label,
+        modifiedConfig,
+        question: testCase.input,
+        reasoning: result.reasoning,
+        starterConfig,
+      })
+      console.log(`  Reason: ${result.reasoning}`)
+    }
+
+    return result
+  }
+
+  const assertionErrors = evaluateAssertions(modifiedConfig, testCase.verify.assertions ?? [])
 
   if (assertionErrors.length > 0) {
     const result: EvalResult = {
@@ -162,7 +220,7 @@ export async function runCodegenCase(
       assertionErrors,
       category: testCase.category,
       confidence,
-      fixturePath: testCase.fixturePath,
+      configPath: testCase.configPath,
       modelId: resolvedModelId,
       pass: false,
       question: testCase.input,
@@ -182,19 +240,21 @@ export async function runCodegenCase(
         },
       },
     }
-    setCachedResult(key, result)
-    pruneStaleEntries(key, isSameLogicalCase)
+    if (key) {
+      setCachedResult(key, result)
+      pruneStaleEntries(key, isSameLogicalCase)
+    }
     writeFailedCodegenAssertion({
       category: testCase.category,
       confidence,
-      fixturePath: testCase.fixturePath,
+      configPath: testCase.configPath,
       label,
       modifiedConfig,
       question: testCase.input,
       reasoning: result.reasoning,
       starterConfig,
     })
-    console.log(`[${result.category}] ✗ FAIL [ASSERT]  ${testCase.fixturePath}`)
+    console.log(`[${result.category}] ✗ FAIL [ASSERT]  ${testCase.configPath}`)
     for (const err of assertionErrors) {
       console.log(`  ASSERT: ${err}`)
     }
@@ -209,9 +269,15 @@ export async function runCodegenCase(
     reasoning,
     score,
     usage: scorerUsage,
-  } = await scoreConfigChange(testCase.input, testCase.expected, starterConfig, modifiedConfig, {
-    model: scorerModel,
-  })
+  } = await scoreConfigChange(
+    testCase.input,
+    testCase.verify.expected,
+    starterConfig,
+    modifiedConfig,
+    {
+      model: scorerModel,
+    },
+  )
 
   const result: EvalResult = {
     agentExitCode,
@@ -221,8 +287,8 @@ export async function runCodegenCase(
     changeDescription,
     completeness,
     confidence,
+    configPath: testCase.configPath,
     correctness,
-    fixturePath: testCase.fixturePath,
     modelId: resolvedModelId,
     pass,
     question: testCase.input,
@@ -245,15 +311,17 @@ export async function runCodegenCase(
     },
   }
 
-  setCachedResult(key, result)
-  pruneStaleEntries(key, isSameLogicalCase)
+  if (key) {
+    setCachedResult(key, result)
+    pruneStaleEntries(key, isSameLogicalCase)
+  }
 
   if (!pass) {
     writeFailedCodegenAssertion({
       category: testCase.category,
       changeDescription,
       confidence,
-      fixturePath: testCase.fixturePath,
+      configPath: testCase.configPath,
       label,
       modifiedConfig,
       question: testCase.input,
@@ -277,20 +345,51 @@ export async function runCodegenCase(
   return result
 }
 
+async function runRuntimeVerification(
+  testCase: EvalCase,
+  modifiedConfig: string,
+): Promise<string[]> {
+  if (testCase.verify.type !== 'runtime') {
+    throw new Error(
+      `Runtime verifier received ${testCase.verify.type} case: ${testCase.configPath}`,
+    )
+  }
+
+  let payload: Payload | undefined
+  const configDir = path.resolve(fixturesDir, testCase.configPath)
+  const configFile = `payload.generated.${randomUUID()}.config.ts`
+  const configFilePath = path.join(configDir, configFile)
+  const suiteName = path.join('evals', 'fixtures', testCase.configPath)
+
+  writeFileSync(configFilePath, modifiedConfig, 'utf-8')
+
+  try {
+    const { initPayloadInt } = await import('../__helpers/shared/initPayloadInt.js')
+
+    payload = (await initPayloadInt(configDir, suiteName, undefined, configFile)).payload
+
+    return await testCase.verify.check({ payload })
+  } finally {
+    await payload?.destroy()
+    rmSync(configFilePath, { force: true })
+  }
+}
+
 /**
  * Runs codegen evals for an entire dataset and returns aggregate accuracy.
  * Delegates per-case work to runCodegenCase.
  */
 export async function runCodegenDataset(
-  dataset: CodegenEvalCase[],
+  dataset: EvalCase[],
   label: string,
   options: RunCodegenDatasetOptions = {},
 ): Promise<{ accuracy: number; results: EvalResult[] }> {
   const categories = [...new Set(dataset.map((c) => c.category))]
+
   console.log(`\n=== ${label} Eval Results (${dataset.length} cases) ===`)
   console.log(`  Categories: ${categories.join(', ')}`)
   for (const c of dataset) {
-    console.log(`  · ${c.fixturePath}`)
+    console.log(`  · ${c.configPath}`)
   }
 
   if (isCacheBypassed()) {

--- a/test/evals/runCodegenDataset.ts
+++ b/test/evals/runCodegenDataset.ts
@@ -29,8 +29,7 @@ const fixturesDir = path.join(__dirname, 'fixtures')
  * Runs the full codegen pipeline for a single eval case:
  *   1. LLM modifies the per-case starter payload.config.ts
  *   2. TypeScript compiler validates the result (hard check)
- *   3. `verify.type` decides whether to run the LLM scorer or boot the
- *      generated config and check real DB state.
+ *   3. `verify` decides whether to run runtime checks, the LLM scorer, or both.
  *
  * Results are cached by a hash of the inputs. Pass label for logging context.
  */
@@ -72,10 +71,13 @@ export async function runCodegenCase(
       ? r.modelId === resolvedModelId && r.systemPromptKey === systemPromptKey
       : r.modelId === resolvedModelId && r.skillInstall === skillInstall)
 
+  const runtime = testCase.verify.runtime
+  const scorer = testCase.verify.scorer
+  const shouldCache = Boolean(scorer && !runtime)
   const key =
-    testCase.verify.type === 'scorer'
+    scorer && shouldCache
       ? codegenKey({
-          expected: testCase.verify.expected,
+          expected: scorer.expected,
           fixtureContent: starterConfig,
           input: testCase.input,
           modelId: resolvedModelId,
@@ -124,6 +126,7 @@ export async function runCodegenCase(
       question: testCase.input,
       reasoning: `TypeScript compilation failed:\n${tscErrors.join('\n')}`,
       runnerKind: kind,
+      score: scorer ? 0 : undefined,
       skillInstall: kind === 'claude-code' ? skillInstall : undefined,
       starterContent: starterConfig,
       systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
@@ -161,55 +164,6 @@ export async function runCodegenCase(
     return result
   }
 
-  if (testCase.verify.type === 'runtime') {
-    const problems = await runRuntimeVerification(testCase, modifiedConfig)
-    const pass = problems.length === 0
-    const result: EvalResult = {
-      agentExitCode,
-      agentLog,
-      answer: modifiedConfig,
-      category: testCase.category,
-      confidence,
-      configPath: testCase.configPath,
-      modelId: resolvedModelId,
-      pass,
-      question: testCase.input,
-      reasoning: pass ? 'Runtime verification passed' : problems.join('\n'),
-      runnerKind: kind,
-      skillInstall: kind === 'claude-code' ? skillInstall : undefined,
-      starterContent: starterConfig,
-      systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
-      transcript,
-      usage: {
-        runner: runnerUsage,
-        total: {
-          cachedInputTokens: runnerUsage.cachedInputTokens,
-          inputTokens: runnerUsage.inputTokens,
-          outputTokens: runnerUsage.outputTokens,
-          totalTokens: runnerUsage.totalTokens,
-        },
-      },
-    }
-
-    const status = pass ? '✓ PASS' : '✗ FAIL'
-    console.log(`[${result.category}] ${status} [RUNTIME]  ${testCase.configPath}`)
-    if (!pass) {
-      writeFailedCodegenAssertion({
-        category: testCase.category,
-        confidence,
-        configPath: testCase.configPath,
-        label,
-        modifiedConfig,
-        question: testCase.input,
-        reasoning: result.reasoning,
-        starterConfig,
-      })
-      console.log(`  Reason: ${result.reasoning}`)
-    }
-
-    return result
-  }
-
   const assertionErrors = evaluateAssertions(modifiedConfig, testCase.verify.assertions ?? [])
 
   if (assertionErrors.length > 0) {
@@ -226,6 +180,7 @@ export async function runCodegenCase(
       question: testCase.input,
       reasoning: `Structural assertions failed:\n${assertionErrors.join('\n')}`,
       runnerKind: kind,
+      score: scorer ? 0 : undefined,
       skillInstall: kind === 'claude-code' ? skillInstall : undefined,
       starterContent: starterConfig,
       systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
@@ -261,6 +216,63 @@ export async function runCodegenCase(
     return result
   }
 
+  if (runtime) {
+    const problems = await runRuntimeVerification(testCase, modifiedConfig)
+    const pass = problems.length === 0
+    const result: EvalResult = {
+      agentExitCode,
+      agentLog,
+      answer: modifiedConfig,
+      category: testCase.category,
+      confidence,
+      configPath: testCase.configPath,
+      modelId: resolvedModelId,
+      pass,
+      question: testCase.input,
+      reasoning: pass ? 'Runtime verification passed' : problems.join('\n'),
+      runnerKind: kind,
+      score: !pass && scorer ? 0 : undefined,
+      skillInstall: kind === 'claude-code' ? skillInstall : undefined,
+      starterContent: starterConfig,
+      systemPromptKey: kind === 'llm' ? systemPromptKey : undefined,
+      transcript,
+      usage: {
+        runner: runnerUsage,
+        total: {
+          cachedInputTokens: runnerUsage.cachedInputTokens,
+          inputTokens: runnerUsage.inputTokens,
+          outputTokens: runnerUsage.outputTokens,
+          totalTokens: runnerUsage.totalTokens,
+        },
+      },
+    }
+
+    const status = pass ? '✓ PASS' : '✗ FAIL'
+    console.log(`[${result.category}] ${status} [RUNTIME]  ${testCase.configPath}`)
+    if (!pass) {
+      writeFailedCodegenAssertion({
+        category: testCase.category,
+        confidence,
+        configPath: testCase.configPath,
+        label,
+        modifiedConfig,
+        question: testCase.input,
+        reasoning: result.reasoning,
+        starterConfig,
+      })
+      console.log(`  Reason: ${result.reasoning}`)
+      return result
+    }
+
+    if (!scorer) {
+      return result
+    }
+  }
+
+  if (!scorer) {
+    throw new Error(`Eval case has no verifier: ${testCase.configPath}`)
+  }
+
   const {
     changeDescription,
     completeness,
@@ -269,15 +281,9 @@ export async function runCodegenCase(
     reasoning,
     score,
     usage: scorerUsage,
-  } = await scoreConfigChange(
-    testCase.input,
-    testCase.verify.expected,
-    starterConfig,
-    modifiedConfig,
-    {
-      model: scorerModel,
-    },
-  )
+  } = await scoreConfigChange(testCase.input, scorer.expected, starterConfig, modifiedConfig, {
+    model: scorerModel,
+  })
 
   const result: EvalResult = {
     agentExitCode,
@@ -349,10 +355,8 @@ async function runRuntimeVerification(
   testCase: EvalCase,
   modifiedConfig: string,
 ): Promise<string[]> {
-  if (testCase.verify.type !== 'runtime') {
-    throw new Error(
-      `Runtime verifier received ${testCase.verify.type} case: ${testCase.configPath}`,
-    )
+  if (!testCase.verify.runtime) {
+    throw new Error(`Runtime verifier received case without runtime check: ${testCase.configPath}`)
   }
 
   let payload: Payload | undefined
@@ -368,7 +372,7 @@ async function runRuntimeVerification(
 
     payload = (await initPayloadInt(configDir, suiteName, undefined, configFile)).payload
 
-    return await testCase.verify.check({ payload })
+    return await testCase.verify.runtime.check({ payload })
   } finally {
     await payload?.destroy()
     rmSync(configFilePath, { force: true })

--- a/test/evals/scorer/index.ts
+++ b/test/evals/scorer/index.ts
@@ -1,1 +1,2 @@
 export { scoreConfigChange } from './scoreConfigChange.js'
+export { scoreEvidence } from './scoreEvidence.js'

--- a/test/evals/scorer/scoreConfigChange.ts
+++ b/test/evals/scorer/scoreConfigChange.ts
@@ -71,5 +71,17 @@ Important scoring guidance:
   const score = 0.6 * correctness + 0.4 * completeness
   const pass = score >= SCORE_THRESHOLD
 
-  return { ...output, completeness, correctness, pass, score, usage }
+  return {
+    ...output,
+    completeness,
+    correctness,
+    pass,
+    score,
+    usage: {
+      cachedInputTokens: usage.inputTokenDetails.cacheReadTokens ?? 0,
+      inputTokens: usage.inputTokens ?? 0,
+      outputTokens: usage.outputTokens ?? 0,
+      totalTokens: usage.totalTokens ?? 0,
+    },
+  }
 }

--- a/test/evals/scorer/scoreEvidence.ts
+++ b/test/evals/scorer/scoreEvidence.ts
@@ -1,0 +1,70 @@
+import { generateText, Output } from 'ai'
+
+import type { ConfigChangeScorerResult, ScoreConfigChangeOptions } from '../types.js'
+
+import { DEFAULT_SCORER_MODEL } from '../models.js'
+import { ConfigChangeScoreSchema } from '../schemas.js'
+import { SCORE_THRESHOLD } from '../thresholds.js'
+
+/**
+ * Scores arbitrary evidence collected during `verify`, such as database state
+ * read from a real Payload instance.
+ */
+export async function scoreEvidence(
+  instruction: string,
+  expected: string,
+  evidence: unknown,
+  options: ScoreConfigChangeOptions = {},
+): Promise<ConfigChangeScorerResult> {
+  const { model = DEFAULT_SCORER_MODEL } = options
+
+  const { output, usage } = await generateText({
+    model,
+    output: Output.object({ schema: ConfigChangeScoreSchema }),
+    prompt: `Task: ${instruction}
+
+Expected outcome: ${expected}
+
+--- EVIDENCE ---
+${JSON.stringify(evidence, null, 2)}
+
+Score whether the evidence proves the task was completed.`,
+    system: `You are an impartial evaluator of Payload CMS task outcomes.
+
+Score two dimensions independently, each from 0.0 to 1.0:
+
+correctness — Does the evidence show the requested result is present and correct?
+  1.0 = the exact result is present
+  0.7 = the result is present with minor issues
+  0.4 = a related result is present but does not match the requirement
+  0.0 = the result is missing or fundamentally wrong
+
+completeness — Does the evidence cover the full expected outcome?
+  1.0 = all expected data/behavior is shown
+  0.7 = mostly complete, one minor part missing or incorrect
+  0.4 = partially complete, key parts missing
+  0.0 = barely started or absent
+
+Only score what is supported by the evidence. If the evidence is missing the
+needed data, lower completeness even if the generated config might be correct.`,
+  })
+
+  const correctness = Math.max(0, Math.min(1, output.correctness))
+  const completeness = Math.max(0, Math.min(1, output.completeness))
+  const score = 0.6 * correctness + 0.4 * completeness
+  const pass = score >= SCORE_THRESHOLD
+
+  return {
+    ...output,
+    completeness,
+    correctness,
+    pass,
+    score,
+    usage: {
+      cachedInputTokens: usage.inputTokenDetails.cacheReadTokens ?? 0,
+      inputTokens: usage.inputTokens ?? 0,
+      outputTokens: usage.outputTokens ?? 0,
+      totalTokens: usage.totalTokens ?? 0,
+    },
+  }
+}

--- a/test/evals/suites/helpers.ts
+++ b/test/evals/suites/helpers.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import type { CodegenEvalCase } from '../types.js'
+import type { EvalCase } from '../types.js'
 import type { SuiteOptions } from './types.js'
 
 import { runCodegenCase } from '../runCodegenDataset.js'
@@ -11,12 +11,12 @@ type RegisterCodegenOptions = {
   expectPass?: boolean
   /** Custom group name. Defaults to "Codegen". */
   groupName?: string
-  /** Prefix prepended to each test's fixturePath name. */
+  /** Prefix prepended to each test's config path/name. */
   testNamePrefix?: string
 } & SuiteOptions
 
 export function registerCodegenCases(
-  dataset: CodegenEvalCase[],
+  dataset: EvalCase[],
   label: string,
   options: RegisterCodegenOptions = {},
 ) {
@@ -31,25 +31,50 @@ export function registerCodegenCases(
     systemPromptKey,
     testNamePrefix = '',
   } = options
-  describe.concurrent(`${groupName}${labelSuffix}`, () => {
-    for (const testCase of dataset) {
-      it(`${testNamePrefix}${testCase.fixturePath}`, async () => {
-        const result = await runCodegenCase(testCase, label, {
-          agentModel,
-          kind,
-          runnerModel,
-          skillInstall,
-          systemPromptKey,
+
+  const codegenCases = dataset.filter((testCase) => testCase.verify.type === 'scorer')
+  const runtimeCases = dataset.filter((testCase) => testCase.verify.type === 'runtime')
+
+  if (codegenCases.length > 0) {
+    describe.concurrent(`${groupName}${labelSuffix}`, () => {
+      for (const testCase of codegenCases) {
+        it(`${testNamePrefix}${testCase.configPath}`, async () => {
+          const result = await runCodegenCase(testCase, label, {
+            agentModel,
+            kind,
+            runnerModel,
+            skillInstall,
+            systemPromptKey,
+          })
+
+          if (expectPass) {
+            expect(result.pass, caseFailureMessage(result)).toBe(true)
+          } else {
+            expect(
+              result.pass,
+              'Pipeline should have caught the deliberately broken config but it passed',
+            ).toBe(false)
+          }
         })
-        if (expectPass) {
+      }
+    })
+  }
+
+  if (runtimeCases.length > 0) {
+    describe(`Runtime${labelSuffix}`, () => {
+      for (const testCase of runtimeCases) {
+        it(`${testNamePrefix}${testCase.input}`, async () => {
+          const result = await runCodegenCase(testCase, label, {
+            agentModel,
+            kind,
+            runnerModel,
+            skillInstall,
+            systemPromptKey,
+          })
+
           expect(result.pass, caseFailureMessage(result)).toBe(true)
-        } else {
-          expect(
-            result.pass,
-            'Pipeline should have caught the deliberately broken config but it passed',
-          ).toBe(false)
-        }
-      })
-    }
-  })
+        })
+      }
+    })
+  }
 }

--- a/test/evals/suites/helpers.ts
+++ b/test/evals/suites/helpers.ts
@@ -32,51 +32,26 @@ export function registerCodegenCases(
     testNamePrefix = '',
   } = options
 
-  const scorerOnlyCases = dataset.filter(
-    (testCase) => testCase.verify.scorer && !testCase.verify.runtime,
-  )
-  const runtimeCases = dataset.filter((testCase) => testCase.verify.runtime)
-
-  if (scorerOnlyCases.length > 0) {
-    describe.concurrent(`${groupName}${labelSuffix}`, () => {
-      for (const testCase of scorerOnlyCases) {
-        it(`${testNamePrefix}${testCase.configPath}`, async () => {
-          const result = await runCodegenCase(testCase, label, {
-            agentModel,
-            kind,
-            runnerModel,
-            skillInstall,
-            systemPromptKey,
-          })
-
-          if (expectPass) {
-            expect(result.pass, caseFailureMessage(result)).toBe(true)
-          } else {
-            expect(
-              result.pass,
-              'Pipeline should have caught the deliberately broken config but it passed',
-            ).toBe(false)
-          }
+  describe.concurrent(`${groupName}${labelSuffix}`, () => {
+    for (const testCase of dataset) {
+      it(`${testNamePrefix}${testCase.configPath}`, async () => {
+        const result = await runCodegenCase(testCase, label, {
+          agentModel,
+          kind,
+          runnerModel,
+          skillInstall,
+          systemPromptKey,
         })
-      }
-    })
-  }
 
-  if (runtimeCases.length > 0) {
-    describe(`Runtime${labelSuffix}`, () => {
-      for (const testCase of runtimeCases) {
-        it(`${testNamePrefix}${testCase.input}`, async () => {
-          const result = await runCodegenCase(testCase, label, {
-            agentModel,
-            kind,
-            runnerModel,
-            skillInstall,
-            systemPromptKey,
-          })
-
+        if (expectPass) {
           expect(result.pass, caseFailureMessage(result)).toBe(true)
-        })
-      }
-    })
-  }
+        } else {
+          expect(
+            result.pass,
+            'Pipeline should have caught the deliberately broken config but it passed',
+          ).toBe(false)
+        }
+      })
+    }
+  })
 }

--- a/test/evals/suites/helpers.ts
+++ b/test/evals/suites/helpers.ts
@@ -32,12 +32,14 @@ export function registerCodegenCases(
     testNamePrefix = '',
   } = options
 
-  const codegenCases = dataset.filter((testCase) => testCase.verify.type === 'scorer')
-  const runtimeCases = dataset.filter((testCase) => testCase.verify.type === 'runtime')
+  const scorerOnlyCases = dataset.filter(
+    (testCase) => testCase.verify.scorer && !testCase.verify.runtime,
+  )
+  const runtimeCases = dataset.filter((testCase) => testCase.verify.runtime)
 
-  if (codegenCases.length > 0) {
+  if (scorerOnlyCases.length > 0) {
     describe.concurrent(`${groupName}${labelSuffix}`, () => {
-      for (const testCase of codegenCases) {
+      for (const testCase of scorerOnlyCases) {
         it(`${testNamePrefix}${testCase.configPath}`, async () => {
           const result = await runCodegenCase(testCase, label, {
             agentModel,

--- a/test/evals/types.ts
+++ b/test/evals/types.ts
@@ -1,7 +1,9 @@
 import type { LanguageModel } from 'ai'
 import type { Payload } from 'payload'
+import type { ExpectStatic } from 'vitest'
 
-import type { Assertion } from './assertions/types.js'
+import type { ParsedConfig } from './assertions/parseConfig.js'
+import type { EvalConfig } from './evalConfig.js'
 import type { RunnerKind, SkillInstallMode } from './runner/types.js'
 
 // Dataset
@@ -32,23 +34,46 @@ export type EvalCase = {
   configPath: string
   /** Task prompt given to the model. */
   input: string
-  /** Defines how this case is checked. */
-  verify: {
-    /** Optional structural assertions. Failures stop before runtime or scorer. */
-    assertions?: Assertion[]
-    runtime?: {
-      /**
-       * Boots the generated config and calls `check` with a real Payload Local
-       * API object. Return `[]` to pass, or problem strings to fail.
-       */
-      check: (args: { payload: Payload }) => Promise<string[]> | string[]
-    }
-    scorer?: {
-      /** Expected change description passed to the LLM scorer. */
-      expected: string
-    }
-  }
+  /**
+   * Checks the generated config after TypeScript passes.
+   *
+   * Use `config` for deterministic checks against the imported generated
+   * config, `ast` for source-level checks, `payload.*` when the generated
+   * config must boot and write/read real data, and `return score(...)` when
+   * the LLM scorer should judge the result.
+   */
+  verify: (args: EvalVerifyContext) => EvalVerifyResult | Promise<EvalVerifyResult>
 }
+
+export type EvalExpect = ExpectStatic
+
+export type EvalScore = (
+  expected: string,
+  evidence?: unknown,
+) => ConfigChangeScorerResult | Promise<ConfigChangeScorerResult>
+
+export type EvalVerifyContext = {
+  /** Source-level AST summary from the existing TypeScript parser. */
+  ast: ParsedConfig
+  /** Imported generated config, normalized for easy eval assertions. */
+  config: EvalConfig
+  expect: EvalExpect
+  /**
+   * Lazy Payload Local API for the generated config. The eval only boots Payload
+   * if this object is actually used.
+   */
+  payload: Payload
+  /**
+   * Runs the LLM scorer. Return this from `verify` when the scorer should decide
+   * the final score, optionally with runtime evidence to score instead of a pure
+   * config diff.
+   */
+  score: EvalScore
+  /** Complete generated `payload.config.ts` source. */
+  source: string
+}
+
+export type EvalVerifyResult = ConfigChangeScorerResult | void
 
 // Models
 export type ModelKey = 'openai:gpt-4o-mini' | 'openai:gpt-5.2'
@@ -117,8 +142,8 @@ export type EvalResult = {
   /** Scorer sub-score: fraction of key concepts present (0–1) */
   completeness?: number
   confidence: number
-  /** For codegen results: folder under `test/evals/fixtures/` that contains the starter config. */
-  configPath?: string
+  /** Folder under `test/evals/fixtures/` that contains the starter config. */
+  configPath: string
   /** Scorer sub-score: factual accuracy of the answer (0–1) */
   correctness?: number
   /** Runner model ID (e.g. "openai/gpt-5.2") — surfaced in the dashboard for cross-run comparison */
@@ -138,6 +163,8 @@ export type EvalResult = {
    * read sites should default-coerce to `'llm'`.
    */
   runnerKind: RunnerKind
+  /** True when `verify` booted the generated config through the lazy Payload API. */
+  runtimeUsed?: boolean
   /** Weighted score: (0.6 × correctness) + (0.4 × completeness) */
   score?: number
   /** For agent results only: how the skill was installed in the workdir. */

--- a/test/evals/types.ts
+++ b/test/evals/types.ts
@@ -1,4 +1,5 @@
 import type { LanguageModel } from 'ai'
+import type { Payload } from 'payload'
 
 import type { Assertion } from './assertions/types.js'
 import type { RunnerKind, SkillInstallMode } from './runner/types.js'
@@ -19,14 +20,41 @@ export type EvalCategory =
   | 'structure'
   | 'testing'
 
-export type CodegenEvalCase = {
-  /** Optional structural assertions evaluated against the LLM output. Failing any short-circuits the case to fail before the LLM scorer runs. */
-  assertions?: Assertion[]
+export type EvalCase = {
   category: EvalCategory
-  expected: string
-  /** Path to the starter fixture directory relative to test/evals/fixtures/ */
-  fixturePath: string
+  /**
+   * Folder under `test/evals/fixtures/` that contains the `payload.config.ts`
+   * for this case.
+   *
+   * Eval cases read it as the starter config the model edits. Runtime cases
+   * boot the generated config after TypeScript passes.
+   */
+  configPath: string
+  /** Task prompt given to the model. */
   input: string
+  /** Defines how this case is checked. */
+  verify:
+    | {
+        /** Optional structural assertions. Failures short-circuit before the scorer. */
+        assertions?: Assertion[]
+        /** Expected change description passed to the LLM scorer. */
+        expected: string
+        /**
+         * Runs the codegen pipeline: model edits the config, TypeScript and
+         * optional structural assertions run, then the LLM scorer compares the
+         * output to `expected`.
+         */
+        type: 'scorer'
+      }
+    | {
+        check: (args: { payload: Payload }) => Promise<string[]> | string[]
+        /**
+         * Runs the codegen pipeline, boots the generated config, and calls
+         * `check` with a real Payload Local API object. Return `[]` to pass,
+         * or problem strings to fail.
+         */
+        type: 'runtime'
+      }
 }
 
 // Models
@@ -96,10 +124,10 @@ export type EvalResult = {
   /** Scorer sub-score: fraction of key concepts present (0–1) */
   completeness?: number
   confidence: number
+  /** For codegen results: folder under `test/evals/fixtures/` that contains the starter config. */
+  configPath?: string
   /** Scorer sub-score: factual accuracy of the answer (0–1) */
   correctness?: number
-  /** For codegen results: the fixture directory the starter file came from, relative to test/evals/fixtures/. Used by the dashboard to render a diff. */
-  fixturePath?: string
   /** Runner model ID (e.g. "openai/gpt-5.2") — surfaced in the dashboard for cross-run comparison */
   modelId?: string
   pass: boolean

--- a/test/evals/types.ts
+++ b/test/evals/types.ts
@@ -33,28 +33,21 @@ export type EvalCase = {
   /** Task prompt given to the model. */
   input: string
   /** Defines how this case is checked. */
-  verify:
-    | {
-        /** Optional structural assertions. Failures short-circuit before the scorer. */
-        assertions?: Assertion[]
-        /** Expected change description passed to the LLM scorer. */
-        expected: string
-        /**
-         * Runs the codegen pipeline: model edits the config, TypeScript and
-         * optional structural assertions run, then the LLM scorer compares the
-         * output to `expected`.
-         */
-        type: 'scorer'
-      }
-    | {
-        check: (args: { payload: Payload }) => Promise<string[]> | string[]
-        /**
-         * Runs the codegen pipeline, boots the generated config, and calls
-         * `check` with a real Payload Local API object. Return `[]` to pass,
-         * or problem strings to fail.
-         */
-        type: 'runtime'
-      }
+  verify: {
+    /** Optional structural assertions. Failures stop before runtime or scorer. */
+    assertions?: Assertion[]
+    runtime?: {
+      /**
+       * Boots the generated config and calls `check` with a real Payload Local
+       * API object. Return `[]` to pass, or problem strings to fail.
+       */
+      check: (args: { payload: Payload }) => Promise<string[]> | string[]
+    }
+    scorer?: {
+      /** Expected change description passed to the LLM scorer. */
+      expected: string
+    }
+  }
 }
 
 // Models

--- a/test/evals/utils/writeFailedAssertion.ts
+++ b/test/evals/utils/writeFailedAssertion.ts
@@ -16,7 +16,7 @@ export type FailedCodegenAssertion = {
   category: string
   changeDescription?: string
   confidence: number
-  fixturePath: string
+  configPath: string
   label: string
   modifiedConfig: string
   question: string
@@ -28,6 +28,6 @@ export type FailedCodegenAssertion = {
 export function writeFailedCodegenAssertion(data: FailedCodegenAssertion): void {
   const dir = path.join(evalResultsDir, labelToSlug(data.label))
   mkdirSync(dir, { recursive: true })
-  const fileName = `${path.basename(data.fixturePath)}.json`
+  const fileName = `${path.basename(data.configPath)}.json`
   writeFileSync(path.join(dir, fileName), JSON.stringify(data, null, 2), 'utf-8')
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ import { defineConfig } from 'vitest/config'
 const ROOT_DIR = process.cwd()
 const figmaPath = path.resolve(ROOT_DIR, '../enterprise-plugins/packages/figma/src/index.ts')
 const hasFigma = fs.existsSync(figmaPath)
+const evalFixturesDir = path.resolve(ROOT_DIR, 'test/evals/fixtures')
 
 // Resolve graphql to a single copy to avoid duplicate-instance issues (instanceof checks fail).
 // pnpm's isolated linker means graphql isn't hoisted to root node_modules, so we resolve
@@ -91,6 +92,16 @@ export default defineConfig({
         },
       },
       {
+        resolve: {
+          // Eval fixture configs use `@/db-stub.js` as a fixture-local alias.
+          // TSC knows that from `test/evals/fixtures/tsconfig.json`, but runtime
+          // `verify({ config })` imports generated fixture configs through Vite,
+          // so this project needs the same alias for those imports to resolve.
+          alias: [
+            { find: /^@\//, replacement: `${evalFixturesDir}/` },
+            ...(hasFigma ? [{ find: '@payloadcms/figma', replacement: figmaPath }] : []),
+          ],
+        },
         // Runtime eval cases in this project boot a real Payload config, which
         // can import TSX routes from packages/next.
         oxc: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -91,6 +91,14 @@ export default defineConfig({
         },
       },
       {
+        // Runtime eval cases in this project boot a real Payload config, which
+        // can import TSX routes from packages/next.
+        oxc: {
+          jsx: {
+            runtime: 'automatic',
+            importSource: 'react',
+          },
+        },
         test: {
           include: ['test/evals/**/*.spec.ts'],
           name: 'eval',


### PR DESCRIPTION
This PR:
 
- replaces the old eval assertion/scorer api with a cleaner and more flexible `verify` function that reads like a normal vitest test
- adds the ability for evals to boot the generated Payload config and verify real database state, which is the foundation needed for MCP evals

## Why

Some evals need to prove that generated Payload code actually works, not just that the diff looks right to a scorer. We also need this as a foundation for MCP evals, where the important signal is whether the model or tool call wrote the right data to Payload. The old eval shape made this harder because checks were split between a small custom assertion DSL and scorer config, with no way to boot the generated config and inspect real database state.

## Description

This replaces the eval verification DSL with a single `verify` function that feels like writing a Vitest or Playwright test. Eval authors can use familiar `expect(...)` assertions, inspect the imported generated config through `config`, use `ast` for source-level checks (previously called "assertions"), call `payload.*` to lazily boot the generated config and inspect real database state, and `return await score(...)` when a case still needs LLM judgment.

That makes evals easier to learn and much more flexible. A case can be deterministic only, scorer only, runtime only, or any combination of those in one readable flow. Hard `expect` failures stop with score `0`; successful runtime checks can continue to the scorer.

Before, each case was a `CodegenEvalCase` with top-level `fixturePath`, `expected`, and optional `assertions`. That worked for simple config diffs, but it meant learning eval-specific assertion objects and sending the rest to the scorer:

```ts
{
  input: 'Add a posts collection with title and content fields.',
  expected: 'posts collection has a required title field',
  category: 'collections',
  fixturePath: 'collections/codegen/posts-title-content',
  assertions: [
    { kind: 'collectionExists', slug: 'posts' },
    { field: 'title', fieldType: 'text', kind: 'fieldExists', slug: 'posts' },
    { field: 'title', kind: 'fieldOption', option: 'required', slug: 'posts', value: true },
  ],
}
```

Now each case has one `verify` function. The same check reads like a normal test, using the generated config directly:

```ts
{
  category: 'collections',
  configPath: 'collections/codegen/posts-title-content',
  input: 'Add a posts collection with title and content fields.',
  verify: async ({ config, expect, score }) => {
    const posts = config.collections.posts

    expect(posts).toBeDefined()
    expect(posts?.fields.title).toMatchObject({ required: true, type: 'text' })
    expect(posts?.fields.content).toMatchObject({ type: 'richText' })

    return await score('posts collection has title text and content richText fields')
  },
}
```

This PR also adds runtime checks that are just as direct. The first `payload.*` call in your verify function boots a real payload instance:

```ts
{
  category: 'collections',
  configPath: 'collections/runtime/simple-post',
  input: 'Add an onInit hook that creates a post titled "Seeded by runtime eval".',
  verify: async ({ expect, payload }) => {
    const { docs } = await payload.find({
      collection: 'posts',
      where: { title: { equals: 'Seeded by runtime eval' } },
    })

    expect(docs).toHaveLength(1)
  },
}
```

The big unlock is that a single eval can now mix checks that used to be awkward or impossible to compose cleanly. For example, it can prove the generated config boots, inspect database state, and then pass that evidence to the scorer:

```ts
verify: async ({ expect, payload, score }) => {
  const { docs } = await payload.find({
    collection: 'posts',
    where: { title: { equals: 'Seeded by runtime eval' } },
  })

  expect(docs).toHaveLength(1)

  return await score(
    'Payload booted successfully and contains one seeded post with the expected title. The document should be written in a creative way',
    docs,
  )
}
```

This gives us the simple cases and the realistic cases with one API.

```text
agent generates config
-> TypeScript check
-> verify()
-> config checks imported generated config when used
-> ast checks source parser output when used
-> payload.* boots Payload and checks database state when used
-> score(...) runs the scorer when returned
```
