### PR TITLE
fix(ui): stop select filter infinite loop when leaving in/not_in

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/Select/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Select/index.tsx
@@ -5,9 +5,15 @@ import React from 'react'
 
 import type { SelectFilterProps as Props } from './types.js'
 
+import { useEffectEvent } from '../../../../hooks/useEffectEvent.js'
 import { useTranslation } from '../../../../providers/Translation/index.js'
 import { ReactSelect } from '../../../ReactSelect/index.js'
 import { formatOptions } from './formatOptions.js'
+import {
+  isMultiValueOperator,
+  resolveSelectFilterValue,
+  shouldWriteSelectScalar,
+} from './normalizeSelectValue.js'
 
 export const Select: React.FC<Props> = ({
   disabled,
@@ -18,12 +24,15 @@ export const Select: React.FC<Props> = ({
   onChange,
   operator,
   options: optionsFromProps,
-  value,
+  value: valueFromProps,
 }) => {
   const { i18n } = useTranslation()
   const [options, setOptions] = React.useState(formatOptions(optionsFromProps))
 
-  const isMulti = ['in', 'not_in'].includes(operator)
+  const isMulti = isMultiValueOperator(operator)
+  const value = resolveSelectFilterValue(operator, valueFromProps)
+  const lastWrittenRef = React.useRef<unknown>(undefined)
+
   let valueToRender
 
   if (isMulti && Array.isArray(value)) {
@@ -58,6 +67,7 @@ export const Select: React.FC<Props> = ({
         newValue = selectedOption.value
       }
 
+      lastWrittenRef.current = newValue
       onChange(newValue)
     },
     [isMulti, onChange],
@@ -67,11 +77,22 @@ export const Select: React.FC<Props> = ({
     setOptions(formatOptions(optionsFromProps))
   }, [optionsFromProps])
 
-  React.useEffect(() => {
-    if (!isMulti && Array.isArray(value)) {
-      onChange(value[0])
+  // leftover array under a single-value op → write scalar once (avoids update-depth loop)
+  const writeScalarIfNeeded = useEffectEvent(() => {
+    const decision = shouldWriteSelectScalar(operator, valueFromProps, lastWrittenRef.current)
+    if (decision.write) {
+      lastWrittenRef.current = decision.next
+      onChange(decision.next)
+      return
     }
-  }, [isMulti, onChange, value])
+    if (isMulti || !Array.isArray(valueFromProps)) {
+      lastWrittenRef.current = undefined
+    }
+  })
+
+  React.useEffect(() => {
+    writeScalarIfNeeded()
+  }, [operator, valueFromProps])
 
   return (
     <ReactSelect

--- a/packages/ui/src/elements/WhereBuilder/Condition/Select/normalizeSelectValue.spec.ts
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Select/normalizeSelectValue.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isMultiValueOperator,
+  resolveSelectFilterValue,
+  shouldWriteSelectScalar,
+} from './normalizeSelectValue.js'
+
+describe('normalizeSelectValue', () => {
+  describe('isMultiValueOperator', () => {
+    it('treats in / not_in as multi', () => {
+      expect(isMultiValueOperator('in')).toBe(true)
+      expect(isMultiValueOperator('not_in')).toBe(true)
+      expect(isMultiValueOperator('equals')).toBe(false)
+      expect(isMultiValueOperator('not_equals')).toBe(false)
+    })
+  })
+
+  describe('resolveSelectFilterValue', () => {
+    it('unwraps array values under single-value operators', () => {
+      expect(resolveSelectFilterValue('equals', ['a', 'b'])).toBe('a')
+      expect(resolveSelectFilterValue('equals', [])).toBeUndefined()
+    })
+
+    it('keeps arrays under multi-value operators', () => {
+      expect(resolveSelectFilterValue('in', ['a', 'b'])).toEqual(['a', 'b'])
+    })
+
+    it('passes scalars through', () => {
+      expect(resolveSelectFilterValue('equals', 'a')).toBe('a')
+      expect(resolveSelectFilterValue('in', 'a')).toBe('a')
+    })
+  })
+
+  describe('shouldWriteSelectScalar', () => {
+    it('writes once when a multi value is left under a single-value operator', () => {
+      expect(shouldWriteSelectScalar('equals', ['a', 'b'], undefined)).toEqual({
+        write: true,
+        next: 'a',
+      })
+    })
+
+    it('does not re-write the same scalar (breaks max-update-depth loops)', () => {
+      expect(shouldWriteSelectScalar('equals', ['a', 'b'], 'a')).toEqual({ write: false })
+    })
+
+    it('does not write under multi-value operators', () => {
+      expect(shouldWriteSelectScalar('in', ['a', 'b'], undefined)).toEqual({ write: false })
+    })
+  })
+})

--- a/packages/ui/src/elements/WhereBuilder/Condition/Select/normalizeSelectValue.ts
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Select/normalizeSelectValue.ts
@@ -1,0 +1,32 @@
+const MULTI_VALUE_OPERATORS = new Set(['in', 'not_in'])
+
+export function isMultiValueOperator(operator: string | undefined): boolean {
+  return Boolean(operator && MULTI_VALUE_OPERATORS.has(operator))
+}
+
+// single-value ops can still hold an array after switching off in/not_in
+export function resolveSelectFilterValue(
+  operator: string | undefined,
+  value: unknown,
+): unknown {
+  if (!isMultiValueOperator(operator) && Array.isArray(value)) {
+    return value[0]
+  }
+  return value
+}
+
+// only write once for a given scalar so a sticky array doesn't loop
+export function shouldWriteSelectScalar(
+  operator: string | undefined,
+  value: unknown,
+  lastWritten: unknown,
+): { write: false } | { write: true; next: unknown } {
+  if (!isMultiValueOperator(operator) && Array.isArray(value)) {
+    const next = value[0]
+    if (Object.is(lastWritten, next)) {
+      return { write: false }
+    }
+    return { write: true, next }
+  }
+  return { write: false }
+}


### PR DESCRIPTION
fixes #17248

noticed the select list filter could blow up with max update depth after switching from `in` / `not_in` back to something like equals. value was still an array and the effect kept calling onChange.

coerce for display, write the scalar once, and don't write again for the same value. unit tests for the unwrap + the loop guard.