### PR TITLE
fix(graphql): prevent duplicate type for recursive blocks sharing a slug

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -205,13 +205,22 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           parentName: interfaceName,
         })
 
+        // Register the type BEFORE forcing field resolution below: `getFields()`
+        // eagerly resolves nested fields, so a block that nests itself (recursive,
+        // depth-limited block structures sharing one slug/interfaceName) would
+        // otherwise re-enter this handler while the registry is still empty and
+        // construct a duplicate GraphQLObjectType with the same name, producing an
+        // invalid schema ("Schema must contain uniquely named types").
+        graphqlResult.types.blockTypes[block.slug] = objectType
+
         if (Object.keys(objectType.getFields()).length) {
           // Store block slug in extensions for use in select building
           objectType.extensions = {
             ...objectType.extensions,
             blockSlug: block.slug,
           }
-          graphqlResult.types.blockTypes[block.slug] = objectType
+        } else {
+          delete graphqlResult.types.blockTypes[block.slug]
         }
       }
 

--- a/test/graphql/blocks/RecursiveBlock.ts
+++ b/test/graphql/blocks/RecursiveBlock.ts
@@ -1,0 +1,37 @@
+import type { Block, Field } from 'payload'
+
+export const recursiveBlockSlug = 'recursiveItem'
+
+export const recursiveBlockInterfaceName = 'RecursiveItemBlock'
+
+/**
+ * Depth-limited recursive block factory: every nesting level returns a distinct
+ * block config object sharing the same `slug` and `interfaceName`, with the
+ * deepest level omitting the `children` field. This is the documented community
+ * pattern for recursive block structures (navigation trees, nested form
+ * fieldsets, ...) and must produce a single GraphQL type instead of one
+ * duplicate type per nesting level.
+ */
+export const buildRecursiveBlock = (depth: number): Block => {
+  const fields: Field[] = [
+    {
+      name: 'label',
+      type: 'text',
+      required: true,
+    },
+  ]
+
+  if (depth > 1) {
+    fields.push({
+      name: 'children',
+      type: 'blocks',
+      blocks: [buildRecursiveBlock(depth - 1)],
+    })
+  }
+
+  return {
+    slug: recursiveBlockSlug,
+    fields,
+    interfaceName: recursiveBlockInterfaceName,
+  }
+}

--- a/test/graphql/config.ts
+++ b/test/graphql/config.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { ContentBlock } from './blocks/ContentBlock.js'
+import { buildRecursiveBlock } from './blocks/RecursiveBlock.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -36,6 +37,14 @@ export default buildConfigWithDefaults({
           name: 'contentBlockField',
           type: 'blocks',
           blocks: [ContentBlock],
+        },
+        {
+          // Recursive, depth-limited block structure: every level is a distinct
+          // config object sharing the same slug + interfaceName. Must build a
+          // single (self-referential) GraphQL type, not one duplicate per level.
+          name: 'recursiveBlockField',
+          type: 'blocks',
+          blocks: [buildRecursiveBlock(3)],
         },
       ],
       versions: false,

--- a/test/graphql/int.spec.ts
+++ b/test/graphql/int.spec.ts
@@ -1,8 +1,8 @@
-import type { GraphQLInputObjectType } from 'graphql'
+import type { GraphQLInputObjectType, GraphQLObjectType, GraphQLUnionType } from 'graphql'
 import type { Payload } from 'payload'
 
 import { configToSchema } from '@payloadcms/graphql'
-import { GraphQLNonNull } from 'graphql'
+import { getNamedType, GraphQLNonNull } from 'graphql'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -11,6 +11,7 @@ import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
 import { idToString } from '../__helpers/shared/idToString.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { recursiveBlockInterfaceName } from './blocks/RecursiveBlock.js'
 
 let payload: Payload
 let restClient: NextRESTClient
@@ -294,6 +295,89 @@ query {
         .then((res) => res.json())
 
       expect(afterDelete.errors).toBeUndefined()
+    })
+
+    describe('recursive blocks', () => {
+      it('should build a single self-referential type for recursive blocks sharing a slug', () => {
+        // Before the fix this threw at schema construction:
+        // "Schema must contain uniquely named types but contains multiple types
+        // named "RecursiveItemBlock"." — one duplicate type per nesting level.
+        const { schema } = configToSchema(payload.config)
+
+        const blockType = schema.getType(recursiveBlockInterfaceName) as GraphQLObjectType
+
+        expect(blockType).toBeDefined()
+
+        const childrenUnion = getNamedType(blockType.getFields().children!.type) as GraphQLUnionType
+
+        // The nested `children` union must reference the exact same type object,
+        // not a duplicate created while re-entering the blocks field handler.
+        expect(childrenUnion.getTypes()).toContain(blockType)
+      })
+
+      it('should query nested recursive blocks through GraphQL', async () => {
+        const post = await payload.create({
+          collection: 'posts',
+          data: {
+            recursiveBlockField: [
+              {
+                blockType: 'recursiveItem',
+                children: [
+                  {
+                    blockType: 'recursiveItem',
+                    children: [
+                      {
+                        blockType: 'recursiveItem',
+                        label: 'level-3',
+                      },
+                    ],
+                    label: 'level-2',
+                  },
+                ],
+                label: 'level-1',
+              },
+            ],
+            title: 'Post with recursive blocks',
+          },
+        })
+
+        const query = `query {
+          Post(id: ${idToString(post.id, payload)}) {
+            recursiveBlockField {
+              ... on ${recursiveBlockInterfaceName} {
+                label
+                children {
+                  ... on ${recursiveBlockInterfaceName} {
+                    label
+                    children {
+                      ... on ${recursiveBlockInterfaceName} {
+                        label
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`
+
+        const response = await restClient
+          .GRAPHQL_POST({ body: JSON.stringify({ query }) })
+          .then((res) => res.json())
+
+        expect(response.errors).toBeFalsy()
+
+        const [root] = response.data.Post.recursiveBlockField
+
+        expect(root.label).toBe('level-1')
+        expect(root.children[0].label).toBe('level-2')
+        expect(root.children[0].children[0].label).toBe('level-3')
+
+        await payload.delete({
+          collection: 'posts',
+          id: post.id,
+        })
+      })
     })
 
     describe('nullable schema types', () => {


### PR DESCRIPTION
### What?

GraphQL schema creation fails with

```
Error: Schema must contain uniquely named types but contains multiple types named "NavItemBlock".
```

whenever a config uses the documented community pattern for recursive, depth-limited block structures — a factory that returns one block config object per nesting level, all sharing the same `slug` and `interfaceName` (navigation trees, nested form fieldsets, etc.; see e.g. discussion #4238). Every API request against `/api/graphql` then returns a 500, including a trivial `{ __typename }` query.

### Why?

The `blocks` handler in `fieldToSchemaMap` deduplicates block types through the `graphqlResult.types.blockTypes` registry, keyed by block slug — but it only registers the newly built type **after** calling `objectType.getFields()`. That call eagerly resolves the type's fields, which walks any nested `blocks` fields and re-enters the handler **while the registry entry is still missing**. Each nesting level therefore constructs its own `GraphQLObjectType` with the same name, and `new GraphQLSchema(...)` rejects the schema.

### How?

Register the type in `blockTypes` **before** forcing field resolution, and deregister it in the (theoretical) empty-fields case afterwards. Nested occurrences of the same block slug now reuse the exact same type object, producing a single, self-referential GraphQL type — mirroring how the TypeScript type generation already deduplicates these blocks into one interface.

Added tests (`test/graphql`):

- schema-level: `configToSchema` succeeds for a depth-limited recursive block and the nested `children` union references the identical type object (previously threw the duplicate-type error),
- end-to-end: querying 3 levels of nested recursive blocks through GraphQL returns the nested data.

Verified: with the fix reverted, the new tests fail with the exact error above; with the fix, the full `test/graphql` suite passes.

Fixes #17302
