### PR TITLE
fix(drizzle): handle empty in queries on polymorphic relationships

### DIFF
--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -727,6 +727,7 @@ export const getTableColumnFromPath = ({
 
                 if (
                   Array.isArray(value) &&
+                  value.length > 0 &&
                   value.every((val) => typeof val === 'number') &&
                   idTypeTextOrUuid
                 ) {
@@ -749,6 +750,7 @@ export const getTableColumnFromPath = ({
 
                 if (
                   Array.isArray(value) &&
+                  value.length > 0 &&
                   idType === 'uuid' &&
                   hasCustomCollectionWithCustomID &&
                   !value.some((val) => uuidValidate(val))

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1715,6 +1715,40 @@ describe('Relationships', () => {
   })
 
   describe('Polymorphic Relationships', () => {
+    it('should return no documents for an empty in query on a polymorphic relationship', async () => {
+      const movie = await payload.create({
+        collection: 'movies',
+        data: {
+          name: 'Empty in query movie',
+        },
+      })
+      const relationship = await payload.create({
+        collection: polymorphicRelationshipsSlug,
+        data: {
+          polymorphic: {
+            relationTo: 'movies',
+            value: movie.id,
+          },
+        },
+      })
+
+      try {
+        const result = await payload.find({
+          collection: polymorphicRelationshipsSlug,
+          where: {
+            'polymorphic.value': {
+              in: [],
+            },
+          },
+        })
+
+        expect(result.docs).toHaveLength(0)
+      } finally {
+        await payload.delete({ id: relationship.id, collection: polymorphicRelationshipsSlug })
+        await payload.delete({ id: movie.id, collection: 'movies' })
+      }
+    })
+
     it('should allow REST querying on polymorphic relationships', async () => {
       const movie = await payload.create({
         collection: 'movies',


### PR DESCRIPTION
### What?

Keep polymorphic relationship columns when a Drizzle `in` query receives an empty array.

### Why?

The type-pruning guards treated an empty array as matching every value-type check. For UUID-backed polymorphic relationships, this removed every query column, dropped the filter entirely, and returned all documents instead of none.

### How?

Apply the existing numeric and UUID type-pruning rules only to non-empty arrays. A focused integration test creates a polymorphic relationship, queries it with `in: []`, verifies that no documents are returned, and cleans up its records.

Validation:

- `PAYLOAD_DATABASE=sqlite-uuid pnpm test:int relationships` (58 passed, 4 skipped)
- `PAYLOAD_DATABASE=postgres-uuid pnpm test:int relationships` (58 passed, 4 skipped)
- `pnpm build:drizzle`
- Prettier, ESLint, and `git diff --check` on the changed files

Fixes #16195
