### PR TITLE
fix: resolve hierarchy path ancestors using the request draft intent

### DIFF
--- a/packages/payload/src/hierarchy/hooks/collectionAfterRead.ts
+++ b/packages/payload/src/hierarchy/hooks/collectionAfterRead.ts
@@ -80,7 +80,15 @@ export const hierarchyCollectionAfterRead =
       const { slugPath, titlePath } = await computePaths({
         collection,
         doc,
-        draft: doc._status === 'draft',
+        // Prefer the request's draft intent captured in beforeOperation: a
+        // published document read with `draft: true` (e.g. live preview) must
+        // still resolve its ancestors at their draft versions. `doc._status`
+        // only reflects this document's own state, so it is just a fallback
+        // for paths that don't go through a read operation.
+        draft:
+          typeof context?.hierarchyRequestDraft === 'boolean'
+            ? context.hierarchyRequestDraft
+            : doc._status === 'draft',
         locale:
           isTitleLocalized && req.locale === 'all'
             ? 'all'

--- a/packages/payload/src/hierarchy/hooks/collectionBeforeOperation.ts
+++ b/packages/payload/src/hierarchy/hooks/collectionBeforeOperation.ts
@@ -1,5 +1,6 @@
 /**
  * beforeOperation Hook Responsibilities:
+ * - Capture the request's draft intent in context so afterRead resolves ancestors at the right version
  * - Detect when path fields (_h_slugPath, _h_titlePath) are selected
  * - Auto-include required fields (parent, title, slugField) for ancestor traversal
  * - Track auto-added fields in context so afterRead can strip them from response
@@ -65,7 +66,7 @@ export const hierarchyCollectionBeforeOperation = <TSlug extends CollectionSlug>
   return (hookArgs) => {
     const { args, context, operation } = hookArgs
 
-    // Only process read operations that have select
+    // Only process read operations
     if (
       operation !== 'find' &&
       operation !== 'findByID' &&
@@ -76,8 +77,17 @@ export const hierarchyCollectionBeforeOperation = <TSlug extends CollectionSlug>
       return
     }
 
-    // Type guard - these operations have select in their args
-    const operationArgs = args as { select?: Record<string, unknown> }
+    // Type guard - these operations have draft and select in their args
+    const operationArgs = args as { draft?: boolean; select?: Record<string, unknown> }
+
+    // Capture the request's draft intent so afterRead can resolve ancestors
+    // against the same draft/published view the request asked for. The
+    // document's own `_status` cannot tell us this - a published document
+    // read with `draft: true` should still walk the draft parent chain.
+    if (typeof operationArgs.draft === 'boolean') {
+      context.hierarchyRequestDraft = operationArgs.draft
+    }
+
     const select = operationArgs.select
 
     // No select means all fields are returned - no augmentation needed

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -643,6 +643,54 @@ describe('Hierarchy', () => {
 
       expect(updatedChild._h_slugPath).toBe('tech/electronics/phones')
     })
+
+    it('should resolve ancestors against the request draft intent when the document itself has no draft', async () => {
+      // Parent is published as "About", then a draft-only rename to "About Us"
+      // that is never published.
+      const parent = await payload.create({
+        collection: 'organizations',
+        data: { _status: 'published', parent: null, title: 'About' },
+      })
+
+      await payload.update({
+        id: parent.id,
+        collection: 'organizations',
+        data: { title: 'About Us' },
+        draft: true,
+      })
+
+      // Child is published and has no pending draft of its own, so its
+      // `_status` stays 'published'.
+      const child = await payload.create({
+        collection: 'organizations',
+        data: { _status: 'published', parent: parent.id, title: 'Guide' },
+      })
+
+      // Reading the child in draft mode (e.g. live preview) should walk the
+      // parent chain using the draft view the request asked for, even though
+      // the child itself is published.
+      const draftChild = await payload.findByID({
+        id: child.id,
+        collection: 'organizations',
+        context: { computeHierarchyPaths: true },
+        draft: true,
+      })
+
+      expect(draftChild._status).toBe('published')
+      expect(draftChild._h_titlePath).toBe('About Us/Guide')
+      expect(draftChild._h_slugPath).toBe('about-us/guide')
+
+      // A published read still resolves against the published parent title.
+      const publishedChild = await payload.findByID({
+        id: child.id,
+        collection: 'organizations',
+        context: { computeHierarchyPaths: true },
+        draft: false,
+      })
+
+      expect(publishedChild._h_titlePath).toBe('About/Guide')
+      expect(publishedChild._h_slugPath).toBe('about/guide')
+    })
   })
 
   describe('Localization', () => {


### PR DESCRIPTION
### What?

When a hierarchy collection document is read with `draft: true`, the computed `_h_slugPath` / `_h_titlePath` now resolve the ancestor chain at the draft version the request asked for. Previously the draft flag passed to `computePaths` came from the document's own `_status`.

### Why?

`doc._status` only says whether this specific document has unpublished changes, it says nothing about the request. So a published child read in live preview (`draft: true`) walked its ancestors with `draft: false` and got the published parent titles/slugs. With a parent that had a draft-only rename, the child's breadcrumb showed the published slug instead of the draft one.

### How?

The hierarchy plugin's own `beforeOperation` hook already runs for read operations and receives the operation args, so it now stashes `args.draft` in `context.hierarchyRequestDraft` (same pattern as the existing `computeHierarchyPathsViaSelect` flag). `afterRead` prefers that value and only falls back to the old `doc._status === 'draft'` check for paths that don't go through a read operation. `draft` is already a boolean by the time the hook runs on every surface (REST coerces it via `parseParams`, local API and GraphQL pass it directly).

Added an int test: published parent with a draft-only rename plus a published child. Reading the child with `draft: true` yields the draft parent path, and with `draft: false` still yields the published one. The first assertion fails without the fix, the full hierarchy suite (35 tests) passes with it.

Fixes #17223
