### PR TITLE
fix(drizzle): size sqlite batch inserts by widest row

### DIFF
--- a/packages/drizzle/src/sqlite/insert.ts
+++ b/packages/drizzle/src/sqlite/insert.ts
@@ -11,7 +11,7 @@ export const insert: Insert = async function (
   // Batch insert if limitedBoundParameters: true
   if (this.limitedBoundParameters && Array.isArray(values)) {
     const results: Record<string, unknown>[] = []
-    const colsPerRow = Object.keys(values[0]).length
+    const colsPerRow = values.reduce((max, row) => Math.max(max, Object.keys(row).length), 1)
     const maxParams = 100
     const maxRowsPerBatch = Math.max(1, Math.floor(maxParams / colsPerRow))
 

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -108,6 +108,20 @@ export const getConfig: () => Partial<Config> = () => ({
       ],
     },
     {
+      slug: 'draft-with-array',
+      versions: { drafts: true },
+      fields: [
+        {
+          name: 'items',
+          type: 'array',
+          fields: Array.from({ length: 8 }, (_, i) => ({
+            name: `text${i + 1}`,
+            type: 'text' as const,
+          })),
+        },
+      ],
+    },
+    {
       slug: 'simple-localized',
       fields: [
         {

--- a/test/database/sqlite-bound-parameters-limit.int.spec.ts
+++ b/test/database/sqlite-bound-parameters-limit.int.spec.ts
@@ -4,8 +4,8 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { afterAll, beforeAll, expect, it } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { describe } from '../__helpers/int/vitest.js'
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -96,6 +96,48 @@ describe(
       for (const docInRes of res.docs) {
         expect(docs.some((doc) => doc.id === docInRes.id)).toBeTruthy()
       }
+    })
+
+    it('should size batch inserts by the widest row when limitedBoundParameters: true', async () => {
+      // Repro for https://github.com/payloadcms/payload/issues/16964
+      const originalExecute = payload.db.drizzle.$client.execute.bind(payload.db.drizzle.$client)
+
+      payload.db.drizzle.$client.execute = async function execute(...args) {
+        const [{ args: boundParameters }] = args as [{ args: any[] }]
+
+        if (Array.isArray(boundParameters) && boundParameters.length > 100) {
+          throw new Error('Exceeded limit of bound parameters!')
+        }
+
+        return await originalExecute(...args)
+      }
+
+      payload.db.limitedBoundParameters = true
+
+      const items = Array.from({ length: 20 }, (_, i) =>
+        i === 0
+          ? { text1: 'only-first' }
+          : Object.fromEntries(Array.from({ length: 8 }, (_, j) => [`text${j + 1}`, `r${i}-${j}`])),
+      )
+
+      let created: Awaited<ReturnType<typeof payload.create>> | undefined
+
+      await expect(
+        (async () => {
+          created = await payload.create({
+            collection: 'draft-with-array',
+            data: { items },
+          })
+        })(),
+      ).resolves.toBeUndefined()
+
+      payload.db.drizzle.$client.execute = originalExecute
+
+      expect(created!.items).toHaveLength(20)
+      expect(created!.items[0].text1).toBe('only-first')
+      expect(created!.items[19].text8).toBe('r19-7')
+
+      await payload.delete({ collection: 'draft-with-array', id: created!.id })
     })
 
     it('should avoid ambiguous column name errors when limitedBoundParameters: true and multiple joins are present', async () => {


### PR DESCRIPTION
Port of https://github.com/payloadcms/payload/pull/17234 to `3.x`