### PR TITLE
fix(ui): presentational fields skipped in form state when admin.condition is false 

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -186,10 +186,13 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
     fieldState.fieldSchema = field
   }
 
-  // Short-circuit to prevent hidden fields from recursing and rendering.
-  // Note: `tab` is excluded bc tab visibility is keyed by `field.id` rather than `path`.
-  // The tab branch below owns that write and the skip-recursion.
-  if (passesCondition === false && field.type !== 'tab') {
+  // Short-circuit hidden fields to prevent recursing and rendering. Two exclusions:
+  // - `tab`: visibility is keyed by `field.id` (not `path`); the tab branch owns that write.
+  // - presentational containers (row, collapsible, unnamed group): they hold no value, so
+  //   returning here drops their nested fields' values.
+  const isPresentationalWithSubFields = fieldHasSubFields(field) && !fieldAffectsData(field)
+
+  if (passesCondition === false && field.type !== 'tab' && !isPresentationalWithSubFields) {
     if (fieldAffectsData(field) && data?.[field.name] !== undefined) {
       fieldState.value = data[field.name]
       fieldState.initialValue = data[field.name]
@@ -833,6 +836,13 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
     if (!filter || filter(args)) {
       state[path] = {
         disableFormData: true,
+      }
+
+      // Presentational containers are hidden client-side via `withCondition`, which reads
+      // `passesCondition` from their own state entry. Must be set here since these fields
+      // are excluded from the short-circuit above (which would otherwise carry the flag).
+      if (passesCondition === false) {
+        state[path].passesCondition = false
       }
     }
 

--- a/test/form-state/collections/Conditions/index.ts
+++ b/test/form-state/collections/Conditions/index.ts
@@ -19,6 +19,31 @@ export const ConditionsCollection: CollectionConfig = {
         },
       },
     },
+    {
+      type: 'row',
+      admin: {
+        condition: (data) => data?.showField === true,
+      },
+      fields: [
+        {
+          name: 'conditionalRowField',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      type: 'collapsible',
+      label: 'Conditional Collapsible',
+      admin: {
+        condition: (data) => data?.showField === true,
+      },
+      fields: [
+        {
+          name: 'conditionalCollapsibleField',
+          type: 'text',
+        },
+      ],
+    },
   ],
   versions: false,
 }

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -299,6 +299,77 @@ describe('Form State', () => {
     await payload.delete({ collection: conditionsSlug, id: visibleDoc.id })
   })
 
+  it('should preserve values of fields nested inside a row hidden by admin.condition', async () => {
+    const req = await createLocalReq({ user }, payload)
+
+    const hiddenDoc = await payload.create({
+      collection: conditionsSlug,
+      data: {
+        showField: false,
+        conditionalRowField: 'value in db',
+      },
+    })
+
+    const { state: stateHidden } = await buildFormState({
+      mockRSCs: true,
+      id: hiddenDoc.id,
+      collectionSlug: conditionsSlug,
+      data: hiddenDoc,
+      docPermissions: undefined,
+      docPreferences: {
+        fields: {},
+      },
+      documentFormState: undefined,
+      operation: 'update',
+      renderAllFields: true,
+      req,
+      schemaPath: conditionsSlug,
+    })
+
+    expect(stateHidden?.conditionalRowField).toBeDefined()
+    expect(stateHidden?.conditionalRowField?.value).toBe('value in db')
+
+    // The row itself must still carry `passesCondition: false` so the client hides it via
+    // `withCondition` (rather than rendering an empty, visible row).
+    expect(stateHidden?.['_index-2']?.passesCondition).toBe(false)
+
+    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id })
+  })
+
+  it('should preserve values of fields nested inside a collapsible hidden by admin.condition', async () => {
+    const req = await createLocalReq({ user }, payload)
+
+    const hiddenDoc = await payload.create({
+      collection: conditionsSlug,
+      data: {
+        showField: false,
+        conditionalCollapsibleField: 'collapsible db value',
+      },
+    })
+
+    const { state: stateHidden } = await buildFormState({
+      mockRSCs: true,
+      id: hiddenDoc.id,
+      collectionSlug: conditionsSlug,
+      data: hiddenDoc,
+      docPermissions: undefined,
+      docPreferences: {
+        fields: {},
+      },
+      documentFormState: undefined,
+      operation: 'update',
+      renderAllFields: true,
+      req,
+      schemaPath: conditionsSlug,
+    })
+
+    // Same regression class as `row`: a collapsible is a presentational container, so its
+    // nested field's value must survive even though the collapsible is hidden.
+    expect(stateHidden?.conditionalCollapsibleField?.value).toBe('collapsible db value')
+
+    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id })
+  })
+
   it('should render custom Field component when admin.condition flips from false to true via onChange', async () => {
     const req = await createLocalReq({ user }, payload)
 

--- a/test/form-state/payload-types.ts
+++ b/test/form-state/payload-types.ts
@@ -96,6 +96,8 @@ export interface Config {
   locale: null;
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -202,6 +204,8 @@ export interface Condition {
   id: string;
   showField?: boolean | null;
   conditionalCustomField?: string | null;
+  conditionalRowField?: string | null;
+  conditionalCollapsibleField?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -383,6 +387,8 @@ export interface AutosavePostsSelect<T extends boolean = true> {
 export interface ConditionsSelect<T extends boolean = true> {
   showField?: T;
   conditionalCustomField?: T;
+  conditionalRowField?: T;
+  conditionalCollapsibleField?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -457,6 +463,39 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection: 'posts' | 'autosave-posts' | 'conditions' | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?: ('posts' | 'autosave-posts' | 'conditions' | 'users')[] | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### What

Presentational fields (`row`,`collapsible`, or unnamed `group`) with `admin.condition` set to `false` were dropped entirely from form state. 

### Why

Regression introduced in #16819 (backport of #16780). It added a short circuit in `addFieldStatePromise` to skip rendering hidden fields. For a presentational field (which holds no value of its own), the early return fired **before** recursing into `field.fields`, so nested field state  was never built. 

### Fix

Excludes presentational fields from the early return, letting them fall through to the `fieldHasSubFields` logic. This allows nested fields to preserve to their values and still skip rendering (they short circuit themselves).

### Tests

Added to `test/form-state`

NOTE: 3.x equivalent of this change [here](https://github.com/payloadcms/payload/pull/17224).