### PR TITLE
feat(ui): add livePreview.openByDefault config option

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -430,7 +430,9 @@ export const renderDocument = async ({
           breakpoints={livePreviewConfig?.breakpoints}
           isLivePreviewEnabled={isLivePreviewEnabled && operation !== 'create'}
           isLivePreviewing={Boolean(
-            entityPreferences?.value?.editViewType === 'live-preview' && livePreviewURL,
+            (entityPreferences?.value?.editViewType === undefined
+              ? livePreviewConfig?.openByDefault
+              : entityPreferences.value.editViewType === 'live-preview') && livePreviewURL,
           )}
           isPreviewEnabled={Boolean(isPreviewEnabled)}
           previewURL={previewURL}

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -181,6 +181,13 @@ export type LivePreviewConfig = {
     width: number | string
   }[]
   /**
+   * When `true`, Live Preview opens automatically the first time a user views a document,
+   * before they have manually toggled it on. Once the user toggles Live Preview on or off,
+   * their stored preference takes precedence and this setting is ignored.
+   * @default false
+   */
+  openByDefault?: boolean
+  /**
    * The URL of the frontend application. This will be rendered within an `iframe` as its `src`.
    * Payload will send a `window.postMessage()` to this URL with the document data in real-time.
    * The frontend application is responsible for receiving the message and updating the UI accordingly.

--- a/test/live-preview/collections/OpenByDefault.ts
+++ b/test/live-preview/collections/OpenByDefault.ts
@@ -1,0 +1,25 @@
+import type { CollectionConfig } from 'payload'
+
+import { openByDefaultSlug } from '../shared.js'
+
+export const OpenByDefault: CollectionConfig = {
+  slug: openByDefaultSlug,
+  admin: {
+    description: 'Live Preview opens automatically on first visit via `openByDefault`.',
+    useAsTitle: 'title',
+    livePreview: {
+      openByDefault: true,
+      url: `http://localhost:${process.env.PORT || 3000}/live-preview`,
+    },
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  versions: false,
+}

--- a/test/live-preview/config.ts
+++ b/test/live-preview/config.ts
@@ -9,6 +9,7 @@ import { CollectionLevelConfig } from './collections/CollectionLevelConfig.js'
 import { ConditionalURL } from './collections/ConditionalURL.js'
 import { CustomLivePreview } from './collections/CustomLivePreview.js'
 import { Media } from './collections/Media.js'
+import { OpenByDefault } from './collections/OpenByDefault.js'
 import { Pages } from './collections/Pages.js'
 import { Posts } from './collections/Posts.js'
 import { SSR } from './collections/SSR.js'
@@ -66,6 +67,7 @@ export default buildConfigWithDefaults({
     Categories,
     Media,
     CollectionLevelConfig,
+    OpenByDefault,
     StaticURLCollection,
     CustomLivePreview,
     ConditionalURL,

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -44,6 +44,7 @@ import {
   customLivePreviewSlug,
   desktopBreakpoint,
   mobileBreakpoint,
+  openByDefaultSlug,
   pagesSlug,
   postsSlug,
   renderedPageTitleID,
@@ -170,6 +171,38 @@ describe('Live Preview', () => {
     await expect(toggler).toHaveClass(/live-preview-toggler--active/)
     await expect(iframe).toBeVisible()
 
+    await toggleLivePreview(page, {
+      targetState: 'off',
+    })
+
+    await page.reload()
+
+    await expect(toggler).not.toHaveClass(/live-preview-toggler--active/)
+    await expect(iframe).toBeHidden()
+  })
+
+  test('collection — opens live preview by default on first visit when openByDefault is set', async () => {
+    const openByDefaultURL = new AdminUrlUtil(serverURL, openByDefaultSlug)
+
+    await deletePreferences({
+      payload,
+      user,
+      key: `collection-${openByDefaultSlug}`,
+    })
+
+    await page.goto(openByDefaultURL.create)
+    await page.locator('#field-title').fill('Open By Default')
+    await saveDocAndAssert(page)
+
+    const toggler = page.locator('button#live-preview-toggler')
+    await expect(toggler).toBeVisible()
+
+    // No stored preference exists, so openByDefault should auto-open the panel
+    await expect(toggler).toHaveClass(/live-preview-toggler--active/)
+    const { iframe } = await getLivePreviewIframe(page)
+    await expect(iframe).toBeVisible()
+
+    // Once the user toggles off, their stored preference wins over openByDefault
     await toggleLivePreview(page, {
       targetState: 'off',
     })

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -78,6 +78,7 @@ export interface Config {
     categories: Category;
     media: Media;
     'collection-level-config': CollectionLevelConfig;
+    'open-by-default': OpenByDefault;
     'static-url': StaticUrl;
     'custom-live-preview': CustomLivePreview;
     'conditional-url': ConditionalUrl;
@@ -97,6 +98,7 @@ export interface Config {
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     'collection-level-config': CollectionLevelConfigSelect<false> | CollectionLevelConfigSelect<true>;
+    'open-by-default': OpenByDefaultSelect<false> | OpenByDefaultSelect<true>;
     'static-url': StaticUrlSelect<false> | StaticUrlSelect<true>;
     'custom-live-preview': CustomLivePreviewSelect<false> | CustomLivePreviewSelect<true>;
     'conditional-url': ConditionalUrlSelect<false> | ConditionalUrlSelect<true>;
@@ -900,6 +902,18 @@ export interface CollectionLevelConfig {
   createdAt: string;
 }
 /**
+ * Live Preview opens automatically on first visit via `openByDefault`.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "open-by-default".
+ */
+export interface OpenByDefault {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "static-url".
  */
@@ -1122,6 +1136,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'collection-level-config';
         value: string | CollectionLevelConfig;
+      } | null)
+    | ({
+        relationTo: 'open-by-default';
+        value: string | OpenByDefault;
       } | null)
     | ({
         relationTo: 'static-url';
@@ -1671,6 +1689,15 @@ export interface MediaSelect<T extends boolean = true> {
  * via the `definition` "collection-level-config_select".
  */
 export interface CollectionLevelConfigSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "open-by-default_select".
+ */
+export interface OpenByDefaultSelect<T extends boolean = true> {
   title?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/test/live-preview/shared.ts
+++ b/test/live-preview/shared.ts
@@ -7,6 +7,7 @@ export const postsSlug = 'posts'
 export const mediaSlug = 'media'
 export const categoriesSlug = 'categories'
 export const collectionLevelConfigSlug = 'collection-level-config'
+export const openByDefaultSlug = 'open-by-default'
 export const usersSlug = 'users'
 
 export const mobileBreakpoint = {


### PR DESCRIPTION
Identical to #17211, back-ported for 3.x.
