### PR TITLE
feat(ui): surface content-api usage limit errors

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -300,6 +300,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'general:filterWhere',
   'general:globals',
   'general:goBack',
+  'general:gotIt',
   'general:groupByLabel',
   'general:enhancedContrastMode',
   'general:hideSidebar',
@@ -505,6 +506,13 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'upload:fileSize',
   'upload:noFile',
   'upload:download',
+
+  'usageLimits:couldNotSaveDocument',
+  'usageLimits:documentLimitReached',
+  'usageLimits:reviewCollection',
+  'usageLimits:unableToCreateDocument',
+  'usageLimits:unableToSaveDocumentTooLarge',
+  'usageLimits:unableToUpload',
 
   'validation:emailAddress',
   'validation:enterNumber',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -364,6 +364,7 @@ export const arTranslations: DefaultTranslationsObject = {
     filterWhere: 'تصفية {{label}} حيث',
     globals: 'عامة',
     goBack: 'العودة',
+    gotIt: 'تم الاستلام',
     groupByLabel: 'التجميع حسب {{label}}',
     hideSidebar: 'إخفاء الشريط الجانبي',
     import: 'استيراد',
@@ -587,6 +588,15 @@ export const arTranslations: DefaultTranslationsObject = {
     sizes: 'الاحجام',
     sizesFor: 'أحجام لـ {{label}}',
     width: 'العرض',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'تعذر حفظ المستند',
+    documentLimitReached:
+      'لقد وصلت إلى الحد الأقصى لعدد المستندات المسموح به. يرجى حذف بعض المستندات الحالية لمواصلة الإنشاء.',
+    reviewCollection: 'مراجعة {{label}}',
+    unableToCreateDocument: 'غير قادر على إنشاء مستند. تم الوصول إلى الحد الأقصى للسعة التخزينية.',
+    unableToSaveDocumentTooLarge: 'تعذّر حفظ المستند، النص كبير جدًا',
+    unableToUpload: 'غير قادر على التحميل. يرجى إفراغ بعض المساحة للمتابعة.',
   },
   validation: {
     emailAddress: 'يرجى إدخال عنوان بريد إلكتروني صحيح.',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -377,6 +377,7 @@ export const azTranslations: DefaultTranslationsObject = {
     filterWhere: '{{label}} filtrlə',
     globals: 'Qloballar',
     goBack: 'Geri qayıt',
+    gotIt: 'Başa düşdüm',
     groupByLabel: '{{label}} ilə qruplaşdırın',
     hideSidebar: 'Yan paneli gizlət',
     import: 'İdxal',
@@ -605,6 +606,15 @@ export const azTranslations: DefaultTranslationsObject = {
     sizes: 'Ölçülər',
     sizesFor: '{{label}} üçün ölçülər',
     width: 'En',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Sənədi saxlamaq mümkün olmadı',
+    documentLimitReached:
+      'Sənəd limitinizə çatmısınız. Yeni sənəd yaratmağa davam etmək üçün mövcud sənədlərdən bəzilərini silin.',
+    reviewCollection: '{{label}}-i nəzərdən keçirin',
+    unableToCreateDocument: 'Sənəd yaratmaq mümkün deyil. Saxlanma limiti aşılmışdır.',
+    unableToSaveDocumentTooLarge: 'Sənədi saxlamaq mümkün deyil, mətn çox böyükdür',
+    unableToUpload: 'Yükləmə mümkün deyil. Davam etmək üçün boş yer azad edin.',
   },
   validation: {
     emailAddress: 'Xahiş edirik doğru elektron poçt ünvanını daxil edin.',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -373,6 +373,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     filterWhere: 'Филтрирай {{label}} където',
     globals: 'Глобални',
     goBack: 'Върни се',
+    gotIt: 'Разбрах.',
     groupByLabel: 'Групирай по {{label}}',
     hideSidebar: 'Скрийте страничната лента',
     import: 'Внос',
@@ -599,6 +600,15 @@ export const bgTranslations: DefaultTranslationsObject = {
     sizes: 'Големини',
     sizesFor: 'Размери за {{label}}',
     width: 'Ширина',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Неуспешно запазване на документа',
+    documentLimitReached:
+      'Достигнахте лимита на вашите документи. Изтрийте някои съществуващи документи, за да продължите да създавате.',
+    reviewCollection: 'Прегледайте {{label}}',
+    unableToCreateDocument: 'Неуспешно създаване на документ. Достигнат е лимитът за съхранение.',
+    unableToSaveDocumentTooLarge: 'Неуспешно запазване на документа, текстът е твърде голям.',
+    unableToUpload: 'Неуспешно качване. Освободете място, за да продължите.',
   },
   validation: {
     emailAddress: 'Моля, въведи валиден имейл адрес.',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -379,6 +379,7 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     filterWhere: '{{label}} যেখানে ফিল্টার করুন',
     globals: 'গ্লোবালগুলি',
     goBack: 'পিছনে যান',
+    gotIt: 'বুঝেছি',
     groupByLabel: '{{label}} অনুযায়ী গ্রুপ করুন',
     hideSidebar: 'সাইডবার লুকান',
     import: 'ইম্পোর্ট করুন',
@@ -607,6 +608,15 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     sizes: 'আকারগুলি',
     sizesFor: '{{label}} এর জন্য আকারগুলি',
     width: 'প্রস্থ',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'ডকুমেন্ট সংরক্ষণ করা যায়নি',
+    documentLimitReached:
+      'আপনার document সীমায় পৌঁছেছেন। তৈরি করতে থাকলে কিছু বিদ্যমান document মুছে ফেলুন।',
+    reviewCollection: '{{label}} পর্যালোচনা করুন',
+    unableToCreateDocument: 'ডকুমেন্ট তৈরি করা যাচ্ছে না। সংরক্ষণ সীমা অতিক্রম করা হয়েছে।',
+    unableToSaveDocumentTooLarge: 'নথিটি সংরক্ষণ করা সম্ভব নয়, কারণ পাঠ্যটি অত্যন্ত বৃহৎ।',
+    unableToUpload: 'আপলোড করা যাচ্ছে না। চালিয়ে যেতে স্থান খালি করুন।',
   },
   validation: {
     emailAddress: 'একটি বৈধ ইমেইল ঠিকানা লিখুন।',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -378,6 +378,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
     filterWhere: '{{label}} যেখানে ফিল্টার করুন',
     globals: 'গ্লোবালগুলি',
     goBack: 'পিছনে যান',
+    gotIt: 'বুঝেছি',
     groupByLabel: '{{label}} দ্বারা গ্রুপ করুন',
     hideSidebar: 'সাইডবার লুকান',
     import: 'ইম্পোর্ট করুন',
@@ -606,6 +607,15 @@ export const bnInTranslations: DefaultTranslationsObject = {
     sizes: 'আকারগুলি',
     sizesFor: '{{label}} এর জন্য আকারগুলি',
     width: 'প্রস্থ',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'নথি সংরক্ষণ করা যায়নি',
+    documentLimitReached:
+      'আপনি আপনার document সীমা পৌঁছে গেছেন। নতুন তৈরি করতে হলে কিছু বিদ্যমান document মুছে দিন।',
+    reviewCollection: '{{label}} পর্যালোচনা করুন',
+    unableToCreateDocument: 'ডকুমেন্ট তৈরি করা সম্ভব নয়। সংরক্ষণ সীমা অতিক্রান্ত হয়েছে।',
+    unableToSaveDocumentTooLarge: 'নথিটি সংরক্ষণ করা সম্ভব নয়, কারণ পাঠ্যটি অত্যন্ত বড়',
+    unableToUpload: 'আপলোড করতে অসমর্থ। চালিয়ে যেতে হলে স্থান খালি করুন।',
   },
   validation: {
     emailAddress: 'একটি বৈধ ইমেইল ঠিকানা লিখুন।',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -376,6 +376,7 @@ export const caTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtra {{label}} on',
     globals: 'Globals',
     goBack: 'Torna enrere',
+    gotIt: 'Entès',
     groupByLabel: 'Agrupa per {{label}}',
     hideSidebar: 'Amaga la barra lateral',
     import: 'Importar',
@@ -603,6 +604,15 @@ export const caTranslations: DefaultTranslationsObject = {
     sizes: 'Mides',
     sizesFor: 'Mides per a {{label}}',
     width: 'Amplada',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'No s’ha pogut desar el document',
+    documentLimitReached:
+      'Heu assolit el límit de documents. Suprimiu alguns documents existents per poder continuar creant-ne.',
+    reviewCollection: 'Revisió {{label}}',
+    unableToCreateDocument: "No es pot crear el document. S'ha assolit el límit d'emmagatzematge.",
+    unableToSaveDocumentTooLarge: 'No es pot desar el document, el text és massa gran',
+    unableToUpload: 'No es pot carregar. Allibereu espai per continuar.',
   },
   validation: {
     emailAddress: 'Si us plau, introdueix una adreça de correu electrònic vàlida.',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -369,6 +369,7 @@ export const csTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrovat {{label}} kde',
     globals: 'Globální',
     goBack: 'Vrátit se',
+    gotIt: 'Rozumím',
     groupByLabel: 'Seskupit podle {{label}}',
     hideSidebar: 'Skrýt postranní panel',
     import: 'Import',
@@ -595,6 +596,15 @@ export const csTranslations: DefaultTranslationsObject = {
     sizes: 'Velikosti',
     sizesFor: 'Velikosti pro {{label}}',
     width: 'Šířka',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Dokument se nepodařilo uložit',
+    documentLimitReached:
+      'Dosáhli jste limitu dokumentů. Pro pokračování ve vytváření smažte některé stávající dokumenty.',
+    reviewCollection: 'Zkontrolujte {{label}}',
+    unableToCreateDocument: 'Nelze vytvořit dokument. Byla dosažena kapacita úložiště.',
+    unableToSaveDocumentTooLarge: 'Nelze uložit dokument, text je příliš rozsáhlý.',
+    unableToUpload: 'Nelze nahrát. Uvolněte místo pro pokračování.',
   },
   validation: {
     emailAddress: 'Zadejte prosím platnou e-mailovou adresu.',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -372,6 +372,7 @@ export const daTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filter {{label}} hvor',
     globals: 'Globale',
     goBack: 'Gå tilbage',
+    gotIt: 'Forstået',
     groupByLabel: 'Gruppér efter {{label}}',
     hideSidebar: 'Skjul sidepanel',
     import: 'Import',
@@ -599,6 +600,15 @@ export const daTranslations: DefaultTranslationsObject = {
     sizes: 'Størrelse',
     sizesFor: 'Størrelse for {{label}}',
     width: 'Bredde',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Kunne ikke gemme dokument',
+    documentLimitReached:
+      'Du har nået din dokumentgrænse. Slet nogle eksisterende dokumenter for at fortsætte med at oprette nye.',
+    reviewCollection: 'Gennemse {{label}}',
+    unableToCreateDocument: 'Kan ikke oprette dokument. Lagergrænsen er nået.',
+    unableToSaveDocumentTooLarge: 'Kan ikke gemme dokument, teksten er for stor',
+    unableToUpload: 'Kan ikke uploade. Frigør plads for at fortsætte.',
   },
   validation: {
     emailAddress: 'Indtast venligst en gyldig e-mailadresse.',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -384,6 +384,7 @@ export const deTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filter {{label}}, wo',
     globals: 'Globale Dokumente',
     goBack: 'Zurück',
+    gotIt: 'Verstanden',
     groupByLabel: 'Nach {{label}} gruppieren',
     hideSidebar: 'Seitenleiste ausblenden',
     import: 'Importieren',
@@ -612,6 +613,16 @@ export const deTranslations: DefaultTranslationsObject = {
     sizes: 'Bildgrößen',
     sizesFor: 'Bildgrößen für {{label}}',
     width: 'Breite',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Dokument konnte nicht gespeichert werden',
+    documentLimitReached:
+      'Sie haben Ihr Dokumentenlimit erreicht. Löschen Sie einige bestehende Dokumente, um weiterhin erstellen zu können.',
+    reviewCollection: '{{label}} überprüfen',
+    unableToCreateDocument: 'Dokument kann nicht erstellt werden. Speicherlimit erreicht.',
+    unableToSaveDocumentTooLarge:
+      'Dokument kann nicht gespeichert werden, der Text ist zu umfangreich.',
+    unableToUpload: 'Hochladen nicht möglich. Schaffen Sie Speicherplatz, um fortzufahren.',
   },
   validation: {
     emailAddress: 'Bitte gib eine korrekte E-Mail-Adresse an.',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -374,6 +374,7 @@ export const enTranslations = {
     filterWhere: 'Filter {{label}} where',
     globals: 'Globals',
     goBack: 'Go back',
+    gotIt: 'Got it',
     groupByLabel: 'Group by {{label}}',
     hideSidebar: 'Hide sidebar',
     import: 'Import',
@@ -599,6 +600,15 @@ export const enTranslations = {
     sizes: 'Sizes',
     sizesFor: 'Sizes for {{label}}',
     width: 'Width',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Couldn’t save document',
+    documentLimitReached:
+      'You have reached your document limit. Delete some existing documents in order to keep creating.',
+    reviewCollection: 'Review {{label}}',
+    unableToCreateDocument: 'Unable to create document. Storage limit reached.',
+    unableToSaveDocumentTooLarge: 'Unable to save document, text is too large',
+    unableToUpload: 'Unable to upload. Free up space to continue.',
   },
   validation: {
     emailAddress: 'Please enter a valid email address.',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -379,6 +379,7 @@ export const esTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrar {{label}} donde',
     globals: 'Globales',
     goBack: 'Volver',
+    gotIt: 'Entendido',
     groupByLabel: 'Agrupar por {{label}}',
     hideSidebar: 'Ocultar barra lateral',
     import: 'Importar',
@@ -606,6 +607,16 @@ export const esTranslations: DefaultTranslationsObject = {
     sizes: 'Tamaños',
     sizesFor: 'Tamaños para {{label}}',
     width: 'Ancho',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'No se pudo guardar el documento.',
+    documentLimitReached:
+      'Ha alcanzado el límite de documentos. Elimine algunos documentos existentes para poder seguir creando.',
+    reviewCollection: 'Revisar {{label}}',
+    unableToCreateDocument:
+      'No es posible crear el documento. Se ha alcanzado el límite de almacenamiento.',
+    unableToSaveDocumentTooLarge: 'No se puede guardar el documento, el texto es demasiado extenso',
+    unableToUpload: 'No se puede cargar. Libere espacio para continuar.',
   },
   validation: {
     emailAddress: 'Por favor, introduce un correo electrónico válido.',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -371,6 +371,7 @@ export const etTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtreeri {{label}} kus',
     globals: 'Globaalsed',
     goBack: 'Mine tagasi',
+    gotIt: 'Sain aru',
     groupByLabel: 'Rühmita {{label}} järgi',
     hideSidebar: 'Peida külgriba',
     import: 'Importimine',
@@ -594,6 +595,15 @@ export const etTranslations: DefaultTranslationsObject = {
     sizes: 'Suurused',
     sizesFor: 'Suurused {{label}} jaoks',
     width: 'Laius',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Dokumenti salvestamine ebaõnnestus',
+    documentLimitReached:
+      'Olete jõudnud oma dokumentide piirini. Uute dokumentide loomiseks kustutage osa olemasolevatest dokumentidest.',
+    reviewCollection: 'Vaadake üle {{label}}',
+    unableToCreateDocument: 'Dokumendi loomine ebaõnnestus. Salvestusmahu limiit on saavutatud.',
+    unableToSaveDocumentTooLarge: 'Dokumendi salvestamine ebaõnnestus, tekst on liiga mahukas',
+    unableToUpload: 'Üleslaadimine ebaõnnestus. Jätkamiseks vabastage ruumi.',
   },
   validation: {
     emailAddress: 'Palun sisesta kehtiv e-posti aadress.',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -366,6 +366,7 @@ export const faTranslations: DefaultTranslationsObject = {
     filterWhere: 'فیلتر کردن {{label}} بر اساس',
     globals: 'سراسری‌ها (Globals)',
     goBack: 'بازگشت',
+    gotIt: 'دریافت شد',
     groupByLabel: 'گروه‌بندی بر اساس {{label}}',
     hideSidebar: 'پنهان کردن نوار کناری',
     import: 'ورود اطلاعات',
@@ -590,6 +591,16 @@ export const faTranslations: DefaultTranslationsObject = {
     sizes: 'اندازه‌ها',
     sizesFor: 'اندازه‌ها برای {{label}}',
     width: 'عرض',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'ذخیره سند امکان‌پذیر نبود.',
+    documentLimitReached:
+      'شما به حد مجاز اسناد خود رسیده‌اید. برای ادامه ایجاد اسناد جدید، برخی از اسناد موجود را حذف کنید.',
+    reviewCollection: 'بازبینی {{label}}',
+    unableToCreateDocument:
+      'امکان ایجاد سند وجود ندارد. محدودیت فضای ذخیره‌سازی به پایان رسیده است.',
+    unableToSaveDocumentTooLarge: 'امکان ذخیره سند وجود ندارد، متن بیش از حد بزرگ است.',
+    unableToUpload: 'امکان بارگذاری وجود ندارد. برای ادامه، فضا را آزاد کنید.',
   },
   validation: {
     emailAddress: 'لطفاً یک آدرس ایمیل معتبر وارد کنید.',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -384,6 +384,7 @@ export const frTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrer {{label}} où',
     globals: 'Globals(es)',
     goBack: 'Retourner',
+    gotIt: 'Compris',
     groupByLabel: 'Regrouper par {{label}}',
     hideSidebar: 'Masquer la barre latérale',
     import: 'Importation',
@@ -612,6 +613,16 @@ export const frTranslations: DefaultTranslationsObject = {
     sizes: 'Tailles',
     sizesFor: 'Tailles pour {{label}}',
     width: 'Largeur',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Impossible d’enregistrer le document',
+    documentLimitReached:
+      'Vous avez atteint la limite de vos documents. Supprimez certains documents existants afin de pouvoir continuer à en créer.',
+    reviewCollection: 'Revoir {{label}}',
+    unableToCreateDocument: 'Impossible de créer le document. Limite de stockage atteinte.',
+    unableToSaveDocumentTooLarge:
+      'Impossible d’enregistrer le document, le texte est trop volumineux',
+    unableToUpload: 'Impossible de téléverser. Libérez de l’espace pour continuer.',
   },
   validation: {
     emailAddress: 'S’il vous plaît, veuillez entrer une adresse e-mail valide.',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -361,6 +361,7 @@ export const heTranslations: DefaultTranslationsObject = {
     filterWhere: 'סנן {{label}} בהם',
     globals: 'גלובלים',
     goBack: 'חזור',
+    gotIt: 'הובן',
     groupByLabel: 'קבץ לפי {{label}}',
     hideSidebar: 'הסתר סרגל צד',
     import: 'יבוא',
@@ -581,6 +582,14 @@ export const heTranslations: DefaultTranslationsObject = {
     sizes: 'גדלים',
     sizesFor: 'גדלים עבור {{label}}',
     width: 'רוחב',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'לא ניתן היה לשמור את המסמך',
+    documentLimitReached: 'הגעת למגבלת המסמכים שלך. מחק מסמכים קיימים כדי להמשיך ליצור.',
+    reviewCollection: 'סקור את {{label}}',
+    unableToCreateDocument: 'לא ניתן ליצור מסמך. הגעת למגבלת האחסון.',
+    unableToSaveDocumentTooLarge: 'לא ניתן לשמור את המסמך, הטקסט גדול מדי',
+    unableToUpload: 'לא ניתן להעלות. יש לפנות שטח אחסון כדי להמשיך.',
   },
   validation: {
     emailAddress: 'נא להזין כתובת דוא"ל תקנית.',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -372,6 +372,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filter {{label}} gdje',
     globals: 'Globali',
     goBack: 'Vrati se',
+    gotIt: 'Razumio sam',
     groupByLabel: 'Grupiraj po {{label}}',
     hideSidebar: 'Sakrij bočnu traku',
     import: 'Uvoz',
@@ -598,6 +599,15 @@ export const hrTranslations: DefaultTranslationsObject = {
     sizes: 'Veličine',
     sizesFor: 'Veličine za {{label}}',
     width: 'Širina',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Nije bilo moguće spremiti dokument',
+    documentLimitReached:
+      'Dostigli ste ograničenje broja dokumenata. Izbrišite neke postojeće dokumente kako biste mogli nastaviti s kreiranjem.',
+    reviewCollection: 'Pregledajte {{label}}',
+    unableToCreateDocument: 'Nije moguće stvoriti dokument. Dosegnuto je ograničenje pohrane.',
+    unableToSaveDocumentTooLarge: 'Nije moguće spremiti dokument, tekst je prevelik',
+    unableToUpload: 'Nije moguće prenijeti. Oslobodite prostor za nastavak.',
   },
   validation: {
     emailAddress: 'Molimo unesite valjanu e-mail adresu.',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -379,6 +379,7 @@ export const huTranslations: DefaultTranslationsObject = {
     filterWhere: 'Szűrő {{label}} ahol',
     globals: 'Globálisok',
     goBack: 'Vissza',
+    gotIt: 'Értettem',
     groupByLabel: 'Csoportosítás {{label}} szerint',
     hideSidebar: 'Oldalsáv elrejtése',
     import: 'Behozatal',
@@ -605,6 +606,15 @@ export const huTranslations: DefaultTranslationsObject = {
     sizes: 'Méretek',
     sizesFor: 'Méretek a {{címke}} számára',
     width: 'Szélesség',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'A dokumentum mentése nem sikerült.',
+    documentLimitReached:
+      'Elérte a dokumentumlimitjét. Töröljön néhány meglévő dokumentumot, hogy folytathassa az új dokumentumok létrehozását.',
+    reviewCollection: 'Felülvizsgálat {{label}}',
+    unableToCreateDocument: 'Nem sikerült létrehozni a dokumentumot. A tárhelykorlát elérve.',
+    unableToSaveDocumentTooLarge: 'Nem sikerült elmenteni a dokumentumot, a szöveg túl hosszú.',
+    unableToUpload: 'Nem sikerült feltölteni. Szabadítson fel tárhelyet a folytatáshoz.',
   },
   validation: {
     emailAddress: 'Kérjük, adjon meg egy érvényes e-mail címet.',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -374,6 +374,7 @@ export const hyTranslations: DefaultTranslationsObject = {
     filterWhere: 'Ֆիլտրել {{label}}-ը, որտեղ',
     globals: 'Համընդհանուրներ',
     goBack: 'Հետ գնալ',
+    gotIt: 'Հասկացա',
     groupByLabel: 'Խմբավորել {{label}}-ով',
     hideSidebar: 'Թաքցնել կողային վահանակը',
     import: 'Ներմուծում',
@@ -603,6 +604,15 @@ export const hyTranslations: DefaultTranslationsObject = {
     sizes: 'Չափեր',
     sizesFor: 'Չափեր {{label}}-ի համար',
     width: 'Լայնություն',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Չհաջողվեց պահպանել փաստաթուղթը',
+    documentLimitReached:
+      'Դուք հասել եք ձեր փաստաթղթերի սահմանաչափին։ Խնդրում ենք ջնջել որոշ առկա փաստաթղթեր, որպեսզի շարունակեք ստեղծել նորեր։',
+    reviewCollection: 'Վերանայել {{label}}',
+    unableToCreateDocument: 'Անհնար է ստեղծել փաստաթուղթ։ Պահպանման սահմանաչափը ժամկետանց է։',
+    unableToSaveDocumentTooLarge: 'Հնարավոր չէ պահպանել փաստաթուղթը, տեքստը չափազանց ծավալուն է։',
+    unableToUpload: 'Հնարավոր չէ վերբեռնել։ Շարունակելու համար ազատեք տեղը։',
   },
   validation: {
     emailAddress: 'Խնդրում ենք մուտքագրել վավեր էլ. փոստի հասցե։',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -375,6 +375,7 @@ export const idTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filter {{label}} di mana',
     globals: 'Global',
     goBack: 'Kembali',
+    gotIt: 'Dimengerti',
     groupByLabel: 'Kelompokkan berdasarkan {{label}}',
     hideSidebar: 'Sembunyikan bilah samping',
     import: 'Impor',
@@ -603,6 +604,15 @@ export const idTranslations: DefaultTranslationsObject = {
     sizes: 'Ukuran',
     sizesFor: 'Ukuran untuk {{label}}',
     width: 'Lebar',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Tidak dapat menyimpan dokumen',
+    documentLimitReached:
+      'Anda telah mencapai batas dokumen Anda. Hapus beberapa dokumen yang ada untuk dapat terus membuat dokumen baru.',
+    reviewCollection: 'Tinjau {{label}}',
+    unableToCreateDocument: 'Tidak dapat membuat dokumen. Batas penyimpanan telah tercapai.',
+    unableToSaveDocumentTooLarge: 'Tidak dapat menyimpan dokumen, teks terlalu besar',
+    unableToUpload: 'Tidak dapat mengunggah. Kosongkan ruang untuk melanjutkan.',
   },
   validation: {
     emailAddress: 'Harap masukkan alamat email yang valid.',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -371,6 +371,7 @@ export const isTranslations: DefaultTranslationsObject = {
     filterWhere: 'Sía {{label}} þar sem',
     globals: 'Einstakir hlutir',
     goBack: 'Til baka',
+    gotIt: 'Fannst',
     groupByLabel: 'Flokka eftir {{label}}',
     hideSidebar: 'Felaðu hliðarstiku',
     import: 'Flytja inn',
@@ -597,6 +598,15 @@ export const isTranslations: DefaultTranslationsObject = {
     sizes: 'Stærðir',
     sizesFor: 'Stærðir fyrir {{label}}',
     width: 'Breidd',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Ekki tókst að vista skjalið',
+    documentLimitReached:
+      'Þú hefur náð hámarksfjölda skjala. Vinsamlegast eyttu einhverjum núverandi skjölum til að geta haldið áfram að búa til ný.',
+    reviewCollection: 'Yfirlit {{label}}',
+    unableToCreateDocument: 'Ekki hægt að búa til skjal. Geymslupláss er fullnýtt.',
+    unableToSaveDocumentTooLarge: 'Ekki hægt að vista skjal, textinn er of stór',
+    unableToUpload: 'Ekki tókst að hlaða upp. Hreinsið til að halda áfram.',
   },
   validation: {
     emailAddress: 'Vinsamlegast settu inn gilt netfang.',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -378,6 +378,7 @@ export const itTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtra {{label}} se',
     globals: 'Globali',
     goBack: 'Torna indietro',
+    gotIt: 'Ricevuto',
     groupByLabel: 'Raggruppa per {{label}}',
     hideSidebar: 'Nascondi barra laterale',
     import: 'Importare',
@@ -605,6 +606,15 @@ export const itTranslations: DefaultTranslationsObject = {
     sizes: 'Formati',
     sizesFor: 'Dimensioni per {{label}}',
     width: 'Larghezza',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Impossibile salvare il documento',
+    documentLimitReached:
+      'Hai raggiunto il limite di documenti. Elimina alcuni documenti esistenti per continuare a crearne di nuovi.',
+    reviewCollection: 'Revisiona {{label}}',
+    unableToCreateDocument: 'Impossibile creare il documento. Limite di archiviazione raggiunto.',
+    unableToSaveDocumentTooLarge: 'Impossibile salvare il documento, il testo è troppo grande',
+    unableToUpload: 'Impossibile caricare. Liberare spazio per continuare.',
   },
   validation: {
     emailAddress: 'Si prega di inserire un indirizzo email valido.',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -376,6 +376,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     filterWhere: '{{label}} の絞り込み',
     globals: 'グローバル',
     goBack: '戻る',
+    gotIt: '承知しました',
     groupByLabel: '{{label}}でグループ化する',
     hideSidebar: 'サイドバーを非表示にする',
     import: 'インポート',
@@ -599,6 +600,15 @@ export const jaTranslations: DefaultTranslationsObject = {
     sizes: '容量',
     sizesFor: '{{label}}のサイズ',
     width: '横幅',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'ドキュメントを保存できませんでした',
+    documentLimitReached:
+      'ドキュメントの上限に達しました。新たに作成を続けるには、既存のドキュメントを削除してください。',
+    reviewCollection: '{{label}}を確認',
+    unableToCreateDocument: 'ドキュメントを作成できません。ストレージ上限に達しました。',
+    unableToSaveDocumentTooLarge: 'ドキュメントを保存できません。テキストが大きすぎます。',
+    unableToUpload: 'アップロードできません。続行するには容量を空けてください。',
   },
   validation: {
     emailAddress: '有効なメールアドレスを入力してください。',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -371,6 +371,7 @@ export const koTranslations: DefaultTranslationsObject = {
     filterWhere: '{{label}} 필터링 조건',
     globals: '글로벌',
     goBack: '돌아가기',
+    gotIt: '알겠습니다.',
     groupByLabel: '{{label}}로 그룹화',
     hideSidebar: '사이드바 숨기기',
     import: '수입',
@@ -596,6 +597,15 @@ export const koTranslations: DefaultTranslationsObject = {
     sizes: '크기',
     sizesFor: '{{label}} 크기',
     width: '너비',
+  },
+  usageLimits: {
+    couldNotSaveDocument: '문서를 저장할 수 없습니다.',
+    documentLimitReached:
+      '문서 한도에 도달하셨습니다. 계속해서 생성하려면 기존 문서 일부를 삭제해 주시기 바랍니다.',
+    reviewCollection: '{{label}} 검토',
+    unableToCreateDocument: '문서를 생성할 수 없습니다. 저장 용량 한도에 도달했습니다.',
+    unableToSaveDocumentTooLarge: '문서를 저장할 수 없습니다. 텍스트가 너무 큽니다.',
+    unableToUpload: '업로드할 수 없습니다. 계속하려면 공간을 확보하십시오.',
   },
   validation: {
     emailAddress: '유효한 이메일 주소를 입력하세요.',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -377,6 +377,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtruoti {{label}}, kur',
     globals: 'Globalai',
     goBack: 'Grįžkite',
+    gotIt: 'Supratau',
     groupByLabel: 'Grupuoti pagal {{label}}',
     hideSidebar: 'Slėpti šoninę juostą',
     import: 'Importas',
@@ -601,6 +602,15 @@ export const ltTranslations: DefaultTranslationsObject = {
     sizes: 'Dydžiai',
     sizesFor: 'Dydžiai skirti {{label}}',
     width: 'Plotis',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Nepavyko išsaugoti dokumento',
+    documentLimitReached:
+      'Jūs pasiekėte savo dokumentų limitą. Ištrinkite kai kuriuos esamus dokumentus, kad galėtumėte toliau kurti.',
+    reviewCollection: 'Peržiūrėti {{label}}',
+    unableToCreateDocument: 'Nepavyko sukurti dokumento. Pasiekta saugojimo riba.',
+    unableToSaveDocumentTooLarge: 'Nepavyko išsaugoti dokumento, tekstas yra per didelis',
+    unableToUpload: 'Nepavyko įkelti. Atlaisvinkite vietos, kad galėtumėte tęsti.',
   },
   validation: {
     emailAddress: 'Įveskite galiojantį el. pašto adresą.',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -373,6 +373,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrēt {{label}} kur',
     globals: 'Globālie',
     goBack: 'Doties atpakaļ',
+    gotIt: 'Sapratu',
     groupByLabel: 'Grupēt pēc {{label}}',
     hideSidebar: 'Paslēpt sānjoslu',
     import: 'Imports',
@@ -598,6 +599,15 @@ export const lvTranslations: DefaultTranslationsObject = {
     sizes: 'Izmēri',
     sizesFor: 'Izmēri priekš {{label}}',
     width: 'Platums',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Neizdevās saglabāt dokumentu',
+    documentLimitReached:
+      'Jūs esat sasniedzis savu dokumentu limitu. Dzēsiet dažus esošos dokumentus, lai varētu turpināt veidot jaunus.',
+    reviewCollection: 'Pārskatīt {{label}}',
+    unableToCreateDocument: 'Neizdevās izveidot dokumentu. Ir sasniegts krātuves limits.',
+    unableToSaveDocumentTooLarge: 'Neizdevās saglabāt dokumentu, teksts ir pārāk liels',
+    unableToUpload: 'Nevar augšupielādēt. Atbrīvojiet vietu, lai turpinātu.',
   },
   validation: {
     emailAddress: 'Lūdzu, ievadiet derīgu e-pasta adresi.',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -378,6 +378,7 @@ export const myTranslations: DefaultTranslationsObject = {
     filterWhere: 'နေရာတွင် စစ်ထုတ်ပါ။',
     globals: 'Globals',
     goBack: 'နောက်သို့',
+    gotIt: 'နားလည်ပါသည်',
     groupByLabel: '{{label}} ဖြင့် အုပ်စုဖွဲ့ပါ',
     hideSidebar: 'ဘေး栏ကိုလှမ်းဖွင့်ပါ',
     import: 'သွင်းကုန်',
@@ -607,6 +608,16 @@ export const myTranslations: DefaultTranslationsObject = {
     sizes: 'အရွယ်အစားများ',
     sizesFor: '{{label}} အတွက် အရွယ်အစားများ',
     width: 'အကျယ်',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'စာရွက်ကို သိမ်းပိုက်၍ မရနိုင်ပါ။',
+    documentLimitReached:
+      'သင်သည် သင်၏ Document ကန့်သတ်ချက်ကို လွန်ခဲ့ပြီ။ ဆက်လက် ပြုလုပ်လိုပါက ရှိပြီးသား Document များကို ဖျက်ပစ်ရန် လိုအပ်ပါသည်။',
+    reviewCollection: 'ပြန်လည်သုံးသပ်ရန် {{label}}',
+    unableToCreateDocument: 'စာရွက်စာတမ်း မဖန်တီးနိုင်ပါ။ သိမ်းဆည်းမှုပမာဏ အလွန်တားနေသည်။',
+    unableToSaveDocumentTooLarge:
+      'စာရွက်ကို သိမ်းဆည်း၍မရပါ၊ စာသားအရွယ်အစားသည် အလွန်ကြီးပြင်းနေပါသည်။',
+    unableToUpload: 'တင်သွင်း၍မရနိုင်ပါ။ ဆက်လက်လုပ်ဆောင်ရန် အခန်းဝင်နေရာအားလပ်အောင်ပြုလုပ်ပါ။',
   },
   validation: {
     emailAddress: 'မှန်ကန်သော အီးမေးလ်လိပ်စာကို ထည့်သွင်းပါ။',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -375,6 +375,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrer {{label}} der',
     globals: 'Globalt innhold',
     goBack: 'Gå tilbake',
+    gotIt: 'Forstått',
     groupByLabel: 'Grupper etter {{label}}',
     hideSidebar: 'Skjul sidepanel',
     import: 'Import',
@@ -602,6 +603,15 @@ export const nbTranslations: DefaultTranslationsObject = {
     sizes: 'Størrelser',
     sizesFor: 'Størrelser for {{label}}',
     width: 'Bredde',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Kunne ikke lagre dokument',
+    documentLimitReached:
+      'Du har nådd dokumentgrensen din. Slett noen eksisterende dokumenter for å fortsette å opprette nye.',
+    reviewCollection: 'Gjennomgå {{label}}',
+    unableToCreateDocument: 'Kan ikke opprette dokument. Lagringsgrense nådd.',
+    unableToSaveDocumentTooLarge: 'Kan ikke lagre dokumentet, teksten er for stor',
+    unableToUpload: 'Kan ikke laste opp. Frigjør plass for å fortsette.',
   },
   validation: {
     emailAddress: 'Vennligst skriv inn en gyldig e-postadresse.',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -380,6 +380,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filter {{label}} waar',
     globals: 'Globalen',
     goBack: 'Ga terug',
+    gotIt: 'Begrepen',
     groupByLabel: 'Groepeer op {{label}}',
     hideSidebar: 'Zijbalk verbergen',
     import: 'Importeren',
@@ -607,6 +608,15 @@ export const nlTranslations: DefaultTranslationsObject = {
     sizes: 'Groottes',
     sizesFor: 'Maten voor {{label}}',
     width: 'Breedte',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Kon het document niet opslaan',
+    documentLimitReached:
+      'U heeft uw documentlimiet bereikt. Verwijder enkele bestaande documenten om door te kunnen gaan met het aanmaken.',
+    reviewCollection: 'Beoordeel {{label}}',
+    unableToCreateDocument: 'Kan geen document aanmaken. Opslaglimiet bereikt.',
+    unableToSaveDocumentTooLarge: 'Kan het document niet opslaan, de tekst is te groot',
+    unableToUpload: 'Kan niet uploaden. Maak ruimte vrij om door te gaan.',
   },
   validation: {
     emailAddress: 'Voer een geldig e-mailadres in.',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -373,6 +373,7 @@ export const plTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtruj gdzie',
     globals: 'Globalne',
     goBack: 'Wróć',
+    gotIt: 'Zrozumiano',
     groupByLabel: 'Grupuj według {{label}}',
     hideSidebar: 'Ukryj panel boczny',
     import: 'Import',
@@ -598,6 +599,16 @@ export const plTranslations: DefaultTranslationsObject = {
     sizes: 'Rozmiary',
     sizesFor: 'Rozmiary dla {{label}}',
     width: 'Szerokość',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Nie można zapisać dokumentu',
+    documentLimitReached:
+      'Osiągnięto limit dokumentów. Proszę usunąć niektóre istniejące dokumenty, aby móc kontynuować tworzenie.',
+    reviewCollection: 'Przejrzyj {{label}}',
+    unableToCreateDocument:
+      'Nie można utworzyć dokumentu. Osiągnięto limit przestrzeni magazynowej.',
+    unableToSaveDocumentTooLarge: 'Nie można zapisać dokumentu, tekst jest zbyt obszerny.',
+    unableToUpload: 'Nie można przesłać. Zwolnij miejsce, aby kontynuować.',
   },
   validation: {
     emailAddress: 'Wprowadź poprawny adres email.',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -375,6 +375,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrar {{label}} em que',
     globals: 'Globais',
     goBack: 'Voltar',
+    gotIt: 'Entendido',
     groupByLabel: 'Agrupar por {{label}}',
     hideSidebar: 'Ocultar barra lateral',
     import: 'Importar',
@@ -602,6 +603,15 @@ export const ptTranslations: DefaultTranslationsObject = {
     sizes: 'Tamanhos',
     sizesFor: 'Tamanhos para {{label}}',
     width: 'Largura',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Não foi possível salvar o documento',
+    documentLimitReached:
+      'Você atingiu o limite de documentos. Exclua alguns documentos existentes para continuar criando.',
+    reviewCollection: 'Revisar {{label}}',
+    unableToCreateDocument: 'Não foi possível criar o documento. Limite de armazenamento atingido.',
+    unableToSaveDocumentTooLarge: 'Não foi possível salvar o documento, o texto é muito extenso',
+    unableToUpload: 'Não foi possível fazer o upload. Libere espaço para continuar.',
   },
   validation: {
     emailAddress: 'Por favor, insira um endereço de email válido.',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -379,6 +379,7 @@ export const roTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrează {{label}} unde',
     globals: 'Globale',
     goBack: 'Înapoi',
+    gotIt: 'Am înțeles',
     groupByLabel: 'Grupare după {{label}}',
     hideSidebar: 'Ascunde bara laterală',
     import: 'Import',
@@ -605,6 +606,15 @@ export const roTranslations: DefaultTranslationsObject = {
     sizes: 'Dimensiuni',
     sizesFor: 'Mărimi pentru {{label}}',
     width: 'Lățime',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Nu s-a putut salva documentul',
+    documentLimitReached:
+      'Ați atins limita de documente. Ștergeți unele documente existente pentru a putea continua crearea.',
+    reviewCollection: 'Revizuire {{label}}',
+    unableToCreateDocument: 'Nu se poate crea documentul. Limita de stocare a fost atinsă.',
+    unableToSaveDocumentTooLarge: 'Nu se poate salva documentul, textul este prea lung.',
+    unableToUpload: 'Nu se poate încărca. Eliberați spațiu pentru a continua.',
   },
   validation: {
     emailAddress: 'Vă rugăm să introduceți o adresă de email validă.',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -373,6 +373,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     filterWhere: 'Филтер {{label}} где',
     globals: 'Глобали',
     goBack: 'Врати се',
+    gotIt: 'Razumem',
     groupByLabel: 'Grupiši po {{label}}',
     hideSidebar: 'Sakrij bočnu traku',
     import: 'Uvoz',
@@ -598,6 +599,16 @@ export const rsTranslations: DefaultTranslationsObject = {
     sizes: 'Величине',
     sizesFor: 'Величине за {{label}}',
     width: 'Ширина',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Nije moguće sačuvati dokument',
+    documentLimitReached:
+      'Dostigli ste svoj limit dokumenata. Obrišite neke postojeće dokumente kako biste mogli nastaviti sa kreiranjem.',
+    reviewCollection: 'Pregledajte {{label}}',
+    unableToCreateDocument:
+      'Nije moguće kreirati dokument. Dostignut je ograničenje za skladištenje.',
+    unableToSaveDocumentTooLarge: 'Nije moguće sačuvati dokument, tekst je prevelik',
+    unableToUpload: 'Nije moguće otpremiti. Oslobodite prostor kako biste nastavili.',
   },
   validation: {
     emailAddress: 'Молимо Вас унесите валидну емаил адресу.',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -373,6 +373,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filter {{label}} gde',
     globals: 'Globali',
     goBack: 'Vrati se',
+    gotIt: 'Razumem',
     groupByLabel: 'Grupiši po {{label}}',
     hideSidebar: 'Sakrij bočnu traku',
     import: 'Uvoz',
@@ -599,6 +600,15 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     sizes: 'Veličine',
     sizesFor: 'Veličine za {{label}}',
     width: 'Širina',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Nije bilo moguće sačuvati dokument',
+    documentLimitReached:
+      'Dostigli ste ograničenje za broj dokumenata. Obrišite postojeće dokumente kako biste mogli nastaviti sa kreiranjem.',
+    reviewCollection: 'Pregledajte {{label}}',
+    unableToCreateDocument: 'Nije moguće kreirati dokument. Dostignut je limit skladišta.',
+    unableToSaveDocumentTooLarge: 'Nije moguće sačuvati dokument, tekst je prevelik',
+    unableToUpload: 'Nije moguće otpremiti. Oslobodite prostor da biste nastavili.',
   },
   validation: {
     emailAddress: 'Molimo Vas unesite validnu email adresu.',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -377,6 +377,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     filterWhere: 'Где фильтровать',
     globals: 'Глобальные',
     goBack: 'Назад',
+    gotIt: 'Понял',
     groupByLabel: 'Группировать по {{label}}',
     hideSidebar: 'Скрыть боковую панель',
     import: 'Импорт',
@@ -604,6 +605,15 @@ export const ruTranslations: DefaultTranslationsObject = {
     sizes: 'Размеры',
     sizesFor: 'Размеры для {{label}}',
     width: 'Ширина',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Не удалось сохранить документ',
+    documentLimitReached:
+      'Вы достигли лимита документов. Удалите некоторые существующие документы, чтобы продолжить создание.',
+    reviewCollection: 'Просмотреть {{label}}',
+    unableToCreateDocument: 'Невозможно создать документ. Превышен лимит хранилища.',
+    unableToSaveDocumentTooLarge: 'Не удалось сохранить документ, текст слишком большой',
+    unableToUpload: 'Не удалось загрузить. Освободите место для продолжения.',
   },
   validation: {
     emailAddress: 'Пожалуйста, введите корректный адрес email.',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -373,6 +373,7 @@ export const skTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrovat kde je {{label}}',
     globals: 'Globalné',
     goBack: 'Vrátiť sa',
+    gotIt: 'Rozumiem',
     groupByLabel: 'Zoskupiť podľa {{label}}',
     hideSidebar: 'Skryť bočný panel',
     import: 'Dovoz',
@@ -596,6 +597,15 @@ export const skTranslations: DefaultTranslationsObject = {
     sizes: 'Veľkosti',
     sizesFor: 'Veľkosti pre {{label}}',
     width: 'Šírka',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Dokument sa nepodarilo uložiť',
+    documentLimitReached:
+      'Dosiahli ste svoj limit dokumentov. Odstráňte niektoré existujúce dokumenty, aby ste mohli pokračovať v tvorbe.',
+    reviewCollection: 'Skontrolovať {{label}}',
+    unableToCreateDocument: 'Nie je možné vytvoriť dokument. Bol dosiahnutý limit úložiska.',
+    unableToSaveDocumentTooLarge: 'Dokument nie je možné uložiť, text je príliš rozsiahly',
+    unableToUpload: 'Nie je možné nahrať. Uvoľnite miesto, aby ste mohli pokračovať.',
   },
   validation: {
     emailAddress: 'Zadajte prosím platnú e-mailovú adresu.',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -371,6 +371,7 @@ export const slTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtriraj {{label}} kjer',
     globals: 'Globalne nastavitve',
     goBack: 'Nazaj',
+    gotIt: 'Razumem',
     groupByLabel: 'Razvrsti po {{label}}',
     hideSidebar: 'Skrij stransko vrstico',
     import: 'Uvoz',
@@ -597,6 +598,15 @@ export const slTranslations: DefaultTranslationsObject = {
     sizes: 'Velikosti',
     sizesFor: 'Velikosti za {{label}}',
     width: 'Širina',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Ni bilo mogoče shraniti dokumenta',
+    documentLimitReached:
+      'Dosegli ste svojo omejitev dokumentov. Izbrišite nekaj obstoječih dokumentov, da boste lahko nadaljevali z ustvarjanjem.',
+    reviewCollection: 'Preglejte {{label}}',
+    unableToCreateDocument: 'Ni mogoče ustvariti dokumenta. Dosežena je omejitev shranjevanja.',
+    unableToSaveDocumentTooLarge: 'Shranjevanje dokumenta ni mogoče, besedilo je preobsežno.',
+    unableToUpload: 'Nalaganje ni mogoče. Sprostite prostor za nadaljevanje.',
   },
   validation: {
     emailAddress: 'Vnesite veljaven e-poštni naslov.',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -374,6 +374,7 @@ export const svTranslations: DefaultTranslationsObject = {
     filterWhere: 'Filtrera {{label}} där',
     globals: 'Globala',
     goBack: 'Gå tillbaka',
+    gotIt: 'Uppfattat',
     groupByLabel: 'Gruppera efter {{label}}',
     hideSidebar: 'Dölj sidofält',
     import: 'Importera',
@@ -601,6 +602,15 @@ export const svTranslations: DefaultTranslationsObject = {
     sizes: 'Storlekar',
     sizesFor: 'Storlekar för {{label}}',
     width: 'Bredd',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Kunde inte spara dokument',
+    documentLimitReached:
+      'Du har nått din dokumentgräns. Ta bort några befintliga dokument för att fortsätta skapa.',
+    reviewCollection: 'Granska {{label}}',
+    unableToCreateDocument: 'Det går inte att skapa dokument. Lagringsgränsen har uppnåtts.',
+    unableToSaveDocumentTooLarge: 'Det går inte att spara dokumentet, texten är för stor',
+    unableToUpload: 'Det gick inte att ladda upp. Frigör utrymme för att fortsätta.',
   },
   validation: {
     emailAddress: 'Vänligen ange en giltig e-postadress.',

--- a/packages/translations/src/languages/ta.ts
+++ b/packages/translations/src/languages/ta.ts
@@ -374,6 +374,7 @@ export const taTranslations: DefaultTranslationsObject = {
     filterWhere: '{{label}}-ஐ வடிகட்டு',
     globals: 'பொதுவானவை',
     goBack: 'மீண்டும் செல்',
+    gotIt: 'புரிந்தேன்',
     groupByLabel: '{{label}}-ஆல் குழுபடுத்து',
     hideSidebar: 'பக்கப்பட்டியை மறைக்கவும்',
     import: 'இறக்குமதி',
@@ -601,6 +602,15 @@ export const taTranslations: DefaultTranslationsObject = {
     sizes: 'அளவுகள்',
     sizesFor: '{{label}} க்கான அளவுகள்',
     width: 'அகலம்',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'டாக்குமெண்ட் சேமிக்க முடியவில்லை',
+    documentLimitReached:
+      'நீங்கள் உங்கள் Document வரம்பை அடைந்துள்ளீர்கள். தொடர்ந்தும் உருவாக்க, சில புதிய Documents-இனை உருவாக்கும் முன், இருப்பிலுள்ள சில Documents-ஐ நீக்கவும்.',
+    reviewCollection: '{{label}}-ஐ மதிப்பாய்வு செய்யவும்',
+    unableToCreateDocument: 'ஆவணத்தை உருவாக்க முடியவில்லை. சேமிப்பு வரம்பு எட்டப்பட்டுள்ளது.',
+    unableToSaveDocumentTooLarge: 'ஆவணத்தை சேமிக்க முடியவில்லை, உரை மிகப்பெரியது',
+    unableToUpload: 'பதிவேற்ற முடியவில்லை. தொடர வேண்டுமெனில் இடத்தை காலியாக்குங்கள்.',
   },
   validation: {
     emailAddress: 'சரியான மின்னஞ்சல் முகவரியை உள்ளிடவும்.',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -367,6 +367,7 @@ export const thTranslations: DefaultTranslationsObject = {
     filterWhere: 'กรอง {{label}} เฉพาะ',
     globals: 'Globals',
     goBack: 'กลับไป',
+    gotIt: 'รับทราบ',
     groupByLabel: 'จัดกลุ่มตาม {{label}}',
     hideSidebar: 'ซ่อนแถบด้านข้าง',
     import: 'นำเข้า',
@@ -589,6 +590,15 @@ export const thTranslations: DefaultTranslationsObject = {
     sizes: 'ขนาด',
     sizesFor: 'ขนาดสำหรับ {{label}}',
     width: 'ความกว้าง',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'ไม่สามารถบันทึก Document ได้',
+    documentLimitReached:
+      'คุณได้ถึงขีดจำกัดของ Document แล้ว กรุณาลบ Document ที่มีอยู่บางส่วนเพื่อดำเนินการสร้างต่อ',
+    reviewCollection: 'ตรวจสอบ {{label}}',
+    unableToCreateDocument: 'ไม่สามารถสร้าง Document ได้ เนื่องจากเกินขีดจำกัดการจัดเก็บข้อมูล',
+    unableToSaveDocumentTooLarge: 'ไม่สามารถบันทึก Document ได้ เนื่องจากข้อความมีขนาดใหญ่เกินไป',
+    unableToUpload: 'ไม่สามารถอัปโหลดได้ กรุณาเพิ่มพื้นที่ว่างเพื่อดำเนินการต่อ',
   },
   validation: {
     emailAddress: 'กรุณาระบุอีเมลที่ถูกต้อง',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -378,6 +378,7 @@ export const trTranslations: DefaultTranslationsObject = {
     filterWhere: '{{label}} filtrele:',
     globals: 'Globaller',
     goBack: 'Geri dön',
+    gotIt: 'Anlaşıldı',
     groupByLabel: "{{label}}'ye göre grupla",
     hideSidebar: 'Kenar çubuğunu gizle',
     import: 'İthalat',
@@ -606,6 +607,15 @@ export const trTranslations: DefaultTranslationsObject = {
     sizes: 'Boyutlar',
     sizesFor: '{{label}} için boyutlar',
     width: 'Genişlik',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Belge kaydedilemedi',
+    documentLimitReached:
+      'Belge limitinize ulaştınız. Yeni belge oluşturmaya devam edebilmek için mevcut belgelerden bazılarını silin.',
+    reviewCollection: "{{label}}'i inceleyin",
+    unableToCreateDocument: 'Belge oluşturulamıyor. Depolama sınırına ulaşıldı.',
+    unableToSaveDocumentTooLarge: 'Belge kaydedilemiyor, metin çok büyük',
+    unableToUpload: 'Yükleme yapılamıyor. Devam edebilmek için alan boşaltın.',
   },
   validation: {
     emailAddress: 'Lütfen geçerli bir e-posta adresi girin.',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -370,6 +370,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     filterWhere: 'Де фільтрувати {{label}}',
     globals: 'Глобальні',
     goBack: 'Повернутися',
+    gotIt: 'Зрозуміло',
     groupByLabel: 'Групувати за {{label}}',
     hideSidebar: 'Сховати бічну панель',
     import: 'Імпорт',
@@ -595,6 +596,15 @@ export const ukTranslations: DefaultTranslationsObject = {
     sizes: 'Розміри',
     sizesFor: 'Розміри для {{label}}',
     width: 'Ширина',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Не вдалося зберегти документ',
+    documentLimitReached:
+      'Ви досягли ліміту документів. Видаліть деякі наявні документи, щоб мати змогу створювати нові.',
+    reviewCollection: 'Переглянути {{label}}',
+    unableToCreateDocument: 'Не вдалося створити документ. Досягнуто межі сховища.',
+    unableToSaveDocumentTooLarge: 'Неможливо зберегти документ, текст занадто великий',
+    unableToUpload: 'Не вдалося завантажити. Звільніть місце для продовження.',
   },
   validation: {
     emailAddress: 'Будь ласка, введіть коректну адресу електронної пошти.',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -375,6 +375,7 @@ export const viTranslations: DefaultTranslationsObject = {
     filterWhere: 'Lọc {{label}} với điều kiện:',
     globals: 'Cấu hình chung (globals)',
     goBack: 'Quay lại',
+    gotIt: 'Đã hiểu',
     groupByLabel: 'Nhóm theo {{label}}',
     hideSidebar: 'Ẩn thanh bên',
     import: 'Nhập',
@@ -600,6 +601,15 @@ export const viTranslations: DefaultTranslationsObject = {
     sizes: 'Các độ phân giải',
     sizesFor: 'Kích thước cho {{label}}',
     width: 'Chiều rộng',
+  },
+  usageLimits: {
+    couldNotSaveDocument: 'Không thể lưu tài liệu',
+    documentLimitReached:
+      'Bạn đã đạt đến giới hạn document của mình. Vui lòng xóa một số document hiện có để tiếp tục tạo mới.',
+    reviewCollection: 'Xem lại {{label}}',
+    unableToCreateDocument: 'Không thể tạo tài liệu. Đã đạt đến giới hạn lưu trữ.',
+    unableToSaveDocumentTooLarge: 'Không thể lưu tài liệu, văn bản quá lớn',
+    unableToUpload: 'Không thể tải lên. Hãy giải phóng dung lượng để tiếp tục.',
   },
   validation: {
     emailAddress: 'Địa chỉ email không hợp lệ.',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -354,6 +354,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     filterWhere: '过滤 {{label}}',
     globals: '全局',
     goBack: '返回',
+    gotIt: '明白',
     groupByLabel: '按 {{label}} 分组',
     hideSidebar: '隐藏侧边栏',
     import: '导入',
@@ -573,6 +574,14 @@ export const zhTranslations: DefaultTranslationsObject = {
     sizes: '尺寸',
     sizesFor: '{{label}} 的尺寸',
     width: '宽度',
+  },
+  usageLimits: {
+    couldNotSaveDocument: '无法保存文档',
+    documentLimitReached: '您已达到文档数量上限。请删除部分现有文档以继续创建。',
+    reviewCollection: '审核 {{label}}',
+    unableToCreateDocument: '无法创建文档。已达到存储限制。',
+    unableToSaveDocumentTooLarge: '无法保存文档，文本过大',
+    unableToUpload: '无法上传。请释放空间以继续操作。',
   },
   validation: {
     emailAddress: '请输入一个有效的电子邮件地址。',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -352,6 +352,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     filterWhere: '篩選 {{label}}，條件為',
     globals: '全域',
     goBack: '返回',
+    gotIt: '了解',
     groupByLabel: '依 {{label}} 分組',
     hideSidebar: '隱藏側邊欄',
     import: '匯入',
@@ -571,6 +572,14 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     sizes: '尺寸',
     sizesFor: '{{label}} 的尺寸',
     width: '寬度',
+  },
+  usageLimits: {
+    couldNotSaveDocument: '無法儲存文件',
+    documentLimitReached: '您已達到文件上限。請刪除部分現有文件以繼續建立新文件。',
+    reviewCollection: '檢閱 {{label}}',
+    unableToCreateDocument: '無法建立文件。已達到儲存上限。',
+    unableToSaveDocumentTooLarge: '無法儲存文件，文字內容過大',
+    unableToUpload: '無法上傳。請釋放空間以繼續。',
   },
   validation: {
     emailAddress: '請輸入有效的電子郵件地址。',

--- a/packages/ui/src/elements/CloudLimitModal/index.css
+++ b/packages/ui/src/elements/CloudLimitModal/index.css
@@ -1,0 +1,8 @@
+@layer payload-default {
+  .cloud-limit-modal__review-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacer-1);
+    color: var(--ramp-blue-600);
+  }
+}

--- a/packages/ui/src/elements/CloudLimitModal/index.tsx
+++ b/packages/ui/src/elements/CloudLimitModal/index.tsx
@@ -1,0 +1,72 @@
+'use client'
+import { useModal } from '@faceless-ui/modal'
+import { getTranslation } from '@payloadcms/translations'
+import { formatAdminURL } from 'payload/shared'
+import React from 'react'
+
+import { NewTabIcon } from '../../icons/NewTab/index.js'
+import { useConfig } from '../../providers/Config/index.js'
+import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
+import { useTranslation } from '../../providers/Translation/index.js'
+import { ConfirmationModal } from '../ConfirmationModal/index.js'
+import './index.css'
+
+type Props = {
+  modalSlug: string
+  onRetry: () => void
+}
+
+/**
+ * TODO: Verify against real Content API errors once the plugin/backend limit-error work is merged.
+ */
+export function CloudLimitDocumentCountModal({ modalSlug, onRetry }: Props) {
+  const {
+    config: {
+      routes: { admin: adminRoute },
+    },
+    getEntityConfig,
+  } = useConfig()
+  const { collectionSlug } = useDocumentInfo()
+  const { i18n } = useTranslation()
+  const { closeModal } = useModal()
+
+  const collectionConfig = collectionSlug ? getEntityConfig({ collectionSlug }) : null
+  const collectionLabel = collectionConfig
+    ? getTranslation(collectionConfig.labels?.plural, i18n)
+    : 'documents'
+  const listURL = collectionSlug
+    ? formatAdminURL({ adminRoute, path: `/collections/${collectionSlug}` })
+    : undefined
+
+  return (
+    <ConfirmationModal
+      body={
+        <p>
+          You have reached your document limit. Delete some existing documents in order to keep
+          creating.
+        </p>
+      }
+      cancelLabel="Got it"
+      confirmLabel="Retry"
+      footerLinkAction={
+        listURL ? (
+          <a
+            className="cloud-limit-modal__review-link"
+            href={listURL}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {`Review ${collectionLabel}`}
+            <NewTabIcon size={16} />
+          </a>
+        ) : null
+      }
+      heading="Couldn’t save document"
+      modalSlug={modalSlug}
+      onConfirm={() => {
+        closeModal(modalSlug)
+        onRetry()
+      }}
+    />
+  )
+}

--- a/packages/ui/src/elements/CloudLimitModal/index.tsx
+++ b/packages/ui/src/elements/CloudLimitModal/index.tsx
@@ -16,9 +16,6 @@ type Props = {
   onRetry: () => void
 }
 
-/**
- * TODO: Verify against real Content API errors once the plugin/backend limit-error work is merged.
- */
 export function CloudLimitDocumentCountModal({ modalSlug, onRetry }: Props) {
   const {
     config: {
@@ -27,7 +24,7 @@ export function CloudLimitDocumentCountModal({ modalSlug, onRetry }: Props) {
     getEntityConfig,
   } = useConfig()
   const { collectionSlug } = useDocumentInfo()
-  const { i18n } = useTranslation()
+  const { i18n, t } = useTranslation()
   const { closeModal } = useModal()
 
   const collectionConfig = collectionSlug ? getEntityConfig({ collectionSlug }) : null
@@ -40,14 +37,9 @@ export function CloudLimitDocumentCountModal({ modalSlug, onRetry }: Props) {
 
   return (
     <ConfirmationModal
-      body={
-        <p>
-          You have reached your document limit. Delete some existing documents in order to keep
-          creating.
-        </p>
-      }
-      cancelLabel="Got it"
-      confirmLabel="Retry"
+      body={<p>{t('usageLimits:documentLimitReached')}</p>}
+      cancelLabel={t('general:gotIt')}
+      confirmLabel={t('general:retry')}
       footerLinkAction={
         listURL ? (
           <a
@@ -56,12 +48,12 @@ export function CloudLimitDocumentCountModal({ modalSlug, onRetry }: Props) {
             rel="noopener noreferrer"
             target="_blank"
           >
-            {`Review ${collectionLabel}`}
+            {t('usageLimits:reviewCollection', { label: collectionLabel })}
             <NewTabIcon size={16} />
           </a>
         ) : null
       }
-      heading="Couldn’t save document"
+      heading={t('usageLimits:couldNotSaveDocument')}
       modalSlug={modalSlug}
       onConfirm={() => {
         closeModal(modalSlug)

--- a/packages/ui/src/elements/CloudLimitModal/shared.ts
+++ b/packages/ui/src/elements/CloudLimitModal/shared.ts
@@ -1,0 +1,55 @@
+/**
+ * Content API "cloud limit" enforcement errors, surfaced to the admin UI:
+ * a modal for the document-count limit, and toasts for the data-size and asset-storage
+ * limits. Each is keyed off the stable `code` the Content API returns.
+ *
+ * TODO: Two upstream dependencies must ship for this to fire end-to-end, and this should be re-verified against real
+ * Content API errors afterwards:
+ *   1. The @payloadcms/figma plugin must preserve the Content API error `code`/status
+ *      instead of flattening it into a generic Error (currently masked to a 500).
+ *   2. The plugin's document writes must reach the enforcing Content API endpoints
+ *      (document-count + data-size are only enforced on the v1 write pipeline today).
+ */
+export const cloudLimitErrorCodes = {
+  assetStorage: 'cloud_limit.cms_assets_bytes_exceeded',
+  documentCount: 'cloud_limit.document_count_exceeded',
+  documentDataSize: 'cloud_limit.per_document_data_bytes_exceeded',
+} as const
+
+/** TODO: Add translations */
+export const cloudLimitToastMessages: Record<string, string> = {
+  [cloudLimitErrorCodes.assetStorage]: 'Unable to upload. Free up space to continue.',
+  [cloudLimitErrorCodes.documentDataSize]: 'Unable to save document, text is too large',
+}
+
+/**
+ * Toast copy for the document-count limit. Shown instead of the modal when autosave is
+ * enabled, since an autosaving document has no explicit save action to retry.
+ */
+export const cloudLimitDocumentCountToastMessage =
+  'Unable to create document. Storage limit reached.'
+
+export const cloudLimitDocumentCountModalSlug = 'cloud-limit-document-count'
+
+export const formatCloudLimitDocumentCountModalSlug = (editDepth: number): string =>
+  `${cloudLimitDocumentCountModalSlug}-${editDepth}`
+
+const knownCloudLimitCodes = Object.values(cloudLimitErrorCodes) as string[]
+
+export function isCloudLimitErrorCode(code: unknown): code is string {
+  return typeof code === 'string' && knownCloudLimitCodes.includes(code)
+}
+
+type CloudLimitErrorJSON = {
+  errors?: Array<{ data?: { code?: string } | null } | null> | null
+}
+
+export function getCloudLimitErrorCode(json: CloudLimitErrorJSON): string | undefined {
+  return json?.errors?.map((err) => err?.data?.code).find(isCloudLimitErrorCode)
+}
+
+export function getCloudLimitErrorCodeFromError(error: unknown): string | undefined {
+  const code = (error as { data?: { code?: unknown } } | null | undefined)?.data?.code
+
+  return isCloudLimitErrorCode(code) ? code : undefined
+}

--- a/packages/ui/src/elements/CloudLimitModal/shared.ts
+++ b/packages/ui/src/elements/CloudLimitModal/shared.ts
@@ -1,33 +1,18 @@
-/**
- * Content API "cloud limit" enforcement errors, surfaced to the admin UI:
- * a modal for the document-count limit, and toasts for the data-size and asset-storage
- * limits. Each is keyed off the stable `code` the Content API returns.
- *
- * TODO: Two upstream dependencies must ship for this to fire end-to-end, and this should be re-verified against real
- * Content API errors afterwards:
- *   1. The @payloadcms/figma plugin must preserve the Content API error `code`/status
- *      instead of flattening it into a generic Error (currently masked to a 500).
- *   2. The plugin's document writes must reach the enforcing Content API endpoints
- *      (document-count + data-size are only enforced on the v1 write pipeline today).
- */
+import type { ClientTranslationKeys } from '@payloadcms/translations'
+
 export const cloudLimitErrorCodes = {
   assetStorage: 'cloud_limit.cms_assets_bytes_exceeded',
   documentCount: 'cloud_limit.document_count_exceeded',
   documentDataSize: 'cloud_limit.per_document_data_bytes_exceeded',
 } as const
 
-/** TODO: Add translations */
-export const cloudLimitToastMessages: Record<string, string> = {
-  [cloudLimitErrorCodes.assetStorage]: 'Unable to upload. Free up space to continue.',
-  [cloudLimitErrorCodes.documentDataSize]: 'Unable to save document, text is too large',
+export const cloudLimitToastMessageKeys: Partial<Record<string, ClientTranslationKeys>> = {
+  [cloudLimitErrorCodes.assetStorage]: 'usageLimits:unableToUpload',
+  [cloudLimitErrorCodes.documentDataSize]: 'usageLimits:unableToSaveDocumentTooLarge',
 }
 
-/**
- * Toast copy for the document-count limit. Shown instead of the modal when autosave is
- * enabled, since an autosaving document has no explicit save action to retry.
- */
-export const cloudLimitDocumentCountToastMessage =
-  'Unable to create document. Storage limit reached.'
+export const cloudLimitDocumentCountToastMessageKey: ClientTranslationKeys =
+  'usageLimits:unableToCreateDocument'
 
 export const cloudLimitDocumentCountModalSlug = 'cloud-limit-document-count'
 

--- a/packages/ui/src/elements/CloudLimitModal/useCloudLimitErrorHandler.ts
+++ b/packages/ui/src/elements/CloudLimitModal/useCloudLimitErrorHandler.ts
@@ -6,10 +6,11 @@ import { toast } from 'sonner'
 
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useTranslation } from '../../providers/Translation/index.js'
 import {
-  cloudLimitDocumentCountToastMessage,
+  cloudLimitDocumentCountToastMessageKey,
   cloudLimitErrorCodes,
-  cloudLimitToastMessages,
+  cloudLimitToastMessageKeys,
   formatCloudLimitDocumentCountModalSlug,
 } from './shared.js'
 
@@ -19,6 +20,7 @@ export function useCloudLimitErrorHandler(): {
 } {
   const { openModal } = useModal()
   const { docConfig } = useDocumentInfo()
+  const { t } = useTranslation()
   const editDepth = useEditDepth()
 
   const documentCountModalSlug = formatCloudLimitDocumentCountModalSlug(editDepth)
@@ -27,15 +29,19 @@ export function useCloudLimitErrorHandler(): {
     (code: string): void => {
       if (code === cloudLimitErrorCodes.documentCount) {
         if (hasAutosaveEnabled(docConfig)) {
-          toast.info(cloudLimitDocumentCountToastMessage)
+          toast.info(t(cloudLimitDocumentCountToastMessageKey))
         } else {
           openModal(documentCountModalSlug)
         }
-      } else if (cloudLimitToastMessages[code]) {
-        toast.info(cloudLimitToastMessages[code])
+      } else {
+        const messageKey = cloudLimitToastMessageKeys[code]
+
+        if (messageKey) {
+          toast.info(t(messageKey))
+        }
       }
     },
-    [docConfig, openModal, documentCountModalSlug],
+    [docConfig, openModal, documentCountModalSlug, t],
   )
 
   return { documentCountModalSlug, showCloudLimitError }

--- a/packages/ui/src/elements/CloudLimitModal/useCloudLimitErrorHandler.ts
+++ b/packages/ui/src/elements/CloudLimitModal/useCloudLimitErrorHandler.ts
@@ -1,0 +1,42 @@
+'use client'
+import { useModal } from '@faceless-ui/modal'
+import { hasAutosaveEnabled } from 'payload/shared'
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+
+import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
+import { useEditDepth } from '../../providers/EditDepth/index.js'
+import {
+  cloudLimitDocumentCountToastMessage,
+  cloudLimitErrorCodes,
+  cloudLimitToastMessages,
+  formatCloudLimitDocumentCountModalSlug,
+} from './shared.js'
+
+export function useCloudLimitErrorHandler(): {
+  documentCountModalSlug: string
+  showCloudLimitError: (code: string) => void
+} {
+  const { openModal } = useModal()
+  const { docConfig } = useDocumentInfo()
+  const editDepth = useEditDepth()
+
+  const documentCountModalSlug = formatCloudLimitDocumentCountModalSlug(editDepth)
+
+  const showCloudLimitError = useCallback(
+    (code: string): void => {
+      if (code === cloudLimitErrorCodes.documentCount) {
+        if (hasAutosaveEnabled(docConfig)) {
+          toast.info(cloudLimitDocumentCountToastMessage)
+        } else {
+          openModal(documentCountModalSlug)
+        }
+      } else if (cloudLimitToastMessages[code]) {
+        toast.info(cloudLimitToastMessages[code])
+      }
+    },
+    [docConfig, openModal, documentCountModalSlug],
+  )
+
+  return { documentCountModalSlug, showCloudLimitError }
+}

--- a/packages/ui/src/elements/ConfirmationModal/index.css
+++ b/packages/ui/src/elements/ConfirmationModal/index.css
@@ -4,4 +4,10 @@
     flex-direction: column;
     gap: var(--spacer-2);
   }
+
+  .confirmation-modal__footer-link {
+    display: flex;
+    align-items: center;
+    margin-inline-end: auto;
+  }
 }

--- a/packages/ui/src/elements/ConfirmationModal/index.tsx
+++ b/packages/ui/src/elements/ConfirmationModal/index.tsx
@@ -19,6 +19,7 @@ export type ConfirmationModalProps = {
   className?: string
   confirmingLabel?: string
   confirmLabel?: string
+  footerLinkAction?: React.ReactNode
   heading: React.ReactNode
   modalSlug: string
   onCancel?: OnCancel
@@ -32,6 +33,7 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
     className,
     confirmingLabel,
     confirmLabel,
+    footerLinkAction,
     heading,
     modalSlug,
     onCancel,
@@ -47,6 +49,9 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
         </div>
       </DialogBody>
       <DialogFooter>
+        {footerLinkAction ? (
+          <div className="confirmation-modal__footer-link">{footerLinkAction}</div>
+        ) : null}
         <DialogCancel label={cancelLabel} onClick={onCancel} />
         <DialogConfirm label={confirmLabel} loadingLabel={confirmingLabel} onClick={onConfirm} />
       </DialogFooter>

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -488,8 +488,7 @@ export const Form: React.FC<FormProps> = (props) => {
           contextRef.current = { ...contextRef.current } // triggers rerender of all components that subscribe to form
 
           // Content API "cloud limit" errors returned in the save response (doc-count, data-size).
-          // TODO: verify once the @payloadcms/figma plugin
-          // preserves the error code/status and its writes reach the enforcing v1 endpoints.
+          // TODO: verify once the @payloadcms/figma plugin preserves the error code/status
           const cloudLimitCode = getCloudLimitErrorCode(json)
           if (cloudLimitCode) {
             handleCloudLimitError(cloudLimitCode)

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -22,6 +22,12 @@ import type {
   SubmitOptions,
 } from './types.js'
 
+import { CloudLimitDocumentCountModal } from '../../elements/CloudLimitModal/index.js'
+import {
+  getCloudLimitErrorCode,
+  getCloudLimitErrorCodeFromError,
+} from '../../elements/CloudLimitModal/shared.js'
+import { useCloudLimitErrorHandler } from '../../elements/CloudLimitModal/useCloudLimitErrorHandler.js'
 import { FieldErrorsToast } from '../../elements/Toasts/fieldErrors.js'
 import { useDebouncedEffect } from '../../hooks/useDebouncedEffect.js'
 import { useEffectEvent } from '../../hooks/useEffectEvent.js'
@@ -62,6 +68,8 @@ export const Form: React.FC<FormProps> = (props) => {
     useDocumentInfo()
 
   const validateDrafts = hasDraftValidationEnabled(docConfig)
+
+  const { documentCountModalSlug, showCloudLimitError } = useCloudLimitErrorHandler()
 
   const {
     action,
@@ -269,6 +277,7 @@ export const Form: React.FC<FormProps> = (props) => {
 
       // create new toast promise which will resolve manually later
       let errorToast, successToast
+      let submittingToastID: number | string | undefined
 
       const promise = new Promise((resolve, reject) => {
         successToast = resolve
@@ -284,7 +293,7 @@ export const Form: React.FC<FormProps> = (props) => {
         successToast = (data) => toast.success(data)
         errorToast = (data) => toast.error(data)
       } else {
-        toast.promise(promise, {
+        submittingToastID = toast.promise(promise, {
           error: (data) => {
             return data as string
           },
@@ -292,7 +301,15 @@ export const Form: React.FC<FormProps> = (props) => {
           success: (data) => {
             return data as string
           },
-        })
+        }) as number | string
+      }
+
+      const handleCloudLimitError = (code: string): void => {
+        if (submittingToastID !== undefined) {
+          toast.dismiss(submittingToastID)
+        }
+
+        showCloudLimitError(code)
       }
 
       if (e) {
@@ -470,6 +487,15 @@ export const Form: React.FC<FormProps> = (props) => {
 
           contextRef.current = { ...contextRef.current } // triggers rerender of all components that subscribe to form
 
+          // Content API "cloud limit" errors returned in the save response (doc-count, data-size).
+          // TODO: verify once the @payloadcms/figma plugin
+          // preserves the error code/status and its writes reach the enforcing v1 endpoints.
+          const cloudLimitCode = getCloudLimitErrorCode(json)
+          if (cloudLimitCode) {
+            handleCloudLimitError(cloudLimitCode)
+            return
+          }
+
           if (json.message) {
             errorToast(json.message)
             return
@@ -524,10 +550,19 @@ export const Form: React.FC<FormProps> = (props) => {
 
         return { formState: contextRef.current.fields, res }
       } catch (err) {
-        console.error('Error submitting form', err) // eslint-disable-line no-console
         setProcessing(false)
         setSubmitted(true)
         setDisabled(false)
+
+        // Client-side upload limits (e.g. asset storage) throw here instead of returning a 4xx
+        // response, so run the same cloud-limit handling on the thrown error.
+        const cloudLimitCode = getCloudLimitErrorCodeFromError(err)
+        if (cloudLimitCode) {
+          handleCloudLimitError(cloudLimitCode)
+          return
+        }
+
+        console.error('Error submitting form', err) // eslint-disable-line no-console
         errorToast(err.message)
       }
     },
@@ -551,6 +586,7 @@ export const Form: React.FC<FormProps> = (props) => {
       waitForAutocomplete,
       setModified,
       setSubmitted,
+      showCloudLimitError,
     ],
   )
 
@@ -869,46 +905,54 @@ export const Form: React.FC<FormProps> = (props) => {
   const El: 'form' = (el as unknown as 'form') || 'form'
 
   return (
-    <El
-      action={typeof action === 'function' ? void action : action}
-      className={classes}
-      /**
-       * data-form-ready signals if the form is ready to be used. This is used by our e2e tests
-       * to wait for the form to be ready before interacting with it, reducing flakiness if the test is run in
-       * slow network conditions.
-       */
-      data-form-ready={!processing && isMounted && !initializing}
-      method={method}
-      noValidate
-      onSubmit={(e) => void contextRef.current.submit({}, e)}
-      ref={formRef}
-    >
-      <DocumentFormContextComponent {...documentFormContextProps}>
-        <FormContext value={contextRef.current}>
-          <FormWatchContext
-            value={{
-              fields: formState,
-              ...contextRef.current,
-            }}
-          >
-            <SubmittedContext value={submitted}>
-              <InitializingContext value={!isMounted || (isMounted && initializing)}>
-                <ProcessingContext value={processing}>
-                  <BackgroundProcessingContext value={backgroundProcessing}>
-                    <ModifiedContext value={modified}>
-                      {/* eslint-disable-next-line @eslint-react/no-context-provider */}
-                      <FormFieldsContext.Provider value={fieldsReducer}>
-                        {children}
-                      </FormFieldsContext.Provider>
-                    </ModifiedContext>
-                  </BackgroundProcessingContext>
-                </ProcessingContext>
-              </InitializingContext>
-            </SubmittedContext>
-          </FormWatchContext>
-        </FormContext>
-      </DocumentFormContextComponent>
-    </El>
+    <React.Fragment>
+      <El
+        action={typeof action === 'function' ? void action : action}
+        className={classes}
+        /**
+         * data-form-ready signals if the form is ready to be used. This is used by our e2e tests
+         * to wait for the form to be ready before interacting with it, reducing flakiness if the test is run in
+         * slow network conditions.
+         */
+        data-form-ready={!processing && isMounted && !initializing}
+        method={method}
+        noValidate
+        onSubmit={(e) => void contextRef.current.submit({}, e)}
+        ref={formRef}
+      >
+        <DocumentFormContextComponent {...documentFormContextProps}>
+          <FormContext value={contextRef.current}>
+            <FormWatchContext
+              value={{
+                fields: formState,
+                ...contextRef.current,
+              }}
+            >
+              <SubmittedContext value={submitted}>
+                <InitializingContext value={!isMounted || (isMounted && initializing)}>
+                  <ProcessingContext value={processing}>
+                    <BackgroundProcessingContext value={backgroundProcessing}>
+                      <ModifiedContext value={modified}>
+                        {/* eslint-disable-next-line @eslint-react/no-context-provider */}
+                        <FormFieldsContext.Provider value={fieldsReducer}>
+                          {children}
+                        </FormFieldsContext.Provider>
+                      </ModifiedContext>
+                    </BackgroundProcessingContext>
+                  </ProcessingContext>
+                </InitializingContext>
+              </SubmittedContext>
+            </FormWatchContext>
+          </FormContext>
+        </DocumentFormContextComponent>
+      </El>
+      {collectionSlug ? (
+        <CloudLimitDocumentCountModal
+          modalSlug={documentCountModalSlug}
+          onRetry={() => void submit({})}
+        />
+      ) : null}
+    </React.Fragment>
   )
 }
 

--- a/test/admin/collections/CloudLimits/index.ts
+++ b/test/admin/collections/CloudLimits/index.ts
@@ -1,0 +1,87 @@
+import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload'
+
+import { APIError } from 'payload'
+
+import { cloudLimitsAutosaveCollectionSlug, cloudLimitsCollectionSlug } from '../../slugs.js'
+
+/**
+ * Content API "cloud limit" enforcement errors, keyed by the title that triggers them. Saving a
+ * document whose title matches one of these throws the corresponding `APIError` from a
+ * `beforeChange` hook, so the admin UI (document-count modal, and toasts for data-size and
+ * asset-storage) can be exercised in e2e without the real Content API backend.
+ *
+ * The `code`/`status`/`message` shape mirrors what the Content API returns: `APIError`'s `data`
+ * is serialized to `json.errors[i].data`, so the limit `code` reaches the client at
+ * `json.errors[i].data.code` — the path the UI keys off.
+ */
+export const cloudLimitTriggers = {
+  assetStorage: {
+    code: 'cloud_limit.cms_assets_bytes_exceeded',
+    message: 'Content system has exceeded its CMS asset storage limit.',
+    status: 409,
+    title: '__ASSET__',
+  },
+  documentCount: {
+    code: 'cloud_limit.document_count_exceeded',
+    message: 'Content system has reached its maximum document count of 100.',
+    status: 409,
+    title: '__DOC_LIMIT__',
+  },
+  documentDataSize: {
+    code: 'cloud_limit.per_document_data_bytes_exceeded',
+    message: 'Document data size 5134 bytes exceeds the maximum of 2000 bytes.',
+    status: 413,
+    title: '__DATA_SIZE__',
+  },
+} as const
+
+const triggerByTitle = Object.fromEntries(
+  Object.values(cloudLimitTriggers).map((trigger) => [trigger.title, trigger]),
+)
+
+const throwCloudLimitError: CollectionBeforeChangeHook = ({ data }) => {
+  const trigger = typeof data?.title === 'string' ? triggerByTitle[data.title] : undefined
+
+  if (trigger) {
+    throw new APIError(trigger.message, trigger.status, { code: trigger.code })
+  }
+
+  return data
+}
+
+export const CloudLimits: CollectionConfig = {
+  slug: cloudLimitsCollectionSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  hooks: {
+    beforeChange: [throwCloudLimitError],
+  },
+}
+
+export const CloudLimitsAutosave: CollectionConfig = {
+  slug: cloudLimitsAutosaveCollectionSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  hooks: {
+    beforeChange: [throwCloudLimitError],
+  },
+  versions: {
+    drafts: {
+      autosave: true,
+    },
+  },
+}

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Array } from './collections/Array.js'
 import { BaseListFilter } from './collections/BaseListFilter.js'
+import { CloudLimits, CloudLimitsAutosave } from './collections/CloudLimits/index.js'
 import { CustomCollectionView } from './collections/CustomCollectionView.js'
 import { CollectionCustomDocumentControls } from './collections/CustomDocumentControls.js'
 import { CustomFields } from './collections/CustomFields/index.js'
@@ -254,6 +255,8 @@ export default buildConfigWithDefaults({
     NoTimestampsCollection,
     Localized,
     FullyFeatured,
+    CloudLimits,
+    CloudLimitsAutosave,
   ],
   globals: [
     GlobalHidden,

--- a/test/admin/e2e/cloud-limits/e2e.spec.ts
+++ b/test/admin/e2e/cloud-limits/e2e.spec.ts
@@ -1,0 +1,127 @@
+import type { Page } from '@playwright/test'
+
+import { expect } from '@playwright/test'
+
+import type { Config } from '../../payload-types.js'
+
+import {
+  ensureCompilationIsDone,
+  initPageConsoleErrorCatch,
+} from '../../../__helpers/e2e/helpers.js'
+import { test } from '../../../__helpers/e2e/playwright.js'
+import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
+import { cloudLimitTriggers } from '../../collections/CloudLimits/index.js'
+import { BASE_PATH, customAdminRoutes } from '../../shared.js'
+import { cloudLimitsAutosaveCollectionSlug, cloudLimitsCollectionSlug } from '../../slugs.js'
+
+process.env.NEXT_BASE_PATH = BASE_PATH
+
+const { beforeAll, beforeEach, describe } = test
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+
+const filename = fileURLToPath(import.meta.url)
+const currentFolder = path.dirname(filename)
+const dirname = path.resolve(currentFolder, '../../')
+
+const reviewLink = '.cloud-limit-modal__review-link'
+const toastContainer = '.payload-toast-container'
+const infoToast = `${toastContainer} .toast-info`
+const errorToast = `${toastContainer} .toast-error`
+
+describe('Cloud limits', () => {
+  let page: Page
+  let serverURL: string
+  let cloudLimitsURL: AdminUrlUtil
+  let cloudLimitsAutosaveURL: AdminUrlUtil
+
+  beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(TEST_TIMEOUT_LONG)
+    process.env.SEED_IN_CONFIG_ONINIT = 'false'
+    ;({ serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
+
+    cloudLimitsURL = new AdminUrlUtil(serverURL, cloudLimitsCollectionSlug)
+    cloudLimitsAutosaveURL = new AdminUrlUtil(serverURL, cloudLimitsAutosaveCollectionSlug)
+
+    const context = await browser.newContext()
+    page = await context.newPage()
+    initPageConsoleErrorCatch(page)
+
+    await ensureCompilationIsDone({ customAdminRoutes, page, serverURL })
+  })
+
+  beforeEach(async () => {
+    await reInitializeDB({
+      serverURL,
+      snapshotKey: 'adminTests',
+    })
+
+    await ensureCompilationIsDone({ customAdminRoutes, page, serverURL })
+  })
+
+  test('should show the document-count modal on save when autosave is disabled', async () => {
+    await page.goto(cloudLimitsURL.create)
+    await page.locator('#field-title').fill(cloudLimitTriggers.documentCount.title)
+    await page.click('#action-save', { delay: 100 })
+
+    // The review link is unique to this modal; the slug is depth-scoped so avoid matching on it.
+    await expect(page.locator(reviewLink)).toBeVisible()
+    await expect(page.getByText('You have reached your document limit')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible()
+
+    // The bespoke modal replaces the generic error toast.
+    await expect(page.locator(errorToast)).toBeHidden()
+  })
+
+  test('should re-attempt the save when clicking Retry in the document-count modal', async () => {
+    await page.goto(cloudLimitsURL.create)
+    await page.locator('#field-title').fill(cloudLimitTriggers.documentCount.title)
+    await page.click('#action-save', { delay: 100 })
+
+    await expect(page.locator(reviewLink)).toBeVisible()
+    await page.getByRole('button', { name: 'Retry' }).click()
+
+    // The title still exceeds the limit, so retrying re-triggers the error and the modal returns.
+    await expect(page.locator(reviewLink)).toBeVisible()
+  })
+
+  test('should show a neutral toast for the per-document data-size limit', async () => {
+    await page.goto(cloudLimitsURL.create)
+    await page.locator('#field-title').fill(cloudLimitTriggers.documentDataSize.title)
+    await page.click('#action-save', { delay: 100 })
+
+    await expect(page.locator(infoToast)).toContainText(
+      'Unable to save document, text is too large',
+    )
+    await expect(page.locator(errorToast)).toBeHidden()
+    await expect(page.locator(reviewLink)).toBeHidden()
+  })
+
+  test('should show a neutral toast for the asset-storage limit', async () => {
+    await page.goto(cloudLimitsURL.create)
+    await page.locator('#field-title').fill(cloudLimitTriggers.assetStorage.title)
+    await page.click('#action-save', { delay: 100 })
+
+    await expect(page.locator(infoToast)).toContainText(
+      'Unable to upload. Free up space to continue.',
+    )
+    await expect(page.locator(errorToast)).toBeHidden()
+  })
+
+  test('should show a toast instead of the modal for the document-count limit when autosave is enabled', async () => {
+    await page.goto(cloudLimitsAutosaveURL.create)
+
+    // Autosave fires on change, so no explicit save action is needed.
+    await page.locator('#field-title').fill(cloudLimitTriggers.documentCount.title)
+
+    await expect(page.locator(infoToast)).toContainText(
+      'Unable to create document. Storage limit reached.',
+    )
+    await expect(page.locator(reviewLink)).toBeHidden()
+  })
+})

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -60,111 +60,6 @@ export type SupportedTimezones =
   | 'Pacific/Noumea'
   | 'Pacific/Auckland'
   | 'Pacific/Fiji';
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_EC517269".
- */
-export type LexicalNodes_EC517269 =
-  | SerializedTextNode
-  | SerializedTabNode
-  | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_EC517269>
-  | SerializedRelationshipNode<
-      | 'posts'
-      | 'users'
-      | 'hidden-collection'
-      | 'not-in-view-collection'
-      | 'collection-no-api-view'
-      | 'custom-document-controls'
-      | 'custom-views-one'
-      | 'custom-views-two'
-      | 'custom-collection-view'
-      | 'reorder-tabs'
-      | 'custom-fields'
-      | 'group-one-collection-ones'
-      | 'group-one-collection-twos'
-      | 'group-two-collection-ones'
-      | 'group-two-collection-twos'
-      | 'geo'
-      | 'array'
-      | 'disable-duplicate'
-      | 'disable-copy-to-locale'
-      | 'edit-menu-items'
-      | 'format-doc-url'
-      | 'base-list-filters'
-      | 'with300documents'
-      | 'with-list-drawer'
-      | 'placeholder'
-      | 'use-as-title-group-field'
-      | 'disable-bulk-edit'
-      | 'custom-list-drawer'
-      | 'list-view-select-api'
-      | 'virtuals'
-      | 'no-timestamps'
-      | 'localized'
-      | 'fully-featured'
-      | 'payload-kv'
-      | 'payload-locked-documents'
-      | 'payload-preferences'
-      | 'payload-migrations'
-    >;
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_6CCD2587".
- */
-export type LexicalNodes_6CCD2587 =
-  | SerializedTextNode
-  | SerializedTabNode
-  | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_6CCD2587>
-  | SerializedHorizontalRuleNode
-  | SerializedUploadNode<'uploads'>
-  | SerializedUploadNode<'uploads-two'>
-  | SerializedQuoteNode<LexicalNodes_6CCD2587>
-  | SerializedRelationshipNode<
-      | 'posts'
-      | 'users'
-      | 'hidden-collection'
-      | 'not-in-view-collection'
-      | 'collection-no-api-view'
-      | 'custom-document-controls'
-      | 'custom-views-one'
-      | 'custom-views-two'
-      | 'custom-collection-view'
-      | 'reorder-tabs'
-      | 'custom-fields'
-      | 'group-one-collection-ones'
-      | 'group-one-collection-twos'
-      | 'group-two-collection-ones'
-      | 'group-two-collection-twos'
-      | 'geo'
-      | 'array'
-      | 'disable-duplicate'
-      | 'disable-copy-to-locale'
-      | 'edit-menu-items'
-      | 'format-doc-url'
-      | 'base-list-filters'
-      | 'with300documents'
-      | 'with-list-drawer'
-      | 'placeholder'
-      | 'use-as-title-group-field'
-      | 'disable-bulk-edit'
-      | 'custom-list-drawer'
-      | 'list-view-select-api'
-      | 'virtuals'
-      | 'no-timestamps'
-      | 'localized'
-      | 'fully-featured'
-      | 'payload-kv'
-      | 'payload-locked-documents'
-      | 'payload-preferences'
-      | 'payload-migrations'
-    >
-  | SerializedAutoLinkNode<LexicalNodes_6CCD2587, LexicalLinkFields>
-  | SerializedLinkNode<LexicalNodes_6CCD2587, LexicalLinkFields>
-  | SerializedListNode<LexicalNodes_6CCD2587>
-  | SerializedListItemNode<LexicalNodes_6CCD2587>
-  | SerializedHeadingNode<LexicalNodes_6CCD2587>;
 
 export interface Config {
   auth: {
@@ -207,6 +102,8 @@ export interface Config {
     'no-timestamps': NoTimestamp;
     localized: Localized;
     'fully-featured': FullyFeatured;
+    'cloud-limits': CloudLimit;
+    'cloud-limits-autosave': CloudLimitsAutosave;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -249,6 +146,8 @@ export interface Config {
     'no-timestamps': NoTimestampsSelect<false> | NoTimestampsSelect<true>;
     localized: LocalizedSelect<false> | LocalizedSelect<true>;
     'fully-featured': FullyFeaturedSelect<false> | FullyFeaturedSelect<true>;
+    'cloud-limits': CloudLimitsSelect<false> | CloudLimitsSelect<true>;
+    'cloud-limits-autosave': CloudLimitsAutosaveSelect<false> | CloudLimitsAutosaveSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -371,7 +270,11 @@ export interface Post {
   title?: string | null;
   description?: string | null;
   number?: number | null;
-  richText?: LexicalRichText<LexicalNodes_EC517269> | null;
+  richText?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
   someTextField?: string | null;
   namedGroup?: {
     someTextField?: string | null;
@@ -540,7 +443,14 @@ export interface CustomField {
         id?: string | null;
       }[]
     | null;
-  blocksFieldWithBeforeAfterInputs?: BlockFields[] | null;
+  blocksFieldWithBeforeAfterInputs?:
+    | {
+        textField?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'blockFields';
+      }[]
+    | null;
   text?: string | null;
   groupFieldWithBeforeAfterInputs?: {
     textOne?: string | null;
@@ -549,16 +459,6 @@ export interface CustomField {
   radioFieldWithBeforeAfterInputs?: ('one' | 'two' | 'three') | null;
   updatedAt: string;
   createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "BlockFields".
- */
-export interface BlockFields {
-  textField?: string | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'blockFields';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -800,13 +700,70 @@ export interface FullyFeatured {
   id: string;
   title: string;
   slug?: string | null;
-  content?: LexicalRichText<LexicalNodes_6CCD2587> | null;
+  content?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
   /**
    * Short summary for list views and SEO
    */
   excerpt?: string | null;
   heroImage?: (string | null) | Upload;
-  layout?: (RichTextBlock | ImageBlock | CtaBlock | CardGridBlock)[] | null;
+  layout?:
+    | (
+        | {
+            richText?:
+              | {
+                  [k: string]: unknown;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'richTextBlock';
+          }
+        | {
+            image: string | Upload;
+            caption?: string | null;
+            size?: ('small' | 'medium' | 'fullWidth') | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'imageBlock';
+          }
+        | {
+            heading: string;
+            description?: string | null;
+            links?:
+              | {
+                  label: string;
+                  url: string;
+                  style?: ('primary' | 'secondary' | 'outline') | null;
+                  id?: string | null;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'ctaBlock';
+          }
+        | {
+            cards?:
+              | {
+                  title: string;
+                  description?: string | null;
+                  image?: (string | null) | Upload;
+                  link?: {
+                    label?: string | null;
+                    url?: string | null;
+                  };
+                  id?: string | null;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'cardGridBlock';
+          }
+      )[]
+    | null;
   tags?:
     | {
         tag: string;
@@ -835,65 +792,24 @@ export interface FullyFeatured {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "RichTextBlock".
+ * via the `definition` "cloud-limits".
  */
-export interface RichTextBlock {
-  richText?: LexicalRichText<LexicalNodes_6CCD2587> | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'richTextBlock';
+export interface CloudLimit {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "ImageBlock".
+ * via the `definition` "cloud-limits-autosave".
  */
-export interface ImageBlock {
-  image: string | Upload;
-  caption?: string | null;
-  size?: ('small' | 'medium' | 'fullWidth') | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'imageBlock';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "CtaBlock".
- */
-export interface CtaBlock {
-  heading: string;
-  description?: string | null;
-  links?:
-    | {
-        label: string;
-        url: string;
-        style?: ('primary' | 'secondary' | 'outline') | null;
-        id?: string | null;
-      }[]
-    | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'ctaBlock';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "CardGridBlock".
- */
-export interface CardGridBlock {
-  cards?:
-    | {
-        title: string;
-        description?: string | null;
-        image?: (string | null) | Upload;
-        link?: {
-          label?: string | null;
-          url?: string | null;
-        };
-        id?: string | null;
-      }[]
-    | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'cardGridBlock';
+export interface CloudLimitsAutosave {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1058,6 +974,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'fully-featured';
         value: string | FullyFeatured;
+      } | null)
+    | ({
+        relationTo: 'cloud-limits';
+        value: string | CloudLimit;
+      } | null)
+    | ({
+        relationTo: 'cloud-limits-autosave';
+        value: string | CloudLimitsAutosave;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -1642,6 +1566,25 @@ export interface FullyFeaturedSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "cloud-limits_select".
+ */
+export interface CloudLimitsSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "cloud-limits-autosave_select".
+ */
+export interface CloudLimitsAutosaveSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -1936,7 +1879,9 @@ export interface CollectionQueryWidget {
       | 'virtuals'
       | 'no-timestamps'
       | 'localized'
-      | 'fully-featured';
+      | 'fully-featured'
+      | 'cloud-limits'
+      | 'cloud-limits-autosave';
     where?:
       | {
           [k: string]: unknown;
@@ -1995,6 +1940,8 @@ export interface ActivityWidget {
           | 'no-timestamps'
           | 'localized'
           | 'fully-featured'
+          | 'cloud-limits'
+          | 'cloud-limits-autosave'
         )[]
       | null;
   };
@@ -2006,140 +1953,6 @@ export interface ActivityWidget {
  */
 export interface Auth {
   [k: string]: unknown;
-}
-
-/** @internal Core Lexical types — see @payloadcms/richtext-lexical. */
-export type LexicalElementFormat = 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-export type LexicalElementDirection = ('ltr' | 'rtl') | null;
-
-export interface SerializedLexicalElementBase<TChildren> {
-  children: TChildren[];
-  direction: LexicalElementDirection;
-  format: LexicalElementFormat;
-  indent: number;
-  textFormat?: number;
-  textStyle?: string;
-  version: number;
-}
-
-export type LexicalTextMode = 'normal' | 'token' | 'segmented';
-
-export interface SerializedTextNode {
-  type: 'text';
-  detail: number;
-  format: number;
-  mode: LexicalTextMode;
-  style: string;
-  text: string;
-  version: number;
-}
-
-export interface SerializedTabNode {
-  type: 'tab';
-  detail: number;
-  format: number;
-  mode: LexicalTextMode;
-  style: string;
-  text: string;
-  version: number;
-}
-
-export interface SerializedLineBreakNode {
-  type: 'linebreak';
-  version: number;
-}
-
-export interface SerializedParagraphNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
-  type: 'paragraph';
-  textFormat: number;
-  textStyle: string;
-}
-
-export type SerializedRelationshipNode<TSlugs extends keyof Config['collections']> = {
-  type: 'relationship';
-  format: LexicalElementFormat;
-  version: number;
-} & {
-  [TSlug in TSlugs]: {
-    relationTo: TSlug;
-    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
-  };
-}[TSlugs];
-
-/** Shape of a Lexical `richText` field. */
-export interface LexicalRichText<TNode> {
-  root: {
-    children: TNode[];
-    direction: LexicalElementDirection;
-    format: LexicalElementFormat;
-    indent: number;
-    type: 'root';
-    version: number;
-  };
-}
-
-export interface SerializedHorizontalRuleNode {
-  type: 'horizontalrule';
-  version: number;
-}
-
-export type SerializedUploadNode<TSlugs extends keyof Config['collections'], TFields = { [k: string]: unknown }> = {
-  type: 'upload';
-  format: LexicalElementFormat;
-  id: string;
-  version: number;
-  fields: TFields;
-} & {
-  [TSlug in TSlugs]: {
-    relationTo: TSlug;
-    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
-  };
-}[TSlugs];
-
-export interface SerializedQuoteNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
-  type: 'quote';
-}
-
-export interface LexicalLinkFields {
-  [k: string]: unknown;
-  doc?: {
-    relationTo: string;
-    value: Config['db']['defaultIDType'] | { [k: string]: unknown; id: Config['db']['defaultIDType'] };
-  } | null;
-  linkType: 'custom' | 'internal';
-  newTab: boolean;
-  url?: string;
-}
-export interface SerializedLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
-  type: 'link';
-  fields: TFields;
-  id?: string;
-}
-export interface SerializedAutoLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
-  type: 'autolink';
-  fields: TFields;
-}
-
-export interface SerializedListNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
-  type: 'list';
-  checked?: boolean;
-  listType: 'number' | 'bullet' | 'check';
-  start: number;
-  tag: 'ul' | 'ol';
-}
-
-export interface SerializedListItemNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
-  type: 'listitem';
-  checked?: boolean;
-  value: number;
-}
-
-export interface SerializedHeadingNode<
-  TChildren,
-  TTag extends 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
-> extends SerializedLexicalElementBase<TChildren> {
-  type: 'heading';
-  tag: TTag;
 }
 
 

--- a/test/admin/slugs.ts
+++ b/test/admin/slugs.ts
@@ -30,6 +30,8 @@ export const listDrawerSlug = 'with-list-drawer'
 export const virtualsSlug = 'virtuals'
 export const formatDocURLCollectionSlug = 'format-doc-url'
 export const fullyFeaturedCollectionSlug = 'fully-featured'
+export const cloudLimitsCollectionSlug = 'cloud-limits'
+export const cloudLimitsAutosaveCollectionSlug = 'cloud-limits-autosave'
 export const collectionSlugs = [
   usersCollectionSlug,
   customViews1CollectionSlug,


### PR DESCRIPTION
## What
Surfaces the following new FC usage limit errors:

- `cloud_limit.cms_assets_bytes_exceeded` when upload size is exceeded
- `cloud_limit.document_count_exceeded` when total allowed document count is reached
- `cloud_limit.per_document_data_bytes_exceeded` when maximum document JSON size is reached

Design [here](https://staging.figma.com/design/Qc8as4jXaTxJh9JWBw8QHC/-Payload--Document-limits?node-id=558-59776&m=dev).

**IMPORTANT:**
I tested this by throwing dummy errors that replicate the error code and status.
Currently when testing against the actual `content-api`, the error messages are getting masked into a generic 500 status error. This seems to be happening in `figma/payload/payload-plugin/src/db-content-api` where we catch and re-throw any error as:
```ts
  if (error) {
    throw new Error(`Content API create error: ${JSON.stringify(error)}`)   // line 713
  }
```

Once this is resolved, we need to revalidate that this works end to end.

[22/07/26] The above has been resolved. However, there is a v0/v1 pipeline mismatch that now needs to be updated before we are able to test this e2e.

**UI Preview**
https://github.com/user-attachments/assets/5c5785de-c2f2-4705-b065-5532a43f94a4

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214135836200190