### PR TITLE
fix(ui): stabilize portaled react-select menu positioning

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -365,6 +365,7 @@
     "@faceless-ui/modal": "3.0.1",
     "@faceless-ui/scroll-info": "2.0.0",
     "@faceless-ui/window-info": "3.0.1",
+    "@floating-ui/dom": "1.7.6",
     "@monaco-editor/react": "4.7.0",
     "@payloadcms/translations": "workspace:*",
     "bson-objectid": "2.0.4",

--- a/packages/ui/src/css/z-index.css
+++ b/packages/ui/src/css/z-index.css
@@ -1,0 +1,9 @@
+@layer payload-default {
+  :root {
+    --z-popup: 60;
+    --z-nav: 20;
+    --z-modal: 30;
+    --z-status: 40;
+    --z-portal-element: 9999;
+  }
+}

--- a/packages/ui/src/elements/ReactSelect/DefaultMenuPortal.tsx
+++ b/packages/ui/src/elements/ReactSelect/DefaultMenuPortal.tsx
@@ -17,6 +17,10 @@ type FloatingMenuPortalStyle = {
   '--rs-floating-menu-max-height'?: string
 } & CSSProperties
 
+type ThemedMenuPortalInnerProps = {
+  'data-theme'?: string
+} & React.JSX.IntrinsicElements['div']
+
 type DefaultMenuPortalProps<
   Opt,
   IsMulti extends boolean,
@@ -110,12 +114,12 @@ export function DefaultMenuPortal<Opt, IsMulti extends boolean, Group extends Gr
   }, [appendTo, controlElement, updatePosition])
 
   if (!appendTo || !controlElement) {
-    return (
-      <rsComponents.MenuPortal
-        {...props}
-        innerProps={{ ...innerProps, 'data-theme': menuPortalTheme ?? theme }}
-      />
-    )
+    const themedInnerProps: ThemedMenuPortalInnerProps = {
+      ...innerProps,
+      'data-theme': menuPortalTheme ?? theme,
+    }
+
+    return <rsComponents.MenuPortal {...props} innerProps={themedInnerProps} />
   }
 
   const { className, style, ...restInnerProps } = innerProps

--- a/packages/ui/src/elements/ReactSelect/DefaultMenuPortal.tsx
+++ b/packages/ui/src/elements/ReactSelect/DefaultMenuPortal.tsx
@@ -135,7 +135,7 @@ export function DefaultMenuPortal<Opt, IsMulti extends boolean, Group extends Gr
           left: 0,
           position: 'fixed',
           top: 0,
-          zIndex: 9999,
+          zIndex: 'var(--z-portal-element)',
         } as FloatingMenuPortalStyle
       }
     >

--- a/packages/ui/src/elements/ReactSelect/DefaultMenuPortal.tsx
+++ b/packages/ui/src/elements/ReactSelect/DefaultMenuPortal.tsx
@@ -1,0 +1,143 @@
+import type { CSSProperties } from 'react'
+import type { GroupBase } from 'react-select'
+
+import { autoUpdate, computePosition, flip, offset, shift, size } from '@floating-ui/dom'
+import React, { useCallback, useLayoutEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { components as rsComponents } from 'react-select'
+
+import type { CustomSelectProps } from './types.js'
+
+import { useTheme } from '../../providers/Theme/index.js'
+
+const FLOATING_MENU_PADDING = 16
+const FLOATING_MENU_OFFSET = 4
+
+type FloatingMenuPortalStyle = {
+  '--rs-floating-menu-max-height'?: string
+} & CSSProperties
+
+type DefaultMenuPortalProps<
+  Opt,
+  IsMulti extends boolean,
+  Group extends GroupBase<Opt>,
+> = React.ComponentProps<typeof rsComponents.MenuPortal<Opt, IsMulti, Group>>
+
+export function DefaultMenuPortal<Opt, IsMulti extends boolean, Group extends GroupBase<Opt>>(
+  props: DefaultMenuPortalProps<Opt, IsMulti, Group>,
+) {
+  const { appendTo, children, controlElement, innerProps = {}, menuPlacement } = props
+  const { theme } = useTheme()
+  const floatingRef = useRef<HTMLDivElement | null>(null)
+  const rafRef = useRef<null | number>(null)
+  const selectProps = props.selectProps as {
+    customProps?: CustomSelectProps
+  } & typeof props.selectProps
+  const menuPortalTheme = selectProps.customProps?.menuPortalTheme
+
+  const updatePosition = useCallback(async () => {
+    const floatingElement = floatingRef.current
+
+    if (!controlElement || !floatingElement) {
+      return
+    }
+
+    const placement = menuPlacement === 'top' ? 'top-start' : 'bottom-start'
+    const { x, y } = await computePosition(controlElement, floatingElement, {
+      middleware: [
+        offset(FLOATING_MENU_OFFSET),
+        flip({ padding: FLOATING_MENU_PADDING }),
+        shift({ padding: FLOATING_MENU_PADDING }),
+        size({
+          apply({ availableHeight, elements, rects }) {
+            const maxHeight = `${Math.max(1, Math.floor(availableHeight))}px`
+            const width = `${Math.floor(rects.reference.width)}px`
+
+            Object.assign(elements.floating.style, {
+              '--rs-floating-menu-max-height': maxHeight,
+              minWidth: width,
+              width,
+            })
+          },
+          padding: FLOATING_MENU_PADDING,
+        }),
+      ],
+      placement,
+      strategy: 'fixed',
+    })
+
+    Object.assign(floatingElement.style, {
+      left: `${x}px`,
+      top: `${y}px`,
+    })
+  }, [controlElement, menuPlacement])
+
+  const setFloatingElement = useCallback(
+    (element: HTMLDivElement | null) => {
+      floatingRef.current = element
+      void updatePosition()
+    },
+    [updatePosition],
+  )
+
+  useLayoutEffect(() => {
+    const floatingElement = floatingRef.current
+
+    if (!appendTo || !controlElement || !floatingElement || typeof window === 'undefined') {
+      return
+    }
+
+    const cleanupAutoUpdate = autoUpdate(controlElement, floatingElement, updatePosition, {
+      elementResize: 'ResizeObserver' in window,
+    })
+    const visualViewport = window.visualViewport
+
+    visualViewport?.addEventListener('resize', updatePosition)
+    visualViewport?.addEventListener('scroll', updatePosition)
+    rafRef.current = window.requestAnimationFrame(() => {
+      void updatePosition()
+    })
+
+    return () => {
+      cleanupAutoUpdate()
+      visualViewport?.removeEventListener('resize', updatePosition)
+      visualViewport?.removeEventListener('scroll', updatePosition)
+
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current)
+      }
+    }
+  }, [appendTo, controlElement, updatePosition])
+
+  if (!appendTo || !controlElement) {
+    return (
+      <rsComponents.MenuPortal
+        {...props}
+        innerProps={{ ...innerProps, 'data-theme': menuPortalTheme ?? theme }}
+      />
+    )
+  }
+
+  const { className, style, ...restInnerProps } = innerProps
+  const menuWrapper = (
+    <div
+      {...restInnerProps}
+      className={['rs__floating-menu-portal', className].filter(Boolean).join(' ')}
+      data-theme={menuPortalTheme ?? theme}
+      ref={setFloatingElement}
+      style={
+        {
+          ...style,
+          left: 0,
+          position: 'fixed',
+          top: 0,
+          zIndex: 9999,
+        } as FloatingMenuPortalStyle
+      }
+    >
+      {children}
+    </div>
+  )
+
+  return createPortal(menuWrapper, appendTo)
+}

--- a/packages/ui/src/elements/ReactSelect/getMenuListStyles.ts
+++ b/packages/ui/src/elements/ReactSelect/getMenuListStyles.ts
@@ -6,12 +6,22 @@ type MenuListStyles = NonNullable<StylesConfig<Option, boolean, GroupBase<Option
 
 export const getMenuListStyles = (
   externalStyles?: StylesConfig<Option, boolean, GroupBase<Option>>,
+  shouldUseFloatingMenuPortal?: boolean,
 ): MenuListStyles => {
   return (
     rsStyles: CSSObjectWithLabel,
     state: Parameters<NonNullable<StylesConfig<Option>['menuList']>>[1],
-  ) => ({
-    ...rsStyles,
-    ...externalStyles?.menuList?.(rsStyles, state),
-  })
+  ) => {
+    const styles: CSSObjectWithLabel = {
+      ...rsStyles,
+      ...(shouldUseFloatingMenuPortal && {
+        maxHeight: `var(--rs-floating-menu-max-height, ${String(rsStyles.maxHeight)}px)`,
+      }),
+    }
+
+    return {
+      ...styles,
+      ...externalStyles?.menuList?.(styles, state),
+    }
+  }
 }

--- a/packages/ui/src/elements/ReactSelect/getMenuStyles.ts
+++ b/packages/ui/src/elements/ReactSelect/getMenuStyles.ts
@@ -1,0 +1,35 @@
+import type { CSSObjectWithLabel, GroupBase, StylesConfig } from 'react-select'
+
+import type { Option } from './types.js'
+
+type MenuStyles = NonNullable<StylesConfig<Option, boolean, GroupBase<Option>>['menu']>
+
+type Args = {
+  externalStyles?: StylesConfig<Option, boolean, GroupBase<Option>>
+  shouldUseFloatingMenuPortal: boolean
+}
+
+export const getMenuStyles = ({
+  externalStyles,
+  shouldUseFloatingMenuPortal,
+}: Args): MenuStyles => {
+  return (
+    rsStyles: CSSObjectWithLabel,
+    state: Parameters<NonNullable<StylesConfig<Option>['menu']>>[1],
+  ) => {
+    const styles: CSSObjectWithLabel = {
+      ...rsStyles,
+      zIndex: undefined,
+      ...(shouldUseFloatingMenuPortal && {
+        bottom: undefined,
+        position: 'static',
+        top: undefined,
+      }),
+    }
+
+    return {
+      ...styles,
+      ...externalStyles?.menu?.(styles, state),
+    }
+  }
+}

--- a/packages/ui/src/elements/ReactSelect/index.css
+++ b/packages/ui/src/elements/ReactSelect/index.css
@@ -102,6 +102,13 @@
     margin-bottom: var(--spacer-1);
   }
 
+  .rs__floating-menu-portal {
+    .rs__menu--placement-bottom,
+    .rs__menu--placement-top {
+      margin-block: 0;
+    }
+  }
+
   .rs__menu-list {
     overflow-y: auto;
   }

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -171,7 +171,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       ...(menuPortalTarget && {
         menuPortal: (rsStyles, state) => ({
           ...rsStyles,
-          zIndex: 9999,
+          zIndex: 'var(--z-portal-element)',
           ...externalStyles?.menuPortal?.(rsStyles, state),
         }),
       }),

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -3,6 +3,7 @@ import type { JSX, KeyboardEventHandler } from 'react'
 import type { GroupBase, MenuListProps, MenuProps, StylesConfig } from 'react-select'
 
 import { arrayMove } from '@dnd-kit/sortable'
+import { useWindowInfo } from '@faceless-ui/window-info'
 import { getTranslation } from '@payloadcms/translations'
 import React, {
   useCallback,
@@ -59,10 +60,13 @@ const MENU_VIEWPORT_GAP = 16 // space between the control and the edge of the wi
 
 const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
   const { i18n, t } = useTranslation()
+  const {
+    breakpoints: { s: smallBreak },
+  } = useWindowInfo()
   const [inputValue, setInputValue] = useState('') // for creatable select
   const uuid = useId()
   const [hasMounted, setHasMounted] = useState(false)
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [internalIsMenuOpen, setIsMenuOpen] = useState(false)
   const [maxMenuHeight, setMaxMenuHeight] = useState(DEFAULT_MAX_MENU_HEIGHT)
   const [menuPlacement, setMenuPlacement] = useState<'auto' | 'bottom' | 'top'>('auto')
   const containerRef = useRef<HTMLDivElement>(null)
@@ -79,6 +83,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     isCreatable,
     isLoading,
     isSearchable = true,
+    menuIsOpen: menuIsOpenProp,
     menuPortalTarget: menuPortalTargetProp,
     menuPosition: menuPositionProp,
     noOptionsMessage = () => t('general:noOptions'),
@@ -93,6 +98,8 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     value,
   } = props
 
+  const isMobile = Boolean(smallBreak)
+
   const menuPortalTarget =
     menuPortalTargetProp === undefined
       ? typeof document !== 'undefined'
@@ -101,6 +108,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       : menuPortalTargetProp
 
   const menuPosition = menuPositionProp ?? (menuPortalTarget ? 'fixed' : undefined)
+  const isMenuOpen = menuIsOpenProp ?? internalIsMenuOpen
   const captureMenuScroll = getCaptureMenuScroll({
     captureMenuScroll: captureMenuScrollProp,
     menuPortalTarget,
@@ -127,6 +135,29 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     setMaxMenuHeight(Math.max(Math.min(Math.floor(availableHeight), DEFAULT_MAX_MENU_HEIGHT), 1))
   }, [isMenuOpen])
 
+  const handleMenuClose = useCallback(() => {
+    setIsMenuOpen(false)
+    onMenuClose?.()
+  }, [onMenuClose])
+
+  const handleWindowScroll = useCallback(
+    (event: Event) => {
+      const scrollTarget = event.target
+      const isScrollWithinMenu =
+        scrollTarget instanceof Element && Boolean(scrollTarget.closest('.rs__menu'))
+
+      if (isMobile && menuPortalTarget && !isScrollWithinMenu) {
+        handleMenuClose()
+        return
+      }
+
+      if (!isMobile) {
+        updateMenuViewportSettings()
+      }
+    },
+    [handleMenuClose, isMobile, menuPortalTarget, updateMenuViewportSettings],
+  )
+
   useEffect(() => {
     setHasMounted(true)
   }, [])
@@ -141,13 +172,13 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     updateMenuViewportSettings()
 
     window.addEventListener('resize', updateMenuViewportSettings)
-    window.addEventListener('scroll', updateMenuViewportSettings, true)
+    window.addEventListener('scroll', handleWindowScroll, { capture: true, passive: true })
 
     return () => {
       window.removeEventListener('resize', updateMenuViewportSettings)
-      window.removeEventListener('scroll', updateMenuViewportSettings, true)
+      window.removeEventListener('scroll', handleWindowScroll, { capture: true })
     }
-  }, [isMenuOpen, updateMenuViewportSettings])
+  }, [handleWindowScroll, isMenuOpen, updateMenuViewportSettings])
 
   // Debounce the loading state so that fast option fetches (e.g. relationship
   // fields that resolve almost instantly) don't cause the clear indicator to
@@ -167,11 +198,6 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     setIsMenuOpen(true)
     requestAnimationFrame(updateMenuViewportSettings)
     onMenuOpen?.()
-  }
-
-  const handleMenuClose = () => {
-    setIsMenuOpen(false)
-    onMenuClose?.()
   }
 
   const menuClassName = useCallback(
@@ -228,6 +254,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     isSearchable,
     loadingMessage: () => t('general:loading') + '...',
     maxMenuHeight,
+    menuIsOpen: isMenuOpen,
     menuPlacement,
     menuPortalTarget,
     menuPosition,

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -70,6 +70,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
   const [maxMenuHeight, setMaxMenuHeight] = useState(DEFAULT_MAX_MENU_HEIGHT)
   const [menuPlacement, setMenuPlacement] = useState<'auto' | 'bottom' | 'top'>('auto')
   const containerRef = useRef<HTMLDivElement>(null)
+  const hasMobileOutsideScrollIntentRef = useRef(false)
 
   const {
     captureMenuScroll: captureMenuScrollProp,
@@ -146,7 +147,12 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       const isScrollWithinMenu =
         scrollTarget instanceof Element && Boolean(scrollTarget.closest('.rs__menu'))
 
-      if (isMobile && menuPortalTarget && !isScrollWithinMenu) {
+      if (
+        isMobile &&
+        menuPortalTarget &&
+        !isScrollWithinMenu &&
+        hasMobileOutsideScrollIntentRef.current
+      ) {
         handleMenuClose()
         return
       }
@@ -157,6 +163,12 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     },
     [handleMenuClose, isMobile, menuPortalTarget, updateMenuViewportSettings],
   )
+
+  const handleWindowTouchMove = useCallback((event: TouchEvent) => {
+    const touchTarget = event.target
+    hasMobileOutsideScrollIntentRef.current =
+      touchTarget instanceof Element && !touchTarget.closest('.rs__menu')
+  }, [])
 
   useEffect(() => {
     setHasMounted(true)
@@ -173,12 +185,14 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
 
     window.addEventListener('resize', updateMenuViewportSettings)
     window.addEventListener('scroll', handleWindowScroll, { capture: true, passive: true })
+    window.addEventListener('touchmove', handleWindowTouchMove, { capture: true, passive: true })
 
     return () => {
       window.removeEventListener('resize', updateMenuViewportSettings)
       window.removeEventListener('scroll', handleWindowScroll, { capture: true })
+      window.removeEventListener('touchmove', handleWindowTouchMove, { capture: true })
     }
-  }, [handleWindowScroll, isMenuOpen, updateMenuViewportSettings])
+  }, [handleWindowScroll, handleWindowTouchMove, isMenuOpen, updateMenuViewportSettings])
 
   // Debounce the loading state so that fast option fetches (e.g. relationship
   // fields that resolve almost instantly) don't cause the clear indicator to
@@ -195,6 +209,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
   )
 
   const handleMenuOpen = () => {
+    hasMobileOutsideScrollIntentRef.current = false
     setIsMenuOpen(true)
     requestAnimationFrame(updateMenuViewportSettings)
     onMenuOpen?.()

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -1,35 +1,27 @@
 'use client'
-import type { JSX, KeyboardEventHandler } from 'react'
-import type { GroupBase, MenuListProps, MenuProps, StylesConfig } from 'react-select'
+import type { KeyboardEventHandler } from 'react'
+import type { GroupBase, MenuListProps, MenuProps } from 'react-select'
 
 import { arrayMove } from '@dnd-kit/sortable'
-import { useWindowInfo } from '@faceless-ui/window-info'
 import { getTranslation } from '@payloadcms/translations'
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
-import Select, { components as rsComponents } from 'react-select'
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import Select from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 
 import type { Option, ReactSelectAdapterProps } from './types.js'
 export type { Option } from './types.js'
 
 import { useDebouncedEffect } from '../../hooks/useDebouncedEffect.js'
-import { useTheme } from '../../providers/Theme/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { DraggableSortable } from '../DraggableSortable/index.js'
 import { ShimmerEffect } from '../ShimmerEffect/index.js'
 import { ClearIndicator } from './ClearIndicator/index.js'
 import { Control } from './Control/index.js'
+import { DefaultMenuPortal } from './DefaultMenuPortal.js'
 import { DropdownIndicator } from './DropdownIndicator/index.js'
 import { getCaptureMenuScroll } from './getCaptureMenuScroll.js'
 import { getMenuListStyles } from './getMenuListStyles.js'
+import { getMenuStyles } from './getMenuStyles.js'
 import { Input } from './Input/index.js'
 import { generateMultiValueDraggableID, MultiValue } from './MultiValue/index.js'
 import { MultiValueLabel } from './MultiValueLabel/index.js'
@@ -38,39 +30,13 @@ import { SingleValue } from './SingleValue/index.js'
 import { ValueContainer } from './ValueContainer/index.js'
 import './index.css'
 
-// Propagates the nearest scoped theme (via ThemeProvider) into the portal div,
-// falling back to the global theme. Ensures dropdown menus portaled to
-// document.body inherit the correct theme (e.g. dark Popup).
-function ThemedMenuPortal<Opt, IsMulti extends boolean, Group extends GroupBase<Opt>>(
-  props: React.ComponentProps<typeof rsComponents.MenuPortal<Opt, IsMulti, Group>>,
-) {
-  const { theme } = useTheme()
-  const menuPortalTheme = (props.selectProps as any)?.customProps?.menuPortalTheme
-  return (
-    <rsComponents.MenuPortal
-      {...props}
-      innerProps={{ 'data-theme': menuPortalTheme ?? theme } as JSX.IntrinsicElements['div']}
-    />
-  )
-}
-
 const DEFAULT_MAX_MENU_HEIGHT = 300
-const MIN_USABLE_MENU_HEIGHT = 140
-const MENU_VIEWPORT_GAP = 16 // space between the control and the edge of the window
 
 const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
   const { i18n, t } = useTranslation()
-  const {
-    breakpoints: { s: smallBreak },
-  } = useWindowInfo()
   const [inputValue, setInputValue] = useState('') // for creatable select
   const uuid = useId()
   const [hasMounted, setHasMounted] = useState(false)
-  const [internalIsMenuOpen, setIsMenuOpen] = useState(false)
-  const [maxMenuHeight, setMaxMenuHeight] = useState(DEFAULT_MAX_MENU_HEIGHT)
-  const [menuPlacement, setMenuPlacement] = useState<'auto' | 'bottom' | 'top'>('auto')
-  const containerRef = useRef<HTMLDivElement>(null)
-  const hasMobileOutsideScrollIntentRef = useRef(false)
 
   const {
     captureMenuScroll: captureMenuScrollProp,
@@ -84,7 +50,6 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     isCreatable,
     isLoading,
     isSearchable = true,
-    menuIsOpen: menuIsOpenProp,
     menuPortalTarget: menuPortalTargetProp,
     menuPosition: menuPositionProp,
     noOptionsMessage = () => t('general:noOptions'),
@@ -99,8 +64,6 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     value,
   } = props
 
-  const isMobile = Boolean(smallBreak)
-
   const menuPortalTarget =
     menuPortalTargetProp === undefined
       ? typeof document !== 'undefined'
@@ -108,92 +71,16 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
         : null
       : menuPortalTargetProp
 
-  const menuPosition =
-    menuPositionProp ?? (menuPortalTarget ? (isMobile ? 'absolute' : 'fixed') : undefined)
-  const isMenuOpen = menuIsOpenProp ?? internalIsMenuOpen
+  const menuPosition = menuPositionProp ?? (menuPortalTarget ? 'fixed' : undefined)
+  const shouldUseFloatingMenuPortal = Boolean(menuPortalTarget && !components?.MenuPortal)
   const captureMenuScroll = getCaptureMenuScroll({
     captureMenuScroll: captureMenuScrollProp,
     menuPortalTarget,
   })
 
-  const updateMenuViewportSettings = useCallback(() => {
-    if (!isMenuOpen || typeof window === 'undefined') {
-      return
-    }
-
-    const controlEl = containerRef.current?.querySelector('.rs__control')
-
-    if (!controlEl) {
-      return
-    }
-
-    const controlRect = controlEl.getBoundingClientRect()
-    const availableBelow = Math.max(window.innerHeight - controlRect.bottom - MENU_VIEWPORT_GAP, 0)
-    const availableAbove = Math.max(controlRect.top - MENU_VIEWPORT_GAP, 0)
-    const shouldOpenTop = availableBelow < MIN_USABLE_MENU_HEIGHT && availableAbove > availableBelow
-    const availableHeight = shouldOpenTop ? availableAbove : availableBelow
-
-    setMenuPlacement(shouldOpenTop ? 'top' : 'bottom')
-    setMaxMenuHeight(Math.max(Math.min(Math.floor(availableHeight), DEFAULT_MAX_MENU_HEIGHT), 1))
-  }, [isMenuOpen])
-
-  const handleMenuClose = useCallback(() => {
-    setIsMenuOpen(false)
-    onMenuClose?.()
-  }, [onMenuClose])
-
-  const handleWindowScroll = useCallback(
-    (event: Event) => {
-      const scrollTarget = event.target
-      const isScrollWithinMenu =
-        scrollTarget instanceof Element && Boolean(scrollTarget.closest('.rs__menu'))
-
-      if (
-        isMobile &&
-        menuPortalTarget &&
-        !isScrollWithinMenu &&
-        hasMobileOutsideScrollIntentRef.current
-      ) {
-        handleMenuClose()
-        return
-      }
-
-      if (!isMobile) {
-        updateMenuViewportSettings()
-      }
-    },
-    [handleMenuClose, isMobile, menuPortalTarget, updateMenuViewportSettings],
-  )
-
-  const handleWindowTouchMove = useCallback((event: TouchEvent) => {
-    const touchTarget = event.target
-    hasMobileOutsideScrollIntentRef.current =
-      touchTarget instanceof Element && !touchTarget.closest('.rs__menu')
-  }, [])
-
   useEffect(() => {
     setHasMounted(true)
   }, [])
-
-  useLayoutEffect(() => {
-    if (!isMenuOpen) {
-      setMenuPlacement('auto')
-      setMaxMenuHeight(DEFAULT_MAX_MENU_HEIGHT)
-      return
-    }
-
-    updateMenuViewportSettings()
-
-    window.addEventListener('resize', updateMenuViewportSettings)
-    window.addEventListener('scroll', handleWindowScroll, { capture: true, passive: true })
-    window.addEventListener('touchmove', handleWindowTouchMove, { capture: true, passive: true })
-
-    return () => {
-      window.removeEventListener('resize', updateMenuViewportSettings)
-      window.removeEventListener('scroll', handleWindowScroll, { capture: true })
-      window.removeEventListener('touchmove', handleWindowTouchMove, { capture: true })
-    }
-  }, [handleWindowScroll, handleWindowTouchMove, isMenuOpen, updateMenuViewportSettings])
 
   // Debounce the loading state so that fast option fetches (e.g. relationship
   // fields that resolve almost instantly) don't cause the clear indicator to
@@ -208,13 +95,6 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     [isLoading],
     250,
   )
-
-  const handleMenuOpen = () => {
-    hasMobileOutsideScrollIntentRef.current = false
-    setIsMenuOpen(true)
-    requestAnimationFrame(updateMenuViewportSettings)
-    onMenuOpen?.()
-  }
 
   const menuClassName = useCallback(
     (state: MenuProps<Option, boolean, GroupBase<Option>>) => {
@@ -243,7 +123,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       Control,
       DropdownIndicator,
       Input,
-      MenuPortal: ThemedMenuPortal,
+      MenuPortal: DefaultMenuPortal,
       MultiValue,
       MultiValueLabel,
       MultiValueRemove,
@@ -269,26 +149,21 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     isLoading: isLoadingDebounced,
     isSearchable,
     loadingMessage: () => t('general:loading') + '...',
-    maxMenuHeight,
-    menuIsOpen: isMenuOpen,
-    menuPlacement,
+    maxMenuHeight: DEFAULT_MAX_MENU_HEIGHT,
+    menuPlacement: 'auto' as const,
     menuPortalTarget,
     menuPosition,
     menuShouldBlockScroll: false,
     noOptionsMessage,
     onChange,
-    onMenuClose: handleMenuClose,
-    onMenuOpen: handleMenuOpen,
+    onMenuClose,
+    onMenuOpen,
     options,
     placeholder: getTranslation(placeholder, i18n),
     styles: {
-      // Remove the default react-select z-index from the menu so that our custom
-      // z-index in the "payload-default" css layer can take effect, in such a way
-      // that end users can easily override it as with other styles.
-      menu: (rsStyles, state) => ({
-        ...rsStyles,
-        zIndex: undefined,
-        ...externalStyles?.menu?.(rsStyles, state),
+      menu: getMenuStyles({
+        externalStyles,
+        shouldUseFloatingMenuPortal,
       }),
       // When portaling to document.body, the portal container needs an explicit
       // z-index so the menu appears above drawers and dialogs. unstyled={true}
@@ -313,7 +188,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       }),
       // Keep react-select's computed maxHeight so the menu can fit available
       // viewport space near screen edges (instead of using a fixed class value).
-      menuList: getMenuListStyles(externalStyles),
+      menuList: getMenuListStyles(externalStyles, shouldUseFloatingMenuPortal),
     },
     unstyled: true,
   }
@@ -324,7 +199,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
 
   if (!isCreatable) {
     return (
-      <div ref={containerRef}>
+      <div>
         <Select<Option, boolean, GroupBase<Option>>
           {...props}
           {...sharedSelectProps}
@@ -386,7 +261,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
   }
 
   return (
-    <div ref={containerRef}>
+    <div>
       <CreatableSelect<Option, boolean, GroupBase<Option>>
         {...props}
         {...sharedSelectProps}

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -108,7 +108,8 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
         : null
       : menuPortalTargetProp
 
-  const menuPosition = menuPositionProp ?? (menuPortalTarget ? 'fixed' : undefined)
+  const menuPosition =
+    menuPositionProp ?? (menuPortalTarget ? (isMobile ? 'absolute' : 'fixed') : undefined)
   const isMenuOpen = menuIsOpenProp ?? internalIsMenuOpen
   const captureMenuScroll = getCaptureMenuScroll({
     captureMenuScroll: captureMenuScrollProp,

--- a/packages/ui/src/elements/ReactSelect/types.ts
+++ b/packages/ui/src/elements/ReactSelect/types.ts
@@ -9,7 +9,7 @@ import type {
 
 import type { DocumentDrawerProps } from '../DocumentDrawer/types.js'
 
-type CustomSelectProps = {
+export type CustomSelectProps = {
   disableKeyDown?: boolean
   disableMouseDown?: boolean
   draggableProps?: any

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,4 +1,5 @@
 @import './css/preflight.css';
+@import './css/z-index.css';
 @import './css/colors.css';
 @import './css/design-tokens.css';
 @import './css/typography.css';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1760,6 +1760,9 @@ importers:
       '@faceless-ui/window-info':
         specifier: 3.0.1
         version: 3.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@floating-ui/dom':
+        specifier: 1.7.6
+        version: 1.7.6
       '@monaco-editor/react':
         specifier: 4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3989,11 +3992,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}


### PR DESCRIPTION
Stabilizes body-portaled ReactSelect menus by replacing the brittle manual portal positioning path with Floating UI positioning while preserving Payload's themed menu rendering.

ReactSelect still owns option rendering, keyboard behavior, ARIA, and selection state. Payload now owns the outer portaled wrapper position through `@floating-ui/dom`, which keeps the menu anchored across mobile viewport changes, scroll, keyboard/browser-chrome movement, and viewport edge collisions.

Dependency impact:
- Adds `@floating-ui/dom` as an explicit `@payloadcms/ui` dependency.
- Does not add a new resolved Floating UI version to the install graph; `@floating-ui/dom@1.7.6` was already present via `react-select` and `react-datepicker`.
- Focused ReactSelect bundle measurement: 164.8 KB raw / 56.3 KB gzip before, 177.2 KB raw / 61.0 KB gzip after, delta +12.4 KB raw / +4.8 KB gzip.

### Before

https://github.com/user-attachments/assets/2f5f47f8-3879-46c4-85ad-b7b79ff1e785

### After

https://github.com/user-attachments/assets/e8c8b83e-b554-4768-a2c3-afcdef88e25f
