### PR TITLE
fix(tanstack-start): block stale-match revalidation on admin route loaders

### DIFF
--- a/packages/tanstack-start/src/routes/adminRoutes.tsx
+++ b/packages/tanstack-start/src/routes/adminRoutes.tsx
@@ -55,15 +55,23 @@ export function payloadAdminSplatRoute({ load }: { load: AdminLoad }) {
   return {
     component: AdminPage,
     head: ({ loaderData }: { loaderData?: any }) => getAdminMeta(loaderData?.metadata),
-    // Surface query params in `loaderDeps` so `?locale=es` re-runs the loader.
-    loader: async ({ location, params }: { location: any; params: any }) => {
-      const data = await runLoader(load, params._splat ?? '', location.searchStr)
-      if (data?._notFound) {
-        // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router requires throwing notFound objects
-        throw notFound({ data: { routeKey: data.routeKey, rscPayload: data.rscPayload } })
-      }
-      return data
+    // `staleReloadMode: 'blocking'` (a property of the loader *object*, not a
+    // sibling route option — router-core only reads it off a non-function loader)
+    // makes stale-match revalidation await the fresh loader before committing,
+    // instead of the default background SWR that flashes the pre-navigation list
+    // (e.g. a just-created doc missing) until the reload lands.
+    loader: {
+      handler: async ({ location, params }: { location: any; params: any }) => {
+        const data = await runLoader(load, params._splat ?? '', location.searchStr)
+        if (data?._notFound) {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router requires throwing notFound objects
+          throw notFound({ data: { routeKey: data.routeKey, rscPayload: data.rscPayload } })
+        }
+        return data
+      },
+      staleReloadMode: 'blocking',
     },
+    // Surface query params in `loaderDeps` so `?locale=es` re-runs the loader.
     loaderDeps: ({ search }: { search: Record<string, unknown> }) => ({
       searchKey: JSON.stringify(search),
     }),
@@ -80,13 +88,16 @@ export function payloadAdminIndexRoute({ load }: { load: AdminLoad }) {
   return {
     component: AdminPage,
     head: ({ loaderData }: { loaderData?: any }) => getAdminMeta(loaderData?.metadata),
-    loader: async ({ location }: { location: any }) => {
-      const data = await runLoader(load, '', location.searchStr)
-      if (data?._notFound) {
-        // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router requires throwing notFound objects
-        throw notFound()
-      }
-      return data
+    loader: {
+      handler: async ({ location }: { location: any }) => {
+        const data = await runLoader(load, '', location.searchStr)
+        if (data?._notFound) {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router requires throwing notFound objects
+          throw notFound()
+        }
+        return data
+      },
+      staleReloadMode: 'blocking',
     },
     loaderDeps: ({ search }: { search: Record<string, unknown> }) => ({
       searchKey: JSON.stringify(search),

--- a/packages/tanstack-start/src/routes/layoutRoute.tsx
+++ b/packages/tanstack-start/src/routes/layoutRoute.tsx
@@ -60,5 +60,11 @@ export function payloadLayoutRoute({
     )
   }
 
-  return { component: PayloadLayout, loader: () => load() }
+  // `staleReloadMode` lives on the loader *object* — router-core only reads it
+  // off a non-function loader — so stale-match revalidation blocks on the fresh
+  // loader instead of flashing stale layout data via the default background SWR.
+  return {
+    component: PayloadLayout,
+    loader: { handler: () => load(), staleReloadMode: 'blocking' },
+  }
 }


### PR DESCRIPTION
Switches the admin route loaders from stale-while-revalidate (SWR) to "blocking", so navigation awaits fresh data before committing instead of flashing a stale route match. Creating a doc then returning to the list no longer shows the pre-navigation table (missing the new row) until a background reload catches up.

Does do by forcing out of SWR by setting [`staleReloadMode: 'blocking'`](https://tanstack.com/router/latest/docs/guide/data-loading) on all routes:

```ts
export const Route = createFileRoute('/posts')({
  loader: {
    handler: () => fetchPosts(),
    staleReloadMode: 'blocking',
  },
})
```

Before:

https://github.com/user-attachments/assets/6e5157e6-5c99-4f54-84ce-1bcc56418458

After:

https://github.com/user-attachments/assets/c401095b-76cc-43e4-a5a5-ae9335e582fe