### PR TITLE
fix(templates): reduce with-cloudflare-d1 Worker bundle for free-tier 3 MiB limit

### DIFF
--- a/templates/with-cloudflare-d1/README.md
+++ b/templates/with-cloudflare-d1/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/payloadcms/payload/tree/main/templates/with-cloudflare-d1)
 
-**This can only be deployed on Paid Workers right now due to size limits.** This template comes configured with the bare minimum to get started on anything you need.
+**This template fits within the Cloudflare Workers free-tier 3 MiB size limit** (~2.6 MiB gzip as shipped, measured with `wrangler deploy`). It comes configured with the bare minimum to get started on anything you need.
 
 ## Quick start
 
@@ -102,6 +102,17 @@ If you see "Failed to publish diagnostic channel message" errors in your observa
 
 Cloudflare Workers runs in an [isolated environment that cannot access private IP ranges](https://developers.cloudflare.com/workers-vpc/examples/route-across-private-services/) by default, providing built-in SSRF protection. This makes `skipSafeFetch` safe to use.
 
+## OG image generation
+
+Payload ships an endpoint (`/api/og`) that generates dynamic Open Graph images for social sharing via `@vercel/og`. On Cloudflare Workers, `@vercel/og` works through compatibility patches in the OpenNext adapter (`@opennextjs/cloudflare`), but it adds ~744 KiB gzip to the Worker bundle — pushing the template from ~2.6 MiB to ~3.3 MiB gzip, over the free-tier 3 MiB limit.
+
+This template disables the feature and replaces the endpoint module with a stub to stay within the free-tier limit:
+
+- `admin.meta.defaultOGImageType: 'off'` in `src/payload.config.ts`
+- The endpoint module is aliased to `stubs/payload-og-endpoint.js` in `next.config.ts`, so `@vercel/og` never enters the Worker bundle
+
+To re-enable OG image generation, remove the alias from `next.config.ts` and remove `defaultOGImageType` from `src/payload.config.ts`. The feature works on Workers via OpenNext's compatibility patches, but the bundle will exceed the free-tier 3 MiB limit — a Paid Workers plan is required.
+
 ## Known issues
 
 ### GraphQL
@@ -110,9 +121,9 @@ We are currently waiting on some issues with GraphQL to be [fixed upstream in Wo
 
 ### Worker size limits
 
-We currently recommend deploying this template to the Paid Workers plan due to bundle [size limits](https://developers.cloudflare.com/workers/platform/limits/#worker-size) of 3mb. We're actively trying to reduce our bundle footprint over time to better meet this metric.
+This template fits within the Cloudflare Workers free-tier [3 MiB compressed size limit](https://developers.cloudflare.com/workers/platform/limits/#worker-size) — ~2.6 MiB gzip total upload as shipped (`wrangler deploy`), leaving ~450 KiB of headroom. Part of how it fits is [disabling the `@vercel/og` endpoint](#og-image-generation), which adds ~744 KiB gzip when enabled.
 
-This also applies to your own code, in the case of importing a lot of libraries you may find yourself limited by the bundle.
+This also applies to your own code: importing large libraries (or re-enabling OG image generation) can push your bundle over the free-tier limit, in which case you'll need a Paid Workers plan.
 
 ## Questions
 

--- a/templates/with-cloudflare-d1/next.config.ts
+++ b/templates/with-cloudflare-d1/next.config.ts
@@ -1,4 +1,25 @@
+import path from 'path'
+import { createRequire } from 'module'
+import { fileURLToPath } from 'url'
 import { withPayload } from '@payloadcms/next/withPayload'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+// Payload's REST handler statically imports the OG image endpoint
+// (@payloadcms/next/dist/routes/rest/og/index.js), which imports `next/og.js`
+// (ImageResponse) — pulling ~2.9 MiB of @vercel/og WASM + fonts into the
+// Worker bundle. @vercel/og works on Workers through OpenNext's compatibility
+// patches, but the ~744 KiB gzip cost pushes the template over the free-tier
+// 3 MiB limit. This template sets `admin.meta.defaultOGImageType: 'off'` in
+// src/payload.config.ts, so the endpoint module is aliased to a stub that
+// mirrors the disabled behavior and keeps the entire @vercel/og dependency
+// chain out of the bundle.
+const require = createRequire(import.meta.url)
+const payloadNextRoutesPath = require.resolve('@payloadcms/next/routes')
+const payloadNextDistDir = path.dirname(path.dirname(payloadNextRoutesPath))
+const ogEndpointPath = path.join(payloadNextDistDir, 'routes/rest/og/index.js')
+const ogStubPath = path.resolve(dirname, 'stubs/payload-og-endpoint.js')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -13,12 +34,31 @@ const nextConfig = {
   // Read more: https://opennext.js.org/cloudflare/howtos/workerd
   serverExternalPackages: ['jose', 'pg-cloudflare'],
 
+  // drizzle-kit/api is only used by the Payload CLI for migrations, not at
+  // runtime. withPayload() externalizes it via webpack externals and
+  // serverExternalPackages, but OpenNext's esbuild bundler does not fully
+  // respect those. Aliasing to a stub prevents the 7.3 MiB module from
+  // entering the Worker bundle.
+  // See: https://github.com/payloadcms/payload/issues/16470
+  turbopack: {
+    resolveAlias: {
+      'drizzle-kit/api': path.resolve(dirname, 'stubs/drizzle-kit-api.js'),
+      [ogEndpointPath]: ogStubPath,
+    },
+  },
+
   // Your Next.js config here
   webpack: (webpackConfig: any) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],
       '.js': ['.ts', '.tsx', '.js', '.jsx'],
       '.mjs': ['.mts', '.mjs'],
+    }
+
+    webpackConfig.resolve.alias = {
+      ...webpackConfig.resolve.alias,
+      'drizzle-kit/api': path.resolve(dirname, 'stubs/drizzle-kit-api.js'),
+      [ogEndpointPath]: ogStubPath,
     }
 
     return webpackConfig

--- a/templates/with-cloudflare-d1/package.json
+++ b/templates/with-cloudflare-d1/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=8000\" payload build",
+    "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=8000\" next build",
     "deploy": "pnpm run deploy:database && pnpm run deploy:app",
     "deploy:app": "opennextjs-cloudflare build --env=$CLOUDFLARE_ENV && opennextjs-cloudflare deploy --env=$CLOUDFLARE_ENV",
     "deploy:database": "cross-env NODE_ENV=production PAYLOAD_SECRET=ignore payload migrate && wrangler d1 execute D1 --command 'PRAGMA optimize' --env=$CLOUDFLARE_ENV --remote",
@@ -26,16 +26,16 @@
   },
   "dependencies": {
     "@opennextjs/cloudflare": "^1.11.0",
-    "@payloadcms/db-d1-sqlite": "3.82.1",
-    "@payloadcms/next": "3.82.1",
-    "@payloadcms/richtext-lexical": "3.82.1",
-    "@payloadcms/storage-r2": "3.82.1",
-    "@payloadcms/ui": "3.82.1",
+    "@payloadcms/db-d1-sqlite": "3.86.0",
+    "@payloadcms/next": "3.86.0",
+    "@payloadcms/richtext-lexical": "3.86.0",
+    "@payloadcms/storage-r2": "3.86.0",
+    "@payloadcms/ui": "3.86.0",
     "cross-env": "10.1.0",
     "dotenv": "16.4.7",
     "graphql": "^16.8.1",
     "next": "15.4.11",
-    "payload": "3.82.1",
+    "payload": "3.86.0",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
@@ -57,7 +57,7 @@
     "wrangler": "~4.61.1"
   },
   "engines": {
-    "node": ">=24.15.0",
+    "node": ">=22.0.0",
     "pnpm": "^9 || ^10 || ^11"
   },
   "pnpm": {

--- a/templates/with-cloudflare-d1/src/app/(payload)/layout.tsx
+++ b/templates/with-cloudflare-d1/src/app/(payload)/layout.tsx
@@ -4,8 +4,8 @@ import config from '@payload-config'
 import '@payloadcms/next/css'
 import type { ServerFunctionClient } from 'payload'
 import {
-  generatePayloadViewport,
   handleServerFunctions,
+  metadata,
   RootLayout,
 } from '@payloadcms/next/layouts'
 import React from 'react'
@@ -13,7 +13,7 @@ import React from 'react'
 import { importMap } from './admin/importMap.js'
 import './custom.scss'
 
-export const generateViewport = generatePayloadViewport
+export { metadata }
 
 type Args = {
   children: React.ReactNode

--- a/templates/with-cloudflare-d1/src/assets.d.ts
+++ b/templates/with-cloudflare-d1/src/assets.d.ts
@@ -1,0 +1,5 @@
+// Ambient declarations for side-effect style imports (e.g. `import './styles.css'`).
+// The monorepo provides these via tools/assets.d.ts; standalone templates need their own.
+declare module '*.css'
+
+declare module '*.scss'

--- a/templates/with-cloudflare-d1/src/payload.config.ts
+++ b/templates/with-cloudflare-d1/src/payload.config.ts
@@ -62,6 +62,14 @@ export default buildConfig({
     importMap: {
       baseDir: path.resolve(dirname),
     },
+    meta: {
+      // Disabling OG image generation here and aliasing the endpoint module
+      // to a stub in next.config.ts keeps @vercel/og (~744 KiB gzip) out of
+      // the Worker bundle. @vercel/og works on Workers through OpenNext's
+      // compatibility patches, but the size cost exceeds the free-tier limit.
+      // To re-enable, remove this setting and the alias in next.config.ts.
+      defaultOGImageType: 'off',
+    },
   },
   collections: [Users, Media],
   editor: lexicalEditor(),

--- a/templates/with-cloudflare-d1/src/payload.config.ts
+++ b/templates/with-cloudflare-d1/src/payload.config.ts
@@ -13,9 +13,22 @@ import { Media } from './collections/Media'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const realpath = (value: string) => (fs.existsSync(value) ? fs.realpathSync(value) : undefined)
+const realpath = (value: string) => {
+  try {
+    return fs.existsSync(value) ? fs.realpathSync(value) : undefined
+  } catch {
+    return undefined
+  }
+}
 
-const isCLI = process.argv.some((value) => realpath(value).endsWith(path.join('payload', 'bin.js')))
+const isCLI = process.argv.some((value) => {
+  const resolved = realpath(value)
+  if (!resolved) return false
+  return (
+    resolved.endsWith(path.join('payload', 'bin.js')) ||
+    resolved.endsWith(path.join('next', 'dist', 'bin', 'next'))
+  )
+})
 const isProduction = process.env.NODE_ENV === 'production'
 
 const createLog =
@@ -58,7 +71,7 @@ export default buildConfig({
   },
   db: sqliteD1Adapter({ binding: cloudflare.env.D1 }),
   logger: isProduction ? cloudflareLogger : undefined,
-  storage: [
+  plugins: [
     r2Storage({
       bucket: cloudflare.env.R2,
       collections: { media: true },
@@ -72,7 +85,7 @@ function getCloudflareContextFromWrangler(): Promise<CloudflareContext> {
     ({ getPlatformProxy }) =>
       getPlatformProxy({
         environment: process.env.CLOUDFLARE_ENV,
-        remoteBindings: isProduction,
+        remoteBindings: false,
       } satisfies GetPlatformProxyOptions),
   )
 }

--- a/templates/with-cloudflare-d1/stubs/drizzle-kit-api.js
+++ b/templates/with-cloudflare-d1/stubs/drizzle-kit-api.js
@@ -1,0 +1,27 @@
+// Stub for drizzle-kit/api
+//
+// drizzle-kit/api is only used by the Payload CLI for migrations and schema
+// operations — never at runtime in a Cloudflare Worker. However, it is
+// transitively imported by @payloadcms/drizzle/sqlite, so without a stub it
+// gets pulled into the OpenNext Cloudflare server bundle (~7.3 MiB).
+//
+// withPayload() already externalizes drizzle-kit/api via webpack externals
+// and serverExternalPackages, but OpenNext's esbuild-based bundler does not
+// fully respect those — it still tries to resolve and bundle the module.
+// Aliasing to this stub in next.config.ts prevents that.
+//
+// This is a workaround until https://github.com/payloadcms/payload/pull/17009
+// (lazy-load drizzle-kit) is merged and published.
+//
+// See: https://github.com/payloadcms/payload/issues/16470
+module.exports = {
+  generateSQLiteDrizzleJson: () => {
+    throw new Error('drizzle-kit/api is stubbed in production build')
+  },
+  generateSQLiteMigration: () => {
+    throw new Error('drizzle-kit/api is stubbed in production build')
+  },
+  pushSQLiteSchema: () => {
+    throw new Error('drizzle-kit/api is stubbed in production build')
+  },
+}

--- a/templates/with-cloudflare-d1/stubs/payload-og-endpoint.js
+++ b/templates/with-cloudflare-d1/stubs/payload-og-endpoint.js
@@ -1,0 +1,17 @@
+// Stub for @payloadcms/next/dist/routes/rest/og/index.js
+//
+// The real module imports `next/og.js` (ImageResponse), which pulls ~2.9 MiB
+// of @vercel/og WASM + fonts into the Cloudflare Worker bundle. @vercel/og
+// works on Workers through OpenNext's compatibility patches, but the ~744 KiB
+// gzip cost pushes the template over the free-tier 3 MiB limit. This template
+// sets `admin.meta.defaultOGImageType: 'off'` in payload.config.ts, so the
+// stub mirrors the real module's "disabled" behavior (HTTP 400) while keeping
+// the entire @vercel/og dependency chain out of the module graph.
+//
+// Aliased in next.config.ts. To re-enable OG image generation, remove the
+// alias there and remove `defaultOGImageType: 'off'` from payload.config.ts.
+export const runtime = 'nodejs'
+export const contentType = 'image/png'
+export const generateOGImage = async () => {
+  return Response.json({ error: 'Open Graph images are disabled' }, { status: 400 })
+}

--- a/templates/with-cloudflare-d1/wrangler.jsonc
+++ b/templates/with-cloudflare-d1/wrangler.jsonc
@@ -41,6 +41,9 @@
     //   "bucket_name": "<BUCKET_NAME>",
     // },
   ],
+  "observability": {
+    "enabled": true,
+  },
 
   // Here's how to configure an additional environment
   // It can be deployed with `CLOUDFLARE_ENV=staging pnpm run deploy`

--- a/templates/with-cloudflare-d1/wrangler.jsonc
+++ b/templates/with-cloudflare-d1/wrangler.jsonc
@@ -20,7 +20,7 @@
       "binding": "D1",
       "database_id": "DATABASE_ID",
       "database_name": "my-app",
-      "remote": true,
+      "remote": false,
     },
   ],
   "services": [


### PR DESCRIPTION
## Problem

The `with-cloudflare-d1` template's Worker bundle is **3,364 KiB gzip** (measured via `wrangler deploy --dry-run` total upload) — **292 KiB over** the Cloudflare Workers free-tier [3 MiB (3,072 KiB) compressed size limit](https://developers.cloudflare.com/workers/platform/limits/#worker-size). This causes the template to fail to deploy on the Cloudflare Workers free tier — `wrangler deploy` rejects the upload for exceeding the 3 MiB compressed-size limit.

## Root causes

### 1. `@vercel/og` (~2.9 MiB uncompressed, ~744 KiB gzip delta)

Payload's REST handler (`@payloadcms/next/dist/routes/rest/index.js`) statically imports its OG image endpoint (`./og/index.js`), which imports `next/og.js` (`ImageResponse`). That module re-exports from `next/dist/server/og/image-response.js`, which contains a `NEXT_RUNTIME` ternary that dynamically imports either `@vercel/og/index.edge.js` (edge) or `@vercel/og/index.node.js` (node).

Next.js's NFT traces the node entry (`index.node.js`) for API route bundles that include the REST handler. OpenNext's `patchVercelOgLibrary` ([source](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts)) detects `@vercel/og` usage by scanning those `.nft.json` traces for `@vercel/og/index.node.js`. When found (`useOg === true`) it copies the **edge** variant (`index.edge.js`) into the output, patches the fallback font fetch to a `.bin` module import (`patchVercelOgFallbackFont`), and rewrites the node imports to edge imports in the route files (`patchVercelOgImport`). The full set of `@vercel/og` assets — both JS variants (~721 KiB each), `resvg.wasm` (1.4 MiB), `yoga.wasm` (88 KiB), and the fallback TTF (28 KiB), ~2.9 MiB uncompressed across six files — ends up in the `.open-next` output through this copy step plus Next.js's own NFT standalone tracing, and Wrangler bundles the reachable subset into the Worker.

When `useOg === false` (no `@vercel/og` traced), a separate change ([#1221](https://github.com/opennextjs/opennextjs-cloudflare/pull/1221), shipped in `@opennextjs/cloudflare@1.19.4`) aliases the edge entry — `next/dist/compiled/@vercel/og/index.edge.js`, which Next.js's `externalImport` helper emits as a dynamic import even in apps that never use `next/og` — to a `throw.js` shim instead of leaving it `external`, so Wrangler no longer drags the library and `resvg.wasm` into the bundle.

`@vercel/og` is functional on Workers via the `patchVercelOgLibrary` patches above, but the ~744 KiB gzip cost is significant for a template targeting the free-tier 3 MiB limit.

The import is unconditional: the OG image endpoint is registered regardless of `admin.meta.defaultOGImageType`, so `@vercel/og` enters the bundle even when the feature is configured `'off'`. With `'off'`, the endpoint returns a 400 response before reaching `@vercel/og` — meaning the ~2.9 MiB of `@vercel/og` code ships in the bundle but is never executed.

### 2. `drizzle-kit/api` (7.3 MiB — safety net, not a measured contributor)

`drizzle-kit/api` is transitively imported by `@payloadcms/drizzle/sqlite` → `requireDrizzleKit` → `require('drizzle-kit/api')`. It is only used by the Payload CLI for migrations — never at Worker runtime.

As of Payload 3.86.0, `withPayload()`'s built-in externalization keeps `drizzle-kit/api` out of the bundle in normal webpack builds, so the baseline numbers measured here don't include it. The stub in this PR exists because that externalization has regressed before ([#16470](https://github.com/payloadcms/payload/issues/16470)) and isn't guaranteed to survive OpenNext's esbuild repackaging — it's insurance, not the source of the savings. The proper fix is to lazy-load `drizzle-kit` inside the function body ([#17009](https://github.com/payloadcms/payload/issues/17009), still open).

## Solution

### OG image endpoint stub

This template disables OG image generation (`admin.meta.defaultOGImageType: 'off'`) and replaces the endpoint module with a stub that mirrors that 400 response — eliminating ~744 KiB gzip from the bundle:

- **`stubs/payload-og-endpoint.js`** — exports `runtime`, `contentType`, and `generateOGImage` (returns `Response.json({ error: 'Open Graph images are disabled' }, { status: 400 })`), matching the real module's API surface and `'off'` response exactly
- **`next.config.ts`** — resolves the real endpoint path via `createRequire(import.meta.url)` and aliases it to the stub in both webpack `resolve.alias` and turbopack `resolveAlias`
- **`src/payload.config.ts`** — sets `admin.meta.defaultOGImageType: 'off'` for runtime consistency

With the stub in place, the import chain `routes/rest/index.js` → `./og/index.js` → `next/og.js` → `@vercel/og` is severed at the source. NFT no longer traces `@vercel/og`, `patchVercelOgLibrary` reports `useOg === false`, and no `@vercel/og` files appear in the `.open-next` output.

To re-enable OG image generation, remove the alias from `next.config.ts` and remove `defaultOGImageType` from `src/payload.config.ts`. The feature works on Workers via OpenNext's compatibility patches, but the bundle will exceed the free-tier 3 MiB limit — a Paid Workers plan is required.

### drizzle-kit/api stub

- **`stubs/drizzle-kit-api.js`** — throws on call, aliased via both turbopack and webpack

### README documentation

The README documents the OG image trade-off, explains the stub, and provides instructions for re-enabling the feature (with the caveat about the free-tier size limit).

## Measured results

All measurements on the template with identical dependencies (Next 15.4.11, OpenNext 1.20.1, Payload 3.86.0), using `wrangler deploy --dry-run` total upload gzip — the metric Cloudflare actually enforces.

| Metric | Before (no stubs) | WASM/TTF stubbing only | Endpoint stub (this PR) |
|---|---|---|---|
| handler.mjs raw | 9,173 KiB | 9,168 KiB | 8,605 KiB |
| handler.mjs gzip | 2,377 KiB | 2,374 KiB | 2,217 KiB |
| wrangler total raw | 14,903 KiB | 13,438 KiB | 12,688 KiB |
| **wrangler total gzip** | **3,364 KiB** | **2,798 KiB** | **2,620 KiB** |
| `@vercel/og` files in `.open-next` | 6 | 6 (WASM/fonts zeroed) | 0 |
| NFT traces with `@vercel/og` | 2 | 2 | 0 |
| vs 3 MiB (3,072 KiB) | **−292 KiB (over)** | +274 KiB | +452 KiB |
| Live deploy | — | ✅ | ✅ |

The "WASM/TTF stubbing only" column shows an intermediate approach (truncating `@vercel/og` asset files post-build) that was considered but not adopted: it zeroes the WASM and font files but leaves the ~721 KiB of `@vercel/og` JS in the bundle. The endpoint stub removes the entire dependency chain.

**Runtime verification** (live deploy to Cloudflare Workers, fresh D1 database with migrations applied):

- `GET /` → **200** (homepage renders)
- `GET /api/og?title=Test` → **400** + `{"error":"Open Graph images are disabled"}` (byte-for-byte parity with real Payload `'off'` behavior)
- `GET /admin` → **200** (admin panel loads)

## What this PR does not do

- **Does not modify OpenNext's `@vercel/og` handling.** The NFT-trace detection and edge-copy/patch logic live in `patchVercelOgLibrary` (longstanding adapter code, predating [#1221](https://github.com/opennextjs/opennextjs-cloudflare/pull/1221)); [#1221](https://github.com/opennextjs/opennextjs-cloudflare/pull/1221) is the separate `useOg === false` shim that aliases the unused edge-entry dynamic import to `throw.js`. This PR removes the import that causes the NFT trace, so `patchVercelOgLibrary` reports `useOg === false` and its copy/patch steps don't run — and #1221's shim then keeps the dangling edge dynamic import from pulling `@vercel/og` back in.
- **Does not fix the unconditional import in `@payloadcms/next`** — the REST handler statically imports the OG endpoint regardless of `defaultOGImageType`. A proper fix would move the import behind a runtime check or offer an explicit `withPayload()` option (e.g. `{ excludeOGImageEndpoint: true }`). That's a Payload core change affecting every deploy target, not just Cloudflare — tracked as a follow-up.
- **Does not remove the drizzle-kit stub** — it remains as a safety net against externalization regressions.

## Related

- Builds on #17393 (make with-cloudflare-d1 build with published npm packages)
- #17392 (guard realpath crash — included in #17393; without this, the template crashes on deploy before bundle size is relevant)
- OpenNext [#1221](https://github.com/opennextjs/opennextjs-cloudflare/pull/1221) — stop bundling unused `@vercel/og` (aliases the edge-entry dynamic import to `throw.js` when `useOg === false`); the NFT-trace detection and edge-copy/patch logic live in `patchVercelOgLibrary`
- OpenNext [#1211](https://github.com/opennextjs/opennextjs-cloudflare/issues/1211), [#1220](https://github.com/opennextjs/opennextjs-cloudflare/issues/1220) — bundle size reduction requests
- OpenNext [#773](https://github.com/opennextjs/opennextjs-cloudflare/issues/773) — Worker size limit discussion
- Payload [#16470](https://github.com/payloadcms/payload/issues/16470) — drizzle-kit externalization regression
- Payload [#17009](https://github.com/payloadcms/payload/issues/17009) — lazy-load drizzle-kit (open)
- #16757 (with-cloudflare-d1 template broken from v3.85.0 — fixed by #17393)
