### PR TITLE
fix(next): expand admin font subsets for multilingual glyph support

### DIFF
--- a/packages/next/src/adapters/layout.tsx
+++ b/packages/next/src/adapters/layout.tsx
@@ -12,12 +12,12 @@ import { nextServerAdapter } from './server.js'
 import '@payloadcms/ui/scss/app.scss'
 
 const inter = Inter({
-  subsets: ['latin'],
+  subsets: ['latin', 'latin-ext', 'cyrillic', 'cyrillic-ext', 'greek', 'greek-ext', 'vietnamese'],
   variable: '--font-family-sans',
 })
 
 const robotoMono = Roboto_Mono({
-  subsets: ['latin'],
+  subsets: ['latin', 'latin-ext', 'cyrillic', 'cyrillic-ext', 'greek', 'vietnamese'],
   variable: '--font-family-mono',
 })
 


### PR DESCRIPTION
## What?
The admin panel's Inter/Roboto Mono fonts were loaded via `next/font/google` with only the `latin` subset, so non-Latin-diacritic scripts (Vietnamese, Cyrillic, Greek) rendered with missing/incorrect glyphs — even though Payload ships translations for languages like `vi`, `ru`, `uk`, `bg`, and `el`.

## Why?
Fixes #14893. A user reported broken glyph rendering when switching the admin UI to Vietnamese. The root cause (confirmed by reading `packages/next/src/adapters/layout.tsx`) is that `next/font/google` only downloads glyphs for the subsets you explicitly request — `subsets: ['latin']` excludes the Vietnamese-specific Unicode ranges entirely, so the browser has no glyphs to render for those characters.

## How?
Added `latin-ext`, `cyrillic`, `cyrillic-ext`, `greek`/`greek-ext`, and `vietnamese` to the `subsets` array for both `Inter` and `Roboto_Mono` in `layout.tsx`. This covers every Latin/Cyrillic/Greek-script language in `packages/translations`.

Genuinely non-Latin/Cyrillic/Greek scripts (CJK, Arabic, Hebrew, Thai, Tamil, etc.) are unaffected either way — Inter and Roboto Mono don't ship glyphs for those scripts at any subset, so they already fall back to the system font stack via the `sans-serif` generic in `--font-body`. This change only fixes the languages Inter/Roboto Mono actually have coverage for but weren't being asked to include.

## Verification
- `pnpm run build:core` — all 46 packages build successfully with no errors
- `tsc --noEmit` on `packages/next` — 0 errors (the subset names are validated against Next.js's own `next/font/google` types, so any invalid subset name would fail here)
- Ran `pnpm dev` locally and confirmed the admin panel renders normally with no regressions
