### PR TITLE
fix(ui): hide timezone picker chevron when field is read-only

### DIFF
--- a/packages/ui/src/elements/TimezonePicker/index.tsx
+++ b/packages/ui/src/elements/TimezonePicker/index.tsx
@@ -31,7 +31,12 @@ const SmallDropdownIndicator: React.FC<
 > = (props) => {
   const {
     innerProps: { ref, ...restInnerProps },
+    isDisabled,
   } = props
+
+  if (isDisabled) {
+    return null
+  }
 
   return (
     <button


### PR DESCRIPTION
## What?

Previously the dropdown chevron on the timezone picker was visible even when the field is read-only, now it's hidden:
<img width="427" height="215" alt="image" src="https://github.com/user-attachments/assets/b0f9f45f-089a-46a1-9838-2b40c3690829" />

## Why?

A disabled/read-only timezone picker showed an interactive-looking chevron with no way to act on it