### PR TITLE
fix(ui): add accessible label to pagination arrows

### DIFF
--- a/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
+++ b/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
@@ -15,6 +15,9 @@ export type ClickableArrowProps = {
 export const ClickableArrow: React.FC<ClickableArrowProps> = (props) => {
   const { direction = 'right', isDisabled = false, updatePage } = props
 
+  const ariaLabel =
+  direction === 'left' ? 'Previous page' : 'Next page'
+
   const classes = [
     baseClass,
     isDisabled && `${baseClass}--is-disabled`,
@@ -25,12 +28,14 @@ export const ClickableArrow: React.FC<ClickableArrowProps> = (props) => {
 
   return (
     <button
+      aria-label={ariaLabel}
       className={classes}
       disabled={isDisabled}
       onClick={!isDisabled ? updatePage : undefined}
       type="button"
+
     >
-      <ChevronIcon />
+      <ChevronIcon area-hidden="true" />
     </button>
   )
 }

--- a/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
+++ b/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
@@ -1,7 +1,9 @@
 'use client'
+
 import React from 'react'
 
 import { ChevronIcon } from '../../../icons/Chevron/index.js'
+import { useTranslation } from '../../../providers/Translation/index.js'
 import './index.css'
 
 const baseClass = 'clickable-arrow'
@@ -14,9 +16,10 @@ export type ClickableArrowProps = {
 
 export const ClickableArrow: React.FC<ClickableArrowProps> = (props) => {
   const { direction = 'right', isDisabled = false, updatePage } = props
+  const { t } = useTranslation()
 
   const ariaLabel =
-  direction === 'left' ? 'Previous page' : 'Next page'
+    direction === 'left' ? t('general:previous') : t('general:next')
 
   const classes = [
     baseClass,
@@ -33,9 +36,8 @@ export const ClickableArrow: React.FC<ClickableArrowProps> = (props) => {
       disabled={isDisabled}
       onClick={!isDisabled ? updatePage : undefined}
       type="button"
-
     >
-      <ChevronIcon  />
+      <ChevronIcon />
     </button>
   )
 }

--- a/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
+++ b/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
@@ -35,7 +35,7 @@ export const ClickableArrow: React.FC<ClickableArrowProps> = (props) => {
       type="button"
 
     >
-      <ChevronIcon area-hidden="true" />
+      <ChevronIcon  />
     </button>
   )
 }


### PR DESCRIPTION
### What?

Adds accessible names to the admin pagination arrow buttons and marks the decorative chevron icon as hidden from assistive technologies.

### Why?

The pagination controls are icon-only buttons and currently have no accessible name, causing screen readers to announce them only as "button". This triggers the axe-core `button-name` accessibility rule and makes the controls difficult to understand for screen-reader users.

### How?

* Added an `aria-label` to `ClickableArrow`.
* Derived the label from the `direction` prop:

  * `left` → `Previous page`
  * `right` → `Next page`


Fixes #17377
