### PR TITLE
fix: resolve thumbnailURL to direct cloud storage URLs

### DIFF
--- a/packages/payload/src/uploads/generateFilePathOrURL.spec.ts
+++ b/packages/payload/src/uploads/generateFilePathOrURL.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Config } from '../config/types.js'
+
+import { generateFilePathOrURL } from './generateFilePathOrURL.js'
+
+describe('generateFilePathOrURL', () => {
+  const serverURL = 'https://my-app.example.com'
+  const config = { routes: { api: '/api' }, serverURL } as Config
+
+  it('returns an external URL as-is when serverURL is configured', () => {
+    const result = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config,
+      filename: 'image.png',
+      relative: false,
+      serverURL,
+      urlOrPath: 'https://cdn.example.com/image.png',
+    })
+
+    expect(result).toBe('https://cdn.example.com/image.png')
+  })
+
+  it('returns an external URL as-is when serverURL is not configured', () => {
+    // Regression test: an empty/undefined serverURL previously caused every
+    // external URL (e.g. a cloud storage / CDN URL) to be misidentified as
+    // internal, since `someString.startsWith('')` is always `true`.
+    const result = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config: { routes: { api: '/api' } } as Config,
+      filename: 'image.png',
+      relative: false,
+      serverURL: '',
+      urlOrPath: 'https://cdn.example.com/image.png',
+    })
+
+    expect(result).toBe('https://cdn.example.com/image.png')
+  })
+
+  it('falls back to the local file URL when urlOrPath is same-origin as serverURL', () => {
+    const result = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config,
+      filename: 'image.png',
+      relative: false,
+      serverURL,
+      urlOrPath: `${serverURL}/api/media/file/image.png`,
+    })
+
+    expect(result).toBe(`${serverURL}/api/media/file/image.png`)
+  })
+
+  it('falls back to the local file URL when urlOrPath is a relative path', () => {
+    const result = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config,
+      filename: 'image.png',
+      relative: false,
+      serverURL,
+      urlOrPath: '/api/media/file/image.png',
+    })
+
+    expect(result).toBe(`${serverURL}/api/media/file/image.png`)
+  })
+
+  it('returns null when neither urlOrPath nor filename are provided', () => {
+    const result = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config,
+      filename: undefined,
+      relative: false,
+      serverURL,
+      urlOrPath: undefined,
+    })
+
+    expect(result).toBeNull()
+  })
+})

--- a/packages/payload/src/uploads/generateFilePathOrURL.ts
+++ b/packages/payload/src/uploads/generateFilePathOrURL.ts
@@ -27,7 +27,13 @@ export function generateFilePathOrURL({
   urlOrPath: string | undefined
 }): null | string {
   if (urlOrPath) {
-    if (!urlOrPath.startsWith('/') && !urlOrPath.startsWith(serverURL || '')) {
+    const isRelativePath = urlOrPath.startsWith('/')
+    // Only treat urlOrPath as belonging to this server if a serverURL is actually
+    // configured. Otherwise `''.startsWith('')` is always true, which would cause
+    // every external (e.g. cloud storage / CDN) URL to be misidentified as internal.
+    const isSameOriginAsServer = Boolean(serverURL) && urlOrPath.startsWith(serverURL as string)
+
+    if (!isRelativePath && !isSameOriginAsServer) {
       // external url
       return urlOrPath
     }

--- a/packages/payload/src/utilities/appendUploadSelectFields.spec.ts
+++ b/packages/payload/src/utilities/appendUploadSelectFields.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ClientCollectionConfig } from '../index.js'
+
+import { appendUploadSelectFields } from './appendUploadSelectFields.js'
+
+describe('appendUploadSelectFields', () => {
+  it('includes size url when adminThumbnail is a string size name', () => {
+    const collectionConfig = {
+      slug: 'media',
+      upload: {
+        adminThumbnail: 'thumbnail',
+        imageSizes: [
+          {
+            name: 'thumbnail',
+            width: 400,
+            height: 300,
+          },
+        ],
+      },
+    } as ClientCollectionConfig
+
+    const select = {}
+    appendUploadSelectFields({ collectionConfig, select })
+
+    expect(select).toEqual({
+      mimeType: true,
+      thumbnailURL: true,
+      sizes: {
+        thumbnail: {
+          filename: true,
+          url: true,
+        },
+      },
+    })
+  })
+})

--- a/packages/payload/src/utilities/appendUploadSelectFields.ts
+++ b/packages/payload/src/utilities/appendUploadSelectFields.ts
@@ -32,6 +32,7 @@ export const appendUploadSelectFields = ({
       select.sizes = {
         [collectionConfig.upload.adminThumbnail]: {
           filename: true,
+          url: true,
         },
       }
     } else {

--- a/test/storage-s3/int.spec.ts
+++ b/test/storage-s3/int.spec.ts
@@ -237,6 +237,68 @@ describe('@payloadcms/storage-s3', () => {
       await payload.delete({ collection: mediaWithDirectAccessSlug, id: upload.id })
     })
 
+    it('should resolve thumbnailURL to the direct S3 URL on a full (non-select) read', async () => {
+      // Regression test: when `serverURL` is not configured (the default in this
+      // test suite, and common in real-world configs that rely on relative URLs),
+      // `thumbnailURL` incorrectly fell back to the internal `/api/.../file/...`
+      // path instead of passing through the direct S3 URL already resolved on
+      // `sizes.thumbnail.url`.
+      const upload = await payload.create({
+        collection: mediaWithDirectAccessSlug,
+        data: {},
+        filePath: path.resolve(dirname, '../uploads/image.png'),
+      })
+
+      expect(upload.thumbnailURL).toContain(process.env.S3_ENDPOINT)
+      expect(upload.thumbnailURL).toContain(getTestBucketName())
+      expect(upload.thumbnailURL).not.toMatch(/^\/api\//)
+
+      const fullRead = await payload.findByID({
+        id: upload.id,
+        collection: mediaWithDirectAccessSlug,
+      })
+
+      expect(fullRead.thumbnailURL).toContain(process.env.S3_ENDPOINT)
+      expect(fullRead.thumbnailURL).not.toMatch(/^\/api\//)
+
+      await payload.delete({ id: upload.id, collection: mediaWithDirectAccessSlug })
+    })
+
+    it('should resolve thumbnailURL to the direct S3 URL when querying with a select that only includes upload fields', async () => {
+      // Mirrors the `select` shape that `appendUploadSelectFields` builds for the
+      // admin list view and relationship fields: only `sizes.<adminThumbnail>.filename`
+      // and `.url`, not the rest of the document.
+      const upload = await payload.create({
+        collection: mediaWithDirectAccessSlug,
+        data: {},
+        filePath: path.resolve(dirname, '../uploads/image.png'),
+      })
+
+      const { docs } = await payload.find({
+        collection: mediaWithDirectAccessSlug,
+        select: {
+          mimeType: true,
+          sizes: {
+            thumbnail: {
+              filename: true,
+              url: true,
+            },
+          },
+          thumbnailURL: true,
+        },
+        where: { id: { equals: upload.id } },
+      })
+
+      // Without `url: true` in the `sizes.thumbnail` select, this field is never
+      // fetched from the database, so `thumbnailURL` falls back to the internal
+      // `/api/.../file/...` path instead of the direct S3 URL.
+      expect(docs[0]?.thumbnailURL).toContain(process.env.S3_ENDPOINT)
+      expect(docs[0]?.thumbnailURL).toContain(getTestBucketName())
+      expect(docs[0]?.thumbnailURL).not.toMatch(/^\/api\//)
+
+      await payload.delete({ id: upload.id, collection: mediaWithDirectAccessSlug })
+    })
+
     it('should return direct S3 URL without encoding issues for normal filenames', async () => {
       const upload = await payload.create({
         collection: mediaWithDirectAccessSlug,


### PR DESCRIPTION
### What?

Fixes #12659

When using cloud storage with `adminThumbnail` set to a string size name (for example `'thumbnail'`), `thumbnailURL` could resolve to `/api/{collection}/file/...` instead of the direct CDN or S3 URL. This affected admin list thumbnails and any API response that relied on `thumbnailURL`.

### Why?

Two independent bugs in core:

1. **`appendUploadSelectFields`**  
   For string `adminThumbnail`, the list-view select only projected `sizes.<name>.filename`, not `.url`. Without the stored URL in the projection, the `thumbnailURL` afterRead hook falls back to building a local API path from the filename.

2. **`generateFilePathOrURL`**  
   When `serverURL` is unset, which is common for relative-URL deployments, `urlOrPath.startsWith(serverURL || '')` becomes `startsWith('')`. That is always true, so external URLs were treated as same-origin and discarded in favor of the local file path.

Related: #15988 adds `generateFileURL` hooks on `thumbnailURL` in plugin-cloud-storage. That work is complementary. It regenerates URLs on read when `generateFileURL` is configured. This PR fixes select projection and external URL detection in core.

### How?

- Add `url: true` to the `sizes.<adminThumbnail>` select in `appendUploadSelectFields`, matching the behavior of the non-string `adminThumbnail` branch.
- In `generateFilePathOrURL`, only treat `urlOrPath` as same-origin when `serverURL` is actually configured.

### Verification

- [x] `pnpm test:unit appendUploadSelectFields generateFilePathOrURL`
- [x] `pnpm test:int storage-s3`
- [x] `pnpm test:int plugin-cloud-storage`
- [x] `pnpm test:int uploads`