### PR TITLE
fix(ui): keep folder create drawers open during autosave

### DIFF
--- a/packages/ui/src/elements/DocumentDrawer/ControlledDocumentDrawer.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/ControlledDocumentDrawer.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useModal } from '@faceless-ui/modal'
+import React from 'react'
+
+import type { DocumentDrawerProps } from './types.js'
+
+import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { DocumentDrawer, formatDocumentDrawerSlug } from './index.js'
+
+type ControlledDocumentDrawerProps = {
+  readonly isOpen: boolean
+  readonly onOpenChange?: (isOpen: boolean) => void
+} & Omit<DocumentDrawerProps, 'drawerSlug'>
+
+/**
+ * A controlled wrapper around `DocumentDrawer` for views that want to drive
+ * drawer visibility from state instead of the imperative `useDocumentDrawer` hook.
+ */
+export const ControlledDocumentDrawer: React.FC<ControlledDocumentDrawerProps> = ({
+  id,
+  collectionSlug,
+  isOpen,
+  onOpenChange,
+  ...rest
+}) => {
+  const drawerDepth = useEditDepth()
+  const uuid = React.useId()
+  const { closeModal, modalState, openModal } = useModal()
+  const drawerSlug = React.useMemo(
+    () =>
+      formatDocumentDrawerSlug({
+        id,
+        collectionSlug,
+        depth: drawerDepth,
+        uuid,
+      }),
+    [collectionSlug, drawerDepth, id, uuid],
+  )
+  const isDrawerOpen = Boolean(modalState[drawerSlug]?.isOpen)
+  const previousIsDrawerOpen = React.useRef(isDrawerOpen)
+
+  React.useEffect(() => {
+    if (isOpen && !isDrawerOpen) {
+      openModal(drawerSlug)
+    }
+
+    if (!isOpen && isDrawerOpen) {
+      closeModal(drawerSlug)
+    }
+  }, [closeModal, drawerSlug, isDrawerOpen, isOpen, openModal])
+
+  React.useEffect(() => {
+    if (previousIsDrawerOpen.current !== isDrawerOpen) {
+      previousIsDrawerOpen.current = isDrawerOpen
+      onOpenChange?.(isDrawerOpen)
+    }
+  }, [isDrawerOpen, onOpenChange])
+
+  React.useEffect(() => {
+    return () => {
+      closeModal(drawerSlug)
+    }
+  }, [closeModal, drawerSlug])
+
+  return (
+    <DocumentDrawer {...rest} collectionSlug={collectionSlug} drawerSlug={drawerSlug} id={id} />
+  )
+}

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -18,7 +18,7 @@ import './index.scss'
 
 export const documentDrawerBaseClass = 'doc-drawer'
 
-const formatDocumentDrawerSlug = ({
+export const formatDocumentDrawerSlug = ({
   id,
   collectionSlug,
   depth,

--- a/packages/ui/src/elements/FolderView/Drawers/MoveToFolder/index.tsx
+++ b/packages/ui/src/elements/FolderView/Drawers/MoveToFolder/index.tsx
@@ -19,7 +19,6 @@ import { useDocumentDrawer } from '../../../DocumentDrawer/index.js'
 import { Drawer } from '../../../Drawer/index.js'
 import { DrawerActionHeader } from '../../../DrawerActionHeader/index.js'
 import { DrawerContentContainer } from '../../../DrawerContentContainer/index.js'
-import { ListCreateNewDocInFolderButton } from '../../../ListHeader/TitleActions/ListCreateNewDocInFolderButton.js'
 import { LoadingOverlay } from '../../../Loading/index.js'
 import { NoListResults } from '../../../NoListResults/index.js'
 import { Translation } from '../../../Translation/index.js'
@@ -102,7 +101,7 @@ function LoadFolderData(props: MoveToFolderDrawerProps) {
         setFolderResultsComponent(result.FolderResultsComponent || null)
         setFolderID(folderIDToPopulate)
         setHasLoaded(true)
-      } catch (e) {
+      } catch (_error) {
         setBreadcrumbs([])
         setSubfolders([])
         setDocuments([])
@@ -178,6 +177,8 @@ function Content({
     useDocumentDrawer({
       collectionSlug: folderCollectionSlug,
     })
+  const newFolderAssignedCollections =
+    folderID == null ? props.folderAssignedCollections : folderType
 
   const getSelectedFolder = React.useCallback((): {
     id: null | number | string
@@ -286,36 +287,34 @@ function Content({
           ]}
         />
         {subfolders.length > 0 && (
-          <>
-            <Button
-              buttonStyle="pill"
-              className={`${baseClass}__add-folder-button`}
-              margin={false}
-              onClick={() => {
-                openFolderDrawer()
-              }}
-            >
-              {t('fields:addLabel', {
-                label: getTranslation(folderCollectionConfig.labels?.singular, i18n),
-              })}
-            </Button>
-            <FolderDocumentDrawer
-              initialData={{
-                [folderFieldName]: folderID,
-                folderType,
-              }}
-              onSave={(result) => {
-                void onCreateSuccess({
-                  collectionSlug: folderCollectionConfig.slug,
-                  doc: result.doc,
-                })
-                closeFolderDrawer()
-              }}
-              redirectAfterCreate={false}
-            />
-          </>
+          <Button
+            buttonStyle="pill"
+            className={`${baseClass}__add-folder-button`}
+            margin={false}
+            onClick={() => {
+              openFolderDrawer()
+            }}
+          >
+            {t('fields:addLabel', {
+              label: getTranslation(folderCollectionConfig.labels?.singular, i18n),
+            })}
+          </Button>
         )}
       </div>
+      <FolderDocumentDrawer
+        initialData={{
+          [folderFieldName]: folderID,
+          folderType: newFolderAssignedCollections,
+        }}
+        onSave={(result) => {
+          void onCreateSuccess({
+            collectionSlug: folderCollectionConfig.slug,
+            doc: result.doc,
+          })
+          closeFolderDrawer()
+        }}
+        redirectAfterCreate={false}
+      />
 
       <DrawerContentContainer className={`${baseClass}__body-section`}>
         {subfolders.length > 0 ? (
@@ -323,16 +322,17 @@ function Content({
         ) : (
           <NoListResults
             Actions={[
-              <ListCreateNewDocInFolderButton
-                buttonLabel={`${t('general:create')} ${getTranslation(folderCollectionConfig.labels?.singular, i18n).toLowerCase()}`}
-                buttonSize="medium"
+              <Button
                 buttonStyle="primary"
-                collectionSlugs={[folderCollectionSlug]}
-                folderAssignedCollections={props.folderAssignedCollections}
+                className={`${baseClass}__create-folder-button`}
                 key="create-folder"
-                onCreateSuccess={onCreateSuccess}
-                slugPrefix="create-new-folder-from-drawer--no-results"
-              />,
+                onClick={() => {
+                  openFolderDrawer()
+                }}
+                size="medium"
+              >
+                {`${t('general:create')} ${getTranslation(folderCollectionConfig.labels?.singular, i18n).toLowerCase()}`}
+              </Button>,
             ]}
             Message={
               <>

--- a/packages/ui/src/elements/ListHeader/TitleActions/ListCreateNewDocInFolderButton.tsx
+++ b/packages/ui/src/elements/ListHeader/TitleActions/ListCreateNewDocInFolderButton.tsx
@@ -2,15 +2,12 @@
 
 import type { ClientCollectionConfig, CollectionSlug } from 'payload'
 
-import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
 import React from 'react'
 
 import { useConfig } from '../../../providers/Config/index.js'
-import { useFolder } from '../../../providers/Folders/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 import { Button } from '../../Button/index.js'
-import { DocumentDrawer, useDocumentDrawer } from '../../DocumentDrawer/index.js'
 import { Popup, PopupList } from '../../Popup/index.js'
 
 const baseClass = 'create-new-doc-in-folder'
@@ -20,9 +17,7 @@ export function ListCreateNewDocInFolderButton({
   buttonSize = 'small',
   buttonStyle = 'pill',
   collectionSlugs,
-  folderAssignedCollections,
-  onCreateSuccess,
-  slugPrefix,
+  onRequestCreate,
 }: {
   buttonLabel: string
   buttonSize?: 'large' | 'medium' | 'small' | 'xsmall'
@@ -37,23 +32,10 @@ export function ListCreateNewDocInFolderButton({
     | 'tab'
     | 'transparent'
   collectionSlugs: CollectionSlug[]
-  folderAssignedCollections: CollectionSlug[]
-  onCreateSuccess: (args: {
-    collectionSlug: CollectionSlug
-    doc: Record<string, unknown>
-  }) => Promise<void> | void
-  slugPrefix: string
+  onRequestCreate: (collectionSlug: CollectionSlug) => void
 }) {
-  const newDocInFolderDrawerSlug = `${slugPrefix}-new-doc-in-folder-drawer`
   const { i18n } = useTranslation()
-  const { closeModal, openModal } = useModal()
   const { config } = useConfig()
-  const { folderCollectionConfig, folderCollectionSlug, folderFieldName, folderID } = useFolder()
-  const [FolderDocumentDrawer, , { closeDrawer: closeFolderDrawer, openDrawer: openFolderDrawer }] =
-    useDocumentDrawer({
-      collectionSlug: folderCollectionSlug,
-    })
-  const [createCollectionSlug, setCreateCollectionSlug] = React.useState<string | undefined>()
   const [enabledCollections] = React.useState<ClientCollectionConfig[]>(() =>
     collectionSlugs.reduce((acc, collectionSlug) => {
       const collectionConfig = config.collections.find(({ slug }) => slug === collectionSlug)
@@ -76,14 +58,7 @@ export function ListCreateNewDocInFolderButton({
           buttonStyle={buttonStyle}
           className={`${baseClass}__button`}
           el="div"
-          onClick={() => {
-            if (enabledCollections[0].slug === folderCollectionConfig.slug) {
-              openFolderDrawer()
-            } else {
-              setCreateCollectionSlug(enabledCollections[0].slug)
-              openModal(newDocInFolderDrawerSlug)
-            }
-          }}
+          onClick={() => onRequestCreate(enabledCollections[0].slug)}
           size={buttonSize}
         >
           {buttonLabel}
@@ -107,60 +82,13 @@ export function ListCreateNewDocInFolderButton({
           <PopupList.ButtonGroup>
             {enabledCollections.map((collection, index) => {
               return (
-                <PopupList.Button
-                  key={index}
-                  onClick={() => {
-                    if (collection.slug === folderCollectionConfig.slug) {
-                      openFolderDrawer()
-                    } else {
-                      setCreateCollectionSlug(collection.slug)
-                      openModal(newDocInFolderDrawerSlug)
-                    }
-                  }}
-                >
+                <PopupList.Button key={index} onClick={() => onRequestCreate(collection.slug)}>
                   {getTranslation(collection.labels.singular, i18n)}
                 </PopupList.Button>
               )
             })}
           </PopupList.ButtonGroup>
         </Popup>
-      )}
-
-      {createCollectionSlug && (
-        <DocumentDrawer
-          collectionSlug={createCollectionSlug}
-          drawerSlug={newDocInFolderDrawerSlug}
-          initialData={{
-            [folderFieldName]: folderID,
-          }}
-          onSave={async ({ doc }) => {
-            await onCreateSuccess({
-              collectionSlug: createCollectionSlug,
-              doc,
-            })
-            closeModal(newDocInFolderDrawerSlug)
-          }}
-          redirectAfterCreate={false}
-        />
-      )}
-
-      {collectionSlugs.includes(folderCollectionConfig.slug) && (
-        <FolderDocumentDrawer
-          initialData={{
-            [folderFieldName]: folderID,
-            folderType: createCollectionSlug
-              ? folderAssignedCollections || [createCollectionSlug]
-              : folderAssignedCollections,
-          }}
-          onSave={async (result) => {
-            await onCreateSuccess({
-              collectionSlug: folderCollectionConfig.slug,
-              doc: result.doc,
-            })
-            closeFolderDrawer()
-          }}
-          redirectAfterCreate={false}
-        />
       )}
     </React.Fragment>
   )

--- a/packages/ui/src/views/BrowseByFolder/index.tsx
+++ b/packages/ui/src/views/BrowseByFolder/index.tsx
@@ -1,14 +1,15 @@
 'use client'
 
 import type { DragEndEvent } from '@dnd-kit/core'
-import type { FolderListViewClientProps } from 'payload'
+import type { CollectionSlug, FolderListViewClientProps } from 'payload'
 
 import { useDndMonitor } from '@dnd-kit/core'
 import { getTranslation } from '@payloadcms/translations'
 import { useRouter } from 'next/navigation.js'
-import { PREFERENCE_KEYS } from 'payload/shared'
+import { hasAutosaveEnabled, PREFERENCE_KEYS } from 'payload/shared'
 import React, { Fragment } from 'react'
 
+import { ControlledDocumentDrawer } from '../../elements/DocumentDrawer/ControlledDocumentDrawer.js'
 import { DroppableBreadcrumb } from '../../elements/FolderView/Breadcrumbs/index.js'
 import { ColoredFolderIcon } from '../../elements/FolderView/ColoredFolderIcon/index.js'
 import { CurrentFolderActions } from '../../elements/FolderView/CurrentFolderActions/index.js'
@@ -24,6 +25,7 @@ import { ListCreateNewDocInFolderButton } from '../../elements/ListHeader/TitleA
 import { NoListResults } from '../../elements/NoListResults/index.js'
 import { SearchBar } from '../../elements/SearchBar/index.js'
 import { useStepNav } from '../../elements/StepNav/index.js'
+import { useConfig } from '../../providers/Config/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { FolderProvider, useFolder } from '../../providers/Folders/index.js'
 import { usePreferences } from '../../providers/Preferences/index.js'
@@ -97,6 +99,7 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
   } = props
 
   const router = useRouter()
+  const { config } = useConfig()
   const { i18n, t } = useTranslation()
   const drawerDepth = useEditDepth()
   const { setStepNav } = useStepNav()
@@ -112,6 +115,7 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
     documents,
     dragOverlayItem,
     folderCollectionConfig,
+    folderFieldName,
     folderID,
     folderType,
     getFolderRoute,
@@ -123,6 +127,8 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
     setIsDragging,
     subfolders,
   } = useFolder()
+  const [createDrawerCollectionSlug, setCreateDrawerCollectionSlug] =
+    React.useState<CollectionSlug>()
 
   const [activeView, setActiveView] = React.useState<'grid' | 'list'>(viewPreference || 'grid')
   const [searchPlaceholder] = React.useState(() => {
@@ -156,6 +162,11 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
   const listHeaderTitle = !breadcrumbs.length
     ? t('folder:browseByFolder')
     : breadcrumbs[breadcrumbs.length - 1].name
+  const activeCreateDrawerCollectionSlug = createDrawerCollectionSlug || folderCollectionConfig.slug
+  const activeCreateDrawerCollectionConfig = config.collections.find(
+    ({ slug }) => slug === activeCreateDrawerCollectionSlug,
+  )
+  const isCreatingFolder = activeCreateDrawerCollectionSlug === folderCollectionConfig.slug
 
   const handleSetViewType = React.useCallback(
     (view: 'grid' | 'list') => {
@@ -229,6 +240,11 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
   const nonFolderCollectionSlugs = allowCreateCollectionSlugs.filter(
     (slug) => slug !== folderCollectionConfig.slug,
   )
+  const folderAssignedCollectionSlugs = Array.isArray(folderType) ? folderType : []
+
+  const handleRequestCreate = React.useCallback((collectionSlug: CollectionSlug) => {
+    setCreateDrawerCollectionSlug(collectionSlug)
+  }, [])
 
   return (
     <Fragment>
@@ -258,10 +274,8 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
                       : `${t('general:create')} ${getTranslation(folderCollectionConfig.labels?.singular, i18n).toLowerCase()}`
                   }
                   collectionSlugs={allowCreateCollectionSlugs}
-                  folderAssignedCollections={Array.isArray(folderType) ? folderType : []}
                   key="create-new-button"
-                  onCreateSuccess={clearRouteCache}
-                  slugPrefix="create-document--header-pill"
+                  onRequestCreate={handleRequestCreate}
                 />
               ),
             ].filter(Boolean)}
@@ -317,10 +331,8 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
                     buttonSize="medium"
                     buttonStyle="primary"
                     collectionSlugs={[folderCollectionConfig.slug]}
-                    folderAssignedCollections={Array.isArray(folderType) ? folderType : []}
                     key="create-folder"
-                    onCreateSuccess={clearRouteCache}
-                    slugPrefix="create-folder--no-results"
+                    onRequestCreate={handleRequestCreate}
                   />
                 ),
                 folderID && nonFolderCollectionSlugs.length > 0 && (
@@ -329,10 +341,8 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
                     buttonSize="medium"
                     buttonStyle="primary"
                     collectionSlugs={nonFolderCollectionSlugs}
-                    folderAssignedCollections={Array.isArray(folderType) ? folderType : []}
                     key="create-document"
-                    onCreateSuccess={clearRouteCache}
-                    slugPrefix="create-document--no-results"
+                    onRequestCreate={handleRequestCreate}
                   />
                 ),
               ].filter(Boolean)}
@@ -351,6 +361,31 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
       {selectedItemKeys.size > 0 && dragOverlayItem && (
         <DragOverlaySelection item={dragOverlayItem} selectedCount={selectedItemKeys.size} />
       )}
+      <ControlledDocumentDrawer
+        collectionSlug={activeCreateDrawerCollectionSlug}
+        initialData={{
+          [folderFieldName]: folderID,
+          ...(isCreatingFolder ? { folderType: folderAssignedCollectionSlugs } : {}),
+        }}
+        isOpen={Boolean(createDrawerCollectionSlug)}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setCreateDrawerCollectionSlug(undefined)
+          }
+        }}
+        onSave={({ operation }) => {
+          const isAutosaveCollection = hasAutosaveEnabled(activeCreateDrawerCollectionConfig)
+
+          if (isAutosaveCollection || operation === 'create') {
+            clearRouteCache()
+          }
+
+          if (operation === 'create' && !isAutosaveCollection) {
+            setCreateDrawerCollectionSlug(undefined)
+          }
+        }}
+        redirectAfterCreate={false}
+      />
     </Fragment>
   )
 }

--- a/packages/ui/src/views/CollectionFolder/index.tsx
+++ b/packages/ui/src/views/CollectionFolder/index.tsx
@@ -1,15 +1,16 @@
 'use client'
 
 import type { DragEndEvent } from '@dnd-kit/core'
-import type { FolderListViewClientProps } from 'payload'
+import type { CollectionSlug, FolderListViewClientProps } from 'payload'
 
 import { useDndMonitor } from '@dnd-kit/core'
 import { getTranslation } from '@payloadcms/translations'
 import { useRouter } from 'next/navigation.js'
-import { formatAdminURL } from 'payload/shared'
+import { formatAdminURL, hasAutosaveEnabled } from 'payload/shared'
 import React, { Fragment } from 'react'
 
 import { DefaultListViewTabs } from '../../elements/DefaultListViewTabs/index.js'
+import { ControlledDocumentDrawer } from '../../elements/DocumentDrawer/ControlledDocumentDrawer.js'
 import { DroppableBreadcrumb } from '../../elements/FolderView/Breadcrumbs/index.js'
 import { ColoredFolderIcon } from '../../elements/FolderView/ColoredFolderIcon/index.js'
 import { CurrentFolderActions } from '../../elements/FolderView/CurrentFolderActions/index.js'
@@ -110,6 +111,8 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
     dragOverlayItem,
     folderCollectionConfig,
     folderCollectionSlug,
+    folderFieldName,
+    folderID,
     FolderResultsComponent,
     folderType,
     getSelectedItems,
@@ -133,6 +136,8 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
   const {
     breakpoints: { s: smallBreak },
   } = useWindowInfo()
+  const [createDrawerCollectionSlug, setCreateDrawerCollectionSlug] =
+    React.useState<CollectionSlug>()
 
   const onDragEnd = React.useCallback(
     async (event: DragEndEvent) => {
@@ -146,9 +151,9 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
             itemsToMove: getSelectedItems(),
             toFolderID: event.over.data.current.id,
           })
-        } catch (error) {
+        } catch (_error) {
           // eslint-disable-next-line no-console
-          console.error('Error moving items:', error)
+          console.error('Error moving items:', _error)
         }
 
         clearRouteCache()
@@ -166,6 +171,11 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
     },
     [collectionSlug, setPreference, clearRouteCache],
   )
+  const activeCreateDrawerCollectionSlug = createDrawerCollectionSlug || folderCollectionSlug
+  const activeCreateDrawerCollectionConfig = config.collections.find(
+    ({ slug }) => slug === activeCreateDrawerCollectionSlug,
+  )
+  const isCreatingFolder = activeCreateDrawerCollectionSlug === folderCollectionSlug
 
   React.useEffect(() => {
     if (!drawerDepth) {
@@ -253,6 +263,11 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
   ])
 
   const totalDocsAndSubfolders = documents.length + subfolders.length
+  const folderAssignedCollectionSlugs = Array.isArray(folderType) ? folderType : [collectionSlug]
+
+  const handleRequestCreate = React.useCallback((requestedCollectionSlug: CollectionSlug) => {
+    setCreateDrawerCollectionSlug(requestedCollectionSlug)
+  }, [])
 
   return (
     <Fragment>
@@ -291,12 +306,8 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
                       : `${t('general:create')} ${getTranslation(folderCollectionConfig.labels?.singular, i18n).toLowerCase()}`
                   }
                   collectionSlugs={allowCreateCollectionSlugs}
-                  folderAssignedCollections={
-                    Array.isArray(folderType) ? folderType : [collectionSlug]
-                  }
                   key="create-new-button"
-                  onCreateSuccess={clearRouteCache}
-                  slugPrefix="create-document--header-pill"
+                  onRequestCreate={handleRequestCreate}
                 />
               ),
               <ListBulkUploadButton
@@ -334,12 +345,8 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
                     buttonSize="medium"
                     buttonStyle="primary"
                     collectionSlugs={[folderCollectionConfig.slug]}
-                    folderAssignedCollections={
-                      Array.isArray(folderType) ? folderType : [collectionSlug]
-                    }
                     key="create-folder"
-                    onCreateSuccess={clearRouteCache}
-                    slugPrefix="create-folder--no-results"
+                    onRequestCreate={handleRequestCreate}
                   />
                 ),
                 allowCreateCollectionSlugs.includes(collectionSlug) && (
@@ -348,12 +355,8 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
                     buttonSize="medium"
                     buttonStyle="primary"
                     collectionSlugs={[collectionSlug]}
-                    folderAssignedCollections={
-                      Array.isArray(folderType) ? folderType : [collectionSlug]
-                    }
                     key="create-document"
-                    onCreateSuccess={clearRouteCache}
-                    slugPrefix="create-document--no-results"
+                    onRequestCreate={handleRequestCreate}
                   />
                 ),
               ].filter(Boolean)}
@@ -372,6 +375,31 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
       {selectedItemKeys.size > 0 && dragOverlayItem && (
         <DragOverlaySelection item={dragOverlayItem} selectedCount={selectedItemKeys.size} />
       )}
+      <ControlledDocumentDrawer
+        collectionSlug={activeCreateDrawerCollectionSlug}
+        initialData={{
+          [folderFieldName]: folderID,
+          ...(isCreatingFolder ? { folderType: folderAssignedCollectionSlugs } : {}),
+        }}
+        isOpen={Boolean(createDrawerCollectionSlug)}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setCreateDrawerCollectionSlug(undefined)
+          }
+        }}
+        onSave={({ operation }) => {
+          const isAutosaveCollection = hasAutosaveEnabled(activeCreateDrawerCollectionConfig)
+
+          if (isAutosaveCollection || operation === 'create') {
+            clearRouteCache()
+          }
+
+          if (operation === 'create' && !isAutosaveCollection) {
+            setCreateDrawerCollectionSlug(undefined)
+          }
+        }}
+        redirectAfterCreate={false}
+      />
     </Fragment>
   )
 }

--- a/test/__helpers/e2e/folders/createFolderFromDoc.ts
+++ b/test/__helpers/e2e/folders/createFolderFromDoc.ts
@@ -10,12 +10,10 @@ type Args = {
 
 export async function createFolderFromDoc({
   folderName,
-  page,
   folderType = ['Posts'],
+  page,
 }: Args): Promise<void> {
-  const addFolderButton = page.locator('.create-new-doc-in-folder__button', {
-    hasText: 'Create folder',
-  })
+  const addFolderButton = page.getByRole('button', { name: 'Create folder' })
   const drawer = page.locator('dialog .collection-edit--payload-folders')
 
   await expect(async () => {
@@ -26,9 +24,9 @@ export async function createFolderFromDoc({
   }).toPass({ timeout: 15000 })
 
   await createFolderDoc({
-    page,
     folderName,
     folderType,
+    page,
   })
 
   const folderCard = page.locator('.folder-file-card__name', { hasText: folderName }).first()

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -24,7 +24,9 @@ import {
   getSelectInputOptions,
   getSelectInputValue,
   openSelectMenu,
+  selectInput,
 } from '../__helpers/e2e/selectInput.js'
+import { waitForAutoSaveToRunAndComplete } from '../__helpers/e2e/waitForAutoSaveToRunAndComplete.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../__helpers/shared/clearAndSeed/reInitializeDB.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
@@ -35,6 +37,7 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 test.describe('Folders', () => {
+  let autosaveURL: AdminUrlUtil
   let page: Page
   let postURL: AdminUrlUtil
   let OmittedFromBrowseBy: AdminUrlUtil
@@ -46,6 +49,7 @@ test.describe('Folders', () => {
 
     const { serverURL: serverFromInit } = await initPayloadE2ENoConfig({ dirname })
     serverURL = serverFromInit
+    autosaveURL = new AdminUrlUtil(serverURL, 'autosave')
     postURL = new AdminUrlUtil(serverURL, postSlug)
     OmittedFromBrowseBy = new AdminUrlUtil(serverURL, omittedFromBrowseBySlug)
 
@@ -260,6 +264,70 @@ test.describe('Folders', () => {
         has: page.locator('text=Document Created From Folder'),
       })
       await expect(folderCard).toBeVisible()
+    })
+
+    test('should keep autosave drawer open after autosave when creating from folder view', async () => {
+      await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))
+
+      const folderDrawer = page.locator('dialog .collection-edit--payload-folders')
+      await page
+        .locator(
+          '.list-header__title-and-actions .create-new-doc-in-folder__button:has-text("Create folder")',
+        )
+        .click()
+      await expect(folderDrawer).toBeVisible()
+      await folderDrawer.locator('#field-name').fill('Autosave Folder')
+      await selectInput({
+        multiSelect: true,
+        options: ['Posts', 'Autosaves'],
+        selectLocator: folderDrawer.locator('#field-folderType'),
+      })
+      await folderDrawer.getByRole('button', { name: 'Save', exact: true }).click()
+      await expect(page.locator('.payload-toast-container')).toContainText('successfully')
+      await closeAllToasts(page)
+      await expect(folderDrawer).toBeHidden()
+
+      await clickFolderCard({ folderName: 'Autosave Folder', page, doubleClick: true })
+
+      const createDocumentButton = page.locator('.create-new-doc-in-folder__popup-button', {
+        hasText: 'Create document',
+      })
+      const autosaveButton = page.locator('.popup__content .popup-button-list__button', {
+        hasText: 'Autosave',
+      })
+      const drawer = page.locator('dialog#create-document--no-results-new-doc-in-folder-drawer')
+      const titleInput = drawer.locator('#field-title')
+
+      await createDocumentButton.click()
+      await autosaveButton.click()
+      await expect(drawer).toBeVisible()
+      await titleInput.fill('Autosave Draft From Folder')
+
+      await waitForAutoSaveToRunAndComplete(drawer)
+
+      await expect(drawer).toBeVisible()
+      await expect(titleInput).toHaveValue('Autosave Draft From Folder')
+    })
+
+    test('should keep autosave drawer open after autosave when creating from collection folder view', async () => {
+      await page.goto(autosaveURL.byFolder)
+      await createFolder({ folderName: 'Autosave Collection Folder', folderType: [], page })
+      await clickFolderCard({ doubleClick: true, folderName: 'Autosave Collection Folder', page })
+
+      const createDocumentButton = page.locator('.create-new-doc-in-folder__button', {
+        hasText: 'Create document',
+      })
+      const drawer = page.locator('dialog#create-document--no-results-new-doc-in-folder-drawer')
+      const titleInput = drawer.locator('#field-title')
+
+      await createDocumentButton.click()
+      await expect(drawer).toBeVisible()
+      await titleInput.fill('Autosave Draft From Collection Folder')
+
+      await waitForAutoSaveToRunAndComplete(drawer)
+
+      await expect(drawer).toBeVisible()
+      await expect(titleInput).toHaveValue('Autosave Draft From Collection Folder')
     })
 
     test('should create nested folder from folder view', async () => {

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -84,6 +84,29 @@ test.describe('Folders', () => {
       await folderButton.click()
       await expectNoResultsAndCreateFolderButton({ page })
     })
+
+    test('should prefill current collection when creating folder from move drawer root state', async () => {
+      await page.goto(postURL.create)
+      await createPostWithNoFolder()
+
+      const folderPill = page.locator('.doc-controls .move-doc-to-folder', { hasText: 'No Folder' })
+      await folderPill.click()
+
+      const createFolderButton = page.getByRole('button', { name: 'Create folder' })
+      await createFolderButton.click()
+
+      const drawer = page.locator('dialog .collection-edit--payload-folders')
+      const selectLocator = drawer.locator('#field-folderType')
+
+      await expect(drawer).toBeVisible()
+      await expect
+        .poll(async () => {
+          const options = await getSelectInputValue<true>({ multiSelect: true, selectLocator })
+
+          return options
+        })
+        .toEqual(['Posts'])
+    })
   })
 
   test.describe('Creating folders', () => {
@@ -254,8 +277,10 @@ test.describe('Folders', () => {
       await expect(postButton).toBeVisible()
       await postButton.click()
 
-      const drawer = page.locator('dialog#create-document--no-results-new-doc-in-folder-drawer')
+      const drawer = page.locator('[id^=doc-drawer_posts_]').first()
       const titleInput = drawer.locator('input[name="title"]')
+
+      await expect(drawer).toBeVisible()
       await titleInput.fill('Document Created From Folder')
       await drawer.getByRole('button', { name: 'Save', exact: true }).click()
 
@@ -289,17 +314,19 @@ test.describe('Folders', () => {
 
       await clickFolderCard({ folderName: 'Autosave Folder', page, doubleClick: true })
 
-      const createDocumentButton = page.locator('.create-new-doc-in-folder__popup-button', {
+      const createNewDropdown = page.locator('.create-new-doc-in-folder__popup-button', {
         hasText: 'Create document',
       })
+      await createNewDropdown.click()
+
       const autosaveButton = page.locator('.popup__content .popup-button-list__button', {
         hasText: 'Autosave',
       })
-      const drawer = page.locator('dialog#create-document--no-results-new-doc-in-folder-drawer')
-      const titleInput = drawer.locator('#field-title')
-
-      await createDocumentButton.click()
       await autosaveButton.click()
+
+      const drawer = page.locator('[id^=doc-drawer_autosave_]').first()
+      const documentCards = page.locator('.folder-file-card')
+      const titleInput = drawer.locator('#field-title')
       await expect(drawer).toBeVisible()
       await titleInput.fill('Autosave Draft From Folder')
 
@@ -307,6 +334,9 @@ test.describe('Folders', () => {
 
       await expect(drawer).toBeVisible()
       await expect(titleInput).toHaveValue('Autosave Draft From Folder')
+      await drawer.locator('.doc-drawer__header-close').click()
+      await expect(drawer).toBeHidden()
+      await expect(documentCards).toHaveCount(1)
     })
 
     test('should keep autosave drawer open after autosave when creating from collection folder view', async () => {
@@ -317,7 +347,8 @@ test.describe('Folders', () => {
       const createDocumentButton = page.locator('.create-new-doc-in-folder__button', {
         hasText: 'Create document',
       })
-      const drawer = page.locator('dialog#create-document--no-results-new-doc-in-folder-drawer')
+      const drawer = page.locator('[id^=doc-drawer_autosave_]').first()
+      const documentCards = page.locator('.folder-file-card')
       const titleInput = drawer.locator('#field-title')
 
       await createDocumentButton.click()
@@ -328,8 +359,10 @@ test.describe('Folders', () => {
 
       await expect(drawer).toBeVisible()
       await expect(titleInput).toHaveValue('Autosave Draft From Collection Folder')
+      await drawer.locator('.doc-drawer__header-close').click()
+      await expect(drawer).toBeHidden()
+      await expect(documentCards).toHaveCount(1)
     })
-
     test('should create nested folder from folder view', async () => {
       await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))
       await createFolder({ folderName: 'Parent Folder', page })


### PR DESCRIPTION
Keeps folder-view create drawers stable while autosave runs by moving drawer ownership up to the folder views and driving `DocumentDrawer` visibility from explicit state.

This change adds regression coverage for the autosave drawer-close behavior first, then fixes the folder and collection-folder create flows so autosave no longer kicks the user back to the folder view mid-draft. It also simplifies `ListCreateNewDocInFolderButton` into a pure trigger component, keeps the `MoveToFolder` create-folder flow parent-owned, and reuses the shared `formatDocumentDrawerSlug` helper so the updated drawer selectors stay aligned with the rest of the test suite.

<!-- e2e-pr-media:start -->
### Before
https://github.com/user-attachments/assets/71567644-3aa7-4a70-af61-e7590b9a2857

### After
https://github.com/user-attachments/assets/8d0ee22e-ebc0-4e6c-8a75-4d6dd5e2c1b1
<!-- e2e-pr-media:end -->
