### PR TITLE
fix: apply localized defaultValue only to the current locale

### DIFF
--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -64,6 +64,12 @@ const formatDefaultValue = (field: FieldAffectingData) =>
     ? field.defaultValue
     : undefined
 
+const stripSchemaDefault = (schema: SchemaTypeOptions<any>): SchemaTypeOptions<any> => {
+  const { default: _default, ...schemaWithoutDefault } = schema
+
+  return schemaWithoutDefault
+}
+
 const formatBaseSchema = ({
   buildSchemaOptions,
   field,
@@ -111,11 +117,13 @@ const localizeSchema = (
     localization &&
     Array.isArray(localization.locales)
   ) {
+    const localeSubSchema = stripSchemaDefault(schema)
+
     return {
       type: localization.localeCodes.reduce(
         (localeSchema, locale) => ({
           ...localeSchema,
-          [locale]: schema,
+          [locale]: localeSubSchema,
         }),
         {
           _id: false,

--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -150,6 +150,9 @@ export const traverseFields = ({
       targetIndexes = localesIndexes
     }
 
+    const isLocaleColumn = targetTable === localesColumns
+    const columnWithDefault = (column: RawColumn) => withDefault(column, field, isLocaleColumn)
+
     if (
       (field.unique || field.index || ['relationship', 'upload'].includes(field.type)) &&
       !['array', 'blocks', 'group'].includes(field.type) &&
@@ -372,13 +375,10 @@ export const traverseFields = ({
       }
       case 'blocks': {
         if (adapter.blocksAsJSON) {
-          targetTable[fieldName] = withDefault(
-            {
-              name: columnName,
-              type: 'jsonb',
-            },
-            field,
-          )
+          targetTable[fieldName] = columnWithDefault({
+            name: columnName,
+            type: 'jsonb',
+          })
           break
         }
 
@@ -609,13 +609,10 @@ export const traverseFields = ({
         break
       }
       case 'checkbox': {
-        targetTable[fieldName] = withDefault(
-          {
-            name: columnName,
-            type: 'boolean',
-          },
-          field,
-        )
+        targetTable[fieldName] = columnWithDefault({
+          name: columnName,
+          type: 'boolean',
+        })
 
         break
       }
@@ -623,28 +620,22 @@ export const traverseFields = ({
       case 'code':
       case 'email':
       case 'textarea': {
-        targetTable[fieldName] = withDefault(
-          {
-            name: columnName,
-            type: 'varchar',
-          },
-          field,
-        )
+        targetTable[fieldName] = columnWithDefault({
+          name: columnName,
+          type: 'varchar',
+        })
 
         break
       }
 
       case 'date': {
-        targetTable[fieldName] = withDefault(
-          {
-            name: columnName,
-            type: 'timestamp',
-            mode: 'string',
-            precision: 3,
-            withTimezone: true,
-          },
-          field,
-        )
+        targetTable[fieldName] = columnWithDefault({
+          name: columnName,
+          type: 'timestamp',
+          mode: 'string',
+          precision: 3,
+          withTimezone: true,
+        })
 
         break
       }
@@ -710,13 +701,10 @@ export const traverseFields = ({
 
       case 'json':
       case 'richText': {
-        targetTable[fieldName] = withDefault(
-          {
-            name: columnName,
-            type: 'jsonb',
-          },
-          field,
-        )
+        targetTable[fieldName] = columnWithDefault({
+          name: columnName,
+          type: 'jsonb',
+        })
 
         break
       }
@@ -744,26 +732,20 @@ export const traverseFields = ({
             )
           }
         } else {
-          targetTable[fieldName] = withDefault(
-            {
-              name: columnName,
-              type: 'numeric',
-            },
-            field,
-          )
+          targetTable[fieldName] = columnWithDefault({
+            name: columnName,
+            type: 'numeric',
+          })
         }
 
         break
       }
 
       case 'point': {
-        targetTable[fieldName] = withDefault(
-          {
-            name: columnName,
-            type: 'geometry',
-          },
-          field,
-        )
+        targetTable[fieldName] = columnWithDefault({
+          name: columnName,
+          type: 'geometry',
+        })
 
         break
       }
@@ -912,15 +894,12 @@ export const traverseFields = ({
             },
           }
         } else {
-          targetTable[fieldName] = withDefault(
-            {
-              name: columnName,
-              type: 'enum',
-              enumName,
-              options,
-            },
-            field,
-          )
+          targetTable[fieldName] = columnWithDefault({
+            name: columnName,
+            type: 'enum',
+            enumName,
+            options,
+          })
         }
         break
       }
@@ -1014,13 +993,10 @@ export const traverseFields = ({
             )
           }
         } else {
-          targetTable[fieldName] = withDefault(
-            {
-              name: columnName,
-              type: 'varchar',
-            },
-            field,
-          )
+          targetTable[fieldName] = columnWithDefault({
+            name: columnName,
+            type: 'varchar',
+          })
         }
         break
       }

--- a/packages/drizzle/src/schema/withDefault.ts
+++ b/packages/drizzle/src/schema/withDefault.ts
@@ -2,8 +2,16 @@ import type { FieldAffectingData } from 'payload'
 
 import type { RawColumn } from '../types.js'
 
-export const withDefault = (column: RawColumn, field: FieldAffectingData): RawColumn => {
-  if (typeof field.defaultValue === 'undefined' || typeof field.defaultValue === 'function') {
+export const withDefault = (
+  column: RawColumn,
+  field: FieldAffectingData,
+  isLocaleColumn = false,
+): RawColumn => {
+  if (
+    isLocaleColumn ||
+    typeof field.defaultValue === 'undefined' ||
+    typeof field.defaultValue === 'function'
+  ) {
     return column
   }
 

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -710,7 +710,9 @@ export const traverseFields = <T extends Record<string, unknown>>({
         }
       }
       if (typeof locale === 'string') {
-        ref[locale] = val
+        if (val !== null && typeof val !== 'undefined') {
+          ref[locale] = val
+        }
       } else {
         result[field.name] = val
       }

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -157,6 +157,22 @@ export const promise = async ({
     parentIsLocalized: parentIsLocalized!,
   })
 
+  const storedLocalizedValue =
+    fieldAffectsDataResult &&
+    shouldLocalizeField &&
+    typeof siblingDoc[field.name!] === 'object' &&
+    siblingDoc[field.name!] !== null &&
+    !Array.isArray(siblingDoc[field.name!])
+      ? (siblingDoc[field.name!] as Record<string, unknown>)
+      : null
+
+  const localeExistsInStorage = Boolean(
+    storedLocalizedValue &&
+      locale &&
+      locale !== 'all' &&
+      Object.prototype.hasOwnProperty.call(storedLocalizedValue, locale),
+  )
+
   const shouldHoistLocalizedValue: boolean = Boolean(
     flattenLocales &&
       fieldAffectsDataResult &&
@@ -404,11 +420,19 @@ export const promise = async ({
 
     // Set defaultValue on the field for globals being returned without being first created
     // or collection documents created prior to having a default.
+    // For localized fields, only apply defaults for locales that exist in storage.
+    const canApplyLocalizedDefaultValue =
+      !shouldLocalizeField ||
+      locale === 'all' ||
+      storedLocalizedValue === null ||
+      localeExistsInStorage
+
     if (
       !removedFieldValue &&
       allowDefaultValue &&
       typeof siblingDoc[field.name!] === 'undefined' &&
-      typeof field.defaultValue !== 'undefined'
+      typeof field.defaultValue !== 'undefined' &&
+      canApplyLocalizedDefaultValue
     ) {
       siblingDoc[field.name!] = await getDefaultValue({
         defaultValue: field.defaultValue,
@@ -417,6 +441,27 @@ export const promise = async ({
         user: req.user,
         value: siblingDoc[field.name!],
       })
+    }
+
+    if (
+      locale === 'all' &&
+      storedLocalizedValue &&
+      fieldAffectsDataResult &&
+      shouldLocalizeField &&
+      typeof siblingDoc[field.name!] === 'object' &&
+      siblingDoc[field.name!] !== null &&
+      !Array.isArray(siblingDoc[field.name!])
+    ) {
+      const currentValue = siblingDoc[field.name!] as Record<string, unknown>
+
+      for (const localeKey of Object.keys(currentValue)) {
+        if (
+          !Object.prototype.hasOwnProperty.call(storedLocalizedValue, localeKey) ||
+          storedLocalizedValue[localeKey] === null
+        ) {
+          delete currentValue[localeKey]
+        }
+      }
     }
 
     if (field.type === 'relationship' || field.type === 'upload' || field.type === 'join') {

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -22,6 +22,25 @@ import { relationshipPopulationPromise } from './relationshipPopulationPromise.j
 import { traverseFields } from './traverseFields.js'
 import { virtualFieldPopulationPromise } from './virtualFieldPopulationPromise.js'
 
+const isEmptyStoredLocalizedEntry = (value: unknown): boolean => {
+  if (value === null || typeof value === 'undefined') {
+    return true
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const objectValue = value as Record<string, unknown>
+
+    return (
+      Object.keys(objectValue).length === 0 ||
+      Object.values(objectValue).every(
+        (entry) => entry === null || typeof entry === 'undefined' || entry === '',
+      )
+    )
+  }
+
+  return false
+}
+
 type Args = {
   /**
    * Data of the nearest parent block. If no parent block exists, this will be the `undefined`
@@ -170,7 +189,8 @@ export const promise = async ({
     storedLocalizedValue &&
       locale &&
       locale !== 'all' &&
-      Object.prototype.hasOwnProperty.call(storedLocalizedValue, locale),
+      Object.prototype.hasOwnProperty.call(storedLocalizedValue, locale) &&
+      !isEmptyStoredLocalizedEntry(storedLocalizedValue[locale]),
   )
 
   const shouldHoistLocalizedValue: boolean = Boolean(
@@ -235,7 +255,14 @@ export const promise = async ({
       // Fill groups with empty objects so fields with hooks within groups can populate
       // themselves virtually as necessary
       if (fieldAffectsDataResult && typeof siblingDoc[field.name] === 'undefined') {
-        siblingDoc[field.name] = {}
+        const shouldSkipEmptyGroupFill =
+          shouldLocalizeField &&
+          locale !== 'all' &&
+          (storedLocalizedValue === null || !localeExistsInStorage)
+
+        if (!shouldSkipEmptyGroupFill) {
+          siblingDoc[field.name] = {}
+        }
       }
 
       break
@@ -457,7 +484,7 @@ export const promise = async ({
       for (const localeKey of Object.keys(currentValue)) {
         if (
           !Object.prototype.hasOwnProperty.call(storedLocalizedValue, localeKey) ||
-          storedLocalizedValue[localeKey] === null
+          isEmptyStoredLocalizedEntry(storedLocalizedValue[localeKey])
         ) {
           delete currentValue[localeKey]
         }

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -10,6 +10,7 @@ import { type RequestContext, validateBlocksFilterOptions } from '../../../index
 import { deepMergeWithSourceArrays } from '../../../utilities/deepMerge.js'
 import { getTranslatedLabel } from '../../../utilities/getTranslatedLabel.js'
 import { fieldAffectsData, fieldShouldBeLocalized, tabHasName } from '../../config/types.js'
+import { getDefaultValue } from '../../getDefaultValue.js'
 import { getFieldPaths } from '../../getFieldPaths.js'
 import { getExistingRowDoc } from './getExistingRowDoc.js'
 import { traverseFields } from './traverseFields.js'
@@ -266,18 +267,57 @@ export const promise = async ({
 
     // Push merge locale action if applicable
     if (localization && fieldShouldBeLocalized({ field, parentIsLocalized })) {
-      mergeLocaleActions.push(() => {
+      const incomingFieldKeys = req.context.incomingFieldKeys as Set<string> | undefined
+      const fieldWasProvided = incomingFieldKeys
+        ? incomingFieldKeys.has(field.name!)
+        : Object.prototype.hasOwnProperty.call(data, field.name!)
+
+      mergeLocaleActions.push(async () => {
         const localeData: Record<string, unknown> = {}
 
-        for (const locale of localization.localeCodes) {
-          const fieldValue =
-            locale === req.locale
-              ? siblingData[field.name!]
-              : siblingDocWithLocales?.[field.name!]?.[locale]
+        if (operation === 'update' && !fieldWasProvided) {
+          delete siblingData[field.name!]
 
-          // update locale value if it's not undefined
-          if (typeof fieldValue !== 'undefined') {
-            localeData[locale] = fieldValue
+          // Partial locale update: preserve existing values for other locales only.
+          // Do not write defaults or fallback-filled values into the active locale.
+          for (const locale of localization.localeCodes) {
+            if (locale === operationLocale) {
+              continue
+            }
+
+            const fieldValue = siblingDocWithLocales?.[field.name!]?.[locale]
+
+            if (typeof fieldValue !== 'undefined') {
+              localeData[locale] = fieldValue
+            }
+          }
+        } else {
+          for (const locale of localization.localeCodes) {
+            let fieldValue =
+              locale === operationLocale
+                ? siblingData[field.name!]
+                : siblingDocWithLocales?.[field.name!]?.[locale]
+
+            if (
+              locale === operationLocale &&
+              operation === 'create' &&
+              typeof fieldValue === 'undefined' &&
+              'defaultValue' in field &&
+              typeof field.defaultValue !== 'undefined' &&
+              !req.context?.isRestoringVersion
+            ) {
+              fieldValue = await getDefaultValue({
+                defaultValue: field.defaultValue,
+                locale: operationLocale,
+                req,
+                user: req.user,
+              })
+            }
+
+            // update locale value if it's not undefined
+            if (typeof fieldValue !== 'undefined') {
+              localeData[locale] = fieldValue
+            }
           }
         }
 

--- a/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
@@ -18,9 +18,13 @@ export async function getFallbackValue({
     if (typeof siblingDoc[field.name] !== 'undefined') {
       fallbackValue = cloneDataFromOriginalDoc(siblingDoc[field.name])
     } else if ('defaultValue' in field && typeof field.defaultValue !== 'undefined') {
+      const localization = req.payload.config.localization
+      const defaultLocale =
+        localization && typeof localization !== 'boolean' ? localization.defaultLocale : 'en'
+
       fallbackValue = await getDefaultValue({
         defaultValue: field.defaultValue,
-        locale: req.locale || '',
+        locale: req.locale || defaultLocale,
         req,
         user: req.user,
       })

--- a/packages/payload/src/fields/hooks/beforeValidate/index.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/index.ts
@@ -37,6 +37,10 @@ export const beforeValidate = async <T extends JsonObject>({
   overrideAccess,
   req,
 }: Args<T>): Promise<T> => {
+  if (operation === 'update') {
+    req.context.incomingFieldKeys = new Set(Object.keys(incomingData))
+  }
+
   await traverseFields({
     id,
     collection,

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -6,7 +6,12 @@ import type { JsonObject, JsonValue, PayloadRequest } from '../../../types/index
 import type { Block, Field, TabAsField } from '../../config/types.js'
 
 import { MissingEditorProp } from '../../../errors/index.js'
-import { fieldAffectsData, tabHasName, valueIsValueWithRelation } from '../../config/types.js'
+import {
+  fieldAffectsData,
+  fieldShouldBeLocalized,
+  tabHasName,
+  valueIsValueWithRelation,
+} from '../../config/types.js'
 import { getFieldPaths } from '../../getFieldPaths.js'
 import { getExistingRowDoc } from '../beforeChange/getExistingRowDoc.js'
 import { getFallbackValue } from './getFallbackValue.js'
@@ -278,7 +283,14 @@ export const promise = async <T>({
       executed: false,
       value: undefined,
     }
-    if (typeof siblingData[field.name!] === 'undefined' && !req.context?.isRestoringVersion) {
+    const fieldIsLocalized = fieldShouldBeLocalized({ field, parentIsLocalized })
+    const shouldApplyLocalizedDefaultValue = !(fieldIsLocalized && operation === 'update')
+
+    if (
+      typeof siblingData[field.name!] === 'undefined' &&
+      !req.context?.isRestoringVersion &&
+      shouldApplyLocalizedDefaultValue
+    ) {
       fallbackResult.value = await getFallbackValue({ field, req, siblingDoc })
       fallbackResult.executed = true
     }
@@ -347,7 +359,11 @@ export const promise = async <T>({
       }
     }
 
-    if (typeof siblingData[field.name!] === 'undefined' && !req.context?.isRestoringVersion) {
+    if (
+      typeof siblingData[field.name!] === 'undefined' &&
+      !req.context?.isRestoringVersion &&
+      shouldApplyLocalizedDefaultValue
+    ) {
       siblingData[field.name!] = !fallbackResult.executed
         ? await getFallbackValue({ field, req, siblingDoc })
         : fallbackResult.value

--- a/test/localized-default-value/config.ts
+++ b/test/localized-default-value/config.ts
@@ -1,0 +1,65 @@
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { devUser } from '../credentials.js'
+import { collectionSlug, defaultLocale, spanishLocale, staticDefaultValue } from './shared.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+export default buildConfigWithDefaults({
+  admin: {
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+  },
+  collections: [
+    {
+      slug: collectionSlug,
+      access: {
+        create: () => true,
+        delete: () => true,
+        read: () => true,
+        update: () => true,
+      },
+      fields: [
+        {
+          name: 'title',
+          localized: true,
+          type: 'text',
+        },
+        {
+          name: 'myField',
+          defaultValue: staticDefaultValue,
+          localized: true,
+          type: 'text',
+        },
+        {
+          name: 'localeAwareField',
+          defaultValue: ({ locale }) => `default-${locale}`,
+          localized: true,
+          type: 'text',
+        },
+      ],
+      versions: false,
+    },
+  ],
+  localization: {
+    defaultLocale,
+    fallback: false,
+    locales: [defaultLocale, spanishLocale],
+  },
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
+  },
+  typescript: {
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  },
+})

--- a/test/localized-default-value/config.ts
+++ b/test/localized-default-value/config.ts
@@ -3,7 +3,14 @@ import path from 'path'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
-import { collectionSlug, defaultLocale, spanishLocale, staticDefaultValue } from './shared.js'
+import {
+  collectionSlug,
+  defaultLocale,
+  groupNestedDefaultValue,
+  nestedLocalizedGroupDefaultValue,
+  spanishLocale,
+  staticDefaultValue,
+} from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -40,6 +47,30 @@ export default buildConfigWithDefaults({
           defaultValue: ({ locale }) => `default-${locale}`,
           localized: true,
           type: 'text',
+        },
+        {
+          name: 'myGroup',
+          fields: [
+            {
+              name: 'nestedField',
+              defaultValue: groupNestedDefaultValue,
+              type: 'text',
+            },
+          ],
+          localized: true,
+          type: 'group',
+        },
+        {
+          name: 'myNonLocalizedGroup',
+          fields: [
+            {
+              name: 'nestedLocalizedField',
+              defaultValue: nestedLocalizedGroupDefaultValue,
+              localized: true,
+              type: 'text',
+            },
+          ],
+          type: 'group',
         },
       ],
       versions: false,

--- a/test/localized-default-value/int.spec.ts
+++ b/test/localized-default-value/int.spec.ts
@@ -1,0 +1,131 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { collectionSlug, defaultLocale, spanishLocale, staticDefaultValue } from './shared.js'
+
+let payload: Payload
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+type LocalizedFieldAllLocales = {
+  en?: string
+  es?: string
+}
+
+describe('localized defaultValue', () => {
+  beforeAll(async () => {
+    ;({ payload } = await initPayloadInt(dirname))
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  it('should apply defaultValue only to the current locale on create', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'English title',
+      },
+      locale: defaultLocale,
+    })
+
+    expect(doc.myField).toStrictEqual(staticDefaultValue)
+    expect(doc.localeAwareField).toStrictEqual(`default-${defaultLocale}`)
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      locale: 'all',
+    })) as {
+      localeAwareField: LocalizedFieldAllLocales
+      myField: LocalizedFieldAllLocales
+    }
+
+    expect(allLocales.myField.en).toStrictEqual(staticDefaultValue)
+    expect(allLocales.myField.es).toBeUndefined()
+    expect(allLocales.localeAwareField.en).toStrictEqual(`default-${defaultLocale}`)
+    expect(allLocales.localeAwareField.es).toBeUndefined()
+  })
+
+  it('should not apply defaultValue when reading an unwritten locale', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'English title',
+      },
+      locale: defaultLocale,
+    })
+
+    const spanishDoc = await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      fallbackLocale: false,
+      locale: spanishLocale,
+    })
+
+    expect(spanishDoc.myField).toBeUndefined()
+    expect(spanishDoc.localeAwareField).toBeUndefined()
+  })
+
+  it('should apply defaultValue only to the current locale on update', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'Initial title',
+      },
+      locale: defaultLocale,
+    })
+
+    await payload.update({
+      id: doc.id,
+      collection: collectionSlug,
+      data: {
+        title: 'Spanish title',
+      },
+      locale: spanishLocale,
+    })
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      locale: 'all',
+    })) as {
+      localeAwareField: LocalizedFieldAllLocales
+      myField: LocalizedFieldAllLocales
+    }
+
+    expect(allLocales.myField.en).toStrictEqual(staticDefaultValue)
+    expect(allLocales.myField.es).toBeUndefined()
+    expect(allLocales.localeAwareField.en).toStrictEqual(`default-${defaultLocale}`)
+    expect(allLocales.localeAwareField.es).toBeUndefined()
+  })
+
+  it('should apply function defaultValue using the current locale only', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'Spanish title',
+      },
+      locale: spanishLocale,
+    })
+
+    expect(doc.localeAwareField).toStrictEqual(`default-${spanishLocale}`)
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      locale: 'all',
+    })) as {
+      localeAwareField: LocalizedFieldAllLocales
+    }
+
+    expect(allLocales.localeAwareField.en).toBeUndefined()
+    expect(allLocales.localeAwareField.es).toStrictEqual(`default-${spanishLocale}`)
+  })
+})

--- a/test/localized-default-value/int.spec.ts
+++ b/test/localized-default-value/int.spec.ts
@@ -5,7 +5,14 @@ import { fileURLToPath } from 'url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { collectionSlug, defaultLocale, spanishLocale, staticDefaultValue } from './shared.js'
+import {
+  collectionSlug,
+  defaultLocale,
+  groupNestedDefaultValue,
+  nestedLocalizedGroupDefaultValue,
+  spanishLocale,
+  staticDefaultValue,
+} from './shared.js'
 
 let payload: Payload
 
@@ -13,6 +20,20 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 type LocalizedFieldAllLocales = {
+  en?: string
+  es?: string
+}
+
+type LocalizedGroupAllLocales = {
+  en?: {
+    nestedField?: string
+  }
+  es?: {
+    nestedField?: string
+  }
+}
+
+type NestedLocalizedFieldAllLocales = {
   en?: string
   es?: string
 }
@@ -127,5 +148,159 @@ describe('localized defaultValue', () => {
 
     expect(allLocales.localeAwareField.en).toBeUndefined()
     expect(allLocales.localeAwareField.es).toStrictEqual(`default-${spanishLocale}`)
+  })
+
+  it('should apply defaultValue only to nested field in localized group for current locale on create', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'English title',
+      },
+      locale: defaultLocale,
+    })
+
+    expect(doc.myGroup?.nestedField).toStrictEqual(groupNestedDefaultValue)
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      locale: 'all',
+    })) as {
+      myGroup: LocalizedGroupAllLocales
+    }
+
+    expect(allLocales.myGroup.en?.nestedField).toStrictEqual(groupNestedDefaultValue)
+    expect(allLocales.myGroup.es).toBeUndefined()
+  })
+
+  it('should not apply nested group defaultValue when reading an unwritten locale', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'English title',
+      },
+      locale: defaultLocale,
+    })
+
+    const spanishDoc = await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      fallbackLocale: false,
+      locale: spanishLocale,
+    })
+
+    expect(spanishDoc.myGroup).toBeUndefined()
+  })
+
+  it('should apply nested group defaultValue only to the current locale on update', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'Initial title',
+      },
+      locale: defaultLocale,
+    })
+
+    await payload.update({
+      id: doc.id,
+      collection: collectionSlug,
+      data: {
+        title: 'Spanish title',
+      },
+      locale: spanishLocale,
+    })
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      locale: 'all',
+    })) as {
+      myGroup: LocalizedGroupAllLocales
+    }
+
+    expect(allLocales.myGroup.en?.nestedField).toStrictEqual(groupNestedDefaultValue)
+    expect(allLocales.myGroup.es).toBeUndefined()
+  })
+
+  it('should apply defaultValue only to nested localized field in non-localized group for current locale on create', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'English title',
+      },
+      locale: defaultLocale,
+    })
+
+    expect(doc.myNonLocalizedGroup?.nestedLocalizedField).toStrictEqual(
+      nestedLocalizedGroupDefaultValue,
+    )
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      locale: 'all',
+    })) as unknown as {
+      myNonLocalizedGroup: {
+        nestedLocalizedField: NestedLocalizedFieldAllLocales
+      }
+    }
+
+    expect(allLocales.myNonLocalizedGroup.nestedLocalizedField.en).toStrictEqual(
+      nestedLocalizedGroupDefaultValue,
+    )
+    expect(allLocales.myNonLocalizedGroup.nestedLocalizedField.es).toBeUndefined()
+  })
+
+  it('should not apply nested localized field defaultValue in non-localized group when reading an unwritten locale', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'English title',
+      },
+      locale: defaultLocale,
+    })
+
+    const spanishDoc = await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      fallbackLocale: false,
+      locale: spanishLocale,
+    })
+
+    expect(spanishDoc.myNonLocalizedGroup?.nestedLocalizedField).toBeUndefined()
+  })
+
+  it('should apply nested localized field defaultValue in non-localized group only to the current locale on update', async () => {
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: {
+        title: 'Initial title',
+      },
+      locale: defaultLocale,
+    })
+
+    await payload.update({
+      id: doc.id,
+      collection: collectionSlug,
+      data: {
+        title: 'Spanish title',
+      },
+      locale: spanishLocale,
+    })
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      locale: 'all',
+    })) as unknown as {
+      myNonLocalizedGroup: {
+        nestedLocalizedField: NestedLocalizedFieldAllLocales
+      }
+    }
+
+    expect(allLocales.myNonLocalizedGroup.nestedLocalizedField.en).toStrictEqual(
+      nestedLocalizedGroupDefaultValue,
+    )
+    expect(allLocales.myNonLocalizedGroup.nestedLocalizedField.es).toBeUndefined()
   })
 })

--- a/test/localized-default-value/shared.ts
+++ b/test/localized-default-value/shared.ts
@@ -1,0 +1,6 @@
+export const collectionSlug = 'localized-default-value-posts'
+
+export const staticDefaultValue = 'Default Value'
+
+export const defaultLocale = 'en'
+export const spanishLocale = 'es'

--- a/test/localized-default-value/shared.ts
+++ b/test/localized-default-value/shared.ts
@@ -2,5 +2,9 @@ export const collectionSlug = 'localized-default-value-posts'
 
 export const staticDefaultValue = 'Default Value'
 
+export const groupNestedDefaultValue = 'Nested Group Default'
+
+export const nestedLocalizedGroupDefaultValue = 'Nested Localized In Group Default'
+
 export const defaultLocale = 'en'
 export const spanishLocale = 'es'

--- a/test/localized-default-value/tsconfig.eslint.json
+++ b/test/localized-default-value/tsconfig.eslint.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/test/localized-default-value/tsconfig.json
+++ b/test/localized-default-value/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}


### PR DESCRIPTION
## Which branch should this PR target?

- [x] **`main`** — Payload v4 development

---

### What?

Fixes a bug where localized fields with `defaultValue` had that default applied to **all** locales instead of only the locale being created or updated.

Changes span the Payload field hooks (create/update/read paths), the Drizzle adapter (schema + read transform), and the MongoDB adapter (schema). Adds a regression test suite at `test/localized-default-value/`.

### Why?

When a field is marked `localized: true` and has a `defaultValue`, Payload is expected to apply that default **only for the active locale** during create/update, and **not** when reading locales that were never written.

The bug had multiple causes across the stack:

#### 1. Write path — `beforeValidate` applied defaults on update

During update, `beforeValidate` still ran `getFallbackValue()` for localized fields whose value was `undefined` in the incoming payload. That meant updating locale `es` with `{ title: 'Spanish title' }` could still populate `myField` with the default, even though the field was not in the request body.

#### 2. Write path — `beforeChange` merged defaults into the active locale on update

The locale-merge logic in `beforeChange` treated the active locale the same on create and update. On update, if the field was omitted from the request, it could still pick up a default (or a fallback-filled value from the fetched document) for the locale being updated.

#### 3. Read path — `afterRead` applied defaults to unwritten locales

When reading a document (especially with `locale: 'all'`), `afterRead` applied `defaultValue` to any locale key that was `undefined`, including locales that had never been written. That made `findByID({ locale: 'es' })` return a default even when only `en` had been created.

#### 4. Drizzle adapter — SQL column defaults on `_locales` tables (Postgres/SQLite)

For SQL adapters, localized field columns live in a separate `_locales` table. The schema builder used `withDefault()` to set SQL `DEFAULT` constraints from `field.defaultValue` on those columns.

On update, Drizzle deletes all locale rows for a document and re-inserts them. When inserting a new locale row for a partial update (e.g. only `title` for `es`), omitted columns like `my_field` were not included in the `INSERT` — so SQLite/Postgres silently applied the column default (`'Default Value'`), bypassing Payload hooks entirely.

#### 5. MongoDB adapter — Mongoose defaults on locale sub-schemas

MongoDB stores localized values as nested subdocuments (`myField.en`, `myField.es`). `localizeSchema` copied the full Mongoose sub-schema — including `default: field.defaultValue` — onto **every** locale path. Mongoose then applied those defaults for locales that were never written, producing the same user-visible bug as the SQL column-default issue (e.g. `findByID({ locale: 'all' })` returning `myField.es: 'Default Value'` after creating only in `en`).

### How?

**Payload hooks (`packages/payload/src/fields/hooks/`):**

- **`beforeValidate`**
  - Track `req.context.incomingFieldKeys` on update so downstream hooks know which fields were explicitly sent.
  - Skip applying `defaultValue` to localized fields during update (`shouldApplyLocalizedDefaultValue`).
  - Use `req.locale || defaultLocale` (not empty string) in `getFallbackValue`.

- **`beforeChange`**
  - On update, when a localized field was **not** in the incoming data: preserve values for **other** locales from `docWithLocales`, skip the active locale, and do not apply defaults.
  - On create, continue applying `defaultValue` only for `operationLocale`.

- **`afterRead`**
  - Capture the stored localized object before hoisting.
  - Only apply `defaultValue` on read when the requested locale actually exists in storage (or when reading non-localized / `locale: 'all'` edge cases are handled safely).
  - When `locale: 'all'`, strip locale keys that were never stored or are `null` (leftover from partial locale rows in SQL adapters).

**Drizzle adapter (`packages/drizzle/`):**

- **`schema/withDefault.ts`** — Do not set SQL column defaults on columns in `_locales` tables. Localized defaults must be applied in Payload hooks for the active locale only.
- **`transform/read/traverseFields.ts`** — Skip `null` values when assembling localized field objects, so partial locale rows do not surface as `null`/`default` for fields that were never written in that locale.

**MongoDB adapter (`packages/db-mongodb/`):**

- **`models/buildSchema.ts`** — Strip Mongoose `default` from sub-schemas before wrapping them in `localizeSchema`, so defaults are not baked into every locale path at the schema level.

**Tests:**

- `test/localized-default-value/int.spec.ts` — Covers create, update, read-with-fallback-disabled, and function `defaultValue` with locale awareness.

### Test plan

- [x] `pnpm test:int localized-default-value` (SQLite) — 4/4 passing
- [x] `pnpm test:int localized-default-value` (MongoDB) — 4/4 passing
- [ ] Existing locale/defaultValue regression in `test/fields` (`should update without overwriting other locales with defaultValue`)

Fixes #17406