### PR TITLE
fix: prefer draft titles in by folder view

### DIFF
--- a/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
+++ b/packages/payload/src/folders/utils/getFoldersAndDocumentsFromJoin.ts
@@ -40,6 +40,7 @@ export async function queryDocumentsAndFoldersFromJoin({
   const subfolderDoc = (await payload.find({
     collection: payload.config.folders.slug,
     depth: 1,
+    draft: true,
     joins: {
       documentsAndFolders: {
         limit: 100_000_000,

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -36,6 +36,8 @@ const dirname = path.dirname(filename)
 
 test.describe('Folders', () => {
   let page: Page
+  let payload: Awaited<ReturnType<typeof initPayloadE2ENoConfig>>['payload']
+  let draftsURL: AdminUrlUtil
   let postURL: AdminUrlUtil
   let OmittedFromBrowseBy: AdminUrlUtil
   let serverURL: string
@@ -44,8 +46,10 @@ test.describe('Folders', () => {
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
 
-    const { serverURL: serverFromInit } = await initPayloadE2ENoConfig({ dirname })
-    serverURL = serverFromInit
+    const initResult = await initPayloadE2ENoConfig({ dirname })
+    payload = initResult.payload
+    serverURL = initResult.serverURL
+    draftsURL = new AdminUrlUtil(serverURL, 'drafts')
     postURL = new AdminUrlUtil(serverURL, postSlug)
     OmittedFromBrowseBy = new AdminUrlUtil(serverURL, omittedFromBrowseBySlug)
 
@@ -491,6 +495,51 @@ test.describe('Folders', () => {
     test('should create folder from By Folder view', async () => {
       await page.goto(postURL.byFolder)
       await createFolder({ folderName: 'New Folder From Collection', folderType: ['Posts'], page })
+    })
+
+    test('should show the draft title instead of the published title in By Folder view', async () => {
+      const folder = await payload.create({
+        collection: 'payload-folders',
+        data: {
+          name: 'Draft Titles Folder',
+          folderType: ['drafts'],
+        },
+        overrideAccess: true,
+      })
+
+      const doc = await payload.create({
+        collection: 'drafts',
+        data: {
+          folder: folder.id,
+          title: 'Published Title',
+          _status: 'published',
+        },
+        overrideAccess: true,
+      })
+
+      await payload.update({
+        collection: 'drafts',
+        id: doc.id,
+        data: {
+          title: 'Draft Title',
+        },
+        draft: true,
+        overrideAccess: true,
+      })
+
+      await page.goto(draftsURL.byFolder)
+      await clickFolderCard({ folderName: 'Draft Titles Folder', page, doubleClick: true })
+
+      await expect(
+        page.locator('.folder-file-card__name', {
+          hasText: 'Draft Title',
+        }),
+      ).toBeVisible()
+      await expect(
+        page.locator('.folder-file-card__name', {
+          hasText: 'Published Title',
+        }),
+      ).toBeHidden()
     })
   })
 


### PR DESCRIPTION
Prefers draft titles over published titles when rendering versioned documents in `By Folder` views.

Adds a `folders` end-to-end regression that creates a published `drafts` document, saves a newer draft title, and asserts that the folder view shows the draft title instead of the published one.

<!-- e2e-pr-media:start -->
### Before
<!--
- Create a folder.
- Create a published document in that folder.
- Make draft edits to that document.
- Open the document's folder in By Folder view.
- Show the document card with the published title. (Incorrect, should be draft title)
-->
https://github.com/user-attachments/assets/6c677c77-e141-456c-8b13-c53aa9c4b0d1

### After
<!--
- Create a folder.
- Create a published document in that folder.
- Make draft edits to that document.
- Open the document's folder in By Folder view.
- Show the document card with the draft title. (Correct, shows draft title)
-->
https://github.com/user-attachments/assets/82e3ce37-4cb3-4ef0-ad8d-102feb240b0b
<!-- e2e-pr-media:end -->
