### PR TITLE
fix(ui): show minRows error pills for arrays and blocks

### DIFF
--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -304,10 +304,13 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
   const hasMaxRows = maxRows && rows.length >= maxRows
 
   const fieldErrorCount = errorPaths.length
-  const fieldHasErrors = submitted && errorPaths.length > 0
+  const fieldHasErrors = submitted && (fieldErrorCount > 0 || !valid)
+  const displayedErrorCount = fieldErrorCount > 0 ? fieldErrorCount : fieldHasErrors ? 1 : 0
 
   const showRequired = (readOnly || disabled) && rows.length === 0
   const showMinRows = (rows.length && rows.length < minRows) || (required && rows.length === 0)
+  const shouldShowSummaryBanner = !valid && (showRequired || showMinRows)
+  const shouldShowFieldError = showError && !shouldShowSummaryBanner
 
   const styles = useMemo(() => mergeFieldStyles(field), [field])
 
@@ -347,7 +350,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
       id={`field-${path.replace(/\./g, '__')}`}
       style={styles}
     >
-      {showError && (
+      {shouldShowFieldError && (
         <RenderCustomComponent
           CustomComponent={Error}
           Fallback={<FieldError path={path} showError={showError} />}
@@ -370,8 +373,8 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
                 }
               />
             </h3>
-            {fieldHasErrors && fieldErrorCount > 0 && (
-              <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />
+            {displayedErrorCount > 0 && (
+              <ErrorPill count={displayedErrorCount} i18n={i18n} withMessage />
             )}
           </div>
           <ul className={`${baseClass}__header-actions`}>

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -311,9 +311,12 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
 
   const fieldErrorCount = errorPaths.length
   const fieldHasErrors = submitted && fieldErrorCount + (valid ? 0 : 1) > 0
+  const displayedErrorCount = fieldErrorCount > 0 ? fieldErrorCount : fieldHasErrors ? 1 : 0
 
   const showMinRows = rows.length < minRows || (required && rows.length === 0)
   const showRequired = readOnly && rows.length === 0
+  const shouldShowSummaryBanner = !valid && (showRequired || showMinRows)
+  const shouldShowFieldError = showError && !shouldShowSummaryBanner
 
   const styles = useMemo(() => mergeFieldStyles(field), [field])
 
@@ -381,7 +384,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
       id={`field-${path?.replace(/\./g, '__')}`}
       style={styles}
     >
-      {showError && (
+      {shouldShowFieldError && (
         <RenderCustomComponent
           CustomComponent={Error}
           Fallback={<FieldError path={path} showError={showError} />}
@@ -404,8 +407,8 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
                 }
               />
             </h3>
-            {fieldHasErrors && fieldErrorCount > 0 && (
-              <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />
+            {displayedErrorCount > 0 && (
+              <ErrorPill count={displayedErrorCount} i18n={i18n} withMessage />
             )}
           </div>
           <ul className={`${baseClass}__header-actions`}>

--- a/test/field-error-states/collections/ErrorFields/index.ts
+++ b/test/field-error-states/collections/ErrorFields/index.ts
@@ -238,6 +238,47 @@ export const ErrorFieldsCollection: CollectionConfig = {
       ],
     },
     {
+      name: 'arrayWithMinRows',
+      type: 'array',
+      labels: {
+        plural: 'Min Rows',
+        singular: 'Min Row',
+      },
+      minRows: 2,
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+        },
+      ],
+      label: 'With Min Rows',
+    },
+    {
+      name: 'blocksWithMinRows',
+      type: 'blocks',
+      labels: {
+        plural: 'Min Rows Blocks',
+        singular: 'Min Rows Block',
+      },
+      minRows: 2,
+      blocks: [
+        {
+          slug: 'minRowsBlock',
+          labels: {
+            plural: 'Min Rows Blocks',
+            singular: 'Min Rows Block',
+          },
+          fields: [
+            {
+              name: 'name',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+      label: 'With Min Rows Blocks',
+    },
+    {
       name: 'group',
       type: 'group',
       fields: [

--- a/test/field-error-states/e2e.spec.ts
+++ b/test/field-error-states/e2e.spec.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url'
 import type { Config } from './payload-types.js'
 
 import { addArrayRow, removeArrayRow } from '../__helpers/e2e/fields/array/index.js'
+import { addBlock } from '../__helpers/e2e/fields/blocks/index.js'
 import {
   ensureCompilationIsDone,
   getRoutes,
@@ -314,6 +315,50 @@ describe('Field Error States', () => {
 
       // error badge should disappear
       await expect(tabErrorBadge).toBeHidden()
+    })
+
+    test('array error pill should show for minRows errors before child edits', async ({ page }) => {
+      await page.goto(errorFieldsURL.create)
+      await waitForFormReady(page)
+      await prefillBaseRequiredFields(page)
+
+      await addArrayRow(page, { fieldName: 'arrayWithMinRows' })
+      await saveDocAndAssert(page, '#action-save', 'error')
+
+      const arrayErrorPill = page.locator(
+        '#field-arrayWithMinRows .array-field__header .error-pill',
+      )
+      await expect(arrayErrorPill).toBeVisible()
+      await expect(arrayErrorPill).toContainText('1 error')
+      await expect(
+        page.locator('#field-arrayWithMinRows .banner.banner--type-danger'),
+      ).toBeVisible()
+      await expect(page.locator('#field-arrayWithMinRows .field-error')).toHaveCount(0)
+    })
+
+    test('blocks error pill should show for minRows errors before child edits', async ({
+      page,
+    }) => {
+      await page.goto(errorFieldsURL.create)
+      await waitForFormReady(page)
+      await prefillBaseRequiredFields(page)
+
+      await addBlock({
+        page,
+        blockToSelect: 'Min Rows Block',
+        fieldName: 'blocksWithMinRows',
+      })
+      await saveDocAndAssert(page, '#action-save', 'error')
+
+      const blocksErrorPill = page.locator(
+        '#field-blocksWithMinRows .blocks-field__header .error-pill',
+      )
+      await expect(blocksErrorPill).toBeVisible()
+      await expect(blocksErrorPill).toContainText('1 error')
+      await expect(
+        page.locator('#field-blocksWithMinRows .banner.banner--type-danger'),
+      ).toBeVisible()
+      await expect(page.locator('#field-blocksWithMinRows .field-error')).toHaveCount(0)
     })
   })
 })


### PR DESCRIPTION
Ensures `array` and `blocks` headers show an error pill for `minRows` and required-row validation even when child `errorPaths` are still empty. It also suppresses duplicate `FieldError` tooltips when the inline summary `Banner` is already rendering the same requirement error.

Adds focused `field-error-states` coverage for both field types, including assertions that the error pill appears and `.field-error` stays hidden while the danger banner is visible.


### Before

- The error pill was missing on save until fields were edited inside the block
- Duplicative min rows error messages

https://github.com/user-attachments/assets/2c05ce35-6fa1-4880-bcaf-b4099d23d101

### After

- The error pill correctly appears after save
- Removes duplicative error message due to min rows (keeps inline banner)

https://github.com/user-attachments/assets/5636c262-39e1-4a0e-8b13-46081ed8def2


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426840332090