### PR TITLE
fix(storage-vercel-blob): allow overwriting existing blob keys

### DIFF
--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -65,6 +65,7 @@ export function createVercelBlobAdapter({
             pathname: resolved.fileKey,
             token: await generateClientTokenFromReadWriteToken({
               addRandomSuffix,
+              allowOverwrite: true,
               allowedContentTypes: mimeType ? [mimeType] : undefined,
               cacheControlMaxAge,
               maximumSizeInBytes: filesize,

--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -65,8 +65,8 @@ export function createVercelBlobAdapter({
             pathname: resolved.fileKey,
             token: await generateClientTokenFromReadWriteToken({
               addRandomSuffix,
-              allowOverwrite: true,
               allowedContentTypes: mimeType ? [mimeType] : undefined,
+              allowOverwrite: true,
               cacheControlMaxAge,
               maximumSizeInBytes: filesize,
               pathname: resolved.fileKey,

--- a/packages/storage-vercel-blob/src/uploadFile.ts
+++ b/packages/storage-vercel-blob/src/uploadFile.ts
@@ -41,6 +41,7 @@ export async function uploadFile({
   const result = await put(fileKey, buffer, {
     access,
     addRandomSuffix,
+    allowOverwrite: true,
     cacheControlMaxAge,
     contentType: mimeType,
     token,


### PR DESCRIPTION
Restores in-place file replacement for `@payloadcms/storage-vercel-blob` when using `@vercel/blob` v2.

1. `@vercel/blob` v2 rejects writes to existing keys unless `allowOverwrite` is set.
2. Payload crop/edit/replace operations re-upload to the same key by design.

Adds `allowOverwrite: true` to server `put()` calls and client upload token generation so crop, image-edit, and manual replace succeed without changing default filename behavior.

Fixes #17378


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216640171473960
  - https://app.asana.com/0/0/1216650430478046