### PR TITLE
fix(ui): prevent relationship options from clearing while the menu is open

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -105,6 +105,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
   const [enableWordBoundarySearch, setEnableWordBoundarySearch] = useState(false)
   const [menuIsOpen, setMenuIsOpen] = useState(false)
   const hasLoadedFirstPageRef = useRef(false)
+  const isFirstRenderRef = useRef(true)
   const { queueTask } = useQueue()
 
   const [options, dispatchOptions] = useReducer(optionsReducer, [])
@@ -668,10 +669,16 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
   // When (`relationTo` || `filterOptions` || `locale`) changes, reset component
   // Note - effect should not run on first run
   useEffect(() => {
-    // If the menu is open while filterOptions changes
-    // due to latency of form state and fast clicking into this field,
-    // re-fetch options
+    // Skip the first run - there are no loaded options to reset yet, and
+    // clearing here can wipe options that are still being loaded.
+    if (isFirstRenderRef.current) {
+      return
+    }
+
     if (hasLoadedFirstPageRef.current && menuIsOpen) {
+      // If the menu is open while filterOptions changes
+      // due to latency of form state and fast clicking into this field,
+      // re-fetch options in place instead of clearing them.
       setIsLoading(true)
       void updateResultsEffectEvent({
         filterOptions,
@@ -690,21 +697,25 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
               value: valueRef.current as ValueWithRelation,
             }),
       })
+    } else if (!menuIsOpen) {
+      // If the menu is not open, reset the field state
+      // because we need to get new options next time the menu opens.
+      //
+      // This must NOT run while the menu is open: doing so clears the options
+      // that were just loaded (or are still loading, e.g. when `filterOptions`
+      // changes reference due to form-state latency), leaving the dropdown
+      // empty until it is closed and reopened.
+      dispatchOptions({
+        type: 'CLEAR',
+        exemptValues: valueRef.current,
+      })
+
+      setLastFullyLoadedRelation(-1)
+      setLastLoadedPage({})
     }
-
-    // If the menu is not open, still reset the field state
-    // because we need to get new options next time the menu opens
-    dispatchOptions({
-      type: 'CLEAR',
-      exemptValues: valueRef.current,
-    })
-
-    setLastFullyLoadedRelation(-1)
-    setLastLoadedPage({})
   }, [relationTo, filterOptions, locale, path, menuIsOpen, hasMany])
 
   const prevValue = useRef(value)
-  const isFirstRenderRef = useRef(true)
 
   // ///////////////////////////////////
   // Ensure we have an option for each value

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -599,6 +599,39 @@ describe('Relationship Field', () => {
       const options = getSelectMenu({ page })
       await expect(options).toContainText('truth')
     })
+
+    test('should not clear the open menu when `filterOptions` reference changes', async () => {
+      await payload.create({ collection: relationWithTitleSlug, data: { name: 'stays-visible-1' } })
+      await payload.create({ collection: relationWithTitleSlug, data: { name: 'stays-visible-2' } })
+      await payload.create({ collection: relationWithTitleSlug, data: { name: 'stays-visible-3' } })
+
+      await loadCreatePage()
+
+      // Open the polymorphic hasMany relationship and wait for its options to load.
+      const initialLoad = page.waitForResponse(/\/api\/relation-with-title/)
+      await page.locator('#field-relationshipManyFiltered .rs__control').click()
+      await initialLoad
+
+      const menu = getSelectMenu({ page })
+      await expect(menu.locator('.rs__option').first()).toBeVisible()
+      expect(await menu.locator('.rs__option').count()).toBeGreaterThan(1)
+
+      // Serve empty results for any subsequent option (re)fetch, so options can only
+      // remain visible if they were never cleared
+      await page.route(/\/api\/relation-with-title/, (route) =>
+        route.fulfill({
+          body: JSON.stringify({ docs: [], hasNextPage: false, nextPage: null, totalDocs: 0 }),
+          contentType: 'application/json',
+          status: 200,
+        }),
+      )
+
+      await menu.locator('.rs__option').first().click()
+
+      await wait(1500)
+
+      await expect(menu.locator('.rs__option').first()).toBeVisible()
+    })
   })
 
   test('should allow docs with same ID but different collections to be selectable', async () => {


### PR DESCRIPTION
### What?

The Relationship field's options dropdown intermittently renders **empty on first open** — closing and reopening the menu populates it.

### Why?

The reset `useEffect` in `packages/ui/src/fields/Relationship/Input.tsx` (deps `[relationTo, filterOptions, locale, path, menuIsOpen, hasMany]`) has two documented branches:

- **menu open** → re-fetch options in place
- **menu not open** → `CLEAR` + reset pagination so fresh options load next open

…but the `dispatchOptions({ type: 'CLEAR' })` / `setLastFullyLoadedRelation(-1)` / `setLastLoadedPage({})` block was **not gated** on menu state — it ran unconditionally.

`filterOptions` is resolved on the server and delivered via form state, so it receives a **new object reference on every form-state rebuild** (autosave, sibling-field edits, or a `hasMany` field's own value change). When such a rebuild lands while the menu is open — or while the first page of options is still loading — the effect fires and the unconditional `CLEAR` wipes the options that were just loaded, leaving the menu empty until it is closed and reopened. Polymorphic relationships over many collections widen the async load window and make the race easy to lose.

The `// Note - effect should not run on first run` comment also described a first-run guard that was never implemented.

### How?

- Gate the `CLEAR` / pagination-reset block behind `!menuIsOpen`, matching the effect's own comments — an open (or still-loading) menu is re-fetched in place instead of being wiped.
- Add the first-run guard the comment calls for (reusing the existing `isFirstRenderRef`).
- Add an e2e regression test in `test/fields-relationship` that loads options into an open `hasMany` menu, forces a new `filterOptions` reference via a form-state rebuild while the menu stays open, and asserts the options remain visible.

This also appears to be the root cause of the pre-existing flaky `filterOptions` tests in the same file (`should allow dynamic filterOptions` / `should allow dynamic async filterOptions`), annotated `// TODO: Flaky test. Fix this! (This is an actual issue not just an e2e flake)`.

The same code path exists on the v3 line (`@payloadcms/ui@3.85.x`) — happy to open a `3.x` backport if wanted.
