### PR TITLE
fix(next): select global status for versions

### DIFF
--- a/packages/next/src/views/Document/getVersions.spec.ts
+++ b/packages/next/src/views/Document/getVersions.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getVersions } from './getVersions.js'
+
+describe('getVersions', () => {
+  it('checks global published status when fetching a selected global', async () => {
+    const payload = {
+      config: {},
+      countGlobalVersions: vi.fn().mockResolvedValue({ totalDocs: 2 }),
+      findGlobal: vi.fn(async ({ select }) => ({
+        ...(select?._status ? { _status: 'published' } : {}),
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      })),
+      findGlobalVersions: vi.fn().mockResolvedValue({ docs: [{ autosave: true }] }),
+    }
+
+    const result = await getVersions({
+      doc: { _status: 'draft' },
+      docPermissions: { readVersions: true } as any,
+      globalConfig: {
+        fields: [],
+        slug: 'site-settings',
+        versions: {
+          drafts: {
+            autosave: true,
+          },
+        },
+      } as any,
+      payload: payload as any,
+      user: {} as any,
+    })
+
+    expect(payload.findGlobal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          _status: true,
+          updatedAt: true,
+        }),
+      }),
+    )
+    expect(result.hasPublishedDoc).to.equal(true)
+  })
+})

--- a/packages/next/src/views/Document/getVersions.ts
+++ b/packages/next/src/views/Document/getVersions.ts
@@ -237,6 +237,7 @@ export const getVersions = async ({
           depth: 0,
           locale,
           select: {
+            _status: true,
             updatedAt: true,
           },
           user,


### PR DESCRIPTION
Backports the global version status fix for #17164 to the active 3.x line.

The 3.x `@payloadcms/next` path had the same global version lookup: it selected only `updatedAt`, then checked `_status`, so a published global with an autosaved draft could report no published document.

This includes `_status` in that select and adds a regression test for the published-global/autosaved-draft case.

Verified with:

`pnpm exec vitest run --project unit packages/next/src/views/Document/getVersions.spec.ts`

`pnpm exec eslint packages/next/src/views/Document/getVersions.ts packages/next/src/views/Document/getVersions.spec.ts`

`NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @payloadcms/next lint`

`NODE_OPTIONS=--max-old-space-size=4096 pnpm build:next`
