### PR TITLE
fix(plugin-seo): add loading state to auto-generate buttons

### DIFF
--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -5,6 +5,7 @@ import type { TextareaFieldClientProps } from 'payload'
 
 import {
   FieldLabel,
+  Spinner,
   TextareaInput,
   useConfig,
   useDocumentInfo,
@@ -16,7 +17,7 @@ import {
 } from '@payloadcms/ui'
 import { reduceToSerializableFields } from '@payloadcms/ui/shared'
 import { formatAdminURL } from 'payload/shared'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
 import type { GenerateDescription } from '../../types.js'
@@ -68,43 +69,51 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
     value,
   }: FieldType<string> = useField()
 
+  const [isLoading, setIsLoading] = useState(false)
+
   const regenerateDescription = useCallback(async () => {
     if (!hasGenerateDescriptionFn) {
       return
     }
 
-    const endpoint = formatAdminURL({
-      apiRoute: api,
-      path: '/plugin-seo/generate-description',
-    })
+    setIsLoading(true)
 
-    const genDescriptionResponse = await fetch(endpoint, {
-      body: JSON.stringify({
-        id: docInfo.id,
-        collectionSlug: docInfo.collectionSlug,
-        doc: getData(),
-        docPermissions: docInfo.docPermissions,
-        globalSlug: docInfo.globalSlug,
-        hasPublishPermission: docInfo.hasPublishPermission,
-        hasSavePermission: docInfo.hasSavePermission,
-        initialData: docInfo.initialData,
-        initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
-        locale: typeof locale === 'object' ? locale?.code : locale,
-        title,
-      } satisfies Omit<
-        Parameters<GenerateDescription>[0],
-        'collectionConfig' | 'globalConfig' | 'hasPublishedDoc' | 'req' | 'versionCount'
-      >),
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      method: 'POST',
-    })
+    try {
+      const endpoint = formatAdminURL({
+        apiRoute: api,
+        path: '/plugin-seo/generate-description',
+      })
 
-    const { result: generatedDescription } = await genDescriptionResponse.json()
+      const genDescriptionResponse = await fetch(endpoint, {
+        body: JSON.stringify({
+          id: docInfo.id,
+          collectionSlug: docInfo.collectionSlug,
+          doc: getData(),
+          docPermissions: docInfo.docPermissions,
+          globalSlug: docInfo.globalSlug,
+          hasPublishPermission: docInfo.hasPublishPermission,
+          hasSavePermission: docInfo.hasSavePermission,
+          initialData: docInfo.initialData,
+          initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
+          locale: typeof locale === 'object' ? locale?.code : locale,
+          title,
+        } satisfies Omit
+          Parameters < GenerateDescription > [0],
+          'collectionConfig' | 'globalConfig' | 'hasPublishedDoc' | 'req' | 'versionCount'
+          >),
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      })
 
-    setValue(generatedDescription || '')
+      const { result: generatedDescription } = await genDescriptionResponse.json()
+
+      setValue(generatedDescription || '')
+    } finally {
+      setIsLoading(false)
+    }
   }, [
     hasGenerateDescriptionFn,
 
@@ -143,7 +152,8 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
             <React.Fragment>
               &nbsp; &mdash; &nbsp;
               <button
-                disabled={readOnly}
+                aria-busy={isLoading}
+                disabled={readOnly || isLoading}
                 onClick={() => {
                   void regenerateDescription()
                 }}
@@ -152,13 +162,17 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
                   backgroundColor: 'transparent',
                   border: 'none',
                   color: 'currentcolor',
-                  cursor: 'pointer',
+                  cursor: isLoading ? 'wait' : 'pointer',
                   padding: 0,
                   textDecoration: 'underline',
                 }}
                 type="button"
               >
-                {t('plugin-seo:autoGenerate')}
+                {isLoading ? (
+                  <Spinner loadingText={null} size="sm" />
+                ) : (
+                  t('plugin-seo:autoGenerate')
+                )}
               </button>
             </React.Fragment>
           )}
@@ -169,7 +183,7 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
           }}
         >
           {t('plugin-seo:lengthTipDescription', { maxLength, minLength })}
-          <a
+          
             href="https://developers.google.com/search/docs/advanced/appearance/snippet#meta-descriptions"
             rel="noopener noreferrer"
             target="_blank"
@@ -208,6 +222,6 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
       >
         <LengthIndicator maxLength={maxLength} minLength={minLength} text={value} />
       </div>
-    </div>
+    </div >
   )
 }

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -5,6 +5,7 @@ import type { TextFieldClientProps } from 'payload'
 
 import {
   FieldLabel,
+  Spinner,
   TextInput,
   useConfig,
   useDocumentInfo,
@@ -16,7 +17,7 @@ import {
 } from '@payloadcms/ui'
 import { reduceToSerializableFields } from '@payloadcms/ui/shared'
 import { formatAdminURL } from 'payload/shared'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
 import type { GenerateTitle } from '../../types.js'
@@ -66,6 +67,8 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
   const docInfo = useDocumentInfo()
   const { title } = useDocumentTitle()
 
+  const [isLoading, setIsLoading] = useState(false)
+
   const minLength = minLengthFromProps || minLengthDefault
   const maxLength = maxLengthFromProps || maxLengthDefault
 
@@ -74,38 +77,44 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
       return
     }
 
-    const endpoint = formatAdminURL({
-      apiRoute: api,
-      path: '/plugin-seo/generate-title',
-    })
+    setIsLoading(true)
 
-    const genTitleResponse = await fetch(endpoint, {
-      body: JSON.stringify({
-        id: docInfo.id,
-        collectionSlug: docInfo.collectionSlug,
-        doc: getData(),
-        docPermissions: docInfo.docPermissions,
-        globalSlug: docInfo.globalSlug,
-        hasPublishPermission: docInfo.hasPublishPermission,
-        hasSavePermission: docInfo.hasSavePermission,
-        initialData: docInfo.initialData,
-        initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
-        locale: typeof locale === 'object' ? locale?.code : locale,
-        title,
-      } satisfies Omit<
-        Parameters<GenerateTitle>[0],
-        'collectionConfig' | 'globalConfig' | 'hasPublishedDoc' | 'req' | 'versionCount'
-      >),
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      method: 'POST',
-    })
+    try {
+      const endpoint = formatAdminURL({
+        apiRoute: api,
+        path: '/plugin-seo/generate-title',
+      })
 
-    const { result: generatedTitle } = await genTitleResponse.json()
+      const genTitleResponse = await fetch(endpoint, {
+        body: JSON.stringify({
+          id: docInfo.id,
+          collectionSlug: docInfo.collectionSlug,
+          doc: getData(),
+          docPermissions: docInfo.docPermissions,
+          globalSlug: docInfo.globalSlug,
+          hasPublishPermission: docInfo.hasPublishPermission,
+          hasSavePermission: docInfo.hasSavePermission,
+          initialData: docInfo.initialData,
+          initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
+          locale: typeof locale === 'object' ? locale?.code : locale,
+          title,
+        } satisfies Omit
+          Parameters < GenerateTitle > [0],
+          'collectionConfig' | 'globalConfig' | 'hasPublishedDoc' | 'req' | 'versionCount'
+          >),
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      })
 
-    setValue(generatedTitle || '')
+      const { result: generatedTitle } = await genTitleResponse.json()
+
+      setValue(generatedTitle || '')
+    } finally {
+      setIsLoading(false)
+    }
   }, [
     hasGenerateTitleFn,
     api,
@@ -143,7 +152,8 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
             <React.Fragment>
               &nbsp; &mdash; &nbsp;
               <button
-                disabled={readOnly}
+                aria-busy={isLoading}
+                disabled={readOnly || isLoading}
                 onClick={() => {
                   void regenerateTitle()
                 }}
@@ -152,13 +162,13 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
                   backgroundColor: 'transparent',
                   border: 'none',
                   color: 'currentcolor',
-                  cursor: 'pointer',
+                  cursor: isLoading ? 'wait' : 'pointer',
                   padding: 0,
                   textDecoration: 'underline',
                 }}
                 type="button"
               >
-                {t('plugin-seo:autoGenerate')}
+                {isLoading ? <Spinner loadingText={null} size="sm" /> : t('plugin-seo:autoGenerate')}
               </button>
             </React.Fragment>
           )}
@@ -169,7 +179,7 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
           }}
         >
           {t('plugin-seo:lengthTipTitle', { maxLength, minLength })}
-          <a
+          
             href="https://developers.google.com/search/docs/advanced/appearance/title-link#page-titles"
             rel="noopener noreferrer"
             target="_blank"
@@ -209,6 +219,6 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
       >
         <LengthIndicator maxLength={maxLength} minLength={minLength} text={value} />
       </div>
-    </div>
+    </div >
   )
 }


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
The "Auto-generate" button next to the Meta Title and Meta Description fields in @payloadcms/plugin-seo now shows a loading spinner and becomes disabled while regenerateTitle() / regenerateDescription() are in flight, instead of giving no visual feedback at al

### Why?
generateTitle and generateDescription can be defined as async functions (e.g. they call an external API or LLM). Previously, clicking "Auto-generate" gave zero indication that anything was happening — the button stayed enabled and the label never changed — so users would frequently click it multiple times, firing duplicate requests, or assume the button was broken.

### How?
Added local isLoading state (useState) to both MetaTitleComponent and MetaDescriptionComponent.
Wrapped the existing fetch calls inside regenerateTitle/regenerateDescription in try { ... } finally { setIsLoading(false) }, so the loading state always clears — even if the request fails or throws.
The button is now disabled={readOnly || isLoading} and sets aria-busy={isLoading}.
While loading, the button label is swapped for Payload's existing Spinner component (size="sm") — reusing the design system's existing loading pattern rather than inventing a new one. I intentionally didn't switch to the full Button component, since its loading prop comes bundled with buttonStyle box/padding/background variants that would change this control's plain, underlined text-link appearance — an unrelated visual change.
No new dependencies, no unrelated files touched — only the two component files.

Fixes #
Configured generateTitle/generateDescription as artificially slow async functions (setTimeout delay) and confirmed the spinner appears immediately on click, the button is unclickable while pending, and the field updates once resolved.
Confirmed the loading state clears correctly even when the generate function throws/rejects.
Confirmed readOnly fields remain disabled as before, independent of loading state.

Fixes #17239

-->
