### PR TITLE
fix(ui): clip react-select menu so option highlights respect border radius

### DIFF
--- a/packages/ui/src/elements/ReactSelect/index.css
+++ b/packages/ui/src/elements/ReactSelect/index.css
@@ -91,7 +91,7 @@
     border-radius: var(--radius-medium);
     box-shadow: var(--elevation-400-menu-panel);
     background: var(--color-bg);
-    overflow: hidden;
+    overflow: clip;
   }
 
   .rs__menu--placement-bottom {

--- a/packages/ui/src/elements/ReactSelect/index.css
+++ b/packages/ui/src/elements/ReactSelect/index.css
@@ -91,7 +91,7 @@
     border-radius: var(--radius-medium);
     box-shadow: var(--elevation-400-menu-panel);
     background: var(--color-bg);
-    /* overflow: clip; */
+    overflow: hidden;
   }
 
   .rs__menu--placement-bottom {


### PR DESCRIPTION
Adds `overflow: clip` to the react-select `.rs__menu` so option hover (`--is-focused`) and selected (`--is-selected`) background highlights are clipped to the menu's `border-radius`.

Previously the square option backgrounds bled past the menu's rounded corners. The menu height still fits its content and internal scrolling continues to work via `.rs__menu-list`.

#### Before
<img width="371" height="284" alt="Screenshot 2026-07-13 at 10 58 01 AM" src="https://github.com/user-attachments/assets/4f27512b-39c9-484d-b8cd-694d90c17bee" />

#### After
<img width="354" height="289" alt="Screenshot 2026-07-13 at 10 58 18 AM" src="https://github.com/user-attachments/assets/9cf147c0-5db1-48a2-9d3e-4665df157b71" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396007834485