### PR TITLE
fix(storage-vercel-blob): allow overwriting existing blob keys

### DIFF
--- a/packages/storage-vercel-blob/src/getClientUploadRoute.ts
+++ b/packages/storage-vercel-blob/src/getClientUploadRoute.ts
@@ -34,6 +34,7 @@ export const getClientUploadRoute =
 
           return Promise.resolve({
             addRandomSuffix,
+            allowOverwrite: true,
             cacheControlMaxAge,
           })
         },

--- a/packages/storage-vercel-blob/src/uploadFile.ts
+++ b/packages/storage-vercel-blob/src/uploadFile.ts
@@ -41,6 +41,7 @@ export async function uploadFile({
   const result = await put(fileKey, buffer, {
     access,
     addRandomSuffix,
+    allowOverwrite: true,
     cacheControlMaxAge,
     contentType: mimeType,
     token,


### PR DESCRIPTION
Identical to #17383, back-ported for 3.x.