### PR TITLE
fix(richtext-lexical): add missing Persian (fa) heading label translation

### DIFF
--- a/packages/richtext-lexical/src/features/heading/server/i18n.ts
+++ b/packages/richtext-lexical/src/features/heading/server/i18n.ts
@@ -29,7 +29,7 @@ export const i18n: Partial<GenericLanguages> = {
     label: 'Pealkiri {{headingLevel}}',
   },
   fa: {
-    label: '[SKIPPED]',
+    label: 'عنوان {{headingLevel}}',
   },
   fr: {
     label: 'En-tête {{headingLevel}}',


### PR DESCRIPTION
## What?

Replaces the placeholder `'[SKIPPED]'` with a proper Persian translation for the
Lexical heading dropdown label (`lexical:heading:label`).

```diff
  fa: {
-   label: '[SKIPPED]'
+   label: 'عنوان {{headingLevel}}'
  },
```

## Why?

When the admin panel language is Persian (`fa`), the heading dropdown in the
Lexical editor rendered `[SKIPPED]` for all levels (H1–H6) instead of a
localized label. `[SKIPPED]` is a leftover placeholder from the translation
tooling and was shipped as-is.

## How?

Sets the `fa` value of `lexical:heading:label` to `'عنوان {{headingLevel}}'`,
matching the pattern used by the other locales (e.g. `en: 'Heading {{headingLevel}}'`,
`ar: 'العنوان {{headingLevel}}'`). The `{{headingLevel}}` interpolation variable
is kept in Latin so it resolves to the level number (1–6).

**Before:** heading options show `[SKIPPED]`
**After:** heading options show `عنوان 1` … `عنوان 6`

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] Only the `fa` heading label was changed; no other locales/behavior touched.
- [x] Existing tests pass locally.