### PR TITLE
fix(ui): sync aria-expanded attribute with open state in list filters toggler

### DIFF
--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -104,7 +104,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
               className={`${baseClass}__toggle-where`}
               extraButtonProps={{
                 'aria-controls': `${baseClass}-where`,
-                'aria-expanded': visibleDrawer === 'where',
+                'aria-expanded': isWhereOpen,
               }}
               icon={<ChevronIcon direction={isWhereOpen ? 'up' : 'down'} size={16} />}
               id="toggle-list-filters"

--- a/test/__helpers/e2e/filters/openListFilters.ts
+++ b/test/__helpers/e2e/filters/openListFilters.ts
@@ -6,10 +6,11 @@ import { expect } from '@playwright/test'
  * Opens the list filters drawer in the list view. If it's already open, does nothing.
  * Return the filter container locator for further interactions.
  *
- * The drawer is rendered conditionally (only present in the DOM when open), so its
- * visibility is the source of truth for the open/closed state. Click the toggler only
- * when the container isn't already visible, then retry until it is — idempotent and
- * resilient to re-render races (e.g. after a group-by/sort change).
+ * Drives the drawer open off the toggler's `aria-expanded` state (the source of truth)
+ * rather than a point-in-time visibility check of the container. The container flickers
+ * visible mid-animation, and a preceding re-render (e.g. a group-by/sort change) can drop
+ * the open click before it updates React state. Retrying the toggle until `aria-expanded`
+ * reports open makes this idempotent and resilient to that race.
  *
  * The `toPass` retry also covers the dev/SSR case (notably the TanStack Start tests)
  * where the very first click can land on the SSR'd button before React has hydrated and
@@ -30,15 +31,16 @@ export const openListFilters = async (
   const toggler = page.locator(togglerSelector).first()
   await expect(toggler).toBeVisible()
 
-  const openContainer = page.locator(filterContainerSelector).first()
-
   await expect(async () => {
-    if (!(await openContainer.isVisible())) {
+    if ((await toggler.getAttribute('aria-expanded')) !== 'true') {
       await toggler.click()
     }
 
-    await expect(openContainer).toBeVisible()
+    await expect(toggler).toHaveAttribute('aria-expanded', 'true')
   }).toPass({ timeout: 18000 })
+
+  const openContainer = page.locator(filterContainerSelector).first()
+  await expect(openContainer).toBeVisible()
 
   return { filterContainer: openContainer }
 }

--- a/test/__helpers/e2e/filters/openListFilters.ts
+++ b/test/__helpers/e2e/filters/openListFilters.ts
@@ -36,8 +36,12 @@ export const openListFilters = async (
       await toggler.click()
     }
 
-    await expect(toggler).toHaveAttribute('aria-expanded', 'true')
-  }).toPass({ timeout: 18000 })
+    // Use a short, explicit inner timeout. The global `EXPECT_TIMEOUT` is 18s on CI, so without
+    // this a single (lost, pre-hydration) click would consume the entire `toPass` budget and defeat
+    // the retry — the exact failure this helper exists to prevent. A short inner timeout lets
+    // `toPass` re-click until the button has hydrated and the drawer actually opens.
+    await expect(toggler).toHaveAttribute('aria-expanded', 'true', { timeout: 3000 })
+  }).toPass({ timeout: 30000 })
 
   const openContainer = page.locator(filterContainerSelector).first()
   await expect(openContainer).toBeVisible()


### PR DESCRIPTION
Deflakes the "should apply filters to the distinct results of the group-by field" e2e test:

```
Error: Timeout 18000ms exceeded while waiting on the predicate
  at openListFilters (test/__helpers/e2e/filters/openListFilters.ts:40)
  at addListFilter (test/__helpers/e2e/filters/addListFilter.ts:36)
  at test/group-by/e2e.spec.ts:505
```

The `openListFilters` e2e helper drives the toggle off the filters button's `aria-expanded` attribute, clicking and retrying until it reports open. This is idempotent — a redundant reading never re-toggles an already-open panel. Unlike a point-in-time `.where-builder` visibility check, where a stale `false` reading would click again and toggle it back closed.

Two separate bugs kept that from working; both are fixed here:

1. `aria-expanded` never reflected the open state
    
    The filters button derived `aria-expanded` from the local `visibleDrawer` state, which only tracks `query.where` — not the open/closed toggle. In controlled mode, which the default list view uses (`onWhereToggle` is passed), opening the filters before a filter is applied left `aria-expanded="false"` while the panel was open, so the retry loop could never observe `true`.

    `aria-expanded` now reads `isWhereOpen`, the actual open state, which is correct in both controlled and uncontrolled modes.

2. The retry was silently defeated on CI

    The inner `expect(...).toHaveAttribute('aria-expanded', 'true')` used the global `EXPECT_TIMEOUT`, which is `6000 * 3 = 18000ms` on CI — equal to the hardcoded `toPass` budget. The first click can be lost — it may land on the server-rendered toggler before React hydrates, or a preceding re-render (e.g. a group-by or sort change) can drop it before the `onClick` handler is wired. When that happens, the inner poll consumes the entire budget, leaving zero retries and timing out — exactly the case the retry exists to handle. It only reproduced on CI because locally `EXPECT_TIMEOUT` is 6s, leaving room for ~3 retries.

    The inner assertion now uses a short explicit timeout and the `toPass` budget is widened, so a lost click is actually re-tried until the button hydrates.

    Before:

    ```ts
    await expect(async () => {
      if (!(await openContainer.isVisible())) {
        await toggler.click();
      }
      await expect(openContainer).toBeVisible();
    }).toPass({ timeout: 18000 });
    ```

    After:

    ```ts
    await expect(async () => {
      if ((await toggler.getAttribute("aria-expanded")) !== "true") {
        await toggler.click();
      }
      await expect(toggler).toHaveAttribute("aria-expanded", "true", {
        timeout: 3000,
      });
    }).toPass({ timeout: 30000 });

    const openContainer = page.locator(filterContainerSelector).first();
    await expect(openContainer).toBeVisible();
    ```

## Background

Originally fixed in #16816, which moved `openListFilters` off a visibility check and onto `aria-expanded`. The attribute sync then regressed in #16810, which introduced the controlled mode without updating `aria-expanded`.