### PR TITLE
fix(tanstack-start): persist admin nav across navigations instead of remounting

### DIFF
--- a/packages/tanstack-start/src/routes/adminRoutes.tsx
+++ b/packages/tanstack-start/src/routes/adminRoutes.tsx
@@ -28,13 +28,8 @@ const runLoader = async (load: AdminLoad, splat: string, searchStr: string) => {
 }
 
 function AdminPage() {
-  // RSC Flight payload — render in place (no outer `key`) so the persistent
-  // template (nav sidebar, header) reconciles across navigations instead of
-  // remounting and flashing. The per-route remount that resets view-scoped
-  // client providers (e.g. `DocumentInfoProvider`) is applied server-side to the
-  // *view* subtree only, via `renderRoot`'s `viewRemountKey` — see
-  // `loadAdminPage`. Keyed there rather than here so the nav survives while the
-  // view swaps, mirroring Next's layout-persists/page-remounts segment semantics.
+  // Note: React key intentionally omitted here so the persistent template (nav, header) doesn't remount and flash on navigation.
+  // The per-route view key is attached server-side to the view subtree instead, via `renderRoot`'s `key` in `loadAdminPage`.
   const data = useLoaderData({ strict: false })
   return <Fragment>{data?.rscPayload}</Fragment>
 }

--- a/packages/tanstack-start/src/routes/adminRoutes.tsx
+++ b/packages/tanstack-start/src/routes/adminRoutes.tsx
@@ -28,13 +28,15 @@ const runLoader = async (load: AdminLoad, splat: string, searchStr: string) => {
 }
 
 function AdminPage() {
-  // RSC Flight payload — render directly. Key by the loader-derived `routeKey`
-  // (not `location.pathname`, which updates before `useLoaderData` during a
-  // transition and would remount with the previous payload) so navigating to a
-  // different admin page remounts the view, mirroring Next route-segment
-  // semantics. Search params are excluded so search-only changes reconcile in place.
+  // RSC Flight payload — render in place (no outer `key`) so the persistent
+  // template (nav sidebar, header) reconciles across navigations instead of
+  // remounting and flashing. The per-route remount that resets view-scoped
+  // client providers (e.g. `DocumentInfoProvider`) is applied server-side to the
+  // *view* subtree only, via `renderRoot`'s `viewRemountKey` — see
+  // `loadAdminPage`. Keyed there rather than here so the nav survives while the
+  // view swaps, mirroring Next's layout-persists/page-remounts segment semantics.
   const data = useLoaderData({ strict: false })
-  return <Fragment key={data?.routeKey}>{data?.rscPayload}</Fragment>
+  return <Fragment>{data?.rscPayload}</Fragment>
 }
 
 function AdminNotFound(props: { data?: { routeKey?: string; rscPayload?: ReactNode } }) {

--- a/packages/tanstack-start/src/utilities/loadAdminPage.tsx
+++ b/packages/tanstack-start/src/utilities/loadAdminPage.tsx
@@ -243,6 +243,11 @@ export async function loadAdminPage({
       params: Promise.resolve({ segments }) as Parameters<typeof renderRoot>[0]['params'],
       redirect,
       searchParams: Promise.resolve(searchParams),
+      // Per-route key so the *view* remounts on navigation (resetting view-scoped
+      // client providers) while the nav/template reconciles in place. The client
+      // renders the RSC payload without an outer key, so the template — including
+      // the nav sidebar — persists across navigations instead of flashing.
+      viewRemountKey: splat ?? '',
     })
 
     const rscPayload = await renderServerComponent(node as React.ReactElement)

--- a/packages/tanstack-start/src/utilities/loadAdminPage.tsx
+++ b/packages/tanstack-start/src/utilities/loadAdminPage.tsx
@@ -237,17 +237,13 @@ export async function loadAdminPage({
       config: Promise.resolve(config),
       importMap,
       initReq: boundInitReq,
+      key: splat ?? '',
       notFound,
       // `segments` is intentionally `undefined` for the admin root (`/admin`),
       // matching Next's optional catch-all; `renderRoot` handles it at runtime.
       params: Promise.resolve({ segments }) as Parameters<typeof renderRoot>[0]['params'],
       redirect,
       searchParams: Promise.resolve(searchParams),
-      // Per-route key so the *view* remounts on navigation (resetting view-scoped
-      // client providers) while the nav/template reconciles in place. The client
-      // renders the RSC payload without an outer key, so the template — including
-      // the nav sidebar — persists across navigations instead of flashing.
-      viewRemountKey: splat ?? '',
     })
 
     const rscPayload = await renderServerComponent(node as React.ReactElement)

--- a/packages/ui/src/views/Root/index.tsx
+++ b/packages/ui/src/views/Root/index.tsx
@@ -44,12 +44,6 @@ export type RenderRootArgs = {
   config: Promise<SanitizedConfig>
   importMap: ImportMap
   initReq: InitReqFn
-  /** Framework notFound implementation (e.g. next/navigation notFound). Called before req is available. */
-  notFound: () => never
-  params: Promise<{ segments: string[] }>
-  /** Framework redirect implementation (e.g. next/navigation redirect). Called before req is available. */
-  redirect: (url: string) => never
-  searchParams: Promise<{ [key: string]: string | string[] }>
   /**
    * Optional React `key` applied to the rendered view (not the surrounding admin
    * template/nav). Adapters whose router reconciles a single RSC payload in place
@@ -60,7 +54,13 @@ export type RenderRootArgs = {
    * Left `undefined` by Next.js, whose App Router already remounts the page
    * segment while its layout (nav) persists.
    */
-  viewRemountKey?: string
+  key?: string
+  /** Framework notFound implementation (e.g. next/navigation notFound). Called before req is available. */
+  notFound: () => never
+  params: Promise<{ segments: string[] }>
+  /** Framework redirect implementation (e.g. next/navigation redirect). Called before req is available. */
+  redirect: (url: string) => never
+  searchParams: Promise<{ [key: string]: string | string[] }>
 }
 
 export const renderRoot = async ({
@@ -68,11 +68,11 @@ export const renderRoot = async ({
   config: configPromise,
   importMap,
   initReq,
+  key,
   notFound,
   params: paramsPromise,
   redirect,
   searchParams: searchParamsPromise,
-  viewRemountKey,
 }: RenderRootArgs) => {
   const config = await configPromise
 
@@ -348,15 +348,10 @@ export const renderRoot = async ({
     } satisfies AdminViewServerPropsOnly,
   })
 
-  // When an adapter supplies `viewRemountKey`, wrap the view in a keyed boundary
-  // so it remounts on route change while the surrounding template/nav reconciles
-  // in place. `key={undefined}` (Next.js) is a no-op, preserving prior behavior.
-  const KeyedView =
-    viewRemountKey !== undefined ? (
-      <React.Fragment key={viewRemountKey}>{RenderedView}</React.Fragment>
-    ) : (
-      RenderedView
-    )
+  // Wrap the view in a keyed boundary so it remounts on route change while the
+  // surrounding template/nav reconciles in place. `key={undefined}` (Next.js) is
+  // a no-op, preserving prior behavior.
+  const KeyedView = <React.Fragment key={key}>{RenderedView}</React.Fragment>
 
   return (
     <PageConfigProvider config={clientConfig}>

--- a/packages/ui/src/views/Root/index.tsx
+++ b/packages/ui/src/views/Root/index.tsx
@@ -50,6 +50,17 @@ export type RenderRootArgs = {
   /** Framework redirect implementation (e.g. next/navigation redirect). Called before req is available. */
   redirect: (url: string) => never
   searchParams: Promise<{ [key: string]: string | string[] }>
+  /**
+   * Optional React `key` applied to the rendered view (not the surrounding admin
+   * template/nav). Adapters whose router reconciles a single RSC payload in place
+   * across navigations (e.g. TanStack Start) pass a per-route key here so the
+   * *view* remounts on route change — resetting view-scoped client providers like
+   * `DocumentInfoProvider` that hold uncontrolled `useState` from the prior
+   * document — while the persistent nav/template reconciles in place (no flash).
+   * Left `undefined` by Next.js, whose App Router already remounts the page
+   * segment while its layout (nav) persists.
+   */
+  viewRemountKey?: string
 }
 
 export const renderRoot = async ({
@@ -61,6 +72,7 @@ export const renderRoot = async ({
   params: paramsPromise,
   redirect,
   searchParams: searchParamsPromise,
+  viewRemountKey,
 }: RenderRootArgs) => {
   const config = await configPromise
 
@@ -336,11 +348,21 @@ export const renderRoot = async ({
     } satisfies AdminViewServerPropsOnly,
   })
 
+  // When an adapter supplies `viewRemountKey`, wrap the view in a keyed boundary
+  // so it remounts on route change while the surrounding template/nav reconciles
+  // in place. `key={undefined}` (Next.js) is a no-op, preserving prior behavior.
+  const KeyedView =
+    viewRemountKey !== undefined ? (
+      <React.Fragment key={viewRemountKey}>{RenderedView}</React.Fragment>
+    ) : (
+      RenderedView
+    )
+
   return (
     <PageConfigProvider config={clientConfig}>
-      {!templateType && <React.Fragment>{RenderedView}</React.Fragment>}
+      {!templateType && <React.Fragment>{KeyedView}</React.Fragment>}
       {templateType === 'minimal' && (
-        <MinimalTemplate className={templateClassName}>{RenderedView}</MinimalTemplate>
+        <MinimalTemplate className={templateClassName}>{KeyedView}</MinimalTemplate>
       )}
       {templateType === 'default' && (
         <DefaultTemplate
@@ -365,7 +387,7 @@ export const renderRoot = async ({
             globals: visibleEntities?.globals,
           }}
         >
-          {RenderedView}
+          {KeyedView}
         </DefaultTemplate>
       )}
     </PageConfigProvider>


### PR DESCRIPTION
## What

Navigating between admin views (e.g. list → list) remounted the entire admin shell — including the nav sidebar — causing a flash to black.

## Why

The admin splat route keyed the whole RSC payload by `routeKey`, forcing React to remount everything on each navigation. The key existed to reset view-scoped client providers (e.g. `DocumentInfoProvider`) that hold uncontrolled `useState`.

## Fix

Key only the *view* subtree via `renderRoot`'s new `viewRemountKey` (baked in server-side). The client now renders the payload without an outer key, so the nav/template reconciles in place while the view still remounts on route change — mirroring Next's layout-persists / page-remounts semantics. No-op for Next (`viewRemountKey` left undefined).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216597988811186