### PR TITLE
fix(ui): autosave-enabled document drawers close unexpectedly within the list drawer

### DIFF
--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -151,6 +151,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
               context: {
                 getDocPermissions: false,
                 incrementVersionCount: !mostRecentVersionIsAutosaved,
+                isAutosave: true,
               },
               disableFormWhileProcessing: false,
               disableSuccessStatus: true,

--- a/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
@@ -142,7 +142,14 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
   }, [refresh, ListView, selectedOption.value])
 
   const onCreateNew = useCallback(
-    ({ doc }) => {
+    ({ context, doc }) => {
+      // Autosave triggers `onSave` on every interval. Only select the document
+      // and close the drawers on an explicit save, otherwise the entire drawer
+      // stack would collapse while the user is still editing.
+      if (context?.isAutosave) {
+        return
+      }
+
       if (typeof onSelect === 'function') {
         onSelect({
           collectionSlug: selectedOption?.value,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -49,6 +49,10 @@ const PENDING_SUCCESS_TOAST_KEY = 'payload-pending-success-toast'
 export type OnSaveContext = {
   getDocPermissions?: boolean
   incrementVersionCount?: boolean
+  /**
+   * Set to `true` when the save was triggered by autosave rather than an explicit user action.
+   */
+  isAutosave?: boolean
 }
 
 // This component receives props only on _pages_

--- a/test/versions/collections/Posts.ts
+++ b/test/versions/collections/Posts.ts
@@ -16,6 +16,14 @@ const Posts: CollectionConfig = {
       relationTo: autosaveCollectionSlug,
     },
     {
+      name: 'relationToAutosavesWithDrawer',
+      type: 'relationship',
+      admin: {
+        appearance: 'drawer',
+      },
+      relationTo: autosaveCollectionSlug,
+    },
+    {
       name: 'relationToVersions',
       type: 'relationship',
       relationTo: versionCollectionSlug,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -488,6 +488,48 @@ describe('Versions', () => {
       await expect(drawer.locator('.id-label')).toBeVisible()
     })
 
+    test('collection - autosave - should not close the drawer stack when autosave runs within the list drawer', async () => {
+      const { id: postID } = await payload.create({
+        collection: postCollectionSlug,
+        data: {
+          description: 'post description',
+          title: 'post title',
+        },
+      })
+
+      await page.goto(postURL.edit(postID))
+
+      // opening the menu of a `drawer` appearance relationship field opens the list drawer
+      await page.locator('#field-relationToAutosavesWithDrawer .rs__control').click()
+
+      const listDrawer = page.locator('[id^=list-drawer_1_]')
+      await expect(listDrawer).toBeVisible()
+
+      await openDocDrawer(page, 'button.list-header__create-new-button.doc-drawer__toggler')
+
+      const docDrawer = page.locator('[id^=doc-drawer_autosave-posts_1_]')
+      await expect(docDrawer).toBeVisible()
+
+      await docDrawer.locator('#field-title').fill('drawer stack title')
+      await docDrawer.locator('#field-description').fill('drawer stack description')
+
+      await waitForAutoSaveToRunAndComplete(docDrawer)
+
+      // both drawers should remain open after autosave runs
+      await expect(docDrawer).toBeVisible()
+      await expect(listDrawer).toBeVisible()
+
+      // an explicit save should select the document and close both drawers
+      await saveDocAndAssert(page, '[id^=doc-drawer_autosave-posts_1_] button#action-save')
+
+      await expect(docDrawer).toBeHidden()
+      await expect(listDrawer).toBeHidden()
+
+      await expect(
+        page.locator('#field-relationToAutosavesWithDrawer .relationship--single-value__text'),
+      ).toHaveText('drawer stack title')
+    })
+
     test('collection - autosave - should redirect from create to edit URL after first save', async () => {
       await page.goto(autosaveURL.list)
       await page.locator('#create-new-doc').click()

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -62,30 +62,31 @@ export type SupportedTimezones =
   | 'Pacific/Fiji';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_E98BC274".
+ * via the `definition` "LexicalNodes_55A1DAD6".
  */
-export type LexicalNodes_E98BC274 =
+export type LexicalNodes_55A1DAD6 =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_E98BC274>
+  | SerializedParagraphNode<LexicalNodes_55A1DAD6>
   | SerializedBlockNode<MyBlock>
-  | SerializedHeadingNode<LexicalNodes_E98BC274>
+  | SerializedHeadingNode<LexicalNodes_55A1DAD6>
   | SerializedUploadNode<'draft-with-upload'>
   | SerializedUploadNode<'draft-with-upload-cloud-storage'>
   | SerializedUploadNode<'media', LexicalUploadFields_1AB4670B>
   | SerializedUploadNode<'media2'>
-  | SerializedQuoteNode<LexicalNodes_E98BC274>
-  | SerializedListNode<LexicalNodes_E98BC274>
-  | SerializedListItemNode<LexicalNodes_E98BC274>
-  | SerializedAutoLinkNode<LexicalNodes_E98BC274, LexicalLinkFields_0A7E9EC0>
-  | SerializedLinkNode<LexicalNodes_E98BC274, LexicalLinkFields_0A7E9EC0>
+  | SerializedQuoteNode<LexicalNodes_55A1DAD6>
+  | SerializedListNode<LexicalNodes_55A1DAD6>
+  | SerializedListItemNode<LexicalNodes_55A1DAD6>
+  | SerializedAutoLinkNode<LexicalNodes_55A1DAD6, LexicalLinkFields_0A7E9EC0>
+  | SerializedLinkNode<LexicalNodes_55A1DAD6, LexicalLinkFields_0A7E9EC0>
   | SerializedRelationshipNode<
       | 'disable-publish'
       | 'posts'
       | 'autosave-posts'
       | 'autosave-with-draft-button-posts'
       | 'autosave-multi-select-posts'
+      | 'nested-array-select'
       | 'autosave-with-validate-posts'
       | 'draft-posts'
       | 'drafts-no-read-versions'
@@ -118,6 +119,7 @@ export interface Config {
     'autosave-posts': AutosavePost;
     'autosave-with-draft-button-posts': AutosaveWithDraftButtonPost;
     'autosave-multi-select-posts': AutosaveMultiSelectPost;
+    'nested-array-select': NestedArraySelect;
     'autosave-with-validate-posts': AutosaveWithValidatePost;
     'draft-posts': DraftPost;
     'drafts-no-read-versions': DraftsNoReadVersion;
@@ -149,6 +151,7 @@ export interface Config {
     'autosave-posts': AutosavePostsSelect<false> | AutosavePostsSelect<true>;
     'autosave-with-draft-button-posts': AutosaveWithDraftButtonPostsSelect<false> | AutosaveWithDraftButtonPostsSelect<true>;
     'autosave-multi-select-posts': AutosaveMultiSelectPostsSelect<false> | AutosaveMultiSelectPostsSelect<true>;
+    'nested-array-select': NestedArraySelectSelect<false> | NestedArraySelectSelect<true>;
     'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'draft-posts': DraftPostsSelect<false> | DraftPostsSelect<true>;
     'drafts-no-read-versions': DraftsNoReadVersionsSelect<false> | DraftsNoReadVersionsSelect<true>;
@@ -253,6 +256,7 @@ export interface DisablePublish {
 export interface Post {
   id: string;
   relationToAutosaves?: (string | null) | AutosavePost;
+  relationToAutosavesWithDrawer?: (string | null) | AutosavePost;
   relationToVersions?: (string | null) | VersionPost;
   relationToDrafts?: (string | null) | DraftPost;
   updatedAt: string;
@@ -267,7 +271,7 @@ export interface AutosavePost {
   title: string;
   relationship?: (string | null) | Post;
   computedTitle?: string | null;
-  richText?: LexicalRichText<LexicalNodes_E98BC274> | null;
+  richText?: LexicalRichText<LexicalNodes_55A1DAD6> | null;
   json?:
     | {
         [k: string]: unknown;
@@ -346,6 +350,27 @@ export interface AutosaveMultiSelectPost {
   id: string;
   title: string;
   tag?: ('blog' | 'essay' | 'portfolio')[] | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-array-select".
+ */
+export interface NestedArraySelect {
+  id: string;
+  outer?:
+    | {
+        inner?:
+          | {
+              days?: ('monday' | 'tuesday' | 'wednesday')[] | null;
+              id?: string | null;
+            }[]
+          | null;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -565,8 +590,8 @@ export interface Diff {
       )[]
     | null;
   zeroDepthRelationship?: (string | null) | User;
-  richtext?: LexicalRichText<LexicalNodes_E98BC274> | null;
-  richtextWithCustomDiff?: LexicalRichText<LexicalNodes_E98BC274> | null;
+  richtext?: LexicalRichText<LexicalNodes_55A1DAD6> | null;
+  richtextWithCustomDiff?: LexicalRichText<LexicalNodes_55A1DAD6> | null;
   textInRow?: string | null;
   textCannotRead?: string | null;
   select?: ('option1' | 'option2') | null;
@@ -900,6 +925,10 @@ export interface PayloadLockedDocument {
         value: string | AutosaveMultiSelectPost;
       } | null)
     | ({
+        relationTo: 'nested-array-select';
+        value: string | NestedArraySelect;
+      } | null)
+    | ({
         relationTo: 'autosave-with-validate-posts';
         value: string | AutosaveWithValidatePost;
       } | null)
@@ -1029,6 +1058,7 @@ export interface DisablePublishSelect<T extends boolean = true> {
  */
 export interface PostsSelect<T extends boolean = true> {
   relationToAutosaves?: T;
+  relationToAutosavesWithDrawer?: T;
   relationToVersions?: T;
   relationToDrafts?: T;
   updatedAt?: T;
@@ -1072,6 +1102,26 @@ export interface AutosaveWithDraftButtonPostsSelect<T extends boolean = true> {
 export interface AutosaveMultiSelectPostsSelect<T extends boolean = true> {
   title?: T;
   tag?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-array-select_select".
+ */
+export interface NestedArraySelectSelect<T extends boolean = true> {
+  outer?:
+    | T
+    | {
+        inner?:
+          | T
+          | {
+              days?: T;
+              id?: T;
+            };
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1753,6 +1803,7 @@ export interface CollectionQueryWidget {
       | 'autosave-posts'
       | 'autosave-with-draft-button-posts'
       | 'autosave-multi-select-posts'
+      | 'nested-array-select'
       | 'autosave-with-validate-posts'
       | 'draft-posts'
       | 'drafts-no-read-versions'
@@ -1799,6 +1850,7 @@ export interface ActivityWidget {
           | 'autosave-posts'
           | 'autosave-with-draft-button-posts'
           | 'autosave-multi-select-posts'
+          | 'nested-array-select'
           | 'autosave-with-validate-posts'
           | 'draft-posts'
           | 'drafts-no-read-versions'


### PR DESCRIPTION
### What?

Fixes the entire drawer stack (list drawer + document drawer) closing while the user is still editing, whenever autosave runs inside a "Create new" document drawer opened from a list drawer — e.g. a relationship field with `appearance: 'drawer'` whose target collection has autosave enabled.

https://github.com/user-attachments/assets/069abd89-439a-4a88-9d3d-c90f0d8aee1e (recording from the linked issue)

### Why?

The list drawer renders its "Create new" document drawer with `onSave={onCreateNew}`, and `onCreateNew` unconditionally selects the document and closes both drawers on **every** save event.

For autosave-enabled collections this breaks down:

1. The draft is created server-side as soon as the create drawer opens (`views/Document/index.tsx`), so every subsequent save inside the drawer reaches `onSave` with `operation: 'update'`.
2. Autosave runs through the same `Form.submit()` → `onSuccess` → `onSave` chain as an explicit save, so the first autosave interval (while the user is still typing) fires `onCreateNew` and collapses the whole drawer stack mid-edit.

Additionally, since the relationship field's `onSelect` appends to `hasMany` values without deduplication, repeated autosaves could select the same document multiple times.

Note this cannot reuse the fix from #13298 (close only on `operation === 'create'`): in the list drawer flow that would mean autosave-enabled documents are never selected into the field at all, because their saves are always `'update'`.

### How?

Autosave submissions are now marked with `isAutosave: true` on the (already existing, experimental) `OnSaveContext` that flows from `submit()` through the `onSave` chain. `onCreateNew` skips these events:

- Autosave keeps the drawer stack open while the user edits.
- An explicit Save/Publish click carries no `isAutosave` flag, so it selects the document and closes both drawers exactly as before.
- Non-versioned collections are unaffected (`operation: 'create'`, no context).

Only the `Autosave` component ever passes a submit `context`, so there is no collision risk with other save paths.

Includes an e2e test in `test/versions` covering the full flow: open list drawer → create new → autosave runs (stack stays open) → explicit save (document selected, both drawers close).

Fixes #16098
The same bug reproduces on `3.x` (reported against `payload@3.80.0`), so this is likely worth a backport.
