### PR TITLE
fix(next): v3 backport to respect disabled GraphQL config

### DIFF
--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -104,12 +104,18 @@ export const POST =
       request,
     })
 
+    const { payload } = req
+
+    if (payload.config.graphQL?.disable) {
+      return new Response(null, {
+        status: 404,
+      })
+    }
+
     await addDataAndFileToRequest(req)
     addLocalesToRequestFromData(req)
 
     const { schema, validationRules } = await getGraphql(config)
-
-    const { payload } = req
 
     const headers = {}
     const apiResponse = await createHandler({

--- a/test/graphql/int.spec.ts
+++ b/test/graphql/int.spec.ts
@@ -25,6 +25,30 @@ describe('graphql', () => {
   })
 
   describe('graphql', () => {
+    it('should return 404 when GraphQL is disabled', async () => {
+      const originalDisable = payload.config.graphQL?.disable
+
+      payload.config.graphQL.disable = true
+
+      try {
+        const response = await restClient.GRAPHQL_POST({
+          body: JSON.stringify({
+            query: `query {
+          Posts {
+            docs {
+              id
+            }
+          }
+        }`,
+          }),
+        })
+
+        expect(response.status).toBe(404)
+      } finally {
+        payload.config.graphQL.disable = originalDisable
+      }
+    })
+
     it('should not be able to query introspection', async () => {
       const query = `query {
         __schema {


### PR DESCRIPTION
Backport of #17200  to the `3.x` branch.

This applies the same fix to return a 404 response when GraphQL is disabled.