### PR TITLE
fix(ui): remove brackets from untitled document title fallback

### DIFF
--- a/packages/ui/src/utilities/formatDocTitle/index.ts
+++ b/packages/ui/src/utilities/formatDocTitle/index.ts
@@ -73,7 +73,7 @@ export const formatDocTitle = ({
   }
 
   if (!title) {
-    title = typeof fallback === 'string' ? fallback : `[${i18n.t('general:untitled')}]`
+    title = typeof fallback === 'string' ? fallback : i18n.t('general:untitled')
   }
 
   return title

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -1725,7 +1725,7 @@ describe('Access Control', () => {
   describe('blocks field access control', () => {
     test('should respect field-level access control for blocks fields', async () => {
       await page.goto(blocksFieldAccessUrl.create)
-      await expect(page.locator('.doc-header__title')).toContainText('[Untitled]')
+      await expect(page.locator('.doc-header__title')).toContainText('Untitled')
 
       // Editable blocks field should allow adding blocks
       const editableBlocksField = page.locator('#field-editableBlocks')

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -192,7 +192,7 @@ describe('Document View', () => {
   describe('document titles', () => {
     test('collection — should render fallback titles when creating new', async () => {
       await page.goto(postsUrl.create)
-      await checkPageTitle(page, '[Untitled]')
+      await checkPageTitle(page, 'Untitled')
       await checkBreadcrumb(page, 'Create New')
       await saveDocAndAssert(page)
     })


### PR DESCRIPTION
Removes the surrounding brackets from the `untitled` fallback in `formatDocTitle`, so unsaved documents render `Untitled` instead of `[Untitled]`.

#### Before:
<img width="336" height="105" alt="Screenshot 2026-07-09 at 4 47 35 PM" src="https://github.com/user-attachments/assets/7ede6dc8-29c8-41cf-ab24-4fc42af9aea9" />


#### After:
<img width="325" height="105" alt="Screenshot 2026-07-09 at 4 46 53 PM" src="https://github.com/user-attachments/assets/06b65971-23f1-4125-b272-5267c9527f6a" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396007834503