### PR TITLE
fix(next): respect disabled GraphQL config

### DIFF
--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -104,11 +104,6 @@ export const POST =
       request,
     })
 
-    await addDataAndFileToRequest(req)
-    addLocalesToRequestFromData(req)
-
-    const { schema, validationRules } = await getGraphql(config)
-
     const { payload } = req
 
     if (payload.config.graphQL?.disable) {
@@ -116,6 +111,11 @@ export const POST =
         status: 404,
       })
     }
+
+    await addDataAndFileToRequest(req)
+    addLocalesToRequestFromData(req)
+
+    const { schema, validationRules } = await getGraphql(config)
 
     const headers = {}
     const apiResponse = await createHandler({

--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -111,6 +111,12 @@ export const POST =
 
     const { payload } = req
 
+    if (payload.config.graphQL?.disable) {
+      return new Response(null, {
+        status: 404,
+      })
+    }
+
     const headers = {}
     const apiResponse = await createHandler({
       context: { headers, req },

--- a/test/graphql/int.spec.ts
+++ b/test/graphql/int.spec.ts
@@ -25,6 +25,30 @@ describe('graphql', () => {
   })
 
   describe('graphql', () => {
+    it('should return 404 when GraphQL is disabled', async () => {
+      const originalDisable = payload.config.graphQL?.disable
+
+      payload.config.graphQL.disable = true
+
+      try {
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({
+            query: `query {
+          Posts {
+            docs {
+              id
+            }
+          }
+        }`,
+          }),
+        })
+
+        expect(response.status).toBe(404)
+      } finally {
+        payload.config.graphQL.disable = originalDisable
+      }
+    })
+
     it('should not be able to query introspection', async () => {
       const query = `query {
         __schema {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the GraphQL endpoint remains accessible even when `graphQL.disable` is set to `true`.

Closes #17183.

## Changes

- Added a guard in the Next.js GraphQL route handler to respect `graphQL.disable`.
- Returns a 404 response when GraphQL is disabled instead of executing the request.

## Testing

- Ran `pnpm dev graphql`.
- Set `graphQL.disable` to `true` in the GraphQL test configuration.
- Verified that `POST /api/graphql` returns a 404 response instead of executing the GraphQL query.