### PR TITLE
refactor!: use `definePlugin` for all core plugins, explicit options in definePlugin interface

### DIFF
--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -238,6 +238,29 @@ If the field name is dynamic (configurable at runtime), index through `Record<st
 const value = (user as Record<string, unknown>)[fieldNameFromConfig]
 ```
 
+### `multiTenantPlugin` and `searchPlugin` no longer take a type argument
+
+The `<ConfigType>` type parameter on `multiTenantPlugin` and `searchPlugin` — and on `MultiTenantPluginConfig` / `SearchPluginConfig` — has been removed. It only existed to override the `user` / `locale` types, which Payload now infers from your generated types automatically: `userHasAccessToAllTenants` receives the generated `User`, and `search`'s `skipSync` callback receives `TypedLocale | undefined`.
+
+Drop the type argument — your callbacks are typed correctly without it.
+
+```diff
+- multiTenantPlugin<{ user: MyUser }>({ ... })
++ multiTenantPlugin({ ... })
+```
+
+### `definePlugin`: options moved to a named `options` argument
+
+The experimental `definePlugin` helper previously spread user options into the `plugin` callback's args, alongside `config` and `plugins`. Options are now under a single `options` property. `TOptions` is also no longer constrained to `Record<string, unknown>`, so `interface` and generic option types work.
+
+```diff
+export const myPlugin = definePlugin<MyPluginOptions>({
+  slug: 'my-plugin',
+- plugin: ({ config, plugins, collections }) => ({ ...config }),
++ plugin: ({ config, options }) => ({ ...config }),
+})
+```
+
 ### `next/navigation` and `next/link` replaced by framework-agnostic `RouterAdapter` hooks
 
 `@payloadcms/ui` no longer depends on `next` directly. Custom admin components (field components, custom views, plugins) that previously imported router hooks or the `Link` component from `next/*` must now import the framework-agnostic equivalents from `@payloadcms/ui`. Behavior is identical when running on Next.js — the `NextRouterAdapter` shipped by `@payloadcms/next` wires `next/navigation` hooks and `next/link` into the same context — but ui code can now also run on non-Next adapters (e.g. TanStack Start) without modification.

--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -249,13 +249,17 @@ Drop the type argument — your callbacks are typed correctly without it.
 + multiTenantPlugin({ ... })
 ```
 
-### `definePlugin`: options moved to a named `options` argument
+### `definePlugin`: `slug` is required and options moved to a named `options` argument
 
-The experimental `definePlugin` helper previously spread user options into the `plugin` callback's args, alongside `config` and `plugins`. Options are now under a single `options` property. `TOptions` is also no longer constrained to `Record<string, unknown>`, so `interface` and generic option types work.
+Two changes to the experimental `definePlugin` helper:
+
+- **`slug` is now required.** It registers the plugin in the `plugins` map for cross-plugin discovery. Add one to every `definePlugin` call.
+- **Options are a named `options` argument.** They were previously spread into the `plugin` callback's args alongside `config` and `plugins`; they're now under a single `options` property. `TOptions` is also no longer constrained to `Record<string, unknown>`, so `interface` and generic option types work.
 
 ```diff
 export const myPlugin = definePlugin<MyPluginOptions>({
-  slug: 'my-plugin',
+- // slug was optional
++ slug: 'my-plugin',
 - plugin: ({ config, plugins, collections }) => ({ ...config }),
 + plugin: ({ config, options }) => ({ ...config }),
 })

--- a/docs/plugins/plugin-api.mdx
+++ b/docs/plugins/plugin-api.mdx
@@ -50,7 +50,7 @@ export const seoPlugin = definePlugin<SEOPluginOptions>({
 })
 ```
 
-`options` can be any type - an object, an `interface`, or a generic. To make options optional (callable with no arguments), include `undefined` in the type parameter:
+To make options optional (callable with no arguments), include `undefined` in the type parameter:
 
 ```ts
 export const analyticsPlugin = definePlugin<AnalyticsOptions | undefined>({

--- a/docs/plugins/plugin-api.mdx
+++ b/docs/plugins/plugin-api.mdx
@@ -34,17 +34,31 @@ Everything below builds on top of this — none of it is required for simple plu
 
 ## `definePlugin` — recommended for published plugins
 
-`definePlugin` replaces the boilerplate of manually attaching `slug`, `order`, and `options` to the function after the fact. Your plugin function receives a single object containing `config`, a `plugins` map, and any user-provided options spread directly in:
+`definePlugin` replaces the boilerplate of manually attaching `slug`, `order`, and `options` to the function after the fact. Your plugin function receives a single object containing `config`, a `plugins` map, and the user-provided `options`:
 
 ```ts
 export const seoPlugin = definePlugin<SEOPluginOptions>({
   slug: 'plugin-seo',
   order: 10,
-  plugin: ({ config, plugins, collections }) => ({
+  plugin: ({ config, options }) => ({
     ...config,
-    collections: [...(config.collections || []), seoCollection],
+    collections: [
+      ...(config.collections || []),
+      seoCollection(options.collections),
+    ],
   }),
 })
+```
+
+`options` can be any type - an object, an `interface`, or a generic. To make options optional (callable with no arguments), include `undefined` in the type parameter:
+
+```ts
+export const analyticsPlugin = definePlugin<AnalyticsOptions | undefined>({
+  slug: 'plugin-analytics',
+  plugin: ({ config, options }) => ({ ...config }), // options: AnalyticsOptions | undefined
+})
+
+analyticsPlugin() // ✅ no arguments required
 ```
 
 Import it from `payload`:
@@ -127,9 +141,9 @@ export type SEOPluginOptions = {
 export const seoPlugin = definePlugin<SEOPluginOptions>({
   slug: 'plugin-seo',
   order: 10,
-  plugin: ({ config, collections }) => ({
+  plugin: ({ config, options }) => ({
     ...config,
-    // extend config here
+    // extend config here using options
   }),
 })
 
@@ -172,11 +186,11 @@ export type ReaderPluginOptions = {
 export const readerPlugin = definePlugin<ReaderPluginOptions>({
   slug: 'my-reader',
   order: 10,
-  plugin: ({ config, items }) => ({
+  plugin: ({ config, options }) => ({
     ...config,
     custom: {
       ...config.custom,
-      items: items.map((i) => i.name),
+      items: options.items.map((i) => i.name),
     },
   }),
 })

--- a/packages/payload/src/config/definePlugin.ts
+++ b/packages/payload/src/config/definePlugin.ts
@@ -16,17 +16,16 @@ function buildPluginsMap(plugins: Plugin[] | undefined): PluginsMap {
  * Helper for authoring plugins with order, slug, and typed options.
  * Eliminates boilerplate and ensures metadata is always set consistently.
  *
- * The `plugin` function receives a single object containing `config`, `plugins`
- * (a slug-keyed map of other plugins), and any user-provided options spread in.
+ * The `plugin` function receives `config`, `plugins` (a slug-keyed map of other
+ * plugins), and the user-provided `options`.
  *
  * @experimental
  *
  * @example
  * // With options:
- * export const seoPlugin = definePlugin<SEOPluginOptions>({
+ * export const seoPlugin = definePlugin<SEOPluginConfig>({
  *   slug: 'plugin-seo',
- *   order: 10,
- *   plugin: ({ config, plugins, collections }) => ({ ...config }),
+ *   plugin: ({ config, options }) => ({ ...config }),
  * })
  *
  * // Without options:
@@ -40,31 +39,35 @@ export function definePlugin(descriptor: {
   plugin: (args: { config: Config; plugins: PluginsMap }) => Config | Promise<Config>
   slug?: string
 }): () => Plugin
-export function definePlugin<TOptions extends Record<string, unknown>>(descriptor: {
+export function definePlugin<TOptions>(descriptor: {
   order?: number
-  plugin: (args: { config: Config; plugins: PluginsMap } & TOptions) => Config | Promise<Config>
+  plugin: (args: {
+    config: Config
+    options: TOptions
+    plugins: PluginsMap
+  }) => Config | Promise<Config>
   slug?: string
-}): (options: TOptions) => Plugin
-export function definePlugin<TOptions extends Record<string, unknown>>(descriptor: {
+}): undefined extends TOptions ? (options?: TOptions) => Plugin : (options: TOptions) => Plugin
+export function definePlugin<TOptions>(descriptor: {
   order?: number
-  plugin: (args: { config: Config; plugins: PluginsMap } & TOptions) => Config | Promise<Config>
+  plugin: (args: {
+    config: Config
+    options: TOptions
+    plugins: PluginsMap
+  }) => Config | Promise<Config>
   slug?: string
-}): (options?: TOptions) => Plugin {
+}): (options: TOptions) => Plugin {
   return (options?: TOptions): Plugin => {
-    const pluginFn: Plugin = (config) => {
-      const plugins = buildPluginsMap(config.plugins)
-
-      const args = {
-        ...options,
+    const pluginFn: Plugin = (config) =>
+      descriptor.plugin({
         config,
-        plugins,
-      } as { config: Config; plugins: PluginsMap } & TOptions
+        options: options as TOptions,
+        plugins: buildPluginsMap(config.plugins),
+      })
 
-      return descriptor.plugin(args)
+    if (options !== undefined) {
+      pluginFn.options = options as Record<string, unknown>
     }
-
-    pluginFn.options = options as Record<string, unknown>
-
     if (descriptor.slug !== undefined) {
       pluginFn.slug = descriptor.slug
     }

--- a/packages/payload/src/config/definePlugin.ts
+++ b/packages/payload/src/config/definePlugin.ts
@@ -37,7 +37,7 @@ function buildPluginsMap(plugins: Plugin[] | undefined): PluginsMap {
 export function definePlugin(descriptor: {
   order?: number
   plugin: (args: { config: Config; plugins: PluginsMap }) => Config | Promise<Config>
-  slug?: string
+  slug: string
 }): () => Plugin
 export function definePlugin<TOptions>(descriptor: {
   order?: number
@@ -46,7 +46,7 @@ export function definePlugin<TOptions>(descriptor: {
     options: TOptions
     plugins: PluginsMap
   }) => Config | Promise<Config>
-  slug?: string
+  slug: string
 }): undefined extends TOptions ? (options?: TOptions) => Plugin : (options: TOptions) => Plugin
 export function definePlugin<TOptions>(descriptor: {
   order?: number
@@ -55,7 +55,7 @@ export function definePlugin<TOptions>(descriptor: {
     options: TOptions
     plugins: PluginsMap
   }) => Config | Promise<Config>
-  slug?: string
+  slug: string
 }): (options: TOptions) => Plugin {
   return (options?: TOptions): Plugin => {
     const pluginFn: Plugin = (config) =>
@@ -68,9 +68,7 @@ export function definePlugin<TOptions>(descriptor: {
     if (options !== undefined) {
       pluginFn.options = options as Record<string, unknown>
     }
-    if (descriptor.slug !== undefined) {
-      pluginFn.slug = descriptor.slug
-    }
+    pluginFn.slug = descriptor.slug
     if (descriptor.order !== undefined) {
       pluginFn.order = descriptor.order
     }

--- a/packages/plugin-ecommerce/src/index.ts
+++ b/packages/plugin-ecommerce/src/index.ts
@@ -1,5 +1,7 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
-import type { Config, Endpoint } from 'payload'
+import type { Endpoint } from 'payload'
+
+import { definePlugin } from 'payload'
 
 import type { PluginDefaultTranslationsObject } from './translations/types.js'
 import type { EcommercePluginConfig, SanitizedEcommercePluginConfig } from './types/index.js'
@@ -19,9 +21,9 @@ import { getCollectionSlugMap } from './utilities/getCollectionSlugMap.js'
 import { pushTypeScriptProperties } from './utilities/pushTypeScriptProperties.js'
 import { sanitizePluginConfig } from './utilities/sanitizePluginConfig.js'
 
-export const ecommercePlugin =
-  (pluginConfig?: EcommercePluginConfig) =>
-  async (incomingConfig: Config): Promise<Config> => {
+export const ecommercePlugin = definePlugin<EcommercePluginConfig | undefined>({
+  slug: '@payloadcms/plugin-ecommerce',
+  plugin: async ({ config: incomingConfig, options: pluginConfig }) => {
     if (!pluginConfig) {
       return incomingConfig
     }
@@ -356,7 +358,8 @@ export const ecommercePlugin =
     )
 
     return incomingConfig
-  }
+  },
+})
 
 export {
   createAddressesCollection,

--- a/packages/plugin-form-builder/src/index.ts
+++ b/packages/plugin-form-builder/src/index.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'payload'
+import { definePlugin } from 'payload'
 
 import type { FormBuilderPluginConfig } from './types.js'
 
@@ -8,9 +8,9 @@ import { generateSubmissionCollection } from './collections/FormSubmissions/inde
 export { fields } from './collections/Forms/fields.js'
 export { getPaymentTotal } from './utilities/getPaymentTotal.js'
 
-export const formBuilderPlugin =
-  (incomingFormConfig: FormBuilderPluginConfig) =>
-  (config: Config): Config => {
+export const formBuilderPlugin = definePlugin<FormBuilderPluginConfig>({
+  slug: '@payloadcms/plugin-form-builder',
+  plugin: ({ config, options: incomingFormConfig }) => {
     const formConfig: FormBuilderPluginConfig = {
       ...incomingFormConfig,
       fields: {
@@ -48,4 +48,5 @@ export const formBuilderPlugin =
         generateSubmissionCollection(formConfig),
       ],
     }
-  }
+  },
+})

--- a/packages/plugin-import-export/src/index.ts
+++ b/packages/plugin-import-export/src/index.ts
@@ -1,6 +1,4 @@
-import type { Config } from 'payload'
-
-import { deepMergeSimple } from 'payload'
+import { deepMergeSimple, definePlugin } from 'payload'
 
 import type { PluginDefaultTranslationsObject } from './translations/types.js'
 import type {
@@ -31,9 +29,9 @@ import { getPluginCollections } from './utilities/getPluginCollections.js'
  *
  * @see https://payloadcms.com/docs/plugins/import-export
  */
-export const importExportPlugin =
-  (pluginConfig: ImportExportPluginConfig) =>
-  async (config: Config): Promise<Config> => {
+export const importExportPlugin = definePlugin<ImportExportPluginConfig>({
+  slug: '@payloadcms/plugin-import-export',
+  plugin: async ({ config, options: pluginConfig }) => {
     // Get all export/import collections and the mappings from target collections to custom collections
     const { customExportSlugMap, customImportSlugMap, exportCollections, importCollections } =
       await getPluginCollections({
@@ -231,7 +229,8 @@ export const importExportPlugin =
     }
 
     return config
-  }
+  },
+})
 
 declare module 'payload' {
   export interface FieldCustom {

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -22,8 +22,8 @@ export { defineCollectionTool, defineGlobalTool, definePrompt, defineTool } from
 export const mcpPlugin = definePlugin<MCPPluginConfig>({
   slug: '@payloadcms/plugin-mcp',
   order: 10,
-  plugin: ({ config, plugins, ...rawConfig }) => {
-    const pluginConfig = sanitizeMCPConfig({ config, pluginConfig: rawConfig })
+  plugin: ({ config, options, plugins }) => {
+    const pluginConfig = sanitizeMCPConfig({ config, pluginConfig: options })
 
     // Stash the sanitized config on plugin options so `getPluginConfig()` reads it.
     const registered = plugins['@payloadcms/plugin-mcp']

--- a/packages/plugin-multi-tenant/src/components/GlobalViewRedirect/index.ts
+++ b/packages/plugin-multi-tenant/src/components/GlobalViewRedirect/index.ts
@@ -13,7 +13,7 @@ type Args = {
   tenantFieldName: string
   tenantsCollectionSlug: string
   useAsTitle: string
-  userHasAccessToAllTenants: Required<MultiTenantPluginConfig<any>>['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
   viewType: ViewTypes
 } & ServerProps
 

--- a/packages/plugin-multi-tenant/src/endpoints/getTenantOptionsEndpoint.ts
+++ b/packages/plugin-multi-tenant/src/endpoints/getTenantOptionsEndpoint.ts
@@ -6,7 +6,7 @@ import type { MultiTenantPluginConfig } from '../types.js'
 
 import { getTenantOptions } from '../utilities/getTenantOptions.js'
 
-export const getTenantOptionsEndpoint = <ConfigType>({
+export const getTenantOptionsEndpoint = ({
   tenantsArrayFieldName,
   tenantsArrayTenantFieldName,
   tenantsCollectionSlug,
@@ -17,9 +17,7 @@ export const getTenantOptionsEndpoint = <ConfigType>({
   tenantsArrayTenantFieldName: string
   tenantsCollectionSlug: string
   useAsTitle: string
-  userHasAccessToAllTenants: Required<
-    MultiTenantPluginConfig<ConfigType>
-  >['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }): Endpoint => ({
   handler: async (req) => {
     const { payload, user } = req

--- a/packages/plugin-multi-tenant/src/filters/filterDocumentsByTenants.ts
+++ b/packages/plugin-multi-tenant/src/filters/filterDocumentsByTenants.ts
@@ -7,7 +7,7 @@ import { getCollectionIDType } from '../utilities/getCollectionIDType.js'
 import { getTenantFromCookie } from '../utilities/getTenantFromCookie.js'
 import { getUserTenantIDs } from '../utilities/getUserTenantIDs.js'
 
-type Args<ConfigType = unknown> = {
+type Args = {
   /**
    * If the document this filter is run belongs to a tenant, the tenant ID should be passed here.
    * If set, this will be used instead of the tenant cookie
@@ -19,11 +19,9 @@ type Args<ConfigType = unknown> = {
   tenantsArrayFieldName?: string
   tenantsArrayTenantFieldName?: string
   tenantsCollectionSlug: string
-  userHasAccessToAllTenants: Required<
-    MultiTenantPluginConfig<ConfigType>
-  >['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }
-export const filterDocumentsByTenants = <ConfigType = unknown>({
+export const filterDocumentsByTenants = ({
   docTenantID,
   filterFieldName,
   req,
@@ -31,7 +29,7 @@ export const filterDocumentsByTenants = <ConfigType = unknown>({
   tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
   tenantsCollectionSlug,
   userHasAccessToAllTenants,
-}: Args<ConfigType>): null | Where => {
+}: Args): null | Where => {
   const idType = getCollectionIDType({
     collectionSlug: tenantsCollectionSlug,
     payload: req.payload,
@@ -47,12 +45,7 @@ export const filterDocumentsByTenants = <ConfigType = unknown>({
     }
   }
 
-  if (
-    req.user &&
-    userHasAccessToAllTenants(
-      req?.user as ConfigType extends { user: unknown } ? ConfigType['user'] : User,
-    )
-  ) {
+  if (req.user && userHasAccessToAllTenants(req?.user as User)) {
     return null
   }
 

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -1,7 +1,7 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
-import type { CollectionConfig, Config } from 'payload'
+import type { CollectionConfig } from 'payload'
 
-import chalk from 'chalk'
+import { definePlugin } from 'payload'
 import { hasAutosaveEnabled } from 'payload/shared'
 
 import type { PluginDefaultTranslationsObject } from './translations/types.js'
@@ -19,9 +19,9 @@ import { addFilterOptionsToFields } from './utilities/addFilterOptionsToFields.j
 import { combineFilters } from './utilities/combineFilters.js'
 import { miniChalk } from './utilities/miniChalk.js'
 
-export const multiTenantPlugin =
-  <ConfigType>(pluginConfig: MultiTenantPluginConfig<ConfigType>) =>
-  (incomingConfig: Config): Config => {
+export const multiTenantPlugin = definePlugin<MultiTenantPluginConfig>({
+  slug: '@payloadcms/plugin-multi-tenant',
+  plugin: ({ config: incomingConfig, options: pluginConfig }) => {
     if (pluginConfig.enabled === false) {
       return incomingConfig
     }
@@ -29,9 +29,7 @@ export const multiTenantPlugin =
     /**
      * Set defaults
      */
-    const userHasAccessToAllTenants: Required<
-      MultiTenantPluginConfig<ConfigType>
-    >['userHasAccessToAllTenants'] =
+    const userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants'] =
       typeof pluginConfig.userHasAccessToAllTenants === 'function'
         ? pluginConfig.userHasAccessToAllTenants
         : () => false
@@ -118,7 +116,7 @@ export const multiTenantPlugin =
       adminUsersCollection.admin.baseFilter = combineFilters({
         baseFilter,
         customFilter: (args) =>
-          filterDocumentsByTenants<ConfigType>({
+          filterDocumentsByTenants({
             filterFieldName: `${tenantsArrayFieldName}.${tenantsArrayTenantFieldName}`,
             req: args.req,
             tenantsArrayFieldName,
@@ -443,4 +441,5 @@ export const multiTenantPlugin =
     })
 
     return incomingConfig
-  }
+  },
+})

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
@@ -5,7 +5,7 @@ import type { MultiTenantPluginConfig } from '../../types.js'
 import { getTenantOptions } from '../../utilities/getTenantOptions.js'
 import { TenantSelectionProviderClient } from './index.client.js'
 
-type Args<ConfigType> = {
+type Args = {
   children: React.ReactNode
   payload: Payload
   server?: ServerAdapter
@@ -14,9 +14,7 @@ type Args<ConfigType> = {
   tenantsCollectionSlug: string
   useAsTitle: string
   user: User
-  userHasAccessToAllTenants: Required<
-    MultiTenantPluginConfig<ConfigType>
-  >['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }
 
 export const TenantSelectionProvider = async ({
@@ -29,7 +27,7 @@ export const TenantSelectionProvider = async ({
   useAsTitle,
   user,
   userHasAccessToAllTenants,
-}: Args<any>) => {
+}: Args) => {
   if (!server) {
     throw new Error(
       'TenantSelectionProvider requires `server` in ServerProps. Ensure your framework adapter (e.g. @payloadcms/next) populates ServerProps.server.',

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -11,7 +11,7 @@ import type {
   User,
 } from 'payload'
 
-export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
+export type MultiTenantPluginConfig = {
   /**
    * After a tenant is deleted, the plugin will attempt to clean up related documents
    * - removing documents with the tenant ID
@@ -197,9 +197,7 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
    *
    * Useful for super-admin type users
    */
-  userHasAccessToAllTenants?: (
-    user: ConfigTypes extends { user: unknown } ? ConfigTypes['user'] : User,
-  ) => boolean
+  userHasAccessToAllTenants?: (user: User) => boolean
   /**
    * Override the access result on the users collection access control functions
    *

--- a/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
@@ -13,23 +13,21 @@ export const collectionAccessKeys: AllAccessKeys = [
   'unlock',
 ] as const
 
-type Args<ConfigType> = {
-  accessResultCallback?: MultiTenantPluginConfig<ConfigType>['usersAccessResultOverride']
+type Args = {
+  accessResultCallback?: MultiTenantPluginConfig['usersAccessResultOverride']
   adminUsersSlug: string
   collection: CollectionConfig
   fieldName: string
   tenantsArrayFieldName?: string
   tenantsArrayTenantFieldName?: string
-  userHasAccessToAllTenants: Required<
-    MultiTenantPluginConfig<ConfigType>
-  >['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }
 
 /**
  * Adds tenant access constraint to collection
  * - constrains access a users assigned tenants
  */
-export const addCollectionAccess = <ConfigType>({
+export const addCollectionAccess = ({
   accessResultCallback,
   adminUsersSlug,
   collection,
@@ -37,12 +35,12 @@ export const addCollectionAccess = <ConfigType>({
   tenantsArrayFieldName,
   tenantsArrayTenantFieldName,
   userHasAccessToAllTenants,
-}: Args<ConfigType>): void => {
+}: Args): void => {
   collectionAccessKeys.forEach((key) => {
     if (!collection.access) {
       collection.access = {}
     }
-    collection.access[key] = withTenantAccess<ConfigType>({
+    collection.access[key] = withTenantAccess({
       accessFunction: collection.access?.[key],
       accessKey: key,
       accessResultCallback,

--- a/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addFilterOptionsToFields.ts
@@ -5,7 +5,7 @@ import type { MultiTenantPluginConfig } from '../types.js'
 import { defaults } from '../defaults.js'
 import { filterDocumentsByTenants } from '../filters/filterDocumentsByTenants.js'
 
-type AddFilterOptionsToFieldsArgs<ConfigType = unknown> = {
+type AddFilterOptionsToFieldsArgs = {
   blockReferencesWithFilters: string[]
   config: Config | SanitizedConfig
   fields: Field[]
@@ -15,12 +15,10 @@ type AddFilterOptionsToFieldsArgs<ConfigType = unknown> = {
   tenantsArrayFieldName: string
   tenantsArrayTenantFieldName: string
   tenantsCollectionSlug: string
-  userHasAccessToAllTenants: Required<
-    MultiTenantPluginConfig<ConfigType>
-  >['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }
 
-export function addFilterOptionsToFields<ConfigType = unknown>({
+export function addFilterOptionsToFields({
   blockReferencesWithFilters,
   config,
   fields,
@@ -31,7 +29,7 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
   tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
   tenantsCollectionSlug,
   userHasAccessToAllTenants,
-}: AddFilterOptionsToFieldsArgs<ConfigType>): Field[] {
+}: AddFilterOptionsToFieldsArgs): Field[] {
   const newFields = []
   for (const field of fields) {
     let newField: Field = { ...field }
@@ -158,18 +156,16 @@ export function addFilterOptionsToFields<ConfigType = unknown>({
   return newFields
 }
 
-type AddFilterArgs<ConfigType = unknown> = {
+type AddFilterArgs = {
   field: RelationshipField
   tenantEnabledCollectionSlugs: string[]
   tenantFieldName: string
   tenantsArrayFieldName: string
   tenantsArrayTenantFieldName: string
   tenantsCollectionSlug: string
-  userHasAccessToAllTenants: Required<
-    MultiTenantPluginConfig<ConfigType>
-  >['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }
-function addRelationshipFilter<ConfigType = unknown>({
+function addRelationshipFilter({
   field,
   tenantEnabledCollectionSlugs,
   tenantFieldName,
@@ -177,7 +173,7 @@ function addRelationshipFilter<ConfigType = unknown>({
   tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
   tenantsCollectionSlug,
   userHasAccessToAllTenants,
-}: AddFilterArgs<ConfigType>): Field {
+}: AddFilterArgs): Field {
   // User specified filter
   const originalFilter = field.filterOptions
   field.filterOptions = async (args) => {

--- a/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
@@ -26,7 +26,7 @@ type Args = {
   tenantsCollectionSlug: string
   useAsTitle: string
   user?: User
-  userHasAccessToAllTenants: Required<MultiTenantPluginConfig<any>>['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
   view: ViewTypes
 }
 export async function getGlobalViewRedirect({

--- a/packages/plugin-multi-tenant/src/utilities/getTenantOptions.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getTenantOptions.ts
@@ -17,7 +17,7 @@ export const getTenantOptions = async ({
   tenantsCollectionSlug: string
   useAsTitle: string
   user: User
-  userHasAccessToAllTenants: Required<MultiTenantPluginConfig<any>>['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }): Promise<OptionObject[]> => {
   let tenantOptions: OptionObject[] = []
 

--- a/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
@@ -5,21 +5,19 @@ import type { AllAccessKeys, MultiTenantPluginConfig, UserWithTenantsField } fro
 import { combineWhereConstraints } from './combineWhereConstraints.js'
 import { getTenantAccess } from './getTenantAccess.js'
 
-type Args<ConfigType> = {
+type Args = {
   accessFunction?: Access
   accessKey: AllAccessKeys[number]
-  accessResultCallback?: MultiTenantPluginConfig<ConfigType>['usersAccessResultOverride']
+  accessResultCallback?: MultiTenantPluginConfig['usersAccessResultOverride']
   adminUsersSlug: string
   collection: CollectionConfig
   fieldName: string
   tenantsArrayFieldName?: string
   tenantsArrayTenantFieldName?: string
-  userHasAccessToAllTenants: Required<
-    MultiTenantPluginConfig<ConfigType>
-  >['userHasAccessToAllTenants']
+  userHasAccessToAllTenants: Required<MultiTenantPluginConfig>['userHasAccessToAllTenants']
 }
 export const withTenantAccess =
-  <ConfigType>({
+  ({
     accessFunction,
     accessKey,
     accessResultCallback,
@@ -29,7 +27,7 @@ export const withTenantAccess =
     tenantsArrayFieldName,
     tenantsArrayTenantFieldName,
     userHasAccessToAllTenants,
-  }: Args<ConfigType>) =>
+  }: Args) =>
   async (args: AccessArgs): Promise<AccessResult> => {
     const constraints: Where[] = []
     const accessFn =
@@ -55,9 +53,7 @@ export const withTenantAccess =
     if (
       args.req.user &&
       args.req.user.collection === adminUsersSlug &&
-      !userHasAccessToAllTenants(
-        args.req.user as ConfigType extends { user: unknown } ? ConfigType['user'] : User,
-      )
+      !userHasAccessToAllTenants(args.req.user as User)
     ) {
       const tenantConstraint = getTenantAccess({
         fieldName,

--- a/packages/plugin-nested-docs/src/index.ts
+++ b/packages/plugin-nested-docs/src/index.ts
@@ -1,4 +1,6 @@
-import type { Plugin, SingleRelationshipField } from 'payload'
+import type { SingleRelationshipField } from 'payload'
+
+import { definePlugin } from 'payload'
 
 import type { NestedDocsPluginConfig } from './types.js'
 
@@ -12,9 +14,9 @@ import { getParents } from './utilities/getParents.js'
 
 export { createBreadcrumbsField, createParentField, getParents }
 
-export const nestedDocsPlugin =
-  (pluginConfig: NestedDocsPluginConfig): Plugin =>
-  (config) => ({
+export const nestedDocsPlugin = definePlugin<NestedDocsPluginConfig>({
+  slug: '@payloadcms/plugin-nested-docs',
+  plugin: ({ config, options: pluginConfig }) => ({
     ...config,
     collections: (config.collections || []).map((collection) => {
       if (pluginConfig.collections.indexOf(collection.slug) > -1) {
@@ -67,4 +69,5 @@ export const nestedDocsPlugin =
 
       return collection
     }),
-  })
+  }),
+})

--- a/packages/plugin-redirects/src/index.ts
+++ b/packages/plugin-redirects/src/index.ts
@@ -1,5 +1,6 @@
-import type { CollectionConfig, Config, Field, SelectField } from 'payload'
+import type { CollectionConfig, Field, SelectField } from 'payload'
 
+import { definePlugin } from 'payload'
 import { deepMergeSimple } from 'payload/shared'
 
 import type { RedirectsPluginConfig } from './types.js'
@@ -9,9 +10,9 @@ import { translations } from './translations/index.js'
 
 export { redirectOptions, redirectTypes } from './redirectTypes.js'
 export { translations as redirectsTranslations } from './translations/index.js'
-export const redirectsPlugin =
-  (pluginConfig: RedirectsPluginConfig) =>
-  (incomingConfig: Config): Config => {
+export const redirectsPlugin = definePlugin<RedirectsPluginConfig>({
+  slug: '@payloadcms/plugin-redirects',
+  plugin: ({ config: incomingConfig, options: pluginConfig }) => {
     // Merge translations FIRST (before building fields)
     if (!incomingConfig.i18n) {
       incomingConfig.i18n = {}
@@ -124,4 +125,5 @@ export const redirectsPlugin =
       ...incomingConfig,
       collections: [...(incomingConfig?.collections || []), redirectsCollection],
     }
-  }
+  },
+})

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -1,4 +1,6 @@
-import type { CollectionAfterChangeHook, Config } from 'payload'
+import type { CollectionAfterChangeHook } from 'payload'
+
+import { definePlugin } from 'payload'
 
 import type { SanitizedSearchPluginConfig, SearchPluginConfig } from './types.js'
 
@@ -8,9 +10,9 @@ import { generateSearchCollection } from './Search/index.js'
 
 type CollectionAfterChangeHookArgs = Parameters<CollectionAfterChangeHook>[0]
 
-export const searchPlugin =
-  <ConfigTypes = unknown>(incomingPluginConfig: SearchPluginConfig<ConfigTypes>) =>
-  (config: Config): Config => {
+export const searchPlugin = definePlugin<SearchPluginConfig>({
+  slug: '@payloadcms/plugin-search',
+  plugin: ({ config, options: incomingPluginConfig }) => {
     const { collections } = config
 
     // If the user defines `localize` to either true or false, use that
@@ -33,7 +35,7 @@ export const searchPlugin =
         }
       }
 
-      const pluginConfig: SanitizedSearchPluginConfig<ConfigTypes> = {
+      const pluginConfig: SanitizedSearchPluginConfig = {
         // write any config defaults here
         deleteDrafts: true,
         labels,
@@ -85,4 +87,5 @@ export const searchPlugin =
     }
 
     return config
-  }
+  },
+})

--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -7,6 +7,7 @@ import type {
   Payload,
   PayloadRequest,
   StaticLabel,
+  TypedLocale,
 } from 'payload'
 
 export type DocToSync = {
@@ -30,14 +31,14 @@ export type BeforeSync = (args: {
 
 export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 
-export type SkipSyncFunction<ConfigTypes = unknown> = (args: {
+export type SkipSyncFunction = (args: {
   collectionSlug: string
   doc: any
-  locale: ConfigTypes extends { locale: unknown } ? ConfigTypes['locale'] : string | undefined
+  locale: TypedLocale | undefined
   req: PayloadRequest
 }) => boolean | Promise<boolean>
 
-export type SearchPluginConfig<ConfigTypes = unknown> = {
+export type SearchPluginConfig = {
   beforeSync?: BeforeSync
   collections?: string[]
   defaultPriorities?: {
@@ -77,7 +78,7 @@ export type SearchPluginConfig<ConfigTypes = unknown> = {
    *   return !tenant.allowedLocales.includes(locale)
    * }
    */
-  skipSync?: SkipSyncFunction<ConfigTypes>
+  skipSync?: SkipSyncFunction
   /**
    * Controls whether drafts are synced to the search index
    *
@@ -94,14 +95,14 @@ export type ResolvedCollectionLabels = {
   [collection: string]: StaticLabel
 }
 
-export type SearchPluginConfigWithLocales<ConfigTypes = unknown> = {
+export type SearchPluginConfigWithLocales = {
   labels?: CollectionLabels
-} & SearchPluginConfig<ConfigTypes>
+} & SearchPluginConfig
 
-export type SanitizedSearchPluginConfig<ConfigTypes = unknown> = {
+export type SanitizedSearchPluginConfig = {
   reindexBatchSize: number
   syncDrafts: boolean
-} & SearchPluginConfigWithLocales<ConfigTypes>
+} & SearchPluginConfigWithLocales
 
 export type SyncWithSearchArgs = {
   collection: string

--- a/packages/plugin-sentry/src/index.ts
+++ b/packages/plugin-sentry/src/index.ts
@@ -1,5 +1,7 @@
 import type { ScopeContext } from '@sentry/types'
-import type { APIError, Config } from 'payload'
+import type { APIError } from 'payload'
+
+import { definePlugin } from 'payload'
 
 import type { PluginOptions } from './types.js'
 
@@ -26,9 +28,9 @@ export { PluginOptions }
  * })
  * ```
  */
-export const sentryPlugin =
-  (pluginOptions: PluginOptions) =>
-  (config: Config): Config => {
+export const sentryPlugin = definePlugin<PluginOptions>({
+  slug: '@payloadcms/plugin-sentry',
+  plugin: ({ config, options: pluginOptions }) => {
     const { enabled = true, options = {}, Sentry } = pluginOptions
 
     if (!enabled || !Sentry) {
@@ -90,4 +92,5 @@ export const sentryPlugin =
         ],
       },
     }
-  }
+  },
+})

--- a/packages/plugin-seo/src/index.ts
+++ b/packages/plugin-seo/src/index.ts
@@ -1,5 +1,6 @@
 import type { Config, Field, GroupField, TabsField } from 'payload'
 
+import { definePlugin } from 'payload'
 import { deepMergeSimple } from 'payload/shared'
 
 import type {
@@ -17,9 +18,9 @@ import { OverviewField } from './fields/Overview/index.js'
 import { PreviewField } from './fields/Preview/index.js'
 import { translations } from './translations/index.js'
 
-export const seoPlugin =
-  (pluginConfig: SEOPluginConfig) =>
-  (config: Config): Config => {
+export const seoPlugin = definePlugin<SEOPluginConfig>({
+  slug: '@payloadcms/plugin-seo',
+  plugin: ({ config, options: pluginConfig }) => {
     const defaultFields: Field[] = [
       OverviewField({}),
       MetaTitleField({
@@ -297,4 +298,5 @@ export const seoPlugin =
         translations: deepMergeSimple(translations, config.i18n?.translations ?? {}),
       },
     }
-  }
+  },
+})

--- a/packages/plugin-stripe/src/index.ts
+++ b/packages/plugin-stripe/src/index.ts
@@ -1,4 +1,6 @@
-import type { Config, Endpoint } from 'payload'
+import type { Endpoint } from 'payload'
+
+import { definePlugin } from 'payload'
 
 import type { SanitizedStripePluginConfig, StripePluginConfig } from './types.js'
 
@@ -11,9 +13,9 @@ import { stripeWebhooks } from './routes/webhooks.js'
 
 export { stripeProxy } from './utilities/stripeProxy.js'
 
-export const stripePlugin =
-  (incomingStripeConfig: StripePluginConfig) =>
-  (config: Config): Config => {
+export const stripePlugin = definePlugin<StripePluginConfig>({
+  slug: '@payloadcms/plugin-stripe',
+  plugin: ({ config, options: incomingStripeConfig }) => {
     const { collections } = config
 
     // set config defaults here
@@ -110,4 +112,5 @@ export const stripePlugin =
     config.endpoints = endpoints
 
     return config
-  }
+  },
+})

--- a/test/plugins/config.ts
+++ b/test/plugins/config.ts
@@ -26,12 +26,12 @@ declare module 'payload' {
 const readerPlugin = definePlugin<ReaderPluginOptions>({
   slug: 'priority-reader',
   order: 10,
-  plugin: ({ config, items }): Config => ({
+  plugin: ({ config, options }): Config => ({
     ...config,
     custom: {
       ...(config.custom || {}),
       readerSawValue: (config.custom?.writerValue as string) ?? null,
-      readerItems: items.map((i) => i.name),
+      readerItems: options.items.map((i) => i.name),
     },
   }),
 })


### PR DESCRIPTION
Every core plugin now uses the `definePlugin` API instead of a bare `(config) => config` function, so each sets a `slug` and can be found by other plugins through the `plugins` map. Supporting every plugin required one change to `definePlugin` itself.

## `definePlugin` change

Two things changed: `TOptions` is no longer constrained, and options are passed to the callback as a named `options` arg (`{ config, options, plugins }`) instead of being merged into the args.

**Unconstraining `TOptions`** is what lets interface-typed plugins use `definePlugin`. The old signature required `TOptions extends Record<string, unknown>`, which `interface`s don't satisfy - so `plugin-sentry`, whose options are an `interface`, couldn't use it. [See TypeScript playground](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAwg9gOwGYEsDmUC8UDeUDGcANkRPsCogM4D8AXFFcAE4oJoDaAulAL4BQoSFAAKRAK5o2CLFAAUhZOgbwlaAJRYAfLESo0-fm2ARmSAIb5oAZQCiAeXtgK1XPygFipcpQRUGTKzs3PwC-AD04VD2ADIAIgxwzr5UUAC2pmgQACZQxnBQ5sxoVAA0nn4s5mw5UMAFAEpkcMzZADyBbGjl4ggA1ghwAO4IWvzZZERF0Ei9PohQE6gIEGKSbPZE7QAqTi5+UBAAHiYI2alNhK0dLF09-YMjWlpyE1T4rM4tDDjujBJoeiMW7sP5gAFsBhyIolH4VfQqPToPhQABkUF2yWomkwOlU+lC6ihSX2-gxexSOJ0aykCAQhiWNRpGy2bTsjixfheeCoAIYAHJwesEABaKgQOD88pC2lQvCKfR8Knw5G8dQRKKAGXIMeBoPz2RTqPzFnAIKlBsBGOYKFQkCA6gALaCKQLVBCW-mXFrtTrse4DYajfkAOkMkSgADlbAB1RKc1LTQpQBDmDLZe4uqo1XIwqCAFAI8u7TBYrFAhi0+lRxpNE7MEPMZIyVsyEG1MaSXm8Pigvswfn9eZIgb6DB4ZZD5DCyfKkWhEWoANxQEkpBjtlJK7S6NSE4nxteGvzKlv0-iZxgSluyJurCGtg3x7kDvlQQV3sUSqVgu9ylXdZfxpuuLyL8HgeMGEEKugpR-B4hAkGQpIMBwEHBgos7BvB3iklANA0FA3DqOUqErtQmFeIhKRcDBHhqjBar8EAA).

**Naming the arg `options`** avoids a footgun where `config` and `plugins` were reserved names that could be accidentally overwritten. A named `options` arg has no reserved names, and gives plugins one `options` object - the same one already exposed to other plugins via `plugins['slug'].options`. It's also consistent with what we do in richtext-lexical features.

Additionally, with the previous spread pattern, most of our internal plugins were doing the following, because the plugin options were further threaded into other helper functions down the line:

`plugin: ({ config: incomingConfig, plugins, ...pluginConfig }) => {`

This means that in most cases, the separate options argument actually makes things simpler, and you are no longer forced to destructure `plugins` just to get the raw pluginConfig:

`plugin: ({ config: incomingConfig, options: pluginConfig }) => {`

Before/after:

```ts
// old: options merged into args, constrained to Record<string, unknown>
function definePlugin<TOptions extends Record<string, unknown>>(...)
definePlugin<SentryPluginOptions>({ ... })
// ❌ 'PluginOptions' does not satisfy the constraint 'Record<string, unknown>'

// new: options are a named, unconstrained arg
function definePlugin<TOptions>(...)
definePlugin<SentryPluginOptions>({
  slug: '@payloadcms/plugin-sentry',
  plugin: ({ config, options }) => ({ ... }),
})
```

## `slug` is now required

`definePlugin` now requires a `slug`. The slug is what registers a plugin in the `plugins` map for cross-plugin discovery, so every plugin authored with `definePlugin` should declare one and we should encourage this by making it required.

```ts
definePlugin<MyPluginOptions>({
  slug: '@payloadcms/plugin-x', // now required
  plugin: ({ config, options }) => ({ ...config }),
})
```

## Payload plugin changes

All payload plugins convert to `definePlugin<Config>`, with the package name as slug. `ecommerce` uses `definePlugin<EcommercePluginConfig | undefined>` for its optional options.

`multi-tenant` and `search` also dropped their `<ConfigType>` generic. It only overrode the `user` / `locale` types, which Payload already generates through payload types.

## Breaking changes

- `definePlugin` (remains experimental): the callback receives `{ config, options, plugins }` - options are named, not spread.
- `multiTenantPlugin<T>` / `searchPlugin<T>` (and `MultiTenantPluginConfig<T>` / `SearchPluginConfig<T>`) no longer take a type argument. Callbacks are typed correctly via generated types without it.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216345579667229