### PR TITLE
fix(ui): "add below" on blocks field ignores filterOptions

### DIFF
--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -476,8 +476,10 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
                       {...draggableSortableItemProps}
                       addRow={addRow}
                       block={blockConfig}
-                      // Pass all blocks, not just clientBlocksAfterFilter, as existing blocks should still be displayed even if they don't match the new filter
-                      blocks={clientBlocks}
+                      // Only allow choosing filtered blocks in the "Add Below" drawer. The row's own
+                      // current block is rendered from `block` above, not from this `blocks` list, so
+                      // filtering here does not affect the display of existing rows.
+                      blocks={clientBlocksAfterFilter}
                       copyRow={copyRow}
                       duplicateRow={duplicateRow}
                       errorCount={rowErrorCount}

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Page } from '@playwright/test'
 
 import { expect } from '@playwright/test'
 import { copyPasteField } from '__helpers/e2e/copyPasteField.js'
+import { openArrayRowActions } from '__helpers/e2e/fields/array/index.js'
 import {
   addBlock,
   addBlockBelow,
@@ -803,6 +804,36 @@ describe('Block fields', () => {
 
       // There should ONLY be blockFour and blockFive available
 
+      await expect(labels).toHaveCount(2)
+      await expect(labels.nth(0)).toHaveText('Block Four')
+      await expect(labels.nth(1)).toHaveText('Block Five')
+    })
+
+    test('ensure static filterOptions are respected when adding a block below an existing row', async () => {
+      await page.goto(url.create)
+
+      await addBlock({
+        page,
+        fieldName: 'blocksWithFilterOptions',
+        blockToSelect: 'Block Four',
+      })
+
+      // Open the row actions menu for the row added above and choose "Add Below" to inspect
+      // the choices offered in that drawer, which should be filtered the same way as the
+      // main "Add Content" drawer.
+      const { popupContentLocator } = await openArrayRowActions(page, {
+        fieldName: 'blocksWithFilterOptions',
+        rowIndex: 0,
+      })
+
+      await popupContentLocator.locator('.array-actions__action.array-actions__add').click()
+
+      const blocksDrawer = page.locator('[id^=drawer_1_blocks-drawer-]')
+      await expect(blocksDrawer).toBeVisible()
+
+      const labels = blocksDrawer.locator('.thumbnail-card__label')
+
+      // There should ONLY be blockFour and blockFive available, same as the main "Add Content" drawer
       await expect(labels).toHaveCount(2)
       await expect(labels.nth(0)).toHaveText('Block Four')
       await expect(labels.nth(1)).toHaveText('Block Five')


### PR DESCRIPTION
### What?

The "Add Below" row action on a `blocks` field ignores `filterOptions`, offering every block type instead of the filtered subset. The main "Add Content" button already respects `filterOptions` correctly.

Fixes #15829

### Why?

- The `Add Content` drawer passes `clientBlocksAfterFilter` (filtered) into `BlocksDrawer`.
- Each row passes the unfiltered `clientBlocks` into `BlockRow` → `RowActions` → `BlocksDrawer` for the "Add Below" action, with a comment claiming this was needed so "existing blocks should still be displayed even if they don't match the new filter."
- That reasoning doesn't hold: a row's own current block is rendered from the separate `block` (singular) prop, not from the `blocks` list. The `blocks` list is only consumed by `BlocksDrawer`/`BlockSelector` to populate the picker for adding a *new* block — so passing the unfiltered list there just breaks `filterOptions` for "Add Below" without buying anything for existing rows.

### How?

Pass `clientBlocksAfterFilter` instead of `clientBlocks` into `BlockRow`, matching what the main "Add Content" drawer already does.

### Tests

Added an e2e test asserting that "Add Below" on a field with `filterOptions` offers the same filtered set of blocks as the main "Add Content" drawer.
