### PR TITLE
fix(sdk): use qs-esm allowEmptyArrays parameter

### DIFF
--- a/packages/payload/src/utilities/createPayloadRequest.ts
+++ b/packages/payload/src/utilities/createPayloadRequest.ts
@@ -69,6 +69,7 @@ export const createPayloadRequest = async ({
 
   const query = queryToParse
     ? qs.parse(queryToParse, {
+        allowEmptyArrays: true,
         arrayLimit: 1000,
         depth: 10,
         ignoreQueryPrefix: true,

--- a/packages/sdk/src/utilities/buildSearchParams.ts
+++ b/packages/sdk/src/utilities/buildSearchParams.ts
@@ -75,7 +75,8 @@ export const buildSearchParams = (args: OperationArgs): string => {
   }
 
   if (Object.keys(search).length > 0) {
-    return stringify(search, { addQueryPrefix: true })
+    // @ts-expect-error allowEmptyArrays is not in the type definition for qs-esm, but it is supported
+    return stringify(search, { addQueryPrefix: true, allowEmptyArrays: true })
   }
 
   return ''

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -65,6 +65,16 @@ describe('@payloadcms/sdk', () => {
     await payload.delete({ collection: 'posts', where: { id: { in: ids } } })
   })
 
+  it('should return no docs for an empty array in `in` condition', async () => {
+    const result = await sdk.find({
+      collection: 'posts',
+      where: { id: { in: [] } },
+    })
+
+    expect(result.docs).toHaveLength(0)
+    expect(result.totalDocs).toBe(0)
+  })
+
   it('should execute find with trash', async () => {
     const pairWhere = { id: { in: [post.id, postTrash.id] } }
 


### PR DESCRIPTION
Port of https://github.com/payloadcms/payload/pull/17078 to `3.x`