### PR TITLE
fix(plugin-stripe): handle REST proxy errors correctly

### DIFF
--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -97,7 +97,7 @@ const res = await fetch(`/api/stripe/rest`, {
     // Authorization: `JWT ${token}` // NOTE: do this if not in a browser (i.e. curl or Postman)
   },
   body: JSON.stringify({
-    stripeMethod: 'stripe.subscriptions.list',
+    stripeMethod: 'subscriptions.list',
     stripeArgs: [
       {
         customer: 'abc',

--- a/packages/plugin-stripe/src/routes/rest.spec.ts
+++ b/packages/plugin-stripe/src/routes/rest.spec.ts
@@ -1,0 +1,102 @@
+import type { PayloadRequest } from 'payload'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockAddDataAndFileToRequest, mockStripeProxy } = vi.hoisted(() => ({
+  mockAddDataAndFileToRequest: vi.fn(async (_req?: unknown) => undefined),
+  mockStripeProxy: vi.fn(),
+}))
+
+vi.mock('payload', () => {
+  class Forbidden extends Error {
+    status = 403
+
+    constructor(_t?: unknown) {
+      super('Not allowed to perform this action.')
+    }
+  }
+
+  return {
+    addDataAndFileToRequest: mockAddDataAndFileToRequest,
+    Forbidden,
+  }
+})
+
+vi.mock('../utilities/stripeProxy.js', () => ({
+  stripeProxy: mockStripeProxy,
+}))
+
+import { stripeREST } from './rest.js'
+
+const createRequest = ({ user }: { user?: { id: string } } = {}) => {
+  const logger = { error: vi.fn() }
+  const req = {
+    data: {
+      stripeArgs: [{ limit: 2 }],
+      stripeMethod: 'subscriptions.list',
+    },
+    payload: { logger },
+    t: vi.fn(),
+    user,
+  } as unknown as PayloadRequest
+
+  return { logger, req }
+}
+
+const pluginConfig = {
+  stripeSecretKey: 'sk_test_example',
+}
+
+describe('stripeREST', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return the Stripe proxy response for an authenticated request', async () => {
+    mockStripeProxy.mockResolvedValue({ data: { id: 'sub_123' }, status: 200 })
+    const { logger, req } = createRequest({ user: { id: 'user_123' } })
+
+    const response = await stripeREST({ pluginConfig, req })
+
+    expect(mockAddDataAndFileToRequest).toHaveBeenCalledWith(req)
+    expect(mockStripeProxy).toHaveBeenCalledWith({
+      stripeArgs: [{ limit: 2 }],
+      stripeMethod: 'subscriptions.list',
+      stripeSecretKey: 'sk_test_example',
+    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ data: { id: 'sub_123' }, status: 200 })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('should preserve the forbidden status for an unauthenticated request', async () => {
+    const { logger, req } = createRequest()
+
+    const response = await stripeREST({ pluginConfig, req })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      message: 'Not allowed to perform this action.',
+    })
+    expect(mockStripeProxy).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('should log unexpected proxy errors and return a 500 response', async () => {
+    const proxyError = new Error('Stripe is unavailable')
+
+    mockStripeProxy.mockRejectedValue(proxyError)
+    const { logger, req } = createRequest({ user: { id: 'user_123' } })
+
+    const response = await stripeREST({ pluginConfig, req })
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      message: 'An error has occurred in the Stripe plugin REST handler.',
+    })
+    expect(logger.error).toHaveBeenCalledWith({
+      err: proxyError,
+      msg: 'An error has occurred in the Stripe plugin REST handler.',
+    })
+  })
+})

--- a/packages/plugin-stripe/src/routes/rest.ts
+++ b/packages/plugin-stripe/src/routes/rest.ts
@@ -37,13 +37,19 @@ export const stripeREST = async (args: {
     const { status } = responseJSON
     responseStatus = status
   } catch (error: unknown) {
-    const message = `An error has occurred in the Stripe plugin REST handler: '${JSON.stringify(
-      error,
-    )}'`
-    payload.logger.error(message)
-    responseStatus = 500
-    responseJSON = {
-      message,
+    if (error instanceof Forbidden) {
+      responseStatus = error.status
+      responseJSON = {
+        message: error.message,
+      }
+    } else {
+      const message = 'An error has occurred in the Stripe plugin REST handler.'
+
+      payload.logger.error({ err: error, msg: message })
+      responseStatus = 500
+      responseJSON = {
+        message,
+      }
     }
   }
 

--- a/packages/plugin-stripe/src/utilities/stripeProxy.spec.ts
+++ b/packages/plugin-stripe/src/utilities/stripeProxy.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockStripeConstructor, mockStripeResources } = vi.hoisted(() => ({
+  mockStripeConstructor: vi.fn(),
+  mockStripeResources: {
+    subscriptions: {} as Record<string, unknown>,
+  },
+}))
+
+vi.mock('stripe', () => ({
+  default: class MockStripe {
+    subscriptions = mockStripeResources.subscriptions
+
+    constructor(secretKey: string, config: unknown) {
+      mockStripeConstructor(secretKey, config)
+    }
+  },
+}))
+
+import { stripeProxy } from './stripeProxy.js'
+
+describe('stripeProxy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStripeResources.subscriptions = {}
+  })
+
+  it('should call a valid Stripe method with its resource context', async () => {
+    const mockList = vi.fn(function (this: { resource: string }, ...args: unknown[]) {
+      return Promise.resolve({ args, resource: this.resource })
+    })
+    const subscriptions = {
+      list: mockList,
+      resource: 'subscriptions',
+    }
+
+    mockStripeResources.subscriptions = subscriptions
+
+    const result = await stripeProxy({
+      stripeArgs: [{ limit: 2 }],
+      stripeMethod: 'subscriptions.list',
+      stripeSecretKey: 'sk_test_example',
+    })
+
+    expect(mockStripeConstructor).toHaveBeenCalledWith(
+      'sk_test_example',
+      expect.objectContaining({ apiVersion: '2022-08-01' }),
+    )
+    expect(mockList).toHaveBeenCalledWith({ limit: 2 })
+    expect(mockList.mock.contexts[0]).toBe(subscriptions)
+    expect(result).toEqual({
+      data: { args: [{ limit: 2 }], resource: 'subscriptions' },
+      status: 200,
+    })
+  })
+
+  it('should throw an explanatory error for an unknown Stripe method', async () => {
+    await expect(
+      stripeProxy({
+        stripeArgs: [],
+        stripeMethod: 'subscriptions.unknown',
+        stripeSecretKey: 'sk_test_example',
+      }),
+    ).rejects.toThrow(
+      "The provided Stripe method of 'subscriptions.unknown' is not a part of the Stripe API.",
+    )
+  })
+
+  it('should reject non-array Stripe arguments', async () => {
+    const mockList = vi.fn()
+
+    mockStripeResources.subscriptions = { list: mockList }
+
+    await expect(
+      stripeProxy({
+        stripeArgs: { limit: 2 } as unknown as unknown[],
+        stripeMethod: 'subscriptions.list',
+        stripeSecretKey: 'sk_test_example',
+      }),
+    ).rejects.toThrow("Argument 'stripeArgs' must be an array.")
+    expect(mockList).not.toHaveBeenCalled()
+  })
+})

--- a/packages/plugin-stripe/src/utilities/stripeProxy.ts
+++ b/packages/plugin-stripe/src/utilities/stripeProxy.ts
@@ -17,12 +17,12 @@ export const stripeProxy: StripeProxy = async ({ stripeArgs, stripeMethod, strip
     const contextToBind = stripe[topLevelMethod]
     // NOTE: 'lodashGet' uses dot notation to get the property of an object
     // NOTE: Stripe API methods using reference "this" within their functions, so we need to bind context
-    const foundMethod = lodashGet(stripe, stripeMethod).bind(contextToBind)
+    const foundMethod = lodashGet(stripe, stripeMethod)
 
     if (typeof foundMethod === 'function') {
       if (Array.isArray(stripeArgs)) {
         try {
-          const stripeResponse = await foundMethod(...stripeArgs)
+          const stripeResponse = await foundMethod.bind(contextToBind)(...stripeArgs)
           return {
             data: stripeResponse,
             status: 200,


### PR DESCRIPTION
### What?

- Return the existing 403 status for unauthenticated Stripe REST proxy requests.
- Validate Stripe method paths before binding and keep valid resource context binding.
- Avoid exposing unexpected internal error details to REST clients.
- Correct the REST proxy method example in the Stripe plugin documentation.
- Add focused unit coverage for route and proxy behavior.

### Why?

Unknown method paths currently throw a bind TypeError before the intended validation can run. The REST handler also converts expected authorization failures into 500 responses and includes serialized unexpected errors in the public message. These behaviors make client responses misleading and can expose unnecessary implementation details.

### How?

The proxy now checks that the resolved path is a function before binding it. The REST handler preserves Payload Forbidden errors, logs unexpected failures with structured `{ err, msg }` context, and returns a stable generic 500 message. The tests cover successful proxying, resource binding, invalid methods, invalid arguments, forbidden requests, and unexpected errors.

### Validation

- `pnpm exec vitest run --project unit packages/plugin-stripe/src/routes/rest.spec.ts packages/plugin-stripe/src/utilities/stripeProxy.spec.ts`
- `pnpm run build:plugin-stripe`
- `pnpm --filter @payloadcms/plugin-stripe lint`
- Prettier check
- `git diff --check`

### Related issue

No existing issue; this is a maintenance fix discovered during repository review.