### PR TITLE
feat(db-postgres): add numeric operators for deep JSON queries

### DIFF
--- a/packages/drizzle/src/postgres/createJSONQuery/index.ts
+++ b/packages/drizzle/src/postgres/createJSONQuery/index.ts
@@ -13,6 +13,10 @@ const operatorMap: Record<string, string> = {
   not_equals: '!=',
   not_in: 'in',
   not_like: '!like_regex',
+  less_than: '<',
+  less_than_equal: '<=',
+  greater_than: '>',
+  greater_than_equal: '>=',
 }
 
 const sanitizeValue = (value: unknown, operator?: string): string => {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -3782,6 +3782,7 @@ describe('Fields', () => {
                   },
                 },
               ],
+              number: 5
             },
           },
         })
@@ -3813,6 +3814,26 @@ describe('Fields', () => {
               {
                 'json.array.object.notexists': {
                   exists: false,
+                },
+              },
+              {
+                'json.number': {
+                  greater_than: 1,
+                },
+              },
+              {
+                'json.number': {
+                  greater_than_equal: 1,
+                },
+              },
+              {
+                'json.number': {
+                  less_than: 10,
+                },
+              },
+              {
+                'json.number': {
+                  less_than_equal: 10,
                 },
               },
             ],


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?

Missing numeric operators for deep JSON queries.

### Why?

`operatorMap` in `packages\drizzle\src\postgres\createJSONQuery\index.ts` didn't include `less_than`, `less_than_equal`, `greater_than`, `greater_than_equal` operators although it is valid in postgres.

### How?

Add new mapping `less_than`, `less_than_equal`, `greater_than`, `greater_than_equal` to `<`, `<=`, `>`, `>=` respectively in `packages\drizzle\src\postgres\createJSONQuery\index.ts`.