### PR TITLE
fix(tanstack-start): stop admin page remount on router.refresh()

### DIFF
--- a/packages/tanstack-start/src/routes/layoutRoute.tsx
+++ b/packages/tanstack-start/src/routes/layoutRoute.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import type { ComponentProps } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 
 import { ProgressBar, RootProvider } from '@payloadcms/ui'
 import { Outlet, useLoaderData } from '@tanstack/react-router'
+import { useRef } from 'react'
 
 import { TanStackRouterAdapter } from '../elements/RouterAdapter/index.js'
 
@@ -31,6 +32,12 @@ export function payloadLayoutRoute({
   function PayloadLayout() {
     const data = useLoaderData({ strict: false })
 
+    const providersRef = useRef<ReactNode>(undefined)
+    if (providersRef.current === undefined) {
+      providersRef.current = data.providers
+    }
+    const providers = providersRef.current
+
     return (
       <>
         <RootProvider
@@ -50,10 +57,10 @@ export function payloadLayoutRoute({
           user={data.user}
         >
           <ProgressBar />
-          {/* `data.providers` is the custom-provider tree (config.admin.components.providers)
+          {/* `providers` is the custom-provider tree (config.admin.components.providers)
               already wrapping the router <Outlet />; falls back to a bare <Outlet /> when
               no custom providers are configured. */}
-          {data.providers ?? <Outlet />}
+          {providers ?? <Outlet />}
         </RootProvider>
         <div id="portal" />
       </>


### PR DESCRIPTION
The custom-provider tree (config.admin.components.providers) wraps the router <Outlet /> and is rebuilt from a fresh RSC node on every layout loader run. On a same-route refresh — e.g. router.refresh() after a language switch — rendering the new node remounted the embedded <Outlet /> and the whole page subtree instead of reconciling in place. That remount discarded open client UI (the Localizer popup) and leaked its portal, so the localizer kept showing stale, previous-language locale labels.

Pin the first provider tree so its <Outlet /> stays stable across refreshes; the Outlet reactively renders the current route and the provider wrappers are persistent by design. This matches the Next adapter, where router.refresh() reconciles rather than remounts.

Fixes the admin__e2e__general [tanstack-start] "should allow custom translation of locale labels" e2e failure.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
