### PR TITLE
feat: collection-level disableBulkDelete

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -86,6 +86,7 @@ The following options are available:
 | `defaultPopulate`    | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultpopulate-collection-config-property).                                                |
 | `indexes`            | Define compound indexes for this collection. This can be used to either speed up querying/sorting by 2 or more fields at the same time or to ensure uniqueness between several fields.                               |
 | `forceSelect`        | Specify which fields should be selected always, regardless of the `select` query which can be useful that the field exists for access control / hooks. [More details](../queries/select).                            |
+| `disableBulkDelete`  | Disable the bulk delete operation for the collection in the admin panel and the REST API                                                                                                                             |
 | `disableBulkEdit`    | Disable the bulk edit operation for the collection in the admin panel and the REST API                                                                                                                               |
 
 _\* An asterisk denotes that a property is required._

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -417,7 +417,7 @@ export const renderListView = async (
               ...listViewSlots,
               collectionSlug,
               columnState,
-              disableBulkDelete,
+              disableBulkDelete: collectionConfig.disableBulkDelete ?? disableBulkDelete,
               disableBulkEdit: collectionConfig.disableBulkEdit ?? disableBulkEdit,
               disableQueryPresets,
               enableRowSelections,

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -620,6 +620,10 @@ export type CollectionConfig<TSlug extends CollectionSlug = any> = {
    */
   defaultSort?: Sort
   /**
+   * Disable the bulk delete operation for the collection in the admin panel and the API
+   */
+  disableBulkDelete?: boolean
+  /**
    * Disable the bulk edit operation for the collection in the admin panel and the API
    */
   disableBulkEdit?: boolean

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -52,6 +52,10 @@ export const deleteOperation = async <
 ): Promise<BulkOperationResult<TSlug, TSelect>> => {
   let args = incomingArgs
 
+  if (args.collection.config.disableBulkDelete && !args.overrideAccess) {
+    throw new APIError(`Collection ${args.collection.config.slug} has disabled bulk delete`, 403)
+  }
+
   try {
     const shouldCommit = !args.disableTransaction && (await initTransaction(args.req))
     // /////////////////////////////////////

--- a/packages/ui/src/views/CollectionFolder/index.tsx
+++ b/packages/ui/src/views/CollectionFolder/index.tsx
@@ -265,7 +265,7 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
             Actions={[
               !smallBreak && (
                 <ListSelection
-                  disableBulkDelete={disableBulkDelete}
+                  disableBulkDelete={collectionConfig.disableBulkDelete ?? disableBulkDelete}
                   disableBulkEdit={collectionConfig.disableBulkEdit ?? disableBulkEdit}
                   folderAssignedCollections={
                     Array.isArray(folderType) ? folderType : [collectionSlug]

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -281,6 +281,17 @@ export default buildConfigWithDefaults({
       ],
       disableBulkEdit: true,
     },
+    {
+      slug: 'disabled-bulk-delete-docs',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+      ],
+      disableBulkDelete: true,
+      versions: false,
+    },
     LargeDocuments,
   ],
   bodyParser: {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -1919,6 +1919,38 @@ describe('collections-rest', () => {
       }),
     ).resolves.toBeTruthy()
   })
+
+  it('should disable bulk delete for the collection with disableBulkDelete: true', async () => {
+    const res = await restClient.DELETE('/disabled-bulk-delete-docs?where[id][equals]=0')
+    expect(res.status).toBe(403)
+
+    await expect(
+      payload.delete({
+        collection: 'disabled-bulk-delete-docs',
+        where: {},
+        overrideAccess: false,
+      }),
+    ).rejects.toBeInstanceOf(APIError)
+
+    const doc = await payload.create({
+      collection: 'disabled-bulk-delete-docs',
+      data: { text: 'should be deletable by id' },
+    })
+
+    await expect(
+      payload.delete({
+        collection: 'disabled-bulk-delete-docs',
+        id: doc.id,
+      }),
+    ).resolves.toBeTruthy()
+
+    await expect(
+      payload.delete({
+        collection: 'disabled-bulk-delete-docs',
+        where: {},
+      }),
+    ).resolves.toBeTruthy()
+  })
 })
 
 async function createPost(overrides?: Partial<Post>) {

--- a/test/collections-rest/payload-types.ts
+++ b/test/collections-rest/payload-types.ts
@@ -76,6 +76,7 @@ export interface Config {
     'error-on-hooks': ErrorOnHook;
     endpoints: Endpoint;
     'disabled-bulk-edit-docs': DisabledBulkEditDoc;
+    'disabled-bulk-delete-docs': DisabledBulkDeleteDoc;
     'large-documents': LargeDocument;
     'payload-kv': PayloadKv;
     users: User;
@@ -94,6 +95,7 @@ export interface Config {
     'error-on-hooks': ErrorOnHooksSelect<false> | ErrorOnHooksSelect<true>;
     endpoints: EndpointsSelect<false> | EndpointsSelect<true>;
     'disabled-bulk-edit-docs': DisabledBulkEditDocsSelect<false> | DisabledBulkEditDocsSelect<true>;
+    'disabled-bulk-delete-docs': DisabledBulkDeleteDocsSelect<false> | DisabledBulkDeleteDocsSelect<true>;
     'large-documents': LargeDocumentsSelect<false> | LargeDocumentsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
@@ -264,6 +266,16 @@ export interface DisabledBulkEditDoc {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "disabled-bulk-delete-docs".
+ */
+export interface DisabledBulkDeleteDoc {
+  id: string;
+  text?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "large-documents".
  */
 export interface LargeDocument {
@@ -361,6 +373,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'disabled-bulk-edit-docs';
         value: string | DisabledBulkEditDoc;
+      } | null)
+    | ({
+        relationTo: 'disabled-bulk-delete-docs';
+        value: string | DisabledBulkDeleteDoc;
       } | null)
     | ({
         relationTo: 'large-documents';
@@ -514,6 +530,15 @@ export interface EndpointsSelect<T extends boolean = true> {
  * via the `definition` "disabled-bulk-edit-docs_select".
  */
 export interface DisabledBulkEditDocsSelect<T extends boolean = true> {
+  text?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "disabled-bulk-delete-docs_select".
+ */
+export interface DisabledBulkDeleteDocsSelect<T extends boolean = true> {
   text?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
## Summary

Backport of #16944 to the `3.x` branch.

Adds a collection-level `disableBulkDelete` config option, completing the work started in #12850 (which added collection-level `disableBulkEdit`).

Previously, `disableBulkDelete` only existed as a List View UI prop, so setting it hid the bulk delete button but did **not** prevent bulk deletes via the REST, GraphQL, or Local API. A user with `delete` permission could still delete every document at once through `payload.delete({ where })` or `DELETE /api/:collection?where=...`.

This brings `disableBulkDelete` to full parity with `disableBulkEdit`:

- New collection config option `disableBulkDelete`.
- Server-side enforcement: the bulk `deleteOperation` now throws a `403` when `disableBulkDelete` is set and access is not overridden, mirroring the existing guard in `updateOperation`.
- The bulk delete UI action is hidden automatically, because the option is threaded into the List view props.

Single-document deletes (`deleteByID`) are unaffected, so "delete one, not delete many" works out of the box without a custom `access.delete` check.

## Note on the 3.x adaptation

On `main` the entire list view is rendered through a single `renderListView` in `packages/ui`, so one change covered the standard list, trash, and hierarchy views. On `3.x` the list view is still rendered from `packages/next`, and the folder view is separate, so the config is threaded into both:

- `packages/next/src/views/List/index.tsx`
- `packages/ui/src/views/CollectionFolder/index.tsx`

both mirroring exactly how `disableBulkEdit` is already resolved from `collectionConfig` in those files.

## Note on trash / soft delete

This scopes `disableBulkDelete` to the bulk delete operation, exactly mirroring how `disableBulkEdit` guards the bulk update operation. In Payload, bulk "move to trash" is a bulk update (it sets `deletedAt`), so it runs through `updateOperation` and is therefore governed by `disableBulkEdit`, not `disableBulkDelete`. A collection that wants to lock down both bulk edits and bulk removals can set both flags, and they compose cleanly.

## Test plan

- [x] Added a `disabled-bulk-delete-docs` collection with `disableBulkDelete: true` in `test/collections-rest`.
- [x] Added an integration test mirroring the existing `disableBulkEdit` test: REST bulk `DELETE` returns `403`, Local API bulk delete with `overrideAccess: false` rejects with `APIError`, single-document delete by `id` still works, and bulk delete still works when access is overridden.
- [ ] `pnpm run test:int collections-rest -t "bulk"` (run against 3.x before merge)