### PR TITLE
fix: preserve csrf context for same-server file fetches

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -2,6 +2,7 @@ import type { PayloadRequest } from '../types/index.js'
 import type { File, FileData, UploadConfig } from './types.js'
 
 import { APIError } from '../errors/index.js'
+import { getRequestOrigin } from '../utilities/getRequestOrigin.js'
 import { isURLAllowed } from '../utilities/isURLAllowed.js'
 import { safeFetch } from './safeFetch.js'
 
@@ -13,35 +14,56 @@ type Args = {
 export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promise<File> => {
   const { filename, url } = data
 
-  let trimAuthCookies = true
   if (typeof url === 'string') {
     let fileURL = url
+    let trustedServerURL = req.payload.config.serverURL
+
     if (!url.startsWith('http')) {
-      // URL points to the same server - we can send any cookies safely to our server.
-      trimAuthCookies = false
-      const baseUrl = req.headers.get('origin') || `${req.protocol}://${req.headers.get('host')}`
-      fileURL = `${baseUrl}${url}`
+      trustedServerURL ||= getRequestOrigin({ config: req.payload.config, req })
+      fileURL = new URL(url, trustedServerURL || req.origin).toString()
     }
 
-    let cookies = (req.headers.get('cookie') ?? '').split(';')
+    const trustedServerOrigin = trustedServerURL ? new URL(trustedServerURL).origin : null
 
-    if (trimAuthCookies) {
-      cookies = cookies.filter(
-        (cookie) => !cookie.trim().startsWith(req.payload.config.cookiePrefix),
-      )
-    }
-
-    const headers = uploadConfig.externalFileHeaderFilter
+    const customHeaders = uploadConfig.externalFileHeaderFilter
       ? uploadConfig.externalFileHeaderFilter(Object.fromEntries(new Headers(req.headers)))
-      : {
-          cookie: cookies.join(';'),
-        }
+      : undefined
 
     let res
     let redirectCount = 0
     const maxRedirects = 3
 
     while (redirectCount <= maxRedirects) {
+      const isSameServerURL = trustedServerOrigin === new URL(fileURL).origin
+      let headers = customHeaders
+
+      if (!headers) {
+        let cookies = (req.headers.get('cookie') ?? '').split(';')
+
+        if (!isSameServerURL) {
+          cookies = cookies.filter(
+            (cookie) => !cookie.trim().startsWith(req.payload.config.cookiePrefix),
+          )
+        }
+
+        headers = {
+          cookie: cookies.join(';'),
+        }
+
+        if (isSameServerURL) {
+          const origin = req.headers.get('origin')
+          const secFetchSite = req.headers.get('sec-fetch-site')
+
+          if (origin) {
+            headers.origin = origin
+          }
+
+          if (secFetchSite) {
+            headers['sec-fetch-site'] = secFetchSite
+          }
+        }
+      }
+
       const skipSafeFetch: boolean =
         uploadConfig.skipSafeFetch === true
           ? uploadConfig.skipSafeFetch

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -1,3 +1,4 @@
+import type { IncomingHttpHeaders } from 'http'
 import type { AddressInfo } from 'net'
 import type { CollectionSlug, Payload, PayloadRequest, UploadInstructions } from 'payload'
 
@@ -1076,6 +1077,8 @@ describe('Collections - Uploads', () => {
           req: {
             headers: new Headers({
               cookie: testCookies,
+              origin: 'https://payloadcms.com',
+              'sec-fetch-site': 'same-origin',
             }),
           },
         })
@@ -1086,11 +1089,13 @@ describe('Collections - Uploads', () => {
         expect(cookieHeader).not.toContain('payload-token=123')
         expect(cookieHeader).not.toContain('payload-something=789')
         expect(cookieHeader).toContain('other-cookie=456')
+        expect(options.headers.origin).toBeUndefined()
+        expect(options.headers['sec-fetch-site']).toBeUndefined()
 
         fetchSpy.mockRestore()
       })
 
-      it('getExternalFile should not filter out payload cookies when externalFileHeaderFilter is not defined and the URL is not external', async () => {
+      it('should preserve authentication headers for relative and absolute same-server URLs', async () => {
         const testCookies = ['payload-token=123', 'other-cookie=456', 'payload-something=789'].join(
           '; ',
         )
@@ -1106,6 +1111,72 @@ describe('Collections - Uploads', () => {
 
         const port = (server.address() as AddressInfo).port
         const baseUrl = `http://localhost:${port}`
+        const requestOrigin = 'https://admin.example.com'
+        const originalServerURL = payload.config.serverURL
+        payload.config.serverURL = baseUrl
+
+        try {
+          const req = await createPayloadRequest({
+            config: payload.config,
+            request: new Request(baseUrl, {
+              headers: new Headers({
+                cookie: testCookies,
+                origin: requestOrigin,
+                'sec-fetch-site': 'same-origin',
+              }),
+            }),
+          })
+
+          const urls = ['/api/media/image.png', `${baseUrl}/api/media/image.png`]
+          for (const url of urls) {
+            await getExternalFile({
+              data: { url },
+              req,
+              uploadConfig: { skipSafeFetch: true },
+            })
+          }
+
+          for (const [index, [, options]] of fetchSpy.mock.calls.entries()) {
+            const cookieHeader = options.headers.cookie
+
+            expect(fetchSpy.mock.calls[index]![0]).toBe(`${baseUrl}/api/media/image.png`)
+            expect(cookieHeader).toContain('payload-token=123')
+            expect(cookieHeader).toContain('payload-something=789')
+            expect(cookieHeader).toContain('other-cookie=456')
+            expect(options.headers.origin).toBe(requestOrigin)
+            expect(options.headers['sec-fetch-site']).toBe('same-origin')
+          }
+        } finally {
+          fetchSpy.mockRestore()
+          payload.config.serverURL = originalServerURL
+          await new Promise((res) => server.close(res))
+        }
+      })
+
+      it('should strip authentication headers from a cross-origin redirect', async () => {
+        const testCookies = ['payload-token=123', 'other-cookie=456', 'payload-something=789'].join(
+          '; ',
+        )
+        let externalRequestHeaders: IncomingHttpHeaders | undefined
+
+        const externalServer = createServer((req, res) => {
+          externalRequestHeaders = req.headers
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ ok: true }))
+        })
+        await new Promise((res) => externalServer.listen(0, undefined, undefined, res))
+
+        const externalPort = (externalServer.address() as AddressInfo).port
+        const redirectServer = createServer((_req, res) => {
+          res.writeHead(302, { Location: `http://localhost:${externalPort}/image.png` })
+          res.end()
+        })
+        await new Promise((res) => redirectServer.listen(0, undefined, undefined, res))
+
+        const redirectPort = (redirectServer.address() as AddressInfo).port
+        const baseUrl = `http://localhost:${redirectPort}`
+        const originalServerURL = payload.config.serverURL
+        payload.config.serverURL = baseUrl
 
         const req = await createPayloadRequest({
           config: payload.config,
@@ -1113,25 +1184,28 @@ describe('Collections - Uploads', () => {
             headers: new Headers({
               cookie: testCookies,
               origin: baseUrl,
+              'sec-fetch-site': 'same-origin',
             }),
           }),
         })
 
-        await getExternalFile({
-          data: { url: '/api/media/image.png' },
-          req,
-          uploadConfig: { skipSafeFetch: true },
-        })
+        try {
+          await getExternalFile({
+            data: { url: `${baseUrl}/api/media/image.png` },
+            req,
+            uploadConfig: { skipSafeFetch: true },
+          })
 
-        const [[, options]] = fetchSpy.mock.calls
-        const cookieHeader = options.headers.cookie
-
-        expect(cookieHeader).toContain('payload-token=123')
-        expect(cookieHeader).toContain('payload-something=789')
-        expect(cookieHeader).toContain('other-cookie=456')
-
-        fetchSpy.mockRestore()
-        await new Promise((res) => server.close(res))
+          expect(externalRequestHeaders!.cookie).not.toContain('payload-token=123')
+          expect(externalRequestHeaders!.cookie).not.toContain('payload-something=789')
+          expect(externalRequestHeaders!.cookie).toContain('other-cookie=456')
+          expect(externalRequestHeaders!.origin).toBeUndefined()
+          expect(externalRequestHeaders!['sec-fetch-site']).toBeUndefined()
+        } finally {
+          payload.config.serverURL = originalServerURL
+          await new Promise((res) => redirectServer.close(res))
+          await new Promise((res) => externalServer.close(res))
+        }
       })
 
       it('should keep all cookies when externalFileHeaderFilter is defined', async () => {


### PR DESCRIPTION
### What?

- Preserve Payload authentication and CSRF metadata only for trusted same-server file fetches.
- Recognize both relative URLs and absolute URLs that match the configured server origin.
- Strip Payload cookies and CSRF metadata when a fetch redirects cross-origin.

### Why?

Cloud storage focal-point updates can re-fetch an image through a protected Payload route. The internal request kept too little CSRF context, so cookie authentication failed and `req.user` was null. Absolute URLs generated from `serverURL` were also treated as external.

### How?

- Derive header trust from the configured or allowlisted request origin; the browser `Origin` header is forwarded only as CSRF metadata after the target matches that trusted origin.
- Rebuild default headers for every redirect hop, retaining non-Payload cookies while removing Payload cookies, `Origin`, and `Sec-Fetch-Site` from cross-origin requests.
- Keep the `externalFileHeaderFilter` contract unchanged. This also addresses the origin-trust concern raised in #17290 without blanket-stripping authentication required by protected same-server storage routes.
- Validated with Node 24.15.0 and pnpm 11.9.0: `pnpm test:int:sqlite test/uploads/int.spec.ts` (110 passed), `pnpm build:payload --force`, Prettier, source ESLint, and `git diff --check`.

Fixes #17293
