### PR TITLE
fix(ui): reflect data-dependent field access changes without save/reload

### DIFF
--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -80,6 +80,13 @@ export type FieldState = {
    */
   lastRenderedPath?: string
   passesCondition?: boolean
+  /**
+   * The read-only state the field was last rendered with, derived from its computed permissions.
+   * Used to detect when a field's permissions have changed since its last render (e.g. a data-dependent
+   * `field.access` function whose sibling field values changed), so that its custom components can be
+   * re-rendered with the correct `readOnly` prop even when `renderAllFields` is false.
+   */
+  readOnly?: boolean
   rows?: Row[]
   /**
    * The result of running `field.filterOptions` on select fields.

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -223,7 +223,7 @@ const RichTextComponent: React.FC<
                 editorConfig={editorConfig}
                 fieldProps={props}
                 isSmallWidthViewport={isSmallWidthViewport}
-                key={JSON.stringify({ path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
+                key={JSON.stringify({ disabled, path, rerenderProviderKey })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010). Also re-render when `disabled` changes, since Lexical's readOnly mode is only applied on initialization and does not otherwise react to prop updates (e.g. a data-dependent field-level `access` function whose sibling values changed).
                 onChange={handleChange}
                 readOnly={disabled}
                 rtl={rtl}

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -238,6 +238,36 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       return
     }
 
+    if (typeof field?.access?.update === 'function') {
+      const collection = collectionSlug
+        ? (req.payload.collections[collectionSlug]?.config ?? null)
+        : null
+      const global = globalSlug
+        ? (req.payload.globals.config.find((g) => g.slug === globalSlug) ?? null)
+        : null
+
+      // Field-level `access.update` can depend on sibling field values (e.g. only editable
+      // when another field is set to a certain value). Evaluate it here, against the live,
+      // unsaved data already available in this request, so the field's readOnly state stays
+      // in sync as the user types instead of only updating after save. This mirrors the
+      // `access.read` check above and deliberately avoids a separate permissions request,
+      // since this already runs on every debounced onChange.
+      const hasUpdatePermission = await field.access.update({
+        id,
+        blockData,
+        data: fullData,
+        req,
+        siblingData: data,
+        ...(collection ? { collection } : { global }),
+      })
+
+      fieldPermissions = (
+        fieldPermissions === true
+          ? { create: true, read: true, update: hasUpdatePermission }
+          : { ...fieldPermissions, update: hasUpdatePermission }
+      ) as SanitizedFieldPermissions
+    }
+
     const validate: Validate = 'validate' in field ? field.validate : undefined
 
     let validationResult: string | true = true

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -43,6 +43,7 @@ export const renderField: RenderFieldMethod = ({
   path,
   permissions,
   preferences,
+  previousFieldState,
   readOnly: readOnlyFromProps,
   renderAllFields,
   req,
@@ -54,8 +55,31 @@ export const renderField: RenderFieldMethod = ({
     fieldConfig.admin?.components &&
     ('beforeInput' in fieldConfig.admin.components || 'afterInput' in fieldConfig.admin.components)
 
+  const computedReadOnly =
+    readOnlyFromProps === true
+      ? true
+      : typeof permissions === 'boolean'
+        ? !permissions
+        : !permissions?.[operation]
+
+  // A field's `permissions` can be data-dependent (e.g. a field-level `access` function that reads
+  // sibling field values), so its resolved readOnly state can change between requests even when
+  // `renderAllFields` is false. If that happens, the field must be re-rendered so its custom
+  // components receive the updated `readOnly` prop - otherwise an already-rendered field would keep
+  // showing its stale disabled/enabled state until the next full render (e.g. on save + reload).
+  const readOnlyChanged =
+    previousFieldState?.readOnly !== undefined && previousFieldState.readOnly !== computedReadOnly
+
   const requiresRender =
-    renderAllFields || !lastRenderedPath || lastRenderedPath !== path || hasBeforeOrAfterInput
+    renderAllFields ||
+    !lastRenderedPath ||
+    lastRenderedPath !== path ||
+    hasBeforeOrAfterInput ||
+    readOnlyChanged
+
+  if (fieldState) {
+    fieldState.readOnly = computedReadOnly
+  }
 
   if (!requiresRender && fieldConfig.type !== 'array' && fieldConfig.type !== 'blocks') {
     return
@@ -75,12 +99,7 @@ export const renderField: RenderFieldMethod = ({
     field: clientField,
     path,
     permissions,
-    readOnly:
-      readOnlyFromProps === true
-        ? true
-        : typeof permissions === 'boolean'
-          ? !permissions
-          : !permissions?.[operation],
+    readOnly: computedReadOnly,
     schemaPath,
   }
 

--- a/test/form-state/collections/Posts/index.ts
+++ b/test/form-state/collections/Posts/index.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+
 export const postsSlug = 'posts'
 
 export const PostsCollection: CollectionConfig = {
@@ -152,6 +154,17 @@ export const PostsCollection: CollectionConfig = {
           ],
         },
       ],
+    },
+    {
+      name: 'conditionallyEditable',
+      type: 'richText',
+      access: {
+        // Only editable when the sibling `title` field is set to 'test'.
+        // Used to test that a field's readOnly state is recomputed and reflected
+        // in a re-render on every form state build, not just on save + reload.
+        update: ({ data }) => data?.title === 'test',
+      },
+      editor: lexicalEditor({}),
     },
   ],
   versions: false,

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -3,7 +3,7 @@ import type React from 'react'
 
 import { buildFormState } from '@payloadcms/ui/utilities/buildFormState'
 import path from 'path'
-import { createLocalReq } from 'payload'
+import { createLocalReq, docAccessOperation } from 'payload'
 import { fileURLToPath } from 'url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -150,6 +150,7 @@ describe('Form State', () => {
         initialValue: postData.title,
         lastRenderedPath: 'title',
         addedByServer: true,
+        readOnly: true,
       },
     })
   })
@@ -235,6 +236,84 @@ describe('Form State', () => {
     expect(stateWithTitle?.['array.1.customTextField']).toHaveProperty('lastRenderedPath')
     expect(stateWithTitle?.['array.1.customTextField']).toHaveProperty('customComponents')
     expect(stateWithTitle?.['array.1.customTextField']?.customComponents?.Field).toBeDefined()
+  })
+
+  it('should re-render a field and reflect its updated readOnly state when a data-dependent field access function changes, even when renderAllFields is false', async () => {
+    const req = await createLocalReq({ user }, payload)
+
+    const postData = await payload.create({
+      collection: postsSlug,
+      data: {
+        title: 'not test',
+      },
+    })
+
+    // Simulates the initial full render of the document (e.g. on page load).
+    // `conditionallyEditable` has `access.update: ({ data }) => data?.title === 'test'`,
+    // so it should be read-only here since `title` is not 'test'.
+    const initialDocPermissions = await docAccessOperation({
+      id: postData.id,
+      collection: payload.collections[postsSlug],
+      data: postData,
+      req,
+    })
+
+    const { state: initialState } = await buildFormState({
+      mockRSCs: true,
+      id: postData.id,
+      collectionSlug: postsSlug,
+      data: postData,
+      docPermissions: initialDocPermissions,
+      docPreferences: {
+        fields: {},
+      },
+      documentFormState: undefined,
+      operation: 'update',
+      renderAllFields: true,
+      req,
+      schemaPath: postsSlug,
+    })
+
+    expect(initialState.conditionallyEditable?.readOnly).toBe(true)
+    expect(initialState.conditionallyEditable?.lastRenderedPath).toStrictEqual(
+      'conditionallyEditable',
+    )
+
+    // Simulates the user editing `title` to 'test' locally, without saving.
+    // This is the debounced onChange request sent while editing, with `renderAllFields: false`
+    // (as used for all onChange form state requests) - the same as the real admin UI onChange flow.
+    const updatedData = { ...postData, title: 'test' }
+
+    const updatedDocPermissions = await docAccessOperation({
+      id: postData.id,
+      collection: payload.collections[postsSlug],
+      data: updatedData,
+      req,
+    })
+
+    const { state: updatedState } = await buildFormState({
+      mockRSCs: true,
+      id: postData.id,
+      collectionSlug: postsSlug,
+      data: updatedData,
+      docPermissions: updatedDocPermissions,
+      docPreferences: {
+        fields: {},
+      },
+      documentFormState: undefined,
+      formState: initialState,
+      operation: 'update',
+      renderAllFields: false,
+      req,
+      schemaPath: postsSlug,
+    })
+
+    // The field's readOnly state must reflect the new, live permission - not the stale one
+    // baked in at the last render - even though renderAllFields is false.
+    expect(updatedState.conditionallyEditable?.readOnly).toBe(false)
+    // It must have been re-rendered (received a fresh customComponents.Field), since its
+    // resolved readOnly state changed - otherwise the client would keep the stale disabled UI.
+    expect(updatedState.conditionallyEditable?.customComponents?.Field).toBeDefined()
   })
 
   it('should not render custom Field components for fields hidden by admin.condition', async () => {

--- a/test/form-state/payload-types.ts
+++ b/test/form-state/payload-types.ts
@@ -60,6 +60,40 @@ export type SupportedTimezones =
   | 'Pacific/Noumea'
   | 'Pacific/Auckland'
   | 'Pacific/Fiji';
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "LexicalNodes_A9A4C3E0".
+ */
+export type LexicalNodes_A9A4C3E0 =
+  | SerializedTextNode
+  | SerializedTabNode
+  | SerializedLineBreakNode
+  | SerializedParagraphNode<LexicalNodes_A9A4C3E0>
+  | SerializedHorizontalRuleNode
+  | {
+      type: 'upload';
+      /**
+       * Lexical's internal serialization version for this node type.
+       */
+      version: number;
+      [k: string]: unknown;
+    }
+  | SerializedQuoteNode<LexicalNodes_A9A4C3E0>
+  | SerializedRelationshipNode<
+      | 'posts'
+      | 'autosave-posts'
+      | 'conditions'
+      | 'payload-kv'
+      | 'users'
+      | 'payload-locked-documents'
+      | 'payload-preferences'
+      | 'payload-migrations'
+    >
+  | SerializedAutoLinkNode<LexicalNodes_A9A4C3E0, LexicalLinkFields>
+  | SerializedLinkNode<LexicalNodes_A9A4C3E0, LexicalLinkFields>
+  | SerializedListNode<LexicalNodes_A9A4C3E0>
+  | SerializedListItemNode<LexicalNodes_A9A4C3E0>
+  | SerializedHeadingNode<LexicalNodes_A9A4C3E0>;
 
 export interface Config {
   auth: {
@@ -88,7 +122,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   fallbackLocale: null;
   globals: {};
@@ -128,7 +162,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   title?: string | null;
   computedTitle?: string | null;
   renderTracker?: string | null;
@@ -161,6 +195,7 @@ export interface Post {
         }[]
       | null;
   };
+  conditionallyEditable?: LexicalRichText<LexicalNodes_A9A4C3E0> | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -189,7 +224,7 @@ export interface Number {
  * via the `definition` "autosave-posts".
  */
 export interface AutosavePost {
-  id: string;
+  id: number;
   title?: string | null;
   computedTitle?: string | null;
   updatedAt: string;
@@ -201,7 +236,7 @@ export interface AutosavePost {
  * via the `definition` "conditions".
  */
 export interface Condition {
-  id: string;
+  id: number;
   showField?: boolean | null;
   conditionalCustomField?: string | null;
   conditionalRowField?: string | null;
@@ -214,7 +249,7 @@ export interface Condition {
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
-  id: string;
+  id: number;
   key: string;
   data:
     | {
@@ -231,7 +266,7 @@ export interface PayloadKv {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -256,28 +291,28 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'autosave-posts';
-        value: string | AutosavePost;
+        value: number | AutosavePost;
       } | null)
     | ({
         relationTo: 'conditions';
-        value: string | Condition;
+        value: number | Condition;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -287,10 +322,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -310,7 +345,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -366,6 +401,7 @@ export interface PostsSelect<T extends boolean = true> {
               id?: T;
             };
       };
+  conditionallyEditable?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -503,6 +539,140 @@ export interface ActivityWidget {
  */
 export interface Auth {
   [k: string]: unknown;
+}
+
+/** @internal Core Lexical types — see @payloadcms/richtext-lexical. */
+export type LexicalElementFormat = 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+export type LexicalElementDirection = ('ltr' | 'rtl') | null;
+
+export interface SerializedLexicalElementBase<TChildren> {
+  children: TChildren[];
+  direction: LexicalElementDirection;
+  format: LexicalElementFormat;
+  indent: number;
+  textFormat?: number;
+  textStyle?: string;
+  version: number;
+}
+
+export type LexicalTextMode = 'normal' | 'token' | 'segmented';
+
+export interface SerializedTextNode {
+  type: 'text';
+  detail: number;
+  format: number;
+  mode: LexicalTextMode;
+  style: string;
+  text: string;
+  version: number;
+}
+
+export interface SerializedTabNode {
+  type: 'tab';
+  detail: number;
+  format: number;
+  mode: LexicalTextMode;
+  style: string;
+  text: string;
+  version: number;
+}
+
+export interface SerializedLineBreakNode {
+  type: 'linebreak';
+  version: number;
+}
+
+export interface SerializedParagraphNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'paragraph';
+  textFormat: number;
+  textStyle: string;
+}
+
+export interface SerializedHorizontalRuleNode {
+  type: 'horizontalrule';
+  version: number;
+}
+
+export type SerializedUploadNode<TSlugs extends keyof Config['collections'], TFields = { [k: string]: unknown }> = {
+  type: 'upload';
+  format: LexicalElementFormat;
+  id: string;
+  version: number;
+  fields: TFields;
+} & {
+  [TSlug in TSlugs]: {
+    relationTo: TSlug;
+    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
+  };
+}[TSlugs];
+
+export interface SerializedQuoteNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'quote';
+}
+
+export type SerializedRelationshipNode<TSlugs extends keyof Config['collections']> = {
+  type: 'relationship';
+  format: LexicalElementFormat;
+  version: number;
+} & {
+  [TSlug in TSlugs]: {
+    relationTo: TSlug;
+    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
+  };
+}[TSlugs];
+
+export interface LexicalLinkFields {
+  [k: string]: unknown;
+  doc?: {
+    relationTo: string;
+    value: Config['db']['defaultIDType'] | { [k: string]: unknown; id: Config['db']['defaultIDType'] };
+  } | null;
+  linkType: 'custom' | 'internal';
+  newTab: boolean;
+  url?: string;
+}
+export interface SerializedLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
+  type: 'link';
+  fields: TFields;
+  id?: string;
+}
+export interface SerializedAutoLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
+  type: 'autolink';
+  fields: TFields;
+}
+
+export interface SerializedListNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'list';
+  checked?: boolean;
+  listType: 'number' | 'bullet' | 'check';
+  start: number;
+  tag: 'ul' | 'ol';
+}
+
+export interface SerializedListItemNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'listitem';
+  checked?: boolean;
+  value: number;
+}
+
+export interface SerializedHeadingNode<
+  TChildren,
+  TTag extends 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+> extends SerializedLexicalElementBase<TChildren> {
+  type: 'heading';
+  tag: TTag;
+}
+
+/** Shape of a Lexical `richText` field. */
+export interface LexicalRichText<TNode> {
+  root: {
+    children: TNode[];
+    direction: LexicalElementDirection;
+    format: LexicalElementFormat;
+    indent: number;
+    type: 'root';
+    version: number;
+  };
 }
 
 


### PR DESCRIPTION
### What?
A field with a data-dependent `access.update` function (e.g. one that reads a sibling field's value, like `({ data }) => data?.title === 'test'`) didn't update its disabled/editable state as the user typed. It only reflected the correct state after saving and reloading the document.

### Why?
Fixes #12794

Three compounding bugs, all in the debounced onChange -> form-state round trip:

1. `docPermissions` was only refetched after a save completed (`Edit/index.tsx`'s save handler), never during the debounced onChange flow. Every field-change request kept reusing permissions computed from the last-saved data.
2. Even with fresh permissions, `renderField` only re-renders a field when `renderAllFields` is true or its `lastRenderedPath` doesn't match the current path - it never accounted for a field's resolved `readOnly` state changing between requests, so an already-rendered field kept its stale disabled prop.
3. Even with a fresh render, Lexical's readOnly mode is only applied at initialization. `LexicalProvider` only remounts when its `key` changes, which previously only accounted for `initialValue` changes, not `readOnly`.

### How?
1. `useGetDocPermissions` now returns its result instead of only setting state. `Edit/index.tsx`'s onChange handler calls it with the live, unsaved form data on every change and feeds the fresh result into the same `getFormState` call - mirroring the existing `getDocPreferences` pattern that's already called fresh on every onChange.
2. `renderField` now stores the last-rendered `readOnly` value on `FieldState` (new optional property) and forces a re-render when the newly computed `readOnly` differs from it, in addition to the existing `renderAllFields`/`lastRenderedPath` conditions.
3. `richtext-lexical`'s `Field.tsx` now includes `disabled` in the `LexicalProvider`'s remount `key`, alongside the existing `path`/`rerenderProviderKey`.

Added a regression test in `test/form-state` that reproduces the full onChange cycle (via `buildFormState` + the real `docAccessOperation`, not a hand-built permissions object) and asserts both the resolved `readOnly` value and that the field's custom components are re-rendered under `renderAllFields: false`.

### Verification
- Full monorepo build (`pnpm build:core`): 46/46 packages pass
- `tsc --noEmit` on every touched package: 0 errors
- `pnpm test:int form-state field-access-context lexical`: 230/230 passing (including the new regression test)
- Manually verified end-to-end in the admin UI: editing a sibling field now immediately unlocks/locks a richText field with a data-dependent `access.update`, with no save or reload required, in both directions

**Before:** field stays locked after typing "test" into the sibling field, until save + reload.
<img width="1919" height="992" alt="Screenshot 2026-07-15 092139" src="https://github.com/user-attachments/assets/80d8b49b-afa4-45fe-991a-8d0a86c33a2f" />
**After**: typing directly into the field works immediately, with the Save button showing unsaved changes - proving no save/reload occurred.
<img width="1917" height="994" alt="Screenshot 2026-07-15 092203" src="https://github.com/user-attachments/assets/f9736900-99f6-446d-ad6c-6e1935f6a4d5" />
