### PR TITLE
fix(plugin-mcp): use web-standard transport so /api/mcp works on workerd

### DIFF
--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -1,10 +1,135 @@
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import crypto from 'crypto'
 import { type PayloadHandler, type TypedUser, UnauthorizedError, type Where } from 'payload'
 
 import type { MCPAccessSettings, MCPPluginConfig } from '../types.js'
 
 import { createRequestFromPayloadRequest } from '../mcp/createRequest.js'
-import { getMCPHandler } from '../mcp/getMcpHandler.js'
+import { buildMcpServer, getMCPHandler } from '../mcp/getMcpHandler.js'
+
+const methodNotAllowedResponse = () =>
+  new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Method not allowed.',
+      },
+      id: null,
+    }),
+    {
+      headers: {
+        Allow: 'POST',
+        'Content-Type': 'application/json',
+      },
+      status: 405,
+    },
+  )
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const getMessageID = (message: unknown) => {
+  if (!isRecord(message)) {
+    return
+  }
+
+  const { id } = message
+
+  return typeof id === 'number' || typeof id === 'string' ? String(id) : undefined
+}
+
+const instrumentTransport = (
+  transport: WebStandardStreamableHTTPServerTransport,
+  onEvent?: (event: unknown) => void,
+) => {
+  if (!onEvent) {
+    return
+  }
+
+  const requestMetadata = new Map<
+    string,
+    {
+      method: string
+      requestId: string
+      startTime: number
+    }
+  >()
+
+  const emit = (event: Record<string, unknown>) => {
+    onEvent({
+      ...event,
+      timestamp: Date.now(),
+    })
+  }
+
+  transport.onmessage = (message) => {
+    const messageRecord: unknown = message
+
+    if (!isRecord(messageRecord) || typeof messageRecord.method !== 'string') {
+      return
+    }
+
+    const requestId = crypto.randomUUID()
+    const messageID = getMessageID(messageRecord)
+
+    if (messageID) {
+      requestMetadata.set(messageID, {
+        method: messageRecord.method,
+        requestId,
+        startTime: Date.now(),
+      })
+    }
+
+    emit({
+      method: messageRecord.method,
+      parameters: messageRecord.params,
+      requestId,
+      status: 'success',
+      type: 'REQUEST_RECEIVED',
+    })
+  }
+
+  const send = transport.send.bind(transport)
+
+  transport.send = async (message, options) => {
+    const messageRecord: unknown = message
+    const messageID = getMessageID(messageRecord)
+    const metadata = messageID ? requestMetadata.get(messageID) : undefined
+
+    if (
+      messageID &&
+      metadata &&
+      isRecord(messageRecord) &&
+      ('result' in messageRecord || 'error' in messageRecord)
+    ) {
+      emit({
+        duration: Date.now() - metadata.startTime,
+        error: messageRecord.error,
+        method: metadata.method,
+        requestId: metadata.requestId,
+        result: messageRecord.result,
+        status: 'error' in messageRecord ? 'error' : 'success',
+        type: 'REQUEST_COMPLETED',
+      })
+      requestMetadata.delete(messageID)
+    }
+
+    try {
+      await send(message, options)
+    } catch (error) {
+      emit({
+        context: 'Error sending MCP response',
+        error,
+        severity: 'error',
+        source: 'request',
+        type: 'ERROR',
+      })
+
+      throw error
+    }
+  }
+}
 
 export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
   const mcpHandler: PayloadHandler = async (req) => {
@@ -63,28 +188,32 @@ export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
       ? await pluginOptions.overrideAuth(req, getDefaultMcpAccessSettings)
       : await getDefaultMcpAccessSettings()
 
-    // @modelcontextprotocol/sdk's StreamableHTTPServerTransport uses @hono/node-server's
-    // getRequestListener, which replaces global.Request and global.Response with Hono
-    // custom classes. Unfortunately, we cannot pass overrideGlobalObjects: false because the option is
-    // consumed inside the SDK transport and is not exposed to callers.
-    // Save originals here and restore after the handler resolves so that Next.js
-    // instanceof Response checks on subsequent route handlers keep working.
-    const globals = globalThis as Record<string, unknown>
-    const originalResponse = globals['Response']
-    const originalRequest = globals['Request']
-
-    const handler = getMCPHandler(pluginOptions, mcpAccessSettings, req)
     const request = createRequestFromPayloadRequest(req)
 
-    try {
+    if ((MCPHandlerOptions.disableSse ?? true) === false) {
+      const handler = getMCPHandler(pluginOptions, mcpAccessSettings, req)
+
       return await handler(request)
+    }
+
+    if (req.method !== 'POST') {
+      return methodNotAllowedResponse()
+    }
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: undefined,
+    })
+    instrumentTransport(transport, MCPHandlerOptions.onEvent)
+
+    const server = buildMcpServer(pluginOptions, mcpAccessSettings, req)
+
+    await server.connect(transport)
+
+    try {
+      return await transport.handleRequest(request)
     } finally {
-      if (globals['Response'] !== originalResponse) {
-        Object.defineProperty(globalThis, 'Response', { value: originalResponse })
-      }
-      if (globals['Request'] !== originalRequest) {
-        Object.defineProperty(globalThis, 'Request', { value: originalRequest })
-      }
+      await server.close()
     }
   }
   return mcpHandler

--- a/packages/plugin-mcp/src/mcp/getMcpHandler.ts
+++ b/packages/plugin-mcp/src/mcp/getMcpHandler.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema4 } from 'json-schema'
 
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { createMcpHandler } from 'mcp-handler'
 import { join } from 'path'
 import { APIError, configToJSONSchema, type PayloadRequest, type TypedUser } from 'payload'
@@ -43,7 +44,13 @@ import { createJobTool } from './tools/job/create.js'
 import { runJobTool } from './tools/job/run.js'
 import { updateJobTool } from './tools/job/update.js'
 
-export const getMCPHandler = (
+/**
+ * Transport-agnostic core: returns a callback that registers every enabled
+ * collection/global/custom tool onto an `McpServer`. Shared by the default
+ * web-standard transport path (`buildMcpServer`) and the legacy `mcp-handler`
+ * SSE path (`getMCPHandler`).
+ */
+export const getRegisterServerTools = (
   pluginOptions: MCPPluginConfig,
   mcpAccessSettings: MCPAccessSettings,
   req: PayloadRequest,
@@ -83,7 +90,6 @@ export const getMCPHandler = (
   const customMCPPrompts = MCPOptions.prompts || []
   const customMCPResources = MCPOptions.resources || []
   const MCPHandlerOptions = MCPOptions.handlerOptions || {}
-  const serverOptions = MCPOptions.serverOptions || {}
   const useVerboseLogs = MCPHandlerOptions.verboseLogs ?? false
 
   // Experimental MCP Tool Requirements
@@ -105,427 +111,467 @@ export const getMCPHandler = (
       ? experimentalTools.jobs.jobsDirPath
       : join(process.cwd(), 'src/jobs')
 
-  try {
-    return createMcpHandler(
-      (server) => {
-        // Get enabled collections
-        const enabledCollectionSlugs = getEnabledSlugs(collectionsPluginConfig, 'collection')
+  return (server: McpServer) => {
+    // Get enabled collections
+    const enabledCollectionSlugs = getEnabledSlugs(collectionsPluginConfig, 'collection')
 
-        // Collection Operation Tools
-        enabledCollectionSlugs.forEach((enabledCollectionSlug) => {
-          try {
-            const rawSchema = configSchema.definitions?.[enabledCollectionSlug] as JSONSchema4
+    // Collection Operation Tools
+    enabledCollectionSlugs.forEach((enabledCollectionSlug) => {
+      try {
+        const rawSchema = configSchema.definitions?.[enabledCollectionSlug] as JSONSchema4
 
-            const virtualFieldNames = getCollectionVirtualFieldNames(
-              payload.config,
-              enabledCollectionSlug,
-            )
-            const schema = removeVirtualFieldsFromSchema(
-              JSON.parse(JSON.stringify(rawSchema)) as JSONSchema4,
-              virtualFieldNames,
-            )
+        const virtualFieldNames = getCollectionVirtualFieldNames(
+          payload.config,
+          enabledCollectionSlug,
+        )
+        const schema = removeVirtualFieldsFromSchema(
+          JSON.parse(JSON.stringify(rawSchema)) as JSONSchema4,
+          virtualFieldNames,
+        )
 
-            const toolCapabilities = mcpAccessSettings?.[
-              `${toCamelCase(enabledCollectionSlug)}`
-            ] as Record<string, unknown>
-            const allowCreate: boolean | undefined = toolCapabilities?.create as boolean
-            const allowUpdate: boolean | undefined = toolCapabilities?.update as boolean
-            const allowFind: boolean | undefined = toolCapabilities?.find as boolean
-            const allowDelete: boolean | undefined = toolCapabilities?.delete as boolean
+        const toolCapabilities = mcpAccessSettings?.[
+          `${toCamelCase(enabledCollectionSlug)}`
+        ] as Record<string, unknown>
+        const allowCreate: boolean | undefined = toolCapabilities?.create as boolean
+        const allowUpdate: boolean | undefined = toolCapabilities?.update as boolean
+        const allowFind: boolean | undefined = toolCapabilities?.find as boolean
+        const allowDelete: boolean | undefined = toolCapabilities?.delete as boolean
 
-            if (allowCreate) {
-              registerTool(
-                allowCreate,
-                `Create ${enabledCollectionSlug}`,
-                () =>
-                  createResourceTool(
-                    server,
-                    req,
-                    user,
-                    useVerboseLogs,
-                    enabledCollectionSlug,
-                    collectionsPluginConfig,
-                    schema,
-                  ),
-                payload,
-                useVerboseLogs,
-              )
-            }
-            if (allowUpdate) {
-              registerTool(
-                allowUpdate,
-                `Update ${enabledCollectionSlug}`,
-                () =>
-                  updateResourceTool(
-                    server,
-                    req,
-                    user,
-                    useVerboseLogs,
-                    enabledCollectionSlug,
-                    collectionsPluginConfig,
-                    schema,
-                  ),
-                payload,
-                useVerboseLogs,
-              )
-            }
-            if (allowFind) {
-              registerTool(
-                allowFind,
-                `Find ${enabledCollectionSlug}`,
-                () =>
-                  findResourceTool(
-                    server,
-                    req,
-                    user,
-                    useVerboseLogs,
-                    enabledCollectionSlug,
-                    collectionsPluginConfig,
-                  ),
-                payload,
-                useVerboseLogs,
-              )
-            }
-            if (allowDelete) {
-              registerTool(
-                allowDelete,
-                `Delete ${enabledCollectionSlug}`,
-                () =>
-                  deleteResourceTool(
-                    server,
-                    req,
-                    user,
-                    useVerboseLogs,
-                    enabledCollectionSlug,
-                    collectionsPluginConfig,
-                  ),
-                payload,
-                useVerboseLogs,
-              )
-            }
-          } catch (error) {
-            throw new APIError(
-              `Error registering tools for collection ${enabledCollectionSlug}: ${String(error)}`,
-              500,
-            )
-          }
-        })
-
-        // Global Operation Tools
-        const enabledGlobalSlugs = getEnabledSlugs(globalsPluginConfig, 'global')
-
-        enabledGlobalSlugs.forEach((enabledGlobalSlug) => {
-          try {
-            const rawSchema = configSchema.definitions?.[enabledGlobalSlug] as JSONSchema4
-
-            const virtualFieldNames = getGlobalVirtualFieldNames(payload.config, enabledGlobalSlug)
-            const schema = removeVirtualFieldsFromSchema(
-              JSON.parse(JSON.stringify(rawSchema)) as JSONSchema4,
-              virtualFieldNames,
-            )
-
-            const toolCapabilities = mcpAccessSettings?.[
-              `${toCamelCase(enabledGlobalSlug)}`
-            ] as Record<string, unknown>
-            const allowFind: boolean | undefined = toolCapabilities?.['find'] as boolean
-            const allowUpdate: boolean | undefined = toolCapabilities?.['update'] as boolean
-
-            if (allowFind) {
-              registerTool(
-                allowFind,
-                `Find ${enabledGlobalSlug}`,
-                () =>
-                  findGlobalTool(
-                    server,
-                    req,
-                    user,
-                    useVerboseLogs,
-                    enabledGlobalSlug,
-                    globalsPluginConfig,
-                  ),
-                payload,
-                useVerboseLogs,
-              )
-            }
-            if (allowUpdate) {
-              registerTool(
-                allowUpdate,
-                `Update ${enabledGlobalSlug}`,
-                () =>
-                  updateGlobalTool(
-                    server,
-                    req,
-                    user,
-                    useVerboseLogs,
-                    enabledGlobalSlug,
-                    globalsPluginConfig,
-                    schema,
-                  ),
-                payload,
-                useVerboseLogs,
-              )
-            }
-          } catch (error) {
-            throw new APIError(
-              `Error registering tools for global ${enabledGlobalSlug}: ${String(error)}`,
-              500,
-            )
-          }
-        })
-
-        // Custom tools
-        customMCPTools.forEach((tool) => {
-          const camelCasedToolName = toCamelCase(tool.name)
-          const isToolEnabled = mcpAccessSettings['payload-mcp-tool']?.[camelCasedToolName] ?? false
-
+        if (allowCreate) {
           registerTool(
-            isToolEnabled,
-            tool.name,
+            allowCreate,
+            `Create ${enabledCollectionSlug}`,
             () =>
-              server.registerTool(
-                tool.name,
-                {
-                  description: tool.description,
-                  inputSchema: tool.parameters,
-                },
-                payloadToolHandler(tool.handler),
+              createResourceTool(
+                server,
+                req,
+                user,
+                useVerboseLogs,
+                enabledCollectionSlug,
+                collectionsPluginConfig,
+                schema,
               ),
             payload,
             useVerboseLogs,
           )
-        })
-
-        // Custom prompts
-        customMCPPrompts.forEach((prompt) => {
-          const camelCasedPromptName = toCamelCase(prompt.name)
-          const isPromptEnabled =
-            mcpAccessSettings['payload-mcp-prompt']?.[camelCasedPromptName] ?? false
-
-          if (isPromptEnabled) {
-            server.registerPrompt(
-              prompt.name,
-              {
-                argsSchema: prompt.argsSchema,
-                description: prompt.description,
-                title: prompt.title,
-              },
-              payloadPromptHandler(prompt.handler),
-            )
-            if (useVerboseLogs) {
-              payload.logger.info(`[payload-mcp] ✅ Prompt: ${prompt.title} Registered.`)
-            }
-          } else if (useVerboseLogs) {
-            payload.logger.info(`[payload-mcp] ⏭️ Prompt: ${prompt.title} Skipped.`)
-          }
-        })
-
-        // Custom resources
-        customMCPResources.forEach((resource) => {
-          const camelCasedResourceName = toCamelCase(resource.name)
-          const isResourceEnabled =
-            mcpAccessSettings['payload-mcp-resource']?.[camelCasedResourceName] ?? false
-
-          if (isResourceEnabled) {
-            server.registerResource(
-              resource.name,
-              // @ts-expect-error - Overload type is not working however -- ResourceTemplate OR String is a valid type
-              resource.uri,
-              {
-                description: resource.description,
-                mimeType: resource.mimeType,
-                title: resource.title,
-              },
-              payloadResourceHandler(resource.handler),
-            )
-
-            if (useVerboseLogs) {
-              payload.logger.info(`[payload-mcp] ✅ Resource: ${resource.title} Registered.`)
-            }
-          } else if (useVerboseLogs) {
-            payload.logger.info(`[payload-mcp] ⏭️ Resource: ${resource.title} Skipped.`)
-          }
-        })
-
-        // Experimental - Collection Schema Modfication Tools
-        if (
-          mcpAccessSettings.collections?.create &&
-          experimentalTools.collections?.enabled &&
-          isDevelopment
-        ) {
+        }
+        if (allowUpdate) {
           registerTool(
-            mcpAccessSettings.collections.create,
-            'Create Collection',
+            allowUpdate,
+            `Update ${enabledCollectionSlug}`,
             () =>
-              createCollectionTool(server, req, useVerboseLogs, collectionsDirPath, configFilePath),
+              updateResourceTool(
+                server,
+                req,
+                user,
+                useVerboseLogs,
+                enabledCollectionSlug,
+                collectionsPluginConfig,
+                schema,
+              ),
             payload,
             useVerboseLogs,
           )
         }
-        if (
-          mcpAccessSettings.collections?.delete &&
-          experimentalTools.collections?.enabled &&
-          isDevelopment
-        ) {
+        if (allowFind) {
           registerTool(
-            mcpAccessSettings.collections.delete,
-            'Delete Collection',
+            allowFind,
+            `Find ${enabledCollectionSlug}`,
             () =>
-              deleteCollectionTool(server, req, useVerboseLogs, collectionsDirPath, configFilePath),
+              findResourceTool(
+                server,
+                req,
+                user,
+                useVerboseLogs,
+                enabledCollectionSlug,
+                collectionsPluginConfig,
+              ),
             payload,
             useVerboseLogs,
           )
         }
-
-        if (
-          mcpAccessSettings.collections?.find &&
-          experimentalTools.collections?.enabled &&
-          isDevelopment
-        ) {
+        if (allowDelete) {
           registerTool(
-            mcpAccessSettings.collections.find,
-            'Find Collection',
-            () => findCollectionTool(server, req, useVerboseLogs, collectionsDirPath),
-            payload,
-            useVerboseLogs,
-          )
-        }
-
-        if (
-          mcpAccessSettings.collections?.update &&
-          experimentalTools.collections?.enabled &&
-          isDevelopment
-        ) {
-          registerTool(
-            mcpAccessSettings.collections.update,
-            'Update Collection',
+            allowDelete,
+            `Delete ${enabledCollectionSlug}`,
             () =>
-              updateCollectionTool(server, req, useVerboseLogs, collectionsDirPath, configFilePath),
+              deleteResourceTool(
+                server,
+                req,
+                user,
+                useVerboseLogs,
+                enabledCollectionSlug,
+                collectionsPluginConfig,
+              ),
             payload,
             useVerboseLogs,
           )
         }
+      } catch (error) {
+        throw new APIError(
+          `Error registering tools for collection ${enabledCollectionSlug}: ${String(error)}`,
+          500,
+        )
+      }
+    })
 
-        // Experimental - Payload Config Modification Tools
-        if (mcpAccessSettings.config?.find && experimentalTools.config?.enabled && isDevelopment) {
-          registerTool(
-            mcpAccessSettings.config.find,
-            'Find Config',
-            () => findConfigTool(server, req, useVerboseLogs, configFilePath),
-            payload,
-            useVerboseLogs,
-          )
-        }
+    // Global Operation Tools
+    const enabledGlobalSlugs = getEnabledSlugs(globalsPluginConfig, 'global')
 
-        if (
-          mcpAccessSettings.config?.update &&
-          experimentalTools.config?.enabled &&
-          isDevelopment
-        ) {
-          registerTool(
-            mcpAccessSettings.config.update,
-            'Update Config',
-            () => updateConfigTool(server, req, useVerboseLogs, configFilePath),
-            payload,
-            useVerboseLogs,
-          )
-        }
+    enabledGlobalSlugs.forEach((enabledGlobalSlug) => {
+      try {
+        const rawSchema = configSchema.definitions?.[enabledGlobalSlug] as JSONSchema4
 
-        // Experimental - Job Modification Tools
-        if (mcpAccessSettings.jobs?.create && experimentalTools.jobs?.enabled && isDevelopment) {
-          registerTool(
-            mcpAccessSettings.jobs.create,
-            'Create Job',
-            () => createJobTool(server, req, useVerboseLogs, jobsDirPath),
-            payload,
-            useVerboseLogs,
-          )
-        }
+        const virtualFieldNames = getGlobalVirtualFieldNames(payload.config, enabledGlobalSlug)
+        const schema = removeVirtualFieldsFromSchema(
+          JSON.parse(JSON.stringify(rawSchema)) as JSONSchema4,
+          virtualFieldNames,
+        )
 
-        if (mcpAccessSettings.jobs?.update && experimentalTools.jobs?.enabled && isDevelopment) {
-          registerTool(
-            mcpAccessSettings.jobs.update,
-            'Update Job',
-            () => updateJobTool(server, req, useVerboseLogs, jobsDirPath),
-            payload,
-            useVerboseLogs,
-          )
-        }
+        const toolCapabilities = mcpAccessSettings?.[`${toCamelCase(enabledGlobalSlug)}`] as Record<
+          string,
+          unknown
+        >
+        const allowFind: boolean | undefined = toolCapabilities?.['find'] as boolean
+        const allowUpdate: boolean | undefined = toolCapabilities?.['update'] as boolean
 
-        if (mcpAccessSettings.jobs?.run && experimentalTools.jobs?.enabled && isDevelopment) {
+        if (allowFind) {
           registerTool(
-            mcpAccessSettings.jobs.run,
-            'Run Job',
-            () => runJobTool(server, req, useVerboseLogs),
+            allowFind,
+            `Find ${enabledGlobalSlug}`,
+            () =>
+              findGlobalTool(
+                server,
+                req,
+                user,
+                useVerboseLogs,
+                enabledGlobalSlug,
+                globalsPluginConfig,
+              ),
             payload,
             useVerboseLogs,
           )
         }
+        if (allowUpdate) {
+          registerTool(
+            allowUpdate,
+            `Update ${enabledGlobalSlug}`,
+            () =>
+              updateGlobalTool(
+                server,
+                req,
+                user,
+                useVerboseLogs,
+                enabledGlobalSlug,
+                globalsPluginConfig,
+                schema,
+              ),
+            payload,
+            useVerboseLogs,
+          )
+        }
+      } catch (error) {
+        throw new APIError(
+          `Error registering tools for global ${enabledGlobalSlug}: ${String(error)}`,
+          500,
+        )
+      }
+    })
 
-        // Experimental - Auth Modification Tools
-        if (mcpAccessSettings.auth?.auth && experimentalTools.auth?.enabled && isDevelopment) {
-          registerTool(
-            mcpAccessSettings.auth.auth,
-            'Auth',
-            () => authTool(server, req, useVerboseLogs),
-            payload,
-            useVerboseLogs,
-          )
-        }
+    // Custom tools
+    customMCPTools.forEach((tool) => {
+      const camelCasedToolName = toCamelCase(tool.name)
+      const isToolEnabled = mcpAccessSettings['payload-mcp-tool']?.[camelCasedToolName] ?? false
 
-        if (mcpAccessSettings.auth?.login && experimentalTools.auth?.enabled && isDevelopment) {
-          registerTool(
-            mcpAccessSettings.auth.login,
-            'Login',
-            () => loginTool(server, req, useVerboseLogs),
-            payload,
-            useVerboseLogs,
-          )
-        }
+      registerTool(
+        isToolEnabled,
+        tool.name,
+        () =>
+          server.registerTool(
+            tool.name,
+            {
+              description: tool.description,
+              inputSchema: tool.parameters,
+            },
+            payloadToolHandler(tool.handler),
+          ),
+        payload,
+        useVerboseLogs,
+      )
+    })
 
-        if (mcpAccessSettings.auth?.verify && experimentalTools.auth?.enabled && isDevelopment) {
-          registerTool(
-            mcpAccessSettings.auth.verify,
-            'Verify',
-            () => verifyTool(server, req, useVerboseLogs),
-            payload,
-            useVerboseLogs,
-          )
-        }
+    // Custom prompts
+    customMCPPrompts.forEach((prompt) => {
+      const camelCasedPromptName = toCamelCase(prompt.name)
+      const isPromptEnabled =
+        mcpAccessSettings['payload-mcp-prompt']?.[camelCasedPromptName] ?? false
 
-        if (mcpAccessSettings.auth?.resetPassword && experimentalTools.auth?.enabled) {
-          registerTool(
-            mcpAccessSettings.auth.resetPassword,
-            'Reset Password',
-            () => resetPasswordTool(server, req, useVerboseLogs),
-            payload,
-            useVerboseLogs,
-          )
+      if (isPromptEnabled) {
+        server.registerPrompt(
+          prompt.name,
+          {
+            argsSchema: prompt.argsSchema,
+            description: prompt.description,
+            title: prompt.title,
+          },
+          payloadPromptHandler(prompt.handler),
+        )
+        if (useVerboseLogs) {
+          payload.logger.info(`[payload-mcp] ✅ Prompt: ${prompt.title} Registered.`)
         }
+      } else if (useVerboseLogs) {
+        payload.logger.info(`[payload-mcp] ⏭️ Prompt: ${prompt.title} Skipped.`)
+      }
+    })
 
-        if (mcpAccessSettings.auth?.forgotPassword && experimentalTools.auth?.enabled) {
-          registerTool(
-            mcpAccessSettings.auth.forgotPassword,
-            'Forgot Password',
-            () => forgotPasswordTool(server, req, useVerboseLogs),
-            payload,
-            useVerboseLogs,
-          )
-        }
+    // Custom resources
+    customMCPResources.forEach((resource) => {
+      const camelCasedResourceName = toCamelCase(resource.name)
+      const isResourceEnabled =
+        mcpAccessSettings['payload-mcp-resource']?.[camelCasedResourceName] ?? false
 
-        if (mcpAccessSettings.auth?.unlock && experimentalTools.auth?.enabled) {
-          registerTool(
-            mcpAccessSettings.auth.unlock,
-            'Unlock',
-            () => unlockTool(server, req, useVerboseLogs),
-            payload,
-            useVerboseLogs,
-          )
-        }
+      if (isResourceEnabled) {
+        server.registerResource(
+          resource.name,
+          // @ts-expect-error - Overload type is not working however -- ResourceTemplate OR String is a valid type
+          resource.uri,
+          {
+            description: resource.description,
+            mimeType: resource.mimeType,
+            title: resource.title,
+          },
+          payloadResourceHandler(resource.handler),
+        )
 
         if (useVerboseLogs) {
-          payload.logger.info('[payload-mcp] 🚀 MCP Server Ready.')
+          payload.logger.info(`[payload-mcp] ✅ Resource: ${resource.title} Registered.`)
         }
+      } else if (useVerboseLogs) {
+        payload.logger.info(`[payload-mcp] ⏭️ Resource: ${resource.title} Skipped.`)
+      }
+    })
+
+    // Experimental - Collection Schema Modfication Tools
+    if (
+      mcpAccessSettings.collections?.create &&
+      experimentalTools.collections?.enabled &&
+      isDevelopment
+    ) {
+      registerTool(
+        mcpAccessSettings.collections.create,
+        'Create Collection',
+        () => createCollectionTool(server, req, useVerboseLogs, collectionsDirPath, configFilePath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+    if (
+      mcpAccessSettings.collections?.delete &&
+      experimentalTools.collections?.enabled &&
+      isDevelopment
+    ) {
+      registerTool(
+        mcpAccessSettings.collections.delete,
+        'Delete Collection',
+        () => deleteCollectionTool(server, req, useVerboseLogs, collectionsDirPath, configFilePath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (
+      mcpAccessSettings.collections?.find &&
+      experimentalTools.collections?.enabled &&
+      isDevelopment
+    ) {
+      registerTool(
+        mcpAccessSettings.collections.find,
+        'Find Collection',
+        () => findCollectionTool(server, req, useVerboseLogs, collectionsDirPath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (
+      mcpAccessSettings.collections?.update &&
+      experimentalTools.collections?.enabled &&
+      isDevelopment
+    ) {
+      registerTool(
+        mcpAccessSettings.collections.update,
+        'Update Collection',
+        () => updateCollectionTool(server, req, useVerboseLogs, collectionsDirPath, configFilePath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    // Experimental - Payload Config Modification Tools
+    if (mcpAccessSettings.config?.find && experimentalTools.config?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.config.find,
+        'Find Config',
+        () => findConfigTool(server, req, useVerboseLogs, configFilePath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.config?.update && experimentalTools.config?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.config.update,
+        'Update Config',
+        () => updateConfigTool(server, req, useVerboseLogs, configFilePath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    // Experimental - Job Modification Tools
+    if (mcpAccessSettings.jobs?.create && experimentalTools.jobs?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.jobs.create,
+        'Create Job',
+        () => createJobTool(server, req, useVerboseLogs, jobsDirPath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.jobs?.update && experimentalTools.jobs?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.jobs.update,
+        'Update Job',
+        () => updateJobTool(server, req, useVerboseLogs, jobsDirPath),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.jobs?.run && experimentalTools.jobs?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.jobs.run,
+        'Run Job',
+        () => runJobTool(server, req, useVerboseLogs),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    // Experimental - Auth Modification Tools
+    if (mcpAccessSettings.auth?.auth && experimentalTools.auth?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.auth.auth,
+        'Auth',
+        () => authTool(server, req, useVerboseLogs),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.auth?.login && experimentalTools.auth?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.auth.login,
+        'Login',
+        () => loginTool(server, req, useVerboseLogs),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.auth?.verify && experimentalTools.auth?.enabled && isDevelopment) {
+      registerTool(
+        mcpAccessSettings.auth.verify,
+        'Verify',
+        () => verifyTool(server, req, useVerboseLogs),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.auth?.resetPassword && experimentalTools.auth?.enabled) {
+      registerTool(
+        mcpAccessSettings.auth.resetPassword,
+        'Reset Password',
+        () => resetPasswordTool(server, req, useVerboseLogs),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.auth?.forgotPassword && experimentalTools.auth?.enabled) {
+      registerTool(
+        mcpAccessSettings.auth.forgotPassword,
+        'Forgot Password',
+        () => forgotPasswordTool(server, req, useVerboseLogs),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (mcpAccessSettings.auth?.unlock && experimentalTools.auth?.enabled) {
+      registerTool(
+        mcpAccessSettings.auth.unlock,
+        'Unlock',
+        () => unlockTool(server, req, useVerboseLogs),
+        payload,
+        useVerboseLogs,
+      )
+    }
+
+    if (useVerboseLogs) {
+      payload.logger.info('[payload-mcp] 🚀 MCP Server Ready.')
+    }
+  }
+}
+
+/**
+ * Builds an MCP server with every enabled Payload tool registered. This lets
+ * the endpoint choose a runtime-specific transport without coupling tool
+ * registration to `mcp-handler`.
+ */
+export const buildMcpServer = (
+  pluginOptions: MCPPluginConfig,
+  mcpAccessSettings: MCPAccessSettings,
+  req: PayloadRequest,
+): McpServer => {
+  const serverOptions = pluginOptions.mcp?.serverOptions || {}
+
+  try {
+    const server = new McpServer(
+      serverOptions.serverInfo ?? { name: 'Payload MCP Server', version: '1.0.0' },
+      {
+        instructions: serverOptions.instructions,
       },
+    )
+
+    getRegisterServerTools(pluginOptions, mcpAccessSettings, req)(server)
+
+    return server
+  } catch (error) {
+    throw new APIError(`Error initializing MCP handler: ${String(error)}`, 500)
+  }
+}
+
+/**
+ * Legacy `mcp-handler` based handler. This remains available for the SSE/Redis
+ * transport path when `handlerOptions.disableSse` is explicitly set to `false`.
+ */
+export const getMCPHandler = (
+  pluginOptions: MCPPluginConfig,
+  mcpAccessSettings: MCPAccessSettings,
+  req: PayloadRequest,
+) => {
+  const { payload } = req
+  const MCPOptions = pluginOptions.mcp || {}
+  const MCPHandlerOptions = MCPOptions.handlerOptions || {}
+  const serverOptions = MCPOptions.serverOptions || {}
+  const useVerboseLogs = MCPHandlerOptions.verboseLogs ?? false
+
+  try {
+    return createMcpHandler(
+      getRegisterServerTools(pluginOptions, mcpAccessSettings, req),
       {
         instructions: serverOptions.instructions,
         serverInfo: serverOptions.serverInfo,

--- a/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.ts
+++ b/packages/plugin-mcp/src/utils/schemaConversion/convertCollectionSchemaToZod.ts
@@ -40,13 +40,14 @@ export const convertCollectionSchemaToZod = (schema: JSONSchema4) => {
   } catch (error) {
     // If schema conversion fails (e.g., due to Zod v4 toJSONSchema null-check bug
     // with record schemas that have undefined valueType, or bundler transforms
-    // stripping Zod internals), return a permissive schema so tools/list doesn't
-    // crash entirely. The tool will still be listed but without strict validation.
+    // stripping Zod internals), return a permissive object schema so tools/list
+    // doesn't crash entirely. Resource create/update tools expect `.shape` and
+    // `.partial()`, so a record schema is not a safe fallback here.
     // See: https://github.com/colinhacks/zod/issues/5821
     console.warn(
       `[plugin-mcp] Schema conversion failed, using permissive fallback:`,
       error instanceof Error ? error.message : error,
     )
-    return z.record(z.any())
+    return z.object({}).catchall(z.any())
   }
 }


### PR DESCRIPTION
> **Prior art / credit:** This is the same fix as **#16253** by @sjkey (swap `mcp-handler`'s Node transport for `WebStandardStreamableHTTPServerTransport`) — full credit to that PR. I hit this independently in production. Since #16253 is marked `stale` and targets `main` (which has since moved to `4.0.0-beta.0`, restructuring this area), I'm opening this as a **`3.x`-targeted, production-verified** counterpart so there's a mergeable option on the v3 line. **Happy to close this in favor of #16253** if you'd rather rebase that onto `3.x`.
>
> Related: #14716

### What / Why

Authenticated requests to `/api/mcp` hang on **Cloudflare Workers (workerd)** and the runtime cancels them (`error 1101`, HTTP 500). The unauthenticated `401` path returns before the transport runs, so the failure is easy to miss in a smoke test.

**Root cause.** `getMCPHandler` delegates to [`mcp-handler`](https://www.npmjs.com/package/mcp-handler), whose Streamable HTTP path uses `@modelcontextprotocol/sdk`'s Node `StreamableHTTPServerTransport`. That transport pulls in `@hono/node-server`'s `getRequestListener`, which replaces `global.Request` / `global.Response` with Hono classes. `overrideGlobalObjects: false` isn't reachable from callers, so today's code swaps the globals and restores them in a `finally`. Under workerd the response promise never settles, so the request hangs. (Same root cause called out in #16253 and #15856.)

### The fix

- Replace the Node transport with the SDK's `WebStandardStreamableHTTPServerTransport` (pure Fetch API) in stateless JSON mode (`sessionIdGenerator: undefined`, `enableJsonResponse: true`). No global mutation, so nothing to save/restore.
- Extract tool registration into a transport-agnostic `getRegisterServerTools`, shared by the new default path (`buildMcpServer`) and the **legacy `mcp-handler` SSE path**, preserved behind `handlerOptions.disableSse: false`.
- Harden the schema-conversion fallback to `z.object({}).catchall(z.any())` instead of `z.record(z.any())`, since resource create/update tools call `.shape` / `.partial()` and a record type throws (see #16339).

### Verification

Verified end-to-end in **production** on Cloudflare Workers via `opennextjs-cloudflare` against a real D1-backed Payload app: authenticated `initialize` + `tools/list` (12 tools) + `tools/call` (collection `find` and global `find`) all return promptly instead of hanging. The unauthenticated `401` still returns quickly.

### Notes for reviewers

- Same approach as #16253; this one targets **`3.x`** and is production-verified.
- Most of the line churn in `getMcpHandler.ts` is **re-indentation** from moving the registration closure into `getRegisterServerTools`; ignoring whitespace it's ~215 insertions / ~39 deletions across the three files.
- `main` (`4.0.x`) restructured this area and isn't touched here.
- Kept as **draft** pending maintainer direction on which PR to carry forward.
