### PR TITLE
fix(ui): sync hierarchy type filter defaults

### DIFF
--- a/packages/ui/src/views/HierarchyList/TypeFilter/index.tsx
+++ b/packages/ui/src/views/HierarchyList/TypeFilter/index.tsx
@@ -28,6 +28,10 @@ export function TypeFilter({ i18n, onChange, options, selectedValues }: TypeFilt
     [onChange, options],
   )
 
+  if (options.length === 0) {
+    return null
+  }
+
   return (
     <Popup
       className={baseClass}

--- a/packages/ui/src/views/HierarchyList/index.tsx
+++ b/packages/ui/src/views/HierarchyList/index.tsx
@@ -5,7 +5,7 @@ import type { ListViewClientProps } from 'payload'
 import { getTranslation } from '@payloadcms/translations'
 import { formatAdminURL } from 'payload/shared'
 import * as qs from 'qs-esm'
-import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { Fragment, useCallback, useEffect, useMemo } from 'react'
 
 import type { CollectionOption } from '../../elements/CreateDocumentButton/index.js'
 import type { StepNavItem } from '../../elements/StepNav/index.js'
@@ -243,20 +243,15 @@ export function HierarchyListView(props: ListViewClientProps) {
     return options
   }, [allowedCollections, getEntityConfig, hierarchyConfig?.relatedCollections, i18n])
 
-  // Get type filter from URL params (comma-separated list)
   const typeFilterFromURL = searchParams.get('typeFilter')
-  const typeFilterValues = typeFilterFromURL ? typeFilterFromURL.split(',') : null
-
-  // Track selected types (default: from URL or all selected)
-  const [selectedTypes, setSelectedTypes] = useState<string[]>(
-    () => typeFilterValues || typeOptions.map((opt) => opt.value),
+  const selectedTypes = useMemo(
+    () => (typeFilterFromURL ? typeFilterFromURL.split(',') : typeOptions.map((opt) => opt.value)),
+    [typeFilterFromURL, typeOptions],
   )
 
   // Update URL when type filter changes
   const handleTypeFilterChange = useCallback(
     (values: string[]) => {
-      setSelectedTypes(values)
-
       // Build new URL with updated typeFilter param
       const currentParams: Record<string, string> = {}
       searchParams.forEach((v, k) => {


### PR DESCRIPTION
Keeps the hierarchy list `Type` filter selection derived from the current `typeFilter` URL param and available options so it does not render as refined before options are ready. Hides the `Type` filter when no type options exist, preventing the empty popup/clear control state.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426405121647