### PR TITLE
chore(ui): adjust radio field spacing and order

### DIFF
--- a/packages/ui/src/fields/RadioGroup/index.css
+++ b/packages/ui/src/fields/RadioGroup/index.css
@@ -20,7 +20,7 @@
     ul {
       list-style: none;
       padding: 0;
-      margin: 0;
+      margin: var(--spacer-1) 0 var(--spacer-2) 0;
     }
 
     &.error {
@@ -48,6 +48,7 @@
       display: flex;
       flex-direction: column;
       gap: var(--spacer-2);
+      align-items: flex-start;
     }
   }
 

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -94,6 +94,10 @@ const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
         />
       </div>
       <div className={`${fieldBaseClass}__wrap`}>
+        <RenderCustomComponent
+          CustomComponent={Description}
+          Fallback={<FieldDescription description={description} path={path} />}
+        />
         {BeforeInput}
         <ul className={`${baseClass}--group`} id={`field-${path.replace(/\./g, '__')}`}>
           {options.map((option) => {
@@ -133,10 +137,6 @@ const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
           })}
         </ul>
         {AfterInput}
-        <RenderCustomComponent
-          CustomComponent={Description}
-          Fallback={<FieldDescription description={description} path={path} />}
-        />
       </div>
     </div>
   )


### PR DESCRIPTION
- Adjusts the spacing around radio inputs
- Moves description below label for more logical position

| before | after |
|---|---|
| <img width="433" height="773" alt="Screenshot 2026-07-09 at 10 35 47 AM" src="https://github.com/user-attachments/assets/d36d66ab-d930-4de1-af45-9c8b56a28777" /> | <img width="433" height="773" alt="Screenshot 2026-07-09 at 10 35 31 AM" src="https://github.com/user-attachments/assets/0ae8d2ca-3056-4609-b644-867be136a7cf" /> |