### PR TITLE
fix(ui): align multi-value label horizontal padding to 6px

### DIFF
--- a/packages/ui/src/css/spacing.css
+++ b/packages/ui/src/css/spacing.css
@@ -2,6 +2,7 @@
   :root {
     --spacer-0: 0;
     --spacer-1: 0.25rem; /** 4px */
+    --spacer-1-5: 0.375rem; /** 6px */
     --spacer-2: 0.5rem; /** 8px */
     --spacer-2-5: 0.75rem; /** 12px */
     --spacer-3: 1rem; /** 16px */

--- a/packages/ui/src/elements/ReactSelect/MultiValueLabel/index.css
+++ b/packages/ui/src/elements/ReactSelect/MultiValueLabel/index.css
@@ -8,11 +8,11 @@
     align-items: center;
     max-width: 9.375rem;
     color: currentColor;
-    padding-left: calc((var(--spacer-1) + var(--spacer-2)) / 2); /* 6px */
+    padding-left: var(--spacer-1-5);
   }
 
   .multi-value-label--disabled {
-    padding-right: calc((var(--spacer-1) + var(--spacer-2)) / 2); /* 6px */
+    padding-right: var(--spacer-1-5);
   }
 
   .multi-value-label__text {

--- a/packages/ui/src/elements/ReactSelect/MultiValueLabel/index.css
+++ b/packages/ui/src/elements/ReactSelect/MultiValueLabel/index.css
@@ -8,11 +8,11 @@
     align-items: center;
     max-width: 9.375rem;
     color: currentColor;
-    padding-left: var(--spacer-1);
+    padding-left: calc((var(--spacer-1) + var(--spacer-2)) / 2); /* 6px */
   }
 
   .multi-value-label--disabled {
-    padding-right: var(--spacer-1);
+    padding-right: calc((var(--spacer-1) + var(--spacer-2)) / 2); /* 6px */
   }
 
   .multi-value-label__text {

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.css
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   .relationship--multi-value-label {
     display: flex;
-    padding-inline-start: var(--spacer-2);
+    padding-inline-start: calc((var(--spacer-1) + var(--spacer-2)) / 2); /* 6px */
     gap: var(--spacer-1);
   }
 

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.css
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.css
@@ -1,7 +1,7 @@
 @layer payload-default {
   .relationship--multi-value-label {
     display: flex;
-    padding-inline-start: calc((var(--spacer-1) + var(--spacer-2)) / 2); /* 6px */
+    padding-inline-start: var(--spacer-1-5);
     gap: var(--spacer-1);
   }
 


### PR DESCRIPTION
Adjusts the horizontal padding on select multi-value chips to a consistent 6px, resolving inconsistent spacing between the `ReactSelect` and `Relationship` field labels.

The `ReactSelect` label used `--spacer-1` (4px), which read slightly tight against the chip border, while the `Relationship` label used `--spacer-2` (8px). Introduces a `--spacer-1-5` token (6px) and applies it to both labels, plus the disabled `ReactSelect` variant so chips without a remove button stay symmetric.

#### Before
<img width="441" height="207" alt="Screenshot 2026-07-20 at 3 25 35 PM" src="https://github.com/user-attachments/assets/73ed5858-c846-4a33-8ac4-b3e314424812" />
<img width="608" height="104" alt="Screenshot 2026-07-20 at 3 25 47 PM" src="https://github.com/user-attachments/assets/6b8c49ea-62f9-4dde-a98e-b3123585b2ac" />

#### After
<img width="446" height="241" alt="Screenshot 2026-07-20 at 3 13 22 PM" src="https://github.com/user-attachments/assets/58f052da-2557-4835-ac3c-ab698f43d301" />
<img width="601" height="102" alt="Screenshot 2026-07-20 at 3 13 40 PM" src="https://github.com/user-attachments/assets/b5925bf5-51cd-4097-bffb-5225e261f6e0" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216715137951779