### PR TITLE
fix(ui): make entire submenu header clickable in user menu

### DIFF
--- a/packages/ui/src/elements/UserMenu/SubMenuHeader/index.tsx
+++ b/packages/ui/src/elements/UserMenu/SubMenuHeader/index.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 
 import { ChevronIcon } from '../../../icons/Chevron/index.js'
-import { Button } from '../../Button/index.js'
 import { MenuSeparator } from '../../MenuSeparator/index.js'
 
 export const SubMenuHeader: React.FC<{
@@ -11,16 +10,17 @@ export const SubMenuHeader: React.FC<{
 }> = ({ onBack, title }) => (
   <div className="user-menu__submenu-header" data-popup-prevent-close>
     <div className="user-menu__submenu-header-wrap">
-      <div className="user-menu__submenu-header-row">
-        <Button
-          aria-label={title}
-          buttonStyle="ghost"
-          className="user-menu__submenu-back"
-          icon={<ChevronIcon direction="left" size={24} />}
-          onClick={onBack}
-        />
-        <p className="user-menu__submenu-title">{title}</p>
-      </div>
+      <button
+        aria-label={title}
+        className="user-menu__submenu-header-row"
+        onClick={onBack}
+        type="button"
+      >
+        <span className="user-menu__submenu-back">
+          <ChevronIcon direction="left" size={24} />
+        </span>
+        <span className="user-menu__submenu-title">{title}</span>
+      </button>
     </div>
     <MenuSeparator />
   </div>

--- a/packages/ui/src/elements/UserMenu/index.css
+++ b/packages/ui/src/elements/UserMenu/index.css
@@ -84,7 +84,7 @@
 
 .user-menu__submenu-header-row:hover {
   outline: none;
-  background-color: var(--popup-item-bg-hover, var(--color-bg-selected-strong));
+  background-color: var(--popup-item-bg-hover, var(--color-bg-transparent-hover));
   color: var(--popup-item-color-hover, var(--color-text-onselected-strong));
 }
 

--- a/packages/ui/src/elements/UserMenu/index.css
+++ b/packages/ui/src/elements/UserMenu/index.css
@@ -67,11 +67,36 @@
   display: flex;
   align-items: center;
   gap: var(--spacer-1);
+  width: 100%;
+  padding: 0 var(--spacer-1);
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: inherit;
+  border-radius: var(--popup-item-radius);
+  color: var(--popup-item-color, var(--color-text));
+}
+
+.user-menu__submenu-header-row:focus-visible {
+  outline: var(--accessibility-outline);
+  outline-offset: -1px;
+}
+
+.user-menu__submenu-header-row:hover {
+  outline: none;
+  background-color: var(--popup-item-bg-hover, var(--color-bg-selected-strong));
+  color: var(--popup-item-color-hover, var(--color-text-onselected-strong));
+}
+
+.user-menu__submenu-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .user-menu__submenu-title {
   margin: 0;
-  color: var(--color-text);
+  color: inherit;
   font-family: var(--text-body-medium-font-family);
   font-size: var(--text-body-medium-font-size);
   font-weight: var(--text-body-medium-font-weight);


### PR DESCRIPTION
Makes the whole `SubMenuHeader` row a clickable back control instead of only the chevron button.

Replaces the nested ghost `Button` with a single full-width `<button>` wrapping the chevron and title, and applies the shared `--popup-item-bg-hover` / `--popup-item-color-hover` hover tokens from `PopupButtonList` so the entire header highlights on hover.

### Before
<img width="389" height="278" alt="Screenshot 2026-07-09 at 4 12 33 PM" src="https://github.com/user-attachments/assets/3273cb93-62da-480a-aac3-338648cb330b" />


### After

#### Hover state
<img width="263" height="241" alt="Screenshot 2026-07-10 at 3 59 45 PM" src="https://github.com/user-attachments/assets/6473508a-db15-429f-a00c-99764b1e6bcf" />


#### Focus state
<img width="390" height="278" alt="Screenshot 2026-07-09 at 4 12 55 PM" src="https://github.com/user-attachments/assets/82c9c4e1-0ccb-4e6b-a8ff-e3d869cf5d49" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396007834491