### PR TITLE
fix(ui): table borders on schedule publishing drawer

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.css
+++ b/packages/ui/src/elements/RelationshipTable/index.css
@@ -39,8 +39,6 @@
   .relationship-table .table {
     margin-bottom: 0;
     background: var(--color-bg);
-    border: var(--stroke-width-small) solid var(--color-border);
-    border-radius: var(--radius-medium);
     overflow: auto;
 
     table {

--- a/packages/ui/src/elements/Table/index.css
+++ b/packages/ui/src/elements/Table/index.css
@@ -148,6 +148,7 @@
 
   /* Condensed appearance */
   .table--appearance-condensed {
+    border: var(--stroke-width-small) solid var(--color-border);
     border-radius: var(--radius-medium);
     scrollbar-width: thin;
     scrollbar-color: var(--scrollbar-color) transparent;


### PR DESCRIPTION
## What?

Removes the border/border-radius from `RelationshipTable`'s table and instead scopes it to `.table--appearance-condensed` so schedule publishing drawer tables render correctly. Previously the bottom border was missing from this table, now:
<img width="651" height="192" alt="image" src="https://github.com/user-attachments/assets/fe6cc6b7-1d80-4c2e-99d8-aae468ffd3a6" />

## Why?

The relationship table's border styling was leaking into the schedule publishing drawer table, causing incorrect double borders/styling