### PR TITLE
fix(ui): refresh join-dependent filter options

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -45,6 +45,7 @@ type RelationshipTableComponentProps = {
   readonly initialData?: PaginatedDocs
   readonly initialDrawerData?: DocumentDrawerProps['initialData']
   readonly Label?: React.ReactNode
+  readonly onDataChange?: (data: PaginatedDocs) => void
   readonly parent?: {
     collectionSlug: CollectionSlug
     id: number | string
@@ -68,6 +69,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
     initialData: initialDataFromProps,
     initialDrawerData,
     Label,
+    onDataChange,
     parent,
     relationTo,
   } = props
@@ -124,17 +126,30 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
 
   const { getTableState } = useServerFunctions()
 
-  const renderTable = useCallback(
-    async (data?: PaginatedDocs) => {
+  const getTableStateForQuery = useCallback(
+    async ({
+      data,
+      page,
+      shouldUseInteractiveQuery = true,
+    }: {
+      data?: PaginatedDocs
+      page?: number
+      shouldUseInteractiveQuery?: boolean
+    } = {}) => {
+      const interactiveQuery = shouldUseInteractiveQuery ? query : undefined
       const newQuery: ListQuery = {
         limit: field?.defaultLimit || collectionConfig?.admin?.pagination?.defaultLimit,
         sort: field.defaultSort || collectionConfig?.defaultSort,
-        ...(query || {}),
-        where: { ...(query?.where || {}) },
+        ...(interactiveQuery || {}),
+        where: { ...(interactiveQuery?.where || {}) },
       }
 
       if (filterOptions) {
         newQuery.where = hoistQueryParamsToAnd(newQuery.where, filterOptions)
+      }
+
+      if (typeof page === 'number') {
+        newQuery.page = page
       }
 
       // map columns from string[] to CollectionPreferences['columns']
@@ -150,11 +165,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
           ? !field.admin.disableRowTypes
           : Array.isArray(relationTo)
 
-      const {
-        data: newData,
-        state: newColumnState,
-        Table: NewTable,
-      } = await getTableState({
+      return getTableState({
         collectionSlug: relationTo,
         columns: transformColumnsToPreferences(query?.columns) || defaultColumns,
         data,
@@ -168,11 +179,6 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
         renderRowTypes,
         tableAppearance: 'condensed',
       })
-
-      setData(newData)
-      setTable(NewTable)
-      setColumnState(newColumnState)
-      setIsLoadingTable(false)
     },
     [
       field.defaultLimit,
@@ -192,6 +198,38 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
     ],
   )
 
+  const applyTableStateResult = useCallback((result: Awaited<ReturnType<typeof getTableState>>) => {
+    if (!result || !('Table' in result) || !result.data) {
+      setIsLoadingTable(false)
+      return
+    }
+
+    const { data: newData, state: newColumnState, Table: NewTable } = result
+
+    setData(newData)
+    setTable(NewTable)
+    setColumnState(newColumnState)
+    setIsLoadingTable(false)
+
+    return newData
+  }, [])
+
+  const renderTable = useCallback(
+    async (data?: PaginatedDocs) => {
+      const result = await getTableStateForQuery({ data })
+
+      return applyTableStateResult(result)
+    },
+    [applyTableStateResult, getTableStateForQuery],
+  )
+
+  const getCanonicalTableState = useCallback(async () => {
+    return getTableStateForQuery({
+      page: 1,
+      shouldUseInteractiveQuery: false,
+    })
+  }, [getTableStateForQuery])
+
   const handleTableRender = useEffectEvent((query: ListQuery, disableTable: boolean) => {
     if (!disableTable && (!Table || query)) {
       void renderTable()
@@ -203,7 +241,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
   }, [query, disableTable])
 
   const onDrawerSave = useCallback<DocumentDrawerProps['onSave']>(
-    ({ doc, operation }) => {
+    async ({ doc, operation }) => {
       if (operation === 'create') {
         closeDrawer()
       }
@@ -219,23 +257,54 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
         withNewOrUpdatedData.docs = [doc, ...data.docs]
       }
 
-      void renderTable(withNewOrUpdatedData)
+      const canonicalTableState = await getCanonicalTableState()
+      const formData =
+        canonicalTableState && 'Table' in canonicalTableState ? canonicalTableState.data : undefined
+
+      if (query || !formData) {
+        await renderTable(withNewOrUpdatedData)
+      } else {
+        applyTableStateResult(canonicalTableState)
+      }
+
+      if (formData) {
+        onDataChange?.(formData)
+      }
     },
-    [data?.docs, renderTable, closeDrawer],
+    [
+      data?.docs,
+      renderTable,
+      closeDrawer,
+      getCanonicalTableState,
+      onDataChange,
+      query,
+      applyTableStateResult,
+    ],
   )
 
   const onDrawerDelete = useCallback<DocumentDrawerProps['onDelete']>(
-    (args) => {
+    async (args) => {
       const newDocs = data.docs.filter((doc) => doc.id !== args.id)
 
-      void renderTable({
-        ...data,
-        docs: newDocs,
-      })
+      const canonicalTableState = await getCanonicalTableState()
+      const formData =
+        canonicalTableState && 'Table' in canonicalTableState ? canonicalTableState.data : undefined
 
+      if (query || !formData) {
+        await renderTable({
+          ...data,
+          docs: newDocs,
+        })
+      } else {
+        applyTableStateResult(canonicalTableState)
+      }
+
+      if (formData) {
+        onDataChange?.(formData)
+      }
       setCurrentDrawerID(undefined)
     },
-    [data, renderTable],
+    [data, renderTable, getCanonicalTableState, onDataChange, query, applyTableStateResult],
   )
 
   const onDrawerOpen = useCallback<OnDrawerOpen>((id, collectionSlug) => {

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -11,11 +11,12 @@ import type {
 
 import ObjectIdImport from 'bson-objectid'
 import { fieldAffectsData, flattenTopLevelFields } from 'payload/shared'
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { ErrorPill } from '../../elements/ErrorPill/index.js'
 import { RelationshipTable } from '../../elements/RelationshipTable/index.js'
 import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
+import { useForm } from '../../forms/Form/context.js'
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useConfig } from '../../providers/Config/index.js'
@@ -140,6 +141,7 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
     customComponents: { AfterInput, BeforeInput, Description, Label } = {},
     errorPaths,
     path,
+    setValue,
     showError,
     value,
   } = useField<PaginatedDocs>({
@@ -148,6 +150,16 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
 
   const fieldErrorCount = errorPaths?.length || (showError ? 1 : 0)
   const fieldHasErrors = fieldErrorCount > 0
+
+  const { requestFormStateRefresh } = useForm()
+
+  const handleDataChange = useCallback(
+    (data: PaginatedDocs) => {
+      setValue(data, true)
+      requestFormStateRefresh()
+    },
+    [requestFormStateRefresh, setValue],
+  )
 
   const filterOptions: null | Where = useMemo(() => {
     if (!docID) {
@@ -233,6 +245,7 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
             {fieldHasErrors && <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />}
           </div>
         }
+        onDataChange={handleDataChange}
         parent={
           typeof docID !== 'undefined'
             ? {

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -111,6 +111,8 @@ export const Form: React.FC<FormProps> = (props) => {
 
   const [submitted, setSubmitted] = useState(false)
 
+  const [formStateRefreshCounter, setFormStateRefreshCounter] = useState(0)
+
   /**
    * Tracks wether the form state passes validation.
    * For example the state could be submitted but invalid as field errors have been returned.
@@ -175,6 +177,11 @@ export const Form: React.FC<FormProps> = (props) => {
   contextRef.current.fields = formState
 
   const prevFormState = useRef(formState)
+  const prevFormStateRefreshCounter = useRef(formStateRefreshCounter)
+
+  const requestFormStateRefresh = useCallback(() => {
+    setFormStateRefreshCounter((current) => current + 1)
+  }, [])
 
   const validateForm = useCallback(async () => {
     const validatedFieldState = {}
@@ -769,6 +776,7 @@ export const Form: React.FC<FormProps> = (props) => {
   contextRef.current.formRef = formRef
   contextRef.current.reset = reset
   contextRef.current.replaceState = replaceState
+  contextRef.current.requestFormStateRefresh = requestFormStateRefresh
   contextRef.current.dispatchFields = dispatchFields
   contextRef.current.addFieldRow = addFieldRow
   contextRef.current.removeFieldRow = removeFieldRow
@@ -851,14 +859,20 @@ export const Form: React.FC<FormProps> = (props) => {
 
   useDebouncedEffect(
     () => {
-      if ((isFirstRenderRef.current || !dequal(formState, prevFormState.current)) && modified) {
+      const hasFormStateChanged =
+        isFirstRenderRef.current || !dequal(formState, prevFormState.current)
+      const hasRequestedFormStateRefresh =
+        formStateRefreshCounter !== prevFormStateRefreshCounter.current
+
+      if ((hasFormStateChanged && modified) || hasRequestedFormStateRefresh) {
         executeOnChange(submitted)
       }
 
       prevFormState.current = formState
+      prevFormStateRefreshCounter.current = formStateRefreshCounter
       isFirstRenderRef.current = false
     },
-    [modified, submitted, formState],
+    [modified, submitted, formState, formStateRefreshCounter],
     250,
   )
 

--- a/packages/ui/src/forms/Form/initContextState.ts
+++ b/packages/ui/src/forms/Form/initContextState.ts
@@ -6,6 +6,7 @@ import type {
   CreateFormData,
   DispatchFields,
   GetSiblingData,
+  RequestFormStateRefresh,
   Reset,
   SetModified,
   SetProcessing,
@@ -25,6 +26,7 @@ const setProcessing: SetProcessing = () => undefined
 const setBackgroundProcessing: SetProcessing = () => undefined
 const setSubmitted: SetSubmitted = () => undefined
 const reset: Reset = () => undefined
+const requestFormStateRefresh: RequestFormStateRefresh = () => undefined
 
 export const initContextState: Context = {
   addFieldRow: () => undefined,
@@ -45,6 +47,7 @@ export const initContextState: Context = {
   removeFieldRow: () => undefined,
   replaceFieldRow: () => undefined,
   replaceState: () => undefined,
+  requestFormStateRefresh,
   reset,
   setBackgroundProcessing,
   setDisabled: () => undefined,

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -147,6 +147,7 @@ export type GetData = () => Data
 export type GetSiblingData = (path: string) => Data
 export type GetDataByPath = <T = unknown>(path: string) => T
 export type SetModified = (modified: boolean) => void
+export type RequestFormStateRefresh = () => void
 export type SetSubmitted = (submitted: boolean) => void
 export type SetProcessing = (processing: boolean) => void
 
@@ -320,6 +321,10 @@ export type Context = {
     subFieldState?: FormState
   }) => void
   replaceState: (state: FormState) => void
+  /**
+   * Requests fresh server form state without marking the form as modified.
+   */
+  requestFormStateRefresh: RequestFormStateRefresh
   reset: Reset
   /**
    * If the form has started processing in the background (e.g.

--- a/test/joins/collections/Categories.ts
+++ b/test/joins/collections/Categories.ts
@@ -62,6 +62,27 @@ export const Categories: CollectionConfig = {
       maxDepth: 1,
     },
     {
+      name: 'defaultPost',
+      type: 'relationship',
+      filterOptions: ({ data }) => {
+        const joinedPostIDs = data.relatedPosts?.docs?.map(
+          (post: { id: number | string } | number | string) =>
+            typeof post === 'object' ? post.id : post,
+        )
+
+        if (!joinedPostIDs?.length) {
+          return false
+        }
+
+        return {
+          id: {
+            in: joinedPostIDs,
+          },
+        }
+      },
+      relationTo: postsSlug,
+    },
+    {
       name: 'noRowTypes',
       type: 'join',
       collection: postsSlug,

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -17,6 +17,7 @@ import {
   // throttleTest,
 } from '../__helpers/e2e/helpers.js'
 import { navigateToDoc } from '../__helpers/e2e/navigateToDoc.js'
+import { getSelectMenu } from '../__helpers/e2e/selectInput.js'
 import { waitForAutoSaveToRunAndComplete } from '../__helpers/e2e/waitForAutoSaveToRunAndComplete.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../__helpers/shared/clearAndSeed/reInitializeDB.js'
@@ -42,6 +43,7 @@ let client: RESTClient
 const { beforeAll, beforeEach, describe } = test
 
 describe('Join Field', () => {
+  const createdPostTitles: string[] = []
   let page: Page
   let categoriesURL: AdminUrlUtil
   let foldersURL: AdminUrlUtil
@@ -104,6 +106,21 @@ describe('Join Field', () => {
 
     const folder = await payload.find({ collection: 'folders', sort: 'createdAt', depth: 0 })
     rootParentID = folder.docs[0]!.id
+  })
+
+  test.afterEach(async () => {
+    for (const title of createdPostTitles) {
+      await payload.delete({
+        collection: postsSlug,
+        where: {
+          title: {
+            equals: title,
+          },
+        },
+      })
+    }
+
+    createdPostTitles.length = 0
   })
 
   test('should populate joined relationships in table cells of list view', async () => {
@@ -572,6 +589,41 @@ describe('Join Field', () => {
     // `{ relationTo, value }` lookup.
     await expect(actingField.locator('tbody tr td', { hasText: exactText(title) })).toBeHidden()
     await expect(siblingField.locator('tbody tr td', { hasText: exactText(title) })).toBeHidden()
+  })
+
+  test('should refresh functional filterOptions when a joined document is created', async () => {
+    const postTitle = 'Post created from join field'
+
+    createdPostTitles.push(postTitle)
+
+    await page.goto(categoriesURL.edit(categoryID))
+
+    const saveButton = page.locator('#action-save')
+    const joinField = page.locator('#field-relatedPosts.field-type.join')
+
+    await expect(saveButton).toBeDisabled()
+    await expect(joinField).toBeVisible()
+
+    const addButton = joinField.locator('.relationship-table__actions button.doc-drawer__toggler', {
+      hasText: exactText('Add new'),
+    })
+
+    await addButton.click()
+
+    const drawer = page.locator('[id^=doc-drawer_posts_1_]')
+
+    await expect(drawer).toBeVisible()
+    await drawer.locator('#field-title').fill(postTitle)
+    await saveDocAndAssert(page, '[id^=doc-drawer_posts_1_] button#action-save')
+    await expect(drawer).toBeHidden()
+
+    const defaultPostField = page.locator('#field-defaultPost')
+
+    await defaultPostField.locator('.rs__control').click()
+    await expect(
+      getSelectMenu({ page }).locator('.rs__option', { hasText: exactText(postTitle) }),
+    ).toBeVisible()
+    await expect(saveButton).toBeDisabled()
   })
 
   test('should edit joined document and update relationship table', async () => {

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -380,6 +380,7 @@ export interface Category {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  defaultPost?: (string | null) | Post;
   noRowTypes?: {
     docs?: (string | Post)[];
     hasNextPage?: boolean;
@@ -1106,6 +1107,7 @@ export interface PostsSelect<T extends boolean = true> {
 export interface CategoriesSelect<T extends boolean = true> {
   name?: T;
   relatedPosts?: T;
+  defaultPost?: T;
   noRowTypes?: T;
   hasManyPosts?: T;
   hasManyPostsLocalized?: T;


### PR DESCRIPTION
### What?

- Refresh parent form state after a joined document is created, updated, or deleted from a Join field drawer.
- Re-evaluate functional `filterOptions` without marking the parent document as modified.
- Keep the canonical Join value independent from interactive table filtering, sorting, and pagination.
- Add an end-to-end regression for the create flow and its clean parent form state.

### Why?

A Join relationship table refreshes its own rows after drawer CRUD, but the parent Form keeps the previous Join value. Functional relationship `filterOptions` that depend on that Join therefore stay stale until the page is reloaded.

### How?

`RelationshipTable` now reports canonical first-page `PaginatedDocs` after successful drawer mutations and safely handles failed table-state responses. The Join field writes that data into form state with modification disabled, then requests the existing debounced server form-state flow explicitly. The Form tracks those requests separately from the dirty flag, so dependent fields refresh while the parent Save action remains disabled. The canonical table-state result is reused for the visible table in the normal no-query path; active interactive queries retain their own render fallback.

The branch is rebased onto the current `main` and retains the sibling and polymorphic Join refresh coverage added upstream.

### Validation

- Node 24.16.0 targeted Playwright coverage: 9/9 passing (functional filter refresh plus create, update, delete, autosave, sibling, and polymorphic Join flows)
- Full `joins` Playwright suite: 35/35 passing
- `pnpm run build:ui`
- ESLint on changed UI source: 0 errors (3 pre-existing `no-explicit-any` warnings outside this diff)
- Prettier check on all changed files
- `git diff --check`
- Manual browser QA: new joined post appeared in the dependent relationship options without reload, parent Save remained disabled, and no console errors or Next.js overlay were present

Fixes #11661
