### PR TITLE
fix(ui): render untitled document title placeholder in secondary color

### DIFF
--- a/packages/ui/src/elements/RenderTitle/index.css
+++ b/packages/ui/src/elements/RenderTitle/index.css
@@ -22,6 +22,10 @@
     letter-spacing: inherit;
   }
 
+  .render-title--placeholder {
+    color: var(--color-text-secondary);
+  }
+
   .render-title__id {
     vertical-align: middle;
     position: relative;

--- a/packages/ui/src/elements/RenderTitle/index.tsx
+++ b/packages/ui/src/elements/RenderTitle/index.tsx
@@ -6,6 +6,7 @@ import { Link } from '../../elements/Link/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
+import { useTranslation } from '../../providers/Translation/index.js'
 import { IDLabel } from '../IDLabel/index.js'
 import './index.css'
 
@@ -29,6 +30,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
 
   const { id, collectionSlug, globalSlug, isInitializing } = useDocumentInfo()
   const { title: titleFromContext } = useDocumentTitle()
+  const { t } = useTranslation()
   const {
     config: {
       routes: { admin: adminRoute },
@@ -38,6 +40,8 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
   const title = titleFromProps || titleFromContext || fallback
 
   const idAsTitle = title === id
+
+  const isPlaceholder = !titleFromProps && !fallback && title === t('general:untitled')
 
   const Tag = element
 
@@ -54,7 +58,12 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
 
   return (
     <Tag
-      className={[className, baseClass, idAsTitle && `${baseClass}--has-id`]
+      className={[
+        className,
+        baseClass,
+        idAsTitle && `${baseClass}--has-id`,
+        isPlaceholder && `${baseClass}--placeholder`,
+      ]
         .filter(Boolean)
         .join(' ')}
       data-doc-id={id}

--- a/packages/ui/src/elements/RenderTitle/index.tsx
+++ b/packages/ui/src/elements/RenderTitle/index.tsx
@@ -41,7 +41,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
 
   const idAsTitle = title === id
 
-  const isPlaceholder = !titleFromProps && !fallback && title === t('general:untitled')
+  const isPlaceholder = !id && !titleFromProps && title === t('general:untitled')
 
   const Tag = element
 

--- a/packages/ui/src/elements/RenderTitle/index.tsx
+++ b/packages/ui/src/elements/RenderTitle/index.tsx
@@ -6,7 +6,6 @@ import { Link } from '../../elements/Link/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
-import { useTranslation } from '../../providers/Translation/index.js'
 import { IDLabel } from '../IDLabel/index.js'
 import './index.css'
 
@@ -29,8 +28,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
   const { className, element = 'h1', fallback, renderAsLink, title: titleFromProps } = props
 
   const { id, collectionSlug, globalSlug, isInitializing } = useDocumentInfo()
-  const { title: titleFromContext } = useDocumentTitle()
-  const { t } = useTranslation()
+  const { isPlaceholder: titleIsPlaceholder, title: titleFromContext } = useDocumentTitle()
   const {
     config: {
       routes: { admin: adminRoute },
@@ -41,7 +39,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
 
   const idAsTitle = title === id
 
-  const isPlaceholder = !id && !titleFromProps && title === t('general:untitled')
+  const isPlaceholder = !titleFromProps && titleIsPlaceholder
 
   const Tag = element
 

--- a/packages/ui/src/elements/RenderTitle/index.tsx
+++ b/packages/ui/src/elements/RenderTitle/index.tsx
@@ -28,7 +28,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
   const { className, element = 'h1', fallback, renderAsLink, title: titleFromProps } = props
 
   const { id, collectionSlug, globalSlug, isInitializing } = useDocumentInfo()
-  const { isPlaceholder: titleIsPlaceholder, title: titleFromContext } = useDocumentTitle()
+  const { isPlaceholder, title: titleFromContext } = useDocumentTitle()
   const {
     config: {
       routes: { admin: adminRoute },
@@ -39,7 +39,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
 
   const idAsTitle = title === id
 
-  const isPlaceholder = !titleFromProps && titleIsPlaceholder
+  const showPlaceholder = !titleFromProps && isPlaceholder
 
   const Tag = element
 
@@ -60,7 +60,7 @@ export const RenderTitle: React.FC<RenderTitleProps> = (props) => {
         className,
         baseClass,
         idAsTitle && `${baseClass}--has-id`,
-        isPlaceholder && `${baseClass}--placeholder`,
+        showPlaceholder && `${baseClass}--placeholder`,
       ]
         .filter(Boolean)
         .join(' ')}

--- a/packages/ui/src/providers/DocumentTitle/index.tsx
+++ b/packages/ui/src/providers/DocumentTitle/index.tsx
@@ -8,6 +8,7 @@ import { useDocumentInfo } from '../DocumentInfo/index.js'
 import { useTranslation } from '../Translation/index.js'
 
 export type DocumentTitleContext = {
+  isPlaceholder: boolean
   setDocumentTitle: (title: string) => void
   title: string
 }
@@ -53,5 +54,7 @@ export const DocumentTitleProvider: React.FC<{
     )
   }, [data, dateFormat, i18n, id, collectionSlug, docConfig, globalSlug])
 
-  return <Context value={{ setDocumentTitle, title }}>{children}</Context>
+  const isPlaceholder = title === i18n.t('general:untitled')
+
+  return <Context value={{ isPlaceholder, setDocumentTitle, title }}>{children}</Context>
 }


### PR DESCRIPTION
Renders the `Untitled` placeholder in the document header using `--color-text-secondary` while a document has no title yet, distinguishing it from a real title which keeps `--color-text`.

The `DocumentTitle` context now exposes an `isPlaceholder` flag, derived from the same title state so it tracks live typing. `RenderTitle` consumes that flag and applies a `render-title--placeholder` modifier class, keeping the placeholder check in the provider that owns the `Untitled` fallback rather than doing a translation comparison in the view.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216537669158397