### PR TITLE
fix(drizzle): array field named `numbers`, `texts`, or `rels` crashes queries

### DIFF
--- a/packages/drizzle/src/find/buildFindManyArgs.ts
+++ b/packages/drizzle/src/find/buildFindManyArgs.ts
@@ -97,7 +97,9 @@ export const buildFindManyArgs = ({
     withTabledFields,
   })
 
-  if (adapter.tables[`${tableName}_texts`] && withTabledFields.texts) {
+  const rawRelations = adapter.rawRelations[tableName]
+
+  if (rawRelations?._texts && withTabledFields.texts) {
     result.with._texts = {
       columns: {
         id: false,
@@ -107,7 +109,7 @@ export const buildFindManyArgs = ({
     }
   }
 
-  if (adapter.tables[`${tableName}_numbers`] && withTabledFields.numbers) {
+  if (rawRelations?._numbers && withTabledFields.numbers) {
     result.with._numbers = {
       columns: {
         id: false,
@@ -117,7 +119,7 @@ export const buildFindManyArgs = ({
     }
   }
 
-  if (adapter.tables[`${tableName}${adapter.relationshipsSuffix}`] && withTabledFields.rels) {
+  if (rawRelations?._rels && withTabledFields.rels) {
     result.with._rels = {
       columns: {
         id: false,

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -1054,6 +1054,42 @@ export const getConfig: () => Partial<Config> = () => ({
       ],
     },
     {
+      slug: 'reserved-field-names',
+      fields: [
+        {
+          name: 'numbers',
+          type: 'array',
+          fields: [
+            {
+              name: 'drawPosition',
+              type: 'number',
+            },
+          ],
+        },
+        {
+          name: 'texts',
+          type: 'array',
+          fields: [
+            {
+              name: 'value',
+              type: 'text',
+            },
+          ],
+        },
+        {
+          name: 'rels',
+          type: 'array',
+          fields: [
+            {
+              name: 'value',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+      versions: false,
+    },
+    {
       slug: 'virtual-linked-tenants',
       fields: [
         {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3167,6 +3167,30 @@ describe('database', () => {
     })
   })
 
+  describe('reserved field names', () => {
+    it('should query a collection with an array field named `numbers`, `texts`, or `rels`', async () => {
+      const created = await payload.create({
+        collection: 'reserved-field-names',
+        data: {
+          numbers: [{ drawPosition: 1 }],
+          texts: [{ value: 'hello' }],
+          rels: [{ value: 'world' }],
+        },
+      })
+
+      const found = await payload.findByID({
+        collection: 'reserved-field-names',
+        id: created.id,
+      })
+
+      expect(found.numbers?.[0]?.drawPosition).toStrictEqual(1)
+      expect(found.texts?.[0]?.value).toStrictEqual('hello')
+      expect(found.rels?.[0]?.value).toStrictEqual('world')
+
+      await payload.delete({ collection: 'reserved-field-names', id: created.id })
+    })
+  })
+
   describe('Schema generation', { db: 'drizzle' }, () => {
     it('should generate Drizzle Postgres schema', async () => {
       const generatedAdapterName = process.env.PAYLOAD_DATABASE

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -90,6 +90,7 @@ export interface Config {
     'blocks-docs': BlocksDoc;
     'unique-fields': UniqueField;
     'select-has-many': SelectHasMany;
+    'reserved-field-names': ReservedFieldName;
     'virtual-linked-tenants': VirtualLinkedTenant;
     'virtual-linked-roles': VirtualLinkedRole;
     'virtual-linked-projects': VirtualLinkedProject;
@@ -128,6 +129,7 @@ export interface Config {
     'blocks-docs': BlocksDocsSelect<false> | BlocksDocsSelect<true>;
     'unique-fields': UniqueFieldsSelect<false> | UniqueFieldsSelect<true>;
     'select-has-many': SelectHasManySelect<false> | SelectHasManySelect<true>;
+    'reserved-field-names': ReservedFieldNamesSelect<false> | ReservedFieldNamesSelect<true>;
     'virtual-linked-tenants': VirtualLinkedTenantsSelect<false> | VirtualLinkedTenantsSelect<true>;
     'virtual-linked-roles': VirtualLinkedRolesSelect<false> | VirtualLinkedRolesSelect<true>;
     'virtual-linked-projects': VirtualLinkedProjectsSelect<false> | VirtualLinkedProjectsSelect<true>;
@@ -730,6 +732,33 @@ export interface SelectHasMany {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "reserved-field-names".
+ */
+export interface ReservedFieldName {
+  id: string;
+  numbers?:
+    | {
+        drawPosition?: number | null;
+        id?: string | null;
+      }[]
+    | null;
+  texts?:
+    | {
+        value?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  rels?:
+    | {
+        value?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "virtual-linked-tenants".
  */
 export interface VirtualLinkedTenant {
@@ -904,6 +933,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'select-has-many';
         value: string | SelectHasMany;
+      } | null)
+    | ({
+        relationTo: 'reserved-field-names';
+        value: string | ReservedFieldName;
       } | null)
     | ({
         relationTo: 'virtual-linked-tenants';
@@ -1436,6 +1469,32 @@ export interface UniqueFieldsSelect<T extends boolean = true> {
 export interface SelectHasManySelect<T extends boolean = true> {
   roles?: T;
   food?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "reserved-field-names_select".
+ */
+export interface ReservedFieldNamesSelect<T extends boolean = true> {
+  numbers?:
+    | T
+    | {
+        drawPosition?: T;
+        id?: T;
+      };
+  texts?:
+    | T
+    | {
+        value?: T;
+        id?: T;
+      };
+  rels?:
+    | T
+    | {
+        value?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
Port of https://github.com/payloadcms/payload/pull/17240 to `3.x`