### PR TITLE
ci: remove --json from pnpm publish to fix release hang on pnpm v11

### DIFF
--- a/tools/releaser/src/release.ts
+++ b/tools/releaser/src/release.ts
@@ -211,7 +211,7 @@ async function main() {
 
   // Publish only payload to get 5 min auth token
   packageDetails = packageDetails.filter((p) => p.name !== 'payload')
-  runCmd(`pnpm publish -C packages/payload --no-git-checks --json --tag ${tag}`, execOpts)
+  runCmd(`pnpm publish -C packages/payload --no-git-checks --tag ${tag}`, execOpts)
 
   const results: PublishResult[] = []
   for (const pkg of packageDetails) {
@@ -278,7 +278,7 @@ async function publishSinglePackage(pkg: PackageDetails, opts?: { dryRun?: boole
   console.log(chalk.bold(`🚀 ${pkg.name} publishing...`))
 
   try {
-    const cmdArgs = ['publish', '-C', pkg.packagePath, '--no-git-checks', '--json', '--tag', tag]
+    const cmdArgs = ['publish', '-C', pkg.packagePath, '--no-git-checks', '--tag', tag]
     if (dryRun) {
       cmdArgs.push('--dry-run')
       console.log(chalk.gray(`\n${logPrefix} pnpm ${cmdArgs.join(' ')}\n`))


### PR DESCRIPTION
# Overview

Fixes the release script hanging after "Tagging release" since the pnpm v11 upgrade (#17169).

pnpm v11's native `publish` treats `--json` as non-interactive and emits the web-auth URL as JSON instead of prompting, so the 2FA link never surfaces and the release hangs.

## Key Changes

- **Drop `--json` from `pnpm publish` in the releaser**

## References / Links

- [ci: upgrade pnpm to v11 (#17169)](https://github.com/payloadcms/payload/pull/17169) — the upgrade that surfaced this
- [pnpm 11.0 release notes](https://pnpm.io/blog/releases/11.0) — native publish, no longer delegates to the npm CLI
- [pnpm#11476](https://github.com/pnpm/pnpm/issues/11476) — `--json` emits empty stdout on publish
- [nx#35575](https://github.com/nrwl/nx/issues/35575) — pnpm 11 native publish writes nothing to stdout
- [Migrating from pnpm v10 to v11](https://pnpm.io/migration)
