### PR TITLE
fix(ui): clear accepted leave navigation targets

### DIFF
--- a/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
@@ -158,11 +158,15 @@ export const usePreventLeave = ({
 
   useEffect(() => {
     if (hasAccepted && cancelledURL.current) {
+      const nextURL = cancelledURL.current
+
+      cancelledURL.current = ''
+
       if (onAccept) {
         onAccept()
       }
 
-      startRouteTransition(() => router.push(cancelledURL.current))
+      startRouteTransition(() => router.push(nextURL))
     }
   }, [hasAccepted, onAccept, router, startRouteTransition])
 }

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1182,10 +1182,12 @@ describe('General', () => {
       await expect(page.locator('#action-duplicate')).toBeHidden()
     })
 
-    test('should properly close leave-without-saving modal after clicking leave-anyway button', async () => {
+    test('should allow subsequent navigation after clicking leave-anyway button', async () => {
       const { id } = await createPost()
+
       await page.goto(postsUrl.edit(id))
       const title = 'title'
+
       await page.locator('#field-title').fill(title)
       await saveDocHotkeyAndAssert(page)
       await expect(page.locator('#field-title')).toHaveValue(title)
@@ -1204,6 +1206,12 @@ describe('General', () => {
 
       // Assert that the class on the modal container changes to 'payload__modal-container--exitDone'
       await expect(modalContainer).toHaveClass(/payload__modal-container--exitDone/)
+
+      await page.waitForURL((url) => url.pathname === new URL(postsUrl.list).pathname)
+      await page.locator('#create-new-doc').click()
+
+      await expect(page.locator('#field-title')).toBeVisible()
+      await expect(page).toHaveURL(postsUrl.create)
     })
   })
 


### PR DESCRIPTION
### What?

- Consume a cancelled navigation target before starting the accepted route transition.
- Extend the admin E2E regression through a subsequent Create New navigation.

### Why?

The accepted URL remained in a ref after the first transition. If the effect ran again, it could push the stale list URL and immediately undo the user's next navigation.

### How?

- Snapshot and clear the ref before invoking `onAccept` and `router.push`.
- Verify the full dirty form, Leave anyway, list, and Create New flow in Chromium.
- Validated with Node 24.15.0 and pnpm 11.9.0: the focused E2E passed 1/1, `pnpm build:ui --force` passed, and Prettier, source ESLint, and `git diff --check` passed.

Fixes #17233
