### PR TITLE
fix(plugin-seo): add loading state to auto-generate buttons

### DIFF
--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -16,7 +16,7 @@ import {
 } from '@payloadcms/ui'
 import { reduceToSerializableFields } from '@payloadcms/ui/shared'
 import { formatAdminURL } from 'payload/shared'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
 import type { GenerateDescription } from '../../types.js'
@@ -50,6 +50,7 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
   } = useConfig()
 
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
+  const [isGeneratingDescription, setIsGeneratingDescription] = useState(false)
 
   const locale = useLocale()
   const { getData } = useForm()
@@ -122,6 +123,15 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
     setValue,
     title,
   ])
+  const handleRegenerateDescription = useCallback(async () => {
+    setIsGeneratingDescription(true)
+
+    try {
+      await regenerateDescription()
+    } finally {
+      setIsGeneratingDescription(false)
+    }
+  }, [regenerateDescription])
 
   return (
     <div
@@ -143,9 +153,9 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
             <React.Fragment>
               &nbsp; &mdash; &nbsp;
               <button
-                disabled={readOnly}
+                disabled={readOnly || isGeneratingDescription}
                 onClick={() => {
-                  void regenerateDescription()
+                  void handleRegenerateDescription()
                 }}
                 style={{
                   background: 'none',
@@ -158,7 +168,9 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
                 }}
                 type="button"
               >
-                {t('plugin-seo:autoGenerate')}
+                {isGeneratingDescription
+                  ? `${t('plugin-seo:autoGenerate')}...`
+                  : t('plugin-seo:autoGenerate')}
               </button>
             </React.Fragment>
           )}

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -16,7 +16,7 @@ import {
 } from '@payloadcms/ui'
 import { reduceToSerializableFields } from '@payloadcms/ui/shared'
 import { formatAdminURL } from 'payload/shared'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
 import type { GenerateTitle } from '../../types.js'
@@ -45,6 +45,7 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
   } = props
 
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
+  const [isGeneratingTitle, setIsGeneratingTitle] = useState(false)
 
   const {
     config: {
@@ -122,6 +123,15 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
     setValue,
     title,
   ])
+  const handleRegenerateTitle = useCallback(async () => {
+    setIsGeneratingTitle(true)
+
+    try {
+      await regenerateTitle()
+    } finally {
+      setIsGeneratingTitle(false)
+    }
+  }, [regenerateTitle])
 
   return (
     <div
@@ -143,9 +153,9 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
             <React.Fragment>
               &nbsp; &mdash; &nbsp;
               <button
-                disabled={readOnly}
+                disabled={readOnly || isGeneratingTitle}
                 onClick={() => {
-                  void regenerateTitle()
+                  void handleRegenerateTitle()
                 }}
                 style={{
                   background: 'none',
@@ -158,7 +168,9 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
                 }}
                 type="button"
               >
-                {t('plugin-seo:autoGenerate')}
+                {isGeneratingTitle
+                  ? `${t('plugin-seo:autoGenerate')}...`
+                  : t('plugin-seo:autoGenerate')}
               </button>
             </React.Fragment>
           )}


### PR DESCRIPTION
## Summary

Adds a loading state to the SEO plugin's Auto-generate buttons.

### Changes

- Disable the Auto-generate button while the async request is in progress.
- Show a loading text (`Auto-generate...`) during generation.
- Re-enable the button after the request completes or fails.
- Applied to both:
  - `MetaTitleComponent`
  - `MetaDescriptionComponent`

Fixes #17239 