### PR TITLE
fix(richtext-lexical): coerce integer upload and relationship IDs to number during HTML conversion

### DIFF
--- a/packages/richtext-lexical/src/features/relationship/client/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/client/nodes/RelationshipNode.tsx
@@ -22,10 +22,13 @@ const RelationshipComponent = React.lazy(() =>
 )
 
 function $relationshipElementToNode(domNode: HTMLDivElement): DOMConversionOutput | null {
-  const id = domNode.getAttribute('data-lexical-relationship-id')
+  let id: null | number | string = domNode.getAttribute('data-lexical-relationship-id')
   const relationTo = domNode.getAttribute('data-lexical-relationship-relationTo')
 
   if (id != null && relationTo != null) {
+    if (String(Number(id)) === id) {
+      id = Number(id)
+    }
     const node = $createRelationshipNode({
       relationTo,
       value: id,

--- a/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
@@ -17,10 +17,13 @@ import {
 import type { RelationshipData, SerializedRelationshipNode } from '../schema.js'
 
 function $relationshipElementToServerNode(domNode: HTMLDivElement): DOMConversionOutput | null {
-  const id = domNode.getAttribute('data-lexical-relationship-id')
+  let id: null | number | string = domNode.getAttribute('data-lexical-relationship-id')
   const relationTo = domNode.getAttribute('data-lexical-relationship-relationTo')
 
   if (id != null && relationTo != null) {
+    if (String(Number(id)) === id) {
+      id = Number(id)
+    }
     const node = $createServerRelationshipNode({
       relationTo,
       value: id,

--- a/packages/richtext-lexical/src/features/upload/server/nodes/conversions.ts
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/conversions.ts
@@ -40,10 +40,13 @@ export function $convertUploadElement(
     domNode.hasAttribute('data-lexical-upload-relation-to') &&
     domNode.hasAttribute('data-lexical-upload-id')
   ) {
-    const id = domNode.getAttribute('data-lexical-upload-id')
+    let id: null | number | string = domNode.getAttribute('data-lexical-upload-id')
     const relationTo = domNode.getAttribute('data-lexical-upload-relation-to')
 
     if (id != null && relationTo != null) {
+      if (String(Number(id)) === id) {
+        id = Number(id)
+      }
       const node = $createNode({
         data: {
           fields: {},


### PR DESCRIPTION
### What?
We are modifying the Lexical HTML converter (`$convertUploadElement` and `$relationshipElementToNode`) so that when it extracts integer IDs from the `data-lexical-[type]-id` HTML attribute, it correctly casts them into `Number` types instead of leaving them as strings.

### Why?
When a Payload project is configured to use integer IDs for a collection (e.g. `media`), saving a Rich Text field containing Upload or Relationship nodes can fail validation. Because the Lexical DOM parser natively grabs HTML attributes as strings, it was passing a string (e.g. `"2"`) into `$createNode` instead of the integer `2`. This causes Payload's internal lifecycle hooks to reject the payload entirely with a `ValidationError`.

### How?
Inside `conversions.ts` and `RelationshipNode.tsx`, we added a strict type-coercion check:
```typescript
if (String(Number(id)) === id) {
  id = Number(id)
}
```
### Screenshots
<img width="1536" height="863" alt="Screenshot 2026-07-16 142351" src="https://github.com/user-attachments/assets/841f58e2-80f1-404b-b351-54f44af37297" />

<img width="1292" height="391" alt="Screenshot 2026-07-16 142417" src="https://github.com/user-attachments/assets/3d5fd648-ebe2-48ec-a853-f2744b543a3b" />

<img width="1032" height="497" alt="Screenshot 2026-07-16 142444" src="https://github.com/user-attachments/assets/000ce95d-8189-4e06-a048-6673c74b707c" />

<img width="1536" height="863" alt="Screenshot 2026-07-16 142507" src="https://github.com/user-attachments/assets/80cb38ed-61d9-441e-8523-6f9fcefdb7c7" />

Closes #17344