### PR TITLE
fix(ui): restore drawer body scrolling on iOS Safari

### DIFF
--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -117,6 +117,8 @@ const DrawerInner: React.FC<Props> = ({
           .join(' ')}
         // Fixes https://github.com/payloadcms/payload/issues/13778
         closeOnBlur={false}
+        // Prevents body-scroll-lock from blocking iOS touch scroll inside the drawer; background scroll is handled by CSS (`body:has(.drawer--is-open)`).
+        lockBodyScroll={false}
         slug={slug}
         style={
           {


### PR DESCRIPTION
Restores native touch scrolling in document and list drawers on iOS Safari.

On iOS, `@faceless-ui/modal` hands `body-scroll-lock` the modal element as the "keep scrollable" target, but the drawer actually scrolls a different element. As a result `body-scroll-lock` calls `preventDefault()` on every `touchmove` and the drawer body cannot be scrolled on touch devices. Desktop is unaffected because it scrolls via wheel events.

Passes `lockBodyScroll={false}` to the drawer's `Modal`. Background scroll stays locked via the existing CSS (`body:has(.drawer--is-open) { overflow: hidden }`).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216396007834481