### PR TITLE
fix(ui): keep 0 and false in WhereBuilder filter values

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -21,6 +21,7 @@ import { Button } from '../Button/index.js'
 import { Condition } from './Condition/index.js'
 import './index.css'
 import { fieldTypeConditions, getValidFieldOperators } from './field-types.js'
+import { resolveWhereValue } from './resolveWhereValue.js'
 
 const baseClass = 'where-builder'
 
@@ -267,7 +268,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
                   const operator =
                     (Object.keys(condition?.[fieldPath] || {})?.[0] as Operator) || undefined
 
-                  const value = condition?.[fieldPath]?.[operator] || undefined
+                  const value = resolveWhereValue(condition?.[fieldPath]?.[operator])
 
                   const isFirstCondition = orIndex === 0 && andIndex === 0
                   const join: 'and' | 'or' = andIndex === 0 ? 'or' : 'and'

--- a/packages/ui/src/elements/WhereBuilder/resolveWhereValue.spec.ts
+++ b/packages/ui/src/elements/WhereBuilder/resolveWhereValue.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveWhereValue } from './resolveWhereValue.js'
+
+describe('resolveWhereValue', () => {
+  it('keeps 0 and false', () => {
+    expect(resolveWhereValue(0)).toBe(0)
+    expect(resolveWhereValue(false)).toBe(false)
+    expect(resolveWhereValue('')).toBe('')
+  })
+
+  it('turns null/undefined into undefined', () => {
+    expect(resolveWhereValue(null)).toBeUndefined()
+    expect(resolveWhereValue(undefined)).toBeUndefined()
+  })
+})

--- a/packages/ui/src/elements/WhereBuilder/resolveWhereValue.ts
+++ b/packages/ui/src/elements/WhereBuilder/resolveWhereValue.ts
@@ -1,0 +1,4 @@
+// nullish only so 0 / false stay as real filter values
+export function resolveWhereValue(raw: unknown): unknown {
+  return raw ?? undefined
+}


### PR DESCRIPTION
the where builder was reading filter values with `||`, so a value of `0` (or `false`) got wiped when rendering the row. switched to nullish coalescing so those stay.

tiny helper + unit tests.