### PR TITLE
fix(tanstack-start): stay logged in and confirm delete modals appear back when refreshing the page

### DIFF
--- a/packages/tanstack-start/src/layouts/Root/index.tsx
+++ b/packages/tanstack-start/src/layouts/Root/index.tsx
@@ -14,6 +14,7 @@ import React from 'react'
 import '@payloadcms/ui/scss/app.scss'
 
 import { TanStackRouterAdapter } from '../../elements/RouterAdapter/index.js'
+import { PAYLOAD_HEAD_STYLE } from './withPayloadRoot.js'
 
 export type RootLayoutData = {
   clientConfig: ClientConfig
@@ -48,7 +49,7 @@ export function RootLayout({ children, data, serverFunction }: RootLayoutProps) 
   return (
     <html data-theme={data.theme} dir={dir} lang={data.languageCode} suppressHydrationWarning>
       <head>
-        <style>{`@layer payload-default, payload;`}</style>
+        <style>{PAYLOAD_HEAD_STYLE}</style>
       </head>
       <body>
         <RootProvider

--- a/packages/tanstack-start/src/layouts/Root/withPayloadRoot.tsx
+++ b/packages/tanstack-start/src/layouts/Root/withPayloadRoot.tsx
@@ -24,6 +24,32 @@ export function buildThemeInitScript(cookiePrefix: string = 'payload'): string {
  */
 export const THEME_INIT_SCRIPT: string = buildThemeInitScript()
 
+/**
+ * The Payload admin head `<style>`: declares the `@layer` order and hides
+ * closed modals from first paint.
+ *
+ * `@faceless-ui/modal` hides closed modals with CSS it injects from a
+ * client-side `<style>` tag (its `generateCSS`), so those rules are absent
+ * during SSR and the first hydration frames. Because `@payloadcms/ui`'s
+ * `dialog` styles render modals regardless of the `open` attribute, any
+ * registered-but-closed modal (e.g. the delete confirmation or stay-logged-in
+ * dialogs) would flash on screen after a refresh until that `<style>` mounts.
+ * Next.js doesn't hit this, but TanStack Start's hydration exposes the gap —
+ * the same reason the theme bootstrap above is hoisted into the SSR'd head. So
+ * ship faceless-ui's visibility rules here too, present at first paint, so
+ * closed modals stay hidden until they actually open.
+ */
+export const PAYLOAD_HEAD_STYLE: string =
+  `@layer payload-default, payload;` +
+  `@layer payload-default{` +
+  `.payload__modal-container,.payload__modal-item{visibility:hidden}` +
+  `.payload__modal-container--appear,.payload__modal-container--appearDone,` +
+  `.payload__modal-container--enter,.payload__modal-container--enterDone,` +
+  `.payload__modal-container--exit,.payload__modal-item--appear,` +
+  `.payload__modal-item--appearDone,.payload__modal-item--enter,` +
+  `.payload__modal-item--enterDone,.payload__modal-item--exit{visibility:visible}` +
+  `}`
+
 export type PayloadAdminShellProps = {
   readonly children: React.ReactNode
   /**
@@ -50,7 +76,7 @@ export function PayloadAdminShell({ children, cookiePrefix }: PayloadAdminShellP
     <html suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-        <style>{`@layer payload-default, payload;`}</style>
+        <style>{PAYLOAD_HEAD_STYLE}</style>
         <HeadContent />
       </head>
       <body>


### PR DESCRIPTION
Fixes a bug with the tanstack adapter: when refreshing the page - the "stay logged in" and "confirm delete" modals appear back

Asana task - https://app.asana.com/1/10497086658021/project/1213894651174880/task/1216204011123959