### PR TITLE
fix(ui): prevent input focus zoom on iPhone

### DIFF
--- a/packages/ui/src/layouts/Root/index.spec.ts
+++ b/packages/ui/src/layouts/Root/index.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { getViewportMeta, isIPhoneUserAgent } from './viewport.js'
+
+describe('RootLayout', () => {
+  it('should apply the focus zoom viewport workaround to iPhone user agents only', () => {
+    const iPhoneUserAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+    const androidUserAgent =
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36'
+
+    expect(isIPhoneUserAgent(iPhoneUserAgent)).toBe(true)
+    expect(isIPhoneUserAgent(androidUserAgent)).toBe(false)
+    expect(isIPhoneUserAgent(undefined)).toBe(false)
+    expect(getViewportMeta(iPhoneUserAgent).props).toEqual({
+      content: 'width=device-width, initial-scale=1, maximum-scale=1',
+      name: 'viewport',
+    })
+    expect(getViewportMeta(androidUserAgent).props).toEqual({
+      content: 'width=device-width, initial-scale=1',
+      name: 'viewport',
+    })
+  })
+})

--- a/packages/ui/src/layouts/Root/index.tsx
+++ b/packages/ui/src/layouts/Root/index.tsx
@@ -20,6 +20,7 @@ import { getRequestHighContrast } from '../../utilities/getRequestHighContrast.j
 import { getRequestTheme } from '../../utilities/getRequestTheme.js'
 import { initReq } from '../../utilities/initReq.js'
 import { NestProviders } from './NestProviders.js'
+import { getViewportMeta } from './viewport.js'
 // eslint-disable-next-line payload/no-imports-from-self -- Self-import via package path ensures consumer's bundler resolves the full SCSS chain (design tokens, preflight, etc.) in prod builds
 import '@payloadcms/ui/scss/app.scss'
 
@@ -155,6 +156,7 @@ const RootLayoutContent = async ({
   await applyLocaleFiltering({ clientConfig, config, req })
 
   const fontClassNames = fonts.map((f) => f.variable ?? f.className).filter(Boolean)
+  const viewportMeta = getViewportMeta(headers.get('user-agent') ?? undefined)
 
   return (
     <html
@@ -167,6 +169,7 @@ const RootLayoutContent = async ({
       suppressHydrationWarning={config?.admin?.suppressHydrationWarning ?? false}
     >
       <head>
+        {viewportMeta}
         <style>{`@layer payload-default, payload;`}</style>
         {headFromProps}
       </head>

--- a/packages/ui/src/layouts/Root/viewport.tsx
+++ b/packages/ui/src/layouts/Root/viewport.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export const isIPhoneUserAgent = (userAgent?: string): boolean => {
+  return /\biPhone\b/.test(userAgent ?? '')
+}
+
+const defaultViewportContent = 'width=device-width, initial-scale=1'
+
+export const getViewportMeta = (userAgent?: string): React.ReactNode => {
+  const content = isIPhoneUserAgent(userAgent)
+    ? `${defaultViewportContent}, maximum-scale=1`
+    : defaultViewportContent
+
+  return <meta content={content} name="viewport" />
+}


### PR DESCRIPTION
Adds an iPhone-specific admin viewport meta tag to prevent iOS Safari from auto-zooming focused inputs without changing field typography.

Android and other devices keep the default zoomable viewport so pinch zoom is not restricted there.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426840332100