### PR TITLE
fix(tanstack-start): show route-transition progress bar for full navigation

### DIFF
--- a/packages/payload/src/admin/adapters/router.ts
+++ b/packages/payload/src/admin/adapters/router.ts
@@ -30,16 +30,23 @@ export type RouterAdapterRouter = {
   back: () => void
   /**
    * Navigate to a new path.
+   *
+   * May return a promise that resolves once navigation settles. Route
+   * transitions (the top loading bar) await it to stay visible for the full
+   * navigation. Adapters whose router integrates with React transitions
+   * (Next.js) can return `void` instead.
    */
-  push: (path: string, options?: { scroll?: boolean }) => void
+  push: (path: string, options?: { scroll?: boolean }) => Promise<void> | void
   /**
    * Refresh the current route.
    */
   refresh: () => void
   /**
    * Replace the current path with a new one.
+   *
+   * May return a promise that resolves once navigation settles (see {@link push}).
    */
-  replace: (path: string, options?: { scroll?: boolean }) => void
+  replace: (path: string, options?: { scroll?: boolean }) => Promise<void> | void
   /**
    * Use this property to standardize behaviors across different router implementations.
    * Set it up to sync client state to the URL without triggering a second server load.

--- a/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
+++ b/packages/tanstack-start/src/elements/RouterAdapter/index.tsx
@@ -103,10 +103,14 @@ export const TanStackRouterAdapter: RouterAdapterComponent = ({ children }) => {
 
   const back = useCallback(() => router.history.back(), [router])
 
+  // Return the `navigate` promise (resolves once the navigation and its blocking
+  // loader settle) so `startRouteTransition` keeps the route-transition progress
+  // bar visible for the full navigation — TanStack's router drives its own
+  // internal React transition, so without awaiting this the shared optimistic
+  // `isTransitioning` flag would flip back before the new view loads.
   const push = useCallback(
-    (path: string, options?: { scroll?: boolean }) => {
-      void router.navigate({ ...toNavOptions(path), resetScroll: options?.scroll })
-    },
+    (path: string, options?: { scroll?: boolean }) =>
+      router.navigate({ ...toNavOptions(path), resetScroll: options?.scroll }),
     [router, toNavOptions],
   )
 
@@ -115,9 +119,8 @@ export const TanStackRouterAdapter: RouterAdapterComponent = ({ children }) => {
   }, [router])
 
   const replace = useCallback(
-    (path: string, options?: { scroll?: boolean }) => {
-      void router.navigate({ ...toNavOptions(path), replace: true, resetScroll: options?.scroll })
-    },
+    (path: string, options?: { scroll?: boolean }) =>
+      router.navigate({ ...toNavOptions(path), replace: true, resetScroll: options?.scroll }),
     [router, toNavOptions],
   )
 

--- a/packages/ui/src/elements/CommandPalette/index.tsx
+++ b/packages/ui/src/elements/CommandPalette/index.tsx
@@ -119,7 +119,7 @@ export const CommandPalette: React.FC = () => {
         return
       }
       close()
-      router.push(href)
+      void router.push(href)
     },
     [close, router],
   )

--- a/packages/ui/src/elements/DefaultListViewTabs/index.tsx
+++ b/packages/ui/src/elements/DefaultListViewTabs/index.tsx
@@ -64,7 +64,7 @@ export const DefaultListViewTabs: React.FC<DefaultListViewTabsProps> = ({
       path,
     })
 
-    router.push(url)
+    void router.push(url)
   }
 
   const collectionLabel = getTranslation(collectionConfig?.labels?.plural, i18n)

--- a/packages/ui/src/elements/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/EditMany/DrawerContent.tsx
@@ -275,7 +275,7 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
   }, [collection, searchParams, selectAll, ids, locale, where])
 
   const onSuccess = () => {
-    router.replace(
+    void router.replace(
       qs.stringify(
         {
           ...parseSearchParams(searchParams),

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
@@ -97,7 +97,7 @@ export const HierarchySidebarTab: React.FC<
         path: `/collections/${hierarchyCollectionSlug}/hierarchy?${queryParam}=${id}`,
       })
       startRouteTransition(() => {
-        router.push(url)
+        void router.push(url)
         router.refresh()
       })
     },

--- a/packages/ui/src/elements/Link/index.tsx
+++ b/packages/ui/src/elements/Link/index.tsx
@@ -71,10 +71,9 @@ export const Link: React.FC<Props> = ({
 
         const navigate = () => {
           if (replace) {
-            void router.replace(url, { scroll })
-          } else {
-            void router.push(url, { scroll })
+            return router.replace(url, { scroll })
           }
+          return router.push(url, { scroll })
         }
 
         startRouteTransition(navigate)

--- a/packages/ui/src/elements/ListHeader/TitleActions/ListEmptyTrashButton.tsx
+++ b/packages/ui/src/elements/ListHeader/TitleActions/ListEmptyTrashButton.tsx
@@ -131,7 +131,7 @@ export function ListEmptyTrashButton({
         })
       }
 
-      router.replace(
+      void router.replace(
         qs.stringify(
           {
             ...Object.fromEntries(searchParams.entries()),

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -75,7 +75,7 @@ export const Localizer: React.FC<{
                       )
 
                       startRouteTransition(() => {
-                        router.push(url)
+                        void router.push(url)
                       })
                     }}
                   >

--- a/packages/ui/src/elements/PublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/PublishMany/DrawerContent.tsx
@@ -141,7 +141,7 @@ export function PublishManyDrawerContent(props: PublishManyDrawerContentProps) {
               })
             }
 
-            router.replace(
+            void router.replace(
               qs.stringify(
                 {
                   ...parseSearchParams(searchParams),

--- a/packages/ui/src/elements/RestoreMany/index.tsx
+++ b/packages/ui/src/elements/RestoreMany/index.tsx
@@ -143,7 +143,7 @@ export const RestoreMany: React.FC<Props> = (props) => {
 
     toggleAll()
 
-    router.replace(
+    void router.replace(
       qs.stringify(
         {
           ...parseSearchParams(searchParams),

--- a/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
@@ -128,7 +128,7 @@ export function UnpublishManyDrawerContent(props: UnpublishManyDrawerContentProp
               })
             }
 
-            router.replace(
+            void router.replace(
               qs.stringify(
                 {
                   ...parseSearchParams(searchParams),

--- a/packages/ui/src/providers/Hierarchy/index.tsx
+++ b/packages/ui/src/providers/Hierarchy/index.tsx
@@ -251,7 +251,7 @@ export const HierarchyProvider: React.FC<HierarchyProviderProps> = ({ children }
         adminRoute,
         path: `/collections/${collectionSlug}${id !== null ? `?${queryParam}=${id}` : ''}`,
       })
-      router.push(url)
+      void router.push(url)
       router.refresh()
     },
     [adminRoute, collectionSlug, parentFieldName, router],

--- a/packages/ui/src/providers/RouteTransition/ProgressBar/index.tsx
+++ b/packages/ui/src/providers/RouteTransition/ProgressBar/index.tsx
@@ -6,7 +6,13 @@ import './index.css'
 
 const transitionDuration = 200
 const baseClass = 'progress-bar'
-const initialDelay = 150
+// Minimum time the bar stays on screen once a navigation starts. Guarantees a
+// visible sweep even for near-instant client navigations (e.g. TanStack routing
+// to already-loaded data), which would otherwise finish before the bar appeared.
+const minVisibleDuration = 400
+// Progress shown the moment the bar appears, so there is always something
+// visible before `transitionProgress` begins advancing.
+const initialProgress = 0.1
 
 /**
  * Renders a progress bar that shows the progress of a route transition.
@@ -24,38 +30,43 @@ const initialDelay = 150
 export const ProgressBar = () => {
   const { isTransitioning, transitionProgress } = useRouteTransition()
   const [progressToShow, setProgressToShow] = React.useState<null | number>(null)
-  const shouldDelayProgress = useRef(true)
+  const shownAtRef = useRef<null | number>(null)
 
   useEffect(() => {
-    let clearTimerID: NodeJS.Timeout
-    let delayTimerID: NodeJS.Timeout
+    let completeTimerID: NodeJS.Timeout
+    let hideTimerID: NodeJS.Timeout
 
     if (isTransitioning) {
-      if (shouldDelayProgress.current) {
-        delayTimerID = setTimeout(() => {
-          setProgressToShow(transitionProgress)
-          shouldDelayProgress.current = false
-        }, initialDelay)
-      } else {
-        setProgressToShow(transitionProgress)
+      // Show the bar immediately and remember when, so we can keep it on screen
+      // for at least `minVisibleDuration` no matter how fast the navigation is.
+      if (shownAtRef.current === null) {
+        shownAtRef.current = performance.now()
       }
-    } else {
-      shouldDelayProgress.current = true
 
-      // Fast forward to 100% when the transition is complete
-      // Then fade out the progress bar directly after
-      setProgressToShow(1)
+      setProgressToShow(Math.max(transitionProgress, initialProgress))
+    } else if (shownAtRef.current !== null) {
+      // A navigation just finished (the guard skips the initial mount, where no
+      // navigation was ever in progress). Keep the bar visible for the rest of
+      // `minVisibleDuration`, then fast-forward to 100% and fade out.
+      const elapsed = performance.now() - shownAtRef.current
+      const remaining = Math.max(0, minVisibleDuration - elapsed)
 
-      // Wait for CSS transition to finish before hiding the progress bar
-      // This includes both the fast-forward to 100% and the subsequent fade-out
-      clearTimerID = setTimeout(() => {
-        setProgressToShow(null)
-      }, transitionDuration * 2)
+      shownAtRef.current = null
+
+      completeTimerID = setTimeout(() => {
+        setProgressToShow(1)
+
+        // Wait for the CSS transition to finish before hiding the progress bar.
+        // This covers both the fast-forward to 100% and the subsequent fade-out.
+        hideTimerID = setTimeout(() => {
+          setProgressToShow(null)
+        }, transitionDuration * 2)
+      }, remaining)
     }
 
     return () => {
-      clearTimeout(clearTimerID)
-      clearTimeout(delayTimerID)
+      clearTimeout(completeTimerID)
+      clearTimeout(hideTimerID)
     }
   }, [isTransitioning, transitionProgress])
 

--- a/packages/ui/src/providers/RouteTransition/ProgressBar/index.tsx
+++ b/packages/ui/src/providers/RouteTransition/ProgressBar/index.tsx
@@ -53,6 +53,14 @@ export const ProgressBar = () => {
 
       shownAtRef.current = null
 
+      // Force a visible value here, at normal priority. For fast client
+      // navigations (e.g. TanStack routing that settles in a single round-trip)
+      // the growing render above — driven by the optimistic `isTransitioning`
+      // flag — is discarded before it paints, so the bar would otherwise only
+      // flash to 100% at the tail. Setting it now guarantees the bar is on
+      // screen for the whole `remaining` window before completing.
+      setProgressToShow((prev) => Math.max(prev ?? 0, initialProgress))
+
       completeTimerID = setTimeout(() => {
         setProgressToShow(1)
 

--- a/packages/ui/src/providers/RouteTransition/index.tsx
+++ b/packages/ui/src/providers/RouteTransition/index.tsx
@@ -61,12 +61,18 @@ export const RouteTransitionProvider: React.FC<RouteTransitionProps> = ({ childr
   }, [isTransitioning, initiateProgress])
 
   const startRouteTransition: StartRouteTransition = useCallback(
-    (callback?: () => void) => {
+    (callback?: () => Promise<void> | void) => {
       startTransition(() => {
         setIsTransitioning(true)
 
+        // Return the callback's result so an async navigation (a returned
+        // promise) keeps the transition — and the optimistic `isTransitioning`
+        // flag — pending until navigation settles, making the progress bar
+        // track the full navigation. Routers that integrate with React
+        // transitions (Next.js) return `void` here, preserving the classic
+        // synchronous behavior.
         if (typeof callback === 'function') {
-          callback()
+          return callback()
         }
       })
     },
@@ -84,7 +90,7 @@ type RouteTransitionProps = {
   children: React.ReactNode
 }
 
-type StartRouteTransition = (callback?: () => void) => void
+type StartRouteTransition = (callback?: () => Promise<void> | void) => void
 
 type RouteTransitionContextValue = {
   isTransitioning: boolean
@@ -97,7 +103,7 @@ const RouteTransitionContext = React.createContext<RouteTransitionContextValue>(
   // Default implementation: just call the callback directly (no transition animation)
   startRouteTransition: (callback) => {
     if (typeof callback === 'function') {
-      callback()
+      void callback()
     }
   },
   transitionProgress: 0,

--- a/packages/ui/src/utilities/handleBackToDashboard.tsx
+++ b/packages/ui/src/utilities/handleBackToDashboard.tsx
@@ -14,5 +14,5 @@ export const handleBackToDashboard = ({ adminRoute, router, serverURL }: BackToD
     path: '',
     serverURL,
   })
-  router.push(redirectRoute)
+  void router.push(redirectRoute)
 }

--- a/packages/ui/src/utilities/handleGoBack.tsx
+++ b/packages/ui/src/utilities/handleGoBack.tsx
@@ -14,5 +14,5 @@ export const handleGoBack = ({ adminRoute, collectionSlug, router, serverURL }: 
     adminRoute,
     path: collectionSlug ? `/collections/${collectionSlug}` : '/',
   })
-  router.push(redirectRoute)
+  void router.push(redirectRoute)
 }

--- a/packages/ui/src/views/List/ListSelection/index.tsx
+++ b/packages/ui/src/views/List/ListSelection/index.tsx
@@ -137,7 +137,7 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
             afterDelete={() => {
               toggleAll()
 
-              router.replace(
+              void router.replace(
                 qs.stringify(
                   {
                     ...parseSearchParams(searchParams),

--- a/packages/ui/src/views/ResetPassword/ResetPasswordForm/index.tsx
+++ b/packages/ui/src/views/ResetPassword/ResetPasswordForm/index.tsx
@@ -40,9 +40,9 @@ export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
   const onSuccess = React.useCallback(async () => {
     const user = await fetchFullUser()
     if (user) {
-      history.push(adminRoute)
+      void history.push(adminRoute)
     } else {
-      history.push(
+      void history.push(
         formatAdminURL({
           adminRoute,
           path: loginRoute,

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1231,33 +1231,17 @@ describe('General', () => {
   })
 
   describe('progress bar', () => {
-    test.fixme('should show progress bar on page navigation', async () => {
-      // TODO: This test is extremely flaky in CI. Not a surprise, the progress bar only shows if the timing is right. Need to fix this and make extra sure it passes in CI without retries.
+    test('should show progress bar on page navigation', async () => {
       // eslint-disable-next-line playwright/no-networkidle
       await page.goto(postsUrl.admin, { waitUntil: 'networkidle' })
       // Wait for hydration - otherwise playwright clicks the card early and nothing happens
       await wait(1000)
 
-      // Throttle network to ensure navigation takes > 500ms so progress bar is visible
-      // Progress bar has 150ms initial delay before showing, so fast navigations won't show it
-      const client = await page.context().newCDPSession(page)
-      await client.send('Network.emulateNetworkConditions', {
-        downloadThroughput: (500 * 1024) / 8, // 500 kbps
-        latency: 400, // 400ms latency
-        offline: false,
-        uploadThroughput: (500 * 1024) / 8,
-      })
-
+      // The progress bar stays on screen for a guaranteed minimum duration once a
+      // navigation starts, so it is reliably visible even for fast navigations —
+      // no network throttling required.
       await page.locator('.collections__card-list .card').first().click()
       await expect(page.locator('.progress-bar')).toBeVisible()
-
-      // Reset network conditions
-      await client.send('Network.emulateNetworkConditions', {
-        downloadThroughput: -1,
-        latency: 0,
-        offline: false,
-        uploadThroughput: -1,
-      })
     })
   })
 })


### PR DESCRIPTION
## What

The top loading bar didn't track navigation in the TanStack Start admin (unlike Next.js). Two issues:

1. It only flashed to 100% instead of showing progress during the load.
2. Even after fixing (1), the bar stayed invisible for fast client navigations — the anti-flicker delay swallowed it entirely.

## Why

- **Transition flipped early:** TanStack's router runs its own internal React transition, so the shared optimistic `isTransitioning` flag flipped back to false before the destination view finished loading.
- **Anti-flicker delay swallowed fast navs:** the progress bar had a 150ms initial delay before appearing. TanStack navigations to already-loaded data finish faster than that, so the bar never crossed the visibility threshold — only an imperceptible 100% flash at the tail. (On Next.js dev every navigation does a server round-trip well over 150ms, which is why it looked fine there.)

## Fix

- The adapter's `push`/`replace` now return the `router.navigate()` promise, and `startRouteTransition` returns it from the transition so React keeps the transition — and `isTransitioning` — pending until navigation settles. No-op for Next.js (its router methods return `void`).
- The progress bar now shows an immediate visible starting value and stays on screen for a guaranteed minimum duration once a navigation starts, so every navigation renders a real bar regardless of how fast it completes. Slow navigations still track progress as before, and the spurious 100% flash on initial mount is gone.

## Tests

Enables the previously-flaky (`test.fixme`) progress bar e2e test — the guaranteed minimum visible duration removes the timing dependency that made it flaky, so its network-throttling workaround is dropped.