### PR TITLE
chore(skills): update payload skill for native slug field type

### DIFF
--- a/tools/claude-plugin/skills/payload/SKILL.md
+++ b/tools/claude-plugin/skills/payload/SKILL.md
@@ -11,7 +11,7 @@ Payload is a Next.js native CMS with TypeScript-first architecture, providing ad
 
 | Task                     | Solution                                                                   | Details                                                                                                                          |
 | ------------------------ | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Auto-generate slugs      | `slugField()`                                                              | [FIELDS.md#slug-field-helper](reference/FIELDS.md#slug-field-helper)                                                             |
+| Auto-generate slugs      | `{ type: 'slug', useAsSlug: 'title' }`                                     | [FIELDS.md#slug-field](reference/FIELDS.md#slug-field)                                                                           |
 | Restrict content by user | Access control with query                                                  | [ACCESS-CONTROL.md#row-level-security-with-complex-queries](reference/ACCESS-CONTROL.md#row-level-security-with-complex-queries) |
 | Local API user ops       | `user` + `overrideAccess: false`                                           | [QUERIES.md#access-control-in-local-api](reference/QUERIES.md#access-control-in-local-api)                                       |
 | Draft/publish workflow   | `versions: { drafts: true }`                                               | [COLLECTIONS.md#versioning--drafts](reference/COLLECTIONS.md#versioning--drafts)                                                 |
@@ -89,11 +89,11 @@ Apply these defaults when modeling content unless there's a clear reason not to:
   `_status` field (`draft` / `published` / `changed`) — **don't add your own
   `status` field**, it's redundant. Only skip versions for collections that have
   no publish/draft lifecycle (e.g. internal join tables, settings).
-- **Use `slugField()` for all slugs** instead of hand-rolling
+- **Use the native `slug` field type for all slugs** instead of hand-rolling
   `{ name: 'slug', type: 'text', unique: true }`. It auto-generates the slug from
-  the title, adds a regenerate toggle, and handles uniqueness/indexing for you.
-  It defaults to generating from a `title` field — if the collection has no
-  `title`, pass the source field: `slugField({ useAsSlug: 'name' })`.
+  a source field, adds a regenerate toggle, and defaults to `required`, `unique`,
+  `index`, and `position: 'sidebar'`. `useAsSlug` is **required** — name the
+  source field to generate from: `{ name: 'slug', type: 'slug', useAsSlug: 'title' }`.
 - **`position: 'sidebar'` is for short, at-a-glance fields** — status, category,
   author, publish date. Avoid it for long fields that need horizontal space to be
   usable (description, rich text content, long text). Those belong in the main
@@ -103,7 +103,6 @@ Apply these defaults when modeling content unless there's a clear reason not to:
 
 ```ts
 import type { CollectionConfig } from 'payload'
-import { slugField } from 'payload'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
@@ -117,7 +116,7 @@ export const Posts: CollectionConfig = {
   },
   fields: [
     { name: 'title', type: 'text', required: true },
-    slugField(), // auto-generates from `title`, unique + indexed, sidebar position
+    { name: 'slug', type: 'slug', useAsSlug: 'title' }, // auto-generates from `title`, unique + indexed, sidebar position
     { name: 'content', type: 'richText' }, // long field — stays in the main area, not the sidebar
     // short, at-a-glance field — good sidebar candidate
     { name: 'author', type: 'relationship', relationTo: 'users', admin: { position: 'sidebar' } },
@@ -140,8 +139,8 @@ For more collection patterns (auth, upload, drafts, live preview), see [COLLECTI
 // Rich text
 { name: 'content', type: 'richText', required: true }
 
-// Slug — use the helper instead of a hand-rolled text field
-slugField()
+// Slug — use the native field type instead of a hand-rolled text field
+{ name: 'slug', type: 'slug', useAsSlug: 'title' }
 
 // Select (for genuine taxonomy — NOT publish state; use versions.drafts + _status for that)
 { name: 'category', type: 'select', options: ['news', 'tutorial', 'opinion'] }
@@ -451,7 +450,7 @@ import type { Post, User } from '@/payload-types'
 
 - Enable `versions: { drafts: true }` by default on content collections; rely on the
   auto-injected `_status` field rather than adding a custom `status` field
-- Use `slugField()` for slugs instead of hand-rolling a unique text field
+- Use the native `slug` field type for slugs instead of hand-rolling a unique text field
 - Reserve `position: 'sidebar'` for short, at-a-glance fields (status, category,
   author, date); keep long fields (description, rich text) in the main area
 

--- a/tools/claude-plugin/skills/payload/reference/COLLECTIONS.md
+++ b/tools/claude-plugin/skills/payload/reference/COLLECTIONS.md
@@ -6,7 +6,6 @@ Complete reference for collection configurations and patterns.
 
 ```ts
 import type { CollectionConfig } from 'payload'
-import { slugField } from 'payload'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
@@ -33,7 +32,7 @@ export const Posts: CollectionConfig = {
       required: true,
       index: true,
     },
-    slugField(), // unique + indexed, sidebar position — don't hand-roll a slug text field
+    { name: 'slug', type: 'slug', useAsSlug: 'title' }, // unique + indexed, sidebar position — don't hand-roll a slug text field
   ],
   defaultSort: '-createdAt',
   timestamps: true,
@@ -128,7 +127,6 @@ Enable real-time content preview during editing.
 
 ```ts
 import type { CollectionConfig } from 'payload'
-import { slugField } from 'payload'
 
 const generatePreviewPath = ({
   slug,
@@ -164,7 +162,10 @@ export const Pages: CollectionConfig = {
         req,
       }),
   },
-  fields: [{ name: 'title', type: 'text' }, slugField()],
+  fields: [
+    { name: 'title', type: 'text' },
+    { name: 'slug', type: 'slug', useAsSlug: 'title' },
+  ],
 }
 ```
 

--- a/tools/claude-plugin/skills/payload/reference/FIELDS.md
+++ b/tools/claude-plugin/skills/payload/reference/FIELDS.md
@@ -32,52 +32,18 @@ const textField: TextField = {
 > description, rich text content, or long text — those belong in the main document
 > area. (`title` above is shown in the sidebar only to demonstrate the option.)
 
-### Slug Field Helper
+### Slug Field
 
-Built-in helper for auto-generating slugs. **Use this for all slugs** instead of
-hand-rolling a `{ name: 'slug', type: 'text', unique: true }` field — it
-auto-generates the slug from the title, adds a regenerate toggle, and handles
-uniqueness and indexing. Call it with no args when the collection has a `title`
-field — the slug is generated from `title` by default:
-
-```ts
-import { slugField } from 'payload'
-import type { CollectionConfig } from 'payload'
-
-export const Pages: CollectionConfig = {
-  slug: 'pages',
-  fields: [
-    { name: 'title', type: 'text', required: true },
-    slugField(), // name: 'slug', useAsSlug: 'title', required, unique, position: 'sidebar'
-  ],
-}
-```
-
-`useAsSlug` defaults to `'title'`, so if the collection has **no `title` field**,
-you must pass the source field explicitly — otherwise the slug generates from a
-field that doesn't exist:
+Use the native `slug` field type for slugs — never hand-roll a
+`{ type: 'text', unique: true }` field. `useAsSlug` is **required** (names the
+source field; there is no `'title'` default). Defaults to `required`, `unique`,
+`index`, `position: 'sidebar'`. Optional server-side `slugify` fn.
 
 ```ts
-// Collection keyed on `name` instead of `title`
-fields: [{ name: 'name', type: 'text', required: true }, slugField({ useAsSlug: 'name' })]
+{ name: 'slug', type: 'slug', useAsSlug: 'title' }
 ```
 
-Override defaults when needed (`overrides` receives the generated `RowField`):
-
-```ts
-slugField({
-  name: 'slug', // defaults to 'slug'
-  useAsSlug: 'title', // defaults to 'title'
-  checkboxName: 'generateSlug', // defaults to 'generateSlug'
-  localized: true,
-  required: true, // defaults to true
-  position: 'sidebar', // default; the slug is a short field well-suited to the sidebar
-  overrides: (field) => {
-    field.fields[1].label = 'Custom Slug Label'
-    return field
-  },
-})
-```
+Full prop reference: <https://payloadcms.com/docs/fields/slug>
 
 ## Rich Text (Lexical)
 


### PR DESCRIPTION
Updates the Claude skill to account for the new native `slug` field type introduced in https://github.com/payloadcms/payload/pull/17215.

This replaces the old `slugField()` helper, which is no longer exported from `payload`. Call sites migrate to the new field type:

```diff
-import { slugField } from 'payload'
-
-fields: [
-  { name: 'title', type: 'text', required: true },
-  slugField(),
-]
+fields: [
+  { name: 'title', type: 'text', required: true },
+  { name: 'slug', type: 'slug', useAsSlug: 'title' },
+]
```

Also trims the exhaustive prop reference from `FIELDS.md` down to the prescriptive convention (use the native type, don't hand-roll a `text` field, `useAsSlug` is required) and links out to the docs page for the full API. The skill's value is to suggest where to reach by default, not a copy of the reference docs.