### PR TITLE
fix(plugin-multi-tenant): run tenant delete cleanup inside the request transaction

### DIFF
--- a/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
+++ b/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
@@ -88,6 +88,7 @@ export const afterTenantDelete =
       cleanupPromises.push(
         req.payload.delete({
           collection: slug,
+          req,
           where: {
             [tenantFieldName]: {
               in: [id],
@@ -102,6 +103,7 @@ export const afterTenantDelete =
         collection: usersSlug,
         depth: 0,
         limit: 0,
+        req,
         where: {
           [`${usersTenantsArrayFieldName}.${usersTenantsArrayTenantFieldName}`]: {
             in: [id],
@@ -123,6 +125,7 @@ export const afterTenantDelete =
                 },
               ),
             },
+            req,
           }),
         )
       })

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -9,7 +9,13 @@ import type { Relationship } from './payload-types.js'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
-import { multiTenantPostsSlug, relationshipsSlug, tenantsSlug, usersSlug } from './shared.js'
+import {
+  menuSlug,
+  multiTenantPostsSlug,
+  relationshipsSlug,
+  tenantsSlug,
+  usersSlug,
+} from './shared.js'
 
 let payload: Payload
 let restClient: NextRESTClient
@@ -291,6 +297,31 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       await payload.delete({ id: tenantA.id, collection: tenantsSlug })
       await payload.delete({ id: tenantB.id, collection: tenantsSlug })
     })
+  })
+
+  describe('tenant cleanup on delete', () => {
+    it('should delete a tenant that has a global collection document without hanging', async () => {
+      const tenant = await payload.create({
+        collection: tenantsSlug,
+        data: { name: 'Cleanup Tenant', domain: 'cleanup-tenant.test' },
+      })
+
+      await payload.create({
+        collection: menuSlug,
+        data: { tenant: tenant.id, title: 'Cleanup Menu' },
+      })
+
+      const deletedTenant = await payload.delete({ id: tenant.id, collection: tenantsSlug })
+
+      expect(deletedTenant.id).toBe(tenant.id)
+
+      const remainingTenants = await payload.find({
+        collection: tenantsSlug,
+        where: { id: { equals: tenant.id } },
+      })
+
+      expect(remainingTenants.docs).toHaveLength(0)
+    }, 20000)
   })
 
   describe('hasMany tenant field filtering', () => {


### PR DESCRIPTION
Identical to #17045, back-ported for 3.x.