### PR TITLE
fix(ui): strip row components from serializable form state

### DIFF
--- a/packages/ui/src/forms/Form/reduceToSerializableFields.spec.ts
+++ b/packages/ui/src/forms/Form/reduceToSerializableFields.spec.ts
@@ -1,0 +1,46 @@
+import type { FormState } from 'payload'
+import type { ReactNode } from 'react'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { reduceToSerializableFields } from './reduceToSerializableFields.js'
+
+describe('reduceToSerializableFields', () => {
+  it('should remove non-serializable values from fields and array rows', () => {
+    const circularValue: { self?: unknown } = {}
+
+    circularValue.self = circularValue
+
+    const rowLabel = circularValue as unknown as ReactNode
+    const fields: FormState = {
+      links: {
+        customComponents: {
+          Field: rowLabel,
+        },
+        rows: [
+          {
+            blockType: 'link',
+            collapsed: true,
+            customComponents: {
+              RowLabel: rowLabel,
+            },
+            id: 'row-1',
+          },
+        ],
+        validate: vi.fn(),
+        value: 1,
+      },
+    }
+
+    const result = reduceToSerializableFields(fields)
+
+    expect(result).toEqual({
+      links: {
+        rows: [{ blockType: 'link', collapsed: true, id: 'row-1' }],
+        value: 1,
+      },
+    })
+    expect(() => JSON.stringify(result)).not.toThrow()
+    expect(fields.links.rows?.[0].customComponents?.RowLabel).toBe(rowLabel)
+  })
+})

--- a/packages/ui/src/forms/Form/reduceToSerializableFields.ts
+++ b/packages/ui/src/forms/Form/reduceToSerializableFields.ts
@@ -1,13 +1,25 @@
-import { type FormField, type FormState } from 'payload'
+import { type FormField, type FormState, type Row } from 'payload'
 
 type BlacklistedKeys = 'customComponents' | 'validate'
 const blacklistedKeys: BlacklistedKeys[] = ['validate', 'customComponents']
 
+const sanitizeRow = (incomingRow: Row): Row => {
+  const row = { ...incomingRow }
+
+  delete row.customComponents
+
+  return row
+}
+
 const sanitizeField = (incomingField: FormField): FormField => {
-  const field = { ...incomingField } // shallow copy, as we only need to remove top-level keys
+  const field = { ...incomingField }
 
   for (const key of blacklistedKeys) {
     delete field[key]
+  }
+
+  if (field.rows) {
+    field.rows = field.rows.map(sanitizeRow)
   }
 
   return field


### PR DESCRIPTION
### What?

Remove row-level custom components when reducing admin form state to serializable fields.

### Why?

Array and blocks rows can contain a React `RowLabel` component. That value may include circular references, so preview and SEO fields can fail while serializing form state even though top-level custom components are already removed.

### How?

Clone and sanitize each row without mutating the original form state, while preserving row metadata such as IDs, block types, and collapsed state. A focused unit test covers circular row labels, top-level non-serializable values, preserved metadata, and input immutability.

Validation:

- `pnpm test:unit packages/ui/src/forms/Form/reduceToSerializableFields.spec.ts`
- `pnpm eslint --max-warnings=0 packages/ui/src/forms/Form/reduceToSerializableFields.ts`
- `pnpm prettier --check packages/ui/src/forms/Form/reduceToSerializableFields.ts packages/ui/src/forms/Form/reduceToSerializableFields.spec.ts`
- `pnpm build:ui`

Fixes #16786
