### PR TITLE
chore: re-enable dev indicator

### DIFF
--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -51,7 +51,10 @@ export const withPayload = (nextConfig = {}, options = {}) => {
   /** @type {import('next').NextConfig} */
   const baseConfig = {
     ...nextConfig,
-    devIndicators: nextConfig.devIndicators !== undefined ? nextConfig.devIndicators : false,
+    devIndicators:
+      nextConfig.devIndicators !== undefined
+        ? nextConfig.devIndicators
+        : { position: 'bottom-right' },
     env,
     experimental: {
       ...(nextConfig.experimental || {}),

--- a/packages/next/src/withPayload/withPayload.spec.ts
+++ b/packages/next/src/withPayload/withPayload.spec.ts
@@ -26,10 +26,10 @@ describe('withPayload', () => {
     }
   })
 
-  it('should disable devIndicators by default', () => {
+  it('should position devIndicators at the bottom right by default', () => {
     const result = withPayload({})
 
-    expect(result.devIndicators).toBe(false)
+    expect(result.devIndicators).toEqual({ position: 'bottom-right' })
   })
 
   it('should use user-provided devIndicators when specified', () => {


### PR DESCRIPTION
Re-enables the nextjs devindicator, places it to the bottom right by default.

This is so we have some kind of compilation indicator until we can build this into Payload