### PR TITLE
feat(ui): improve search logic in column selector component

### DIFF
--- a/packages/ui/src/elements/ColumnSelection/Popup.tsx
+++ b/packages/ui/src/elements/ColumnSelection/Popup.tsx
@@ -15,6 +15,7 @@ import { Button } from '../Button/index.js'
 import { DraggableSortable } from '../DraggableSortable/index.js'
 import { useDraggableSortable } from '../DraggableSortable/useDraggableSortable/index.js'
 import { Switch } from '../Switch/index.js'
+import { matchesColumnSearch } from './matchesColumnSearch.js'
 import './Popup.css'
 
 const baseClass = 'column-selector'
@@ -207,7 +208,9 @@ export const ColumnSelectionPopup: React.FC<ColumnSelectionPopupProps> = ({
 
     // Filter by search query
     const filtered = searchQuery
-      ? items.filter((item) => item.labelText.toLowerCase().includes(searchQuery.toLowerCase()))
+      ? items.filter((item) =>
+          matchesColumnSearch({ labelText: item.labelText, query: searchQuery }),
+        )
       : items
 
     return {

--- a/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.spec.ts
+++ b/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchesColumnSearch } from './matchesColumnSearch.js'
+
+describe('matchesColumnSearch', () => {
+  it('matches everything when the query is empty', () => {
+    expect(matchesColumnSearch({ labelText: 'Published Date', query: '' })).toBe(true)
+  })
+
+  it('matches everything when the query is only whitespace', () => {
+    expect(matchesColumnSearch({ labelText: 'Published Date', query: '   ' })).toBe(true)
+  })
+
+  describe('single-character queries', () => {
+    it('matches the start of the label', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'p' })).toBe(true)
+    })
+
+    it('matches the start of a later word', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'd' })).toBe(true)
+    })
+
+    it('matches the start of a word after a nested-label separator', () => {
+      expect(matchesColumnSearch({ labelText: 'Meta > Title', query: 't' })).toBe(true)
+    })
+
+    it('is case-insensitive', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'P' })).toBe(true)
+    })
+
+    it('does not match a character in the middle of a word', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'u' })).toBe(false)
+    })
+
+    it('returns false when no word starts with the character', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'z' })).toBe(false)
+    })
+  })
+
+  describe('multi-character queries', () => {
+    it('matches a substring in the middle of the label', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'ish' })).toBe(true)
+    })
+
+    it('matches across a word boundary', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'd da' })).toBe(true)
+    })
+
+    it('is case-insensitive', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'DATE' })).toBe(true)
+    })
+
+    it('returns false when the substring is not present', () => {
+      expect(matchesColumnSearch({ labelText: 'Published Date', query: 'zzz' })).toBe(false)
+    })
+  })
+})

--- a/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.spec.ts
+++ b/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.spec.ts
@@ -35,6 +35,10 @@ describe('matchesColumnSearch', () => {
     it('returns false when no word starts with the character', () => {
       expect(matchesColumnSearch({ labelText: 'Published Date', query: 'z' })).toBe(false)
     })
+
+    it('matches the start of a non-Latin label', () => {
+      expect(matchesColumnSearch({ labelText: 'Пользователь', query: 'п' })).toBe(true)
+    })
   })
 
   describe('multi-character queries', () => {

--- a/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.ts
+++ b/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.ts
@@ -1,4 +1,4 @@
-const WORD_SPLIT_REGEX = /[^a-z0-9]+/i
+const WORD_SPLIT_REGEX = /[^\p{L}\p{N}]+/u
 
 /**
  * Matches a column label against a search query. Single-character queries only

--- a/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.ts
+++ b/packages/ui/src/elements/ColumnSelection/matchesColumnSearch.ts
@@ -1,0 +1,28 @@
+const WORD_SPLIT_REGEX = /[^a-z0-9]+/i
+
+/**
+ * Matches a column label against a search query. Single-character queries only
+ * match the start of a word, keeping single-letter searches low-noise; queries
+ * of two or more characters match anywhere in the label.
+ */
+export function matchesColumnSearch({
+  labelText,
+  query,
+}: {
+  labelText: string
+  query: string
+}): boolean {
+  const normalizedQuery = query.trim().toLowerCase()
+
+  if (!normalizedQuery) {
+    return true
+  }
+
+  const normalizedLabel = labelText.toLowerCase()
+
+  if (normalizedQuery.length === 1) {
+    return normalizedLabel.split(WORD_SPLIT_REGEX).some((word) => word.startsWith(normalizedQuery))
+  }
+
+  return normalizedLabel.includes(normalizedQuery)
+}


### PR DESCRIPTION
Previously it was a simple contains check against string values.

Now it will check only beginning of words if its one letter and then reverting to contains, this leads to better results on first impression.
