### PR TITLE
chore(templates): revalidate archive block data

### DIFF
--- a/templates/website/src/blocks/ArchiveBlock/Component.tsx
+++ b/templates/website/src/blocks/ArchiveBlock/Component.tsx
@@ -1,11 +1,10 @@
 import type { Post, ArchiveBlock as ArchiveBlockProps } from '@/payload-types'
 
-import configPromise from '@payload-config'
-import { getPayload } from 'payload'
 import React from 'react'
 import RichText from '@/components/RichText'
 
 import { CollectionArchive } from '@/components/CollectionArchive'
+import { getCachedArchivePosts } from './getPosts'
 
 export const ArchiveBlock: React.FC<
   ArchiveBlockProps & {
@@ -19,29 +18,15 @@ export const ArchiveBlock: React.FC<
   let posts: Post[] = []
 
   if (populateBy === 'collection') {
-    const payload = await getPayload({ config: configPromise })
-
     const flattenedCategories = categories?.map((category) => {
       if (typeof category === 'object') return category.id
       else return category
     })
 
-    const fetchedPosts = await payload.find({
-      collection: 'posts',
-      depth: 1,
+    posts = await getCachedArchivePosts({
+      categoryIDs: flattenedCategories,
       limit,
-      ...(flattenedCategories && flattenedCategories.length > 0
-        ? {
-            where: {
-              categories: {
-                in: flattenedCategories,
-              },
-            },
-          }
-        : {}),
     })
-
-    posts = fetchedPosts.docs
   } else {
     if (selectedDocs?.length) {
       const filteredSelectedPosts = selectedDocs.map((post) => {

--- a/templates/website/src/blocks/ArchiveBlock/getPosts.ts
+++ b/templates/website/src/blocks/ArchiveBlock/getPosts.ts
@@ -1,0 +1,49 @@
+import type { Category } from '@/payload-types'
+
+import configPromise from '@payload-config'
+import { unstable_cache } from 'next/cache'
+import { getPayload } from 'payload'
+
+import { postsArchiveTag } from '@/cacheTags'
+
+type Args = {
+  categoryIDs?: Category['id'][]
+  limit: number
+}
+
+const queryArchivePosts = unstable_cache(
+  async ({ categoryIDs, limit }: Args) => {
+    const payload = await getPayload({ config: configPromise })
+
+    const posts = await payload.find({
+      collection: 'posts',
+      depth: 1,
+      limit,
+      overrideAccess: false,
+      ...(categoryIDs && categoryIDs.length > 0
+        ? {
+            where: {
+              categories: {
+                in: categoryIDs,
+              },
+            },
+          }
+        : {}),
+    })
+
+    return posts.docs
+  },
+  ['archive-posts'],
+  {
+    tags: [postsArchiveTag],
+  },
+)
+
+export const getCachedArchivePosts = ({ categoryIDs, limit }: Args) => {
+  const normalizedCategoryIDs = categoryIDs?.length ? [...categoryIDs].sort() : undefined
+
+  return queryArchivePosts({
+    categoryIDs: normalizedCategoryIDs,
+    limit,
+  })
+}

--- a/templates/website/src/cacheTags.ts
+++ b/templates/website/src/cacheTags.ts
@@ -1,0 +1,1 @@
+export const postsArchiveTag = 'posts-archive'

--- a/templates/website/src/collections/Posts/hooks/revalidatePost.ts
+++ b/templates/website/src/collections/Posts/hooks/revalidatePost.ts
@@ -3,6 +3,7 @@ import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'paylo
 import { revalidatePath, revalidateTag } from 'next/cache'
 
 import type { Post } from '../../../payload-types'
+import { postsArchiveTag } from '../../../cacheTags'
 
 export const revalidatePost: CollectionAfterChangeHook<Post> = ({
   doc,
@@ -16,6 +17,7 @@ export const revalidatePost: CollectionAfterChangeHook<Post> = ({
       payload.logger.info(`Revalidating post at path: ${path}`)
 
       revalidatePath(path)
+      revalidateTag(postsArchiveTag, 'max')
       revalidateTag('posts-sitemap', 'max')
     }
 
@@ -26,6 +28,7 @@ export const revalidatePost: CollectionAfterChangeHook<Post> = ({
       payload.logger.info(`Revalidating old post at path: ${oldPath}`)
 
       revalidatePath(oldPath)
+      revalidateTag(postsArchiveTag, 'max')
       revalidateTag('posts-sitemap', 'max')
     }
   }
@@ -37,6 +40,7 @@ export const revalidateDelete: CollectionAfterDeleteHook<Post> = ({ doc, req: { 
     const path = `/posts/${doc?.slug}`
 
     revalidatePath(path)
+    revalidateTag(postsArchiveTag, 'max')
     revalidateTag('posts-sitemap', 'max')
   }
 

--- a/templates/website/tests/int/archiveBlockCache.int.spec.ts
+++ b/templates/website/tests/int/archiveBlockCache.int.spec.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCachedArchivePosts } from '@/blocks/ArchiveBlock/getPosts'
+import { postsArchiveTag } from '@/cacheTags'
+import { revalidateDelete, revalidatePost } from '@/collections/Posts/hooks/revalidatePost'
+
+const mocks = vi.hoisted(() => ({
+  find: vi.fn(),
+  getPayload: vi.fn(),
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  unstableCache: vi.fn((callback) => callback),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: Promise.resolve({}),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: mocks.revalidatePath,
+  revalidateTag: mocks.revalidateTag,
+  unstable_cache: mocks.unstableCache,
+}))
+
+vi.mock('payload', () => ({
+  getPayload: mocks.getPayload,
+}))
+
+type AfterChangeArgs = Parameters<typeof revalidatePost>[0]
+type AfterDeleteArgs = Parameters<typeof revalidateDelete>[0]
+
+const createAfterChangeArgs = ({
+  currentStatus,
+  previousStatus,
+}: {
+  currentStatus: 'draft' | 'published'
+  previousStatus: 'draft' | 'published'
+}) =>
+  ({
+    doc: { _status: currentStatus, slug: 'hello-world' },
+    previousDoc: { _status: previousStatus, slug: 'hello-world' },
+    req: {
+      context: {},
+      payload: {
+        logger: {
+          info: vi.fn(),
+        },
+      },
+    },
+  }) as unknown as AfterChangeArgs
+
+describe('Archive Block cache', () => {
+  beforeEach(() => {
+    mocks.find.mockReset()
+    mocks.getPayload.mockReset()
+    mocks.revalidatePath.mockReset()
+    mocks.revalidateTag.mockReset()
+
+    mocks.getPayload.mockResolvedValue({ find: mocks.find })
+    mocks.find.mockResolvedValue({ docs: [{ id: 'post-1' }] })
+  })
+
+  it('should cache archive queries under the shared posts tag', () => {
+    expect(mocks.unstableCache).toHaveBeenCalledWith(expect.any(Function), ['archive-posts'], {
+      tags: [postsArchiveTag],
+    })
+  })
+
+  it('should query only public posts with normalized category IDs', async () => {
+    const posts = await getCachedArchivePosts({
+      categoryIDs: ['category-2', 'category-1'],
+      limit: 5,
+    })
+
+    expect(mocks.find).toHaveBeenCalledWith({
+      collection: 'posts',
+      depth: 1,
+      limit: 5,
+      overrideAccess: false,
+      where: {
+        categories: {
+          in: ['category-1', 'category-2'],
+        },
+      },
+    })
+    expect(posts).toEqual([{ id: 'post-1' }])
+  })
+
+  it('should omit the category filter when no categories are selected', async () => {
+    await getCachedArchivePosts({ categoryIDs: [], limit: 3 })
+
+    expect(mocks.find).toHaveBeenCalledWith({
+      collection: 'posts',
+      depth: 1,
+      limit: 3,
+      overrideAccess: false,
+    })
+  })
+
+  it('should revalidate archive queries when a post is published', async () => {
+    await revalidatePost(
+      createAfterChangeArgs({ currentStatus: 'published', previousStatus: 'draft' }),
+    )
+
+    expect(mocks.revalidateTag).toHaveBeenCalledWith(postsArchiveTag, 'max')
+  })
+
+  it('should revalidate archive queries when a post is unpublished', async () => {
+    await revalidatePost(
+      createAfterChangeArgs({ currentStatus: 'draft', previousStatus: 'published' }),
+    )
+
+    expect(mocks.revalidateTag).toHaveBeenCalledWith(postsArchiveTag, 'max')
+  })
+
+  it('should not revalidate archive queries for unpublished draft changes', async () => {
+    await revalidatePost(createAfterChangeArgs({ currentStatus: 'draft', previousStatus: 'draft' }))
+
+    expect(mocks.revalidateTag).not.toHaveBeenCalledWith(postsArchiveTag, 'max')
+  })
+
+  it('should revalidate archive queries when a post is deleted', async () => {
+    await revalidateDelete({
+      doc: { slug: 'hello-world' },
+      req: { context: {} },
+    } as unknown as AfterDeleteArgs)
+
+    expect(mocks.revalidateTag).toHaveBeenCalledWith(postsArchiveTag, 'max')
+  })
+})


### PR DESCRIPTION
### What?

Caches collection-populated Website Template Archive Block queries and revalidates them when posts are published, unpublished, or deleted.

### Why?

Archive Blocks can remain stale after post changes because their Local API query is part of a statically cached route and the template does not know every page that contains the block. A shared data tag invalidates every Archive Block consumer without tracking page paths.

### How?

- Moves the collection-mode post query into one `unstable_cache` function tagged with `posts-archive`, consistent with the template's existing caching model.
- Passes the limit and normalized category IDs as function arguments so each query variant gets its own cache key.
- Revalidates the shared tag from the existing post publish, unpublish, and delete hooks.
- Keeps `overrideAccess: false` on the cached query so draft or unpublished posts cannot enter the shared cache.
- Adds focused coverage for cache registration, access enforcement, query normalization, and hook invalidation.

This overlaps with https://github.com/payloadcms/payload/pull/15944, which adds `overrideAccess: false` to the current inline query. This PR relocates that query and preserves the same access-control requirement; it is not intended to supersede #15944 and should be rebased if that PR merges first.

### Testing

- `pnpm exec vitest run --config ./vitest.config.mts tests/int/archiveBlockCache.int.spec.ts` (7 passed)
- Focused Prettier and diff checks
- Full template build attempted: application compilation completed, then monorepo type checking stopped on the existing `packages/db-mongodb/src/find.ts:151` type error. No changed-file type errors were reported.

Related discussion: https://github.com/payloadcms/payload/discussions/15722
