### PR TITLE
fix(ui): vertically center drag handle and select-all checkbox in orderable table

### DIFF
--- a/packages/ui/src/elements/SelectAll/index.css
+++ b/packages/ui/src/elements/SelectAll/index.css
@@ -1,5 +1,7 @@
 @layer payload-default {
   .select-all__checkbox {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 }

--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -111,6 +111,12 @@
       vertical-align: middle;
     }
 
+    .cell-_dragHandle > div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
     tbody tr {
       position: relative;
       border-top: var(--stroke-width-small) solid var(--color-border);


### PR DESCRIPTION
Centers the drag handle icon and the select-all checkbox within orderable collection table rows.

Both elements are `inline-flex` boxes rendered inside a taller block-level wrapper, so they aligned to the top of the line-box instead of the row's vertical center (off by ~2px).

`.cell-_dragHandle > div` and `.select-all__checkbox` now use `flex` centering, collapsing the wrapper to the element's height so the cell's `vertical-align: middle` centers it.

#### Before:
<img width="309" height="402" alt="Screenshot 2026-07-14 at 10 36 59 AM" src="https://github.com/user-attachments/assets/70f0e46c-e53b-4501-8f6e-858cccb5e9b0" />

<img width="389" height="89" alt="Screenshot 2026-07-14 at 10 55 14 AM" src="https://github.com/user-attachments/assets/58792473-4a00-4669-8de0-3a43b2512db9" />

#### After:
<img width="335" height="396" alt="Screenshot 2026-07-14 at 11 05 39 AM" src="https://github.com/user-attachments/assets/e5cfd738-6335-42f4-b4e0-46509caa3518" />

<img width="444" height="90" alt="Screenshot 2026-07-14 at 11 02 35 AM" src="https://github.com/user-attachments/assets/65cf6c67-fa06-454d-891a-a2908f0f3d39" />