### PR TITLE
fix(ui): fix richtext padding, table borders, and timezone picker chevron

### DIFF
--- a/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.css
+++ b/packages/richtext-lexical/src/features/toolbars/fixed/client/Toolbar/index.css
@@ -46,13 +46,11 @@
       border-radius: 0 0 var(--radius-medium) var(--radius-medium) !important;
 
       > .editor-scroller > .editor {
+        --content-editable-padding-block-start: var(--spacer-2);
+
         > .ContentEditable__root {
           padding-top: var(--spacer-2);
         }
-      }
-
-      > .editor-scroller > .editor > div > .LexicalEditorTheme__placeholder {
-        top: var(--spacer-4);
       }
     }
   }

--- a/packages/richtext-lexical/src/lexical/LexicalEditor.css
+++ b/packages/richtext-lexical/src/lexical/LexicalEditor.css
@@ -2,6 +2,8 @@
   .rich-text-lexical {
     .editor {
       position: relative;
+      --content-editable-padding-block-start: var(--spacer-3);
+      --content-editable-padding-inline-start: var(--spacer-3);
     }
 
     .editor-container {
@@ -17,7 +19,8 @@
 
     .LexicalEditorTheme__placeholder {
       position: absolute;
-      top: var(--spacer-4);
+      top: var(--content-editable-padding-block-start);
+      inset-inline-start: var(--content-editable-padding-inline-start);
       color: var(--color-text-secondary);
       user-select: none;
       -webkit-user-select: none;
@@ -28,25 +31,20 @@
     }
   }
 
-  .rich-text-lexical--show-gutter
-    > .rich-text-lexical__wrap
-    > .rich-text-lexical__editor-content
-    > .editor-container
-    > .editor-scroller
-    > .editor
-    > div
-    > .LexicalEditorTheme__placeholder {
-    inset-inline-start: var(--spacer-5);
-  }
+  @media (min-width: 768px) {
+    .rich-text-lexical .editor {
+      --content-editable-padding-block-start: var(--spacer-4);
+      --content-editable-padding-inline-start: var(--spacer-5);
+    }
 
-  .rich-text-lexical:not(.rich-text-lexical--show-gutter)
-    > .rich-text-lexical__wrap
-    > .rich-text-lexical__editor-content
-    > .editor-container
-    > .editor-scroller
-    > .editor
-    > div
-    > .LexicalEditorTheme__placeholder {
-    inset-inline-start: 0;
+    .rich-text-lexical:not(.rich-text-lexical--show-gutter)
+      > .rich-text-lexical__wrap
+      > .rich-text-lexical__editor-content
+      > .editor-container
+      > .editor-scroller
+      > .editor {
+      --content-editable-padding-block-start: var(--spacer-2);
+      --content-editable-padding-inline-start: 0px;
+    }
   }
 }

--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
@@ -5,7 +5,11 @@
     position: relative;
     tab-size: 1;
     outline: 0;
-    padding: var(--spacer-2) var(--spacer-3);
+    padding: var(--spacer-3) var(--spacer-3);
+    /* Kept at spacer-4 regardless of viewport: InsertParagraphAtEnd overlaps this
+       bottom padding by the same amount to place its hover "+" affordance, so
+       shrinking it here would make that control cover the last line of text. */
+    padding-bottom: var(--spacer-4);
 
     &:focus-visible {
       outline: none !important;

--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
@@ -5,10 +5,7 @@
     position: relative;
     tab-size: 1;
     outline: 0;
-    padding-top: var(--spacer-2);
-    padding-bottom: var(--spacer-2);
-    padding-inline-start: 0;
-    padding-inline-end: 0;
+    padding: var(--spacer-2) var(--spacer-3);
 
     &:focus-visible {
       outline: none !important;
@@ -19,14 +16,19 @@
     }
   }
 
-  .rich-text-lexical--show-gutter
-    > .rich-text-lexical__wrap
-    > .rich-text-lexical__editor-content
-    > .editor-container
-    > .editor-scroller
-    > .editor {
-    > .ContentEditable__root {
+  @media (min-width: 768px) {
+    .ContentEditable__root {
       padding: var(--spacer-4) var(--spacer-5);
+    }
+
+    .rich-text-lexical:not(.rich-text-lexical--show-gutter)
+      > .rich-text-lexical__wrap
+      > .rich-text-lexical__editor-content
+      > .editor-container
+      > .editor-scroller
+      > .editor
+      > .ContentEditable__root {
+      padding: var(--spacer-2) 0;
     }
   }
 

--- a/packages/ui/src/elements/RelationshipTable/index.css
+++ b/packages/ui/src/elements/RelationshipTable/index.css
@@ -39,8 +39,6 @@
   .relationship-table .table {
     margin-bottom: 0;
     background: var(--color-bg);
-    border: var(--stroke-width-small) solid var(--color-border);
-    border-radius: var(--radius-medium);
     overflow: auto;
 
     table {

--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -142,6 +142,7 @@
 
   /* Condensed appearance */
   .table--appearance-condensed {
+    border: var(--stroke-width-small) solid var(--color-border);
     border-radius: var(--radius-medium);
     scrollbar-width: thin;
     scrollbar-color: var(--scrollbar-color) transparent;

--- a/packages/ui/src/elements/TimezonePicker/index.tsx
+++ b/packages/ui/src/elements/TimezonePicker/index.tsx
@@ -31,7 +31,12 @@ const SmallDropdownIndicator: React.FC<
 > = (props) => {
   const {
     innerProps: { ref, ...restInnerProps },
+    isDisabled,
   } = props
+
+  if (isDisabled) {
+    return null
+  }
 
   return (
     <button


### PR DESCRIPTION
## What?

- Fixes rich text editor content padding so it applies horizontal spacing at mobile widths, and only removes it in gutter-less desktop layouts. Previously the placeholder text here was misaligned at mobile, now:
<img width="369" height="208" alt="image" src="https://github.com/user-attachments/assets/c4eea888-ced9-4a30-860c-e541873b494e" />

- Removes the border/border-radius from `RelationshipTable`'s table and instead scopes it to `.table--appearance-condensed` so schedule publishing drawer tables render correctly. Previously the bottom border was missing from this table, now:
<img width="651" height="192" alt="image" src="https://github.com/user-attachments/assets/fe6cc6b7-1d80-4c2e-99d8-aae468ffd3a6" />

- Previously the dropdown chevron on the timezone picker was visible even when the field is read-only, now it's hidden:
<img width="427" height="215" alt="image" src="https://github.com/user-attachments/assets/b0f9f45f-089a-46a1-9838-2b40c3690829" />


## Why?

- The lexical `ContentEditable__root` previously had no horizontal padding outside the gutter/desktop case, causing text to sit flush against the edges on mobile
- The relationship table's border styling was leaking into the schedule publishing drawer table, causing incorrect double borders/styling
- A disabled/read-only timezone picker showed an interactive-looking chevron with no way to act on it