### PR TITLE
fix(ui): reduce APIKeyInput field font size to 11px

### DIFF
--- a/packages/ui/src/elements/APIKeyInput/index.css
+++ b/packages/ui/src/elements/APIKeyInput/index.css
@@ -35,8 +35,8 @@
     outline: none;
     color: var(--color-text);
     font-family: var(--font-family-mono);
-    font-size: var(--text-body-large-font-size);
-    line-height: var(--text-body-large-line-height);
+    font-size: var(--text-body-medium-font-size);
+    line-height: var(--text-body-medium-line-height);
   }
 
   .api-key-input__field:focus,
@@ -47,8 +47,8 @@
 
   .api-key-input__field[type='password'] {
     font-family: var(--font-family-sans);
-    font-size: var(--text-body-large-font-size);
-    font-weight: var(--text-body-large-strong-font-weight);
+    font-size: var(--text-body-medium-font-size);
+    font-weight: var(--text-body-medium-strong-font-weight);
     letter-spacing: 0.025rem;
   }
 


### PR DESCRIPTION
Uses the `--text-body-medium-*` tokens (11px) instead of `--text-body-large-*` (13px) for the `APIKeyInput` field, so the masked value and visible value render at the intended size.

Before:

```css
font-size: var(--text-body-large-font-size);
```

After:

```css
font-size: var(--text-body-medium-font-size);
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396007834516