### PR TITLE
ci: add release bump and publish entry scripts/workflows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,55 @@
+name: publish-release
+
+on:
+  push:
+    tags:
+      - 'v4.*'
+
+env:
+  DO_NOT_TRACK: 1 # Disable Turbopack telemetry
+  NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
+
+concurrency:
+  group: publish-release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish-release-${{ github.ref_name }}
+    if: github.repository_owner == 'payloadcms'
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      - name: Checkout tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Publish
+        run: pnpm release-ci
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_CONFIG_PROVENANCE: true
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H 'Content-type: application/json; charset=utf-8' \
+            --data "$(printf '{"channel":"%s","text":"🚨 publish-release failed for %s — %s/%s/actions/runs/%s"}' \
+              "$SLACK_CHANNEL" "$GITHUB_REF_NAME" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,14 +42,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true
-      - name: Notify Slack on failure
-        if: failure()
-        run: |
-          curl -fsS -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_TOKEN" \
-            -H 'Content-type: application/json; charset=utf-8' \
-            --data "$(printf '{"channel":"%s","text":"🚨 publish-release failed for %s — %s/%s/actions/runs/%s"}' \
-              "$SLACK_CHANNEL" "$GITHUB_REF_NAME" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"
-        env:
-          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,6 @@ jobs:
     environment: release
     permissions:
       id-token: write
-      contents: write
     steps:
       - name: Mint App token
         id: app-token

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,10 @@ name: publish-release
 on:
   push:
     tags:
-      - 'v4.*'
+      # Only the canary line publishes here; stable and internal
+      # (internal/internal-debug) tags never match.
+      # TODO: add 'v4.*-beta.*' (and other lines) when beta releases begin.
+      - 'v4.*-canary.*'
 
 env:
   DO_NOT_TRACK: 1 # Disable Turbopack telemetry

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -42,6 +42,16 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Guard runs before the token is minted so an unauthorized dispatch fails
+      # fast and never gains access to the App credentials.
+      - name: Authorize dispatcher
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          case "$ACTOR" in
+            denolfe|DanRibbens) ;;
+            *) echo "::error::$ACTOR is not authorized to dispatch release-bump"; exit 1 ;;
+          esac
       - name: Mint App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -6,9 +6,11 @@ on:
       preid:
         description: Prerelease identifier
         type: choice
+        # 'beta' is intentionally omitted until the beta relases start,
+        # so a contributor cannot accidentally cut a beta through this flow.
+        # TODO: re-add 'beta' to these options when beta releases begin.
         options:
           - canary
-          - beta
         default: canary
       bump:
         description: Semver bump

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Bump
-        run: pnpm release-bump --preid ${{ inputs.preid }} --bump ${{ inputs.bump }} ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: pnpm release-bump --preid "$PREID" --bump "$BUMP" ${DRY_RUN_FLAG:-}
         env:
+          PREID: ${{ inputs.preid }}
+          BUMP: ${{ inputs.bump }}
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,0 +1,60 @@
+name: release-bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      preid:
+        description: Prerelease identifier
+        type: choice
+        options:
+          - canary
+          - beta
+        default: canary
+      bump:
+        description: Semver bump
+        type: choice
+        options:
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
+        default: prerelease
+      dry_run:
+        description: 'Dry run: log git commands, push nothing'
+        type: boolean
+        default: false
+
+env:
+  DO_NOT_TRACK: 1 # Disable Turbopack telemetry
+  NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
+
+concurrency:
+  group: release-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: release-bump
+    if: github.repository_owner == 'payloadcms'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Bump
+        run: pnpm release-bump --preid ${{ inputs.preid }} --bump ${{ inputs.bump }} ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -19,7 +19,6 @@ on:
           - prerelease
           - prepatch
           - preminor
-          - premajor
         default: prerelease
       dry_run:
         description: 'Dry run: log git commands, push nothing'

--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
     "publish-prerelease": "pnpm --filter releaser publish-prerelease",
     "reinstall": "pnpm clean:all && pnpm install",
     "release": "pnpm --filter releaser release --tag beta",
+    "release-bump": "pnpm --filter releaser release-bump",
+    "release-ci": "pnpm --filter releaser release-ci",
     "runts": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" node --no-deprecation --no-experimental-strip-types --import @swc-node/register/esm-register",
     "script:audit": "pnpm audit -P",
     "script:audit:critical": "pnpm audit -P --audit-level critical",

--- a/tools/releaser/package.json
+++ b/tools/releaser/package.json
@@ -31,6 +31,8 @@
     "list-published": "tsx src/lib/getPackageRegistryVersions.ts",
     "publish-prerelease": "tsx src/publish-prerelease.ts",
     "release": "tsx src/release.ts",
+    "release-bump": "tsx src/release-bump.ts",
+    "release-ci": "tsx src/release-ci.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/tools/releaser/package.json
+++ b/tools/releaser/package.json
@@ -28,7 +28,7 @@
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "list-published": "tsx src/lib/getPackageRegistryVersions.ts",
+    "list-published": "tsx src/list-published.ts",
     "publish-prerelease": "tsx src/publish-prerelease.ts",
     "release": "tsx src/release.ts",
     "release-bump": "tsx src/release-bump.ts",

--- a/tools/releaser/src/lib/assertBumpPreconditions.spec.ts
+++ b/tools/releaser/src/lib/assertBumpPreconditions.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertBumpPreconditions } from './assertBumpPreconditions.js'
+
+const valid = {
+  branch: 'main',
+  bump: 'prerelease',
+  hasGithubToken: true,
+  preid: 'canary',
+  version: '4.0.0-canary.9',
+}
+
+describe('assertBumpPreconditions', () => {
+  it('should pass for valid canary inputs', () => {
+    expect(() => assertBumpPreconditions({ ...valid })).not.toThrow()
+  })
+
+  it('should allow a canary.N -> beta.0 transition (preid need not match the current id)', () => {
+    expect(() => assertBumpPreconditions({ ...valid, preid: 'beta' })).not.toThrow()
+  })
+
+  it('should throw when not on main', () => {
+    expect(() => assertBumpPreconditions({ ...valid, branch: 'feature' })).toThrow(
+      /must be run from 'main'/,
+    )
+  })
+
+  it('should throw for a non-v4 version', () => {
+    expect(() => assertBumpPreconditions({ ...valid, version: '3.85.2' })).toThrow(/Expected a v4/)
+  })
+
+  it('should throw for a stable v4 version with no prerelease id', () => {
+    expect(() => assertBumpPreconditions({ ...valid, version: '4.0.0' })).toThrow(
+      /no prerelease identifier/,
+    )
+  })
+
+  it('should throw for an invalid preid', () => {
+    expect(() => assertBumpPreconditions({ ...valid, preid: 'latest' })).toThrow(/Invalid --preid/)
+  })
+
+  it('should throw for an invalid bump', () => {
+    expect(() => assertBumpPreconditions({ ...valid, bump: 'major' })).toThrow(/Invalid --bump/)
+  })
+
+  it('should throw when GITHUB_TOKEN is missing', () => {
+    expect(() => assertBumpPreconditions({ ...valid, hasGithubToken: false })).toThrow(
+      /GITHUB_TOKEN/,
+    )
+  })
+})

--- a/tools/releaser/src/lib/assertBumpPreconditions.spec.ts
+++ b/tools/releaser/src/lib/assertBumpPreconditions.spec.ts
@@ -43,6 +43,19 @@ describe('assertBumpPreconditions', () => {
     expect(() => assertBumpPreconditions({ ...valid, bump: 'major' })).toThrow(/Invalid --bump/)
   })
 
+  it('should throw for premajor, which would escape the pinned v4 line', () => {
+    expect(() => assertBumpPreconditions({ ...valid, bump: 'premajor' })).toThrow(
+      /leaves the pinned v4 line/,
+    )
+  })
+
+  it.each(['preminor', 'prepatch', 'prerelease'])(
+    'should allow %s, which stays within v4',
+    (bump) => {
+      expect(() => assertBumpPreconditions({ ...valid, bump })).not.toThrow()
+    },
+  )
+
   it('should throw when GITHUB_TOKEN is missing', () => {
     expect(() => assertBumpPreconditions({ ...valid, hasGithubToken: false })).toThrow(
       /GITHUB_TOKEN/,

--- a/tools/releaser/src/lib/assertBumpPreconditions.ts
+++ b/tools/releaser/src/lib/assertBumpPreconditions.ts
@@ -1,5 +1,7 @@
 import semver from 'semver'
 
+import { isPinnedMajor, PINNED_MAJOR } from './pinnedMajor.js'
+
 export const PREIDS = ['beta', 'canary'] as const
 export const PRERELEASE_BUMPS = ['premajor', 'preminor', 'prepatch', 'prerelease'] as const
 
@@ -35,9 +37,9 @@ export function assertBumpPreconditions(
     throw new Error(`Releases must be run from 'main'. Current branch: ${args.branch}.`)
   }
 
-  if (!/^4\./.test(args.version)) {
+  if (!isPinnedMajor(args.version)) {
     throw new Error(
-      `Expected a v4.x version; package.json version is ${args.version}. This flow is pinned to v4 during the beta phase.`,
+      `Expected a v${PINNED_MAJOR}.x version; package.json version is ${args.version}. This flow is pinned to v${PINNED_MAJOR} during the beta phase.`,
     )
   }
 

--- a/tools/releaser/src/lib/assertBumpPreconditions.ts
+++ b/tools/releaser/src/lib/assertBumpPreconditions.ts
@@ -1,11 +1,12 @@
 import semver from 'semver'
 
-import { isPinnedMajor, PINNED_MAJOR } from './pinnedMajor.js'
+import type { Preid } from './preids.js'
 
-export const PREIDS = ['beta', 'canary'] as const
+import { isPinnedMajor, PINNED_MAJOR } from './pinnedMajor.js'
+import { isPreid, PREIDS } from './preids.js'
+
 export const PRERELEASE_BUMPS = ['premajor', 'preminor', 'prepatch', 'prerelease'] as const
 
-export type Preid = (typeof PREIDS)[number]
 export type PrereleaseBump = (typeof PRERELEASE_BUMPS)[number]
 
 type BumpPreconditions = {
@@ -63,8 +64,6 @@ export function assertBumpPreconditions(
     throw new Error('GITHUB_TOKEN env var is required')
   }
 }
-
-const isPreid = (value: string): value is Preid => (PREIDS as readonly string[]).includes(value)
 
 const isPrereleaseBump = (value: string): value is PrereleaseBump =>
   (PRERELEASE_BUMPS as readonly string[]).includes(value)

--- a/tools/releaser/src/lib/assertBumpPreconditions.ts
+++ b/tools/releaser/src/lib/assertBumpPreconditions.ts
@@ -1,0 +1,68 @@
+import semver from 'semver'
+
+export const PREIDS = ['beta', 'canary'] as const
+export const PRERELEASE_BUMPS = ['premajor', 'preminor', 'prepatch', 'prerelease'] as const
+
+export type Preid = (typeof PREIDS)[number]
+export type PrereleaseBump = (typeof PRERELEASE_BUMPS)[number]
+
+type BumpPreconditions = {
+  branch: string
+  bump: string
+  hasGithubToken: boolean
+  preid: string
+  version: string
+}
+
+type ValidatedBumpPreconditions = {
+  branch: string
+  bump: PrereleaseBump
+  hasGithubToken: boolean
+  preid: Preid
+  version: string
+}
+
+/**
+ * Validates every bump precondition, throwing (fail-closed) on the first violation
+ * so the caller aborts before any git write. Ported from the inline guards in
+ * release.ts. The version must carry *a* prerelease identifier, but it need not
+ * match `preid` — a canary.N → beta.0 transition is expected and allowed.
+ */
+export function assertBumpPreconditions(
+  args: BumpPreconditions,
+): asserts args is ValidatedBumpPreconditions {
+  if (args.branch !== 'main') {
+    throw new Error(`Releases must be run from 'main'. Current branch: ${args.branch}.`)
+  }
+
+  if (!/^4\./.test(args.version)) {
+    throw new Error(
+      `Expected a v4.x version; package.json version is ${args.version}. This flow is pinned to v4 during the beta phase.`,
+    )
+  }
+
+  if (!semver.prerelease(args.version)?.[0]) {
+    throw new Error(
+      `Stable releases are disallowed during the v4 beta phase; version ${args.version} has no prerelease identifier.`,
+    )
+  }
+
+  if (!isPreid(args.preid)) {
+    throw new Error(`Invalid --preid '${args.preid}'. Must be one of: ${PREIDS.join(', ')}.`)
+  }
+
+  if (!isPrereleaseBump(args.bump)) {
+    throw new Error(
+      `Invalid --bump '${args.bump}'. Must be one of: ${PRERELEASE_BUMPS.join(', ')}.`,
+    )
+  }
+
+  if (!args.hasGithubToken) {
+    throw new Error('GITHUB_TOKEN env var is required')
+  }
+}
+
+const isPreid = (value: string): value is Preid => (PREIDS as readonly string[]).includes(value)
+
+const isPrereleaseBump = (value: string): value is PrereleaseBump =>
+  (PRERELEASE_BUMPS as readonly string[]).includes(value)

--- a/tools/releaser/src/lib/assertBumpPreconditions.ts
+++ b/tools/releaser/src/lib/assertBumpPreconditions.ts
@@ -60,6 +60,17 @@ export function assertBumpPreconditions(
     )
   }
 
+  // Guard the *resulting* version, not just the current one: `premajor` from a v4
+  // version yields v5, which would commit a v5 tag to main and brick every later
+  // bump (they'd fail the pinned-major check above). Only bumps that stay within
+  // the pinned major are allowed during the beta phase.
+  const nextVersion = semver.inc(args.version, args.bump, undefined, args.preid)
+  if (!nextVersion || semver.major(nextVersion) !== PINNED_MAJOR) {
+    throw new Error(
+      `Bump '${args.bump}' would produce ${nextVersion ?? 'an invalid version'}, which leaves the pinned v${PINNED_MAJOR} line.`,
+    )
+  }
+
   if (!args.hasGithubToken) {
     throw new Error('GITHUB_TOKEN env var is required')
   }

--- a/tools/releaser/src/lib/assertBumpPreconditions.ts
+++ b/tools/releaser/src/lib/assertBumpPreconditions.ts
@@ -27,9 +27,9 @@ type ValidatedBumpPreconditions = {
 
 /**
  * Validates every bump precondition, throwing (fail-closed) on the first violation
- * so the caller aborts before any git write. Ported from the inline guards in
- * release.ts. The version must carry *a* prerelease identifier, but it need not
- * match `preid` — a canary.N → beta.0 transition is expected and allowed.
+ * so the caller aborts before any git write. The version must carry *a* prerelease
+ * identifier, but it need not match `preid` — a canary.N → beta.0 transition is
+ * expected and allowed.
  */
 export function assertBumpPreconditions(
   args: BumpPreconditions,

--- a/tools/releaser/src/lib/getPackageRegistryVersions.ts
+++ b/tools/releaser/src/lib/getPackageRegistryVersions.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk'
 import pLimit from 'p-limit'
-import { pathToFileURL } from 'url'
 
 import { getPackageDetails } from './getPackageDetails.js'
 import { packagePublishList } from './publishList.js'
@@ -55,12 +54,4 @@ export const getPackageRegistryVersions = async (): Promise<void> => {
   console.log(header)
   console.log()
   console.log(results.sort().join('\n'))
-}
-
-// Run the registry-version report only when invoked directly (e.g. `pnpm
-// list-published`), never as a side effect of importing this module for
-// `isVersionPublished`. The prior guard compared import.meta.url to itself, which
-// is always true, so any importer triggered the full report + network fetches.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  await getPackageRegistryVersions()
 }

--- a/tools/releaser/src/lib/getPackageRegistryVersions.ts
+++ b/tools/releaser/src/lib/getPackageRegistryVersions.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import pLimit from 'p-limit'
+import { pathToFileURL } from 'url'
 
 import { getPackageDetails } from './getPackageDetails.js'
 import { packagePublishList } from './publishList.js'
@@ -56,6 +57,10 @@ export const getPackageRegistryVersions = async (): Promise<void> => {
   console.log(results.sort().join('\n'))
 }
 
-if (import.meta.url === new URL(import.meta.url).href) {
+// Run the registry-version report only when invoked directly (e.g. `pnpm
+// list-published`), never as a side effect of importing this module for
+// `isVersionPublished`. The prior guard compared import.meta.url to itself, which
+// is always true, so any importer triggered the full report + network fetches.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   await getPackageRegistryVersions()
 }

--- a/tools/releaser/src/lib/getWorkspace.ts
+++ b/tools/releaser/src/lib/getWorkspace.ts
@@ -36,7 +36,7 @@ type PublishOpts = {
   tag?: 'beta' | 'canary' | 'internal' | 'internal-debug' | 'latest'
 }
 
-type Workspace = {
+export type Workspace = {
   version: () => Promise<string>
   bumpVersion: (type: PackageReleaseType, opts?: { preid?: 'beta' | 'canary' }) => Promise<string>
   build: (opts?: { debug?: boolean }) => Promise<void>

--- a/tools/releaser/src/lib/pinnedMajor.ts
+++ b/tools/releaser/src/lib/pinnedMajor.ts
@@ -1,0 +1,14 @@
+import semver from 'semver'
+
+/**
+ * The single major version the release flow is pinned to during the v4 beta phase.
+ * Both entry scripts and the changelog tag filter derive their v4 checks from this
+ * one constant so lifting the pin (e.g. to v5) is a one-line change.
+ */
+export const PINNED_MAJOR = 4
+
+export const isPinnedMajor = (version: string): boolean =>
+  semver.valid(version) !== null && semver.major(version) === PINNED_MAJOR
+
+/** The `git tag --list` glob matching every tag on the pinned major, e.g. `v4.*`. */
+export const pinnedMajorTagGlob = `v${PINNED_MAJOR}.*`

--- a/tools/releaser/src/lib/preids.ts
+++ b/tools/releaser/src/lib/preids.ts
@@ -1,0 +1,13 @@
+/**
+ * The prerelease identifiers this release flow is allowed to publish, and the
+ * single source of truth for both the bump preconditions and the publish gate.
+ * Anything outside this set (a stable version, or an `internal`/`rc`/unknown
+ * prerelease line) must be rejected rather than defaulted — extend this list to
+ * onboard a new publishable line.
+ */
+export const PREIDS = ['beta', 'canary'] as const
+
+export type Preid = (typeof PREIDS)[number]
+
+export const isPreid = (value: unknown): value is Preid =>
+  typeof value === 'string' && (PREIDS as readonly string[]).includes(value)

--- a/tools/releaser/src/list-published.ts
+++ b/tools/releaser/src/list-published.ts
@@ -1,0 +1,11 @@
+/**
+ * Bin for `pnpm list-published`: prints each publishable package's latest/beta/canary
+ * dist-tag versions from the npm registry. Kept separate from the library module so
+ * the report never runs as a side effect of importing `isVersionPublished`.
+ */
+import { getPackageRegistryVersions } from './lib/getPackageRegistryVersions.js'
+
+getPackageRegistryVersions().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/tools/releaser/src/release-bump.spec.ts
+++ b/tools/releaser/src/release-bump.spec.ts
@@ -47,7 +47,7 @@ describe('runReleaseBump', () => {
     expect(deps.workspace.bumpVersion).not.toHaveBeenCalled()
   })
 
-  it('should allow a canary -> beta transition', async () => {
+  it('should pass the requested preid through to bumpVersion (not hardcode canary)', async () => {
     const deps = makeDeps({
       workspace: {
         bumpVersion: vi.fn(async () => '4.0.0-beta.0'),

--- a/tools/releaser/src/release-bump.spec.ts
+++ b/tools/releaser/src/release-bump.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { runReleaseBump } from './release-bump.js'
+
+const baseDeps = () => ({
+  env: { GITHUB_TOKEN: 'token' } as NodeJS.ProcessEnv,
+  log: vi.fn(),
+  readBranch: () => 'main',
+  run: vi.fn(),
+  workspace: {
+    bumpVersion: vi.fn(async () => '4.0.0-canary.10'),
+    version: vi.fn(async () => '4.0.0-canary.9'),
+  },
+})
+
+const makeDeps = (
+  over: Partial<ReturnType<typeof baseDeps>> = {},
+): ReturnType<typeof baseDeps> => ({ ...baseDeps(), ...over })
+
+describe('runReleaseBump', () => {
+  it('should bump, configure identity, commit, tag, then push in order', async () => {
+    const deps = makeDeps()
+
+    const next = await runReleaseBump({ bump: 'prerelease', deps, dryRun: false, preid: 'canary' })
+
+    expect(next).toBe('4.0.0-canary.10')
+    expect(deps.workspace.bumpVersion).toHaveBeenCalledWith('prerelease', { preid: 'canary' })
+
+    const cmds = deps.run.mock.calls.map((call) => call[0] as string)
+    expect(cmds).toContain('git add packages/**/package.json package.json')
+    expect(cmds).toContain('git commit -m "chore(release): v4.0.0-canary.10"')
+    expect(cmds).toContain('git tag -a v4.0.0-canary.10 -m v4.0.0-canary.10')
+
+    const tagIdx = cmds.indexOf('git tag -a v4.0.0-canary.10 -m v4.0.0-canary.10')
+    const pushIdx = cmds.findIndex((cmd) => cmd.startsWith('git push --atomic'))
+    expect(pushIdx).toBeGreaterThan(tagIdx)
+  })
+
+  it('should abort before any git write or bump when not on main', async () => {
+    const deps = makeDeps({ readBranch: () => 'feature' })
+
+    await expect(
+      runReleaseBump({ bump: 'prerelease', deps, dryRun: false, preid: 'canary' }),
+    ).rejects.toThrow(/main/)
+
+    expect(deps.run).not.toHaveBeenCalled()
+    expect(deps.workspace.bumpVersion).not.toHaveBeenCalled()
+  })
+
+  it('should allow a canary -> beta transition', async () => {
+    const deps = makeDeps({
+      workspace: {
+        bumpVersion: vi.fn(async () => '4.0.0-beta.0'),
+        version: vi.fn(async () => '4.0.0-canary.9'),
+      },
+    })
+
+    const next = await runReleaseBump({ bump: 'prerelease', deps, dryRun: false, preid: 'beta' })
+
+    expect(next).toBe('4.0.0-beta.0')
+    expect(deps.workspace.bumpVersion).toHaveBeenCalledWith('prerelease', { preid: 'beta' })
+  })
+
+  it('should log the push and never execute it in dry-run', async () => {
+    const deps = makeDeps()
+
+    await runReleaseBump({ bump: 'prerelease', deps, dryRun: true, preid: 'canary' })
+
+    const runCmds = deps.run.mock.calls.map((call) => call[0] as string)
+    expect(runCmds.some((cmd) => cmd.startsWith('git push'))).toBe(false)
+
+    const logs = deps.log.mock.calls.map((call) => call[0] as string)
+    expect(logs.some((line) => line.includes('git push --atomic'))).toBe(true)
+  })
+})

--- a/tools/releaser/src/release-bump.ts
+++ b/tools/releaser/src/release-bump.ts
@@ -1,0 +1,108 @@
+/**
+ * Bump-workflow entry point (P2 of the dispatch → tag → publish flow).
+ *
+ * Computes the next prerelease version from main's committed version, commits it,
+ * tags it, and pushes HEAD:main + the tag (with a rebase-retry loop). It does NOT
+ * build or publish — the pushed tag triggers the separate publish workflow.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=... pnpm release-bump --preid <canary|beta> \
+ *     --bump <prerelease|prepatch|preminor|premajor> [--dry-run]
+ *
+ * In --dry-run, git commands are logged (not executed) and nothing is pushed, but
+ * the version bump is still written to local package.json (bumpVersion has no
+ * dry-run path). Discarded on ephemeral CI; locally revert with
+ * `git checkout -- packages package.json`.
+ */
+import { PROJECT_ROOT } from '@tools/constants'
+import { execSync } from 'child_process'
+import minimist from 'minimist'
+import { pathToFileURL } from 'url'
+
+import type { Workspace } from './lib/getWorkspace.js'
+
+import { assertBumpPreconditions } from './lib/assertBumpPreconditions.js'
+import { getWorkspace } from './lib/getWorkspace.js'
+import { pushWithRebaseRetry } from './lib/pushWithRebaseRetry.js'
+
+type ReleaseBumpDeps = {
+  env: NodeJS.ProcessEnv
+  log: (message: string) => void
+  readBranch: () => string
+  run: (cmd: string) => void
+  workspace: Pick<Workspace, 'bumpVersion' | 'version'>
+}
+
+export const runReleaseBump = async ({
+  bump,
+  deps,
+  dryRun,
+  preid,
+}: {
+  bump: string
+  deps: ReleaseBumpDeps
+  dryRun: boolean
+  preid: string
+}): Promise<string> => {
+  const { env, log, readBranch, run, workspace } = deps
+
+  const validated = {
+    branch: readBranch(),
+    bump,
+    hasGithubToken: Boolean(env.GITHUB_TOKEN),
+    preid,
+    version: await workspace.version(),
+  }
+
+  assertBumpPreconditions(validated)
+
+  const nextVersion = await workspace.bumpVersion(validated.bump, { preid: validated.preid })
+  const tag = `v${nextVersion}`
+
+  log(`\n  ${validated.version} => ${nextVersion}  (tag ${tag})\n`)
+
+  run(`git config user.name "github-actions[bot]"`)
+  run(`git config user.email "github-actions[bot]@users.noreply.github.com"`)
+  run(`git add packages/**/package.json package.json`)
+  run(`git commit -m "chore(release): ${tag}"`)
+  run(`git tag -a ${tag} -m ${tag}`)
+
+  await pushWithRebaseRetry({ dryRun, log, run, tag })
+
+  return nextVersion
+}
+
+async function main(): Promise<void> {
+  const argv = minimist(process.argv.slice(2))
+  const bump = typeof argv.bump === 'string' ? argv.bump : 'prerelease'
+  const preid = typeof argv.preid === 'string' ? argv.preid : 'canary'
+  const dryRun = Boolean(argv['dry-run'])
+
+  const run = (cmd: string): void => {
+    if (dryRun) {
+      console.log(`[dry-run] ${cmd}`)
+      return
+    }
+    execSync(cmd, { cwd: PROJECT_ROOT, stdio: 'inherit' })
+  }
+
+  await runReleaseBump({
+    bump,
+    deps: {
+      env: process.env,
+      log: console.log,
+      readBranch: () => execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim(),
+      run,
+      workspace: getWorkspace(),
+    },
+    dryRun,
+    preid,
+  })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error: unknown) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/tools/releaser/src/release-bump.ts
+++ b/tools/releaser/src/release-bump.ts
@@ -1,5 +1,5 @@
 /**
- * Bump-workflow entry point (P2 of the dispatch → tag → publish flow).
+ * Bump-workflow entry point in the dispatch → tag → publish release flow.
  *
  * Computes the next prerelease version from main's committed version, commits it,
  * tags it, and pushes HEAD:main + the tag (with a rebase-retry loop). It does NOT

--- a/tools/releaser/src/release-ci.spec.ts
+++ b/tools/releaser/src/release-ci.spec.ts
@@ -96,7 +96,7 @@ describe('runReleaseCi', () => {
     expect(deps.workspace.build).not.toHaveBeenCalled()
   })
 
-  it('should refuse an unsupported prerelease line instead of defaulting to latest', async () => {
+  it('should refuse an unsupported prerelease line', async () => {
     const deps = makeDeps({
       workspace: {
         build: vi.fn(async () => {}),

--- a/tools/releaser/src/release-ci.spec.ts
+++ b/tools/releaser/src/release-ci.spec.ts
@@ -92,8 +92,22 @@ describe('runReleaseCi', () => {
       },
     })
 
-    await expect(runReleaseCi({ deps, dryRun: false })).rejects.toThrow(/not supported/)
+    await expect(runReleaseCi({ deps, dryRun: false })).rejects.toThrow(/prerelease line must be/)
     expect(deps.workspace.build).not.toHaveBeenCalled()
+  })
+
+  it('should refuse an unsupported prerelease line instead of defaulting to latest', async () => {
+    const deps = makeDeps({
+      workspace: {
+        build: vi.fn(async () => {}),
+        publish: vi.fn(async () => {}),
+        version: vi.fn(async () => '4.1.0-internal.abc1234'),
+      },
+    })
+
+    await expect(runReleaseCi({ deps, dryRun: false })).rejects.toThrow(/prerelease line must be/)
+    expect(deps.workspace.build).not.toHaveBeenCalled()
+    expect(deps.workspace.publish).not.toHaveBeenCalled()
   })
 
   it('should skip build, publish, and draft in dry-run but still generate notes', async () => {

--- a/tools/releaser/src/release-ci.spec.ts
+++ b/tools/releaser/src/release-ci.spec.ts
@@ -41,8 +41,10 @@ describe('runReleaseCi', () => {
       tag: 'v4.0.0-canary.10',
     })
 
+    const notesOrder = deps.generateReleaseNotes.mock.invocationCallOrder[0]
     const buildOrder = deps.workspace.build.mock.invocationCallOrder[0]
     const publishOrder = deps.workspace.publish.mock.invocationCallOrder[0]
+    expect(buildOrder).toBeGreaterThan(notesOrder)
     expect(publishOrder).toBeGreaterThan(buildOrder)
   })
 

--- a/tools/releaser/src/release-ci.spec.ts
+++ b/tools/releaser/src/release-ci.spec.ts
@@ -9,6 +9,7 @@ const baseDeps = () => ({
     releaseNotes: 'notes',
     releaseUrl: 'https://gh/new',
   })),
+  hasGithubToken: true,
   log: vi.fn(),
   workspace: {
     build: vi.fn(async () => {}),
@@ -57,6 +58,14 @@ describe('runReleaseCi', () => {
     await runReleaseCi({ deps, dryRun: false })
 
     expect(deps.workspace.publish).toHaveBeenCalledWith({ dryRun: false, tag: 'beta' })
+  })
+
+  it('should refuse before building when GITHUB_TOKEN is missing', async () => {
+    const deps = makeDeps({ hasGithubToken: false })
+
+    await expect(runReleaseCi({ deps, dryRun: false })).rejects.toThrow(/GITHUB_TOKEN/)
+    expect(deps.workspace.build).not.toHaveBeenCalled()
+    expect(deps.workspace.publish).not.toHaveBeenCalled()
   })
 
   it('should refuse a non-v4 version before building (major guard)', async () => {

--- a/tools/releaser/src/release-ci.spec.ts
+++ b/tools/releaser/src/release-ci.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { runReleaseCi } from './release-ci.js'
+
+const baseDeps = () => ({
+  createDraftGitHubRelease: vi.fn(async () => ({ releaseUrl: 'https://gh/release' })),
+  findChangelogBaseTag: vi.fn(async () => 'v4.0.0-canary.9'),
+  generateReleaseNotes: vi.fn(async () => ({
+    releaseNotes: 'notes',
+    releaseUrl: 'https://gh/new',
+  })),
+  log: vi.fn(),
+  workspace: {
+    build: vi.fn(async () => {}),
+    publish: vi.fn(async () => {}),
+    version: vi.fn(async () => '4.0.0-canary.10'),
+  },
+})
+
+const makeDeps = (
+  over: Partial<ReturnType<typeof baseDeps>> = {},
+): ReturnType<typeof baseDeps> => ({ ...baseDeps(), ...over })
+
+describe('runReleaseCi', () => {
+  it('should build, publish, generate notes, and create a draft in order', async () => {
+    const deps = makeDeps()
+
+    await runReleaseCi({ deps, dryRun: false })
+
+    expect(deps.workspace.build).toHaveBeenCalledOnce()
+    expect(deps.workspace.publish).toHaveBeenCalledWith({ dryRun: false, tag: 'canary' })
+    expect(deps.findChangelogBaseTag).toHaveBeenCalledWith({ version: '4.0.0-canary.10' })
+    expect(deps.generateReleaseNotes).toHaveBeenCalledWith({
+      fromVersion: 'v4.0.0-canary.9',
+      toVersion: 'HEAD',
+    })
+    expect(deps.createDraftGitHubRelease).toHaveBeenCalledWith({
+      branch: 'main',
+      releaseNotes: 'notes',
+      tag: 'v4.0.0-canary.10',
+    })
+
+    const buildOrder = deps.workspace.build.mock.invocationCallOrder[0]
+    const publishOrder = deps.workspace.publish.mock.invocationCallOrder[0]
+    expect(publishOrder).toBeGreaterThan(buildOrder)
+  })
+
+  it('should derive the beta dist-tag from a beta version', async () => {
+    const deps = makeDeps({
+      workspace: {
+        build: vi.fn(async () => {}),
+        publish: vi.fn(async () => {}),
+        version: vi.fn(async () => '4.0.0-beta.3'),
+      },
+    })
+
+    await runReleaseCi({ deps, dryRun: false })
+
+    expect(deps.workspace.publish).toHaveBeenCalledWith({ dryRun: false, tag: 'beta' })
+  })
+
+  it('should refuse a non-v4 version before building (major guard)', async () => {
+    const deps = makeDeps({
+      workspace: {
+        build: vi.fn(async () => {}),
+        publish: vi.fn(async () => {}),
+        version: vi.fn(async () => '3.85.2'),
+      },
+    })
+
+    await expect(runReleaseCi({ deps, dryRun: false })).rejects.toThrow(/pinned to v4/)
+    expect(deps.workspace.build).not.toHaveBeenCalled()
+  })
+
+  it('should refuse a stable v4 version with no beta/canary id', async () => {
+    const deps = makeDeps({
+      workspace: {
+        build: vi.fn(async () => {}),
+        publish: vi.fn(async () => {}),
+        version: vi.fn(async () => '4.0.0'),
+      },
+    })
+
+    await expect(runReleaseCi({ deps, dryRun: false })).rejects.toThrow(/not supported/)
+    expect(deps.workspace.build).not.toHaveBeenCalled()
+  })
+
+  it('should skip build, publish, and draft in dry-run but still generate notes', async () => {
+    const deps = makeDeps()
+
+    await runReleaseCi({ deps, dryRun: true })
+
+    expect(deps.workspace.build).not.toHaveBeenCalled()
+    expect(deps.workspace.publish).not.toHaveBeenCalled()
+    expect(deps.createDraftGitHubRelease).not.toHaveBeenCalled()
+    expect(deps.generateReleaseNotes).toHaveBeenCalledOnce()
+  })
+})

--- a/tools/releaser/src/release-ci.ts
+++ b/tools/releaser/src/release-ci.ts
@@ -19,6 +19,7 @@ import type { Workspace } from './lib/getWorkspace.js'
 import { findChangelogBaseTag, lineFromVersion } from './lib/findChangelogBaseTag.js'
 import { isVersionPublished } from './lib/getPackageRegistryVersions.js'
 import { getWorkspace } from './lib/getWorkspace.js'
+import { PINNED_MAJOR, pinnedMajorTagGlob } from './lib/pinnedMajor.js'
 import { createDraftGitHubRelease } from './utils/createDraftGitHubRelease.js'
 import { generateReleaseNotes } from './utils/generateReleaseNotes.js'
 
@@ -33,6 +34,7 @@ type ReleaseCiDeps = {
     fromVersion?: string
     toVersion?: string
   }) => Promise<{ releaseNotes: string; releaseUrl: string }>
+  hasGithubToken: boolean
   log: (message: string) => void
   workspace: Pick<Workspace, 'build' | 'publish' | 'version'>
 }
@@ -44,15 +46,29 @@ export const runReleaseCi = async ({
   deps: ReleaseCiDeps
   dryRun: boolean
 }): Promise<void> => {
-  const { createDraftGitHubRelease, findChangelogBaseTag, generateReleaseNotes, log, workspace } =
-    deps
+  const {
+    createDraftGitHubRelease,
+    findChangelogBaseTag,
+    generateReleaseNotes,
+    hasGithubToken,
+    log,
+    workspace,
+  } = deps
+
+  // Fail fast before publishing: release notes and the draft release both need a
+  // token, so a missing one must abort up front rather than after packages ship.
+  if (!hasGithubToken) {
+    throw new Error('GITHUB_TOKEN env var is required')
+  }
 
   const version = await workspace.version()
 
-  // Major-version guard: defense-in-depth against a non-v4 tag reaching this
-  // flow. A v3 beta would otherwise pass the dist-tag classifier and mis-publish.
-  if (semver.major(version) !== 4) {
-    throw new Error(`release-ci is pinned to v4; refusing to publish version ${version}.`)
+  // Major-version guard: defense-in-depth against a non-pinned-major tag reaching
+  // this flow. A v3 beta would otherwise pass the dist-tag classifier and mis-publish.
+  if (semver.major(version) !== PINNED_MAJOR) {
+    throw new Error(
+      `release-ci is pinned to v${PINNED_MAJOR}; refusing to publish version ${version}.`,
+    )
   }
 
   const line = lineFromVersion(version)
@@ -98,7 +114,7 @@ async function main(): Promise<void> {
   const dryRun = Boolean(argv['dry-run'])
 
   const listTags = (): string[] =>
-    execSync(`git tag --list 'v4.*'`, { encoding: 'utf8' })
+    execSync(`git tag --list '${pinnedMajorTagGlob}'`, { encoding: 'utf8' })
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean)
@@ -109,6 +125,7 @@ async function main(): Promise<void> {
       findChangelogBaseTag: ({ version }) =>
         findChangelogBaseTag({ isPublished: isVersionPublished, listTags, version }),
       generateReleaseNotes,
+      hasGithubToken: Boolean(process.env.GITHUB_TOKEN),
       log: console.log,
       workspace: getWorkspace(),
     },

--- a/tools/releaser/src/release-ci.ts
+++ b/tools/releaser/src/release-ci.ts
@@ -16,10 +16,11 @@ import { pathToFileURL } from 'url'
 
 import type { Workspace } from './lib/getWorkspace.js'
 
-import { findChangelogBaseTag, lineFromVersion } from './lib/findChangelogBaseTag.js'
+import { findChangelogBaseTag } from './lib/findChangelogBaseTag.js'
 import { isVersionPublished } from './lib/getPackageRegistryVersions.js'
 import { getWorkspace } from './lib/getWorkspace.js'
 import { PINNED_MAJOR, pinnedMajorTagGlob } from './lib/pinnedMajor.js'
+import { isPreid, PREIDS } from './lib/preids.js'
 import { createDraftGitHubRelease } from './utils/createDraftGitHubRelease.js'
 import { generateReleaseNotes } from './utils/generateReleaseNotes.js'
 
@@ -71,18 +72,19 @@ export const runReleaseCi = async ({
     )
   }
 
-  const line = lineFromVersion(version)
-  if (line === 'latest') {
+  // Fail closed: only the allowlisted prerelease lines may publish. A stable
+  // version (no preid) or an unsupported line (e.g. internal) must throw rather
+  // than default to the production 'latest' dist-tag.
+  const preid = semver.prerelease(version)?.[0]
+  if (!isPreid(preid)) {
     throw new Error(
-      `Stable ('latest') publishes are not supported by this flow; version ${version} has no beta/canary prerelease id.`,
+      `Refusing to publish ${version}: prerelease line must be one of ${PREIDS.join(', ')} (got ${preid ?? 'none'}).`,
     )
   }
-  const tag = line // narrowed to 'beta' | 'canary'
+  const tag = preid // narrowed to 'beta' | 'canary'
 
   log(`\n  Publishing ${version} to dist-tag '${tag}'${dryRun ? ' (dry-run)' : ''}\n`)
 
-  // Generate release notes before building/publishing so a changelog failure aborts
-  // cleanly instead of stranding a run that has already shipped packages to npm.
   const fromVersion = await findChangelogBaseTag({ version })
   const { releaseNotes, releaseUrl } = await generateReleaseNotes({
     fromVersion,

--- a/tools/releaser/src/release-ci.ts
+++ b/tools/releaser/src/release-ci.ts
@@ -1,0 +1,124 @@
+/**
+ * Publish-workflow entry point (P2). Reads the committed version from the checked-out
+ * tag, builds, publishes to npm (fail-fast, idempotent, topological order), then
+ * generates release notes and upserts a DRAFT GitHub release. No version bump — the
+ * bump workflow already committed and tagged the version this run publishes.
+ *
+ * Usage: pnpm release-ci [--dry-run]
+ *
+ * In --dry-run, build/publish/draft are skipped (logged); the read-only notes
+ * preview still runs.
+ */
+import { execSync } from 'child_process'
+import minimist from 'minimist'
+import semver from 'semver'
+import { pathToFileURL } from 'url'
+
+import type { Workspace } from './lib/getWorkspace.js'
+
+import { findChangelogBaseTag, lineFromVersion } from './lib/findChangelogBaseTag.js'
+import { isVersionPublished } from './lib/getPackageRegistryVersions.js'
+import { getWorkspace } from './lib/getWorkspace.js'
+import { createDraftGitHubRelease } from './utils/createDraftGitHubRelease.js'
+import { generateReleaseNotes } from './utils/generateReleaseNotes.js'
+
+type ReleaseCiDeps = {
+  createDraftGitHubRelease: (args: {
+    branch: string
+    releaseNotes: string
+    tag: string
+  }) => Promise<{ releaseUrl: string }>
+  findChangelogBaseTag: (args: { version: string }) => Promise<string | undefined>
+  generateReleaseNotes: (args: {
+    fromVersion?: string
+    toVersion?: string
+  }) => Promise<{ releaseNotes: string; releaseUrl: string }>
+  log: (message: string) => void
+  workspace: Pick<Workspace, 'build' | 'publish' | 'version'>
+}
+
+export const runReleaseCi = async ({
+  deps,
+  dryRun,
+}: {
+  deps: ReleaseCiDeps
+  dryRun: boolean
+}): Promise<void> => {
+  const { createDraftGitHubRelease, findChangelogBaseTag, generateReleaseNotes, log, workspace } =
+    deps
+
+  const version = await workspace.version()
+
+  // Major-version guard (D19): defense-in-depth against a non-v4 tag reaching this
+  // flow. A v3 beta would otherwise pass the dist-tag classifier and mis-publish.
+  if (semver.major(version) !== 4) {
+    throw new Error(`release-ci is pinned to v4; refusing to publish version ${version}.`)
+  }
+
+  const line = lineFromVersion(version)
+  if (line === 'latest') {
+    throw new Error(
+      `Stable ('latest') publishes are not supported by this flow; version ${version} has no beta/canary prerelease id.`,
+    )
+  }
+  const tag = line // narrowed to 'beta' | 'canary'
+
+  log(`\n  Publishing ${version} to dist-tag '${tag}'${dryRun ? ' (dry-run)' : ''}\n`)
+
+  if (dryRun) {
+    log(`[dry-run] would build all packages`)
+    log(`[dry-run] would publish all packages to dist-tag '${tag}'`)
+  } else {
+    await workspace.build()
+    await workspace.publish({ dryRun, tag })
+  }
+
+  const fromVersion = await findChangelogBaseTag({ version })
+  const { releaseNotes, releaseUrl } = await generateReleaseNotes({
+    fromVersion,
+    toVersion: 'HEAD',
+  })
+  log(`Release URL: ${releaseUrl}`)
+
+  if (dryRun) {
+    log(`[dry-run] would create/upsert draft GitHub release for v${version}`)
+    return
+  }
+
+  const { releaseUrl: draftUrl } = await createDraftGitHubRelease({
+    branch: 'main',
+    releaseNotes,
+    tag: `v${version}`,
+  })
+  log(`Draft release: ${draftUrl}`)
+}
+
+async function main(): Promise<void> {
+  const argv = minimist(process.argv.slice(2))
+  const dryRun = Boolean(argv['dry-run'])
+
+  const listTags = (): string[] =>
+    execSync(`git tag --list 'v4.*'`, { encoding: 'utf8' })
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+  await runReleaseCi({
+    deps: {
+      createDraftGitHubRelease,
+      findChangelogBaseTag: ({ version }) =>
+        findChangelogBaseTag({ isPublished: isVersionPublished, listTags, version }),
+      generateReleaseNotes,
+      log: console.log,
+      workspace: getWorkspace(),
+    },
+    dryRun,
+  })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error: unknown) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/tools/releaser/src/release-ci.ts
+++ b/tools/releaser/src/release-ci.ts
@@ -1,5 +1,5 @@
 /**
- * Publish-workflow entry point (P2). Reads the committed version from the checked-out
+ * Publish-workflow entry point. Reads the committed version from the checked-out
  * tag, builds, publishes to npm (fail-fast, idempotent, topological order), then
  * generates release notes and upserts a DRAFT GitHub release. No version bump — the
  * bump workflow already committed and tagged the version this run publishes.
@@ -49,7 +49,7 @@ export const runReleaseCi = async ({
 
   const version = await workspace.version()
 
-  // Major-version guard (D19): defense-in-depth against a non-v4 tag reaching this
+  // Major-version guard: defense-in-depth against a non-v4 tag reaching this
   // flow. A v3 beta would otherwise pass the dist-tag classifier and mis-publish.
   if (semver.major(version) !== 4) {
     throw new Error(`release-ci is pinned to v4; refusing to publish version ${version}.`)

--- a/tools/releaser/src/release-ci.ts
+++ b/tools/releaser/src/release-ci.ts
@@ -81,14 +81,8 @@ export const runReleaseCi = async ({
 
   log(`\n  Publishing ${version} to dist-tag '${tag}'${dryRun ? ' (dry-run)' : ''}\n`)
 
-  if (dryRun) {
-    log(`[dry-run] would build all packages`)
-    log(`[dry-run] would publish all packages to dist-tag '${tag}'`)
-  } else {
-    await workspace.build()
-    await workspace.publish({ dryRun, tag })
-  }
-
+  // Generate release notes before building/publishing so a changelog failure aborts
+  // cleanly instead of stranding a run that has already shipped packages to npm.
   const fromVersion = await findChangelogBaseTag({ version })
   const { releaseNotes, releaseUrl } = await generateReleaseNotes({
     fromVersion,
@@ -97,9 +91,14 @@ export const runReleaseCi = async ({
   log(`Release URL: ${releaseUrl}`)
 
   if (dryRun) {
+    log(`[dry-run] would build all packages`)
+    log(`[dry-run] would publish all packages to dist-tag '${tag}'`)
     log(`[dry-run] would create/upsert draft GitHub release for v${version}`)
     return
   }
+
+  await workspace.build()
+  await workspace.publish({ dryRun, tag })
 
   const { releaseUrl: draftUrl } = await createDraftGitHubRelease({
     branch: 'main',


### PR DESCRIPTION
Adds a decoupled, tag-driven release flow for the v4 prereleases (canary now, beta gated until its line opens): a maintainer dispatches a bump workflow that versions and pushes a tag, and a separate workflow triggered by that tag builds and publishes to npm. This PR lands the entry scripts and the two GitHub Actions workflows that drive them. The workflows stay inert until an admin provisions the release secrets and infrastructure.

## Motivation

Publishing today runs locally and interactively from one maintainer's machine, a bottleneck that is hard to audit. npm is also deprecating the token-based publish path this flow relies on. The release moves to OIDC trusted publishing (tokenless publishing where npm verifies the workflow's identity and attaches provenance, a verified record of what built each artifact).

## Key Changes

- **Bump entry script (`release-bump.ts`)**
  - Reads main's committed version, validates preconditions, then bumps, commits, tags, and pushes.
  - Pushes HEAD and the tag with a rebase-retry loop. A merge that races the push is folded in, not rejected. It never builds or publishes.
- **Publish entry script (`release-ci.ts`)**
  - Reads the version off the checked-out tag, then builds and publishes to npm by dist-tag (npm's named pointer to a version).
  - Generates release notes, then upserts a draft GitHub release. A v4-major guard aborts on any non-v4 tag.
- **Hardened publish path**
  - Publishing is idempotent and fail-fast. A re-run skips already-published packages. The sequence stops at the first failure, so no dependent ships before its dependency.
  - Packages publish in topological order, dependencies before dependents.
- **Bump workflow (`release-bump.yml`)**
  - `workflow_dispatch` with `preid` (the prerelease label) and `bump` inputs. It mints a GitHub App token to push the commit and tag to protected main.
  - The `preid` choice offers `canary` only for now. `beta` is gated until the beta line opens, so a contributor cannot accidentally cut one.
  - Dispatch inputs pass through environment variables, not the shell command, to avoid script injection.
  - A guard step allows only named maintainers to dispatch. It runs before the App token is minted, so an unauthorized run fails without reaching any secret.
- **Publish workflow (`publish-release.yml`)**
  - Fires on a canary prerelease tag push (`v4.*-canary.*`). It checks out the immutable tag (a permanent git ref), then publishes via OIDC with no npm token.
  - Runs under a `release` environment gated to `v4.*` tags.

## Design Decisions

Two workflows joined by an immutable `v4.*` tag. The bump commits and tags; the publish checks out that tag, never main HEAD. Merges that land on main after the tag cannot change what ships. No release PR or branch freeze is needed.

The bump pushes with a GitHub App token, not the default `GITHUB_TOKEN`. A tag pushed with the default token does not trigger downstream workflows. The App token is also the only actor allowed to bypass the tag ruleset and protected main. Both jobs keep least-privilege `permissions`: the publish job requests only `id-token: write`, since the App token, not the default token, performs every git and API write.

Publishing uses OIDC trusted publishing instead of a stored npm token. Provenance is automatic, and it replaces the token path npm is deprecating. The `internal` prerelease flow stays on the npm token.

The ruleset and `release` environment scope the tag namespace to `v4.*`, avoiding collisions with the 3.x line's `v3.*` tags. The publish trigger is narrowed to the canary line for now; beta joins when its line opens. A major-version guard in the publish script is a second layer.

## Overall Flow

```mermaid
sequenceDiagram
    participant Dev as Maintainer
    participant Bump as release-bump.yml
    participant Repo as main + v4.* tag
    participant Pub as publish-release.yml
    participant NPM as npm + GitHub

    Dev->>Bump: dispatch (preid, bump)
    Bump->>Bump: assert preconditions, bump version
    Bump->>Repo: commit + tag + push (App token)
    Repo-->>Pub: canary tag push triggers publish
    Pub->>Pub: checkout tag, read version, generate notes
    Pub->>NPM: build, publish via OIDC, draft release
```

## References / Links

- Fixes PYLD-3216
- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers): OIDC-based tokenless publishing with provenance.
- [npm GAT-bypass / 2FA deprecation](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/): the token path this flow replaces.
