### PR TITLE
docs: document PostGIS extensions option for point fields

### DIFF
--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -83,6 +83,26 @@ export default buildConfig({
 | `readReplicas`                   | An array of DB read replicas connection strings, can be used to offload read-heavy traffic.                                                                                                                             |
 | `readReplicasAfterWriteInterval` | How long (ms) after a write to keep routing reads to the primary instead of a replica. Prevents stale reads caused by replication lag. Only relevant when `readReplicas` is set. Default `2000`. Set to `0` to disable. |
 | `blocksAsJSON`                   | Store blocks as a JSON column instead of using the relational structure which can improve performance with a large amount of blocks                                                                                     |
+| `extensions`                     | An array of Postgres extension names to enable (for example `['postgis']`). Payload will create these extensions if they do not already exist.                                                                          |
+
+## PostGIS
+
+To use the [Point field](../fields/point) with Postgres, enable the [PostGIS](https://postgis.net/) extension via the `extensions` option on your database adapter. Your Postgres instance must have PostGIS available (installed on the server or included in your database image).
+
+```ts
+import { postgresAdapter } from '@payloadcms/db-postgres'
+
+export default buildConfig({
+  db: postgresAdapter({
+    pool: {
+      connectionString: process.env.DATABASE_URL,
+    },
+    extensions: ['postgis'],
+  }),
+})
+```
+
+The same `extensions` option is available on `@payloadcms/db-vercel-postgres`.
 
 ## Access to Drizzle
 

--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -87,7 +87,9 @@ export default buildConfig({
 
 ## PostGIS
 
-To use the [Point field](../fields/point) with Postgres, enable the [PostGIS](https://postgis.net/) extension via the `extensions` option on your database adapter. Your Postgres instance must have PostGIS available (installed on the server or included in your database image).
+The [Point field](../fields/point) requires the [PostGIS](https://postgis.net/) extension on Postgres. Payload enables it automatically whenever a Point field is present, running `CREATE EXTENSION IF NOT EXISTS "postgis"` on connect. Your Postgres instance must have PostGIS available (installed on the server or included in your database image), and the connecting role must have privileges to create extensions.
+
+You can also enable PostGIS (or other extensions) explicitly with the `extensions` option on `@payloadcms/db-postgres` or `@payloadcms/db-vercel-postgres`:
 
 ```ts
 import { postgresAdapter } from '@payloadcms/db-postgres'
@@ -101,8 +103,6 @@ export default buildConfig({
   }),
 })
 ```
-
-The same `extensions` option is available on `@payloadcms/db-vercel-postgres`.
 
 ## Access to Drizzle
 

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -27,7 +27,10 @@ export const MyPointField: Field = {
 ```
 
 <Banner type="warning">
-  **Important:** The Point Field currently is not supported in SQLite.
+  **Important:** The Point Field currently is not supported in SQLite. When
+  using Postgres, enable the PostGIS extension via the database adapter's
+  [`extensions`](../database/postgres#postgis) option (for example `extensions:
+  ['postgis']`).
 </Banner>
 
 ## Config

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -27,10 +27,10 @@ export const MyPointField: Field = {
 ```
 
 <Banner type="warning">
-  **Important:** The Point Field currently is not supported in SQLite. When
-  using Postgres, enable the PostGIS extension via the database adapter's
-  [`extensions`](../database/postgres#postgis) option (for example `extensions:
-  ['postgis']`).
+  **Important:** The Point Field currently is not supported in SQLite. On
+  Postgres, Payload enables [PostGIS](../database/postgres#postgis)
+  automatically when a Point field is present. Your database must have PostGIS
+  available, and the connecting role must be able to create extensions.
 </Banner>
 
 ## Config


### PR DESCRIPTION
## Summary
- Documents the `extensions` option on the Postgres adapters, including enabling PostGIS for Point fields
- Cross-links from the Point field docs to the new PostGIS section

Fixes #17262

## Test plan
- [x] Confirm Postgres docs render the new PostGIS section and options table row
- [x] Confirm Point field warning links to `#postgis`
