### PR TITLE
docs: align CONTRIBUTING security-report email with SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Before you submit an issue, please check all existing [open and closed issues](h
 
 ## Security issues & vulnerabilities
 
-If you come across an issue related to security, or a potential attack vector within Payload or one of its dependencies, please DO NOT create a publicly viewable issue. Instead, please contact us directly at [`dev@payloadcms.com`](mailto:dev@payloadcms.com). We will do everything we can to respond to the issue as soon as possible.
+If you come across an issue related to security, or a potential attack vector within Payload or one of its dependencies, please DO NOT create a publicly viewable issue. Instead, please contact us directly at [`security@payloadcms.com`](mailto:security@payloadcms.com). We will do everything we can to respond to the issue as soon as possible.
 
 If you find a vulnerability within the core Payload repository, and we determine that it is remediable and of significant nature, we will be happy to pay you a reward for your findings and diligence. [`Contact us`](mailto:dev@payloadcms.com) to find out more.
 


### PR DESCRIPTION
Hi, and thank you for Payload.

Small docs consistency fix: the security-report address differs between two governance docs.

- `SECURITY.md` (line 5): *"Please report any security issues or concerns to **security@payloadcms.com**."*
- `CONTRIBUTING.md` (line 11): *"…please contact us directly at **dev@payloadcms.com**."*

A researcher who reads `CONTRIBUTING.md` first would report to a different address than `SECURITY.md` intends. Since `SECURITY.md` is the canonical security policy, this PR aligns `CONTRIBUTING.md`'s security-report address to `security@payloadcms.com`.

If `dev@payloadcms.com` is actually the preferred security inbox, just flip the change so `SECURITY.md` matches instead — either way, the two should agree. (I left the rewards-contact line as-is; happy to align that too if you'd like.)

For transparency: I used AI assistance to spot and draft this; I verified both files against the current source myself.
