### PR TITLE
fix(plugin-multi-tenant): apply tenant on confirm

### DIFF
--- a/packages/plugin-multi-tenant/src/components/AssignTenantFieldModal/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/AssignTenantFieldModal/index.client.tsx
@@ -46,8 +46,8 @@ export const AssignTenantFieldTrigger: React.FC = () => {
 }
 
 export const AssignTenantFieldModal: React.FC<{
-  afterModalClose: () => void
-  afterModalOpen: () => void
+  afterModalClose?: () => void
+  afterModalOpen?: () => void
   children: React.ReactNode
   onCancel?: () => void
   onConfirm?: () => void

--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -150,11 +150,7 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
     if (!unique) {
       /** Editing a non-global tenant document */
       return (
-        <AssignTenantFieldModal
-          afterModalClose={() => undefined}
-          afterModalOpen={afterModalOpen}
-          onConfirm={onConfirm}
-        >
+        <AssignTenantFieldModal afterModalOpen={afterModalOpen} onConfirm={onConfirm}>
           <FieldPathContext value={tenantField.path}>
             <FieldContext value={localTenantField}>
               <TenantRelationshipField fieldArgs={fieldArgs} unique={unique} />

--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -1,8 +1,11 @@
 'use client'
 
+import type { FieldType } from '@payloadcms/ui'
 import type { RelationshipFieldClientProps } from 'payload'
 
 import {
+  FieldContext,
+  FieldPathContext,
   Pill,
   RelationshipField,
   useDocumentInfo,
@@ -12,6 +15,8 @@ import {
   useModal,
 } from '@payloadcms/ui'
 import React from 'react'
+
+import type { TenantValue } from '../../types.js'
 
 import { useTenantSelection } from '../../providers/TenantSelectionProvider/index.client.js'
 import {
@@ -29,77 +34,84 @@ type Props = {
 
 export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
   const { entityType, options, selectedTenantID, setEntityType, setTenant } = useTenantSelection()
-  const { setValue, showError, value } = useField<(number | string)[] | (number | string)>()
-  const modified = useFormModified()
-  const { isValid: isFormValid, setModified } = useForm()
+  const tenantField = useField<TenantValue>()
+  const { setValue, showError, value } = tenantField
+  const { isValid: isFormValid } = useForm()
   const { id: docID, collectionSlug } = useDocumentInfo()
   const { isModalOpen, openModal } = useModal()
   const isEditManyModalOpen = collectionSlug
     ? isModalOpen(`edit-${collectionSlug}`) || isModalOpen(`edit-${collectionSlug}-bulk-uploads`)
     : false
-  const isConfirmingRef = React.useRef<boolean>(false)
-  const prevModified = React.useRef(modified)
-  const prevValue = React.useRef<typeof value>(value)
+  const [modalValue, setModalValue] = React.useState<TenantValue | undefined>(value)
+  const localTenantField = React.useMemo<FieldType<TenantValue>>(
+    () => ({
+      ...tenantField,
+      initialValue: modalValue,
+      setValue: (nextValue) => {
+        setModalValue(nextValue as TenantValue | undefined)
+      },
+      value: modalValue as TenantValue,
+    }),
+    [modalValue, tenantField],
+  )
   const showField =
     (options.length > 1 && !fieldArgs.field.admin?.hidden && !fieldArgs.field.hidden) || debug
 
-  const onConfirm = React.useCallback(() => {
-    isConfirmingRef.current = true
-  }, [])
-
-  const afterModalOpen = React.useCallback(() => {
-    prevModified.current = modified
-    prevValue.current = value
-  }, [modified, value])
-
-  const afterModalClose = React.useCallback(() => {
-    let didChange = true
-    if (isConfirmingRef.current) {
-      // did the values actually change?
-      if (fieldArgs.field.hasMany) {
-        const prev = (prevValue.current || []) as (number | string)[]
-        const newValue = (value || []) as (number | string)[]
-        if (prev.length !== newValue.length) {
-          didChange = true
-        } else {
-          const allMatch = newValue.every((val) => prev.includes(val))
-          if (allMatch) {
-            didChange = false
-          }
-        }
-      } else if (value === prevValue.current) {
-        didChange = false
+  function getTenantIDToSelect({
+    selectedTenantID,
+    value,
+  }: {
+    selectedTenantID: number | string | undefined
+    value: TenantValue | undefined
+  }): number | string | undefined {
+    if (Array.isArray(value)) {
+      if (!value.length) {
+        return undefined
       }
 
-      if (didChange) {
-        prevModified.current = true
-        prevValue.current = value
+      if (!selectedTenantID || !value.includes(selectedTenantID)) {
+        return value[0]
       }
+
+      return undefined
     }
 
-    setValue(prevValue.current, true)
-    setModified(prevModified.current)
+    if (value && selectedTenantID !== value) {
+      return value
+    }
 
-    isConfirmingRef.current = false
-  }, [setValue, setModified, value, fieldArgs.field.hasMany])
+    return undefined
+  }
+
+  const syncTenantSelectionFromValue = React.useCallback(
+    (tenantValue: TenantValue | undefined) => {
+      const tenantID = getTenantIDToSelect({ selectedTenantID, value: tenantValue })
+
+      if (tenantID) {
+        setTenant({ id: tenantID, refresh: false })
+      }
+    },
+    [selectedTenantID, setTenant],
+  )
+
+  const onConfirm = React.useCallback(() => {
+    if (hasTenantValueChanged({ hasMany: fieldArgs.field.hasMany, modalValue, value })) {
+      setValue(modalValue)
+      syncTenantSelectionFromValue(modalValue)
+    }
+  }, [fieldArgs.field.hasMany, modalValue, setValue, syncTenantSelectionFromValue, value])
+
+  const afterModalOpen = React.useCallback(() => {
+    setModalValue(value)
+  }, [value])
 
   React.useEffect(() => {
     if (!entityType) {
       setEntityType(unique ? 'global' : 'document')
     } else {
       // unique documents are controlled from the global TenantSelector
-      if (!unique && value) {
-        if (Array.isArray(value)) {
-          if (value.length) {
-            if (!selectedTenantID) {
-              setTenant({ id: value[0], refresh: false })
-            } else if (!value.includes(selectedTenantID)) {
-              setTenant({ id: value[0], refresh: false })
-            }
-          }
-        } else if (selectedTenantID !== value) {
-          setTenant({ id: value, refresh: false })
-        }
+      if (!unique) {
+        syncTenantSelectionFromValue(value)
       }
     }
 
@@ -108,7 +120,7 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
         setEntityType(undefined)
       }
     }
-  }, [unique, options, selectedTenantID, setTenant, value, setEntityType, entityType])
+  }, [entityType, setEntityType, syncTenantSelectionFromValue, unique, value])
 
   React.useEffect(() => {
     if (unique || debug || isEditManyModalOpen) {
@@ -139,11 +151,15 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
       /** Editing a non-global tenant document */
       return (
         <AssignTenantFieldModal
-          afterModalClose={afterModalClose}
+          afterModalClose={() => undefined}
           afterModalOpen={afterModalOpen}
           onConfirm={onConfirm}
         >
-          <TenantRelationshipField fieldArgs={fieldArgs} unique={unique} />
+          <FieldPathContext value={tenantField.path}>
+            <FieldContext value={localTenantField}>
+              <TenantRelationshipField fieldArgs={fieldArgs} unique={unique} />
+            </FieldContext>
+          </FieldPathContext>
         </AssignTenantFieldModal>
       )
     }
@@ -152,6 +168,28 @@ export const TenantField = ({ debug, unique, ...fieldArgs }: Props) => {
   }
 
   return null
+}
+
+const hasTenantValueChanged = ({
+  hasMany,
+  modalValue,
+  value,
+}: {
+  hasMany?: boolean
+  modalValue: TenantValue | undefined
+  value: TenantValue | undefined
+}): boolean => {
+  if (hasMany) {
+    const currentValue = (value || []) as (number | string)[]
+    const nextValue = (modalValue || []) as (number | string)[]
+
+    return (
+      currentValue.length !== nextValue.length ||
+      nextValue.some((nextValueItem) => !currentValue.includes(nextValueItem))
+    )
+  }
+
+  return value !== modalValue
 }
 
 const TenantRelationshipField: React.FC<{

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -11,6 +11,8 @@ import type {
   User,
 } from 'payload'
 
+export type TenantValue = (number | string)[] | (number | string)
+
 export type MultiTenantPluginConfig = {
   /**
    * After a tenant is deleted, the plugin will attempt to clean up related documents

--- a/test/plugin-multi-tenant/e2e.spec.ts
+++ b/test/plugin-multi-tenant/e2e.spec.ts
@@ -312,7 +312,10 @@ test.describe('Multi Tenant', () => {
 
   test.describe('Documents', () => {
     test('should set tenant upon entering document', async () => {
-      test.skip(process.env.PAYLOAD_FRAMEWORK === 'tanstack-start', 'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.')
+      test.skip(
+        process.env.PAYLOAD_FRAMEWORK === 'tanstack-start',
+        'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.',
+      )
       await loginClientSide({
         data: credentials.admin,
         page,
@@ -342,7 +345,10 @@ test.describe('Multi Tenant', () => {
     })
 
     test('should allow tenant switching cancellation', async () => {
-      test.skip(process.env.PAYLOAD_FRAMEWORK === 'tanstack-start', 'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.')
+      test.skip(
+        process.env.PAYLOAD_FRAMEWORK === 'tanstack-start',
+        'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.',
+      )
       await loginClientSide({
         data: credentials.admin,
         page,
@@ -360,14 +366,39 @@ test.describe('Multi Tenant', () => {
         urlUtil: menuItemsURL,
       })
 
-      await selectDocumentTenant({
-        action: 'cancel',
+      await closeNav(page)
+      await openAssignTenantModal({ page, payload })
+      await selectInput({
         page,
-        payload,
-        tenant: 'Steel Cat',
+        multiSelect: false,
+        option: 'Steel Cat',
+        selectLocator: page.locator('.tenantField'),
       })
 
       await expect(page.locator('#action-save')).toBeDisabled()
+      await expect
+        .poll(async () => {
+          return await getSelectedTenantFilterName({ page, payload })
+        })
+        .toBe('Blue Dog')
+
+      const assignTenantModal = page.locator('#assign-tenant-field-modal')
+      await assignTenantModal.locator('button', { hasText: 'Cancel' }).click()
+      await expect(assignTenantModal).toBeHidden()
+
+      await expect(page.locator('#action-save')).toBeDisabled()
+
+      await closeNav(page)
+      await openAssignTenantModal({ page, payload })
+      await expect
+        .poll(async () =>
+          getSelectInputValue({
+            multiSelect: false,
+            selectLocator: page.locator('.tenantField'),
+            selectType: 'relationship',
+          }),
+        )
+        .toBe('Blue Dog')
 
       await page.goto(menuItemsURL.list)
       await expect
@@ -378,7 +409,10 @@ test.describe('Multi Tenant', () => {
     })
 
     test('should allow tenant switching confirmation', async () => {
-      test.skip(process.env.PAYLOAD_FRAMEWORK === 'tanstack-start', 'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.')
+      test.skip(
+        process.env.PAYLOAD_FRAMEWORK === 'tanstack-start',
+        'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.',
+      )
       await loginClientSide({
         data: credentials.admin,
         page,
@@ -396,11 +430,32 @@ test.describe('Multi Tenant', () => {
         urlUtil: menuItemsURL,
       })
 
-      await selectDocumentTenant({
+      await closeNav(page)
+      await openAssignTenantModal({ page, payload })
+      await selectInput({
         page,
-        payload,
-        tenant: 'Steel Cat',
+        multiSelect: false,
+        option: 'Steel Cat',
+        selectLocator: page.locator('.tenantField'),
       })
+
+      await expect(page.locator('#action-save')).toBeDisabled()
+      await expect
+        .poll(async () => {
+          return await getSelectedTenantFilterName({ page, payload })
+        })
+        .toBe('Blue Dog')
+
+      const assignTenantModal = page.locator('#assign-tenant-field-modal')
+      await assignTenantModal.locator('button', { hasText: 'Confirm' }).click()
+      await expect(assignTenantModal).toBeHidden()
+
+      await expect(page.locator('#action-save')).toBeEnabled()
+      await expect
+        .poll(async () => {
+          return await getSelectedTenantFilterName({ page, payload })
+        })
+        .toBe('Steel Cat')
 
       await saveDocAndAssert(page)
     })
@@ -1242,7 +1297,10 @@ test.describe('Multi Tenant', () => {
     })
 
     test('should filter sidebar tree when switching tenants without page navigation', async () => {
-      test.skip(process.env.PAYLOAD_FRAMEWORK === 'tanstack-start', 'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.')
+      test.skip(
+        process.env.PAYLOAD_FRAMEWORK === 'tanstack-start',
+        'TanStack: known post-hydration RSC view remount detaches the view mid-interaction (see framework adapter notes); re-enable when the TanStack RSC hydration is fixed.',
+      )
       // This test reproduces the user flow:
       // 1. Log in and go to folders
       // 2. Select Folders tab in sidebar
@@ -1357,7 +1415,12 @@ async function openAssignTenantModal({
   // Open the assign tenant modal
   const docControlsPopup = page.locator('.popup__content')
   const docControlsButton = page.locator('.doc-controls__popup .popup__trigger-wrap button')
-  await expect(docControlsButton).toBeVisible()
+
+  if (!(await docControlsButton.isVisible())) {
+    await expect(assignTenantModal).toBeVisible()
+    return
+  }
+
   await docControlsButton.click()
 
   const assignTenantButtonLocator = docControlsPopup.locator('button', { hasText: 'Assign Site' })


### PR DESCRIPTION
Stages Assign Tenant modal changes locally until the user confirms the selection. Cancel now leaves the document form and global tenant selector unchanged, while Confirm applies the tenant field update and syncs the selector from the confirmed value.

### Before
The global tenant selector would immediately update on change inside the assign tenant modal, even before confirming. It would change it back on cancel, but when you have autosave enabled it would attempt to autosave the document with the new tenant before the user confirmed the selection/change.

https://github.com/user-attachments/assets/4b214cb9-a4bb-4590-97e7-aa26b8171923


### After
The global tenant selector only updates once the user confirms the tenant selection.

https://github.com/user-attachments/assets/b8b14872-bbcd-4019-8fa3-3af59ae65c4d

