### PR TITLE
fix(ui): select global status for versions

### DIFF
--- a/packages/ui/src/utilities/getVersions.spec.ts
+++ b/packages/ui/src/utilities/getVersions.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getVersions } from './getVersions.js'
+
+describe('getVersions', () => {
+  it('checks global published status when fetching a selected global', async () => {
+    const payload = {
+      config: {},
+      countGlobalVersions: vi.fn().mockResolvedValue({ totalDocs: 2 }),
+      findGlobal: vi.fn(async ({ select }) => ({
+        ...(select?._status ? { _status: 'published' } : {}),
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      })),
+      findGlobalVersions: vi.fn().mockResolvedValue({ docs: [{ autosave: true }] }),
+    }
+
+    const result = await getVersions({
+      doc: { _status: 'draft' },
+      docPermissions: { readVersions: true } as any,
+      globalConfig: {
+        fields: [],
+        slug: 'site-settings',
+        versions: {
+          drafts: {
+            autosave: true,
+          },
+        },
+      } as any,
+      payload: payload as any,
+      user: {} as any,
+    })
+
+    expect(payload.findGlobal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          _status: true,
+          updatedAt: true,
+        }),
+      }),
+    )
+    expect(result.hasPublishedDoc).to.equal(true)
+  })
+})

--- a/packages/ui/src/utilities/getVersions.ts
+++ b/packages/ui/src/utilities/getVersions.ts
@@ -223,6 +223,7 @@ export const getVersions = async ({
           depth: 0,
           locale,
           select: {
+            _status: true,
             updatedAt: true,
           },
           user,


### PR DESCRIPTION
Fixes #17164.

Global version status detection was selecting only `updatedAt`, then checking `publishedDoc?._status`, so published globals with autosaved drafts were treated as having no published document.

This includes `_status` in the global version lookup and adds a regression test for the published-global/autosaved-draft case.

Verified with:

`pnpm exec vitest run --project unit packages/ui/src/utilities/getVersions.spec.ts`

`pnpm exec eslint packages/ui/src/utilities/getVersions.ts packages/ui/src/utilities/getVersions.spec.ts`
