### PR TITLE
feat(cpa): add non-interactive --yes flag

### DIFF
--- a/packages/create-payload-app/src/lib/apply-yes-defaults.spec.ts
+++ b/packages/create-payload-app/src/lib/apply-yes-defaults.spec.ts
@@ -1,0 +1,80 @@
+import type { CliArgs, ProjectTemplate } from '../types.js'
+
+import { describe, expect, it } from 'vitest'
+
+import { applyYesDefaults } from './apply-yes-defaults.js'
+
+const templates: ProjectTemplate[] = [
+  { name: 'blank', type: 'starter', url: 'x' },
+  { name: 'with-cloudflare-d1', type: 'starter', dbType: 'd1-sqlite', url: 'x' },
+  { name: 'plugin', type: 'plugin', url: 'x' },
+]
+
+function makeArgs(overrides: Record<string, unknown> = {}): CliArgs {
+  return { _: [], ...overrides } as unknown as CliArgs
+}
+
+describe('applyYesDefaults', () => {
+  it('should be a no-op when --yes is not set', () => {
+    const args = makeArgs({ _: ['my-app'], '--db': 'sqlite' })
+    const result = applyYesDefaults(args, templates)
+    expect(result['--template']).toBeUndefined()
+    expect(result['--no-agent']).toBeUndefined()
+  })
+
+  it('should default --template to blank and set --no-agent', () => {
+    const args = makeArgs({ _: ['my-app'], '--db': 'sqlite', '--yes': true })
+    const result = applyYesDefaults(args, templates)
+    expect(result['--template']).toBe('blank')
+    expect(result['--no-agent']).toBe(true)
+  })
+
+  it('should not override an explicit --template or --agent', () => {
+    const args = makeArgs({
+      _: ['my-app'],
+      '--agent': 'claude',
+      '--db': 'sqlite',
+      '--template': 'website',
+      '--yes': true,
+    })
+    const result = applyYesDefaults(args, templates)
+    expect(result['--template']).toBe('website')
+    expect(result['--no-agent']).toBeUndefined()
+  })
+
+  it('should not default --template when --example is set', () => {
+    const args = makeArgs({ _: ['my-app'], '--example': 'custom-server', '--yes': true })
+    const result = applyYesDefaults(args, templates)
+    expect(result['--template']).toBeUndefined()
+  })
+
+  it('should accept "." as a valid project name', () => {
+    const args = makeArgs({ _: ['.'], '--db': 'sqlite', '--yes': true })
+    expect(() => applyYesDefaults(args, templates)).not.toThrow()
+  })
+
+  it('should throw when no project name is given', () => {
+    const args = makeArgs({ '--db': 'sqlite', '--yes': true })
+    expect(() => applyYesDefaults(args, templates)).toThrow(/project name/)
+  })
+
+  it('should throw when a blank starter template has no --db', () => {
+    const args = makeArgs({ _: ['my-app'], '--yes': true })
+    expect(() => applyYesDefaults(args, templates)).toThrow(/--db/)
+  })
+
+  it('should not require --db when the template pins a dbType', () => {
+    const args = makeArgs({ _: ['my-app'], '--template': 'with-cloudflare-d1', '--yes': true })
+    expect(() => applyYesDefaults(args, templates)).not.toThrow()
+  })
+
+  it('should not require --db for a plugin template', () => {
+    const args = makeArgs({ _: ['my-app'], '--template': 'plugin', '--yes': true })
+    expect(() => applyYesDefaults(args, templates)).not.toThrow()
+  })
+
+  it('should not require --db when --example is used', () => {
+    const args = makeArgs({ _: ['my-app'], '--example': 'custom-server', '--yes': true })
+    expect(() => applyYesDefaults(args, templates)).not.toThrow()
+  })
+})

--- a/packages/create-payload-app/src/lib/apply-yes-defaults.ts
+++ b/packages/create-payload-app/src/lib/apply-yes-defaults.ts
@@ -1,0 +1,40 @@
+import type { CliArgs, ProjectTemplate } from '../types.js'
+
+const VALID_DB_TYPES = 'mongodb, postgres, sqlite, vercel-postgres, d1-sqlite'
+
+/**
+ * When `--yes` is set, fills in defaults for prompt-backed choices that were not
+ * set explicitly (template → blank, agent → none) and validates the inputs that
+ * have no safe default (project name, database). Mutates and returns `args`.
+ * A no-op when `--yes` is not set. Explicit flags always take precedence.
+ */
+export function applyYesDefaults(args: CliArgs, validTemplates: ProjectTemplate[]): CliArgs {
+  if (!args['--yes']) {
+    return args
+  }
+
+  const projectName = args['--name'] || args._[0]
+  if (!projectName) {
+    throw new Error(
+      "--yes requires a project name or '.' for the current directory (e.g. create-payload-app my-app --db sqlite -y, or create-payload-app . --db sqlite -y)",
+    )
+  }
+
+  const usingExample = Boolean(args['--example'])
+
+  if (!args['--template'] && !usingExample) {
+    args['--template'] = 'blank'
+  }
+
+  if (!args['--agent'] && !args['--no-agent']) {
+    args['--no-agent'] = true
+  }
+
+  const template = validTemplates.find((t) => t.name === args['--template'])
+  const needsDb = !usingExample && template?.type === 'starter' && !template?.dbType
+  if (needsDb && !args['--db']) {
+    throw new Error(`--yes requires --db (one of: ${VALID_DB_TYPES})`)
+  }
+
+  return args
+}

--- a/packages/create-payload-app/src/lib/select-db.spec.ts
+++ b/packages/create-payload-app/src/lib/select-db.spec.ts
@@ -1,0 +1,37 @@
+import type { CliArgs } from '../types.js'
+
+import { beforeAll, describe, expect, it, vitest } from 'vitest'
+
+import { selectDb } from './select-db.js'
+
+function makeArgs(overrides: Record<string, unknown> = {}): CliArgs {
+  return { _: [], ...overrides } as unknown as CliArgs
+}
+
+describe('selectDb', () => {
+  beforeAll(() => {
+    // eslint-disable-next-line no-console
+    console.log = vitest.fn()
+  })
+
+  it('should accept the recommended connection string when --yes is set (no prompt)', async () => {
+    const args = makeArgs({ '--db': 'sqlite', '--yes': true })
+
+    const result = await selectDb(args, 'my-app')
+
+    expect(result.type).toBe('sqlite')
+    expect(result.dbUri).toBe('file:./my-app.db')
+  })
+
+  it('should prefer an explicit --db-connection-string over --yes', async () => {
+    const args = makeArgs({
+      '--db': 'sqlite',
+      '--db-connection-string': 'file:./custom.db',
+      '--yes': true,
+    })
+
+    const result = await selectDb(args, 'my-app')
+
+    expect(result.dbUri).toBe('file:./custom.db')
+  })
+})

--- a/packages/create-payload-app/src/lib/select-db.spec.ts
+++ b/packages/create-payload-app/src/lib/select-db.spec.ts
@@ -34,4 +34,13 @@ describe('selectDb', () => {
 
     expect(result.dbUri).toBe('file:./custom.db')
   })
+
+  it('should leave dbUri undefined for d1-sqlite when --yes is set', async () => {
+    const args = makeArgs({ '--db': 'd1-sqlite', '--yes': true })
+
+    const result = await selectDb(args, 'my-app')
+
+    expect(result.type).toBe('d1-sqlite')
+    expect(result.dbUri).toBeUndefined()
+  })
 })

--- a/packages/create-payload-app/src/lib/select-db.ts
+++ b/packages/create-payload-app/src/lib/select-db.ts
@@ -77,10 +77,11 @@ export async function selectDb(
     projectName === '.' ? `payload-${getRandomDigitSuffix()}` : slugify(projectName)
   }${dbChoice.dbConnectionSuffix || ''}`
 
-  if (args['--db-accept-recommended']) {
-    dbUri = initialDbUri
-  } else if (args['--db-connection-string']) {
+  if (args['--db-connection-string']) {
     dbUri = args['--db-connection-string']
+  } else if (args['--yes']) {
+    // Non-interactive: accept the recommended connection string without prompting
+    dbUri = initialDbUri
     // D1 Sqlite does not use a connection string so skip this prompt for this database
   } else if (dbType !== 'd1-sqlite') {
     dbUri = await p.text({

--- a/packages/create-payload-app/src/lib/select-db.ts
+++ b/packages/create-payload-app/src/lib/select-db.ts
@@ -79,10 +79,10 @@ export async function selectDb(
 
   if (args['--db-connection-string']) {
     dbUri = args['--db-connection-string']
-  } else if (args['--yes']) {
+  } else if (args['--yes'] && dbType !== 'd1-sqlite') {
     // Non-interactive: accept the recommended connection string without prompting
+    // D1 Sqlite does not use a connection string, so it is left undefined
     dbUri = initialDbUri
-    // D1 Sqlite does not use a connection string so skip this prompt for this database
   } else if (dbType !== 'd1-sqlite') {
     dbUri = await p.text({
       initialValue: initialDbUri,

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -7,6 +7,7 @@ import path from 'path'
 
 import type { CliArgs } from './types.js'
 
+import { applyYesDefaults } from './lib/apply-yes-defaults.js'
 import { configurePayloadConfig } from './lib/configure-payload-config.js'
 import { createProject } from './lib/create-project.js'
 import { parseExample } from './lib/examples.js'
@@ -107,6 +108,8 @@ export class Main {
         process.exit(0)
       }
 
+      applyYesDefaults(this.args, getValidTemplates())
+
       // eslint-disable-next-line no-console
       console.log('\n')
       p.intro(chalk.bgCyan(chalk.black(' create-payload-app ')))
@@ -134,10 +137,12 @@ export class Main {
       // Upgrade Payload in existing project
       if (isPayloadInstalled && nextConfigPath) {
         p.log.warn(`Payload installation detected in current project.`)
-        const shouldUpdate = await p.confirm({
-          initialValue: false,
-          message: chalk.bold(`Upgrade Payload in this project?`),
-        })
+        const shouldUpdate = this.args['--yes']
+          ? true
+          : await p.confirm({
+              initialValue: false,
+              message: chalk.bold(`Upgrade Payload in this project?`),
+            })
 
         if (!p.isCancel(shouldUpdate) && shouldUpdate) {
           const { message, success: updateSuccess } = await updatePayloadInProject(
@@ -171,10 +176,12 @@ export class Main {
           chalk.bold(`${chalk.bgBlack(` ${figures.triangleUp} Next.js `)} project detected!`),
         )
 
-        const proceed = await p.confirm({
-          initialValue: true,
-          message: chalk.bold(`Install ${chalk.green('Payload')} in this project?`),
-        })
+        const proceed = this.args['--yes']
+          ? true
+          : await p.confirm({
+              initialValue: true,
+              message: chalk.bold(`Install ${chalk.green('Payload')} in this project?`),
+            })
         if (p.isCancel(proceed) || !proceed) {
           p.outro(feedbackOutro())
           process.exit(0)

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -43,7 +43,6 @@ export class Main {
         '--agent': String,
         '--branch': String,
         '--db': String,
-        '--db-accept-recommended': Boolean,
         '--db-connection-string': String,
         '--example': String,
         '--help': Boolean,
@@ -73,6 +72,7 @@ export class Main {
         '--beta': Boolean,
         '--debug': Boolean,
         '--dry-run': Boolean,
+        '--yes': Boolean,
 
         // Aliases
         '-a': '--agent',
@@ -81,6 +81,7 @@ export class Main {
         '-h': '--help',
         '-n': '--name',
         '-t': '--template',
+        '-y': '--yes',
       },
       { permissive: true },
     )

--- a/packages/create-payload-app/src/non-interactive.spec.ts
+++ b/packages/create-payload-app/src/non-interactive.spec.ts
@@ -1,0 +1,38 @@
+import type { CliArgs } from './types.js'
+
+import { beforeAll, describe, expect, it, vitest } from 'vitest'
+
+import { applyYesDefaults } from './lib/apply-yes-defaults.js'
+import { selectDb } from './lib/select-db.js'
+import { getValidTemplates } from './lib/templates.js'
+
+function makeArgs(overrides: Record<string, unknown> = {}): CliArgs {
+  return { _: [], ...overrides } as unknown as CliArgs
+}
+
+describe('non-interactive (-y) run', () => {
+  beforeAll(() => {
+    // eslint-disable-next-line no-console
+    console.log = vitest.fn()
+  })
+
+  it('should resolve all choices without prompting for `my-app --db sqlite -y`', async () => {
+    const args = applyYesDefaults(
+      makeArgs({ _: ['my-app'], '--db': 'sqlite', '--yes': true }),
+      getValidTemplates(),
+    )
+
+    expect(args['--template']).toBe('blank')
+    expect(args['--no-agent']).toBe(true)
+
+    const dbDetails = await selectDb(args, 'my-app')
+    expect(dbDetails.type).toBe('sqlite')
+    expect(dbDetails.dbUri).toBe('file:./my-app.db')
+  })
+
+  it('should throw before prompting when --db is missing on a blank starter', () => {
+    expect(() =>
+      applyYesDefaults(makeArgs({ _: ['my-app'], '--yes': true }), getValidTemplates()),
+    ).toThrow(/--db/)
+  })
+})

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -7,7 +7,6 @@ export interface Args extends arg.Spec {
   '--beta': BooleanConstructor
   '--branch': StringConstructor
   '--db': StringConstructor
-  '--db-accept-recommended': BooleanConstructor
   '--db-connection-string': StringConstructor
   '--debug': BooleanConstructor
   '--dry-run': BooleanConstructor
@@ -28,6 +27,7 @@ export interface Args extends arg.Spec {
   '--use-npm': BooleanConstructor
   '--use-pnpm': BooleanConstructor
   '--use-yarn': BooleanConstructor
+  '--yes': BooleanConstructor
 
   // Aliases
 
@@ -36,6 +36,7 @@ export interface Args extends arg.Spec {
   '-h': string
   '-n': string
   '-t': string
+  '-y': string
 }
 
 export type CliArgs = arg.Result<Args>

--- a/packages/create-payload-app/src/utils/messages.spec.ts
+++ b/packages/create-payload-app/src/utils/messages.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vitest } from 'vitest'
+
+import { helpMessage } from './messages.js'
+
+describe('helpMessage', () => {
+  it('should document db flags, secret, and the non-interactive -y flag', () => {
+    const logSpy = vitest.spyOn(console, 'log').mockImplementation(() => {})
+
+    helpMessage()
+
+    const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+
+    expect(output).toContain('--db')
+    expect(output).toContain('--db-connection-string')
+    expect(output).toContain('--secret')
+    expect(output).toContain('--yes')
+    expect(output).toContain('my-project --db sqlite -y')
+    expect(output).not.toContain('--db-accept-recommended')
+
+    logSpy.mockRestore()
+  })
+})

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -30,11 +30,19 @@ export function helpMessage(): void {
       {dim $} {bold npx create-payload-app} my-project
       {dim $} {bold npx create-payload-app} -n my-project -t template-name
 
+      {dim Non-interactive (AI agents / CI) — no prompts}
+
+      {dim $} {bold npx create-payload-app} my-project --db sqlite -y
+
   {bold OPTIONS}
 
       -n     {underline my-payload-app}         Set project name
       -t     {underline template_name}          Choose specific template
       -e     {underline example_name}           Choose specific example
+
+      --db   {underline type}                   Database adapter (mongodb, postgres, sqlite, vercel-postgres, d1-sqlite)
+      --db-connection-string {underline value}  Use a specific database connection string
+      --secret {underline value}                Set the Payload secret (auto-generated if omitted)
 
         {dim Available templates: ${formatTemplates(validTemplates)}}
 
@@ -49,6 +57,8 @@ export function helpMessage(): void {
       --use-bun                     Use bun to install dependencies (experimental)
       --no-deps                     Do not install any dependencies
       --payload-version {underline value}       Install a specific Payload version or npm dist-tag (default: canary)
+      -y, --yes                     Non-interactive mode for AI agents / CI: use defaults for all
+                                    unset prompts. Requires a name and --db (see USAGE above).
       -h                            Show help
 `)
 }


### PR DESCRIPTION
Adds a `-y`/`--yes` flag to `create-payload-app` for non-interactive scaffolding in AI agent and CI environments, and completes the `--help` output.

Removes the _undocumented_ `--db-accept-recommended` flag. Its behavior now folds into `-y`; scripts using it should switch to `-y` (or pass `--db-connection-string` for an explicit value).

Running the CLI in a non-TTY shell previously crashed with `uv_tty_init failed: EINVAL` whenever a prompt needed to render, and the flags required to suppress those prompts were undocumented in `--help`. `-y` fills defaults for every unset prompt-backed choice so the run never blocks.

```bash
# Before: verbose, and --db-accept-recommended was undocumented
npx create-payload-app my-app -t blank --db sqlite --db-accept-recommended --no-agent

# After
npx create-payload-app my-app --db sqlite -y
```

## Key Changes

- **Add `-y`/`--yes` non-interactive flag**
  - Defaults the template to `blank`, skips agent installation, and accepts the recommended database connection string without prompting. Explicit flags always take precedence.
  - Requires a project name (or `.`) and `--db`, throwing a clear error otherwise, so misconfiguration fails fast instead of hanging on a prompt.

- **Remove `--db-accept-recommended`**
  - Its only purpose was non-interactive database setup, which `-y` now covers. It had no references outside its own plumbing.

- **Complete `--help` output**
  - Adds the previously missing `--db`, `--db-connection-string`, and `--secret` flags, plus a labeled non-interactive usage example.

## Design Decisions

- `-y` is a preprocessor that fills in unset flags before any prompt runs, rather than scattered checks inside each prompt helper. The prompt helpers stay unchanged and the defaulting logic lives in one testable place.
- `-y` requires an explicit `--db` and project name instead of guessing them. Both shape where files land and which database the project targets, so a wrong default would waste work; the template safely defaults to `blank`.
- Templates that pin their own database (`with-cloudflare-d1`), plugin templates, and `--example` runs skip the `--db` requirement, since they never reach database selection.

## Overall Flow

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant applyYesDefaults
    participant Prompts

    User->>CLI: create-payload-app my-app --db sqlite -y
    CLI->>applyYesDefaults: resolve defaults + validate
    alt name or --db missing
        applyYesDefaults-->>User: error, exit
    else valid
        applyYesDefaults-->>CLI: template=blank, --no-agent, accept recommended db
        CLI->>Prompts: (all suppressed under --yes)
        CLI-->>User: project scaffolded, no TTY interaction
    end
```
