### PR TITLE
fix(db-mongodb): error on null values in arrays and blocks

### DIFF
--- a/packages/db-mongodb/src/utilities/transform.spec.ts
+++ b/packages/db-mongodb/src/utilities/transform.spec.ts
@@ -406,4 +406,64 @@ describe('transform', () => {
       expect(flattenValuesBefore[i]).toBe(value.toHexString())
     })
   })
+
+  it('should strip null elements from array and blocks fields on read', () => {
+    const data: Record<string, any> = {
+      _id: new Types.ObjectId(),
+      array: [null, { rel_1: new Types.ObjectId() }],
+      arrayLocalized: {
+        en: [null, { rel_1: new Types.ObjectId() }],
+      },
+      blocks: [null, { blockType: 'block', rel_1: new Types.ObjectId() }],
+    }
+
+    const mockAdapter = {
+      allowAdditionalKeys: false,
+      payload: {
+        config,
+      },
+    } as MongooseAdapter
+
+    expect(() =>
+      transform({
+        adapter: mockAdapter,
+        operation: 'read',
+        data,
+        fields: config.collections[0].fields,
+      }),
+    ).not.toThrow()
+
+    expect(data.array).toHaveLength(1)
+    expect(data.array[0]).toMatchObject({})
+    expect(data.arrayLocalized.en).toHaveLength(1)
+    expect(data.blocks).toHaveLength(1)
+    expect(data.blocks[0].blockType).toBe('block')
+  })
+
+  it('should skip null entries in hasMany relationship arrays without coercing them', () => {
+    const validId = new Types.ObjectId()
+    const data: Record<string, any> = {
+      _id: new Types.ObjectId(),
+      rel_2: [null, validId],
+    }
+
+    const mockAdapter = {
+      allowAdditionalKeys: false,
+      payload: {
+        config,
+      },
+    } as MongooseAdapter
+
+    expect(() =>
+      transform({
+        adapter: mockAdapter,
+        operation: 'read',
+        data,
+        fields: config.collections[0].fields,
+      }),
+    ).not.toThrow()
+
+    expect(data.rel_2[0]).toBeNull()
+    expect(data.rel_2[1]).toBe(validId.toHexString())
+  })
 })

--- a/packages/db-mongodb/src/utilities/transform.ts
+++ b/packages/db-mongodb/src/utilities/transform.ts
@@ -180,6 +180,12 @@ const sanitizeRelationship = ({
 
   if (Array.isArray(value)) {
     result = value.map((val) => {
+      // Skip null/undefined entries so a stray null in a hasMany relationship
+      // array doesn't get coerced or crash downstream sanitization.
+      if (val === null || typeof val === 'undefined') {
+        return val
+      }
+
       // Handle has many - polymorphic
       if (isValidRelationObject(val)) {
         const relatedCollectionForSingleValue = config.collections?.find(
@@ -355,6 +361,13 @@ const stripFields = ({
             let hasNull = false
             for (let i = 0; i < localeData.length; i++) {
               const data = localeData[i]
+
+              if (!data || typeof data !== 'object') {
+                localeData[i] = null
+                hasNull = true
+                continue
+              }
+
               let fields: FlattenedField[] | null = null
 
               if (field.type === 'array') {
@@ -417,6 +430,13 @@ const stripFields = ({
 
         for (let i = 0; i < fieldData.length; i++) {
           const data = fieldData[i]
+
+          if (!data || typeof data !== 'object') {
+            fieldData[i] = null
+            hasNull = true
+            continue
+          }
+
           let fields: FlattenedField[] | null = null
 
           if (field.type === 'array') {


### PR DESCRIPTION
## What

`stripFields` in the MongoDB adapter crashed with `Cannot read properties of null` when an `array` or `blocks` field contained a `null` element (e.g. `slides: [null]`), breaking reads such as the admin list view.

## Fix

- Skip `null`/non-object elements when stripping `array`/`blocks` fields (localized and non-localized), filtering them out of the result.
- Guard `null`/`undefined` entries in `hasMany` relationship arrays so they aren't coerced or passed downstream.

## Tests

Added `transform.spec.ts` cases covering null elements in arrays, localized arrays, and blocks, plus null entries in a `hasMany` relationship array.