### PR TITLE
fix: coerce schedulePublish doc.value to collection ID type before update

### DIFF
--- a/packages/payload/src/versions/schedule/job.ts
+++ b/packages/payload/src/versions/schedule/job.ts
@@ -34,8 +34,15 @@ export const getSchedulePublishTask = ({
       }
 
       if (input.doc) {
+        // input.doc.value is always a string (#10481); coerce back to the real ID type.
+        const idType =
+          req.payload.collections[input.doc.relationTo]?.customIDType ??
+          req.payload.db?.defaultIDType ??
+          'text'
+        const id = idType === 'number' ? Number(input.doc.value) : input.doc.value
+
         await req.payload.update({
-          id: input.doc.value,
+          id,
           collection: input.doc.relationTo,
           data: {
             _status,

--- a/test/plugin-nested-docs/collections/Pages.ts
+++ b/test/plugin-nested-docs/collections/Pages.ts
@@ -12,7 +12,9 @@ export const Pages: CollectionConfig = {
     useAsTitle: 'fullTitle',
   },
   versions: {
-    drafts: true,
+    drafts: {
+      schedulePublish: true,
+    },
   },
   access: {
     read: () => true,

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -1,6 +1,7 @@
 import type { ArrayField, Payload, RelationshipField } from 'payload'
 
 import path from 'path'
+import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
@@ -389,6 +390,53 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(draft._status).toBe('draft')
       expect(draft.title).toBe('Breadcrumb Child Draft')
       expect(draft.breadcrumbs?.[0]?.url).toBe('/breadcrumb-parent-updated')
+    })
+  })
+
+  describe('scheduled publish', () => {
+    it('should allow scheduled publish on a collection with a nested-docs breadcrumbs field', async () => {
+      const draft = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'Scheduled Page',
+          slug: 'scheduled-page',
+        },
+        draft: true,
+      })
+
+      expect(draft._status).toBe('draft')
+
+      const currentDate = new Date()
+
+      await payload.jobs.queue({
+        input: {
+          doc: {
+            relationTo: 'pages',
+            // The real schedule-publish UI always sends this as a string
+            // (it comes from client-side form/relationship-picker state),
+            // regardless of the collection's actual ID type. Cast explicitly
+            // here to reproduce that instead of relying on the incidental
+            // JS type of `draft.id` in a Local API call.
+            value: String(draft.id),
+          },
+        },
+        task: 'schedulePublish',
+        waitUntil: new Date(currentDate.getTime() + 3000),
+      })
+
+      await wait(4000)
+
+      await payload.jobs.run()
+
+      const retrieved = await payload.findByID({
+        id: draft.id,
+        collection: 'pages',
+        draft: false,
+      })
+
+      expect(retrieved._status).toBe('published')
+
+      await payload.delete({ collection: 'pages', id: draft.id })
     })
   })
 


### PR DESCRIPTION
Fixes #17229

### What happened

`input.doc.value` on a `schedulePublish` job is always stored as a string (#10481, which fixed job querying against numeric Postgres IDs by casting the stored value to string). `getSchedulePublishTask`'s handler passed that string straight into `payload.update({ id: input.doc.value, ... })` without coercing it back to the collection's real ID type.

That's harmless on its own, but it leaks into any self-referencing relationship field recomputed during the update — e.g. the `breadcrumbs.doc` field added by `@payloadcms/plugin-nested-docs` — and fails that field's relationship-ID-type validation (`isValidID` requires `typeof value === 'number'` for numeric ID collections).

Full repro/root-cause writeup is in #17229.

### The fix

Compute the target collection's real ID type and coerce `input.doc.value` to a `number` when needed, before passing it as `id` to `payload.update()`.

### Test plan

Added a regression test in `test/plugin-nested-docs/int.spec.ts` (enabled `schedulePublish: true` on that project's `pages` fixture collection, which is already wired into `nestedDocsPlugin`). The test explicitly does `value: String(draft.id)` when queuing the job — matching what the real schedule-publish UI sends via client-side relationship-picker state — since calling `payload.jobs.queue()`/`schedulePublishHandler` directly from Node passes a native `number` and doesn't trigger the bug on its own.

Verified locally against Postgres:
- Reverting just the `job.ts` fix reproduces the exact reported error: `Error: The following field is invalid: Breadcrumbs 1 > Doc`
- With the fix, all 12 tests in `test/plugin-nested-docs/int.spec.ts` pass

```
PAYLOAD_DATABASE=postgres npx vitest run --project int test/plugin-nested-docs/int.spec.ts
```