### PR TITLE
fix: memoize version collection fields to bound flattenedFieldsCache growth

### DIFF
--- a/packages/payload/src/versions/buildCollectionFields.spec.ts
+++ b/packages/payload/src/versions/buildCollectionFields.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SanitizedCollectionConfig } from '../collections/config/types.js'
+import type { SanitizedConfig } from '../config/types.js'
+
+import { buildVersionCollectionFields } from './buildCollectionFields.js'
+
+const makeCollection = (slug: string, drafts = true): SanitizedCollectionConfig =>
+  ({
+    slug,
+    fields: [
+      { name: 'id', type: 'text' },
+      { name: 'title', type: 'text' },
+    ],
+    flattenedFields: [
+      { name: 'id', type: 'text' },
+      { name: 'title', type: 'text' },
+    ],
+    versions: { drafts },
+  }) as unknown as SanitizedCollectionConfig
+
+const config = { localization: false } as unknown as SanitizedConfig
+
+describe('buildVersionCollectionFields', () => {
+  it('returns a referentially stable array across calls for the same collection', () => {
+    const collection = makeCollection('posts')
+    const first = buildVersionCollectionFields(config, collection, true)
+    const second = buildVersionCollectionFields(config, collection, true)
+    // Same reference: the schema is built once and memoized, so identity-keyed
+    // downstream caches (flattenedFieldsCache) hit instead of growing per call.
+    expect(second).toBe(first)
+  })
+
+  it('caches flattened and unflattened variants separately', () => {
+    const collection = makeCollection('pages')
+    const flattened = buildVersionCollectionFields(config, collection, true)
+    const unflattened = buildVersionCollectionFields(config, collection, false)
+    expect(flattened).not.toBe(unflattened)
+    expect(buildVersionCollectionFields(config, collection, true)).toBe(flattened)
+    expect(buildVersionCollectionFields(config, collection, false)).toBe(unflattened)
+  })
+
+  it('memoizes per collection (distinct references for distinct collections)', () => {
+    const a = buildVersionCollectionFields(config, makeCollection('a'), true)
+    const b = buildVersionCollectionFields(config, makeCollection('b'), true)
+    expect(a).not.toBe(b)
+  })
+
+  it('still produces the expected version schema', () => {
+    const fields = buildVersionCollectionFields(config, makeCollection('shape'), true)
+    const names = fields.map((field) => ('name' in field ? field.name : undefined))
+    expect(names).toEqual(expect.arrayContaining(['parent', 'version', 'createdAt', 'updatedAt', 'latest']))
+    const version = fields.find((field) => 'name' in field && field.name === 'version') as {
+      fields: { name?: string }[]
+    }
+    // the `version` group mirrors the collection fields but drops the base `id`
+    expect(version.fields.some((field) => field.name === 'id')).toBe(false)
+    expect(version.fields.some((field) => field.name === 'title')).toBe(true)
+  })
+})

--- a/packages/payload/src/versions/buildCollectionFields.ts
+++ b/packages/payload/src/versions/buildCollectionFields.ts
@@ -4,11 +4,37 @@ import type { Field, FlattenedField } from '../fields/config/types.js'
 
 import { hasAutosaveEnabled, hasDraftsEnabled } from '../utilities/getVersionsConfig.js'
 
+// Cache the version schema per collection. It derives only from the (stable)
+// collection config, so rebuilding a fresh array on every call is wasted work
+// and — since `flattenAllFields` keys `flattenedFieldsCache` by array identity —
+// leaks one cache entry per request. WeakMap so discarded configs are reclaimed;
+// flattened/unflattened are cached separately (flatten changes the version group).
+type VersionCollectionFieldsCacheEntry = {
+  flattened?: FlattenedField[]
+  unflattened?: Field[]
+}
+
+const versionCollectionFieldsCache = new WeakMap<
+  SanitizedCollectionConfig,
+  VersionCollectionFieldsCacheEntry
+>()
+
 export const buildVersionCollectionFields = <T extends boolean = false>(
   config: SanitizedConfig,
   collection: SanitizedCollectionConfig,
   flatten?: T,
 ): true extends T ? FlattenedField[] : Field[] => {
+  let cacheEntry = versionCollectionFieldsCache.get(collection)
+  if (!cacheEntry) {
+    cacheEntry = {}
+    versionCollectionFieldsCache.set(collection, cacheEntry)
+  }
+
+  const cached = flatten ? cacheEntry.flattened : cacheEntry.unflattened
+  if (cached) {
+    return cached as true extends T ? FlattenedField[] : Field[]
+  }
+
   const fields: FlattenedField[] = [
     {
       name: 'parent',
@@ -77,6 +103,12 @@ export const buildVersionCollectionFields = <T extends boolean = false>(
         index: true,
       })
     }
+  }
+
+  if (flatten) {
+    cacheEntry.flattened = fields
+  } else {
+    cacheEntry.unflattened = fields as Field[]
   }
 
   return fields as true extends T ? FlattenedField[] : Field[]


### PR DESCRIPTION
# fix(payload): memoize version collection fields to bound flattenedFieldsCache growth

## What / Why

`buildVersionCollectionFields()` is called on **every** operation against a
versioned/drafts-enabled collection (`find`, `findVersions`, `findVersionByID`,
`countVersions`, `update`, …). Each call allocates a **brand-new `fields` array**
(array literal + `collection.fields.filter(...)`).

Those arrays are then flattened by `flattenAllFields()`, whose module-level
`flattenedFieldsCache` (a plain `Map`) is **keyed by array identity** and always
runs `flattenedFieldsCache.set(fields, result)`. Because the key is a fresh array
each call, the cache never hits and grows by (at least) one strong-referenced
entry **per request** — an unbounded memory leak that scales with request count,
not with the number of collections.

Under public read traffic this is a slow, steady heap climb on every pod.

## Root cause (confirmed from a production heap-snapshot diff)

Two snapshots ~19h apart of the same process (identical traffic) showed a
monotonic heap climb driven by ~218k new `Object` + ~103k new `Array` nodes,
96–97% retained via a single `Map` (`flattenedFieldsCache`) whose `table` held
~36,000 entries (1.8 MB). The entries were `Map<fieldsArray, flattenedFields>`
pairs, and the values were exactly the fields produced here — `parent`,
`version` (group), `publishedLocale`, `latest`, `createdAt`, `updatedAt` — i.e.
the version collection schema, re-created and re-cached on every read.

The schema is **derived purely from the sanitized (stable) collection config**,
so it is identical for every call — it should be built once and reused.

## The fix

Memoize `buildVersionCollectionFields` per collection in a `WeakMap` keyed by the
sanitized collection config, caching the flattened and unflattened variants
separately (the `flatten` flag changes the `version` group shape). This returns a
**referentially stable** array, so:

- redundant per-request rebuilding is eliminated, and
- `flattenedFieldsCache` now hits (stable key) instead of growing — the leak is
  gone, and the cache does what it was designed to do.

`WeakMap` keeps it safe: if a collection config is ever discarded, its entry is
reclaimed.

This touches only `buildVersionCollectionFields`, so all seven call sites benefit
without changes.

## Tests

Added `packages/payload/src/versions/buildCollectionFields.spec.ts`:

- returns a referentially stable array across calls for the same collection;
- caches flattened vs unflattened variants separately (each stable);
- memoizes per collection (distinct references for distinct collections);
- still produces the expected version schema (`parent`/`version`/`createdAt`/
  `updatedAt`/`latest`; the `version` group drops the base `id`, keeps others).

## Affected versions

Present on `main` (4.0.0-beta) and all 3.x releases checked (3.79 → 3.86.0) and
4.0.0-canary — the code is identical across them.
