### PR TITLE
fix(plugin-mcp): point ./internal export at existing barrel file

### DIFF
--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -39,9 +39,9 @@
       "default": "./src/stdio.ts"
     },
     "./internal": {
-      "import": "./src/internal.ts",
-      "types": "./src/internal.ts",
-      "default": "./src/internal.ts"
+      "import": "./src/exports/internal.ts",
+      "types": "./src/exports/internal.ts",
+      "default": "./src/exports/internal.ts"
     }
   },
   "main": "./src/index.ts",
@@ -96,9 +96,9 @@
         "default": "./dist/stdio.js"
       },
       "./internal": {
-        "import": "./dist/internal.js",
-        "types": "./dist/internal.d.ts",
-        "default": "./dist/internal.js"
+        "import": "./dist/exports/internal.js",
+        "types": "./dist/exports/internal.d.ts",
+        "default": "./dist/exports/internal.js"
       }
     },
     "main": "./dist/index.js",


### PR DESCRIPTION
# Overview

Fixes the broken `@payloadcms/plugin-mcp/internal` subpath export. Both its dev and published conditions pointed at files that don't exist.
