### PR TITLE
fix(ui): align locked-row lock icon with checkboxes and unclip its tooltip

### DIFF
--- a/packages/ui/src/elements/Locked/index.css
+++ b/packages/ui/src/elements/Locked/index.css
@@ -24,10 +24,13 @@
     &:focus-visible {
       outline-color: var(--color-border-selected);
     }
+  }
 
-    .locked__tooltip {
-      left: 0;
-      transform: translate3d(0, calc(var(--caret-height) + var(--caret-offset) - 1px), 0);
-    }
+  /* Fixed-position anchor mirroring the icon's rect, so the portaled tooltip (escaping
+   * the table's `overflow` clipping) can position against it. */
+  .locked__tooltip-anchor {
+    position: fixed;
+    z-index: var(--z-popup);
+    pointer-events: none;
   }
 }

--- a/packages/ui/src/elements/Locked/index.tsx
+++ b/packages/ui/src/elements/Locked/index.tsx
@@ -1,7 +1,8 @@
 'use client'
 import type { ClientUser } from 'payload'
 
-import React, { useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import { LockIcon } from '../../icons/Lock/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
@@ -11,31 +12,85 @@ import './index.css'
 
 const baseClass = 'locked'
 
+type AnchorRect = {
+  height: number
+  left: number
+  top: number
+  width: number
+}
+
 export const Locked: React.FC<{
   className?: string
   user: ClientUser
 }> = ({ className, user }) => {
+  const anchorRef = useRef<HTMLDivElement>(null)
   const [hovered, setHovered] = useState(false)
+  const [anchorRect, setAnchorRect] = useState<AnchorRect | null>(null)
   const { t } = useTranslation()
 
   const userToUse = isClientUserObject(user) ? (user.email ?? user.id) : t('general:anotherUser')
+
+  const updateAnchorRect = useCallback(() => {
+    const node = anchorRef.current
+
+    if (!node) {
+      return
+    }
+
+    const { height, left, top, width } = node.getBoundingClientRect()
+    setAnchorRect({ height, left, top, width })
+  }, [])
+
+  useEffect(() => {
+    if (!hovered) {
+      return
+    }
+
+    updateAnchorRect()
+
+    // Keep the portaled tooltip aligned to the icon as the page or an overflow
+    // container scrolls.
+    window.addEventListener('scroll', updateAnchorRect, true)
+    window.addEventListener('resize', updateAnchorRect)
+
+    return () => {
+      window.removeEventListener('scroll', updateAnchorRect, true)
+      window.removeEventListener('resize', updateAnchorRect)
+    }
+  }, [hovered, updateAnchorRect])
 
   return (
     <div
       className={[baseClass, className].filter(Boolean).join(' ')}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      ref={anchorRef}
       role="button"
       tabIndex={0}
     >
-      <Tooltip
-        alignCaret="left"
-        className={`${baseClass}__tooltip`}
-        position="bottom"
-        show={hovered}
-        staticPositioning
-      >{`${userToUse} ${t('general:isEditing')}`}</Tooltip>
       <LockIcon />
+      {hovered &&
+        anchorRect &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className={`${baseClass}__tooltip-anchor`}
+            style={{
+              height: anchorRect.height,
+              left: anchorRect.left,
+              top: anchorRect.top,
+              width: anchorRect.width,
+            }}
+          >
+            <Tooltip
+              alignCaret="center"
+              className={`${baseClass}__tooltip`}
+              position="bottom"
+              show={hovered}
+            >{`${userToUse} ${t('general:isEditing')}`}</Tooltip>
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }

--- a/packages/ui/src/elements/Locked/index.tsx
+++ b/packages/ui/src/elements/Locked/index.tsx
@@ -12,20 +12,13 @@ import './index.css'
 
 const baseClass = 'locked'
 
-type AnchorRect = {
-  height: number
-  left: number
-  top: number
-  width: number
-}
-
 export const Locked: React.FC<{
   className?: string
   user: ClientUser
 }> = ({ className, user }) => {
   const anchorRef = useRef<HTMLDivElement>(null)
   const [hovered, setHovered] = useState(false)
-  const [anchorRect, setAnchorRect] = useState<AnchorRect | null>(null)
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null)
   const { t } = useTranslation()
 
   const userToUse = isClientUserObject(user) ? (user.email ?? user.id) : t('general:anotherUser')
@@ -38,8 +31,7 @@ export const Locked: React.FC<{
       return
     }
 
-    const { height, left, top, width } = node.getBoundingClientRect()
-    setAnchorRect({ height, left, top, width })
+    setAnchorRect(node.getBoundingClientRect())
   }, [])
 
   useEffect(() => {

--- a/packages/ui/src/elements/Locked/index.tsx
+++ b/packages/ui/src/elements/Locked/index.tsx
@@ -29,6 +29,7 @@ export const Locked: React.FC<{
   const { t } = useTranslation()
 
   const userToUse = isClientUserObject(user) ? (user.email ?? user.id) : t('general:anotherUser')
+  const tooltipLabel = `${userToUse} ${t('general:isEditing')}`
 
   const updateAnchorRect = useCallback(() => {
     const node = anchorRef.current
@@ -46,8 +47,6 @@ export const Locked: React.FC<{
       return
     }
 
-    updateAnchorRect()
-
     // Keep the portaled tooltip aligned to the icon as the page or an overflow
     // container scrolls.
     window.addEventListener('scroll', updateAnchorRect, true)
@@ -61,8 +60,22 @@ export const Locked: React.FC<{
 
   return (
     <div
+      aria-label={tooltipLabel}
       className={[baseClass, className].filter(Boolean).join(' ')}
-      onMouseEnter={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
+      onFocus={() => {
+        updateAnchorRect()
+        setHovered(true)
+      }}
+      onKeyDown={(e) => {
+        if (e.key === ' ') {
+          e.preventDefault() // prevent page scroll when focused
+        }
+      }}
+      onMouseEnter={() => {
+        updateAnchorRect()
+        setHovered(true)
+      }}
       onMouseLeave={() => setHovered(false)}
       ref={anchorRef}
       role="button"
@@ -71,7 +84,6 @@ export const Locked: React.FC<{
       <LockIcon />
       {hovered &&
         anchorRect &&
-        typeof document !== 'undefined' &&
         createPortal(
           <div
             className={`${baseClass}__tooltip-anchor`}
@@ -82,12 +94,9 @@ export const Locked: React.FC<{
               width: anchorRect.width,
             }}
           >
-            <Tooltip
-              alignCaret="center"
-              className={`${baseClass}__tooltip`}
-              position="bottom"
-              show={hovered}
-            >{`${userToUse} ${t('general:isEditing')}`}</Tooltip>
+            <Tooltip alignCaret="center" className={`${baseClass}__tooltip`} position="bottom" show>
+              {tooltipLabel}
+            </Tooltip>
           </div>,
           document.body,
         )}

--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -84,6 +84,18 @@
       text-align: center;
     }
 
+    /* Size the locked-row lock icon to the checkbox's 16px box (keeping the column
+     * width stable) and center it like the checkbox; the larger icon overflows. */
+    .cell-_select .locked {
+      display: flex;
+      height: var(--spacer-3);
+      width: var(--spacer-3);
+
+      svg {
+        flex-shrink: 0;
+      }
+    }
+
     #heading-_dragHandle {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Aligns the lock icon shown on locked rows in the list view with the checkbox column, and stops its tooltip from being clipped by the table.

The lock icon renders at 24px, wider than the 16px checkbox it replaces, so it sat misaligned and widened the select column. Its box is now constrained to the checkbox's `--spacer-3` footprint (the larger icon overflows, centered), keeping the column width stable and the glyph aligned both horizontally and vertically.

The tooltip previously rendered inside the table cell, so `.table { overflow: auto }` clipped it — worst on the last row. It's now portaled to `document.body` against a fixed-position anchor mirroring the icon's rect (the same portal approach as `Popup`), so it sits above table content and its caret centers on the icon.

#### Before:
<img width="893" height="520" alt="Screenshot 2026-07-09 at 1 56 05 PM" src="https://github.com/user-attachments/assets/d95a5ed3-ea8a-4842-bb69-4077be211d85" />

#### After:
<img width="867" height="500" alt="Screenshot 2026-07-09 at 1 55 47 PM" src="https://github.com/user-attachments/assets/2933170b-88ff-4036-b422-492c0efc078c" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396142601229
  - https://app.asana.com/0/0/1216396142601216