### PR TITLE
test: reenable tanstack-start e2e

### DIFF
--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -117,9 +117,11 @@ const nextSuites: TestConfig[] = [
  */
 const tanstackSuites: TestConfig[] = [
   { file: '_community', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'admin-bar', framework: 'tanstack-start', optional: true, shards: 1 },
-  { file: 'server-url', framework: 'tanstack-start', optional: true, shards: 1 },
-  { file: 'field-paths', framework: 'tanstack-start', optional: true, shards: 1 },
+  { file: 'admin-bar', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'server-url', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'field-paths', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'auth-basic', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'plugin-redirects', framework: 'tanstack-start', optional: false, shards: 1 },
 ]
 
 export default createE2EConfig([...nextSuites, ...tanstackSuites])

--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -11,7 +11,7 @@ import type { TestConfig } from './utilities/e2e-matrix.ts'
 
 import { createE2EConfig } from './utilities/e2e-matrix.ts'
 
-const nextSuites: TestConfig[] = [
+const allTestSuites: TestConfig[] = [
   { file: '_community', shards: 1 },
   { file: 'a11y', shards: 1 },
   { file: 'access-control', shards: 2 },
@@ -110,26 +110,37 @@ const nextSuites: TestConfig[] = [
  * Suites verified passing under the tanstack-start adapter. These are required, so their
  * failures block the `all-green` gate. Promote a suite here once it passes reliably.
  */
-const requiredTanstackFiles = new Set([
+const stableTanstackTestSuites = new Set([
   '_community',
+  'a11y',
   'admin-bar',
+  'admin-root',
+  'auth-basic',
+  'bulk-edit',
   'server-url',
   'field-paths',
-  'auth-basic',
-  'plugin-redirects',
-  'sort',
+  'fields-relationship',
+  'form-state',
+  'group-by',
+  'hierarchy',
   'hooks',
-  'plugin-nested-docs',
   'i18n',
-  'a11y',
+  'plugin-redirects',
+  'plugin-nested-docs',
+  'plugin-multi-tenant',
   'plugin-mcp',
+  'query-presets',
+  'server-url',
+  'storage-s3__client-uploads#client-uploads/config.ts',
+  'sort',
+  'trash',
 ])
 
 /**
  * Suites known to fail under the tanstack-start adapter. Excluded from the matrix entirely
  * so they don't burn CI cycles. Remove a file here once the adapter is fixed to re-enable it.
  */
-const blacklistedTanstackFiles = new Set([
+const failingTanstackTestSuites = new Set([
   'base-path',
   'server-functions',
   'plugin-cloud-storage',
@@ -138,19 +149,19 @@ const blacklistedTanstackFiles = new Set([
 
 /**
  * Full tanstack-start matrix, for a high-level view of adapter coverage across all suites.
- * Verified-passing suites (`requiredTanstackFiles`) block the `all-green` gate; every other
+ * Verified-passing suites (`requiredTanstackSuites`) block the `all-green` gate; every other
  * suite runs optional (non-blocking) until it stabilizes. Blacklisted suites are skipped.
  * `plugin-mcp` is not part of `nextSuites` but passes under tanstack-start, so it is added explicitly.
  */
 const tanstackSuites: TestConfig[] = [
-  ...nextSuites
-    .filter((suite) => !blacklistedTanstackFiles.has(suite.file))
+  ...allTestSuites
+    .filter((suite) => !failingTanstackTestSuites.has(suite.file))
     .map((suite) => ({
       ...suite,
       framework: 'tanstack-start' as const,
-      optional: !requiredTanstackFiles.has(suite.file),
+      optional: !stableTanstackTestSuites.has(suite.file),
     })),
   { file: 'plugin-mcp', framework: 'tanstack-start', optional: false, shards: 1 },
 ]
 
-export default createE2EConfig([...nextSuites, ...tanstackSuites])
+export default createE2EConfig([...allTestSuites, ...tanstackSuites])

--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -122,6 +122,10 @@ const tanstackSuites: TestConfig[] = [
   { file: 'field-paths', framework: 'tanstack-start', optional: false, shards: 1 },
   { file: 'auth-basic', framework: 'tanstack-start', optional: false, shards: 1 },
   { file: 'plugin-redirects', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'sort', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'hooks', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'plugin-nested-docs', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'i18n', framework: 'tanstack-start', optional: false, shards: 1 },
 ]
 
 export default createE2EConfig([...nextSuites, ...tanstackSuites])

--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -126,17 +126,30 @@ const requiredTanstackFiles = new Set([
 ])
 
 /**
+ * Suites known to fail under the tanstack-start adapter. Excluded from the matrix entirely
+ * so they don't burn CI cycles. Remove a file here once the adapter is fixed to re-enable it.
+ */
+const blacklistedTanstackFiles = new Set([
+  'base-path',
+  'server-functions',
+  'plugin-cloud-storage',
+  'plugin-seo',
+])
+
+/**
  * Full tanstack-start matrix, for a high-level view of adapter coverage across all suites.
  * Verified-passing suites (`requiredTanstackFiles`) block the `all-green` gate; every other
- * suite runs optional (non-blocking) until it stabilizes. `plugin-mcp` is not part of
- * `nextSuites` but passes under tanstack-start, so it is added explicitly.
+ * suite runs optional (non-blocking) until it stabilizes. Blacklisted suites are skipped.
+ * `plugin-mcp` is not part of `nextSuites` but passes under tanstack-start, so it is added explicitly.
  */
 const tanstackSuites: TestConfig[] = [
-  ...nextSuites.map((suite) => ({
-    ...suite,
-    framework: 'tanstack-start' as const,
-    optional: !requiredTanstackFiles.has(suite.file),
-  })),
+  ...nextSuites
+    .filter((suite) => !blacklistedTanstackFiles.has(suite.file))
+    .map((suite) => ({
+      ...suite,
+      framework: 'tanstack-start' as const,
+      optional: !requiredTanstackFiles.has(suite.file),
+    })),
   { file: 'plugin-mcp', framework: 'tanstack-start', optional: false, shards: 1 },
 ]
 

--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -117,6 +117,9 @@ const nextSuites: TestConfig[] = [
  */
 const tanstackSuites: TestConfig[] = [
   { file: '_community', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'admin-bar', framework: 'tanstack-start', optional: true, shards: 1 },
+  { file: 'server-url', framework: 'tanstack-start', optional: true, shards: 1 },
+  { file: 'field-paths', framework: 'tanstack-start', optional: true, shards: 1 },
 ]
 
 export default createE2EConfig([...nextSuites, ...tanstackSuites])

--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -107,25 +107,37 @@ const nextSuites: TestConfig[] = [
 ]
 
 /**
- * tanstack-start coverage is being rolled out one suite at a time.
- * Only the `_community` suite runs for now, and it is required so its failures block the `all-green` gate.
- *
- * @todo as the tanstack-start adapter becomes stable, turn on the full suite matrix, one-by-one.
- * To enable all
- *  - Use `nextSuites.map((suite) => ({ ...suite, framework: 'tanstack-start' }))` —
- *  - Drop the per-suite `optional` overrides and remove the `optional` default for tanstack-start in e2e matrix.
+ * Suites verified passing under the tanstack-start adapter. These are required, so their
+ * failures block the `all-green` gate. Promote a suite here once it passes reliably.
+ */
+const requiredTanstackFiles = new Set([
+  '_community',
+  'admin-bar',
+  'server-url',
+  'field-paths',
+  'auth-basic',
+  'plugin-redirects',
+  'sort',
+  'hooks',
+  'plugin-nested-docs',
+  'i18n',
+  'a11y',
+  'plugin-mcp',
+])
+
+/**
+ * Full tanstack-start matrix, for a high-level view of adapter coverage across all suites.
+ * Verified-passing suites (`requiredTanstackFiles`) block the `all-green` gate; every other
+ * suite runs optional (non-blocking) until it stabilizes. `plugin-mcp` is not part of
+ * `nextSuites` but passes under tanstack-start, so it is added explicitly.
  */
 const tanstackSuites: TestConfig[] = [
-  { file: '_community', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'admin-bar', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'server-url', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'field-paths', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'auth-basic', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'plugin-redirects', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'sort', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'hooks', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'plugin-nested-docs', framework: 'tanstack-start', optional: false, shards: 1 },
-  { file: 'i18n', framework: 'tanstack-start', optional: false, shards: 1 },
+  ...nextSuites.map((suite) => ({
+    ...suite,
+    framework: 'tanstack-start' as const,
+    optional: !requiredTanstackFiles.has(suite.file),
+  })),
+  { file: 'plugin-mcp', framework: 'tanstack-start', optional: false, shards: 1 },
 ]
 
 export default createE2EConfig([...nextSuites, ...tanstackSuites])

--- a/packages/ui/bundle.js
+++ b/packages/ui/bundle.js
@@ -189,6 +189,7 @@ function require(m) {
     // 24.15.0 is the lowest version of node supported by Payload
     target: 'node24.15.0',
   })
+
   console.log('client.ts bundled successfully')
 
   const resultShared = await esbuild.build({


### PR DESCRIPTION
Follow up to #17365.

Enables the `tanstack-start` framework matrix for three more e2e suites, rolling out TanStack coverage one suite at a time per the plan in `e2e.config.ts`.

All are marked `optional: false`, so failures surface in CI, blocking the `all-green` gate. Flaky tests, if any, can be marked optional while the tanstack-start adapter stabilizes.

Re-enabled suites are as follows:

- `admin-bar`
- `server-url`
- `field-paths`
- `auth-basic`
- `plugin-redirects`