### PR TITLE
fix: isolate files in nested local operations

### DIFF
--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../index.js'
 import { getFileByPath } from '../../../uploads/getFileByPath.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
+import { isolateObjectProperty } from '../../../utilities/isolateObjectProperty.js'
 import { createOperation } from '../create.js'
 
 type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
@@ -215,7 +216,8 @@ export async function createLocal<
     )
   }
 
-  const req = await createLocalReq(options as CreateLocalReqOptions, payload)
+  const localReq = await createLocalReq(options as CreateLocalReqOptions, payload)
+  const req = options.req ? isolateObjectProperty(localReq, 'file') : localReq
 
   req.file = file ?? (await getFileByPath(filePath!))
 

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -28,6 +28,7 @@ import type {
 import { APIError } from '../../../errors/index.js'
 import { getFileByPath } from '../../../uploads/getFileByPath.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
+import { isolateObjectProperty } from '../../../utilities/isolateObjectProperty.js'
 import { updateOperation } from '../update.js'
 import { updateByIDOperation } from '../updateByID.js'
 
@@ -249,7 +250,9 @@ async function updateLocal<
     )
   }
 
-  const req = await createLocalReq(options as CreateLocalReqOptions, payload)
+  const localReq = await createLocalReq(options as CreateLocalReqOptions, payload)
+  const req = options.req ? isolateObjectProperty(localReq, 'file') : localReq
+
   req.file = file ?? (await getFileByPath(filePath!))
 
   const args = {

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -31,6 +31,7 @@ import {
   focalOnlySlug,
   mediaSlug,
   mediaWithoutWriteAccessSlug,
+  noFilesRequiredSlug,
   noRestrictFileMimeTypesSlug,
   noRestrictFileTypesSlug,
   pdfOnlySlug,
@@ -719,6 +720,54 @@ describe('Collections - Uploads', () => {
   })
 
   describe('Local API', () => {
+    describe('request isolation', () => {
+      const createdUploadIDs: Array<number | string> = []
+
+      afterEach(async () => {
+        for (const id of createdUploadIDs) {
+          await payload.delete({ id, collection: noFilesRequiredSlug })
+        }
+
+        createdUploadIDs.length = 0
+      })
+
+      it('should preserve req.file when creating a document without a file', async () => {
+        const file = await getFileByPath(path.resolve(dirname, './image.png'))
+        const req = { file } as PayloadRequest
+        const doc = await payload.create({
+          collection: noFilesRequiredSlug,
+          data: {},
+          req,
+        })
+
+        createdUploadIDs.push(doc.id)
+
+        expect(req.file).toBe(file)
+        expect(doc.filename ?? null).toBeNull()
+      })
+
+      it('should preserve req.file when updating a document without a file', async () => {
+        const doc = await payload.create({
+          collection: noFilesRequiredSlug,
+          data: {},
+        })
+        const file = await getFileByPath(path.resolve(dirname, './image.png'))
+        const req = { file } as PayloadRequest
+
+        createdUploadIDs.push(doc.id)
+
+        const updatedDoc = await payload.update({
+          id: doc.id,
+          collection: noFilesRequiredSlug,
+          data: {},
+          req,
+        })
+
+        expect(req.file).toBe(file)
+        expect(updatedDoc.filename ?? null).toBeNull()
+      })
+    })
+
     describe('create', () => {
       it('should create documents when passing filePath', async () => {
         const expectedPath = path.join(dirname, './svg-only')


### PR DESCRIPTION
### What?

- Isolate `req.file` for child Local API create and update operations that reuse a caller request.
- Add create and update regression coverage for upload collections where a file is optional.

### Why?

Nested Local API operations currently write their file state onto the shared request. A file-less child operation can therefore clear the outer request's file before later hooks use it.

### How?

- Use the existing `isolateObjectProperty` utility so child `file` writes remain local while transaction, user, and context state stays shared.
- Verify that the caller retains the exact file reference and the child document remains file-less across adapters.
- Validated with Node 24.15.0 and pnpm 11.9.0: `test/uploads/int.spec.ts` passed 111/111 on SQLite and MongoDB, `pnpm build:payload --force`, Prettier, source ESLint, and `git diff --check` passed.

Fixes #15975
