### PR TITLE
fix(ui): uploads responsiveness layout issues and mobile overflows

### DIFF
--- a/packages/ui/src/elements/BulkUpload/FileSidebar/index.css
+++ b/packages/ui/src/elements/BulkUpload/FileSidebar/index.css
@@ -258,6 +258,10 @@
       padding-inline: var(--file-gutter-h);
     }
 
+    .file-selections__collectionSelect {
+      border-bottom: none;
+    }
+
     .file-selections__header__error {
       padding-inline: 0;
     }

--- a/packages/ui/src/elements/FileManager/FilePreview/index.css
+++ b/packages/ui/src/elements/FileManager/FilePreview/index.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   .file-preview {
     display: flex;
-    flex-direction: row;
+    flex-direction: column-reverse;
     flex: 1 1 0;
     min-height: 0;
     /* Visible so the mini carousel can grow past the panel as the headers scroll away. */
@@ -75,9 +75,9 @@
     min-width: 0;
   }
 
-  @container edit-main (max-width: 768px) {
+  @container edit-main (min-width: 768px) {
     .file-preview {
-      flex-direction: column-reverse;
+      flex-direction: row;
     }
   }
 }

--- a/packages/ui/src/elements/FileManager/index.css
+++ b/packages/ui/src/elements/FileManager/index.css
@@ -58,7 +58,7 @@
     justify-content: center;
   }
 
-  .file-manager__remove {
+  .file-manager__upload .file-manager__remove {
     position: absolute;
     top: var(--gutter-h);
     right: var(--gutter-h);

--- a/packages/ui/src/elements/FileManager/index.css
+++ b/packages/ui/src/elements/FileManager/index.css
@@ -1,13 +1,14 @@
 @layer payload-default {
   .file-manager {
+    --file-fields-max-width: 600px;
     position: relative;
-    flex: 1 0 0;
     align-self: stretch;
     width: 100%;
     margin-bottom: 0;
     border-radius: 0;
     background: var(--color-bg-secondary);
-    min-height: 100px;
+    min-height: 400px;
+    border-bottom: var(--stroke-width-small) solid var(--color-border);
 
     .dropzone {
       border: none;
@@ -16,25 +17,23 @@
   }
 
   .file-manager__panel {
-    position: sticky;
-    top: var(--doc-controls-height);
-    height: calc(
-      100dvh - var(--app-header-height) - var(--doc-controls-height) - var(--doc-header-height)
-    );
+    position: static;
+    height: auto;
+    min-height: 400px;
     display: flex;
     flex-direction: column;
     /* Visible so the mini carousel can grow past the panel to fill the area left behind as the
        app/doc headers scroll away (see MiniCarousel). */
     overflow: visible;
-    /* Scroll-driven: grow height as the app header and doc header scroll away, matching the
-       extra space they free up. Mirrors the MiniCarousel approach. Falls back to static height. */
   }
 
   .file-manager__content {
     display: flex;
-    flex-direction: row;
-    flex: 1 1 0;
-    min-height: 0;
+    flex-direction: column;
+    /* flex-basis: auto (not 0) so this sizes to its content when the panel's height is auto
+       (stacked layout) instead of collapsing — flex-basis 0 only makes sense when the panel
+       has a definite height to grow into (see the min-width override below). */
+    flex: 1 1 auto;
     overflow: visible;
   }
 
@@ -44,7 +43,11 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: var(--spacer-4);
+    gap: var(--spacer-4);
+    padding-top: var(--spacer-4);
+    padding-bottom: var(--spacer-4);
+    padding-left: var(--gutter-h);
+    padding-right: var(--gutter-h);
     position: relative;
   }
 
@@ -60,8 +63,8 @@
 
   .file-manager__remove {
     position: absolute;
-    top: var(--spacer-2);
-    right: var(--spacer-2);
+    top: var(--gutter-h);
+    right: var(--gutter-h);
     margin: 0;
     z-index: 1;
   }
@@ -135,20 +138,33 @@
     color: var(--color-text-tertiary);
   }
 
-  @container edit-main (max-width: 1024px) {
+  @container edit-main (min-width: 1024px) {
     .file-manager {
-      min-height: 400px;
-      border-bottom: var(--stroke-width-small) solid var(--color-border);
+      min-height: 100px;
+      border-bottom: none;
+    }
+
+    .file-manager__upload {
+      padding: var(--spacer-4);
+    }
+
+    .file-manager__file-adjustments {
+      max-width: var(--file-fields-max-width);
     }
 
     .file-manager__panel {
-      position: static;
-      height: auto;
-      min-height: 400px;
+      position: sticky;
+      top: var(--doc-controls-height);
+      /* Scroll-driven: grow height as the app header and doc header scroll away, matching the
+         extra space they free up. Mirrors the MiniCarousel approach. Falls back to static height. */
+      height: calc(
+        100dvh - var(--app-header-height) - var(--doc-controls-height) - var(--doc-header-height)
+      );
     }
 
     .file-manager__content {
-      flex-direction: column;
+      flex-direction: row;
+      min-height: 0;
     }
   }
 }

--- a/packages/ui/src/elements/FileManager/index.css
+++ b/packages/ui/src/elements/FileManager/index.css
@@ -44,10 +44,7 @@
     align-items: center;
     justify-content: center;
     gap: var(--spacer-4);
-    padding-top: var(--spacer-4);
-    padding-bottom: var(--spacer-4);
-    padding-left: var(--gutter-h);
-    padding-right: var(--gutter-h);
+    padding: var(--spacer-4) var(--gutter-h);
     position: relative;
   }
 

--- a/packages/ui/src/elements/FileManager/index.tsx
+++ b/packages/ui/src/elements/FileManager/index.tsx
@@ -246,6 +246,13 @@ export const FileManager: React.FC<FileManagerProps> = ({
     [setModified, updateUploadEdits],
   )
 
+  // Reset states for when replacing the file with a new upload
+  useEffect(() => {
+    setSelectedSize(null)
+    setRemovedFile(false)
+    setFileSrc('')
+  }, [data?.url, data?.filename])
+
   useEffect(() => {
     if (initialState?.file?.value instanceof File) {
       setFileSrc(URL.createObjectURL(initialState.file.value))
@@ -260,12 +267,6 @@ export const FileManager: React.FC<FileManagerProps> = ({
       }
     }
   }, [fileSrc])
-
-  useEffect(() => {
-    setSelectedSize(null)
-    setRemovedFile(false)
-    setFileSrc('')
-  }, [data?.url, data?.filename])
 
   useEffect(() => {
     const handleControlFileUrl = async () => {

--- a/packages/ui/src/elements/FileManager/index.tsx
+++ b/packages/ui/src/elements/FileManager/index.tsx
@@ -263,6 +263,8 @@ export const FileManager: React.FC<FileManagerProps> = ({
 
   useEffect(() => {
     setSelectedSize(null)
+    setRemovedFile(false)
+    setFileSrc('')
   }, [data?.url, data?.filename])
 
   useEffect(() => {
@@ -394,6 +396,16 @@ export const FileManager: React.FC<FileManagerProps> = ({
             />
           ) : showUploadInput ? (
             <div className={`${baseClass}__upload`}>
+              {!value && removedFile && data?.filename && (
+                <Button
+                  buttonStyle="secondary"
+                  className={`${baseClass}__remove`}
+                  icon="x"
+                  onClick={() => setRemovedFile(false)}
+                  round
+                  tooltip={t('general:cancel')}
+                />
+              )}
               {!value && (
                 <Dropzone onChange={handleFileSelection}>
                   <div className={`${baseClass}__dropzone-content`}>

--- a/packages/ui/src/elements/MiniCarousel/index.css
+++ b/packages/ui/src/elements/MiniCarousel/index.css
@@ -2,6 +2,7 @@
   .mini-carousel {
     --carousel-item-width: 48px;
     --carousel-item-height: 48px;
+    --carousel-divider-height: 48px;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -57,7 +58,7 @@
 
   .mini-carousel__divider {
     width: var(--stroke-width-small);
-    height: 48px;
+    height: var(--carousel-divider-height);
     margin: 0 var(--spacer-2);
     background: var(--color-border);
     flex-shrink: 0;

--- a/packages/ui/src/elements/MiniCarousel/index.css
+++ b/packages/ui/src/elements/MiniCarousel/index.css
@@ -1,5 +1,7 @@
 @layer payload-default {
   .mini-carousel {
+    --carousel-item-width: 48px;
+    --carousel-item-height: 48px;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -35,8 +37,8 @@
     background: var(--color-bg-secondary);
     cursor: pointer;
     overflow: hidden;
-    width: 48px;
-    height: 48px;
+    width: var(--carousel-item-width);
+    height: var(--carousel-item-height);
   }
 
   .mini-carousel__item img {

--- a/packages/ui/src/elements/MiniCarousel/index.css
+++ b/packages/ui/src/elements/MiniCarousel/index.css
@@ -1,21 +1,20 @@
 @layer payload-default {
   .mini-carousel {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    align-items: center;
     gap: var(--spacer-3);
     padding: var(--spacer-2-5);
-    height: 100%;
+    width: 100%;
+    height: auto;
     flex-shrink: 0;
-    overflow-y: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     background: var(--color-bg-secondary);
-    border-right: var(--stroke-width-small) solid var(--color-border);
-    /* Honor the scroll-driven height below instead of stretching to the flex line. */
-    align-self: flex-start;
-    /* Scroll-driven: grow to fill the gap as the header scrolls away. Falls back to static height. */
-    animation: mini-carousel-fill-scrolled-chrome linear both;
-    animation-timeline: scroll(root block);
-    animation-range: 0 calc(var(--app-header-height) + var(--doc-header-height));
+    border-top: var(--stroke-width-small) solid var(--color-border);
+    /* Stacked layout: no scroll-driven growth, fill via stretch instead. */
+    align-self: stretch;
+    animation: none;
   }
 
   @keyframes mini-carousel-fill-scrolled-chrome {
@@ -55,40 +54,40 @@
   }
 
   .mini-carousel__divider {
-    width: 100%;
-    height: var(--stroke-width-small);
+    width: var(--stroke-width-small);
+    height: 48px;
+    margin: 0 var(--spacer-2);
     background: var(--color-border);
     flex-shrink: 0;
   }
 
-  /* Stacked layout: disable scroll-driven growth and fill via stretch. */
-  @container edit-main (max-width: 1024px) {
+  @container edit-main (min-width: 768px) {
     .mini-carousel {
-      align-self: stretch;
-      height: auto;
-      animation: none;
-    }
-  }
-
-  @container edit-main (max-width: 768px) {
-    .mini-carousel {
-      flex-direction: row;
-      align-items: center;
-      width: 100%;
-      overflow-x: auto;
-      overflow-y: hidden;
-      border-right: 0;
-      border-top: var(--stroke-width-small) solid var(--color-border);
-    }
-
-    .mini-carousel__item {
-      width: 48px;
+      flex-direction: column;
+      align-items: stretch;
+      width: auto;
+      overflow-x: visible;
+      overflow-y: auto;
+      border-top: none;
+      border-right: var(--stroke-width-small) solid var(--color-border);
     }
 
     .mini-carousel__divider {
-      width: var(--stroke-width-small);
-      height: 48px;
-      margin: 0 var(--spacer-2);
+      width: 100%;
+      height: var(--stroke-width-small);
+      margin: 0;
+    }
+  }
+
+  @container edit-main (min-width: 1024px) {
+    .mini-carousel {
+      height: 100%;
+      /* Honor the scroll-driven height below instead of stretching to the flex line. */
+      align-self: flex-start;
+      /* Scroll-driven: grow to fill the gap as the header scrolls away. Falls back to static height. */
+      animation: mini-carousel-fill-scrolled-chrome linear both;
+      animation-timeline: scroll(root block);
+      animation-range: 0 calc(var(--app-header-height) + var(--doc-header-height));
     }
   }
 }

--- a/packages/ui/src/fields/Upload/index.css
+++ b/packages/ui/src/fields/Upload/index.css
@@ -5,13 +5,17 @@
     gap: var(--spacer-2);
   }
 
+  .upload__dropzoneAndUpload .dropzone.dropzone--style-default {
+    padding-block: 0;
+  }
+
   .upload__dropzoneContent {
     display: flex;
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
     row-gap: var(--spacer-2);
-    padding: var(--spacer-2-5);
+    padding: var(--spacer-3);
     gap: var(--spacer-2);
     width: 100%;
   }

--- a/packages/ui/src/fields/Upload/index.css
+++ b/packages/ui/src/fields/Upload/index.css
@@ -9,6 +9,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
+    row-gap: var(--spacer-2);
     padding: var(--spacer-2-5);
     gap: var(--spacer-2);
     width: 100%;
@@ -18,6 +20,13 @@
     display: flex;
     align-items: center;
     gap: var(--spacer-2);
+    flex-wrap: wrap;
+  }
+
+  @supports (flex-wrap: balance) {
+    .upload__dropzoneContent__buttons {
+      flex-wrap: balance;
+    }
   }
 
   .upload__dropzoneContent__orText {

--- a/packages/ui/src/fields/Upload/index.css
+++ b/packages/ui/src/fields/Upload/index.css
@@ -3,6 +3,8 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacer-2);
+    container-type: inline-size;
+    container-name: upload-dropzone;
   }
 
   .upload__dropzoneAndUpload .dropzone.dropzone--style-default {
@@ -12,7 +14,6 @@
   .upload__dropzoneContent {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     flex-wrap: wrap;
     row-gap: var(--spacer-2);
     padding: var(--spacer-3);
@@ -39,6 +40,7 @@
   }
 
   .upload__dragAndDropText {
+    display: none;
     flex-shrink: 0;
     margin: 0;
     text-transform: lowercase;
@@ -56,9 +58,9 @@
     border: var(--stroke-width-small) solid var(--color-border);
   }
 
-  @media (max-width: 768px) {
+  @container upload-dropzone (min-width: 400px) {
     .upload__dragAndDropText {
-      display: none;
+      display: block;
     }
   }
 }

--- a/packages/ui/src/views/Edit/index.css
+++ b/packages/ui/src/views/Edit/index.css
@@ -12,35 +12,32 @@
   }
 
   .collection-edit__main-wrapper--scroll-fields-only {
-    height: calc(
-      100dvh - var(--app-header-height, 0px) - var(--doc-controls-height, 0px) -
-        var(--doc-header-height, 0px)
-    );
-    overflow: hidden;
+    height: auto;
+    overflow: visible;
 
     .collection-edit__main {
-      min-height: 0;
-      overflow: hidden;
+      min-height: initial;
+      overflow: visible;
     }
 
     .document-fields {
-      height: 100%;
-      min-height: 0;
+      height: auto;
+      min-height: initial;
     }
 
     .document-fields--force-sidebar-wrap {
-      overflow-y: auto;
-      overscroll-behavior: contain;
-      scrollbar-width: thin;
-      scrollbar-color: var(--scrollbar-color) transparent;
+      overflow-y: visible;
+      overscroll-behavior: auto;
+      scrollbar-width: auto;
+      scrollbar-color: auto;
     }
 
     .document-fields:not(.document-fields--force-sidebar-wrap) .document-fields__main {
-      min-height: 0;
-      overflow-y: auto;
-      overscroll-behavior: contain;
-      scrollbar-width: thin;
-      scrollbar-color: var(--scrollbar-color) transparent;
+      min-height: initial;
+      overflow-y: visible;
+      overscroll-behavior: auto;
+      scrollbar-width: auto;
+      scrollbar-color: auto;
     }
 
     .document-fields--force-sidebar-wrap .document-fields__main {
@@ -51,9 +48,9 @@
     }
 
     .document-fields__sidebar {
-      overscroll-behavior: contain;
-      scrollbar-width: thin;
-      scrollbar-color: var(--scrollbar-color) transparent;
+      overscroll-behavior: auto;
+      scrollbar-width: auto;
+      scrollbar-color: auto;
     }
 
     .document-fields__sidebar-wrap {
@@ -63,8 +60,8 @@
   }
 
   .template-default__wrap:has(.collection-edit__main-wrapper--scroll-fields-only) {
-    height: 100dvh;
-    overflow: hidden;
+    height: auto;
+    overflow: visible;
   }
 
   .collection-edit__main {
@@ -76,12 +73,22 @@
   }
 
   .collection-edit__main-wrapper--has-upload-panel {
+    flex-direction: column-reverse;
+    gap: var(--spacer-5);
+
     .collection-edit__main {
       flex: 1;
     }
+
     .file-manager {
-      flex: 2;
-      border-inline-start: var(--stroke-width-small) solid var(--color-border);
+      order: 0;
+      /* Stacked — no vertical divider; the file manager's own bottom border separates it. */
+      border-inline-start: 0;
+    }
+
+    .document-fields {
+      flex: 0 0 auto;
+      width: 100%;
     }
 
     .collection-edit__main:not(:has(.field-type)) {
@@ -95,61 +102,62 @@
 
   /* Container query (not viewport) so the layout stacks based on the space actually available
      to the edit view — e.g. inside a narrow document drawer it uses the stacked mobile layout. */
-  @container edit-main (max-width: 1024px) {
+  @container edit-main (min-width: 1024px) {
     .collection-edit__main-wrapper--scroll-fields-only {
-      height: auto;
-      overflow: visible;
+      height: calc(
+        100dvh - var(--app-header-height, 0px) - var(--doc-controls-height, 0px) -
+          var(--doc-header-height, 0px)
+      );
+      overflow: hidden;
 
       .collection-edit__main {
-        min-height: initial;
-        overflow: visible;
+        min-height: 0;
+        overflow: hidden;
       }
 
       .document-fields {
-        height: auto;
-        min-height: initial;
+        height: 100%;
+        min-height: 0;
       }
 
       .document-fields--force-sidebar-wrap {
-        overflow-y: visible;
-        overscroll-behavior: auto;
-        scrollbar-width: auto;
-        scrollbar-color: auto;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        scrollbar-width: thin;
+        scrollbar-color: var(--scrollbar-color) transparent;
       }
 
       .document-fields:not(.document-fields--force-sidebar-wrap) .document-fields__main {
-        min-height: initial;
-        overflow-y: visible;
-        overscroll-behavior: auto;
-        scrollbar-width: auto;
-        scrollbar-color: auto;
+        min-height: 0;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        scrollbar-width: thin;
+        scrollbar-color: var(--scrollbar-color) transparent;
       }
 
       .document-fields__sidebar {
-        overscroll-behavior: auto;
-        scrollbar-width: auto;
-        scrollbar-color: auto;
+        overscroll-behavior: contain;
+        scrollbar-width: thin;
+        scrollbar-color: var(--scrollbar-color) transparent;
       }
     }
 
     .template-default__wrap:has(.collection-edit__main-wrapper--scroll-fields-only) {
-      height: auto;
-      overflow: visible;
+      height: 100dvh;
+      overflow: hidden;
     }
 
     .collection-edit__main-wrapper--has-upload-panel {
-      flex-direction: column-reverse;
-      gap: var(--spacer-5);
+      flex-direction: row;
+      gap: 0;
 
       .file-manager {
-        order: 0;
-        flex: 1 0 0;
-        /* Stacked — no vertical divider; the file manager's own bottom border separates it. */
-        border-inline-start: 0;
+        flex: 2;
+        border-inline-start: var(--stroke-width-small) solid var(--color-border);
       }
 
       .document-fields {
-        flex: 0 0 auto;
+        flex: initial;
         width: 100%;
       }
     }

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -1316,7 +1316,7 @@ describe('Uploads', () => {
       ).toBeVisible()
     })
 
-    test('should wrap the drag and drop text below the dropzone buttons instead of overflowing', async () => {
+    test('should hide the drag and drop text based on the field container width, not the viewport', async () => {
       await page.goto(uploadsOne.list)
 
       const bulkUploadButton = page.locator('.list-header__title-actions button', {
@@ -1328,18 +1328,18 @@ describe('Uploads', () => {
         .locator('.dropzone input[type="file"]')
         .setInputFiles(path.resolve(dirname, './image.png'))
 
-      const dropzoneContent = page.locator('#field-hasManyUpload .upload__dropzoneContent')
-      const buttons = dropzoneContent.locator('.upload__dropzoneContent__buttons')
-      const dragAndDropText = dropzoneContent.locator('.upload__dragAndDropText')
+      await expect(page.locator('#field-hasManyUpload .upload__dropzoneContent')).toHaveCSS(
+        'flex-wrap',
+        'wrap',
+      )
 
-      await expect(dragAndDropText).toBeVisible()
+      await expect(page.locator('#field-hasManyUpload .upload__dragAndDropText')).toBeHidden()
+    })
 
-      const buttonsBox = (await buttons.boundingBox())!
-      const textBox = (await dragAndDropText.boundingBox())!
+    test('should show the drag and drop text when a field has enough room outside the bulk upload drawer', async () => {
+      await gotoAndWaitForForm(page, relationURL.create)
 
-      // Wrapped onto its own line below the buttons, rather than overflowing past them on the
-      // same line.
-      expect(textBox.y).toBeGreaterThanOrEqual(buttonsBox.y + buttonsBox.height - 1)
+      await expect(page.locator('#field-hasManyImage .upload__dragAndDropText')).toBeVisible()
     })
 
     test('should bulk upload non-image files without page errors', async () => {

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -2672,6 +2672,45 @@ describe('Uploads', () => {
     await expect(titleField).toHaveValue('updated title')
   })
 
+  test('should show the file preview for the new file after saving a replaced file', async () => {
+    await gotoAndWaitForForm(page, uploadsTwo.create)
+
+    await page.setInputFiles('input[type="file"]', path.resolve(dirname, './image.png'))
+    await page.locator('#field-prefix').fill('initial')
+    await saveDocAndAssert(page)
+
+    await page.locator('.file-toolbar__filename-btn').click()
+    await page.locator('.popup-button-list__button', { hasText: 'Replace file' }).click()
+    await page.setInputFiles(
+      '.file-manager input[type="file"]',
+      path.resolve(dirname, './test-image.jpg'),
+    )
+    await saveDocAndAssert(page)
+
+    await expect(page.locator('.file-toolbar__filename-btn')).toBeVisible()
+    await expect(page.locator('.file-toolbar__filename-text')).toContainText('test-image')
+    await expect(page.locator('.file-manager .dropzone')).toBeHidden()
+  })
+
+  test('should allow cancelling a replace before selecting a new file', async () => {
+    await gotoAndWaitForForm(page, uploadsTwo.create)
+
+    await page.setInputFiles('input[type="file"]', path.resolve(dirname, './image.png'))
+    await page.locator('#field-prefix').fill('initial')
+    await saveDocAndAssert(page)
+
+    await page.locator('.file-toolbar__filename-btn').click()
+    await page.locator('.popup-button-list__button', { hasText: 'Replace file' }).click()
+
+    await expect(page.locator('.file-manager .dropzone')).toBeVisible()
+
+    await page.locator('.file-manager__remove').click()
+
+    await expect(page.locator('.file-toolbar__filename-btn')).toBeVisible()
+    await expect(page.locator('.file-toolbar__filename-text')).toContainText('image')
+    await expect(page.locator('.file-manager .dropzone')).toBeHidden()
+  })
+
   test('should show data in drawer when editing relationship to upload collection with filesRequiredOnCreate: false', async () => {
     const uploadDoc = await payload.create({
       collection: noFilesRequiredSlug,

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -1316,6 +1316,32 @@ describe('Uploads', () => {
       ).toBeVisible()
     })
 
+    test('should wrap the drag and drop text below the dropzone buttons instead of overflowing', async () => {
+      await page.goto(uploadsOne.list)
+
+      const bulkUploadButton = page.locator('.list-header__title-actions button', {
+        hasText: 'Bulk Upload',
+      })
+      await bulkUploadButton.click()
+
+      await page
+        .locator('.dropzone input[type="file"]')
+        .setInputFiles(path.resolve(dirname, './image.png'))
+
+      const dropzoneContent = page.locator('#field-hasManyUpload .upload__dropzoneContent')
+      const buttons = dropzoneContent.locator('.upload__dropzoneContent__buttons')
+      const dragAndDropText = dropzoneContent.locator('.upload__dragAndDropText')
+
+      await expect(dragAndDropText).toBeVisible()
+
+      const buttonsBox = (await buttons.boundingBox())!
+      const textBox = (await dragAndDropText.boundingBox())!
+
+      // Wrapped onto its own line below the buttons, rather than overflowing past them on the
+      // same line.
+      expect(textBox.y).toBeGreaterThanOrEqual(buttonsBox.y + buttonsBox.height - 1)
+    })
+
     test('should bulk upload non-image files without page errors', async () => {
       // Enable collection ONLY for this test
       collectErrorsFromPage()


### PR DESCRIPTION
## What
- Migrate FileManager, MiniCarousel, and Edit view container queries from max-width to min-width (mobile-first) breakpoints
- Fix the file manager panel not sizing to its content in the stacked (mobile) layout, instead collapsing based on a flex-basis meant only for the fixed-height desktop layout
- Remove dead/redundant flex rules left over from the above that had no effect
- Fix the file preview not switching back after saving a replaced file
- Add a cancel action to back out of a file replace before a new file is selected
- Fix file previews not rendering in the Bulk Upload drawer
- Fix "or drag and drop a file" text overflowing instead of wrapping onto its own line in narrow dropzones
- Remove a duplicate divider line under the collection-select dropdown when the file list is stacked on mobile
- Unify dropzone content padding to a consistent spacer-3 on all sides, matching design, without affecting other dropzone usages (FileManager, BulkUpload)

## Recordings

These recordings show before and after in a sequence.

Fixing the file preview layouts:

https://github.com/user-attachments/assets/b0d6a641-c341-459e-8f44-0237a3fbaafc

Replacing a file workflows:

https://github.com/user-attachments/assets/aaf979c7-08a9-4bb7-92d8-7eb5809d2626

Fixing responsiveness issues on upload fields and within bulk upload:

https://github.com/user-attachments/assets/a42b72b5-da58-498b-9ed8-74337458a875

## Why

All of these issues were sort of together related to the UI of the new File Manager components discovered as part of the bug bash.