### PR TITLE
fix(templates): guard realpath crash in with-cloudflare-d1 on Cloudflare Workers

### DIFF
--- a/templates/with-cloudflare-d1/src/payload.config.ts
+++ b/templates/with-cloudflare-d1/src/payload.config.ts
@@ -13,9 +13,18 @@ import { Media } from './collections/Media'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const realpath = (value: string) => (fs.existsSync(value) ? fs.realpathSync(value) : undefined)
+const realpath = (value: string) => {
+  try {
+    return fs.existsSync(value) ? fs.realpathSync(value) : undefined
+  } catch {
+    return undefined
+  }
+}
 
-const isCLI = process.argv.some((value) => realpath(value).endsWith(path.join('payload', 'bin.js')))
+const isCLI = process.argv.some((value) => {
+  const resolved = realpath(value)
+  return resolved ? resolved.endsWith(path.join('payload', 'bin.js')) : false
+})
 const isProduction = process.env.NODE_ENV === 'production'
 
 const createLog =


### PR DESCRIPTION
## Problem

The `with-cloudflare-d1` template crashes with a 500 on every request when deployed to Cloudflare Workers:

```
TypeError: Cannot read properties of undefined (reading 'endsWith')
```

The `realpath()` helper returns `undefined` when `fs.existsSync()` is false — which is the case for every `process.argv` entry in the Workers runtime (no filesystem). The subsequent `.endsWith()` call on `undefined` throws.

This was introduced in #15098, which replaced a simple regex check with `realpath().endsWith()` to also support `payload run`. The change works in Node.js but doesn't account for the Workers edge environment.

## Fix

Two guards:

1. **Try-catch around `realpath()`** — `fs.existsSync()` and `fs.realpathSync()` may throw in runtimes without a filesystem.
2. **Null check before `.endsWith()`** — if `realpath()` returns `undefined`, return `false` instead of calling a method on `undefined`.

No behavioral change in Node.js — `realpath()` still returns the same values for existing file paths, and `undefined` for non-existent ones (which now safely returns `false` instead of throwing).

## Verification

Deployed to Cloudflare Workers and confirmed:
- Homepage returns 200 (was 500)
- Admin panel loads and renders correctly
- Payload API endpoints respond normally
- No regressions in local dev (`payload generate:types`, `payload migrate:create`)