### PR TITLE
feat!: remove ClientUser in favor of AuthenticatedUser

### DIFF
--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -185,48 +185,60 @@ Several types and utilities that were re-exported from `@payloadcms/ui` and `@pa
 
 Run `npx @payloadcms/codemod --transform migrate-aliased-exports` to migrate automatically. Renamed types are imported using an `as` alias (e.g. `import type { CollectionPreferences as ListPreferences } from 'payload'`) so existing usages keep compiling — drop the alias and rename usages manually if you want to fully commit to the new name.
 
-### User types: `TypedUser` and `UntypedUser` removed; new `AuthenticatedUser`
+### User types consolidated into `User` and `AuthenticatedUser`
 
 Payload's user types have been consolidated so each one has a clear job. This completes a cleanup already planned in 3.x: `UntypedUser` was deprecated for removal in 4.0, and `TypedUser` was marked to be renamed to `User` in 4.0.
 
 Previously, the public `User` type was an alias of the loose `UntypedUser`, while `TypedUser` was the generated type for auth-enabled collections. `ClientUser` was also loose, and the runtime auth fields `_strategy` and `_sid` were not typed on `req.user`.
 
-There are now three types:
+There are now two types:
 
 - **`User`** — the generated type for a user of an auth-enabled collection (what `TypedUser` used to be). Without generated types, it falls back to a documented shape containing Payload's built-in auth fields.
-- **`AuthenticatedUser`** — `User` plus the optional runtime auth fields `_strategy` and `_sid`. This is what `req.user`, `payload.auth()`, and auth strategies return.
-- **`ClientUser`** — the user as seen on the client (`useAuth().user`) and in `me` responses. It is an alias of `AuthenticatedUser`; `_sid` is optional in the type but is not sent to the client.
+- **`AuthenticatedUser`** — `User` plus the optional runtime auth fields `_strategy` and `_sid`. This is what `req.user`, `payload.auth()`, auth strategies, `me` responses, and `useAuth().user` return.
 
-`ClientUser` already included `collection` through its old base type, and `collection` was already present in client responses. The old comment claiming it was server-only was incorrect. The change is that `ClientUser` now uses the generated user shape instead of a loose index signature.
+`AuthenticatedUser` is intentionally shared by server and client auth APIs. It describes the signed-in identity, not an exact serialization or sanitization contract: runtime, hidden, access-controlled, or unselected fields can be absent from individual responses. Use `User` for other stored or read user documents, including user documents rendered in client code.
+
+`_sid` is flow-dependent: request-authenticated users can carry it, while standard login, `me`, and refresh responses omit it.
+
+The `collection` property remains available on authenticated users and in client auth responses. Removing `ClientUser` does not change runtime serialization.
 
 **What changes:**
 
 - `TypedUser` is removed — replace it with `User`.
-- `UntypedUser` is removed — use `User` for a user document, `AuthenticatedUser` for a signed-in request user, or `ClientUser` in client code.
-- `User` and `ClientUser` no longer have a `{ [key: string]: any }` index signature. Custom auth-collection fields require generated types or an explicit augmented type or cast.
+- `UntypedUser` is removed — use `User` for a user document or `AuthenticatedUser` for the signed-in user.
+- `ClientUser` is removed — replace it with `AuthenticatedUser` for `useAuth().user`, `me` responses, and other client auth APIs.
+- `User` and `AuthenticatedUser` no longer have a `{ [key: string]: any }` index signature. Custom auth-collection fields require generated types or an explicit augmented type or cast.
 - `req.user` and `payload.auth().user` are now typed as `AuthenticatedUser`, so `_strategy` and `_sid` type-check.
+- `@payloadcms/plugin-ecommerce`'s `ClientUserWithCart` is removed — replace it with `UserWithCart`.
+- `MeOperationResult.user` and `refreshCookieAsync()` can be `null`, matching their existing runtime behavior. `refreshCookieAsync()` also preserves the custom user type passed to `useAuth<T>()`.
+- Collection `admin.hidden` callbacks now receive `PayloadRequest['user']`, including `null` when there is no authenticated user.
 - The Local API `user` option is now `User | null` instead of the loose `Document` type for collection `count`, `create`, `delete`, `duplicate`, `find`, `findByID`, `findDistinct`, and `update`; collection and global version operations; and global `findOne` and `update`.
 - `UserSession.createdAt` is now optional and nullable (`createdAt?: Date | null | string`) to match the generated session shape. Callers must handle a missing value.
 
 `AuthenticatedUser` is assignable to `User`, so passing `req.user` to Local API operations continues to work. Passing an arbitrary object now type-errors.
 
 ```diff
-- import type { TypedUser, UntypedUser } from 'payload'
+- import type { ClientUser, TypedUser, UntypedUser } from 'payload'
 + import type { AuthenticatedUser, User } from 'payload'
 
 - const user: TypedUser = req.user
 + const user: AuthenticatedUser = req.user
+
+- type CurrentUser = ClientUser
++ type CurrentUser = AuthenticatedUser
 ```
 
-Use `User` for stored or read user documents. Use `AuthenticatedUser` when code specifically receives the signed-in user from `req.user`, `payload.auth()`, or an auth strategy.
+Use `User` for stored or read user documents. Use `AuthenticatedUser` when code specifically receives the signed-in user from `req.user`, `payload.auth()`, an auth strategy, a `me` response, or `useAuth()`.
 
 **For plugin authors:** because `User` no longer has an index signature, reading a field your plugin adds to the user collection off `req.user` (or `User`) no longer type-checks. Declare an augmented type and cast `req.user` to it — this is what the first-party plugins now do (e.g. `@payloadcms/plugin-ecommerce` for its `cart` join field):
 
 ```ts
-import type { User } from 'payload'
+import type { AuthenticatedUser } from 'payload'
 
 // Your plugin adds a `cart` join field (or any custom field) to the user collection.
-type UserWithCart = { cart?: { docs?: (Cart | string)[] } | null } & User
+type UserWithCart = AuthenticatedUser & {
+  cart?: { docs?: (Cart | string)[] } | null
+}
 
 const user = req.user as null | UserWithCart
 user?.cart?.docs // now typed

--- a/packages/payload/src/auth/operations/me.ts
+++ b/packages/payload/src/auth/operations/me.ts
@@ -3,7 +3,6 @@ import { decodeJwt } from 'jose'
 import type { Collection } from '../../collections/config/types.js'
 import type { AuthenticatedUser } from '../../index.js'
 import type { JoinQuery, PayloadRequest, PopulateType, SelectType } from '../../types/index.js'
-import type { ClientUser } from '../types.js'
 
 export type MeOperationResult = {
   collection?: string
@@ -16,7 +15,7 @@ export type MeOperationResult = {
    */
   strategy?: string
   token?: string
-  user?: ClientUser
+  user?: AuthenticatedUser | null
 }
 
 export type Arguments = {

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -136,16 +136,14 @@ export type AuthRuntimeFields = {
 }
 
 /**
+ * Note: AuthenticatedUser still carries the write-only `password` from `User` (always `undefined` at runtime).
+ * Stripping it cleanly isn't possible, because auth operations build the authenticated user
+ * from a read `User` doc, so a `never`-typed `password` would break those assignments
+ */
+/**
  * The signed-in user: the read user plus the runtime auth markers (`_strategy`, `_sid`). This is
  * what `req.user`, `payload.auth()`, the `me` operation, auth strategies, and `useAuth().user`
  * return.
- *
- * This type describes the authenticated identity, not an exact serialization contract. Runtime,
- * hidden, access-controlled, or unselected fields can be absent from individual responses.
- *
- * `AuthenticatedUser` still carries the write-only `password` from `User` (always `undefined` at
- * runtime). Stripping it cleanly is not possible because auth operations build the authenticated
- * user from a read `User` document, so a `never`-typed `password` would break those assignments.
  */
 export type AuthenticatedUser = AuthRuntimeFields & User
 

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -125,7 +125,8 @@ export type SanitizedPermissions = {
  */
 export type AuthRuntimeFields = {
   /**
-   * The session ID of the current request. Present only when sessions are enabled.
+   * The session ID of the current request. May be present on request-authenticated users when
+   * sessions are enabled.
    */
   _sid?: string
   /**
@@ -135,21 +136,18 @@ export type AuthRuntimeFields = {
 }
 
 /**
- * Note: AuthenticatedUser still carries the write-only `password` from `User` (always `undefined` at runtime).
- * Stripping it cleanly isn't possible, because auth operations build the authenticated user
- * from a read `User` doc, so a `never`-typed `password` would break those assignments
- */
-/**
  * The signed-in user: the read user plus the runtime auth markers (`_strategy`, `_sid`). This is
- * what `req.user`, `payload.auth()`, the `me` operation, and auth strategies return.
+ * what `req.user`, `payload.auth()`, the `me` operation, auth strategies, and `useAuth().user`
+ * return.
+ *
+ * This type describes the authenticated identity, not an exact serialization contract. Runtime,
+ * hidden, access-controlled, or unselected fields can be absent from individual responses.
+ *
+ * `AuthenticatedUser` still carries the write-only `password` from `User` (always `undefined` at
+ * runtime). Stripping it cleanly is not possible because auth operations build the authenticated
+ * user from a read `User` document, so a `never`-typed `password` would break those assignments.
  */
 export type AuthenticatedUser = AuthRuntimeFields & User
-
-/**
- * The user as available on the client (`useAuth().user`). It is the authenticated user as
- * serialized to the browser: `collection` and `_strategy` are present, `_sid` is not sent.
- */
-export type ClientUser = AuthenticatedUser
 
 export type UserSession = {
   createdAt?: Date | null | string

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -8,7 +8,7 @@ import type {
   Arguments as RefreshArguments,
   Result as RefreshResult,
 } from '../../auth/operations/refresh.js'
-import type { Auth, ClientUser, IncomingAuthType } from '../../auth/types.js'
+import type { Auth, IncomingAuthType } from '../../auth/types.js'
 import type {
   Access,
   AfterErrorHookArgs,
@@ -503,7 +503,7 @@ export type CollectionAdminOptions = {
   /**
    * Exclude the collection from the admin nav and routes
    */
-  hidden?: ((args: { user: ClientUser }) => boolean) | boolean
+  hidden?: ((args: { user: PayloadRequest['user'] }) => boolean) | boolean
   /**
    * Additional fields to be searched via the full text search
    */

--- a/packages/plugin-ecommerce/src/exports/types.ts
+++ b/packages/plugin-ecommerce/src/exports/types.ts
@@ -1,5 +1,4 @@
 export type {
-  ClientUserWithCart,
   CollectionOverride,
   CollectionSlugMap,
   ContextProps,

--- a/packages/plugin-ecommerce/src/react/provider/index.tsx
+++ b/packages/plugin-ecommerce/src/react/provider/index.tsx
@@ -8,11 +8,11 @@ import React, { createContext, use, useCallback, useEffect, useMemo, useRef, use
 import type {
   AddressesCollection,
   CartsCollection,
-  ClientUserWithCart,
   ContextProps,
   Currency,
   EcommerceConfig,
   EcommerceContextType,
+  UserWithCart,
 } from '../../types/index.js'
 
 const defaultContext: EcommerceContextType = {
@@ -116,7 +116,7 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
 
   const [isLoading, setIsLoading] = useState(false)
 
-  const [user, setUser] = useState<ClientUserWithCart | null>(null)
+  const [user, setUser] = useState<null | UserWithCart>(null)
 
   const [addresses, setAddresses] = useState<AddressesCollection[]>()
 
@@ -660,7 +660,7 @@ export const EcommerceProvider: React.FC<ContextProps> = ({
 
       const userData: {
         error?: string
-        user?: ClientUserWithCart
+        user?: UserWithCart
       } = await response.json()
 
       if (userData.error) {

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -1,7 +1,6 @@
 import type {
   Access,
   AuthenticatedUser,
-  ClientUser,
   CollectionConfig,
   CollectionSlug,
   DefaultDocumentIDType,
@@ -54,9 +53,6 @@ type CartJoin = {
 
 /** Adds the optional reverse `cart` join that a project may define on its user collection. */
 export type UserWithCart = AuthenticatedUser & CartJoin
-
-/** The browser-safe user with the optional cart join. */
-export type ClientUserWithCart = CartJoin & ClientUser
 
 type InitiatePaymentReturnType = {
   /**
@@ -1067,5 +1063,5 @@ export type EcommerceContextType<T extends EcommerceCollections = EcommerceColle
   /**
    * The current authenticated user, or null if not logged in.
    */
-  user: ClientUserWithCart | null
+  user: null | UserWithCart
 }

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -1,10 +1,10 @@
 'use client'
 import type {
-  ClientUser,
   Data,
   SanitizedCollectionConfig,
   SanitizedCollectionPermission,
   SanitizedGlobalPermission,
+  User,
 } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
@@ -85,7 +85,7 @@ export const DocumentControls: React.FC<{
   readonly redirectAfterDuplicate?: boolean
   readonly redirectAfterRestore?: boolean
   readonly slug: SanitizedCollectionConfig['slug']
-  readonly user?: ClientUser
+  readonly user?: User
   /**
    * Controls how the document controls render.
    * - `default`: full controls bar (meta + actions), used on the edit page.

--- a/packages/ui/src/elements/DocumentDrawer/DrawerHeader/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerHeader/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ClientUser } from 'payload'
+import type { User } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import { hasAutosaveEnabled, hasDraftsEnabled } from 'payload/shared'
@@ -33,7 +33,7 @@ export const DocumentDrawerHeader: React.FC<{
   readOnlyForIncomingUser?: boolean
   renderTitleAsLink?: boolean
   Status?: React.ReactNode
-  user?: ClientUser
+  user?: User
 }> = ({
   actions,
   AfterHeader,

--- a/packages/ui/src/elements/DocumentLocked/index.tsx
+++ b/packages/ui/src/elements/DocumentLocked/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientUser } from 'payload'
+import type { User } from 'payload'
 
 import { useModal } from '@faceless-ui/modal'
 import React, { useEffect } from 'react'
@@ -41,7 +41,7 @@ export const DocumentLocked: React.FC<{
   onReadOnly: () => void
   onTakeOver: () => void
   updatedAt?: null | number
-  user?: ClientUser | number | string
+  user?: number | string | User
 }> = ({ handleGoBack, isActive, onReadOnly, onTakeOver, updatedAt, user }) => {
   const { closeModal, openModal } = useModal()
   const { t } = useTranslation()

--- a/packages/ui/src/elements/Locked/index.tsx
+++ b/packages/ui/src/elements/Locked/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientUser } from 'payload'
+import type { User } from 'payload'
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -14,7 +14,7 @@ const baseClass = 'locked'
 
 export const Locked: React.FC<{
   className?: string
-  user: ClientUser
+  user: User
 }> = ({ className, user }) => {
   const anchorRef = useRef<HTMLDivElement>(null)
   const [hovered, setHovered] = useState(false)

--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientUser } from 'payload'
+import type { User } from 'payload'
 
 import React from 'react'
 
@@ -14,7 +14,7 @@ const baseClass = 'select-row'
 export const SelectRow: React.FC<{
   rowData: {
     _isLocked: boolean
-    _userEditing: ClientUser
+    _userEditing: User
     id: string
   }
 }> = ({ rowData }) => {

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientUser, SanitizedPermissions } from 'payload'
+import type { AuthenticatedUser, SanitizedPermissions } from 'payload'
 
 import { useModal } from '@faceless-ui/modal'
 import { formatAdminURL } from 'payload/shared'
@@ -15,7 +15,7 @@ import { useConfig } from '../Config/index.js'
 import { usePathname, useRouter } from '../RouterAdapter/index.js'
 import { useRouteTransition } from '../RouteTransition/index.js'
 
-export type UserWithToken<T = ClientUser> = {
+export type UserWithToken<T = AuthenticatedUser> = {
   /** seconds until expiration */
   exp: number
   refreshedToken?: string
@@ -23,7 +23,7 @@ export type UserWithToken<T = ClientUser> = {
   user: T
 }
 
-export type AuthContext<T = ClientUser> = {
+export type AuthContext<T = AuthenticatedUser> = {
   fetchFullUser: () => Promise<null | T>
   logOut: () => Promise<boolean>
   /**
@@ -62,7 +62,7 @@ export type AuthContext<T = ClientUser> = {
    */
   permissions?: SanitizedPermissions
   refreshCookie: (forceRefresh?: boolean) => void
-  refreshCookieAsync: () => Promise<ClientUser>
+  refreshCookieAsync: () => Promise<null | T>
   refreshPermissions: () => Promise<void>
   setPermissions: (permissions: SanitizedPermissions) => void
   setUser: (user: null | UserWithToken<T>) => void
@@ -79,7 +79,7 @@ const maxTimeoutMs = 2147483647
 type Props = {
   children: React.ReactNode
   permissions?: SanitizedPermissions
-  user?: ClientUser | null
+  user?: AuthenticatedUser | null
 }
 
 export function AuthProvider({
@@ -106,7 +106,7 @@ export function AuthProvider({
   const { closeAllModals, openModal } = useModal()
   const { startRouteTransition } = useRouteTransition()
 
-  const [user, setUserInMemory] = useState<ClientUser | null>(initialUser)
+  const [user, setUserInMemory] = useState<AuthenticatedUser | null>(initialUser)
   const [tokenInMemory, setTokenInMemory] = useState<string>()
   const [tokenExpirationMs, setTokenExpirationMs] = useState<number>()
   const [permissions, setPermissions] = useState<SanitizedPermissions>(initialPermissions)
@@ -235,7 +235,7 @@ export function AuthProvider({
   )
 
   const refreshCookieAsync = useCallback(
-    async (skipSetUser?: boolean): Promise<ClientUser> => {
+    async (skipSetUser?: boolean): Promise<AuthenticatedUser | null> => {
       try {
         const request = await requests.post(
           formatAdminURL({
@@ -408,4 +408,4 @@ export function AuthProvider({
   )
 }
 
-export const useAuth = <T = ClientUser,>(): AuthContext<T> => use(Context) as AuthContext<T>
+export const useAuth = <T = AuthenticatedUser,>(): AuthContext<T> => use(Context) as AuthContext<T>

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientUser, DocumentPreferences } from 'payload'
+import type { DocumentPreferences, User } from 'payload'
 
 import { formatAdminURL } from 'payload/shared'
 import * as qs from 'qs-esm'
@@ -102,7 +102,7 @@ const DocumentInfo: React.FC<
     isLockedFromProps,
   )
 
-  const [currentEditor, setCurrentEditor] = useControllableState<ClientUser | null>(
+  const [currentEditor, setCurrentEditor] = useControllableState<null | User>(
     currentEditorFromProps,
   )
   const [lastUpdateTime, setLastUpdateTime] = useControllableState<number>(lastUpdateTimeFromProps)
@@ -116,7 +116,7 @@ const DocumentInfo: React.FC<
   const documentLockState = useRef<{
     hasShownLockedModal: boolean
     isLocked: boolean
-    user: ClientUser | number | string
+    user: number | string | User
   } | null>({
     hasShownLockedModal: false,
     isLocked: false,
@@ -206,7 +206,7 @@ const DocumentInfo: React.FC<
   )
 
   const updateDocumentEditor = useCallback(
-    async (docID: number | string, slug: string, user: ClientUser | number | string) => {
+    async (docID: number | string, slug: string, user: number | string | User) => {
       // Check if the locked-documents collection exists before making API calls
       if (!hasLockedDocumentsCollection) {
         return

--- a/packages/ui/src/providers/DocumentInfo/types.ts
+++ b/packages/ui/src/providers/DocumentInfo/types.ts
@@ -1,7 +1,6 @@
 import type {
   ClientCollectionConfig,
   ClientGlobalConfig,
-  ClientUser,
   Data,
   DocumentPreferences,
   FormState,
@@ -59,14 +58,14 @@ export type DocumentInfoProps = {
 }
 
 export type DocumentInfoContext = {
-  currentEditor?: ClientUser | null | number | string
+  currentEditor?: null | number | string | User
   data?: Data
   docConfig?: ClientCollectionConfig | ClientGlobalConfig
   documentIsLocked?: boolean
   documentLockState: React.RefObject<{
     hasShownLockedModal: boolean
     isLocked: boolean
-    user: ClientUser | number | string
+    user: number | string | User
   } | null>
   getDocPermissions: GetDocPermissions
   getDocPreferences: () => Promise<DocumentPreferences>
@@ -79,7 +78,7 @@ export type DocumentInfoContext = {
    * Use `data` instead.
    */
   savedDocumentData?: Data
-  setCurrentEditor?: React.Dispatch<React.SetStateAction<ClientUser>>
+  setCurrentEditor?: React.Dispatch<React.SetStateAction<User>>
   setData: (data: Data) => void
   setDocFieldPreferences: (
     field: string,
@@ -94,7 +93,7 @@ export type DocumentInfoContext = {
   setUploadStatus?: (status: 'failed' | 'idle' | 'uploading') => void
   unlockDocument: (docID: number | string, slug: string) => Promise<void>
   unpublishedVersionCount: number
-  updateDocumentEditor: (docID: number | string, slug: string, user: ClientUser) => Promise<void>
+  updateDocumentEditor: (docID: number | string, slug: string, user: User) => Promise<void>
   /**
    * @deprecated This property is deprecated and will be removed in v4.
    * Use `setData` instead.

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -1,10 +1,10 @@
 import type {
   BuildFormStateArgs,
   ClientConfig,
-  ClientUser,
   ErrorResult,
   FormState,
   ServerFunction,
+  User,
 } from 'payload'
 
 import { canAccessAdmin, formatErrors, UnauthorizedError } from 'payload'
@@ -23,7 +23,7 @@ import { handleStaleDataCheck } from './handleStaleDataCheck.js'
 export type LockedState = {
   isLocked: boolean
   lastEditedAt: string
-  user?: ClientUser | number | string
+  user?: number | string | User
 }
 
 export type StaleDataState = {

--- a/packages/ui/src/utilities/getGlobalData.ts
+++ b/packages/ui/src/utilities/getGlobalData.ts
@@ -1,4 +1,4 @@
-import type { ClientUser, PayloadRequest, User } from 'payload'
+import type { PayloadRequest, User } from 'payload'
 
 const globalLockDurationDefault = 300
 
@@ -12,7 +12,7 @@ export async function getGlobalData(req: PayloadRequest) {
   // I thought about moving it to a payload to share it, but we're already
   // exporting all the views props from the next package.
   let globalData: Array<{
-    data: { _isLocked: boolean; _lastEditedAt: string; _userEditing: ClientUser | number | string }
+    data: { _isLocked: boolean; _lastEditedAt: string; _userEditing: number | string | User }
     lockDuration?: number
     slug: string
   }> = []

--- a/packages/ui/src/utilities/handleTakeOver.tsx
+++ b/packages/ui/src/utilities/handleTakeOver.tsx
@@ -1,4 +1,4 @@
-import type { ClientUser } from 'payload'
+import type { AuthenticatedUser, User } from 'payload'
 
 export interface HandleTakeOverParams {
   clearRouteCache?: () => void
@@ -6,20 +6,20 @@ export interface HandleTakeOverParams {
   documentLockStateRef: React.RefObject<{
     hasShownLockedModal: boolean
     isLocked: boolean
-    user: ClientUser | number | string
+    user: number | string | User
   }>
   globalSlug?: string
   id: number | string
   isLockingEnabled: boolean
   isWithinDoc: boolean
-  setCurrentEditor: (value: React.SetStateAction<ClientUser | number | string>) => void
+  setCurrentEditor: (value: React.SetStateAction<number | string | User>) => void
   setIsReadOnlyForIncomingUser?: (value: React.SetStateAction<boolean>) => void
   updateDocumentEditor: (
     docID: number | string,
     slug: string,
-    user: ClientUser | number | string,
+    user: number | string | User,
   ) => Promise<void>
-  user: ClientUser | number | string
+  user: AuthenticatedUser | number | string
 }
 
 export const handleTakeOver = async ({

--- a/packages/ui/src/utilities/isClientUserObject.ts
+++ b/packages/ui/src/utilities/isClientUserObject.ts
@@ -1,5 +1,5 @@
-import type { ClientUser } from 'payload'
+import type { User } from 'payload'
 
-export const isClientUserObject = (user): user is ClientUser => {
+export const isClientUserObject = (user): user is User => {
   return user && typeof user === 'object'
 }

--- a/packages/ui/src/views/Dashboard/Default/index.tsx
+++ b/packages/ui/src/views/Dashboard/Default/index.tsx
@@ -1,4 +1,4 @@
-import type { AdminViewServerPropsOnly, ClientUser, Locale, ServerProps } from 'payload'
+import type { AdminViewServerPropsOnly, Locale, ServerProps, User } from 'payload'
 
 import React from 'react'
 
@@ -26,7 +26,7 @@ export type DashboardViewClientProps = {
 
 export type DashboardViewServerPropsOnly = {
   globalData: Array<{
-    data: { _isLocked: boolean; _lastEditedAt: string; _userEditing: ClientUser | number | string }
+    data: { _isLocked: boolean; _lastEditedAt: string; _userEditing: number | string | User }
     lockDuration?: number
     slug: string
   }>

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ClientUser, DocumentViewClientProps } from 'payload'
+import type { DocumentViewClientProps, User } from 'payload'
 
 import { formatAdminURL, hasAutosaveEnabled } from 'payload/shared'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -234,9 +234,9 @@ export function DefaultEditView({
           documentLockState.current = {
             hasShownLockedModal: documentLockState.current?.hasShownLockedModal || false,
             isLocked: true,
-            user: lockedState.user as ClientUser,
+            user: lockedState.user as User,
           }
-          setCurrentEditor(lockedState.user as ClientUser)
+          setCurrentEditor(lockedState.user as User)
         }
 
         // Update lastUpdateTime when lock state changes

--- a/packages/ui/src/views/HierarchyList/HierarchyTable/SlotTable.tsx
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/SlotTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ClientUser } from 'payload'
+import type { User } from 'payload'
 
 import React from 'react'
 
@@ -75,7 +75,7 @@ export type SlotTableProps<TRow = Record<string, unknown>> = {
    * Returns the user who is editing/locking a row, or undefined if not locked.
    * When a user is returned, a lock icon replaces the checkbox for that row.
    */
-  getRowLockedUser?: (row: TRow, index: number) => ClientUser | undefined
+  getRowLockedUser?: (row: TRow, index: number) => undefined | User
   /**
    * Merge checkbox header with first column header using colspan (default: false)
    * The first column header will span both checkbox and content cells

--- a/packages/ui/src/views/HierarchyList/HierarchyTable/types.ts
+++ b/packages/ui/src/views/HierarchyList/HierarchyTable/types.ts
@@ -1,4 +1,4 @@
-import type { ClientUser, PaginatedDocs } from 'payload'
+import type { PaginatedDocs, User } from 'payload'
 import type React from 'react'
 
 export type RelatedGroup = {
@@ -16,7 +16,7 @@ export type TableRow = {
   _hasChildren?: boolean
   _hierarchyIcon?: React.ReactNode
   _isLocked?: boolean
-  _userEditing?: ClientUser
+  _userEditing?: User
   id: number | string
 }
 

--- a/packages/ui/src/widgets/CollectionCards/getCollectionCardsData.ts
+++ b/packages/ui/src/widgets/CollectionCards/getCollectionCardsData.ts
@@ -1,4 +1,4 @@
-import type { ClientUser, PayloadRequest, SanitizedPermissions } from 'payload'
+import type { PayloadRequest, SanitizedPermissions, User } from 'payload'
 
 import { getAccessResults } from 'payload'
 
@@ -12,7 +12,7 @@ export type GlobalLockData = {
   data: {
     _isLocked: boolean
     _lastEditedAt: string
-    _userEditing: ClientUser | number | string
+    _userEditing: number | string | User
   }
   lockDuration?: number
   slug: string

--- a/packages/ui/src/widgets/CollectionCards/index.client.tsx
+++ b/packages/ui/src/widgets/CollectionCards/index.client.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientUser } from 'payload'
+import type { User } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import { EntityType, formatAdminURL } from 'payload/shared'
@@ -42,7 +42,7 @@ export const CollectionCardsClient: React.FC<CollectionCardsData> = ({
                     let href: string
                     let hasCreatePermission: boolean
                     let isLocked = null
-                    let userEditing: ClientUser | null = null
+                    let userEditing: null | User = null
 
                     if (type === EntityType.collection) {
                       title = getTranslation(label, i18n)
@@ -78,7 +78,7 @@ export const CollectionCardsClient: React.FC<CollectionCardsData> = ({
 
                       if (globalLockData) {
                         isLocked = globalLockData.data._isLocked
-                        userEditing = globalLockData.data._userEditing as ClientUser | null
+                        userEditing = globalLockData.data._userEditing as null | User
 
                         const lockDuration = globalLockData?.lockDuration
                         const lastEditedAt = new Date(globalLockData.data?._lastEditedAt).getTime()

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -1,12 +1,15 @@
 import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 import type {
+  AuthenticatedUser,
   BulkOperationResult,
   CollectionSlug,
   CustomDocumentViewConfig,
   DefaultDocumentViewConfig,
   GeneratedTypes,
   JoinQuery,
+  MeOperationResult,
   PaginatedDocs,
+  PayloadRequest,
   PayloadTypesShape,
   SelectType,
   TypedCollectionSelect,
@@ -76,6 +79,13 @@ import type {
 } from './payload-types.js'
 
 describe('Types testing', () => {
+  describe('authenticated user', () => {
+    test('should use AuthenticatedUser for request and me operation users', () => {
+      expect<PayloadRequest['user']>().type.toBe<AuthenticatedUser | null>()
+      expect<MeOperationResult['user']>().type.toBe<AuthenticatedUser | null | undefined>()
+    })
+  })
+
   test('payload.find', () => {
     expect(payload.find({ collection: 'users' })).type.toBe<Promise<PaginatedDocs<User>>>()
   })


### PR DESCRIPTION
Follow-up to #17151, which made `ClientUser` an exact alias of `AuthenticatedUser` and explicitly left its removal for a separate PR.

This PR:

- removes `ClientUser` and uses `AuthenticatedUser` for the signed-in identity returned by `req.user`, `payload.auth()`, auth strategies, `me`, and `useAuth()`
- uses `User` for stored or read user documents, including editor and lock data rendered on the client
- consolidates `@payloadcms/plugin-ecommerce`'s identical `ClientUserWithCart` and `UserWithCart` types into `UserWithCart`

## Why

`ClientUser` no longer described a distinct shape, so exposing both names made users choose between identical types without adding safety. The public distinction is now semantic:

- `User` is a stored or read auth-collection document
- `AuthenticatedUser` is the current signed-in identity, whether consumed on the server or client

## Breaking changes

- `ClientUser` is removed from `payload`. Use `AuthenticatedUser` for auth API and `useAuth()` users, or `User` for ordinary user documents.
- `ClientUserWithCart` is removed from `@payloadcms/plugin-ecommerce/types`. Use `UserWithCart`.
- `MeOperationResult.user` and `refreshCookieAsync()` now include `null`, matching their existing runtime behavior. `refreshCookieAsync()` also preserves the custom user type passed to `useAuth<T>()`.
- Collection `admin.hidden` callbacks now receive `PayloadRequest['user']`, including `null` when unauthenticated.

```diff
- import type { ClientUser } from 'payload'
+ import type { AuthenticatedUser } from 'payload'

- import type { ClientUserWithCart } from '@payloadcms/plugin-ecommerce/types'
+ import type { UserWithCart } from '@payloadcms/plugin-ecommerce/types'
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216460113762297