### PR TITLE
fix(tanstack-start): externalize package boundaries, bundle client-safe deps in prod build

### DIFF
--- a/packages/tanstack-start/src/withPayload/config/external.ts
+++ b/packages/tanstack-start/src/withPayload/config/external.ts
@@ -6,6 +6,12 @@
 /**
  * Server-only packages (Node-only or only ever used by the server bundle).
  * These are the Vite equivalent of Next.js's `serverExternalPackages`.
+ *
+ * Only genuinely server-only packages belong here. A pure-JS package reachable
+ * from client-safe code (e.g. `pluralize`, imported by `payload`'s `formatLabels`
+ * which ships in the `browser`/`shared` export) must NOT be listed: externalizing
+ * it leaves a bare specifier in a bundled client chunk that pnpm can't resolve
+ * from `dist/` at runtime. Let it bundle instead.
  */
 export const ssrExternalPackages: string[] = [
   'ajv',
@@ -21,7 +27,6 @@ export const ssrExternalPackages: string[] = [
   'graphql',
   'nodemailer',
   'aws4',
-  'pluralize',
   'console-table-printer',
   '@azure/storage-blob',
   '@aws-sdk/client-s3',
@@ -38,6 +43,32 @@ export const ssrExternalPackages: string[] = [
   // Mongo (`@payloadcms/db-mongodb`)
   'mongodb',
   'mongoose',
+]
+
+/**
+ * External packages for the production `vite build` only (not dev serve).
+ *
+ * Externalizes the `@payloadcms/*` package boundaries — plus `payload` — so each
+ * resolves its own transitive Node deps (`pino`, `drizzle-orm`, `libsql`, …) from
+ * its own `node_modules` at runtime. Externalizing only the leaf deps breaks under
+ * pnpm: a leaf imported by bundled code becomes an unresolvable bare specifier from
+ * `dist/`, since pnpm does not hoist it.
+ *
+ * Kept out of dev's `ssr.external` on purpose: the monorepo resolves these to
+ * TypeScript source (`.ts` imported via `.js` specifiers), which only Vite's
+ * transform can resolve — an externalized copy would hit Node's raw resolver and
+ * fail on the `.js`→`.ts` mismatch.
+ */
+export const buildExternalPackages: string[] = [
+  'payload',
+  'payload/node',
+  '@payloadcms/drizzle',
+  '@payloadcms/db-mongodb',
+  '@payloadcms/db-postgres',
+  '@payloadcms/db-vercel-postgres',
+  '@payloadcms/db-sqlite',
+  '@payloadcms/db-d1-sqlite',
+  ...ssrExternalPackages,
 ]
 
 export const payloadNoExternalPatterns: Array<RegExp | string> = [

--- a/packages/tanstack-start/src/withPayload/config/external.ts
+++ b/packages/tanstack-start/src/withPayload/config/external.ts
@@ -4,14 +4,13 @@
  */
 
 /**
- * Server-only packages (Node-only or only ever used by the server bundle).
- * These are the Vite equivalent of Next.js's `serverExternalPackages`.
+ * Packages externalized during dev serve (`ssr.external`). Node's loader resolves
+ * their CJS/UMD directly; letting Vite's dev SSR transform touch them can break
+ * fragile UMD wrappers (e.g. `pluralize`, whose `this`-based global assignment
+ * throws when transformed rather than required).
  *
- * Only genuinely server-only packages belong here. A pure-JS package reachable
- * from client-safe code (e.g. `pluralize`, imported by `payload`'s `formatLabels`
- * which ships in the `browser`/`shared` export) must NOT be listed: externalizing
- * it leaves a bare specifier in a bundled client chunk that pnpm can't resolve
- * from `dist/` at runtime. Let it bundle instead.
+ * Note `pluralize` is deliberately excluded from {@link buildExternalPackages}:
+ * for the production build it must bundle (see there).
  */
 export const ssrExternalPackages: string[] = [
   'ajv',
@@ -27,6 +26,7 @@ export const ssrExternalPackages: string[] = [
   'graphql',
   'nodemailer',
   'aws4',
+  'pluralize',
   'console-table-printer',
   '@azure/storage-blob',
   '@aws-sdk/client-s3',
@@ -58,6 +58,11 @@ export const ssrExternalPackages: string[] = [
  * TypeScript source (`.ts` imported via `.js` specifiers), which only Vite's
  * transform can resolve — an externalized copy would hit Node's raw resolver and
  * fail on the `.js`→`.ts` mismatch.
+ *
+ * `pluralize` is excluded: it is reached from client-safe code (`payload`'s
+ * `formatLabels`, shipped in the `/shared` export), so externalizing it would
+ * leave a bare specifier in a bundled client chunk that pnpm can't resolve from
+ * `dist/` at runtime. It must bundle for the build.
  */
 export const buildExternalPackages: string[] = [
   'payload',
@@ -68,7 +73,7 @@ export const buildExternalPackages: string[] = [
   '@payloadcms/db-vercel-postgres',
   '@payloadcms/db-sqlite',
   '@payloadcms/db-d1-sqlite',
-  ...ssrExternalPackages,
+  ...ssrExternalPackages.filter((pkg) => pkg !== 'pluralize'),
 ]
 
 export const payloadNoExternalPatterns: Array<RegExp | string> = [

--- a/packages/tanstack-start/src/withPayload/index.ts
+++ b/packages/tanstack-start/src/withPayload/index.ts
@@ -149,6 +149,25 @@ export function withPayload(
   } = options
 
   return (env) => {
+    // `pluralize` ships a UMD wrapper that throws when run through Vite's dev SSR
+    // transform, so dev serve keeps it external and lets Node require it.
+    // The production build must bundle it instead: it is reached from the
+    // force-bundled `@payloadcms/ui` / `@payloadcms/translations`, and Vite would
+    // otherwise externalize it into a client chunk as a bare specifier that pnpm
+    // can't resolve from `dist/` at runtime. Dropping it from the externals list
+    // isn't enough — Vite externalizes deps of `noExternal` packages by default,
+    // so it must be forced back in via `noExternal`.
+    const isBuild = env.command === 'build'
+    const noExternalPatterns = isBuild
+      ? [...payloadNoExternalPatterns, 'pluralize']
+      : payloadNoExternalPatterns
+    // Dev serve externalizes the server-only Node packages (including `pluralize`,
+    // whose UMD wrapper breaks under Vite's SSR transform). The prod build instead
+    // externalizes the package boundaries (`buildExternalPackages`) and drops
+    // `pluralize` so it bundles — leaving it in `ssr.external` here would win over
+    // `noExternal` and re-emit the bare specifier.
+    const ssrExternal = isBuild ? buildExternalPackages : ssrExternalPackages
+
     const base: UserConfig = {
       build: {
         cssMinify: 'esbuild',
@@ -167,11 +186,11 @@ export function withPayload(
       environments: {
         rsc: {
           build: { rollupOptions: { external: buildExternalPackages } },
-          resolve: { noExternal: payloadNoExternalPatterns },
+          resolve: { noExternal: noExternalPatterns },
         },
         ssr: {
           build: { rollupOptions: { external: buildExternalPackages } },
-          resolve: { noExternal: payloadNoExternalPatterns },
+          resolve: { noExternal: noExternalPatterns },
         },
       } as any,
       optimizeDeps: {
@@ -202,8 +221,8 @@ export function withPayload(
         tsconfigPaths: true,
       } as any,
       ssr: {
-        external: ssrExternalPackages,
-        noExternal: payloadNoExternalPatterns,
+        external: ssrExternal,
+        noExternal: noExternalPatterns,
       },
     }
 

--- a/packages/tanstack-start/src/withPayload/index.ts
+++ b/packages/tanstack-start/src/withPayload/index.ts
@@ -8,7 +8,11 @@ import rsc from '@vitejs/plugin-rsc'
 import path from 'node:path'
 import { createLogger, mergeConfig } from 'vite'
 
-import { payloadNoExternalPatterns, ssrExternalPackages } from './config/external.js'
+import {
+  buildExternalPackages,
+  payloadNoExternalPatterns,
+  ssrExternalPackages,
+} from './config/external.js'
 import { optimizeDepsExcludeDefaults, optimizeDepsIncludeDefaults } from './config/optimizeDeps.js'
 import { payloadScssImporters } from './config/scss.js'
 import {
@@ -162,11 +166,11 @@ export function withPayload(
       },
       environments: {
         rsc: {
-          build: { rollupOptions: { external: ssrExternalPackages } },
+          build: { rollupOptions: { external: buildExternalPackages } },
           resolve: { noExternal: payloadNoExternalPatterns },
         },
         ssr: {
-          build: { rollupOptions: { external: ssrExternalPackages } },
+          build: { rollupOptions: { external: buildExternalPackages } },
           resolve: { noExternal: payloadNoExternalPatterns },
         },
       } as any,


### PR DESCRIPTION
Fixes the TanStack Start production server crashing in real (non-monorepo) consumer apps, where the build left bare specifiers for Payload's own transitive deps that pnpm can't resolve from `dist` at runtime.

Follow up to #17351, which reworked the `@payloadcms/tanstack-start` export boundaries. This completes the fix for the production build.

## Root causes

Both stem from the same mechanism: the prod `vite build` bundles code that imports a dependency, while the dependency itself is externalized — its import is left as a bare package name (e.g. import "pino"), which Node must look up in `node_modules` when the server runs. pnpm hasn't placed it where the built file can reach it, so it fails.

_Note: this is not an issue in the monorepo as it hides the issue via workspace hoisting and symlinking `node_modules`._

### Transitive `payload` deps

The `payload` package and respective database adapters are inlined into the server bundle, but their transitive deps are externalized.

This includes (but not limited to):
- `pino`
- `mongoose`
- `drizzle-orm`

Those live nested under `payload` in the `.pnpm` store, not the consuming app's `node_modules` — leading to an error like this:

> Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pino' imported from .../dist/server/assets/handleAPIRoute.server-\*.js

This fix is to externalize the `payload` and `@payloadcms/*` package boundaries for the production build, so each package stays a bare import and resolves its own transitive deps from its own `node_modules`. Externalizing only the leaf deps is what breaks — a leaf imported by bundled code becomes an unresolvable bare specifier from `dist`.

_Note: this doesn't impact the monorepo dev server, as it resolves these to TypeScript source (`.ts` imported via `.js` specifiers), which Vite's transform can resolve._

### `pluralize` in a client chunk

`pluralize` is reached from client-safe code, e.g. `formatLabels`, but sits in the externals list, so it's emitted bare into a bundled client chunk:

> Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pluralize' imported from .../dist/server/assets/client-\*.js

The fix is to force `pluralize` to bundle (inline its code into the output chunk) rather than stay external — but only within the prod server (see below).

The problem is this package ships a UMD wrapper that throws when run through Vite's dev SSR transform (`Cannot set properties of undefined (setting 'pluralize')`), so the dev server must keep it external, while `build` bundles it.