### PR TITLE
feat(ui): add livePreview.openByDefault config option

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -222,6 +222,13 @@ export type LivePreviewConfig = {
     width: number | string
   }[]
   /**
+   * When `true`, Live Preview opens automatically the first time a user views a document,
+   * before they have manually toggled it on. Once the user toggles Live Preview on or off,
+   * their stored preference takes precedence and this setting is ignored.
+   * @default false
+   */
+  openByDefault?: boolean
+  /**
    * The URL of the frontend application. This will be rendered within an `iframe` as its `src`.
    * Payload will send a `window.postMessage()` to this URL with the document data in real-time.
    * The frontend application is responsible for receiving the message and updating the UI accordingly.

--- a/packages/ui/src/views/Document/index.tsx
+++ b/packages/ui/src/views/Document/index.tsx
@@ -457,7 +457,9 @@ export const renderDocument = async ({
           breakpoints={livePreviewConfig?.breakpoints}
           isLivePreviewEnabled={isLivePreviewEnabled && operation !== 'create'}
           isLivePreviewing={Boolean(
-            entityPreferences?.value?.editViewType === 'live-preview' && livePreviewURL,
+            (entityPreferences?.value?.editViewType === undefined
+              ? livePreviewConfig?.openByDefault
+              : entityPreferences.value.editViewType === 'live-preview') && livePreviewURL,
           )}
           isPreviewEnabled={Boolean(isPreviewEnabled)}
           previewURL={previewURL}

--- a/test/live-preview/collections/OpenByDefault.ts
+++ b/test/live-preview/collections/OpenByDefault.ts
@@ -1,0 +1,25 @@
+import type { CollectionConfig } from 'payload'
+
+import { openByDefaultSlug } from '../shared.js'
+
+export const OpenByDefault: CollectionConfig = {
+  slug: openByDefaultSlug,
+  admin: {
+    description: 'Live Preview opens automatically on first visit via `openByDefault`.',
+    useAsTitle: 'title',
+    livePreview: {
+      openByDefault: true,
+      url: `http://localhost:${process.env.PORT || 3000}/live-preview`,
+    },
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  versions: false,
+}

--- a/test/live-preview/config.ts
+++ b/test/live-preview/config.ts
@@ -9,6 +9,7 @@ import { CollectionLevelConfig } from './collections/CollectionLevelConfig.js'
 import { ConditionalURL } from './collections/ConditionalURL.js'
 import { CustomLivePreview } from './collections/CustomLivePreview.js'
 import { Media } from './collections/Media.js'
+import { OpenByDefault } from './collections/OpenByDefault.js'
 import { Pages } from './collections/Pages.js'
 import { Posts } from './collections/Posts.js'
 import { SSR } from './collections/SSR.js'
@@ -66,6 +67,7 @@ export default buildConfigWithDefaults({
     Categories,
     Media,
     CollectionLevelConfig,
+    OpenByDefault,
     StaticURLCollection,
     CustomLivePreview,
     ConditionalURL,

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -44,6 +44,7 @@ import {
   customLivePreviewSlug,
   desktopBreakpoint,
   mobileBreakpoint,
+  openByDefaultSlug,
   pagesSlug,
   postsSlug,
   renderedPageTitleID,
@@ -170,6 +171,38 @@ describe('Live Preview', () => {
     await expect(toggler).toHaveClass(/live-preview-toggler--active/)
     await expect(iframe).toBeVisible()
 
+    await toggleLivePreview(page, {
+      targetState: 'off',
+    })
+
+    await page.reload()
+
+    await expect(toggler).not.toHaveClass(/live-preview-toggler--active/)
+    await expect(iframe).toBeHidden()
+  })
+
+  test('collection — opens live preview by default on first visit when openByDefault is set', async () => {
+    const openByDefaultURL = new AdminUrlUtil(serverURL, openByDefaultSlug)
+
+    await deletePreferences({
+      payload,
+      user,
+      key: `collection-${openByDefaultSlug}`,
+    })
+
+    await page.goto(openByDefaultURL.create)
+    await page.locator('#field-title').fill('Open By Default')
+    await saveDocAndAssert(page)
+
+    const toggler = page.locator('button#live-preview-toggler')
+    await expect(toggler).toBeVisible()
+
+    // No stored preference exists, so openByDefault should auto-open the panel
+    await expect(toggler).toHaveClass(/live-preview-toggler--active/)
+    const { iframe } = await getLivePreviewIframe(page)
+    await expect(iframe).toBeVisible()
+
+    // Once the user toggles off, their stored preference wins over openByDefault
     await toggleLivePreview(page, {
       targetState: 'off',
     })

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -62,16 +62,16 @@ export type SupportedTimezones =
   | 'Pacific/Fiji';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_D543C5B5".
+ * via the `definition` "LexicalNodes_D4620076".
  */
-export type LexicalNodes_D543C5B5 =
+export type LexicalNodes_D4620076 =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_D543C5B5>
+  | SerializedParagraphNode<LexicalNodes_D4620076>
   | SerializedHorizontalRuleNode
   | SerializedUploadNode<'media'>
-  | SerializedQuoteNode<LexicalNodes_D543C5B5>
+  | SerializedQuoteNode<LexicalNodes_D4620076>
   | SerializedRelationshipNode<
       | 'users'
       | 'pages'
@@ -81,6 +81,7 @@ export type LexicalNodes_D543C5B5 =
       | 'tenants'
       | 'categories'
       | 'collection-level-config'
+      | 'open-by-default'
       | 'static-url'
       | 'custom-live-preview'
       | 'conditional-url'
@@ -89,24 +90,24 @@ export type LexicalNodes_D543C5B5 =
       | 'payload-preferences'
       | 'payload-migrations'
     >
-  | SerializedAutoLinkNode<LexicalNodes_D543C5B5, LexicalLinkFields>
-  | SerializedLinkNode<LexicalNodes_D543C5B5, LexicalLinkFields>
-  | SerializedListNode<LexicalNodes_D543C5B5>
-  | SerializedListItemNode<LexicalNodes_D543C5B5>
-  | SerializedHeadingNode<LexicalNodes_D543C5B5>;
+  | SerializedAutoLinkNode<LexicalNodes_D4620076, LexicalLinkFields>
+  | SerializedLinkNode<LexicalNodes_D4620076, LexicalLinkFields>
+  | SerializedListNode<LexicalNodes_D4620076>
+  | SerializedListItemNode<LexicalNodes_D4620076>
+  | SerializedHeadingNode<LexicalNodes_D4620076>;
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_EBA54163".
+ * via the `definition` "LexicalNodes_D773765D".
  */
-export type LexicalNodes_EBA54163 =
+export type LexicalNodes_D773765D =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_EBA54163>
+  | SerializedParagraphNode<LexicalNodes_D773765D>
   | SerializedBlockNode<MediaBlock_1EDC4A89>
   | SerializedHorizontalRuleNode
   | SerializedUploadNode<'media'>
-  | SerializedQuoteNode<LexicalNodes_EBA54163>
+  | SerializedQuoteNode<LexicalNodes_D773765D>
   | SerializedRelationshipNode<
       | 'users'
       | 'pages'
@@ -116,6 +117,7 @@ export type LexicalNodes_EBA54163 =
       | 'tenants'
       | 'categories'
       | 'collection-level-config'
+      | 'open-by-default'
       | 'static-url'
       | 'custom-live-preview'
       | 'conditional-url'
@@ -124,28 +126,28 @@ export type LexicalNodes_EBA54163 =
       | 'payload-preferences'
       | 'payload-migrations'
     >
-  | SerializedAutoLinkNode<LexicalNodes_EBA54163, LexicalLinkFields>
-  | SerializedLinkNode<LexicalNodes_EBA54163, LexicalLinkFields>
-  | SerializedListNode<LexicalNodes_EBA54163>
-  | SerializedListItemNode<LexicalNodes_EBA54163>
-  | SerializedHeadingNode<LexicalNodes_EBA54163>;
+  | SerializedAutoLinkNode<LexicalNodes_D773765D, LexicalLinkFields>
+  | SerializedLinkNode<LexicalNodes_D773765D, LexicalLinkFields>
+  | SerializedListNode<LexicalNodes_D773765D>
+  | SerializedListItemNode<LexicalNodes_D773765D>
+  | SerializedHeadingNode<LexicalNodes_D773765D>;
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_660DF7D8".
+ * via the `definition` "LexicalNodes_6238834A".
  */
-export type LexicalNodes_660DF7D8 =
+export type LexicalNodes_6238834A =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_660DF7D8>
+  | SerializedParagraphNode<LexicalNodes_6238834A>
   | SerializedBlockNode<MyBlock>
-  | SerializedHeadingNode<LexicalNodes_660DF7D8>
+  | SerializedHeadingNode<LexicalNodes_6238834A>
   | SerializedUploadNode<'media', LexicalUploadFields_1AB4670B>
-  | SerializedQuoteNode<LexicalNodes_660DF7D8>
-  | SerializedListNode<LexicalNodes_660DF7D8>
-  | SerializedListItemNode<LexicalNodes_660DF7D8>
-  | SerializedAutoLinkNode<LexicalNodes_660DF7D8, LexicalLinkFields_0A7E9EC0>
-  | SerializedLinkNode<LexicalNodes_660DF7D8, LexicalLinkFields_0A7E9EC0>
+  | SerializedQuoteNode<LexicalNodes_6238834A>
+  | SerializedListNode<LexicalNodes_6238834A>
+  | SerializedListItemNode<LexicalNodes_6238834A>
+  | SerializedAutoLinkNode<LexicalNodes_6238834A, LexicalLinkFields_0A7E9EC0>
+  | SerializedLinkNode<LexicalNodes_6238834A, LexicalLinkFields_0A7E9EC0>
   | SerializedRelationshipNode<
       | 'users'
       | 'pages'
@@ -155,6 +157,7 @@ export type LexicalNodes_660DF7D8 =
       | 'tenants'
       | 'categories'
       | 'collection-level-config'
+      | 'open-by-default'
       | 'static-url'
       | 'custom-live-preview'
       | 'conditional-url'
@@ -181,6 +184,7 @@ export interface Config {
     categories: Category;
     media: Media;
     'collection-level-config': CollectionLevelConfig;
+    'open-by-default': OpenByDefault;
     'static-url': StaticUrl;
     'custom-live-preview': CustomLivePreview;
     'conditional-url': ConditionalUrl;
@@ -200,6 +204,7 @@ export interface Config {
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     'collection-level-config': CollectionLevelConfigSelect<false> | CollectionLevelConfigSelect<true>;
+    'open-by-default': OpenByDefaultSelect<false> | OpenByDefaultSelect<true>;
     'static-url': StaticUrlSelect<false> | StaticUrlSelect<true>;
     'custom-live-preview': CustomLivePreviewSelect<false> | CustomLivePreviewSelect<true>;
     'conditional-url': ConditionalUrlSelect<false> | ConditionalUrlSelect<true>;
@@ -223,6 +228,8 @@ export interface Config {
   locale: 'en' | 'es';
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -317,7 +324,7 @@ export interface Page {
   title: string;
   hero: {
     type: 'none' | 'highImpact' | 'lowImpact';
-    richText?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+    richText?: LexicalRichText<LexicalNodes_D4620076> | null;
     media?: (string | null) | Media;
   };
   layout?: (Cta | Content | MediaBlock | Archive)[] | null;
@@ -327,8 +334,8 @@ export interface Page {
   testNumber?: number | null;
   localizedTitle?: string | null;
   relationToLocalized?: (string | null) | Post;
-  richTextLexical?: LexicalRichText<LexicalNodes_EBA54163> | null;
-  richTextLexicalLocalized?: LexicalRichText<LexicalNodes_EBA54163> | null;
+  richTextLexical?: LexicalRichText<LexicalNodes_D773765D> | null;
+  richTextLexicalLocalized?: LexicalRichText<LexicalNodes_D773765D> | null;
   relationshipAsUpload?: (string | null) | Media;
   relationshipMonoHasOne?: (string | null) | Post;
   relationshipMonoHasMany?: (string | Post)[] | null;
@@ -345,7 +352,7 @@ export interface Page {
   arrayOfRelationships?:
     | {
         uploadInArray?: (string | null) | Media;
-        richTextInArray?: LexicalRichText<LexicalNodes_660DF7D8> | null;
+        richTextInArray?: LexicalRichText<LexicalNodes_6238834A> | null;
         relationshipInArrayMonoHasOne?: (string | null) | Post;
         relationshipInArrayMonoHasMany?: (string | Post)[] | null;
         relationshipInArrayPolyHasOne?: {
@@ -389,7 +396,7 @@ export interface Tenant {
  */
 export interface Cta {
   invertBackground?: boolean | null;
-  richText?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+  richText?: LexicalRichText<LexicalNodes_D4620076> | null;
   links?:
     | {
         link: {
@@ -429,7 +436,7 @@ export interface Post {
   title: string;
   hero: {
     type: 'none' | 'highImpact' | 'lowImpact';
-    richText?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+    richText?: LexicalRichText<LexicalNodes_D4620076> | null;
     media?: (string | null) | Media;
   };
   layout?: (Cta | Content | MediaBlock | Archive)[] | null;
@@ -453,7 +460,7 @@ export interface Content {
   columns?:
     | {
         size?: ('oneThird' | 'half' | 'twoThirds' | 'full') | null;
-        richText?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+        richText?: LexicalRichText<LexicalNodes_D4620076> | null;
         enableLink?: boolean | null;
         link?: {
           type?: ('reference' | 'custom') | null;
@@ -486,7 +493,7 @@ export interface Content {
  * via the `definition` "Archive".
  */
 export interface Archive {
-  introContent?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+  introContent?: LexicalRichText<LexicalNodes_D4620076> | null;
   populateBy?: ('collection' | 'selection') | null;
   relationTo?: 'posts' | null;
   categories?: (string | Category)[] | null;
@@ -537,7 +544,7 @@ export interface Ssr {
   title: string;
   hero: {
     type: 'none' | 'highImpact' | 'lowImpact';
-    richText?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+    richText?: LexicalRichText<LexicalNodes_D4620076> | null;
     media?: (string | null) | Media;
   };
   layout?: (Cta | Content | MediaBlock | Archive)[] | null;
@@ -562,7 +569,7 @@ export interface SsrAutosave {
   title: string;
   hero: {
     type: 'none' | 'highImpact' | 'lowImpact';
-    richText?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+    richText?: LexicalRichText<LexicalNodes_D4620076> | null;
     media?: (string | null) | Media;
   };
   layout?: (Cta | Content | MediaBlock | Archive)[] | null;
@@ -582,6 +589,18 @@ export interface SsrAutosave {
  * via the `definition` "collection-level-config".
  */
 export interface CollectionLevelConfig {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Live Preview opens automatically on first visit via `openByDefault`.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "open-by-default".
+ */
+export interface OpenByDefault {
   id: string;
   title?: string | null;
   updatedAt: string;
@@ -608,7 +627,7 @@ export interface CustomLivePreview {
   title: string;
   hero: {
     type: 'none' | 'highImpact' | 'lowImpact';
-    richText?: LexicalRichText<LexicalNodes_D543C5B5> | null;
+    richText?: LexicalRichText<LexicalNodes_D4620076> | null;
     media?: (string | null) | Media;
   };
   layout?: (Cta | Content | MediaBlock | Archive)[] | null;
@@ -690,6 +709,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'collection-level-config';
         value: string | CollectionLevelConfig;
+      } | null)
+    | ({
+        relationTo: 'open-by-default';
+        value: string | OpenByDefault;
       } | null)
     | ({
         relationTo: 'static-url';
@@ -1245,6 +1268,15 @@ export interface CollectionLevelConfigSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "open-by-default_select".
+ */
+export interface OpenByDefaultSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "static-url_select".
  */
 export interface StaticUrlSelect<T extends boolean = true> {
@@ -1525,6 +1557,68 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection:
+      | 'users'
+      | 'pages'
+      | 'posts'
+      | 'ssr'
+      | 'ssr-autosave'
+      | 'tenants'
+      | 'categories'
+      | 'media'
+      | 'collection-level-config'
+      | 'open-by-default'
+      | 'static-url'
+      | 'custom-live-preview'
+      | 'conditional-url';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?:
+      | (
+          | 'users'
+          | 'pages'
+          | 'posts'
+          | 'ssr'
+          | 'ssr-autosave'
+          | 'tenants'
+          | 'categories'
+          | 'media'
+          | 'collection-level-config'
+          | 'open-by-default'
+          | 'static-url'
+          | 'custom-live-preview'
+          | 'conditional-url'
+        )[]
+      | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * Multiple blocks resolve to the `MediaBlock` interface with different fields, so a content hash is appended to keep the generated types stable and unambiguous. Set a unique `interfaceName` on the block to choose the name yourself. See https://payloadcms.com/docs/typescript/generating-types#block-interface-name-collisions

--- a/test/live-preview/shared.ts
+++ b/test/live-preview/shared.ts
@@ -7,6 +7,7 @@ export const postsSlug = 'posts'
 export const mediaSlug = 'media'
 export const categoriesSlug = 'categories'
 export const collectionLevelConfigSlug = 'collection-level-config'
+export const openByDefaultSlug = 'open-by-default'
 export const usersSlug = 'users'
 
 export const mobileBreakpoint = {


### PR DESCRIPTION
Adds an `openByDefault` option to the Live Preview config that opens the Live Preview panel automatically the first time a user views a document, before they have manually toggled it on.

Previously, Live Preview only opened automatically once a user had toggled it on for a given collection or global, which persisted their choice to preferences. On the very first visit there was no way to have it open by default.

A new `openByDefault` property is now available on the `admin.livePreview` config:

```ts
export default buildConfig({
  admin: {
    livePreview: {
      url: 'http://localhost:3000/live-preview',
      openByDefault: true,
    },
  },
})
```

The user's stored preference always wins. `openByDefault` only applies when no preference exists yet — once the user toggles Live Preview on or off, their choice is respected on every subsequent visit and `openByDefault` is ignored.