### PR TITLE
fix(ui): prevent false stale modal after publishing a single locale

### DIFF
--- a/packages/ui/src/utilities/handleStaleDataCheck.spec.ts
+++ b/packages/ui/src/utilities/handleStaleDataCheck.spec.ts
@@ -1,0 +1,57 @@
+import type { PayloadRequest } from 'payload'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleStaleDataCheck } from './handleStaleDataCheck.js'
+
+const createRequest = (currentUpdatedAt: string) =>
+  ({
+    payload: {
+      config: {
+        collections: [{ slug: 'posts', versions: { drafts: true } }],
+        globals: [],
+      },
+      findByID: vi.fn().mockResolvedValue({ updatedAt: currentUpdatedAt }),
+      logger: {
+        error: vi.fn(),
+      },
+    },
+  }) as unknown as PayloadRequest
+
+describe('handleStaleDataCheck', () => {
+  it.each([
+    {
+      currentUpdatedAt: '2026-08-27T12:00:00.000Z',
+      expectedIsStale: false,
+      name: 'same timestamp',
+      originalUpdatedAt: '2026-08-27T12:00:00.000Z',
+    },
+    {
+      currentUpdatedAt: '2026-08-27T11:00:00.000Z',
+      expectedIsStale: true,
+      name: 'older but different timestamp',
+      originalUpdatedAt: '2026-08-27T12:00:00.000Z',
+    },
+    {
+      currentUpdatedAt: '2026-08-27T13:00:00.000Z',
+      expectedIsStale: true,
+      name: 'newer timestamp',
+      originalUpdatedAt: '2026-08-27T12:00:00.000Z',
+    },
+  ])(
+    'should treat a $name according to snapshot identity',
+    async ({ currentUpdatedAt, expectedIsStale, originalUpdatedAt }) => {
+      await expect(
+        handleStaleDataCheck({
+          id: 'post-id',
+          collectionSlug: 'posts',
+          originalUpdatedAt,
+          req: createRequest(currentUpdatedAt),
+        }),
+      ).resolves.toEqual({
+        currentUpdatedAt,
+        isStale: expectedIsStale,
+      })
+    },
+  )
+})

--- a/packages/ui/src/utilities/handleStaleDataCheck.ts
+++ b/packages/ui/src/utilities/handleStaleDataCheck.ts
@@ -65,9 +65,7 @@ export const handleStaleDataCheck = async ({
     // Only stale when the latest version is strictly newer than the edit's baseline.
     // A concurrent edit always moves `updatedAt` forward; an older-or-equal timestamp
     // is the user's own save (e.g. a single-locale publish), not another editor.
-    const isStale =
-      currentUpdatedAt &&
-      new Date(currentUpdatedAt).getTime() > new Date(originalUpdatedAt).getTime()
+    const isStale = currentUpdatedAt && currentUpdatedAt > originalUpdatedAt
 
     return {
       currentUpdatedAt,

--- a/packages/ui/src/utilities/handleStaleDataCheck.ts
+++ b/packages/ui/src/utilities/handleStaleDataCheck.ts
@@ -62,12 +62,9 @@ export const handleStaleDataCheck = async ({
       currentUpdatedAt = currentGlobal?.updatedAt as string
     }
 
-    // The document is only stale when its latest version is strictly NEWER than the
-    // baseline the edit was based on. A concurrent edit always moves `updatedAt`
-    // forward, whereas an older-or-equal timestamp comes from the user's own save —
-    // e.g. publishing a single locale creates a draft snapshot whose `updatedAt` is
-    // older than the just-published version — so a plain "not equal" comparison would
-    // raise a false positive.
+    // Only stale when the latest version is strictly newer than the edit's baseline.
+    // A concurrent edit always moves `updatedAt` forward; an older-or-equal timestamp
+    // is the user's own save (e.g. a single-locale publish), not another editor.
     const isStale =
       currentUpdatedAt &&
       new Date(currentUpdatedAt).getTime() > new Date(originalUpdatedAt).getTime()

--- a/packages/ui/src/utilities/handleStaleDataCheck.ts
+++ b/packages/ui/src/utilities/handleStaleDataCheck.ts
@@ -62,8 +62,15 @@ export const handleStaleDataCheck = async ({
       currentUpdatedAt = currentGlobal?.updatedAt as string
     }
 
-    // Compare timestamps
-    const isStale = currentUpdatedAt && currentUpdatedAt !== originalUpdatedAt
+    // The document is only stale when its latest version is strictly NEWER than the
+    // baseline the edit was based on. A concurrent edit always moves `updatedAt`
+    // forward, whereas an older-or-equal timestamp comes from the user's own save —
+    // e.g. publishing a single locale creates a draft snapshot whose `updatedAt` is
+    // older than the just-published version — so a plain "not equal" comparison would
+    // raise a false positive.
+    const isStale =
+      currentUpdatedAt &&
+      new Date(currentUpdatedAt).getTime() > new Date(originalUpdatedAt).getTime()
 
     return {
       currentUpdatedAt,

--- a/packages/ui/src/utilities/handleStaleDataCheck.ts
+++ b/packages/ui/src/utilities/handleStaleDataCheck.ts
@@ -62,9 +62,6 @@ export const handleStaleDataCheck = async ({
       currentUpdatedAt = currentGlobal?.updatedAt as string
     }
 
-    // Only stale when the latest version is strictly newer than the edit's baseline.
-    // A concurrent edit always moves `updatedAt` forward; an older-or-equal timestamp
-    // is the user's own save (e.g. a single-locale publish), not another editor.
     const isStale = currentUpdatedAt && currentUpdatedAt > originalUpdatedAt
 
     return {

--- a/packages/ui/src/utilities/handleStaleDataCheck.ts
+++ b/packages/ui/src/utilities/handleStaleDataCheck.ts
@@ -62,7 +62,8 @@ export const handleStaleDataCheck = async ({
       currentUpdatedAt = currentGlobal?.updatedAt as string
     }
 
-    const isStale = currentUpdatedAt && currentUpdatedAt > originalUpdatedAt
+    // Compare timestamps
+    const isStale = currentUpdatedAt && currentUpdatedAt !== originalUpdatedAt
 
     return {
       currentUpdatedAt,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -500,6 +500,10 @@ export function DefaultEditView({
         !isTrashed &&
         !autosaveEnabled
 
+      // Capture the baseline we compare against so we can verify below that the
+      // server's latest version is actually NEWER than it.
+      const originalUpdatedAtSent = checkForStaleData ? originalUpdatedAtRef.current : undefined
+
       if (checkForStaleData) {
         hasCheckedForStaleDataRef.current = true
       }
@@ -538,10 +542,17 @@ export function DefaultEditView({
       // Handle stale data detection.
       // Skip if a save was in-flight when this request started, or if the save counter
       // has advanced — either way the newer updatedAt is from our OWN save.
+      // Only treat the document as stale when the server's latest version is strictly
+      // NEWER than our baseline. Publishing a single locale creates a newer published
+      // version while the draft the check reads keeps an older `updatedAt`, so a plain
+      // "not equal" comparison would otherwise raise a false positive.
       if (
         staleDataState?.isStale &&
         !isSavingAtStart &&
-        saveCounterRef.current === saveCounterAtStart
+        saveCounterRef.current === saveCounterAtStart &&
+        originalUpdatedAtSent &&
+        new Date(staleDataState.currentUpdatedAt).getTime() >
+          new Date(originalUpdatedAtSent).getTime()
       ) {
         setShowStaleDataModal(true)
       }

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -500,10 +500,6 @@ export function DefaultEditView({
         !isTrashed &&
         !autosaveEnabled
 
-      // Capture the baseline we compare against so we can verify below that the
-      // server's latest version is actually NEWER than it.
-      const originalUpdatedAtSent = checkForStaleData ? originalUpdatedAtRef.current : undefined
-
       if (checkForStaleData) {
         hasCheckedForStaleDataRef.current = true
       }
@@ -542,17 +538,10 @@ export function DefaultEditView({
       // Handle stale data detection.
       // Skip if a save was in-flight when this request started, or if the save counter
       // has advanced — either way the newer updatedAt is from our OWN save.
-      // Only treat the document as stale when the server's latest version is strictly
-      // NEWER than our baseline. Publishing a single locale creates a newer published
-      // version while the draft the check reads keeps an older `updatedAt`, so a plain
-      // "not equal" comparison would otherwise raise a false positive.
       if (
         staleDataState?.isStale &&
         !isSavingAtStart &&
-        saveCounterRef.current === saveCounterAtStart &&
-        originalUpdatedAtSent &&
-        new Date(staleDataState.currentUpdatedAt).getTime() >
-          new Date(originalUpdatedAtSent).getTime()
+        saveCounterRef.current === saveCounterAtStart
       ) {
         setShowStaleDataModal(true)
       }

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -183,7 +183,10 @@ export function DefaultEditView({
 
   const [editSessionStartTime, setEditSessionStartTime] = useState(Date.now())
 
+  const dataSnapshotUpdatedAtRef = useRef(data?.updatedAt)
   const hasCheckedForStaleDataRef = useRef(false)
+  const lastSavedUpdatedAtRef = useRef<null | string>(null)
+  const localeRef = useRef(locale)
   const originalUpdatedAtRef = useRef(data?.updatedAt)
   const saveCounterRef = useRef(0)
   const isSavingRef = useRef(false)
@@ -315,6 +318,7 @@ export function DefaultEditView({
 
       // Update stale data check refs after successful save
       // This allows detecting if another user modifies the document after this save
+      lastSavedUpdatedAtRef.current = updatedAt
       originalUpdatedAtRef.current = updatedAt
       hasCheckedForStaleDataRef.current = false
       isSavingRef.current = false
@@ -474,10 +478,30 @@ export function DefaultEditView({
       const saveCounterAtStart = saveCounterRef.current
       const isSavingAtStart = isSavingRef.current
 
-      // Sync originalUpdatedAt with current data if it's NEWER (e.g., after router.refresh())
-      if (data?.updatedAt && data.updatedAt > originalUpdatedAtRef.current) {
+      const localeChanged = localeRef.current !== locale
+      const snapshotChanged = dataSnapshotUpdatedAtRef.current !== data?.updatedAt
+
+      if (localeChanged || snapshotChanged) {
+        dataSnapshotUpdatedAtRef.current = data?.updatedAt
+        localeRef.current = locale
+
+        // A locale or server-rendered data change replaces the snapshot being edited. The response
+        // from our own save is already the active baseline, so do not reset it on that rerender.
+        if (localeChanged || data?.updatedAt !== lastSavedUpdatedAtRef.current) {
+          lastSavedUpdatedAtRef.current = null
+          originalUpdatedAtRef.current = data?.updatedAt
+          hasCheckedForStaleDataRef.current = false
+        }
+      }
+
+      // Sync originalUpdatedAt with newer data after a refresh that preserved the same snapshot.
+      if (
+        data?.updatedAt &&
+        data.updatedAt > originalUpdatedAtRef.current &&
+        data.updatedAt !== lastSavedUpdatedAtRef.current
+      ) {
+        lastSavedUpdatedAtRef.current = null
         originalUpdatedAtRef.current = data.updatedAt
-        // Reset check flag so we can detect new stale data
         hasCheckedForStaleDataRef.current = false
       }
 
@@ -504,6 +528,8 @@ export function DefaultEditView({
         hasCheckedForStaleDataRef.current = true
       }
 
+      const originalUpdatedAtAtStart = originalUpdatedAtRef.current
+
       const docPreferences = await getDocPreferences()
 
       const result = await getFormState({
@@ -515,7 +541,7 @@ export function DefaultEditView({
         formState: prevFormState,
         globalSlug,
         operation,
-        originalUpdatedAt: checkForStaleData ? originalUpdatedAtRef.current : undefined,
+        originalUpdatedAt: checkForStaleData ? originalUpdatedAtAtStart : undefined,
         readOnly: isTrashed || isReadOnlyForIncomingUser,
         renderAllFields: false,
         returnLockStatus: isLockingEnabled,
@@ -543,7 +569,17 @@ export function DefaultEditView({
         !isSavingAtStart &&
         saveCounterRef.current === saveCounterAtStart
       ) {
-        setShowStaleDataModal(true)
+        const isOlderSnapshotFromOwnLocalePublish =
+          staleDataState.currentUpdatedAt &&
+          lastSavedUpdatedAtRef.current === originalUpdatedAtAtStart &&
+          originalUpdatedAtRef.current === originalUpdatedAtAtStart &&
+          staleDataState.currentUpdatedAt < originalUpdatedAtAtStart
+
+        if (isOlderSnapshotFromOwnLocalePublish) {
+          originalUpdatedAtRef.current = staleDataState.currentUpdatedAt
+        } else {
+          setShowStaleDataModal(true)
+        }
       }
 
       abortOnChangeRef.current = null
@@ -552,6 +588,7 @@ export function DefaultEditView({
     },
     [
       data?.updatedAt,
+      locale,
       editSessionStartTime,
       isLockingEnabled,
       getDocPreferences,

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -766,6 +766,30 @@ describe('Document View', () => {
 
       await expect(status).toContainText('Published')
     })
+
+    test('should not show stale data modal after repeatedly publishing active locale', async () => {
+      await page.goto(localizedURL.create)
+
+      // Create the document and publish the active locale (English)
+      await page.locator('#field-title').fill('Version 1')
+      await saveDocAndAssert(page)
+
+      // Change and publish the active locale again — a draft snapshot version is
+      // created server-side whose updatedAt the client never receives
+      await page.locator('#field-title').fill('Version 2')
+      await saveDocAndAssert(page)
+
+      // Editing again triggers the stale data check. Because the document was only
+      // ever modified by the current user (by publishing the active locale), the
+      // stale data modal must NOT appear.
+      await page.locator('#field-title').fill('Version 3')
+
+      // Give the debounced onChange stale data check time to run
+      // eslint-disable-next-line payload/no-wait-function
+      await wait(1000)
+
+      await expect(page.locator('.document-stale-data')).toBeHidden()
+    })
   })
 
   describe('reserved field names', () => {

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -770,21 +770,19 @@ describe('Document View', () => {
     test('should not show stale data modal after repeatedly publishing active locale', async () => {
       await page.goto(localizedURL.create)
 
-      // Create the document and publish the active locale (English)
+      // Create and publish the active locale
       await page.locator('#field-title').fill('Version 1')
       await saveDocAndAssert(page)
 
-      // Change and publish the active locale again — a draft snapshot version is
-      // created server-side whose updatedAt the client never receives
+      // Publish the active locale again
       await page.locator('#field-title').fill('Version 2')
       await saveDocAndAssert(page)
 
-      // Editing again triggers the stale data check. Because the document was only
-      // ever modified by the current user (by publishing the active locale), the
-      // stale data modal must NOT appear.
+      // Editing triggers the stale check — but only the current user has touched the
+      // document, so the modal must not appear
       await page.locator('#field-title').fill('Version 3')
 
-      // Give the debounced onChange stale data check time to run
+      // Wait for the debounced stale check to run
       // eslint-disable-next-line payload/no-wait-function
       await wait(1000)
 

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -783,10 +783,41 @@ describe('Document View', () => {
       await page.locator('#field-title').fill('Version 3')
 
       // Wait for the debounced stale check to run
-      // eslint-disable-next-line payload/no-wait-function
       await wait(1000)
 
       await expect(page.locator('.document-stale-data')).toBeHidden()
+
+      // The publish response remains newer than the legacy draft snapshot. A later edit must not
+      // replace the reconciled baseline with that response timestamp again.
+      await page.locator('#field-title').fill('Version 4')
+      await wait(1000)
+
+      await expect(page.locator('.document-stale-data')).toBeHidden()
+    })
+
+    test('should show stale data modal for a concurrent update after publishing active locale', async () => {
+      await page.goto(localizedURL.create)
+      await page.locator('#field-title').fill('Original title')
+      await saveDocAndAssert(page)
+
+      const documentID = new URL(page.url()).pathname.split('/').at(-1)
+      if (!documentID) {
+        throw new Error('Expected the created localized document ID in the URL')
+      }
+
+      await payload.update({
+        id: documentID,
+        collection: localizedCollectionSlug,
+        data: {
+          title: 'Concurrent title',
+        },
+        locale: 'en',
+        overrideAccess: true,
+      })
+
+      await page.locator('#field-title').fill('Local title')
+
+      await expect(page.locator('.document-stale-data')).toBeVisible()
     })
   })
 
@@ -911,9 +942,9 @@ describe('Document View', () => {
       await page.goto(postsUrl.create)
       await page.locator('#field-title').fill('heros')
       await selectInput({
+        filter: 'sean',
         multiSelect: false,
         option: 'sean',
-        filter: 'sean',
         selectLocator: page.locator('#field-relationship'),
         selectType: 'relationship',
       })


### PR DESCRIPTION
Fixes a false "document out of date" modal that appears after publishing only the active locale and continuing to edit on drafts-enabled collections with a localized field and localization.defaultLocalePublishOption set to active.

The legacy 3.x single-locale publish path can return a published response timestamp while the stale-data endpoint continues to expose the older draft snapshot timestamp. A global ordering comparison would hide the false positive, but it would also weaken stale-snapshot identity checks.

This revision keeps the strict timestamp comparison. The edit view now tracks the loaded server snapshot, locale, and the timestamp from the current user own save. When the stale check returns the known older draft snapshot immediately after that active-locale publish, the client reconciles its baseline instead of opening the modal. Newer or otherwise different concurrent updates still show the stale-data warning.

Coverage includes:
- publishing the active locale and editing twice without a false modal
- a concurrent API update still opening the modal
- unit coverage confirming that any different timestamp remains stale at the shared comparator level

main is not affected because single-locale publishing moved from snapshots to localizeStatus, so the response and draft timestamp no longer diverge.

Fixes #16376