### PR TITLE
fix(templates): make with-cloudflare-d1 build with published npm packages

### DIFF
--- a/templates/with-cloudflare-d1/package.json
+++ b/templates/with-cloudflare-d1/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=8000\" payload build",
+    "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=8000\" next build",
     "deploy": "pnpm run deploy:database && pnpm run deploy:app",
     "deploy:app": "opennextjs-cloudflare build --env=$CLOUDFLARE_ENV && opennextjs-cloudflare deploy --env=$CLOUDFLARE_ENV",
     "deploy:database": "cross-env NODE_ENV=production PAYLOAD_SECRET=ignore payload migrate && wrangler d1 execute D1 --command 'PRAGMA optimize' --env=$CLOUDFLARE_ENV --remote",
@@ -26,16 +26,16 @@
   },
   "dependencies": {
     "@opennextjs/cloudflare": "^1.11.0",
-    "@payloadcms/db-d1-sqlite": "3.82.1",
-    "@payloadcms/next": "3.82.1",
-    "@payloadcms/richtext-lexical": "3.82.1",
-    "@payloadcms/storage-r2": "3.82.1",
-    "@payloadcms/ui": "3.82.1",
+    "@payloadcms/db-d1-sqlite": "3.86.0",
+    "@payloadcms/next": "3.86.0",
+    "@payloadcms/richtext-lexical": "3.86.0",
+    "@payloadcms/storage-r2": "3.86.0",
+    "@payloadcms/ui": "3.86.0",
     "cross-env": "10.1.0",
     "dotenv": "16.4.7",
     "graphql": "^16.8.1",
     "next": "15.4.11",
-    "payload": "3.82.1",
+    "payload": "3.86.0",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
@@ -57,7 +57,7 @@
     "wrangler": "~4.61.1"
   },
   "engines": {
-    "node": ">=24.15.0",
+    "node": ">=22.0.0",
     "pnpm": "^9 || ^10 || ^11"
   },
   "pnpm": {

--- a/templates/with-cloudflare-d1/src/app/(payload)/layout.tsx
+++ b/templates/with-cloudflare-d1/src/app/(payload)/layout.tsx
@@ -4,8 +4,8 @@ import config from '@payload-config'
 import '@payloadcms/next/css'
 import type { ServerFunctionClient } from 'payload'
 import {
-  generatePayloadViewport,
   handleServerFunctions,
+  metadata,
   RootLayout,
 } from '@payloadcms/next/layouts'
 import React from 'react'
@@ -13,7 +13,7 @@ import React from 'react'
 import { importMap } from './admin/importMap.js'
 import './custom.scss'
 
-export const generateViewport = generatePayloadViewport
+export { metadata }
 
 type Args = {
   children: React.ReactNode

--- a/templates/with-cloudflare-d1/src/assets.d.ts
+++ b/templates/with-cloudflare-d1/src/assets.d.ts
@@ -1,0 +1,5 @@
+// Ambient declarations for side-effect style imports (e.g. `import './styles.css'`).
+// The monorepo provides these via tools/assets.d.ts; standalone templates need their own.
+declare module '*.css'
+
+declare module '*.scss'

--- a/templates/with-cloudflare-d1/src/payload.config.ts
+++ b/templates/with-cloudflare-d1/src/payload.config.ts
@@ -13,9 +13,22 @@ import { Media } from './collections/Media'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const realpath = (value: string) => (fs.existsSync(value) ? fs.realpathSync(value) : undefined)
+const realpath = (value: string) => {
+  try {
+    return fs.existsSync(value) ? fs.realpathSync(value) : undefined
+  } catch {
+    return undefined
+  }
+}
 
-const isCLI = process.argv.some((value) => realpath(value).endsWith(path.join('payload', 'bin.js')))
+const isCLI = process.argv.some((value) => {
+  const resolved = realpath(value)
+  if (!resolved) return false
+  return (
+    resolved.endsWith(path.join('payload', 'bin.js')) ||
+    resolved.endsWith(path.join('next', 'dist', 'bin', 'next'))
+  )
+})
 const isProduction = process.env.NODE_ENV === 'production'
 
 const createLog =
@@ -58,7 +71,7 @@ export default buildConfig({
   },
   db: sqliteD1Adapter({ binding: cloudflare.env.D1 }),
   logger: isProduction ? cloudflareLogger : undefined,
-  storage: [
+  plugins: [
     r2Storage({
       bucket: cloudflare.env.R2,
       collections: { media: true },
@@ -72,7 +85,7 @@ function getCloudflareContextFromWrangler(): Promise<CloudflareContext> {
     ({ getPlatformProxy }) =>
       getPlatformProxy({
         environment: process.env.CLOUDFLARE_ENV,
-        remoteBindings: isProduction,
+        remoteBindings: false,
       } satisfies GetPlatformProxyOptions),
   )
 }

--- a/templates/with-cloudflare-d1/wrangler.jsonc
+++ b/templates/with-cloudflare-d1/wrangler.jsonc
@@ -20,7 +20,7 @@
       "binding": "D1",
       "database_id": "DATABASE_ID",
       "database_name": "my-app",
-      "remote": true,
+      "remote": false,
     },
   ],
   "services": [


### PR DESCRIPTION
## Problem

The `with-cloudflare-d1` template on `main` references several APIs that have not been published to npm. Anyone installing the template via `create-payload-app` gets TypeScript errors and a failed build.

The root cause: the template is developed inside the monorepo where workspace packages have unreleased APIs. The CI (`post-release-templates.yml`) only bumps lockfiles — it never runs a standalone build — so these breakages go undetected.

## Changes

### 1. `payload build` → `next build` (`package.json`)
`payload build` is not available in any published `payload` CLI version. Changed the build script to `next build`.

### 2. `Config.storage` → `Config.plugins` (`payload.config.ts`)
`storage` is an unreleased API not in any published `@payloadcms/*` package. Changed to `plugins`, which has always existed. (A codemod `migrate-storage-adapters-to-config` exists upstream for this transition.)

This is the same fix proposed in #17217 and reported in #17195 — this PR includes it as part of a broader fix for the template.

### 3. `generatePayloadViewport` → `metadata` (`layout.tsx`)
`generatePayloadViewport` is an unreleased export not in any published `@payloadcms/next` version. Changed to `metadata`, which has always been exported. (A codemod `migrate-next-generate-viewport-export` exists upstream.)

### 4. CSS/SCSS type declarations (`src/assets.d.ts` — new)
The monorepo provides `declare module '*.css'` and `declare module '*.scss'` via `tools/assets.d.ts` (wired through `tsconfig.base.json`). Standalone templates lack this file, causing `TS2882` on side-effect style imports. Added `src/assets.d.ts` with the same declarations.

### 5. `isCLI` detection for `next build` (`payload.config.ts`)
Switching from `payload build` to `next build` means `payload/bin.js` is no longer in `process.argv`, so `isCLI` was always `false` during build. This caused the config to use `getCloudflareContext()` (production path requiring `CLOUDFLARE_API_TOKEN`) instead of `getCloudflareContextFromWrangler()` (local wrangler path). Extended `isCLI` to also detect `next/dist/bin/next`.

### 6. `realpath` crash guard (`payload.config.ts`)
The `realpath()` helper returned `undefined` when `fs.existsSync()` is false — the case for every `process.argv` entry in the Workers runtime — and the subsequent `.endsWith()` call on `undefined` threw. Wrapped in `try/catch` with a null guard. (Supersedes #17392 for this file.)

### 7. `remoteBindings` during build (`payload.config.ts`, `wrangler.jsonc`)
`getCloudflareContextFromWrangler()` was called with `remoteBindings: isProduction`, which during `next build` (`NODE_ENV=production`) tried to connect to real Cloudflare D1/R2 resources. Since this function is only called for CLI/build/dev (never production runtime), changed to `remoteBindings: false`. Also changed the D1 binding in `wrangler.jsonc` from `remote: true` to `remote: false` so the template builds out of the box without pre-configured Cloudflare resources.

### 8. `engines.node` (`package.json`)
Lowered from `>=24.15.0` to `>=22.0.0` for compatibility with Cloudflare Workers Builds (Node 22.16.0).

### 9. Dependency bumps (`package.json`)
Bumped `@payloadcms/*` packages from `3.82.1` to `3.86.0` (latest published).

## Verification

Cloned the template standalone, applied all changes, ran `pnpm install && pnpm run build`:

```
✓ Compiled successfully
✓ Generating static pages (7/7)

Route (app)                                 Size  First Load JS
┌ ƒ /                                    5.47 kB         107 kB
├ ○ /_not-found                             1 kB         103 kB
├ ƒ /admin/[[...segments]]                 393 B         574 kB
├ ƒ /api/[...slug]                         176 B         102 kB
├ ƒ /api/graphql                           133 B         102 kB
├ ƒ /api/graphql-playground                176 B         102 kB
└ ƒ /my-route                              133 B         102 kB
```

TypeScript compilation passes, all 7 routes generate successfully, no errors.

## Relationship to existing issues and PRs

- **Fixes #17195** — `storage` config key doesn't exist in released 3.x (the `storage` → `plugins` change, item 2 above)
- **Supersedes #17217** — `chore(templates): fix with-cloudflare-d1 storage adapter registration` (only fixes the `storage` → `plugins` issue; this PR covers that plus 8 additional breakages)
- **Supersedes #17392** — `fix(templates): guard realpath crash in with-cloudflare-d1 on Cloudflare Workers` (the `realpath` guard is included here, item 6 above)
- Related: #16757 — `with-cloudflare-d1 template is broken from v3.85.0` (fixed in v3.85.2, but the template pins 3.82.1 which has the same class of problem)

## Notes

- Users who want to use a remote D1 database during development should set `remote: true` in `wrangler.jsonc` and provide a real `database_id`.