### PR TITLE
feat(storage-azure): client uploads with chunkLargeFiles can now support files larger than 5gb

### DIFF
--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -216,7 +216,28 @@ pnpm add @payloadcms/storage-azure
 
 - Configure the `collections` object to specify which collections should use the Azure Blob adapter. The slug _must_ match one of your existing collection slugs.
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
-- When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client. You must allow CORS PUT method to your website.
+- When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client.
+
+<Banner type="warning">
+  **`clientUploads` and CORS:** Client uploads use the Azure Blob SDK, which
+  splits large files into blocks (avoiding the ~5GB limit of a single upload
+  request). Because the SDK sends `x-ms-*` headers, the browser issues a CORS
+  preflight, so your storage account's CORS rules must allow the `OPTIONS` and
+  `PUT` methods **and** the required headers. Configure a CORS rule on the Blob
+  service (Storage account → **Resource sharing (CORS)**):
+
+| Field           | Value                                                    |
+| --------------- | -------------------------------------------------------- |
+| Allowed origins | Your site origin (e.g. `https://example.com`)            |
+| Allowed methods | `GET,PUT,OPTIONS` (`HEAD` if reading in-browser)         |
+| Allowed headers | `*` (or at minimum `x-ms-*,content-type,content-length`) |
+| Exposed headers | `*`                                                      |
+| Max age         | `3600`                                                   |
+
+If you previously configured CORS for the older single-`PUT` upload flow,
+broaden `Allowed headers` to include the `x-ms-*` headers when upgrading.
+
+</Banner>
 
 ```ts
 import { azureStorage } from '@payloadcms/storage-azure'

--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -8,8 +8,8 @@ keywords: uploads, images, media, storage, adapters, s3, vercel, google cloud, a
 
 Payload offers additional storage adapters to handle file uploads. These adapters allow you to store files in different locations, such as Amazon S3, Vercel Blob Storage, Google Cloud Storage, and more.
 
-| Service              | Package                                                                                                           |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Service              | Package                                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Vercel Blob          | [`@payloadcms/storage-vercel-blob`](https://github.com/payloadcms/payload/tree/3.x/packages/storage-vercel-blob) |
 | AWS S3               | [`@payloadcms/storage-s3`](https://github.com/payloadcms/payload/tree/3.x/packages/storage-s3)                   |
 | Azure                | [`@payloadcms/storage-azure`](https://github.com/payloadcms/payload/tree/3.x/packages/storage-azure)             |
@@ -218,13 +218,14 @@ pnpm add @payloadcms/storage-azure
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
 - When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client.
 
+- Client uploads send each file in a single request, which Azure caps at ~5GB. To upload larger files, set `clientUploads: { chunkLargeFiles: true }` — this uploads through the Azure Blob SDK, which splits the file into blocks and raises the limit to Azure's block-blob maximum.
+
 <Banner type="warning">
-  **`clientUploads` and CORS:** Client uploads use the Azure Blob SDK, which
-  splits large files into blocks (avoiding the ~5GB limit of a single upload
-  request). Because the SDK sends `x-ms-*` headers, the browser issues a CORS
-  preflight, so your storage account's CORS rules must allow the `OPTIONS` and
-  `PUT` methods **and** the required headers. Configure a CORS rule on the Blob
-  service (Storage account → **Resource sharing (CORS)**):
+  **`chunkLargeFiles` and CORS:** With `chunkLargeFiles: true`, the Azure Blob SDK
+  sends additional `x-ms-*` headers, so the browser issues a CORS preflight. Your
+  storage account's CORS rules must allow the `OPTIONS` and `PUT` methods **and**
+  those headers. Configure a CORS rule on the Blob service (Storage account →
+  **Resource sharing (CORS)**):
 
 | Field           | Value                                                    |
 | --------------- | -------------------------------------------------------- |
@@ -233,9 +234,6 @@ pnpm add @payloadcms/storage-azure
 | Allowed headers | `*` (or at minimum `x-ms-*,content-type,content-length`) |
 | Exposed headers | `*`                                                      |
 | Max age         | `3600`                                                   |
-
-If you previously configured CORS for the older single-`PUT` upload flow,
-broaden `Allowed headers` to include the `x-ms-*` headers when upgrading.
 
 </Banner>
 
@@ -473,13 +471,13 @@ This plugin is configurable to work across many different Payload collections. A
 
 ## Collection-specific options
 
-| Option                        | Type                                                                                                              | Description                                                                                                                                                                                                   |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Option                        | Type                                                                                                             | Description                                                                                                                                                                                                   |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `adapter` \*                  | [Adapter](https://github.com/payloadcms/payload/blob/3.x/packages/plugin-cloud-storage/src/types.ts#L49)         | Pass in the adapter that you'd like to use for this collection. You can also set this field to `null` for local development if you'd like to bypass cloud storage in certain scenarios and use local storage. |
-| `disableLocalStorage`         | `boolean`                                                                                                         | Choose to disable local storage on this collection. Defaults to `true`.                                                                                                                                       |
-| `disablePayloadAccessControl` | `true`                                                                                                            | Set to `true` to disable Payload's Access Control. [More](#payload-access-control)                                                                                                                            |
+| `disableLocalStorage`         | `boolean`                                                                                                        | Choose to disable local storage on this collection. Defaults to `true`.                                                                                                                                       |
+| `disablePayloadAccessControl` | `true`                                                                                                           | Set to `true` to disable Payload's Access Control. [More](#payload-access-control)                                                                                                                            |
 | `generateFileURL`             | [GenerateFileURL](https://github.com/payloadcms/payload/blob/3.x/packages/plugin-cloud-storage/src/types.ts#L67) | Override the generated file URL with one that you create.                                                                                                                                                     |
-| `prefix`                      | `string`                                                                                                          | Set to `media/images` to upload files inside `media/images` folder in the bucket.                                                                                                                             |
+| `prefix`                      | `string`                                                                                                         | Set to `media/images` to upload files inside `media/images` folder in the bucket.                                                                                                                             |
 
 ## Prefix Composition
 

--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -14,7 +14,23 @@ pnpm add @payloadcms/storage-azure
 
 - Configure the `collections` object to specify which collections should use the Azure Blob Storage adapter. The slug _must_ match one of your existing collection slugs.
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
-- When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client. You must allow CORS PUT method to your website.
+- When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client.
+
+### Client uploads and CORS
+
+Client uploads (`clientUploads: true`) use the Azure Blob SDK, which splits large files into blocks and therefore avoids the ~5GB limit of a single upload request. Because the SDK sends `x-ms-*` headers, the browser issues a CORS preflight, so your storage account's CORS rules must allow the `OPTIONS` and `PUT` methods **and** the required headers.
+
+Configure a CORS rule on the Blob service (Storage account → **Resource sharing (CORS)**):
+
+| Field           | Value                                                    |
+| --------------- | -------------------------------------------------------- |
+| Allowed origins | Your site origin (e.g. `https://example.com`)            |
+| Allowed methods | `GET,PUT,OPTIONS` (add `HEAD` if reading in-browser)     |
+| Allowed headers | `*` (or at minimum `x-ms-*,content-type,content-length`) |
+| Exposed headers | `*`                                                      |
+| Max age         | `3600`                                                   |
+
+> If you previously configured CORS for the older single-`PUT` upload flow, broaden `Allowed headers` to include the `x-ms-*` headers when upgrading.
 
 ```ts
 import { azureStorage } from '@payloadcms/storage-azure'

--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -16,11 +16,22 @@ pnpm add @payloadcms/storage-azure
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
 - When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client.
 
-### Client uploads and CORS
+### Large client uploads (files over ~5GB)
 
-Client uploads (`clientUploads: true`) use the Azure Blob SDK, which splits large files into blocks and therefore avoids the ~5GB limit of a single upload request. Because the SDK sends `x-ms-*` headers, the browser issues a CORS preflight, so your storage account's CORS rules must allow the `OPTIONS` and `PUT` methods **and** the required headers.
+By default, client uploads (`clientUploads: true`) send each file in a single request, which Azure caps at ~5GB. To upload larger files, set `chunkLargeFiles: true`:
 
-Configure a CORS rule on the Blob service (Storage account → **Resource sharing (CORS)**):
+```ts
+azureStorage({
+  // ...
+  clientUploads: {
+    chunkLargeFiles: true,
+  },
+})
+```
+
+This uploads through the Azure Blob SDK, which splits the file into blocks (`Put Block` + `Put Block List`) and raises the limit to Azure's block-blob maximum (~190TiB).
+
+Because the SDK sends additional `x-ms-*` headers, the browser issues a CORS preflight, so your storage account's CORS rules must allow the `OPTIONS` and `PUT` methods **and** those headers. Configure a CORS rule on the Blob service (Storage account → **Resource sharing (CORS)**):
 
 | Field           | Value                                                    |
 | --------------- | -------------------------------------------------------- |
@@ -29,8 +40,6 @@ Configure a CORS rule on the Blob service (Storage account → **Resource sharin
 | Allowed headers | `*` (or at minimum `x-ms-*,content-type,content-length`) |
 | Exposed headers | `*`                                                      |
 | Max age         | `3600`                                                   |
-
-> If you previously configured CORS for the older single-`PUT` upload flow, broaden `Allowed headers` to include the `x-ms-*` headers when upgrading.
 
 ```ts
 import { azureStorage } from '@payloadcms/storage-azure'

--- a/packages/storage-azure/src/client/AzureClientUploadHandler.ts
+++ b/packages/storage-azure/src/client/AzureClientUploadHandler.ts
@@ -3,11 +3,16 @@ import { createClientUploadHandler } from '@payloadcms/plugin-cloud-storage/clie
 
 import { handleAzureUpload } from './handleAzureUpload.js'
 
-export const AzureClientUploadHandler = createClientUploadHandler({
+export type AzureClientUploadHandlerExtra = {
+  chunkLargeFiles: boolean
+}
+
+export const AzureClientUploadHandler = createClientUploadHandler<AzureClientUploadHandlerExtra>({
   handler: async ({
     apiRoute,
     collectionSlug,
     docPrefix,
+    extra: { chunkLargeFiles },
     file,
     serverHandlerPath,
     serverURL,
@@ -15,6 +20,7 @@ export const AzureClientUploadHandler = createClientUploadHandler({
   }) => {
     return handleAzureUpload({
       apiRoute,
+      chunkLargeFiles,
       collectionSlug,
       docPrefix,
       file,

--- a/packages/storage-azure/src/client/AzureClientUploadHandler.ts
+++ b/packages/storage-azure/src/client/AzureClientUploadHandler.ts
@@ -1,6 +1,7 @@
 'use client'
 import { createClientUploadHandler } from '@payloadcms/plugin-cloud-storage/client'
-import { formatAdminURL } from 'payload/shared'
+
+import { handleAzureUpload } from './handleAzureUpload.js'
 
 export const AzureClientUploadHandler = createClientUploadHandler({
   handler: async ({
@@ -12,47 +13,14 @@ export const AzureClientUploadHandler = createClientUploadHandler({
     serverURL,
     updateFilename,
   }) => {
-    const endpointRoute = formatAdminURL({
+    return handleAzureUpload({
       apiRoute,
-      path: serverHandlerPath,
+      collectionSlug,
+      docPrefix,
+      file,
+      serverHandlerPath,
       serverURL,
+      updateFilename,
     })
-    const response = await fetch(endpointRoute, {
-      body: JSON.stringify({
-        collectionSlug,
-        docPrefix,
-        filename: file.name,
-        mimeType: file.type,
-      }),
-      credentials: 'include',
-      method: 'POST',
-    })
-
-    const {
-      docPrefix: sanitizedDocPrefix,
-      filename: sanitizedFilename,
-      url,
-    } = (await response.json()) as {
-      docPrefix: string
-      filename?: string
-      url: string
-    }
-
-    if (sanitizedFilename && sanitizedFilename !== file.name) {
-      updateFilename(sanitizedFilename)
-    }
-
-    await fetch(url, {
-      body: file,
-      headers: {
-        'Content-Length': file.size.toString(),
-        'Content-Type': file.type,
-        // Required for azure
-        'x-ms-blob-type': 'BlockBlob',
-      },
-      method: 'PUT',
-    })
-
-    return { prefix: sanitizedDocPrefix }
   },
 })

--- a/packages/storage-azure/src/client/handleAzureUpload.spec.ts
+++ b/packages/storage-azure/src/client/handleAzureUpload.spec.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const uploadDataMock = vi.fn()
+const blockBlobClientMock = vi.fn(function () {
+  return { uploadData: uploadDataMock }
+})
+
+vi.mock('@azure/storage-blob', () => ({
+  BlockBlobClient: blockBlobClientMock,
+}))
+
+import { handleAzureUpload } from './handleAzureUpload.js'
+
+const serverURL = 'https://example.com'
+const apiRoute = '/api'
+const serverHandlerPath = '/storage-azure-generate-signed-url' as const
+const signedURL = 'https://account.blob.core.windows.net/container/file.png?sig=abc'
+
+const createFile = () => new File([new Uint8Array([1, 2, 3])], 'file.png', { type: 'image/png' })
+
+const mockSignedURLResponse = (body: Record<string, unknown>, ok = true) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve(body),
+    ok,
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('handleAzureUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    uploadDataMock.mockResolvedValue(undefined)
+  })
+
+  it('should request a signed URL from the server handler', async () => {
+    const fetchMock = mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+
+    await handleAzureUpload({
+      apiRoute,
+      collectionSlug: 'media',
+      docPrefix: 'docs',
+      file: createFile(),
+      serverHandlerPath,
+      serverURL,
+      updateFilename: vi.fn(),
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [calledURL, init] = fetchMock.mock.calls[0]!
+
+    expect(calledURL).toBe(`${serverURL}${apiRoute}${serverHandlerPath}`)
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({
+      collectionSlug: 'media',
+      docPrefix: 'docs',
+      filename: 'file.png',
+      mimeType: 'image/png',
+    })
+  })
+
+  it('should upload via BlockBlobClient.uploadData rather than a raw PUT', async () => {
+    const fetchMock = mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+    const file = createFile()
+
+    await handleAzureUpload({
+      apiRoute,
+      collectionSlug: 'media',
+      file,
+      serverHandlerPath,
+      serverURL,
+      updateFilename: vi.fn(),
+    })
+
+    expect(blockBlobClientMock).toHaveBeenCalledWith(signedURL)
+    expect(uploadDataMock).toHaveBeenCalledTimes(1)
+
+    const [uploadedFile, options] = uploadDataMock.mock.calls[0]!
+    expect(uploadedFile).toBe(file)
+    expect(options.blockSize).toBeGreaterThan(0)
+    expect(options.concurrency).toBeGreaterThan(0)
+
+    // Only the signed-URL request should hit fetch; no raw PUT to the blob URL.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should pass the file content type to the blob headers', async () => {
+    mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+
+    await handleAzureUpload({
+      apiRoute,
+      collectionSlug: 'media',
+      file: createFile(),
+      serverHandlerPath,
+      serverURL,
+      updateFilename: vi.fn(),
+    })
+
+    const [, options] = uploadDataMock.mock.calls[0]!
+    expect(options.blobHTTPHeaders).toEqual({ blobContentType: 'image/png' })
+  })
+
+  it('should call updateFilename when the server returns a sanitized filename', async () => {
+    mockSignedURLResponse({ docPrefix: 'docs', filename: 'file-1.png', url: signedURL })
+    const updateFilename = vi.fn()
+
+    await handleAzureUpload({
+      apiRoute,
+      collectionSlug: 'media',
+      file: createFile(),
+      serverHandlerPath,
+      serverURL,
+      updateFilename,
+    })
+
+    expect(updateFilename).toHaveBeenCalledWith('file-1.png')
+  })
+
+  it('should not call updateFilename when the filename is unchanged', async () => {
+    mockSignedURLResponse({ docPrefix: 'docs', filename: 'file.png', url: signedURL })
+    const updateFilename = vi.fn()
+
+    await handleAzureUpload({
+      apiRoute,
+      collectionSlug: 'media',
+      file: createFile(),
+      serverHandlerPath,
+      serverURL,
+      updateFilename,
+    })
+
+    expect(updateFilename).not.toHaveBeenCalled()
+  })
+
+  it('should return the sanitized doc prefix', async () => {
+    mockSignedURLResponse({ docPrefix: 'sanitized-docs', url: signedURL })
+
+    const result = await handleAzureUpload({
+      apiRoute,
+      collectionSlug: 'media',
+      file: createFile(),
+      serverHandlerPath,
+      serverURL,
+      updateFilename: vi.fn(),
+    })
+
+    expect(result).toEqual({ prefix: 'sanitized-docs' })
+  })
+
+  it('should throw when the signed URL request fails', async () => {
+    mockSignedURLResponse({}, false)
+
+    await expect(
+      handleAzureUpload({
+        apiRoute,
+        collectionSlug: 'media',
+        file: createFile(),
+        serverHandlerPath,
+        serverURL,
+        updateFilename: vi.fn(),
+      }),
+    ).rejects.toThrow()
+
+    expect(uploadDataMock).not.toHaveBeenCalled()
+  })
+
+  it('should propagate errors from uploadData', async () => {
+    mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+    uploadDataMock.mockRejectedValue(new Error('block upload failed'))
+
+    await expect(
+      handleAzureUpload({
+        apiRoute,
+        collectionSlug: 'media',
+        file: createFile(),
+        serverHandlerPath,
+        serverURL,
+        updateFilename: vi.fn(),
+      }),
+    ).rejects.toThrow('block upload failed')
+  })
+})

--- a/packages/storage-azure/src/client/handleAzureUpload.spec.ts
+++ b/packages/storage-azure/src/client/handleAzureUpload.spec.ts
@@ -27,6 +27,18 @@ const mockSignedURLResponse = (body: Record<string, unknown>, ok = true) => {
   return fetchMock
 }
 
+const invoke = (overrides: Partial<Parameters<typeof handleAzureUpload>[0]> = {}) =>
+  handleAzureUpload({
+    apiRoute,
+    chunkLargeFiles: true,
+    collectionSlug: 'media',
+    file: createFile(),
+    serverHandlerPath,
+    serverURL,
+    updateFilename: vi.fn(),
+    ...overrides,
+  })
+
 describe('handleAzureUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -34,150 +46,119 @@ describe('handleAzureUpload', () => {
     uploadDataMock.mockResolvedValue(undefined)
   })
 
-  it('should request a signed URL from the server handler', async () => {
-    const fetchMock = mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+  describe('shared behavior', () => {
+    it('should request a signed URL from the server handler', async () => {
+      const fetchMock = mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
 
-    await handleAzureUpload({
-      apiRoute,
-      collectionSlug: 'media',
-      docPrefix: 'docs',
-      file: createFile(),
-      serverHandlerPath,
-      serverURL,
-      updateFilename: vi.fn(),
-    })
+      await invoke({ docPrefix: 'docs' })
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [calledURL, init] = fetchMock.mock.calls[0]!
-
-    expect(calledURL).toBe(`${serverURL}${apiRoute}${serverHandlerPath}`)
-    expect(init.method).toBe('POST')
-    expect(JSON.parse(init.body)).toEqual({
-      collectionSlug: 'media',
-      docPrefix: 'docs',
-      filename: 'file.png',
-      mimeType: 'image/png',
-    })
-  })
-
-  it('should upload via BlockBlobClient.uploadData rather than a raw PUT', async () => {
-    const fetchMock = mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
-    const file = createFile()
-
-    await handleAzureUpload({
-      apiRoute,
-      collectionSlug: 'media',
-      file,
-      serverHandlerPath,
-      serverURL,
-      updateFilename: vi.fn(),
-    })
-
-    expect(blockBlobClientMock).toHaveBeenCalledWith(signedURL)
-    expect(uploadDataMock).toHaveBeenCalledTimes(1)
-
-    const [uploadedFile, options] = uploadDataMock.mock.calls[0]!
-    expect(uploadedFile).toBe(file)
-    expect(options.blockSize).toBeGreaterThan(0)
-    expect(options.concurrency).toBeGreaterThan(0)
-
-    // Only the signed-URL request should hit fetch; no raw PUT to the blob URL.
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('should pass the file content type to the blob headers', async () => {
-    mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
-
-    await handleAzureUpload({
-      apiRoute,
-      collectionSlug: 'media',
-      file: createFile(),
-      serverHandlerPath,
-      serverURL,
-      updateFilename: vi.fn(),
-    })
-
-    const [, options] = uploadDataMock.mock.calls[0]!
-    expect(options.blobHTTPHeaders).toEqual({ blobContentType: 'image/png' })
-  })
-
-  it('should call updateFilename when the server returns a sanitized filename', async () => {
-    mockSignedURLResponse({ docPrefix: 'docs', filename: 'file-1.png', url: signedURL })
-    const updateFilename = vi.fn()
-
-    await handleAzureUpload({
-      apiRoute,
-      collectionSlug: 'media',
-      file: createFile(),
-      serverHandlerPath,
-      serverURL,
-      updateFilename,
-    })
-
-    expect(updateFilename).toHaveBeenCalledWith('file-1.png')
-  })
-
-  it('should not call updateFilename when the filename is unchanged', async () => {
-    mockSignedURLResponse({ docPrefix: 'docs', filename: 'file.png', url: signedURL })
-    const updateFilename = vi.fn()
-
-    await handleAzureUpload({
-      apiRoute,
-      collectionSlug: 'media',
-      file: createFile(),
-      serverHandlerPath,
-      serverURL,
-      updateFilename,
-    })
-
-    expect(updateFilename).not.toHaveBeenCalled()
-  })
-
-  it('should return the sanitized doc prefix', async () => {
-    mockSignedURLResponse({ docPrefix: 'sanitized-docs', url: signedURL })
-
-    const result = await handleAzureUpload({
-      apiRoute,
-      collectionSlug: 'media',
-      file: createFile(),
-      serverHandlerPath,
-      serverURL,
-      updateFilename: vi.fn(),
-    })
-
-    expect(result).toEqual({ prefix: 'sanitized-docs' })
-  })
-
-  it('should throw when the signed URL request fails', async () => {
-    mockSignedURLResponse({}, false)
-
-    await expect(
-      handleAzureUpload({
-        apiRoute,
+      const [calledURL, init] = fetchMock.mock.calls[0]!
+      expect(calledURL).toBe(`${serverURL}${apiRoute}${serverHandlerPath}`)
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(init.body)).toEqual({
         collectionSlug: 'media',
-        file: createFile(),
-        serverHandlerPath,
-        serverURL,
-        updateFilename: vi.fn(),
-      }),
-    ).rejects.toThrow()
+        docPrefix: 'docs',
+        filename: 'file.png',
+        mimeType: 'image/png',
+      })
+    })
 
-    expect(uploadDataMock).not.toHaveBeenCalled()
+    it('should call updateFilename when the server returns a sanitized filename', async () => {
+      mockSignedURLResponse({ docPrefix: 'docs', filename: 'file-1.png', url: signedURL })
+      const updateFilename = vi.fn()
+
+      await invoke({ updateFilename })
+
+      expect(updateFilename).toHaveBeenCalledWith('file-1.png')
+    })
+
+    it('should not call updateFilename when the filename is unchanged', async () => {
+      mockSignedURLResponse({ docPrefix: 'docs', filename: 'file.png', url: signedURL })
+      const updateFilename = vi.fn()
+
+      await invoke({ updateFilename })
+
+      expect(updateFilename).not.toHaveBeenCalled()
+    })
+
+    it('should return the sanitized doc prefix', async () => {
+      mockSignedURLResponse({ docPrefix: 'sanitized-docs', url: signedURL })
+
+      const result = await invoke()
+
+      expect(result).toEqual({ prefix: 'sanitized-docs' })
+    })
+
+    it('should throw when the signed URL request fails, before any upload', async () => {
+      mockSignedURLResponse({}, false)
+
+      await expect(invoke()).rejects.toThrow()
+
+      expect(uploadDataMock).not.toHaveBeenCalled()
+      expect(blockBlobClientMock).not.toHaveBeenCalled()
+    })
   })
 
-  it('should propagate errors from uploadData', async () => {
-    mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
-    uploadDataMock.mockRejectedValue(new Error('block upload failed'))
+  describe('chunkLargeFiles: true (SDK block upload)', () => {
+    it('should upload via BlockBlobClient.uploadData rather than a raw PUT', async () => {
+      const fetchMock = mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+      const file = createFile()
 
-    await expect(
-      handleAzureUpload({
-        apiRoute,
-        collectionSlug: 'media',
-        file: createFile(),
-        serverHandlerPath,
-        serverURL,
-        updateFilename: vi.fn(),
-      }),
-    ).rejects.toThrow('block upload failed')
+      await invoke({ chunkLargeFiles: true, file })
+
+      expect(blockBlobClientMock).toHaveBeenCalledWith(signedURL)
+      expect(uploadDataMock).toHaveBeenCalledTimes(1)
+
+      const [uploadedFile, options] = uploadDataMock.mock.calls[0]!
+      expect(uploadedFile).toBe(file)
+      expect(options.blockSize).toBeGreaterThan(0)
+      expect(options.concurrency).toBeGreaterThan(0)
+
+      // Only the signed-URL request should hit fetch; no raw PUT to the blob URL.
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should pass the file content type to the blob headers', async () => {
+      mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+
+      await invoke({ chunkLargeFiles: true })
+
+      const [, options] = uploadDataMock.mock.calls[0]!
+      expect(options.blobHTTPHeaders).toEqual({ blobContentType: 'image/png' })
+    })
+
+    it('should propagate errors from uploadData', async () => {
+      mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+      uploadDataMock.mockRejectedValue(new Error('block upload failed'))
+
+      await expect(invoke({ chunkLargeFiles: true })).rejects.toThrow('block upload failed')
+    })
+  })
+
+  describe('chunkLargeFiles: false (single PUT, default/legacy)', () => {
+    it('should upload via a single raw PUT with the BlockBlob header', async () => {
+      const fetchMock = mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+      const file = createFile()
+
+      await invoke({ chunkLargeFiles: false, file })
+
+      // 1st fetch = signed-URL POST, 2nd = the raw PUT to the blob URL
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      const [putURL, putInit] = fetchMock.mock.calls[1]!
+      expect(putURL).toBe(signedURL)
+      expect(putInit.method).toBe('PUT')
+      expect(putInit.body).toBe(file)
+      expect(putInit.headers['x-ms-blob-type']).toBe('BlockBlob')
+      expect(putInit.headers['Content-Type']).toBe('image/png')
+    })
+
+    it('should not use the Azure SDK', async () => {
+      mockSignedURLResponse({ docPrefix: 'docs', url: signedURL })
+
+      await invoke({ chunkLargeFiles: false })
+
+      expect(blockBlobClientMock).not.toHaveBeenCalled()
+      expect(uploadDataMock).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/storage-azure/src/client/handleAzureUpload.ts
+++ b/packages/storage-azure/src/client/handleAzureUpload.ts
@@ -1,0 +1,78 @@
+'use client'
+import { formatAdminURL } from 'payload/shared'
+
+// Balances upload parallelism against browser memory: `blockSize * concurrency`
+// bytes are buffered in flight. The SDK uses a single Put Blob for small files
+// and switches to Put Block + Put Block List above its single-shot threshold,
+// lifting the ~5 GB single-request ceiling to Azure's block-blob maximum.
+const BLOCK_SIZE = 64 * 1024 * 1024
+const CONCURRENCY = 4
+
+type HandleAzureUploadArgs = {
+  apiRoute: string
+  collectionSlug: string
+  docPrefix?: string
+  file: File
+  serverHandlerPath: `/${string}`
+  serverURL: string
+  updateFilename: (value: string) => void
+}
+
+export const handleAzureUpload = async ({
+  apiRoute,
+  collectionSlug,
+  docPrefix,
+  file,
+  serverHandlerPath,
+  serverURL,
+  updateFilename,
+}: HandleAzureUploadArgs): Promise<{ prefix: string }> => {
+  const endpointRoute = formatAdminURL({
+    apiRoute,
+    path: serverHandlerPath,
+    serverURL,
+  })
+
+  const response = await fetch(endpointRoute, {
+    body: JSON.stringify({
+      collectionSlug,
+      docPrefix,
+      filename: file.name,
+      mimeType: file.type,
+    }),
+    credentials: 'include',
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to retrieve signed URL for Azure client upload')
+  }
+
+  const {
+    docPrefix: sanitizedDocPrefix,
+    filename: sanitizedFilename,
+    url,
+  } = (await response.json()) as {
+    docPrefix: string
+    filename?: string
+    url: string
+  }
+
+  if (sanitizedFilename && sanitizedFilename !== file.name) {
+    updateFilename(sanitizedFilename)
+  }
+
+  // Loaded on demand so @azure/storage-blob is only pulled into the client bundle
+  // when a client upload actually runs, rather than for every Azure adapter user.
+  const { BlockBlobClient } = await import('@azure/storage-blob')
+
+  const blockBlobClient = new BlockBlobClient(url)
+
+  await blockBlobClient.uploadData(file, {
+    blobHTTPHeaders: { blobContentType: file.type },
+    blockSize: BLOCK_SIZE,
+    concurrency: CONCURRENCY,
+  })
+
+  return { prefix: sanitizedDocPrefix }
+}

--- a/packages/storage-azure/src/client/handleAzureUpload.ts
+++ b/packages/storage-azure/src/client/handleAzureUpload.ts
@@ -2,14 +2,18 @@
 import { formatAdminURL } from 'payload/shared'
 
 // Balances upload parallelism against browser memory: `blockSize * concurrency`
-// bytes are buffered in flight. The SDK uses a single Put Blob for small files
-// and switches to Put Block + Put Block List above its single-shot threshold,
-// lifting the ~5 GB single-request ceiling to Azure's block-blob maximum.
+// bytes are buffered in flight (64 MiB * 4 = 256 MiB). Only used on the SDK path.
 const BLOCK_SIZE = 64 * 1024 * 1024
 const CONCURRENCY = 4
 
 type HandleAzureUploadArgs = {
   apiRoute: string
+  /**
+   * When true, upload through the Azure Blob SDK, which splits the file into
+   * blocks (Put Block + Put Block List) and lifts the ~5 GB single-request
+   * limit. When false, use the legacy single Put Blob request.
+   */
+  chunkLargeFiles: boolean
   collectionSlug: string
   docPrefix?: string
   file: File
@@ -20,6 +24,7 @@ type HandleAzureUploadArgs = {
 
 export const handleAzureUpload = async ({
   apiRoute,
+  chunkLargeFiles,
   collectionSlug,
   docPrefix,
   file,
@@ -62,17 +67,30 @@ export const handleAzureUpload = async ({
     updateFilename(sanitizedFilename)
   }
 
-  // Loaded on demand so @azure/storage-blob is only pulled into the client bundle
-  // when a client upload actually runs, rather than for every Azure adapter user.
-  const { BlockBlobClient } = await import('@azure/storage-blob')
+  if (chunkLargeFiles) {
+    // Loaded on demand so @azure/storage-blob is only pulled into the client bundle
+    // when a chunked client upload actually runs, rather than for every Azure user.
+    const { BlockBlobClient } = await import('@azure/storage-blob')
 
-  const blockBlobClient = new BlockBlobClient(url)
+    const blockBlobClient = new BlockBlobClient(url)
 
-  await blockBlobClient.uploadData(file, {
-    blobHTTPHeaders: { blobContentType: file.type },
-    blockSize: BLOCK_SIZE,
-    concurrency: CONCURRENCY,
-  })
+    await blockBlobClient.uploadData(file, {
+      blobHTTPHeaders: { blobContentType: file.type },
+      blockSize: BLOCK_SIZE,
+      concurrency: CONCURRENCY,
+    })
+  } else {
+    await fetch(url, {
+      body: file,
+      headers: {
+        'Content-Length': file.size.toString(),
+        'Content-Type': file.type,
+        // Required for azure
+        'x-ms-blob-type': 'BlockBlob',
+      },
+      method: 'PUT',
+    })
+  }
 
   return { prefix: sanitizedDocPrefix }
 }

--- a/packages/storage-azure/src/generateSignedURL.ts
+++ b/packages/storage-azure/src/generateSignedURL.ts
@@ -65,7 +65,7 @@ export const getGenerateSignedURLHandler = ({
         blobName: fileKey,
         containerName,
         contentType: mimeType,
-        expiresOn: new Date(Date.now() + 30 * 60 * 1000),
+        expiresOn: new Date(Date.now() + 60 * 60 * 1000),
         permissions: BlobSASPermissions.parse('w'),
         startsOn: new Date(),
       },

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -1,5 +1,5 @@
 import type {
-  ClientUploadsConfig,
+  ClientUploadsAccess,
   PluginOptions as CloudStoragePluginOptions,
   CollectionOptions,
 } from '@payloadcms/plugin-cloud-storage/types'
@@ -11,6 +11,20 @@ import { initClientUploads } from '@payloadcms/plugin-cloud-storage/utilities'
 import { createAzureAdapter } from './adapter.js'
 import { getGenerateSignedURLHandler } from './generateSignedURL.js'
 import { getStorageClient as getStorageClientFunc } from './utils/getStorageClient.js'
+
+export type AzureClientUploadsConfig =
+  | {
+      access?: ClientUploadsAccess
+      /**
+       * Upload large files in blocks via the Azure Blob SDK, lifting the ~5GB
+       * single-request limit. Requires broader CORS on the storage account
+       * (the `OPTIONS`/`PUT` methods and `x-ms-*` headers).
+       *
+       * @default false
+       */
+      chunkLargeFiles?: boolean
+    }
+  | boolean
 
 export type AzureStorageOptions = {
   /**
@@ -45,15 +59,16 @@ export type AzureStorageOptions = {
   clientCacheKey?: string
 
   /**
-   * Do uploads directly on the client to bypass limits on Vercel.
+   * Do uploads directly on the client to bypass limits on Vercel. You must allow CORS PUT method to your website.
    *
-   * Client uploads use the Azure Blob SDK, which splits large files into blocks
-   * (avoiding the ~5GB limit of a single upload request). The SDK sends `x-ms-*`
-   * headers, so the browser issues a CORS preflight: your storage account's CORS
-   * rules must allow the `OPTIONS` and `PUT` methods and the required headers
-   * (allowed headers `*`, or at minimum `x-ms-*,content-type,content-length`).
+   * Set `chunkLargeFiles: true` to upload through the Azure Blob SDK, which splits
+   * large files into blocks and lifts the ~5GB single-request limit. The SDK sends
+   * additional `x-ms-*` headers, so your storage account's CORS rules must allow the
+   * `OPTIONS` and `PUT` methods and those headers (allowed headers `*`, or at minimum
+   * `x-ms-*,content-type,content-length`). Left off, uploads use a single request
+   * (the default) and are capped at ~5GB.
    */
-  clientUploads?: ClientUploadsConfig
+  clientUploads?: AzureClientUploadsConfig
 
   /**
    * Collection options to apply the Azure Blob adapter to.
@@ -110,6 +125,12 @@ export const azureStorage: AzureStoragePlugin =
       collections: azureStorageOptions.collections,
       config: incomingConfig,
       enabled: !isPluginDisabled && Boolean(azureStorageOptions.clientUploads),
+      extraClientHandlerProps: () => ({
+        chunkLargeFiles:
+          typeof azureStorageOptions.clientUploads === 'object'
+            ? Boolean(azureStorageOptions.clientUploads.chunkLargeFiles)
+            : false,
+      }),
       serverHandler: getGenerateSignedURLHandler({
         access:
           typeof azureStorageOptions.clientUploads === 'object'

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -45,7 +45,13 @@ export type AzureStorageOptions = {
   clientCacheKey?: string
 
   /**
-   * Do uploads directly on the client to bypass limits on Vercel. You must allow CORS PUT method to your website.
+   * Do uploads directly on the client to bypass limits on Vercel.
+   *
+   * Client uploads use the Azure Blob SDK, which splits large files into blocks
+   * (avoiding the ~5GB limit of a single upload request). The SDK sends `x-ms-*`
+   * headers, so the browser issues a CORS preflight: your storage account's CORS
+   * rules must allow the `OPTIONS` and `PUT` methods and the required headers
+   * (allowed headers `*`, or at minimum `x-ms-*,content-type,content-length`).
    */
   clientUploads?: ClientUploadsConfig
 

--- a/test/storage-azure/client-uploads/config.ts
+++ b/test/storage-azure/client-uploads/config.ts
@@ -49,7 +49,9 @@ export default buildConfigWithDefaults({
       },
       allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
       baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL!,
-      clientUploads: true,
+      clientUploads: {
+        chunkLargeFiles: true,
+      },
       connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING!,
       containerName: process.env.AZURE_STORAGE_CONTAINER_NAME!,
     }),


### PR DESCRIPTION
v3 port of https://github.com/payloadcms/payload/pull/17318

In v4 this is enabled by default, in v3 this is behind a flag because it's potentially breaking as CORS needs additional headers setup.

## What

Adds opt-in support for uploading files larger than ~5GB directly from the client with the Azure storage adapter. A new `clientUploads.chunkLargeFiles` option routes browser uploads through the Azure Blob SDK, which splits the file into blocks instead of sending it in a single request.

## Why

Client uploads (`clientUploads: true`) previously sent each file to Azure in one `Put Blob` request. Azure caps a single `Put Blob` at ~5GB, so any larger file failed outright — which defeats the purpose of client uploads, since they exist specifically to move large files that can't go through the server/proxy body limits.

The Blob SDK's block API (`Put Block` + `Put Block List`) is Azure's supported path for large blobs. It splits the file into blocks, uploads them in parallel, and commits at the end, raising the effective ceiling to the block-blob maximum (~190TiB) while also improving throughput on large transfers.

## Behaviour

- **Default is unchanged.** With `clientUploads: true`, uploads still use the original single-request path and the same CORS requirements. Existing setups behave exactly as before — this is not a breaking change.
- **Large-file support is opt-in.** Set `clientUploads: { chunkLargeFiles: true }` to switch to the SDK block-upload path for files over ~5GB.

```ts
azureStorage({
  clientUploads: {
    chunkLargeFiles: true,
  },
  // ...
})
```

`chunkLargeFiles` routes client uploads through the Azure Blob SDK, which sends extra `x-ms-*` headers and issues CORS preflight (OPTIONS) requests.

The storage account's CORS rules must therefore allow:
 - Methods: OPTIONS, PUT (GET/HEAD too if reading blobs in-browser)
 - Allowed headers: `*` (or at minimum `x-ms-*,content-type,content-length`)
 - Exposed headers: `*`

Without these, block uploads fail in the browser with "RestError: Failed to fetch".
