### PR TITLE
chore(skills): cleanup 'Payload CMS' -> 'Payload' [skip ci]

### DIFF
--- a/tools/claude-plugin/skills/payload/SKILL.md
+++ b/tools/claude-plugin/skills/payload/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: payload
-description: Use when working with Payload CMS projects (payload.config.ts, collections, fields, hooks, access control, Payload API). Use when debugging validation errors, security issues, relationship queries, transactions, or hook behavior.
+description: Use when working with Payload projects (payload.config.ts, collections, fields, hooks, access control, Payload API). Use when debugging validation errors, security issues, relationship queries, transactions, or hook behavior.
 ---
 
-# Payload CMS Application Development
+# Payload Application Development
 
 Payload is a Next.js native CMS with TypeScript-first architecture, providing admin panel, database management, REST/GraphQL APIs, authentication, and file storage.
 

--- a/tools/claude-plugin/skills/payload/reference/ACCESS-CONTROL-ADVANCED.md
+++ b/tools/claude-plugin/skills/payload/reference/ACCESS-CONTROL-ADVANCED.md
@@ -1,4 +1,4 @@
-# Payload CMS Access Control - Advanced Patterns
+# Payload Access Control - Advanced Patterns
 
 Advanced access control patterns including context-aware access, time-based restrictions, factory functions, and production templates.
 

--- a/tools/claude-plugin/skills/payload/reference/ACCESS-CONTROL.md
+++ b/tools/claude-plugin/skills/payload/reference/ACCESS-CONTROL.md
@@ -1,4 +1,4 @@
-# Payload CMS Access Control Reference
+# Payload Access Control Reference
 
 Complete reference for access control patterns across collections, fields, and globals.
 

--- a/tools/claude-plugin/skills/payload/reference/ADAPTERS.md
+++ b/tools/claude-plugin/skills/payload/reference/ADAPTERS.md
@@ -1,4 +1,4 @@
-# Payload CMS Adapters Reference
+# Payload Adapters Reference
 
 Complete reference for database, storage, and email adapters.
 

--- a/tools/claude-plugin/skills/payload/reference/ADVANCED.md
+++ b/tools/claude-plugin/skills/payload/reference/ADVANCED.md
@@ -1,4 +1,4 @@
-# Payload CMS Advanced Features
+# Payload Advanced Features
 
 Complete reference for authentication, jobs, custom endpoints, components, plugins, and localization.
 

--- a/tools/claude-plugin/skills/payload/reference/COLLECTIONS.md
+++ b/tools/claude-plugin/skills/payload/reference/COLLECTIONS.md
@@ -1,4 +1,4 @@
-# Payload CMS Collections Reference
+# Payload Collections Reference
 
 Complete reference for collection configurations and patterns.
 

--- a/tools/claude-plugin/skills/payload/reference/FIELDS.md
+++ b/tools/claude-plugin/skills/payload/reference/FIELDS.md
@@ -1,4 +1,4 @@
-# Payload CMS Field Types Reference
+# Payload Field Types Reference
 
 Complete reference for all Payload field types with examples.
 

--- a/tools/claude-plugin/skills/payload/reference/HOOKS.md
+++ b/tools/claude-plugin/skills/payload/reference/HOOKS.md
@@ -1,4 +1,4 @@
-# Payload CMS Hooks Reference
+# Payload Hooks Reference
 
 Complete reference for collection hooks, field hooks, and hook context patterns.
 

--- a/tools/claude-plugin/skills/payload/reference/PLUGIN-DEVELOPMENT.md
+++ b/tools/claude-plugin/skills/payload/reference/PLUGIN-DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Payload Plugin Development
 
-Complete guide to creating Payload CMS plugins with TypeScript patterns, package structure, and best practices from the official Payload plugin template.
+Complete guide to creating Payload plugins with TypeScript patterns, package structure, and best practices from the official Payload plugin template.
 
 ## Plugin Architecture
 
@@ -95,7 +95,7 @@ plugin-<name>/
 {
   "name": "payload-plugin-example",
   "version": "1.0.0",
-  "description": "A Payload CMS plugin",
+  "description": "A Payload plugin",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/tools/claude-plugin/skills/payload/reference/QUERIES.md
+++ b/tools/claude-plugin/skills/payload/reference/QUERIES.md
@@ -1,4 +1,4 @@
-# Payload CMS Querying Reference
+# Payload Querying Reference
 
 Complete reference for querying data across Local API, REST, and GraphQL.
 


### PR DESCRIPTION
Cleanup terminology "Payload CMS" -> "Payload"