### PR TITLE
fix(ui): disable autocomplete on list search

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -164,6 +164,11 @@ import type {
   UploadFieldSingleValidation,
 } from '../validations.js'
 
+export type BrowserAutoComplete = Extract<
+  React.InputHTMLAttributes<HTMLInputElement>['autoComplete'],
+  string
+>
+
 export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSiblingData = any> = {
   /**
    * The data of the nearest parent block. If the field is not within a block, `blockData` will be equal to `undefined`.
@@ -558,7 +563,7 @@ export interface FieldBaseClient
 export type NumberField = {
   admin?: {
     /** Set this property to a string that will be used for browser autocomplete. */
-    autoComplete?: string
+    autoComplete?: BrowserAutoComplete
     components?: {
       afterInput?: CustomComponent[]
       beforeInput?: CustomComponent[]
@@ -605,7 +610,7 @@ export type NumberFieldClient = {
 
 export type TextField = {
   admin?: {
-    autoComplete?: string
+    autoComplete?: BrowserAutoComplete
     components?: {
       afterInput?: CustomComponent[]
       beforeInput?: CustomComponent[]
@@ -648,7 +653,7 @@ export type TextFieldClient = {
 
 export type EmailField = {
   admin?: {
-    autoComplete?: string
+    autoComplete?: BrowserAutoComplete
     components?: {
       afterInput?: CustomComponent[]
       beforeInput?: CustomComponent[]

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1639,6 +1639,7 @@ export type {
   BlockJSX,
   BlocksField,
   BlocksFieldClient,
+  BrowserAutoComplete,
   CheckboxField,
   CheckboxFieldClient,
   ClientBlock,

--- a/packages/ui/src/elements/Search/ListSearchFilter/index.tsx
+++ b/packages/ui/src/elements/Search/ListSearchFilter/index.tsx
@@ -51,6 +51,7 @@ export function ListSearchFilter({
 
   return (
     <SearchInput
+      autoComplete="off"
       className={className}
       disabled={disabled}
       id="search-filter-input"

--- a/packages/ui/src/elements/Search/SearchInput/index.tsx
+++ b/packages/ui/src/elements/Search/SearchInput/index.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import type { BrowserAutoComplete } from 'payload'
+
 import React, { useCallback } from 'react'
 
 import { SearchIcon } from '../../../icons/Search/index.js'
@@ -12,6 +14,7 @@ const baseClass = 'search-input'
 
 type SearchInputProps = {
   'aria-label'?: string
+  autoComplete?: BrowserAutoComplete
   className?: string
   disabled?: boolean
   id?: string
@@ -25,6 +28,7 @@ type SearchInputProps = {
 export const SearchInput: React.FC<SearchInputProps> = ({
   id,
   'aria-label': ariaLabel,
+  autoComplete,
   className,
   disabled,
   onChange,
@@ -49,6 +53,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
       <SearchIcon />
       <input
         aria-label={ariaLabel ?? placeholder}
+        autoComplete={autoComplete}
         className={`${baseClass}__input`}
         disabled={disabled}
         id={id}

--- a/packages/ui/src/fields/Password/types.ts
+++ b/packages/ui/src/fields/Password/types.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserAutoComplete,
   FieldBaseClient,
   PasswordFieldValidation,
   StaticDescription,
@@ -9,7 +10,7 @@ import type React from 'react'
 import type { MarkOptional } from 'ts-essentials'
 
 export type PasswordFieldProps = {
-  readonly autoComplete?: string
+  readonly autoComplete?: BrowserAutoComplete
   readonly field: MarkOptional<TextFieldClient, 'type'>
   /**
    * @default ''
@@ -37,7 +38,7 @@ export type PasswordFieldProps = {
 
 export type PasswordInputProps = {
   readonly AfterInput?: React.ReactNode
-  readonly autoComplete?: string
+  readonly autoComplete?: BrowserAutoComplete
   readonly BeforeInput?: React.ReactNode
   readonly className?: string
   readonly description?: StaticDescription

--- a/packages/ui/src/fields/Text/types.ts
+++ b/packages/ui/src/fields/Text/types.ts
@@ -1,4 +1,4 @@
-import type { StaticDescription, StaticLabel } from 'payload'
+import type { BrowserAutoComplete, StaticDescription, StaticLabel } from 'payload'
 import type { ChangeEvent, JSX } from 'react'
 import type React from 'react'
 
@@ -23,7 +23,7 @@ export type TextInputProps = {
   readonly Error?: React.ReactNode
   readonly htmlAttributes?: {
     'aria-label'?: JSX.IntrinsicElements['input']['aria-label']
-    autoComplete?: JSX.IntrinsicElements['input']['autoComplete']
+    autoComplete?: BrowserAutoComplete
     readOnly?: JSX.IntrinsicElements['input']['readOnly']
   }
   /**


### PR DESCRIPTION
Disables browser autocomplete for the list search input while preserving the existing debounced search behavior.

Adds a shared `BrowserAutoComplete` type for browser input autocomplete values and applies it to existing text, email, password, and search input props.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426405121652