### PR TITLE
fix(ui): register slugify server function across adapters

### DIFF
--- a/packages/ui/src/fields/Slug/index.tsx
+++ b/packages/ui/src/fields/Slug/index.tsx
@@ -4,6 +4,7 @@ import type { SlugFieldClient } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import React, { useCallback, useState } from 'react'
+import { toast } from 'sonner'
 
 import { Button } from '../../elements/Button/index.js'
 import { FieldDescription } from '../../fields/FieldDescription/index.js'
@@ -61,13 +62,20 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
 
       const valueToSlugify = getDataByPath(useAsSlug)
 
-      const formattedSlug = await slugify({
-        collectionSlug,
-        data: getData(),
-        globalSlug,
-        path: fieldPath,
-        valueToSlugify,
-      })
+      let formattedSlug: null | string | undefined
+
+      try {
+        formattedSlug = await slugify({
+          collectionSlug,
+          data: getData(),
+          globalSlug,
+          path: fieldPath,
+          valueToSlugify,
+        })
+      } catch (_err) {
+        toast.error(t('error:unspecific'))
+        return
+      }
 
       if (formattedSlug === null || formattedSlug === undefined) {
         setValue('')
@@ -91,6 +99,7 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
       collectionSlug,
       globalSlug,
       fieldPath,
+      t,
     ],
   )
 

--- a/packages/ui/src/utilities/handleServerFunctions.ts
+++ b/packages/ui/src/utilities/handleServerFunctions.ts
@@ -8,31 +8,19 @@ import type {
 import { renderTabHandler } from '../elements/Nav/SidebarTabs/renderTabServerFn.js'
 import { _internal_renderFieldHandler } from '../forms/fieldSchemasToFormState/serverFunctions/renderFieldServerFn.js'
 import { getDefaultLayoutHandler, renderWidgetHandler } from '../views/Dashboard/serverFunctions.js'
-import { renderDocumentHandler } from '../views/Document/handleServerFunction.js'
 import { renderDocumentSlotsHandler } from '../views/Document/renderDocumentSlots.js'
-import { renderListHandler } from '../views/List/handleServerFunction.js'
-import { buildFormStateHandler } from './buildFormState.js'
-import { buildTableStateHandler } from './buildTableState.js'
-import { copyDataFromLocaleHandler } from './copyDataFromLocale.js'
 import { initReq } from './initReq.js'
-import { schedulePublishHandler } from './schedulePublishHandler.js'
-import { slugifyHandler } from './slugify.js'
+import { sharedServerFunctions } from './serverFunctionRegistry.js'
 import { switchLanguageHandler } from './switchLanguageHandler.js'
 
 const baseServerFunctions: Record<string, ServerFunction<any, any>> = {
-  'copy-data-from-locale': copyDataFromLocaleHandler,
-  'form-state': buildFormStateHandler,
+  ...sharedServerFunctions,
   'get-default-layout': getDefaultLayoutHandler,
-  'render-document': renderDocumentHandler,
   'render-document-slots': renderDocumentSlotsHandler,
   'render-field': _internal_renderFieldHandler,
-  'render-list': renderListHandler,
   'render-tab': renderTabHandler,
   'render-widget': renderWidgetHandler,
-  'schedule-publish': schedulePublishHandler,
-  slugify: slugifyHandler,
   'switch-language': switchLanguageHandler,
-  'table-state': buildTableStateHandler,
 }
 
 /**

--- a/packages/ui/src/utilities/serverFunctionRegistry.ts
+++ b/packages/ui/src/utilities/serverFunctionRegistry.ts
@@ -6,6 +6,7 @@ import { buildFormStateHandler } from './buildFormState.js'
 import { buildTableStateHandler } from './buildTableState.js'
 import { copyDataFromLocaleHandler } from './copyDataFromLocale.js'
 import { schedulePublishHandler } from './schedulePublishHandler.js'
+import { slugifyHandler } from './slugify.js'
 
 /**
  * Framework-agnostic server function handlers shared across all adapters.
@@ -23,5 +24,6 @@ export const sharedServerFunctions: Record<string, ServerFunction<any, any>> = {
   'render-document': renderDocumentHandler,
   'render-list': renderListHandler,
   'schedule-publish': schedulePublishHandler,
+  slugify: slugifyHandler,
   'table-state': buildTableStateHandler,
 }


### PR DESCRIPTION
The Next.js and TanStack Start server function adapters have drifted apart: each framework maintained its own lists independently, so a handler could exist on one adapter and be missing from the other, e.g. `slugify` within the TanStack adapter.

Within TanStack Start, the `slugify` server function was missing from the registry. Any user-invoked slug regeneration would fail outright, throwing:

```
Unknown Server Function: slugify
```

The fix creates a unified source of truth. Both adapters now derive their handler list from `sharedServerFunctions`, declaring only their RSC-only extras on top. A handler added once reaches every adapter, and the lists can't fall out of sync again.

Also adds additional error handling at the component-level to provide the user with visual feedback.

In a follow-up PR, we should explore how to further prevent drift by removing the TanStack-specific server function wrappers.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216712352001344