### PR TITLE
fix(ui): finesse hierarchy tree keyboard and node interaction

### DIFF
--- a/packages/ui/src/elements/Hierarchy/Tree/TreeNode/index.css
+++ b/packages/ui/src/elements/Hierarchy/Tree/TreeNode/index.css
@@ -8,32 +8,43 @@
       margin-left: 0;
       margin-right: 0;
     }
+
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  .tree-node:focus-visible > .tree-node__content-wrapper > .tree-node__content {
+    outline: var(--accessibility-outline);
+    outline-offset: var(--accessibility-outline-offset);
+  }
+
+  .tree-node__content-wrapper {
+    margin-left: calc(
+      (var(--tree-depth, 0) * var(--tree-indent)) + (var(--spacer-1) * var(--tree-depth))
+    );
+    margin-bottom: var(--tree-row-gap);
   }
 
   .tree-node__content {
-    padding: var(--tree-node-padding-y) var(--spacer-2);
-    padding-left: calc(
-      (var(--tree-depth, 0) * var(--tree-indent)) + (var(--spacer-1) * var(--tree-depth)) +
-        var(--spacer-1)
-    );
+    display: flex;
+    align-items: center;
     transition: background-color 100ms ease;
     font-size: var(--tree-font-size);
     line-height: var(--tree-node-content-height);
-    margin-bottom: var(--tree-row-gap);
   }
 
   .tree-node__toggle {
     background: none;
     border: none;
-    padding: 0;
+    padding-block: var(--spacer-1);
+    padding-inline-start: var(--spacer-1);
     margin: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: default;
     color: var(--color-icon-tertiary);
-    width: var(--tree-chevron-width);
-    height: var(--tree-chevron-width);
     flex-shrink: 0;
     border-radius: var(--button-radius);
 
@@ -42,13 +53,27 @@
     }
   }
 
-  .tree-node__toggle-spacer {
-    width: calc(var(--tree-chevron-width) + var(--tree-chevron-spacing));
-    flex-shrink: 0;
+  .tree-node__node-trigger {
+    border: none;
+    background: none;
+    margin: 0;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    min-width: 0;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--spacer-1);
+    text-align: left;
+    cursor: pointer;
+    padding-block: var(--spacer-1);
+    padding-inline-end: var(--spacer-1);
   }
 
   .tree-node__title {
-    padding-left: var(--spacer-1);
+    padding-left: 0;
+    margin-left: var(--spacer-1);
   }
 
   .tree-node__loading {

--- a/packages/ui/src/elements/Hierarchy/Tree/TreeNode/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/TreeNode/index.tsx
@@ -88,7 +88,7 @@ export const TreeNode = ({
     }
   }, [loadMoreFromHook, setFocusedId])
 
-  const { handleFocus, isFocused, tabIndex } = useFocusableItem({
+  const { handleFocus, tabIndex } = useFocusableItem({
     id: `node-${node.id}`,
     type: 'node',
     ref: nodeRef,
@@ -162,45 +162,51 @@ export const TreeNode = ({
       style={{ '--tree-depth': depth } as React.CSSProperties}
       tabIndex={tabIndex}
     >
-      <div
-        className={[
-          `${baseClass}__content`,
-          'sidebar-row',
-          selected && `${baseClass}__content--selected`,
-          selected && 'sidebar-row--selected',
-        ]
-          .filter(Boolean)
-          .join(' ')}
-      >
-        {hasChildren ? (
+      <div className={`${baseClass}__content-wrapper`}>
+        <div
+          className={[
+            `${baseClass}__content`,
+            'sidebar-row',
+            selected && `${baseClass}__content--selected`,
+            selected && 'sidebar-row--selected',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {hasChildren && (
+            <button
+              aria-label={expanded ? t('general:collapse') : t('general:open')}
+              className={`${baseClass}__toggle`}
+              onClick={handleToggle}
+              onMouseDown={(e) => e.preventDefault()}
+              tabIndex={-1}
+              type="button"
+            >
+              <ChevronIcon direction={expanded ? 'down' : 'right'} size={16} />
+            </button>
+          )}
           <button
-            aria-label={expanded ? t('general:collapse') : t('general:open')}
-            className={`${baseClass}__toggle`}
-            onClick={handleToggle}
+            className={[
+              `${baseClass}__node-trigger`,
+              selected && `${baseClass}__node-trigger--selected`,
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            onClick={handleSelectClick}
             onMouseDown={(e) => e.preventDefault()}
             tabIndex={-1}
+            title={node.title}
             type="button"
           >
-            <ChevronIcon direction={expanded ? 'down' : 'right'} />
+            {Boolean(icon) && <span className="sidebar-row__icon">{icon}</span>}
+            <span className={`${baseClass}__title sidebar-row__title`}>{node.title}</span>
           </button>
-        ) : (
-          <div className={`${baseClass}__toggle-spacer`} />
-        )}
-        {Boolean(icon) && <span className="sidebar-row__icon">{icon}</span>}
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard handled by parent */}
-        <span
-          className={`${baseClass}__title sidebar-row__title`}
-          onClick={handleSelectClick}
-          onMouseDown={(e) => e.preventDefault()}
-          title={node.title}
-        >
-          {node.title}
-        </span>
-        {isLoading && expanded && (
-          <span className={`${baseClass}__loading`}>
-            <Spinner loadingText={null} size="sm" />
-          </span>
-        )}
+          {isLoading && expanded && (
+            <span className={`${baseClass}__loading`}>
+              <Spinner loadingText={null} size="sm" />
+            </span>
+          )}
+        </div>
       </div>
 
       {expanded && children && children.length > 0 && (

--- a/packages/ui/src/elements/Hierarchy/Tree/index.css
+++ b/packages/ui/src/elements/Hierarchy/Tree/index.css
@@ -10,7 +10,6 @@
     --tree-indent: var(--spacer-3);
     --tree-chevron-width: var(--spacer-3);
     --tree-chevron-spacing: var(--spacer-2);
-    --tree-node-padding-y: var(--spacer-1);
     --tree-node-content-height: var(--text-body-medium-line-height);
     --tree-row-gap: var(--spacer-1);
     --tree-font-size: var(--text-body-medium-font-size);
@@ -38,6 +37,7 @@
   .tree__all-option {
     gap: var(--spacer-1);
     padding-left: var(--spacer-2);
+    padding-block: var(--spacer-1);
 
     .sidebar-row__title {
       font-weight: var(--text-body-medium-strong-font-weight);

--- a/packages/ui/src/elements/Hierarchy/Tree/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/index.tsx
@@ -51,7 +51,7 @@ const HierarchyTreeInner: React.FC<HierarchyTreeProps> = ({
   selectedNodeId,
   useAsTitle: useAsTitleProp,
 }) => {
-  const { moveFocus } = useTreeFocus()
+  const { focusedId, moveFocus, setFocusedId } = useTreeFocus()
   const router = useRouter()
   const { i18n, t } = useTranslation()
   const { permissions } = useAuth()
@@ -231,17 +231,47 @@ const HierarchyTreeInner: React.FC<HierarchyTreeProps> = ({
     [onNodeClick],
   )
 
+  const rootFocusableIds = useMemo(
+    () => (rootNodes ? rootNodes.map((node) => `node-${String(node.id)}`) : []),
+    [rootNodes],
+  )
+
+  const firstRootFocusableId = rootFocusableIds[0]
+  const lastRootFocusableId = rootFocusableIds[rootFocusableIds.length - 1]
+
   const handleTreeKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'ArrowDown') {
         e.preventDefault()
+
+        if (
+          focusedId &&
+          firstRootFocusableId &&
+          lastRootFocusableId &&
+          focusedId === lastRootFocusableId
+        ) {
+          setFocusedId(firstRootFocusableId)
+          return
+        }
+
         moveFocus('down')
       } else if (e.key === 'ArrowUp') {
         e.preventDefault()
+
+        if (
+          focusedId &&
+          firstRootFocusableId &&
+          lastRootFocusableId &&
+          focusedId === firstRootFocusableId
+        ) {
+          setFocusedId(lastRootFocusableId)
+          return
+        }
+
         moveFocus('up')
       }
     },
-    [moveFocus],
+    [firstRootFocusableId, focusedId, lastRootFocusableId, moveFocus, setFocusedId],
   )
 
   if (isLoading && !rootNodes) {

--- a/packages/ui/src/elements/SidebarRow/index.css
+++ b/packages/ui/src/elements/SidebarRow/index.css
@@ -23,8 +23,6 @@
     font-size: var(--text-body-medium-font-size);
     font-weight: var(--text-body-medium-font-weight);
     line-height: var(--text-body-medium-line-height);
-    padding-block: var(--spacer-1);
-    padding-inline: var(--spacer-2);
     position: relative;
     user-select: none;
     cursor: pointer;

--- a/test/folders/components/ColoredFolderIcon.tsx
+++ b/test/folders/components/ColoredFolderIcon.tsx
@@ -9,15 +9,16 @@ const baseClass = 'colored-folder-icon'
 
 export type ColoredFolderIconProps = {
   color?: string
+  size?: 16 | 24
 }
 
-export const ColoredFolderIcon: React.FC<ColoredFolderIconProps> = ({ color }) => {
+export const ColoredFolderIcon: React.FC<ColoredFolderIconProps> = ({ color, size = 24 }) => {
   return (
     <span
       className={[baseClass, color ? `${baseClass}--custom-color` : ''].join(' ')}
       style={{ color }}
     >
-      <FolderIcon />
+      <FolderIcon size={size} />
     </span>
   )
 }


### PR DESCRIPTION
Improves hierarchy tree interaction by expanding the node trigger surface, supporting sized custom folder icons, and adding root-level circular keyboard navigation.

The tree now wraps focus between the first and last root nodes on `ArrowUp`/`ArrowDown` while leaving nested-node traversal behavior unchanged.

Also cleans up related tree/sidebar CSS to keep row spacing and focus behavior consistent after the interaction updates.


### Before

https://github.com/user-attachments/assets/188ca99a-754b-499e-9d3f-650bb553f967

### After

https://github.com/user-attachments/assets/ede4b700-ca08-41ff-9f32-1a442cb4d0ec