### PR TITLE
fix(ui): rerender pasted block rows

### DIFF
--- a/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.spec.ts
+++ b/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.spec.ts
@@ -3,7 +3,10 @@ import type { FormState } from 'payload'
 import ObjectIdImport from 'bson-objectid'
 import { describe, expect, it } from 'vitest'
 
-import { mergeFormStateFromClipboard } from './mergeFormStateFromClipboard.js'
+import {
+  mergeFormStateFromClipboard,
+  reduceFormStateByPath,
+} from './mergeFormStateFromClipboard.js'
 import type { ClipboardPasteData } from './types.js'
 
 const ObjectId = (
@@ -11,6 +14,39 @@ const ObjectId = (
 ) as typeof ObjectIdImport
 
 describe('mergeFormStateFromClipboard', () => {
+  describe('clipboard serialization', () => {
+    it('should clear stale render paths from copied fields and rows', () => {
+      const formState: FormState = {
+        'layout.0': {
+          initialValue: 'content',
+          lastRenderedPath: 'layout.0',
+          valid: true,
+          value: 'content',
+        },
+        'layout.0.content': {
+          initialValue: 'content',
+          lastRenderedPath: 'layout.0.content',
+          valid: true,
+          value: 'content',
+        },
+        'layout.0.items': {
+          initialValue: 1,
+          lastRenderedPath: 'layout.0.items',
+          rows: [{ id: 'row-id', lastRenderedPath: 'layout.0.items.0' }],
+          valid: true,
+          value: 1,
+        },
+      }
+
+      const result = reduceFormStateByPath({ formState, path: 'layout', rowIndex: 0 })
+
+      expect(result['layout.0'].lastRenderedPath).toBeUndefined()
+      expect(result['layout.0.content'].lastRenderedPath).toBeUndefined()
+      expect(result['layout.0.items'].lastRenderedPath).toBeUndefined()
+      expect(result['layout.0.items'].rows?.[0]?.lastRenderedPath).toBeUndefined()
+    })
+  })
+
   describe('block ID regeneration', () => {
     it('should generate new IDs when pasting blocks to prevent duplicates', () => {
       const copiedBlockID = new ObjectId().toHexString()

--- a/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.ts
+++ b/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.ts
@@ -23,14 +23,14 @@ export function reduceFormStateByPath({
       continue
     }
 
-    const { customComponents: _, validate: __, ...field } = formState[key]
+    const { customComponents: _, lastRenderedPath: __, validate: ___, ...field } = formState[key]
 
     if (Array.isArray(field.rows)) {
       field.rows = field.rows.map((row) => {
         if (!row || typeof row !== 'object') {
           return row
         }
-        const { customComponents: _, ...serializableRow } = row
+        const { customComponents: _, lastRenderedPath: __, ...serializableRow } = row
         return serializableRow
       })
     }

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -623,9 +623,11 @@ describe('Block fields', () => {
       const field = page.locator('#field-blocks')
       const row = field.locator('#blocks-row-0')
       const rowTextInput = row.locator('#field-blocks__0__text')
+      const richTextEditor = row.locator('#field-blocks__0__richText [contenteditable="true"]')
 
       const textVal = 'row one copy'
       await rowTextInput.fill(textVal)
+      await expect(richTextEditor).toBeVisible()
 
       await copyPasteField({
         page,
@@ -645,6 +647,7 @@ describe('Block fields', () => {
       })
 
       await expect(rowTextInput).toHaveValue(textVal)
+      await expect(richTextEditor).toBeVisible()
     })
 
     test('should copy a block row and paste into a field with the same schema', async () => {


### PR DESCRIPTION
## Summary
- Clear stale `lastRenderedPath` metadata when serializing copied form fields and nested rows.
- Ensure same-path block-row pastes trigger component rendering instead of leaving the block body blank.

## Root cause
Clipboard data preserved render-location metadata while intentionally omitting non-serializable custom components. When a copied block row was pasted back to the same path, the stale render path matched the target path and skipped the server render required to restore those components.

Fixes #17375.

## Validation
- `pnpm exec vitest run --project unit packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.spec.ts --reporter=dot`
- `pnpm exec prettier --check packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.ts packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.spec.ts`
- Regression test fails against the previous serializer and passes with this change.