### PR TITLE
fix(tanstack-start): fire autosave-create redirects on client-side navigation

### DIFF
--- a/packages/tanstack-start/src/utilities/loadAdminPage.tsx
+++ b/packages/tanstack-start/src/utilities/loadAdminPage.tsx
@@ -242,6 +242,25 @@ export async function loadAdminPage({
 
     const rscPayload = await renderServerComponent(node as React.ReactElement)
 
+    // The server-function (client-nav RPC) path returns the flight stream unread —
+    // unlike the router/SSR path, which awaits a decode that drives the render to
+    // completion. So streamed side effects (e.g. DocumentView's autosave-create
+    // `server.redirect()`) haven't run yet and `nav` is empty. Buffer the stream to
+    // completion to force the render (populating `nav`), then hand the client a fresh
+    // replayable stream from that buffer.
+    if (!nav.type) {
+      const wrapper = (
+        rscPayload as unknown as Record<
+          symbol,
+          { createReplayStream?: () => ReadableStream<Uint8Array> } | undefined
+        >
+      )[Symbol.for('tanstack.rsc.stream')]
+      if (typeof wrapper?.createReplayStream === 'function') {
+        const buffer = await new Response(wrapper.createReplayStream()).arrayBuffer()
+        wrapper.createReplayStream = () => new Response(buffer).body as ReadableStream<Uint8Array>
+      }
+    }
+
     // Navigation thrown deep inside a streamed view component (e.g. access
     // denied → notFound, already-authenticated → redirect) is swallowed into
     // the RSC stream and never rejects the render. Honor it from the holder,

--- a/packages/ui/src/views/Document/index.tsx
+++ b/packages/ui/src/views/Document/index.tsx
@@ -487,6 +487,14 @@ export async function DocumentView(props: AdminViewServerProps) {
       throw error
     }
 
+    // The TanStack adapter's `req.server.redirect()` throws `redirect:<url>` as a
+    // control-flow signal — the target is already recorded on `req.server` and
+    // honored upstream in `loadAdminPage`. It isn't a real error, so swallow it
+    // without logging, mirroring the `NEXT_REDIRECT` guard above.
+    if (error?.message?.startsWith('redirect:')) {
+      return
+    }
+
     logError({ err: error, payload: props.initPageResult.req.payload })
 
     if (error.message === 'not-found') {


### PR DESCRIPTION
Fixes autosave-create redirects being lost during client-side navigation in the TanStack Start admin.

Visiting an autosave-drafts collection's create view (e.g. `/admin/collections/autosave-posts/create`) via a full page load correctly redirects to the freshly-created draft, but the same navigation performed client-side (SPA nav) stranded the user on `/create`.

Before:

https://github.com/user-attachments/assets/e460abf8-0731-4f59-9d9f-aa90d44ebf41

After:

https://github.com/user-attachments/assets/4795bc73-c4c6-4278-9168-e4cdca7093ff

Two contributing factors:

1. `loadAdminPage` reads navigation intent from a `nav` holder *after* `renderServerComponent`. On the router/SSR path the framework `await`s a decode that drives the render to completion, so `DocumentView`'s autosave `req.server.redirect()` fires and `nav` is populated. On the server-function (client-nav RPC) path `renderServerComponent` returns the flight stream unread, so the streamed render never runs before `nav` is read — `nav` stays empty and no redirect is returned.

2. `DocumentView`'s catch only recognized Next's `NEXT_REDIRECT` sentinel. The TanStack adapter's `req.server.redirect()` throws `redirect:<url>`, which fell through to `logError` and surfaced as a spurious `ERROR: redirect:...` in the server log even once the redirect worked.

The fix drives the render to completion on the server-function path by buffering the flight stream (`await new Response(stream).arrayBuffer()`), which populates `nav`, then hands the client a fresh replayable stream from that buffer. It also stops treating the `redirect:` control-flow throw as an error.

Related:
- Buffering the stream also makes the flight handle idempotent — the framework's `createRenderableHandle` returns the same single-use stream on every `createReplayStream()` call.
- Relevant e2e test to prevent regression: https://github.com/payloadcms/payload/pull/17161