### PR TITLE
fix: restore test Vite dev server

### DIFF
--- a/app-tanstack/tsconfig.json
+++ b/app-tanstack/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "rootDir": "..",
     "paths": {
-      "@payload-config": ["../test/lexical/config.ts"]
+      "@payload-config": ["../test/_community/config.ts"]
     }
   },
   "include": [

--- a/test/dev.ts
+++ b/test/dev.ts
@@ -68,7 +68,7 @@ if (['admin-root'].includes(testSuiteArg)) {
 // framework name. Resolved value is written back to the env var so downstream helpers
 // and spawned child processes (which read PAYLOAD_FRAMEWORK) stay in sync.
 const frameworkFromFlag = Object.keys(args)
-  .find((arg) => arg.startsWith('framework-'))
+  .find((arg) => arg.startsWith('framework-') && args[arg] === true)
   ?.slice('framework-'.length)
 
 const framework = frameworkFromFlag || process.env.PAYLOAD_FRAMEWORK || 'next'

--- a/test/vite.tanstack.config.ts
+++ b/test/vite.tanstack.config.ts
@@ -1,4 +1,7 @@
 import { withPayload } from '@payloadcms/tanstack-start/vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+import rsc from '@vitejs/plugin-rsc'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -51,21 +54,13 @@ const suiteDir = path.resolve(__dirname, testSuite, 'app-tanstack')
 const srcDirectory = fs.existsSync(suiteDir) ? path.relative(__dirname, suiteDir) : 'app-tanstack'
 
 export default defineConfig(
-  withPayload(undefined, {
-    additionalIgnoreImporters: [
-      /^\.\.\/packages\/tanstack-start\/src\/views\/AdminView\.tsx(?:\?.*)?$/,
-    ],
-    // In the monorepo, Payload's `.client.*` files resolve to `packages/*/src`
-    // (not `node_modules`), so exempt them from the `.client.*` SSR denial too.
-    clientDenialExcludeFiles: ['**/packages/*/src/**'],
-    payloadConfigPath: path.resolve(__dirname, testSuite, 'config.ts'),
-    routesDirectory: 'app',
-    srcDirectory,
-    // Everything test/monorepo-specific is layered on via the single `vite`
-    // override — `withPayload` merges it on top of the Payload defaults. (The
-    // `~@payloadcms/ui/scss` importer and sourcemap-warning silencing are now
-    // handled by `withPayload` itself.)
-    vite: {
+  withPayload(
+    ({ pluginOptions }) => ({
+      plugins: [
+        rsc(pluginOptions.rsc),
+        tanstackStart(pluginOptions.tanstackStart),
+        viteReact(pluginOptions.react),
+      ],
       // Keep build output out of the app dirs (they ship as pure source); the
       // repo root already ignores `dist`.
       build: { outDir: path.resolve(repoRoot, 'dist/app-tanstack') },
@@ -105,6 +100,17 @@ export default defineConfig(
           ],
         },
       },
+    }),
+    {
+      additionalIgnoreImporters: [
+        /^\.\.\/packages\/tanstack-start\/src\/views\/AdminView\.tsx(?:\?.*)?$/,
+      ],
+      // In the monorepo, Payload's `.client.*` files resolve to `packages/*/src`
+      // (not `node_modules`), so exempt them from the `.client.*` SSR denial too.
+      clientDenialExcludeFiles: ['**/packages/*/src/**'],
+      payloadConfigPath: path.resolve(__dirname, testSuite, 'config.ts'),
+      routesDirectory: 'app',
+      srcDirectory,
     },
-  }),
+  ),
 )

--- a/test/vite.tanstack.config.ts
+++ b/test/vite.tanstack.config.ts
@@ -5,7 +5,6 @@ import rsc from '@vitejs/plugin-rsc'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { defineConfig } from 'vite'
 
 // This config drives the TanStack admin app from the `test` package, mirroring
 // how the Next.js test apps live under `test/`. Its dependencies are declared by
@@ -53,64 +52,62 @@ const testSuite = process.env.PAYLOAD_TEST_SUITE || '_community'
 const suiteDir = path.resolve(__dirname, testSuite, 'app-tanstack')
 const srcDirectory = fs.existsSync(suiteDir) ? path.relative(__dirname, suiteDir) : 'app-tanstack'
 
-export default defineConfig(
-  withPayload(
-    ({ pluginOptions }) => ({
-      plugins: [
-        rsc(pluginOptions.rsc),
-        tanstackStart(pluginOptions.tanstackStart),
-        viteReact(pluginOptions.react),
+export default withPayload(
+  ({ pluginOptions }) => ({
+    plugins: [
+      rsc(pluginOptions.rsc),
+      tanstackStart(pluginOptions.tanstackStart),
+      viteReact(pluginOptions.react),
+    ],
+    // Keep build output out of the app dirs (they ship as pure source); the
+    // repo root already ignores `dist`.
+    build: { outDir: path.resolve(repoRoot, 'dist/app-tanstack') },
+    optimizeDeps: {
+      include: [
+        // `recharts` is only reached through the dashboard suite's Revenue
+        // widget, which is rendered on-demand via the `render-widget` server
+        // function. Vite discovers it (and its d3-* subdeps) *after* the
+        // initial crawl, forcing a full dep re-optimization + page reload
+        // mid-test. That reload remounts the admin view and silently drops
+        // client state (e.g. the dashboard's `isEditing`/unsaved layout),
+        // flaking the add/delete/reset widget tests. Pre-bundle it so the
+        // first optimization pass is complete.
+        'recharts',
+        // `@payloadcms/storage-vercel-blob`'s client upload handler imports
+        // `upload` from `@vercel/blob/client`, which depends on the CommonJS
+        // `async-retry`. Because the storage adapter is `noExternal` (bundled
+        // from source), Vite's optimizer never crawls into it to discover
+        // `@vercel/blob/client`, so it ships raw — and `async-retry`'s bare
+        // `require()` throws "require() is not available in the browser
+        // bundle", breaking the upload field (file input never mounts).
+        // Pre-bundling lets esbuild convert the CJS require to ESM.
+        '@vercel/blob/client',
       ],
-      // Keep build output out of the app dirs (they ship as pure source); the
-      // repo root already ignores `dist`.
-      build: { outDir: path.resolve(repoRoot, 'dist/app-tanstack') },
-      optimizeDeps: {
-        include: [
-          // `recharts` is only reached through the dashboard suite's Revenue
-          // widget, which is rendered on-demand via the `render-widget` server
-          // function. Vite discovers it (and its d3-* subdeps) *after* the
-          // initial crawl, forcing a full dep re-optimization + page reload
-          // mid-test. That reload remounts the admin view and silently drops
-          // client state (e.g. the dashboard's `isEditing`/unsaved layout),
-          // flaking the add/delete/reset widget tests. Pre-bundle it so the
-          // first optimization pass is complete.
-          'recharts',
-          // `@payloadcms/storage-vercel-blob`'s client upload handler imports
-          // `upload` from `@vercel/blob/client`, which depends on the CommonJS
-          // `async-retry`. Because the storage adapter is `noExternal` (bundled
-          // from source), Vite's optimizer never crawls into it to discover
-          // `@vercel/blob/client`, so it ships raw — and `async-retry`'s bare
-          // `require()` throws "require() is not available in the browser
-          // bundle", breaking the upload field (file input never mounts).
-          // Pre-bundling lets esbuild convert the CJS require to ESM.
-          '@vercel/blob/client',
+    },
+    envDir: repoRoot,
+    server: {
+      fs: { allow: [repoRoot] },
+      port,
+      strictPort: true,
+      warmup: {
+        clientFiles: [
+          './app-tanstack/app/__root.tsx',
+          './app-tanstack/app/_payload.tsx',
+          './app-tanstack/app/_payload/admin.index.tsx',
+          './app-tanstack/app/_payload/admin.$.tsx',
         ],
       },
-      envDir: repoRoot,
-      server: {
-        fs: { allow: [repoRoot] },
-        port,
-        strictPort: true,
-        warmup: {
-          clientFiles: [
-            './app-tanstack/app/__root.tsx',
-            './app-tanstack/app/_payload.tsx',
-            './app-tanstack/app/_payload/admin.index.tsx',
-            './app-tanstack/app/_payload/admin.$.tsx',
-          ],
-        },
-      },
-    }),
-    {
-      additionalIgnoreImporters: [
-        /^\.\.\/packages\/tanstack-start\/src\/views\/AdminView\.tsx(?:\?.*)?$/,
-      ],
-      // In the monorepo, Payload's `.client.*` files resolve to `packages/*/src`
-      // (not `node_modules`), so exempt them from the `.client.*` SSR denial too.
-      clientDenialExcludeFiles: ['**/packages/*/src/**'],
-      payloadConfigPath: path.resolve(__dirname, testSuite, 'config.ts'),
-      routesDirectory: 'app',
-      srcDirectory,
     },
-  ),
+  }),
+  {
+    additionalIgnoreImporters: [
+      /^\.\.\/packages\/tanstack-start\/src\/views\/AdminView\.tsx(?:\?.*)?$/,
+    ],
+    // In the monorepo, Payload's `.client.*` files resolve to `packages/*/src`
+    // (not `node_modules`), so exempt them from the `.client.*` SSR denial too.
+    clientDenialExcludeFiles: ['**/packages/*/src/**'],
+    payloadConfigPath: path.resolve(__dirname, testSuite, 'config.ts'),
+    routesDirectory: 'app',
+    srcDirectory,
+  },
 )


### PR DESCRIPTION
Two regressions combined broke our test Vite dev server.

1. The dev script was unable to pick up any of our `--framework-*` flags, including:
    - `pnpm dev:tanstack`
    - `pnpm dev --framework-tanstack-start`
    - `process.env.PAYLOAD_FRAMEWORK=tanstack-start`
 2. The test `vite.tanstack.config.ts` was misformated. Since https://github.com/payloadcms/payload/pull/17225, the `withPayload` helper is now expected to instantiate it's own plugins, passing Payload the given options into them.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216589411439775