### PR TITLE
fix(ui): incorrect font size on mobile menu

### DIFF
--- a/packages/ui/src/elements/Nav/index.css
+++ b/packages/ui/src/elements/Nav/index.css
@@ -119,11 +119,6 @@
       --nav-padding-inline-end: var(--gutter-h);
     }
 
-    .nav__link {
-      font-size: var(--text-body-small-font-size);
-      line-height: var(--spacer-4);
-    }
-
     .nav__mobile-close {
       display: flex;
       align-items: center;


### PR DESCRIPTION
This PR corrects the mobile menu font sizing.

### Before
<img width="408" height="837" alt="CleanShot 2026-07-09 at 16 18 34" src="https://github.com/user-attachments/assets/364d2bff-f115-4833-87f1-4d246c54cf91" />


### After
<img width="411" height="835" alt="CleanShot 2026-07-09 at 16 18 43" src="https://github.com/user-attachments/assets/6a1c4e6b-ee28-4d9b-9b6e-8a345f1f4375" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216448563398856