### PR TITLE
fix(ui): always render paginator with single page of results

### DIFF
--- a/packages/ui/src/elements/Pagination/index.css
+++ b/packages/ui/src/elements/Pagination/index.css
@@ -37,6 +37,11 @@
     &:focus-visible {
       outline: none;
     }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
   }
 
   .paginator__page-total {

--- a/packages/ui/src/elements/Pagination/index.tsx
+++ b/packages/ui/src/elements/Pagination/index.tsx
@@ -86,26 +86,25 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
     }
   }
 
-  if (!totalPages || totalPages <= 1) {
-    return null
-  }
+  const isSinglePage = !totalPages || totalPages <= 1
 
   return (
     <div className={baseClass}>
       <ClickableArrow
         direction="left"
-        isDisabled={!hasPrevPage}
+        isDisabled={isSinglePage || !hasPrevPage}
         updatePage={() => updatePage(prevPage ?? Math.max(1, currentPage - 1))}
       />
       <ClickableArrow
         direction="right"
-        isDisabled={!hasNextPage}
+        isDisabled={isSinglePage || !hasNextPage}
         updatePage={() => updatePage(nextPage ?? currentPage + 1)}
       />
       <div className={`${baseClass}__page-input-wrapper`}>
         <input
           aria-label="Go to page"
           className={`${baseClass}__page-input`}
+          disabled={isSinglePage}
           inputMode="numeric"
           max={totalPages}
           min={1}
@@ -116,7 +115,7 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
           type="text"
           value={inputValue}
         />
-        <span className={`${baseClass}__page-total`}>of {totalPages}</span>
+        <span className={`${baseClass}__page-total`}>of {isSinglePage ? 1 : totalPages}</span>
       </div>
     </div>
   )


### PR DESCRIPTION
Renders the `Pagination` component even when there is only one page of results, instead of returning `null`. The arrow buttons and page input are disabled, and the page total reads `of 1`.

This keeps the paginator visible and layout stable regardless of result count.

#### Before
<img width="1404" height="1353" alt="Screenshot 2026-07-09 at 3 38 47 PM" src="https://github.com/user-attachments/assets/c06270cb-2e35-429d-9aa1-6b2213356876" />


#### After
<img width="1596" height="1354" alt="Screenshot 2026-07-09 at 2 15 27 PM" src="https://github.com/user-attachments/assets/67348575-a27a-4669-94d9-fd42740f61d9" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396142601223