### PR TITLE
fix(ui): refresh hierarchy sidebar after changes

### DIFF
--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -101,6 +101,7 @@ const nextSuites: TestConfig[] = [
   { file: 'queues', shards: 1 },
   { file: 'sort', shards: 1 },
   { file: 'server-url', shards: 1 },
+  { file: 'tags', shards: 1 },
   { file: 'trash', shards: 2 },
   { file: 'versions', shards: 3 },
   { file: 'uploads', shards: 3 },

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.server.tsx
@@ -157,6 +157,8 @@ export const HierarchySidebarTabServer: React.FC<HierarchySidebarTabServerProps>
       // Merge ancestor IDs with existing expanded nodes
       const expandedSet = new Set(initialExpandedNodes)
       ancestorIds.forEach((id) => expandedSet.add(id))
+      // Include the selected node itself so its own children are loaded.
+      expandedSet.add(selectedNodeId)
       initialExpandedNodes = Array.from(expandedSet)
     }
 

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
@@ -69,21 +69,32 @@ export const HierarchySidebarTab: React.FC<
   // so forward the current selected parent id — otherwise the reload can't tell which node is
   // being viewed and rebuilds the tree from preference state.
   const tabSlug = `hierarchy-${hierarchyCollectionSlug}`
+  const isActiveTab = sidebarTabs?.activeTabSlug === tabSlug
   const treeRefreshKey = treeRefreshKeys.get(hierarchyCollectionSlug) ?? 0
   const prevTreeRefreshKeyRef = useRef(treeRefreshKey)
   useEffect(() => {
     if (prevTreeRefreshKeyRef.current !== treeRefreshKey) {
       prevTreeRefreshKeyRef.current = treeRefreshKey
+      // Only forward the selected parent id when this tab is active. currentParentParam
+      // reflects the global URL search params, so an inactive tab could otherwise pick up
+      // another hierarchy collection's value if they share the same parentFieldName.
       sidebarTabs?.reloadTabContent(tabSlug, {
-        searchParams: currentParentParam
-          ? { [resolvedParentFieldName]: currentParentParam }
-          : undefined,
+        searchParams:
+          isActiveTab && currentParentParam
+            ? { [resolvedParentFieldName]: currentParentParam }
+            : undefined,
       })
     }
-  }, [treeRefreshKey, sidebarTabs, tabSlug, currentParentParam, resolvedParentFieldName])
+  }, [
+    treeRefreshKey,
+    sidebarTabs,
+    tabSlug,
+    isActiveTab,
+    currentParentParam,
+    resolvedParentFieldName,
+  ])
 
   // Only highlight selected node when this tab is active
-  const isActiveTab = sidebarTabs?.activeTabSlug === tabSlug
   const selectedNodeId = isActiveTab
     ? (currentParentParam ?? selectedNodeIdFromServer ?? undefined)
     : undefined

--- a/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
+++ b/packages/ui/src/elements/Hierarchy/Tree/HierarchySidebarTab.tsx
@@ -60,23 +60,32 @@ export const HierarchySidebarTab: React.FC<
   const { setSelectedFilters: setSelectedFiltersContext, treeRefreshKeys } = useHierarchy()
   const sidebarTabs = useSidebarTabs()
 
+  const resolvedParentFieldName = parentFieldName ?? 'parent'
+  const currentParentParam = searchParams.get(resolvedParentFieldName)
+
   // When refreshTree(slug) is called from the list view (e.g. after mutations), reload this tab.
   // Always reload regardless of active state so inactive tabs are fresh when switched to.
+  // The render-tab server function runs with a fresh request that lacks the client's URL query,
+  // so forward the current selected parent id — otherwise the reload can't tell which node is
+  // being viewed and rebuilds the tree from preference state.
   const tabSlug = `hierarchy-${hierarchyCollectionSlug}`
   const treeRefreshKey = treeRefreshKeys.get(hierarchyCollectionSlug) ?? 0
   const prevTreeRefreshKeyRef = useRef(treeRefreshKey)
   useEffect(() => {
     if (prevTreeRefreshKeyRef.current !== treeRefreshKey) {
       prevTreeRefreshKeyRef.current = treeRefreshKey
-      sidebarTabs?.reloadTabContent(tabSlug)
+      sidebarTabs?.reloadTabContent(tabSlug, {
+        searchParams: currentParentParam
+          ? { [resolvedParentFieldName]: currentParentParam }
+          : undefined,
+      })
     }
-  }, [treeRefreshKey, sidebarTabs, tabSlug])
+  }, [treeRefreshKey, sidebarTabs, tabSlug, currentParentParam, resolvedParentFieldName])
 
   // Only highlight selected node when this tab is active
-  const parentParam = searchParams.get(parentFieldName ?? 'parent')
   const isActiveTab = sidebarTabs?.activeTabSlug === tabSlug
   const selectedNodeId = isActiveTab
-    ? (parentParam ?? selectedNodeIdFromServer ?? undefined)
+    ? (currentParentParam ?? selectedNodeIdFromServer ?? undefined)
     : undefined
 
   const baseFilterKey = baseFilter ? JSON.stringify(baseFilter) : ''
@@ -91,17 +100,16 @@ export const HierarchySidebarTab: React.FC<
 
   const handleNavigateToParent = useCallback(
     ({ id }: { id: number | string }) => {
-      const queryParam = parentFieldName ?? 'parent'
       const url = formatAdminURL({
         adminRoute,
-        path: `/collections/${hierarchyCollectionSlug}/hierarchy?${queryParam}=${id}`,
+        path: `/collections/${hierarchyCollectionSlug}/hierarchy?${resolvedParentFieldName}=${id}`,
       })
       startRouteTransition(() => {
         router.push(url)
         router.refresh()
       })
     },
-    [adminRoute, hierarchyCollectionSlug, parentFieldName, router, startRouteTransition],
+    [adminRoute, hierarchyCollectionSlug, resolvedParentFieldName, router, startRouteTransition],
   )
   return (
     <>

--- a/packages/ui/src/elements/Nav/SidebarTabs/index.client.tsx
+++ b/packages/ui/src/elements/Nav/SidebarTabs/index.client.tsx
@@ -100,12 +100,13 @@ export const SidebarTabsClient: React.FC<SidebarTabsClientProps> = ({
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
 
         const handleRetry = () => {
-          // Clear the error and retry loading
+          // Clear the error and retry loading, threading the original serverArgs through so the
+          // retry doesn't silently fall back to req.query-based rendering (the stale-tree bug).
           const clearedContent = { ...tabContentRef.current }
           delete clearedContent[tabSlug]
           tabContentRef.current = clearedContent
           setTabContent(clearedContent)
-          void loadTabContent(tabSlug)
+          void loadTabContent(tabSlug, { serverArgs })
         }
 
         const newContent = {

--- a/packages/ui/src/elements/Nav/SidebarTabs/index.client.tsx
+++ b/packages/ui/src/elements/Nav/SidebarTabs/index.client.tsx
@@ -58,7 +58,13 @@ export const SidebarTabsClient: React.FC<SidebarTabsClientProps> = ({
   }, [initialTabContents])
 
   const loadTabContent = useCallback(
-    async (tabSlug: string, { revalidate = false }: { revalidate?: boolean } = {}) => {
+    async (
+      tabSlug: string,
+      {
+        revalidate = false,
+        serverArgs,
+      }: { revalidate?: boolean; serverArgs?: Partial<RenderTabServerFnArgs> } = {},
+    ) => {
       const hasCachedContent = Boolean(tabContentRef.current[tabSlug])
 
       // Skip if already loaded (unless revalidating) or currently loading
@@ -75,7 +81,7 @@ export const SidebarTabsClient: React.FC<SidebarTabsClientProps> = ({
       try {
         const result = (await serverFunction({
           name: 'render-tab',
-          args: { tabSlug } as RenderTabServerFnArgs,
+          args: { ...serverArgs, tabSlug } as RenderTabServerFnArgs,
         })) as RenderTabServerFnReturnType
 
         const newContent = {
@@ -118,14 +124,14 @@ export const SidebarTabsClient: React.FC<SidebarTabsClientProps> = ({
   )
 
   const reloadTabContent = useCallback(
-    (tabSlug: string) => {
+    (tabSlug: string, serverArgs?: Partial<RenderTabServerFnArgs>) => {
       // Clear cached content to force reload
       const clearedContent = { ...tabContentRef.current }
       delete clearedContent[tabSlug]
       tabContentRef.current = clearedContent
       setTabContent(clearedContent)
 
-      void loadTabContent(tabSlug)
+      void loadTabContent(tabSlug, { serverArgs })
     },
     [loadTabContent],
   )

--- a/packages/ui/src/elements/Nav/SidebarTabs/renderTabServerFn.ts
+++ b/packages/ui/src/elements/Nav/SidebarTabs/renderTabServerFn.ts
@@ -4,6 +4,7 @@ import type React from 'react'
 import { RenderServerComponent } from '../../RenderServerComponent/index.js'
 
 export type RenderTabServerFnArgs = {
+  searchParams?: Record<string, unknown>
   tabSlug: string
 }
 
@@ -14,7 +15,7 @@ export type RenderTabServerFnReturnType = {
 export const renderTabHandler: ServerFunction<
   RenderTabServerFnArgs,
   RenderTabServerFnReturnType
-> = ({ req, tabSlug }) => {
+> = ({ req, searchParams, tabSlug }) => {
   if (!req.user) {
     throw new Error('Unauthorized')
   }
@@ -42,7 +43,7 @@ export const renderTabHandler: ServerFunction<
         params: req.routeParams,
         payload: req.payload,
         req,
-        searchParams: req.query,
+        searchParams: searchParams ?? req.query,
         user: req.user,
       },
     })

--- a/packages/ui/src/providers/SidebarTabs/index.tsx
+++ b/packages/ui/src/providers/SidebarTabs/index.tsx
@@ -2,13 +2,15 @@
 
 import React, { createContext, use } from 'react'
 
+import type { RenderTabServerFnArgs } from '../../elements/Nav/SidebarTabs/renderTabServerFn.js'
+
 export type SidebarTabsContextType = {
   activeTabSlug: null | string
   /**
    * Reload the content for a specific tab, bypassing the cache.
    * Useful when the tab's data dependencies change.
    */
-  reloadTabContent: (tabSlug: string) => void
+  reloadTabContent: (tabSlug: string, serverArgs?: Partial<RenderTabServerFnArgs>) => void
 }
 
 const SidebarTabsContext = createContext<null | SidebarTabsContextType>(null)
@@ -16,7 +18,7 @@ const SidebarTabsContext = createContext<null | SidebarTabsContextType>(null)
 export type SidebarTabsProviderProps = {
   activeTabSlug: null | string
   children: React.ReactNode
-  reloadTabContent: (tabSlug: string) => void
+  reloadTabContent: (tabSlug: string, serverArgs?: Partial<RenderTabServerFnArgs>) => void
 }
 
 export const SidebarTabsProvider: React.FC<SidebarTabsProviderProps> = ({

--- a/test/tags/e2e.spec.ts
+++ b/test/tags/e2e.spec.ts
@@ -118,8 +118,12 @@ test.describe('Tags', () => {
 
   test.afterAll(async () => {
     for (const id of createdTagIds) {
-      await payload.delete({ id, collection: tagsSlug }).catch(() => {})
+      await payload.delete({ id, collection: tagsSlug })
     }
+  })
+
+  test.afterEach(async () => {
+    await page.unrouteAll()
   })
 
   test.describe('sidebar tree refresh', () => {
@@ -146,21 +150,17 @@ test.describe('Tags', () => {
         await route.continue()
       })
 
-      try {
-        const tree = await openTagsTree()
-        await expandNode(tree, rootName)
-        await expandNode(tree, level1)
-        await expandNode(tree, level2)
-        await expandNode(tree, level3)
+      const tree = await openTagsTree()
+      await expandNode(tree, rootName)
+      await expandNode(tree, level1)
+      await expandNode(tree, level2)
+      await expandNode(tree, level3)
 
-        await enterParent(tree, level3)
+      await enterParent(tree, level3)
 
-        await createChildTag(childName)
+      await createChildTag(childName)
 
-        await expect(tree.getByText(childName)).toBeVisible()
-      } finally {
-        await page.unrouteAll()
-      }
+      await expect(tree.getByText(childName)).toBeVisible()
     })
   })
 })

--- a/test/tags/e2e.spec.ts
+++ b/test/tags/e2e.spec.ts
@@ -1,0 +1,166 @@
+import type { Locator, Page } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import type { PayloadTestSDK } from '../__helpers/shared/sdk/index.js'
+import type { Config, Tag } from './payload-types.js'
+
+import { ensureCompilationIsDone, initPageConsoleErrorCatch } from '../__helpers/e2e/helpers.js'
+import { openNav } from '../__helpers/e2e/toggleNav.js'
+import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
+import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
+import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
+import { tagsSlug } from './config.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+let payload: PayloadTestSDK<Config>
+let serverURL: string
+
+test.describe('Tags', () => {
+  let page: Page
+  let tagsURL: AdminUrlUtil
+
+  const createdTagIds: Tag['id'][] = []
+
+  /** Navigate to the tags list and return the sidebar tree. */
+  const openTagsTree = async (): Promise<Locator> => {
+    await page.goto(tagsURL.list)
+    await openNav(page)
+    await page.getByRole('tab', { name: 'Tags' }).click()
+    const tree = page.getByRole('tree')
+    await expect(tree).toBeVisible()
+    return tree
+  }
+
+  /** Click a tree node name button (at any depth) to navigate into its children view. */
+  const enterParent = async (tree: Locator, parentName: string): Promise<void> => {
+    const node = tree.getByRole('treeitem', { name: new RegExp(parentName) })
+    await expect(node).toBeVisible()
+    const selectButton = node.getByRole('button', { name: parentName, exact: true })
+    await expect(async () => {
+      await selectButton.click()
+      await expect(page).toHaveURL(/_h_tags=/, { timeout: 2000 })
+    }).toPass()
+  }
+
+  /** Expand a tree node if it is not already expanded. */
+  const expandNode = async (tree: Locator, name: string): Promise<void> => {
+    const node = tree.getByRole('treeitem', { name: new RegExp(name) })
+    await expect(node).toBeVisible()
+    if ((await node.getAttribute('aria-expanded')) !== 'true') {
+      await node.getByRole('button', { name: 'Open' }).first().click()
+    }
+    await expect(node).toHaveAttribute('aria-expanded', 'true')
+  }
+
+  /** Create a chain of nested tags via the API. Returns the created docs, root-first. */
+  const createTagChain = async (names: string[]): Promise<Tag[]> => {
+    const created: Tag[] = []
+    let parentId: Tag['id'] | undefined
+
+    for (const name of names) {
+      const data: Record<string, unknown> = { name }
+      if (parentId !== undefined) {
+        data[`_h_${tagsSlug}`] = parentId
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- hierarchy `_h_*` field is not in the generated type
+      const doc = await payload.create({ collection: tagsSlug, data: data as any })
+      created.push(doc)
+      createdTagIds.push(doc.id)
+      parentId = doc.id
+    }
+
+    return created
+  }
+
+  const createChildTag = async (name: string): Promise<Tag> => {
+    await page
+      .locator('.hierarchy-list__controls')
+      .getByRole('button', { name: 'Create New' })
+      .first()
+      .click()
+    await page.getByRole('button', { name: 'Tag', exact: true }).click()
+
+    const drawer = page.locator('.drawer__content')
+    await expect(drawer).toBeVisible()
+    await drawer.getByLabel('Name*').fill(name)
+    await drawer.getByRole('button', { name: 'Save' }).click()
+    await expect(drawer).toBeHidden()
+
+    const { docs } = await payload.find({
+      collection: tagsSlug,
+      where: { name: { equals: name } },
+    })
+    const createdTag = docs[0] as Tag
+    createdTagIds.push(createdTag.id)
+    return createdTag
+  }
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(TEST_TIMEOUT_LONG)
+
+    const { payload: payloadFromInit, serverURL: serverFromInit } =
+      await initPayloadE2ENoConfig<Config>({ dirname })
+
+    payload = payloadFromInit
+    serverURL = serverFromInit
+    tagsURL = new AdminUrlUtil(serverURL, tagsSlug)
+
+    const context = await browser.newContext()
+    page = await context.newPage()
+    initPageConsoleErrorCatch(page)
+    await ensureCompilationIsDone({ page, serverURL })
+  })
+
+  test.afterAll(async () => {
+    for (const id of createdTagIds) {
+      await payload.delete({ id, collection: tagsSlug }).catch(() => {})
+    }
+  })
+
+  test.describe('sidebar tree refresh', () => {
+    test('should show a deeply nested newly created tag in the sidebar without navigating away', async () => {
+      const suffix = Date.now()
+      const rootName = `AAA Deep Root ${suffix}`
+      const level1 = `AAA Deep L1 ${suffix}`
+      const level2 = `AAA Deep L2 ${suffix}`
+      const level3 = `AAA Deep L3 ${suffix}`
+      const childName = `AAA Deep Child ${suffix}`
+
+      await createTagChain([rootName, level1, level2, level3])
+
+      // Simulate the debounce race deterministically: prevent the expanded-node
+      // preference from ever being persisted. This mirrors creating the child before
+      // the 500ms preference-save debounce fires — so the RSC reload's getInitialTreeData
+      // reads a stale preference that omits the deep parent, and its children (including
+      // the new child) are never fetched into the refreshed tree.
+      await page.route('**/api/payload-preferences/hierarchy-tree-tags', async (route) => {
+        if (route.request().method() === 'POST') {
+          await route.fulfill({ body: '{}', contentType: 'application/json', status: 200 })
+          return
+        }
+        await route.continue()
+      })
+
+      try {
+        const tree = await openTagsTree()
+        await expandNode(tree, rootName)
+        await expandNode(tree, level1)
+        await expandNode(tree, level2)
+        await expandNode(tree, level3)
+
+        await enterParent(tree, level3)
+
+        await createChildTag(childName)
+
+        await expect(tree.getByText(childName)).toBeVisible()
+      } finally {
+        await page.unrouteAll()
+      }
+    })
+  })
+})

--- a/test/tags/int.spec.ts
+++ b/test/tags/int.spec.ts
@@ -1,6 +1,8 @@
 import type { Payload } from 'payload'
 
+import { renderTabHandler } from '@payloadcms/ui/rsc'
 import path from 'path'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { fileURLToPath } from 'url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -101,6 +103,74 @@ describe('Tags Helpers', () => {
       )
 
       expect((tagField as any)?.hasMany).toBe(true)
+    })
+  })
+  describe('render-tab searchParams precedence', () => {
+    const tabSlug = 'precedence-tab'
+
+    const getForwardedSearchParams = ({
+      query,
+      searchParams,
+    }: {
+      query?: Record<string, unknown>
+      searchParams?: Record<string, unknown>
+    }): unknown => {
+      let forwardedSearchParams: unknown
+
+      const Content = (props: { searchParams?: unknown }) => {
+        forwardedSearchParams = props.searchParams
+        return null
+      }
+
+      const args = {
+        req: {
+          i18n: {},
+          locale: undefined,
+          payload: {
+            config: {
+              admin: {
+                components: { sidebar: { tabs: [{ slug: tabSlug, components: { Content } }] } },
+              },
+            },
+            importMap: payload.importMap,
+            logger: payload.logger,
+          },
+          query,
+          routeParams: {},
+          user: { id: 'user-1' },
+        },
+        searchParams,
+        tabSlug,
+      } as unknown as Parameters<typeof renderTabHandler>[0]
+
+      const { component } = renderTabHandler(args)
+      renderToStaticMarkup(component)
+
+      return forwardedSearchParams
+    }
+
+    it('should forward the provided searchParams to the rendered tab', () => {
+      const forwarded = getForwardedSearchParams({
+        query: { parent: 'from-query' },
+        searchParams: { parent: 'from-args' },
+      })
+
+      expect(forwarded).toEqual({ parent: 'from-args' })
+    })
+
+    it('should fall back to req.query when searchParams is undefined', () => {
+      const forwarded = getForwardedSearchParams({ query: { parent: 'from-query' } })
+
+      expect(forwarded).toEqual({ parent: 'from-query' })
+    })
+
+    it('should use an explicitly empty searchParams object instead of falling back to req.query', () => {
+      const forwarded = getForwardedSearchParams({
+        query: { parent: 'from-query' },
+        searchParams: {},
+      })
+
+      expect(forwarded).toEqual({})
     })
   })
 })


### PR DESCRIPTION
## What
Creating a new nested tag does not appear in the hierarchy sidebar until navigating away and back.

## Why

Creating a new tag triggers `refreshTree()` which reloads the sidebar. That function runs with a fresh request that does not carry the client's current URL query, so `selectedNodeId` is `null` during the reload. 

The tree is then rebuilt solely from the saved `expandedNodes` preference, which is written with a 500ms debounce. If the nested tag is created before the debounce flushes, `getInitialTreeData` never loads the deeply nested tags, so the new tag stays hidden until a full navigation re-reads fresh state.

## Fix

Updated the hierarchy sidebar to forward the current selected-parent id to `reloadTabContent`, so the reload knows which node is being viewed (independent of the debounced preference).

Backwards compatibility: when no node is selected (root view), nothing is forwarded and behaviour is unchanged.

## Testing

Added a tags `e2e.spec.ts` file with a test to demonstrate this bug