### PR TITLE
fix(richtext-lexical): connect fixed toolbar to editor

### DIFF
--- a/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.css
+++ b/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.css
@@ -43,6 +43,7 @@
     }
 
     + .editor-container {
+      margin-top: calc(var(--spacer-2) * -1);
       border-radius: 0 0 var(--radius-medium) var(--radius-medium) !important;
 
       > .editor-scroller > .editor {

--- a/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.css
+++ b/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.css
@@ -43,7 +43,6 @@
     }
 
     + .editor-container {
-      margin-top: calc(var(--spacer-2) * -1);
       border-radius: 0 0 var(--radius-medium) var(--radius-medium) !important;
 
       > .editor-scroller > .editor {

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -213,22 +213,26 @@ const RichTextComponent: React.FC<
         />
         <ErrorBoundary fallbackRender={fallbackRender} onReset={() => {}}>
           {BeforeInput}
-          {/* Lexical may be in a drawer. We need to define another BulkUploadProvider to ensure that the bulk upload drawer
-          is rendered in the correct depth (not displayed *behind* the current drawer).
-          The `lexical-` prefix prevents drawer-slug collisions with non-lexical `BulkUploadProvider`s up the tree. */}
-          <BulkUploadProvider modalSlugPrefix={`lexical-${path}`}>
-            <LexicalProvider
-              composerKey={pathWithEditDepth}
-              editorConfig={editorConfig}
-              fieldProps={props}
-              isSmallWidthViewport={isSmallWidthViewport}
-              key={JSON.stringify({ path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
-              onChange={handleChange}
-              readOnly={disabled}
-              rtl={rtl}
-              value={value}
-            />
-          </BulkUploadProvider>
+          {/* Wraps the toolbar and editor as a single unit so the `__wrap` flex `gap`
+          treats them as one child and does not separate them. */}
+          <div className={`${baseClass}__editor-content`}>
+            {/* Lexical may be in a drawer. We need to define another BulkUploadProvider to ensure that the bulk upload drawer
+            is rendered in the correct depth (not displayed *behind* the current drawer).
+            The `lexical-` prefix prevents drawer-slug collisions with non-lexical `BulkUploadProvider`s up the tree. */}
+            <BulkUploadProvider modalSlugPrefix={`lexical-${path}`}>
+              <LexicalProvider
+                composerKey={pathWithEditDepth}
+                editorConfig={editorConfig}
+                fieldProps={props}
+                isSmallWidthViewport={isSmallWidthViewport}
+                key={JSON.stringify({ path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
+                onChange={handleChange}
+                readOnly={disabled}
+                rtl={rtl}
+                value={value}
+              />
+            </BulkUploadProvider>
+          </div>
           {AfterInput}
         </ErrorBoundary>
         <RenderCustomComponent

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -213,8 +213,6 @@ const RichTextComponent: React.FC<
         />
         <ErrorBoundary fallbackRender={fallbackRender} onReset={() => {}}>
           {BeforeInput}
-          {/* Wraps the toolbar and editor as a single unit so the `__wrap` flex `gap`
-          treats them as one child and does not separate them. */}
           <div className={`${baseClass}__editor-content`}>
             {/* Lexical may be in a drawer. We need to define another BulkUploadProvider to ensure that the bulk upload drawer
             is rendered in the correct depth (not displayed *behind* the current drawer).

--- a/packages/richtext-lexical/src/lexical/LexicalEditor.css
+++ b/packages/richtext-lexical/src/lexical/LexicalEditor.css
@@ -30,6 +30,7 @@
 
   .rich-text-lexical--show-gutter
     > .rich-text-lexical__wrap
+    > .rich-text-lexical__editor-content
     > .editor-container
     > .editor-scroller
     > .editor
@@ -40,6 +41,7 @@
 
   .rich-text-lexical:not(.rich-text-lexical--show-gutter)
     > .rich-text-lexical__wrap
+    > .rich-text-lexical__editor-content
     > .editor-container
     > .editor-scroller
     > .editor

--- a/packages/richtext-lexical/src/lexical/plugins/handles/DraggableBlockPlugin/index.css
+++ b/packages/richtext-lexical/src/lexical/plugins/handles/DraggableBlockPlugin/index.css
@@ -46,6 +46,7 @@
 
   .rich-text-lexical--show-gutter
     > .rich-text-lexical__wrap
+    > .rich-text-lexical__editor-content
     > .editor-container
     > .editor-scroller
     > .editor {

--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
@@ -21,6 +21,7 @@
 
   .rich-text-lexical--show-gutter
     > .rich-text-lexical__wrap
+    > .rich-text-lexical__editor-content
     > .editor-container
     > .editor-scroller
     > .editor {
@@ -33,6 +34,7 @@
     .rich-text-lexical.rich-text-lexical--show-gutter {
       &.error:not(:hover) {
         > .rich-text-lexical__wrap
+          > .rich-text-lexical__editor-content
           > .editor-container
           > .editor-scroller
           > .editor
@@ -43,6 +45,7 @@
 
       &.error:hover {
         > .rich-text-lexical__wrap
+          > .rich-text-lexical__editor-content
           > .editor-container
           > .editor-scroller
           > .editor
@@ -68,6 +71,7 @@
     .rich-text-lexical.rich-text-lexical--show-gutter {
       &.error {
         > .rich-text-lexical__wrap
+          > .rich-text-lexical__editor-content
           > .editor-container
           > .editor-scroller
           > .editor


### PR DESCRIPTION
Wraps the fixed toolbar and editor in a `rich-text-lexical__editor-content` element so the `.rich-text-lexical__wrap` flex `gap` treats them as a single child, rendering them as one connected unit. The field description keeps its gap since it remains a direct child of `__wrap`.

Introduces a wrapping `<div>` rather than cancelling the gap with a negative margin. The wrapper expresses the grouping structurally and keeps the toolbar's `position: sticky` scoped to the editor content, avoiding a magic-number margin coupled to the `--spacer-2` gap value.

Selectors that targeted `.editor-container` as a direct child of `.rich-text-lexical__wrap` are updated to account for the new `__editor-content` level.

#### Before
<img width="1316" height="302" alt="Screenshot 2026-07-10 at 2 12 04 PM" src="https://github.com/user-attachments/assets/69777fad-5fa7-4f2a-bbc9-c73ed79b2ac2" />


#### After
<img width="1311" height="289" alt="Screenshot 2026-07-10 at 2 12 15 PM" src="https://github.com/user-attachments/assets/192c2cf3-c0d5-492c-bc9f-b898094b8e93" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396007834497