### PR TITLE
fix(deps): remove @payloadcms/next from @payloadcms/richtext-lexical peer deps

### DIFF
--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -414,7 +414,6 @@
   "peerDependencies": {
     "@faceless-ui/modal": "3.0.1",
     "@faceless-ui/scroll-info": "2.0.0",
-    "@payloadcms/next": "workspace:*",
     "payload": "workspace:*",
     "react": "^19.0.1 || ^19.1.2 || ^19.2.1",
     "react-dom": "^19.0.1 || ^19.1.2 || ^19.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1453,9 +1453,6 @@ importers:
       '@lexical/utils':
         specifier: 0.45.0
         version: 0.45.0
-      '@payloadcms/next':
-        specifier: workspace:*
-        version: link:../next
       '@payloadcms/translations':
         specifier: workspace:*
         version: link:../translations


### PR DESCRIPTION
Removes the `@payloadcms/next` peer dependency from `@payloadcms/richtext-lexical`, which was declared but never imported anywhere in the package's source.

This is a problem with TanStack Start projects using the Lexical editor, which transitively receive `@payloadcms/next` dependencies.

This is because since pnpm v7, `auto-install-peers=true` is the default, so pnpm auto-installs missing peer dependencies rather than just warning about them. This pulls `@payloadcms/next` into projects that use Lexical without Next.js even though it's never used.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216589411439763