### PR TITLE
fix(ui): internationalize hardcoded labels in sidebar toggle

### DIFF
--- a/packages/ui/src/elements/SidebarToggle/index.tsx
+++ b/packages/ui/src/elements/SidebarToggle/index.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react'
 
 import { SidebarIcon } from '../../icons/Sidebar/index.js'
+import { useTranslation } from '../../providers/Translation/index.js'
 import { Tooltip } from '../Tooltip/index.js'
 import './index.css'
 
@@ -11,9 +12,9 @@ export const SidebarToggle: React.FC<{
   readonly isActive?: boolean
 }> = ({ isActive = false }) => {
   const [showTooltip, setShowTooltip] = useState(false)
+  const { t } = useTranslation()
 
-  // TODO: translations
-  const label = isActive ? 'Hide Sidebar' : 'Show Sidebar'
+  const label = isActive ? t('general:hideSidebar') : t('general:showSidebar')
 
   return (
     <div


### PR DESCRIPTION
Which branch should this PR target?
main — Payload v4 development. New features, enhancements, and v4 bug fixes go here.

What?
Internationalized the hardcoded fallback UI strings in the SidebarToggle component by integrating the useTranslation hook.

Why?
The "Hide sidebar" and "Show sidebar" labels were previously hardcoded in English prose within the component layout. To support proper internationalization and localization across the entire Payload admin panel dashboard, these labels need to pull dynamically from the application's global translation keys.

How?
Imported the useTranslation hook from @payloadcms/ui.
Extracted the t function inside the SidebarToggle component structure.
Replaced the hardcoded "Hide sidebar" text string with t('general:hideSidebar').
Replaced the hardcoded "Show sidebar" text string with t('general:showSidebar').
