### PR TITLE
fix(ui): restore field spacing for fields nested inside rows

### DIFF
--- a/packages/ui/src/forms/RenderFields/index.css
+++ b/packages/ui/src/forms/RenderFields/index.css
@@ -11,6 +11,10 @@
   }
 
   .render-fields {
+    /* Reset per nesting level so an ancestor's zeroed value (e.g. a row) does
+       not leak into nested fields. */
+    --spacing-field: var(--spacer-3);
+
     & > .field-type {
       margin-bottom: var(--spacing-field);
       position: relative;
@@ -44,8 +48,8 @@
       }
 
       &.group-field {
-        margin-top: calc(var(--gutter-h) * 2);
-        margin-bottom: calc(var(--gutter-h) * 3);
+        margin-top: calc(var(--spacing-field) * 4);
+        margin-bottom: calc(var(--spacing-field) * 3);
 
         &:first-child {
           margin-top: 0;
@@ -55,6 +59,16 @@
           margin-bottom: 0;
         }
       }
+
+      &.group-field--within-group {
+        margin-top: var(--spacing-field);
+      }
+    }
+  }
+
+  @media (max-width: 768px) {
+    .render-fields {
+      --spacing-field: var(--spacer-2-5);
     }
   }
 }


### PR DESCRIPTION
Fixes vertical spacing for fields nested inside a `row` (e.g. a `group` in a `row`), which were rendering with no `margin` between them.

`.row__fields` sets `--spacing-field: 0` to space its own items with `row-gap` instead of margins. Because custom properties inherit, that `0` cascaded into every descendant, so any field nested inside the row lost its spacing.

Root cause:

1. `.render-fields` no longer re-declared `--spacing-field`, so nested render levels inherited the row's zeroed value instead of re-establishing the default.
2. The row zeroed `--spacing-field` on `.row__fields`, which leaked to all descendants rather than just the row's direct items.

The fix re-declares `--spacing-field` on `.render-fields`, so each nesting level resets it and a zeroed ancestor value can no longer leak. The row keeps zeroing `--spacing-field` on `.row__fields` to space its items via `row-gap`, and nested fields recover their normal spacing.

Also reduces the top `margin` on groups nested inside a group (`.group-field--within-group`) so their header aligns with adjacent fields instead of inheriting the larger top-level group spacing.

#### Before:
<img width="1532" height="1353" alt="Screenshot 2026-07-15 at 6 43 18 PM" src="https://github.com/user-attachments/assets/cd1839be-a889-4da8-984c-f23c8bd42d10" />


#### After:
<img width="1533" height="1284" alt="Screenshot 2026-07-15 at 6 39 00 PM" src="https://github.com/user-attachments/assets/919e6784-a326-4c9c-b76e-ca9808faf5fe" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216611001041865