### PR TITLE
fix(tanstack-start): prevent duplicate server load on soft navigation to list view

### DIFF
--- a/packages/next/src/adapters/router.tsx
+++ b/packages/next/src/adapters/router.tsx
@@ -55,6 +55,7 @@ export const NextRouterAdapter: React.FC<{ children: React.ReactNode }> = ({ chi
       push: nextRouter.push,
       refresh: nextRouter.refresh,
       replace: nextRouter.replace,
+      replaceState: (url) => window.history.replaceState(null, '', url),
     }),
     [nextRouter],
   )

--- a/packages/payload/src/admin/adapters/router.ts
+++ b/packages/payload/src/admin/adapters/router.ts
@@ -41,14 +41,14 @@ export type RouterAdapterRouter = {
    */
   replace: (path: string, options?: { scroll?: boolean }) => void
   /**
-   * Update the browser URL to reflect client state (e.g. syncing server-resolved
-   * query defaults back to the address bar) WITHOUT triggering a navigation,
-   * re-render, or data reload — the equivalent of `window.history.replaceState`.
+   * Use this property to standardize behaviors across different router implementations.
    *
-   * Frameworks whose router observes history mutations (e.g. TanStack Router
-   * monkeypatches `history.replaceState`) must suppress their own subscribers so
-   * this does not re-run route loaders. Optional: when absent, callers fall back
-   * to `window.history.replaceState`.
+   * It allows the browser URL to reflect client state WITHOUT triggering a router navigation event.
+   * This is useful in scenarios where you want to update the URL to reflect client state (e.g. query params)
+   * without causing a full page reload or re-running route loaders.
+   *
+   * In Next.js, calling `window.history.replaceState` directly is sufficient, as Next.js does not observe history mutations.
+   * In TanStack Router, they've monkeypatched `history.replaceState` to notify the router of changes.
    */
   replaceState?: (url: string) => void
 }

--- a/packages/payload/src/admin/adapters/router.ts
+++ b/packages/payload/src/admin/adapters/router.ts
@@ -42,13 +42,10 @@ export type RouterAdapterRouter = {
   replace: (path: string, options?: { scroll?: boolean }) => void
   /**
    * Use this property to standardize behaviors across different router implementations.
-   *
-   * It allows the browser URL to reflect client state WITHOUT triggering a router navigation event.
-   * This is useful in scenarios where you want to update the URL to reflect client state (e.g. query params)
-   * without causing a full page reload or re-running route loaders.
+   * Set it up to sync client state to the URL without triggering a second server load.
    *
    * In Next.js, calling `window.history.replaceState` directly is sufficient, as Next.js does not observe history mutations.
-   * In TanStack Router, they've monkeypatched `history.replaceState` to notify the router of changes.
+   * In TanStack Router, however, `history.replaceState` is monkeypatched to notify the router of changes.
    */
   replaceState?: (url: string) => void
 }

--- a/packages/payload/src/admin/adapters/router.ts
+++ b/packages/payload/src/admin/adapters/router.ts
@@ -40,6 +40,17 @@ export type RouterAdapterRouter = {
    * Replace the current path with a new one.
    */
   replace: (path: string, options?: { scroll?: boolean }) => void
+  /**
+   * Update the browser URL to reflect client state (e.g. syncing server-resolved
+   * query defaults back to the address bar) WITHOUT triggering a navigation,
+   * re-render, or data reload — the equivalent of `window.history.replaceState`.
+   *
+   * Frameworks whose router observes history mutations (e.g. TanStack Router
+   * monkeypatches `history.replaceState`) must suppress their own subscribers so
+   * this does not re-run route loaders. Optional: when absent, callers fall back
+   * to `window.history.replaceState`.
+   */
+  replaceState?: (url: string) => void
 }
 
 export type LinkAdapterProps = {

--- a/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
+++ b/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
@@ -112,9 +112,28 @@ export const TanStackRouterAdapter: RouterAdapterComponent = ({ children }) => {
     [router, toNavOptions],
   )
 
+  // Sync client state (e.g. server-resolved query defaults) to the URL without
+  // re-running the route loader. TanStack's browser history monkeypatches
+  // `window.history.replaceState` and notifies `router.load` on every call, so a
+  // raw `replaceState` would change `loaderDeps` and trigger a redundant second
+  // server load. `_ignoreSubscribers` suppresses that notification — the same
+  // flag TanStack uses internally when flushing history.
+  const replaceState = useCallback(
+    (url: string) => {
+      const { history } = router
+      history._ignoreSubscribers = true
+      try {
+        window.history.replaceState(null, '', url)
+      } finally {
+        history._ignoreSubscribers = false
+      }
+    },
+    [router],
+  )
+
   const adaptedRouter = useMemo(
-    () => ({ back, push, refresh, replace }),
-    [back, push, refresh, replace],
+    () => ({ back, push, refresh, replace, replaceState }),
+    [back, push, refresh, replace, replaceState],
   )
 
   // `location.searchStr` is the serialized query string; `location.search` is

--- a/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
+++ b/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
@@ -63,9 +63,11 @@ export const TanStackRouterAdapter: RouterAdapterComponent = ({ children }) => {
 
   const adaptedParams = useMemo(() => {
     const adapted: Record<string, string | string[]> = { ...params }
+
     if ('_splat' in params && typeof params._splat === 'string') {
       adapted.segments = params._splat.split('/').filter(Boolean)
     }
+
     return adapted
   }, [params])
 
@@ -83,28 +85,35 @@ export const TanStackRouterAdapter: RouterAdapterComponent = ({ children }) => {
       pathname: window.location.pathname,
       search: window.location.search,
     })
+
     const queryIndex = relativePath.indexOf('?')
+
     if (queryIndex === -1) {
       return { to: relativePath }
     }
+
     const searchObject = qs.parse(relativePath.slice(queryIndex + 1), {
       depth: 10,
       ignoreQueryPrefix: true,
     })
+
     // Function form replaces the search entirely (no merge with current search).
     return { search: () => searchObject, to: relativePath.slice(0, queryIndex) }
   }, [])
 
   const back = useCallback(() => router.history.back(), [router])
+
   const push = useCallback(
     (path: string, options?: { scroll?: boolean }) => {
       void router.navigate({ ...toNavOptions(path), resetScroll: options?.scroll })
     },
     [router, toNavOptions],
   )
+
   const refresh = useCallback(() => {
     void router.invalidate()
   }, [router])
+
   const replace = useCallback(
     (path: string, options?: { scroll?: boolean }) => {
       void router.navigate({ ...toNavOptions(path), replace: true, resetScroll: options?.scroll })
@@ -112,16 +121,16 @@ export const TanStackRouterAdapter: RouterAdapterComponent = ({ children }) => {
     [router, toNavOptions],
   )
 
-  // Sync client state (e.g. server-resolved query defaults) to the URL without
-  // re-running the route loader. TanStack's browser history monkeypatches
-  // `window.history.replaceState` and notifies `router.load` on every call, so a
-  // raw `replaceState` would change `loaderDeps` and trigger a redundant second
-  // server load. `_ignoreSubscribers` suppresses that notification — the same
-  // flag TanStack uses internally when flushing history.
+  // Mirror Next.js' router behavior to allow syncing client state to the URL without triggering a second server load.
+  // Sync client state (e.g. server-resolved query defaults) to the URL without re-running the route loader.
+  // TanStack's browser history monkeypatches `window.history.replaceState` and notifies `router.load` on every call,
+  // so a raw `replaceState` would change `loaderDeps` and trigger a redundant second server load.
+  // `_ignoreSubscribers` suppresses that notification — the same flag TanStack uses internally when flushing history.
   const replaceState = useCallback(
     (url: string) => {
       const { history } = router
       history._ignoreSubscribers = true
+
       try {
         window.history.replaceState(null, '', url)
       } finally {

--- a/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
+++ b/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
@@ -122,10 +122,8 @@ export const TanStackRouterAdapter: RouterAdapterComponent = ({ children }) => {
   )
 
   // Mirror Next.js' router behavior to allow syncing client state to the URL without triggering a second server load.
-  // Sync client state (e.g. server-resolved query defaults) to the URL without re-running the route loader.
-  // TanStack's browser history monkeypatches `window.history.replaceState` and notifies `router.load` on every call,
-  // so a raw `replaceState` would change `loaderDeps` and trigger a redundant second server load.
-  // `_ignoreSubscribers` suppresses that notification — the same flag TanStack uses internally when flushing history.
+  // TanStack's browser history monkeypatches `window.history.replaceState` and notifies `router.load` on every call.
+  // Use `_ignoreSubscribers` to suppresses that notification — the same flag TanStack uses internally when flushing history.
   const replaceState = useCallback(
     (url: string) => {
       const { history } = router

--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -147,7 +147,14 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
     if (window.location.search !== search) {
       setQuery(newQuery)
       // Important: do not use router.replace here to avoid re-rendering.
-      window.history.replaceState(null, '', search)
+      // Go through the adapter's replaceState so routers that observe history
+      // mutations (e.g. TanStack) don't re-run their loader and double-load the
+      // view. Falls back to the native call for adapters that don't implement it.
+      if (router.replaceState) {
+        router.replaceState(search)
+      } else {
+        window.history.replaceState(null, '', search)
+      }
     }
   })
 

--- a/test/tags/payload-types.ts
+++ b/test/tags/payload-types.ts
@@ -100,6 +100,8 @@ export interface Config {
   locale: null;
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -448,6 +450,39 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection: 'categories' | 'posts' | 'pages' | 'media' | 'tags' | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?: ('categories' | 'posts' | 'pages' | 'media' | 'tags' | 'users')[] | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Navigating into the list view on TanStack Start runs the route loader twice.

This is because on load, the list query provider syncs server-resolved query defaults back to the URL on the client, e.g. `list`, `sort`, etc. This does not inherently require a server roundtrip as one might expect, as the data has already been resolved properly on the server. In Next.js, we achieve this via `window.history.replaceState` which does not notify Next.js' router of the mutation.

In TanStack Router, however, `history.replaceState` is monkeypatched to subscribe to all updates, even those outside its own router methods. This means that during the URL sync, the route loader is called twice, once on initial load, and again when the URL is mutated.

The solution is to expose a new `replaceState` method to standardize this behavior across router implementations:

- Next.js calls `window.history.replaceState` directly.
- TanStack wraps it in `history._ignoreSubscribers`, the flag TanStack sets when flushing its own history, so the router isn't notified.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216204011123980