### PR TITLE
fix(ui): dropdown marks options from other collections as selected when ids collide

### DIFF
--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -800,7 +800,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
                   if (!option) {
                     return undefined
                   }
-                  return hasMany && Array.isArray(relationTo)
+                  return Array.isArray(relationTo)
                     ? `${option.relationTo}_${option.value}`
                     : (option.value as string)
                 }}


### PR DESCRIPTION
### What?

In single-value polymorphic relationship fields, the dropdown marks every option whose id matches the selected document as selected, across collections. With `pages: 2` selected, a `quick-links` doc with id `2` is also painted as selected in the open menu.

### Why?

`getOptionValue` passed to react-select only namespaces options by collection for `hasMany` fields:

```ts
return hasMany && Array.isArray(relationTo)
  ? `${option.relationTo}_${option.value}`
  : (option.value as string)
```

For single-value polymorphic fields it falls through to the bare id, and react-select's selected-option check compares these values, so ids colliding across collections produce false "selected" highlights. Values are stored and matched correctly everywhere else (`findOptionsByValue` compares both `value` and `relationTo`); this is purely the menu paint.

### How?

Apply the same `${relationTo}_${value}` namespacing whenever `relationTo` is an array, regardless of `hasMany`.

Reproduction: create docs with the same id in two collections (fresh collections both start at id 1), point a single-value polymorphic relationship at one of them, open the dropdown: both options are highlighted as selected.
