### PR TITLE
fix(ui): relationship add-new button height in production builds

### DIFF
--- a/packages/ui/src/elements/AddNewRelation/index.css
+++ b/packages/ui/src/elements/AddNewRelation/index.css
@@ -10,7 +10,7 @@
     }
   }
 
-  .relationship-add-new__add-button {
+  .relationship-add-new .relationship-add-new__add-button {
     display: flex;
     position: relative;
     align-items: center;
@@ -35,7 +35,7 @@
     }
   }
 
-  .relationship-add-new__add-button--unstyled {
+  .relationship-add-new .relationship-add-new__add-button--unstyled {
     background: transparent;
     border: none;
     padding: 0;

--- a/packages/ui/src/elements/AddNewRelation/index.css
+++ b/packages/ui/src/elements/AddNewRelation/index.css
@@ -8,38 +8,38 @@
       align-items: stretch;
       height: 100%;
     }
-  }
 
-  .relationship-add-new .relationship-add-new__add-button {
-    display: flex;
-    position: relative;
-    align-items: center;
-    justify-content: center;
-    padding-inline: var(--spacer-1);
-    height: var(--field-min-height-large);
-    margin: 0;
-    background: var(--color-bg-secondary);
-    border: none;
-    border-radius: var(--button-radius);
-    color: var(--color-icon);
-    cursor: pointer;
-    transition: background-color 100ms;
+    .relationship-add-new__add-button {
+      display: flex;
+      position: relative;
+      align-items: center;
+      justify-content: center;
+      padding-inline: var(--spacer-1);
+      height: var(--field-min-height-large);
+      margin: 0;
+      background: var(--color-bg-secondary);
+      border: none;
+      border-radius: var(--button-radius);
+      color: var(--color-icon);
+      cursor: pointer;
+      transition: background-color 100ms;
 
-    &:hover {
-      background: var(--color-bg-secondary-hover);
+      &:hover {
+        background: var(--color-bg-secondary-hover);
+      }
+
+      &:focus-visible {
+        outline: var(--accessibility-outline);
+        outline-offset: var(--accessibility-outline-offset);
+      }
     }
 
-    &:focus-visible {
-      outline: var(--accessibility-outline);
-      outline-offset: var(--accessibility-outline-offset);
+    .relationship-add-new__add-button--unstyled {
+      background: transparent;
+      border: none;
+      padding: 0;
+      width: auto;
+      height: auto;
     }
-  }
-
-  .relationship-add-new .relationship-add-new__add-button--unstyled {
-    background: transparent;
-    border: none;
-    padding: 0;
-    width: auto;
-    height: auto;
   }
 }


### PR DESCRIPTION
Nests the relationship `Add new` button rules under `.relationship-add-new` so their height wins deterministically over the shared `.btn--size-medium` height.

`.relationship-add-new__add-button` and `.btn--size-medium` both set `height` at specificity `0,1,0` within the same `payload-default` cascade layer, so the winner is decided by bundle order. In development the relationship rule loads last and the button spans the full field height; in production `.btn--size-medium` loads last, collapsing the button to `var(--button-height)`.

Nesting the button selectors inside `.relationship-add-new` raises them to `0,2,0`, so `height: var(--field-min-height-large)` wins regardless of stylesheet order. The `--unstyled` modifier is nested the same way and kept after the base rule, preserving its `height: auto` override.

#### Before
<img width="1901" height="1117" alt="Screenshot 2026-07-02 at 10 46 38 AM" src="https://github.com/user-attachments/assets/2f0dfb35-e3e7-46c9-837d-32875aab993f" />

#### After
<img width="1248" height="613" alt="Screenshot 2026-07-02 at 10 58 34 AM" src="https://github.com/user-attachments/assets/080a4cf9-1a9f-442f-b436-41ed02e3a72a" />