### PR TITLE
fix: localized path resolution for fields nested under localized parents

### DIFF
--- a/packages/payload/src/fields/config/sanitizeJoinField.ts
+++ b/packages/payload/src/fields/config/sanitizeJoinField.ts
@@ -109,7 +109,7 @@ export const sanitizeJoinField = ({
 
   if (relationshipField.pathHasLocalized) {
     join.getForeignPath = ({ locale }) => {
-      return relationshipField.localizedPath.replace('<locale>', locale!)
+      return relationshipField.localizedPath.replaceAll('<locale>', locale!)
     }
   }
 

--- a/packages/payload/src/utilities/getFieldByPath.spec.ts
+++ b/packages/payload/src/utilities/getFieldByPath.spec.ts
@@ -85,6 +85,18 @@ const fields = flattenAllFields({
         },
       ],
     },
+    {
+      type: 'group',
+      name: 'localizedGroup',
+      localized: true,
+      fields: [
+        {
+          name: 'textLocalized',
+          type: 'text',
+          localized: true,
+        },
+      ],
+    },
   ],
 })
 
@@ -138,5 +150,14 @@ describe('getFieldByPath', () => {
     const sourceField = (fields[4] as any).blocks?.[1].flattenedFields?.[0]
     expect(sourceField).toBeDefined()
     expect(fieldInBlock?.field).toBe(sourceField)
+  })
+
+  it('adds a <locale> placeholder for every localized segment on the path', () => {
+    // A path that traverses more than one localized field yields multiple
+    // `<locale>` placeholders, so consumers must replace all of them.
+    const result = getFieldByPath({ fields, path: 'localizedGroup.textLocalized' })
+    assert(result)
+    expect(result.pathHasLocalized).toBe(true)
+    expect(result.localizedPath).toBe('localizedGroup.<locale>.textLocalized.<locale>')
   })
 })

--- a/packages/payload/src/utilities/getFieldByPath.spec.ts
+++ b/packages/payload/src/utilities/getFieldByPath.spec.ts
@@ -91,9 +91,30 @@ const fields = flattenAllFields({
       localized: true,
       fields: [
         {
+          name: 'text',
+          type: 'text',
+        },
+        {
           name: 'textLocalized',
           type: 'text',
           localized: true,
+        },
+      ],
+    },
+    {
+      type: 'blocks',
+      name: 'localizedBlocks',
+      localized: true,
+      blocks: [
+        {
+          slug: 'block1',
+          fields: [
+            {
+              name: 'textLocalized',
+              type: 'text',
+              localized: true,
+            },
+          ],
         },
       ],
     },
@@ -152,12 +173,25 @@ describe('getFieldByPath', () => {
     expect(fieldInBlock?.field).toBe(sourceField)
   })
 
-  it('adds a <locale> placeholder for every localized segment on the path', () => {
-    // A path that traverses more than one localized field yields multiple
-    // `<locale>` placeholders, so consumers must replace all of them.
-    const result = getFieldByPath({ fields, path: 'localizedGroup.textLocalized' })
+  it('adds a <locale> segment only for the outermost localized field', () => {
+    // Fields nested under a localized parent are not localized in storage
+    // (see fieldShouldBeLocalized), so the localized path must contain a
+    // single <locale> segment at the outermost localized field.
+    const nestedPlain = getFieldByPath({ fields, path: 'localizedGroup.text' })
+    assert(nestedPlain)
+    expect(nestedPlain.pathHasLocalized).toBe(true)
+    expect(nestedPlain.localizedPath).toBe('localizedGroup.<locale>.text')
+
+    const nestedLocalized = getFieldByPath({ fields, path: 'localizedGroup.textLocalized' })
+    assert(nestedLocalized)
+    expect(nestedLocalized.pathHasLocalized).toBe(true)
+    expect(nestedLocalized.localizedPath).toBe('localizedGroup.<locale>.textLocalized')
+  })
+
+  it('adds a single <locale> segment for localized fields within localized blocks', () => {
+    const result = getFieldByPath({ fields, path: 'localizedBlocks.block1.textLocalized' })
     assert(result)
     expect(result.pathHasLocalized).toBe(true)
-    expect(result.localizedPath).toBe('localizedGroup.<locale>.textLocalized.<locale>')
+    expect(result.localizedPath).toBe('localizedBlocks.<locale>.block1.textLocalized')
   })
 })

--- a/packages/payload/src/utilities/getFieldByPath.ts
+++ b/packages/payload/src/utilities/getFieldByPath.ts
@@ -11,12 +11,14 @@ export const getFieldByPath = ({
   fields,
   includeRelationships = false,
   localizedPath = '',
+  parentIsLocalized = false,
   path,
 }: {
   config?: SanitizedConfig
   fields: FlattenedField[]
   includeRelationships?: boolean
   localizedPath?: string
+  parentIsLocalized?: boolean
   /**
    * The schema path, e.g. `array.group.title`
    */
@@ -32,7 +34,7 @@ export const getFieldByPath = ({
 
   const segments = path.split('.')
 
-  let pathHasLocalized = false
+  let pathHasLocalized = parentIsLocalized
 
   while (segments.length > 0) {
     const segment = segments.shift()
@@ -46,7 +48,14 @@ export const getFieldByPath = ({
 
     if (field.localized) {
       pathHasLocalized = true
-      localizedPath = `${localizedPath}.<locale>`
+
+      // Fields nested under a localized parent are not localized in storage
+      // (see fieldShouldBeLocalized), so only the outermost localized field
+      // adds a <locale> segment to the path.
+      if (!parentIsLocalized) {
+        localizedPath = `${localizedPath}.<locale>`
+        parentIsLocalized = true
+      }
     }
 
     if ('flattenedFields' in field) {
@@ -64,6 +73,9 @@ export const getFieldByPath = ({
       )?.flattenedFields
       if (flattenedFields) {
         currentFields = flattenedFields
+        // The path crosses into another collection's documents, where locale
+        // nesting starts fresh.
+        parentIsLocalized = false
       }
 
       if (segments.length === 1 && segments[0] === 'id') {
@@ -90,6 +102,7 @@ export const getFieldByPath = ({
           fields: block.flattenedFields,
           includeRelationships,
           localizedPath,
+          parentIsLocalized,
           path: segments.join('.'),
         })
       }


### PR DESCRIPTION
### What?

Fixes localized path resolution for fields nested under a **localized parent**. `getFieldByPath` appended a `<locale>` segment for **every** localized field on a path, but storage only nests locale keys at the **outermost** localized field. The resulting `localizedPath` pointed at a path that does not exist in the database, breaking every consumer that resolves it against storage — most visibly join fields, whose MongoDB `$lookup.foreignField` then matches nothing.

### Why?

`fieldShouldBeLocalized` defines the storage semantics: a field under a localized parent is **not** localized again —

```ts
// packages/payload/src/fields/config/types.ts
export function fieldShouldBeLocalized({ field, parentIsLocalized }): boolean {
  return 'localized' in field && field.localized! && !parentIsLocalized
}
```

The db-mongodb schema builder and `buildProjectionFromSelect` both follow it, so for a config like:

```ts
{ name: 'localizedGroup', type: 'group', localized: true, fields: [
  { name: 'textLocalized', type: 'text', localized: true },
]}
```

the stored path is `localizedGroup.<locale>.textLocalized` — one locale key.

But `getFieldByPath` checked raw `field.localized` per segment and produced `localizedGroup.<locale>.textLocalized.<locale>`. Consumers then resolve the placeholder with `.replace('<locale>', locale)`, yielding `localizedGroup.en.textLocalized.<locale>` — a literal `<locale>` in a database path. Affected consumers include:

- `sanitizeJoinField` → `getForeignPath` → `buildJoinAggregation`'s `$lookup.foreignField` (join returns nothing)
- `sanitizeCompoundIndexes` → `buildSchema` index definitions (index created on a nonexistent path)
- db-mongodb `findDistinct`, `buildSortParam`, and `buildSearchParams` (join `where` queries)

Note that simply replacing **all** placeholders with the locale would still be wrong — `localizedGroup.en.textLocalized.en` doesn't exist in storage either. The root cause is the extra placeholder itself.

### How?

`getFieldByPath` now tracks `parentIsLocalized`:

- `pathHasLocalized` semantics are unchanged (true if any segment is localized),
- but only the **outermost** localized field appends `.<locale>` to `localizedPath`,
- the flag carries through block recursion,
- and it resets when the path crosses a relationship into another collection (`includeRelationships`), since locale nesting starts fresh in the related collection's documents.

`sanitizeJoinField` also uses `replaceAll` for the placeholder as defense-in-depth.

### Tests

Extended `getFieldByPath.spec.ts`:

- a plain and a localized field nested in a localized group both resolve to a single `<locale>` segment (`localizedGroup.<locale>.text`, `localizedGroup.<locale>.textLocalized`) with `pathHasLocalized: true`,
- a localized field inside a block of a localized blocks field resolves to `localizedBlocks.<locale>.block1.textLocalized`,
- all pre-existing assertions are unchanged and still pass.
