### PR TITLE
fix(next): render version diff against current block's schema

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -22,7 +22,6 @@ import {
   fieldIsID,
   fieldShouldBeLocalized,
   getFieldPaths,
-  getUniqueListBy,
   tabHasName,
 } from 'payload/shared'
 
@@ -450,25 +449,16 @@ const buildVersionField = ({
           (block) => typeof block !== 'string' && block.slug === blockSlugToMatch,
         ) as FlattenedBlock | undefined)
 
-      let fields = []
-
-      if (toRow.blockType === fromRow.blockType) {
-        fields = toBlock.fields
-      } else {
-        const fromBlockSlugToMatch: string = toRow?.blockType ?? fromRow?.blockType
-
-        const fromBlock =
-          req.payload.blocks[fromBlockSlugToMatch] ??
-          ((field.blockReferences ?? field.blocks).find(
-            (block) => typeof block !== 'string' && block.slug === fromBlockSlugToMatch,
-          ) as FlattenedBlock | undefined)
-
-        if (fromBlock) {
-          fields = getUniqueListBy<Field>([...toBlock.fields, ...fromBlock.fields], 'name')
-        } else {
-          fields = toBlock.fields
-        }
-      }
+      // Always diff against the current (to) block's own field schema. The version
+      // diff's `clientSchemaMap` is keyed by `toBlock.slug`, so only this block's
+      // fields resolve to client fields. Merging another block's fields collapsed
+      // unnamed presentational fields (row / collapsible / unnamed group) — which all
+      // share `name: undefined` — through `getUniqueListBy(..., 'name')`, shifting the
+      // `_index-N` schema paths and throwing "No client field found" whenever a block's
+      // type changed (or was added) between the compared versions. The merge was also a
+      // no-op: `fromBlockSlugToMatch` was computed identically to `blockSlugToMatch`, so
+      // `fromBlock` always resolved to `toBlock`.
+      const fields = toBlock.fields
 
       let blockFieldsPermissions: SanitizedFieldsPermissions = undefined
 


### PR DESCRIPTION
### What?

The version-comparison view (`/admin/collections/<slug>/<id>/versions/<versionId>`) throws `No client field found` (HTTP 500) whenever a `blocks` field row's block type differs between the two compared versions.

This includes the common case of a block being added (or reordered) in a later version: the earlier version's row is empty, so `fromRow.blockType` is `undefined` and never equals `toRow.blockType`.

It reproduces when the affected block has two or more unnamed presentational fields at its top level (for example an unnamed `row`/`collapsible` alongside an unnamed `group`): a fully supported configuration that renders correctly everywhere else (edit view, public queries).

### Why?

In `packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx`, the `blocks` branch merged the two blocks' field arrays when the block types differ:

```ts
fields = getUniqueListBy<Field>([...toBlock.fields, ...fromBlock.fields], 'name')
```

Unnamed presentational fields (`row`, `collapsible`, unnamed `group`) all have `name === undefined`. `getUniqueListBy` builds a `Map` keyed by `name`, so every unnamed field collapses into a single `undefined` entry (last value wins, first insertion position kept). That drops fields and shifts the `_index-N` schema paths out of sync with the per-block `clientSchemaMap` (which is keyed by `toBlock.slug` and built from the current block config), so the subsequent `clientSchemaMap.get(...)` misses and the view throws.

Two supporting observations:

- The merge could not render the other block's fields anyway: the `clientSchemaMap` for this row is keyed by `toBlock.slug`, so any field unique to a different block has no client-field entry and would itself throw `No client field found`.
- The merge was effectively a no-op: `fromBlockSlugToMatch` was computed with the same expression as `blockSlugToMatch` (`toRow?.blockType ?? fromRow?.blockType`), so `fromBlock` always resolved to `toBlock`.

### How?

Diff against the current (`to`) block's own field schema, which is the only field list whose `_index-N` positions match the `clientSchemaMap`:

```ts
const fields = toBlock.fields
```

The now-unused `getUniqueListBy` import is removed. No stored data is read or written, so this rendering-only change cannot affect existing content.

### Reproduction

1. A drafts-enabled collection with a `blocks` field, containing one block whose top-level fields include two unnamed presentational fields:

```ts
{
  slug: 'sectionWithBackground',
  fields: [
    { type: 'row', fields: [{ name: 'visible', type: 'checkbox' }] }, // unnamed
    { name: 'title', type: 'text' },
    {
      type: 'group', // unnamed
      label: 'Background',
      fields: [
        { name: 'customBackground', type: 'checkbox' },
        { name: 'backgroundImage', type: 'upload', relationTo: 'media' },
      ],
    },
  ],
}
```

2. Create a draft with no block, then save (v1). Add one `sectionWithBackground` block, then save (v2).
3. Open v2 in the versions view.

**Before:** `500 - No client field found for <slug>._index-…sectionWithBackground._index-0.customBackground`
**After:** the diff renders.

### Notes

- Targeting `3.x` per the PR template: this file exists only on `3.x`; it has been restructured on `main` (v4).
- I wasn't able to run the full e2e / type-generation matrix locally. Happy to add a regression test under `test/versions` (extending the `Diff` collection plus the `navigateToDiffVersionView` e2e pattern). Let me know your preferred placement, or feel free to push to the branch (maintainer edits are enabled).
