### PR TITLE
fix(plugin-ecommerce): support custom Stripe HTTP clients

### DIFF
--- a/docs/ecommerce/payments.mdx
+++ b/docs/ecommerce/payments.mdx
@@ -62,14 +62,28 @@ export default buildConfig({
 
 The Stripe payment adapter takes the following configuration options:
 
-| Option         | Type     | Description                                                                                                                                                                                 |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| secretKey      | `string` | Your Stripe Secret Key, found in the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).                                                                                              |
-| publishableKey | `string` | Your Stripe Publishable Key, found in the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).                                                                                         |
-| webhookSecret  | `string` | (Optional) Your Stripe Webhooks Signing Secret, found in the [Stripe Dashboard](https://dashboard.stripe.com/webhooks). Required if you want to use webhooks.                               |
-| appInfo        | `object` | (Optional) An object containing `name` and `version` properties to identify your application to Stripe.                                                                                     |
-| webhooks       | `object` | (Optional) An object where the keys are Stripe event types and the values are functions that will be called when that event is received. See [Webhooks](#stripe-webhooks) for more details. |
-| groupOverrides | `object` | (Optional) An object to override the default fields of the payment group. See [Payment Fields](./advanced#payment-fields) for more details.                                                 |
+| Option         | Type         | Description                                                                                                                                                                                 |
+| -------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| secretKey      | `string`     | Your Stripe Secret Key, found in the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).                                                                                              |
+| publishableKey | `string`     | Your Stripe Publishable Key, found in the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).                                                                                         |
+| webhookSecret  | `string`     | (Optional) Your Stripe Webhooks Signing Secret, found in the [Stripe Dashboard](https://dashboard.stripe.com/webhooks). Required if you want to use webhooks.                               |
+| appInfo        | `object`     | (Optional) An object containing `name` and `version` properties to identify your application to Stripe.                                                                                     |
+| httpClient     | `HttpClient` | (Optional) The HTTP client used for Stripe API requests. Use Stripe's fetch HTTP client for fetch-only runtimes such as Cloudflare Workers.                                                 |
+| webhooks       | `object`     | (Optional) An object where the keys are Stripe event types and the values are functions that will be called when that event is received. See [Webhooks](#stripe-webhooks) for more details. |
+| groupOverrides | `object`     | (Optional) An object to override the default fields of the payment group. See [Payment Fields](./advanced#payment-fields) for more details.                                                 |
+
+For fetch-only runtimes such as Cloudflare Workers, configure Stripe's fetch HTTP client:
+
+```ts
+import { stripeAdapter } from '@payloadcms/plugin-ecommerce/payments/stripe'
+import Stripe from 'stripe'
+
+stripeAdapter({
+  httpClient: Stripe.createFetchHttpClient(),
+  publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+  secretKey: process.env.STRIPE_SECRET_KEY,
+})
+```
 
 ### Stripe Webhooks
 

--- a/docs/ecommerce/plugin.mdx
+++ b/docs/ecommerce/plugin.mdx
@@ -700,6 +700,7 @@ pnpm add stripe
 | `webhooks`       | `WebhookHandler[]` | An array of webhook handlers to register within Payload's REST API for Stripe to callback.                                                                                           |
 | `apiVersion`     | `string`           | The Stripe API version to use. See [docs](https://stripe.com/docs/api/versioning). This will be deprecated soon by Stripe's SDK, configure the API version in your Stripe Dashboard. |
 | `appInfo`        | `object`           | The application info to pass to Stripe. See [docs](https://stripe.com/docs/api/app_info).                                                                                            |
+| `httpClient`     | `HttpClient`       | The HTTP client used for Stripe API requests. Use Stripe's fetch HTTP client for fetch-only runtimes such as Cloudflare Workers.                                                     |
 
 ```ts
 import { stripeAdapter } from '@payloadcms/plugin-ecommerce/payments/stripe'
@@ -708,6 +709,18 @@ stripeAdapter({
   secretKey: process.env.STRIPE_SECRET_KEY!,
   publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
   webhookSecret: process.env.STRIPE_WEBHOOKS_SIGNING_SECRET!,
+})
+```
+
+For fetch-only runtimes such as Cloudflare Workers, pass Stripe's fetch HTTP client:
+
+```ts
+import Stripe from 'stripe'
+
+stripeAdapter({
+  httpClient: Stripe.createFetchHttpClient(),
+  publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
+  secretKey: process.env.STRIPE_SECRET_KEY!,
 })
 ```
 

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
@@ -6,6 +6,7 @@ import type { StripeAdapterArgs } from './index.js'
 type Props = {
   apiVersion?: Stripe.StripeConfig['apiVersion']
   appInfo?: Stripe.StripeConfig['appInfo']
+  httpClient?: Stripe.StripeConfig['httpClient']
   secretKey: StripeAdapterArgs['secretKey']
 }
 
@@ -19,7 +20,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
     transactionsSlug = 'transactions',
   }) => {
     const payload = req.payload
-    const { apiVersion, appInfo, secretKey } = props || {}
+    const { apiVersion, appInfo, httpClient, secretKey } = props || {}
 
     const customerEmail = data.customerEmail
 
@@ -42,6 +43,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
         name: 'Stripe Payload Plugin',
         url: 'https://payloadcms.com',
       },
+      httpClient,
     })
 
     try {

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/endpoints/webhooks.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/endpoints/webhooks.ts
@@ -7,13 +7,14 @@ import type { StripeAdapterArgs } from '../index.js'
 type Props = {
   apiVersion?: Stripe.StripeConfig['apiVersion']
   appInfo?: Stripe.StripeConfig['appInfo']
+  httpClient?: Stripe.StripeConfig['httpClient']
   secretKey: StripeAdapterArgs['secretKey']
   webhooks?: StripeAdapterArgs['webhooks']
   webhookSecret: StripeAdapterArgs['webhookSecret']
 }
 
 export const webhooksEndpoint: (props: Props) => Endpoint = (props) => {
-  const { apiVersion, appInfo, secretKey, webhooks, webhookSecret } = props || {}
+  const { apiVersion, appInfo, httpClient, secretKey, webhooks, webhookSecret } = props || {}
 
   const handler: Endpoint['handler'] = async (req) => {
     let returnStatus = 200
@@ -28,6 +29,7 @@ export const webhooksEndpoint: (props: Props) => Endpoint = (props) => {
           name: 'Stripe Payload Plugin',
           url: 'https://payloadcms.com',
         },
+        httpClient,
       })
 
       const body = await req.text()

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/httpClient.spec.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/httpClient.spec.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Stripe } from 'stripe'
+
+const mocks = vi.hoisted(() => ({
+  constructEvent: vi.fn(),
+  customersList: vi.fn(),
+  stripeConstructor: vi.fn(),
+}))
+
+vi.mock('stripe', () => {
+  const MockStripe = function (secretKey: string, config: unknown) {
+    mocks.stripeConstructor(secretKey, config)
+
+    return {
+      customers: {
+        list: mocks.customersList,
+      },
+      webhooks: {
+        constructEvent: mocks.constructEvent,
+      },
+    }
+  }
+
+  return { default: MockStripe }
+})
+
+import { stripeAdapter } from './index.js'
+
+const createMockPayload = () => ({
+  logger: { error: vi.fn() },
+})
+
+describe('Stripe adapter HTTP client', () => {
+  const httpClient = { makeRequest: vi.fn() } as Stripe.StripeConfig['httpClient']
+  const secretKey = 'sk_test_123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.customersList.mockRejectedValue(new Error('stop after Stripe construction'))
+    mocks.constructEvent.mockReturnValue({ type: 'payment_intent.succeeded' })
+  })
+
+  it('should pass the configured HTTP client when initiating a payment', async () => {
+    const adapter = stripeAdapter({
+      httpClient,
+      publishableKey: 'pk_test_123',
+      secretKey,
+    })
+
+    await expect(
+      adapter.initiatePayment({
+        data: {
+          cart: {
+            id: 'cart-123',
+            items: [{ product: 'product-123', quantity: 1 }],
+            subtotal: 1000,
+          },
+          currency: 'USD',
+          customerEmail: 'test@example.com',
+        },
+        req: { payload: createMockPayload() } as any,
+        transactionsSlug: 'transactions',
+      }),
+    ).rejects.toThrow('stop after Stripe construction')
+
+    expect(mocks.stripeConstructor).toHaveBeenCalledWith(
+      secretKey,
+      expect.objectContaining({ httpClient }),
+    )
+  })
+
+  it('should preserve the Stripe default when no HTTP client is configured', async () => {
+    const adapter = stripeAdapter({
+      publishableKey: 'pk_test_123',
+      secretKey,
+    })
+
+    await expect(
+      adapter.initiatePayment({
+        data: {
+          cart: {
+            id: 'cart-123',
+            items: [{ product: 'product-123', quantity: 1 }],
+            subtotal: 1000,
+          },
+          currency: 'USD',
+          customerEmail: 'test@example.com',
+        },
+        req: { payload: createMockPayload() } as any,
+        transactionsSlug: 'transactions',
+      }),
+    ).rejects.toThrow('stop after Stripe construction')
+
+    expect(mocks.stripeConstructor.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ httpClient: undefined }),
+    )
+  })
+
+  it('should pass the configured HTTP client when confirming an order', async () => {
+    const adapter = stripeAdapter({
+      httpClient,
+      publishableKey: 'pk_test_123',
+      secretKey,
+    })
+
+    await expect(
+      adapter.confirmOrder({
+        data: {
+          customerEmail: 'test@example.com',
+          paymentIntentID: 'pi_123',
+        },
+        req: { payload: createMockPayload() } as any,
+      }),
+    ).rejects.toThrow('stop after Stripe construction')
+
+    expect(mocks.stripeConstructor).toHaveBeenCalledWith(
+      secretKey,
+      expect.objectContaining({ httpClient }),
+    )
+  })
+
+  it('should pass the configured HTTP client when handling webhooks', async () => {
+    const adapter = stripeAdapter({
+      httpClient,
+      publishableKey: 'pk_test_123',
+      secretKey,
+      webhookSecret: 'whsec_123',
+    })
+    const webhookEndpoint = adapter.endpoints?.[0]
+
+    await webhookEndpoint?.handler({
+      headers: new Headers({ 'stripe-signature': 'signature' }),
+      payload: createMockPayload(),
+      text: vi.fn().mockResolvedValue('{}'),
+    } as any)
+
+    expect(mocks.stripeConstructor).toHaveBeenCalledWith(
+      secretKey,
+      expect.objectContaining({ httpClient }),
+    )
+  })
+})

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/index.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/index.ts
@@ -40,6 +40,12 @@ export type StripeAdapterArgs = {
    */
   apiVersion?: Stripe.StripeConfig['apiVersion']
   appInfo?: Stripe.StripeConfig['appInfo']
+  /**
+   * The HTTP client used to make requests to Stripe.
+   *
+   * Use `Stripe.createFetchHttpClient()` for fetch-only runtimes such as Cloudflare Workers.
+   */
+  httpClient?: Stripe.StripeConfig['httpClient']
   publishableKey: string
   secretKey: string
   webhooks?: StripeWebhookHandlers
@@ -47,7 +53,8 @@ export type StripeAdapterArgs = {
 } & PaymentAdapterArgs
 
 export const stripeAdapter: (props: StripeAdapterArgs) => PaymentAdapter = (props) => {
-  const { apiVersion, appInfo, groupOverrides, secretKey, webhooks, webhookSecret } = props
+  const { apiVersion, appInfo, groupOverrides, httpClient, secretKey, webhooks, webhookSecret } =
+    props
   const label = props?.label || 'Stripe'
 
   const baseFields: Field[] = [
@@ -86,13 +93,17 @@ export const stripeAdapter: (props: StripeAdapterArgs) => PaymentAdapter = (prop
     confirmOrder: confirmOrder({
       apiVersion,
       appInfo,
+      httpClient,
       secretKey,
     }),
-    endpoints: [webhooksEndpoint({ apiVersion, appInfo, secretKey, webhooks, webhookSecret })],
+    endpoints: [
+      webhooksEndpoint({ apiVersion, appInfo, httpClient, secretKey, webhooks, webhookSecret }),
+    ],
     group: groupField,
     initiatePayment: initiatePayment({
       apiVersion,
       appInfo,
+      httpClient,
       secretKey,
     }),
     label,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -6,6 +6,7 @@ import type { InitiatePaymentReturnType, StripeAdapterArgs } from './index.js'
 type Props = {
   apiVersion?: Stripe.StripeConfig['apiVersion']
   appInfo?: Stripe.StripeConfig['appInfo']
+  httpClient?: Stripe.StripeConfig['httpClient']
   secretKey: StripeAdapterArgs['secretKey']
 }
 
@@ -13,7 +14,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
   (props) =>
   async ({ data, req, transactionsSlug }) => {
     const payload = req.payload
-    const { apiVersion, appInfo, secretKey } = props || {}
+    const { apiVersion, appInfo, httpClient, secretKey } = props || {}
 
     const customerEmail = data.customerEmail
     const currency = data.currency
@@ -51,6 +52,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
         name: 'Stripe Payload Plugin',
         url: 'https://payloadcms.com',
       },
+      httpClient,
     })
 
     try {


### PR DESCRIPTION
## What changed

- add an optional `httpClient` to `StripeAdapterArgs`
- forward the configured client to Stripe instances used by payment initiation, order confirmation, and webhook handlers
- document `Stripe.createFetchHttpClient()` for fetch-only runtimes
- add focused unit coverage for all three Stripe construction paths and the existing default behavior

## Why

Some Cloudflare Workers deployments bundle Stripe through its Node entrypoint. In that case Stripe selects its Node HTTP client, which is not usable in fetch-only runtimes and can leave payment requests hanging.

This change provides a narrow escape hatch without changing the default Stripe client for existing Node deployments.

Fixes #17201.

## Validation

- `pnpm exec vitest run --project unit packages/plugin-ecommerce` — 141 tests passed
- focused Stripe adapter tests — 9 tests passed
- `pnpm run build:plugin-ecommerce`
- package ESLint and Prettier checks
- `git diff --check`

## Remaining validation

The change was not exercised against a live `workerd` deployment. Unit coverage verifies that the caller-provided fetch client reaches every Stripe SDK instance created by the adapter.
