### PR TITLE
fix(plugin-import-export): respect defaultVersionStatus/draft on update-mode imports

### DIFF
--- a/packages/plugin-import-export/src/import/batchProcessor.ts
+++ b/packages/plugin-import-export/src/import/batchProcessor.ts
@@ -356,6 +356,16 @@ async function processImportBatch({
           delete updateData.createdAt
           delete updateData.updatedAt
 
+          // Only handle _status for versioned collections
+          let draftOption: boolean | undefined
+          if (collectionHasVersions) {
+            // Use defaultVersionStatus from config if _status not provided
+            const statusValue = updateData._status || options.defaultVersionStatus
+            const isPublished = statusValue !== 'draft'
+            draftOption = !isPublished
+            updateData._status = statusValue
+          }
+
           // Check if we have multi-locale data and extract it
           const { flatData, hasMultiLocale, localeUpdates } = extractMultiLocaleData(
             updateData,
@@ -389,7 +399,7 @@ async function processImportBatch({
               collection: collectionSlug,
               data: flatData,
               depth: 0,
-              // Don't specify draft - this creates a new draft for versioned collections
+              draft: draftOption,
               overrideAccess: false,
               req: defaultLocaleReq,
               user,
@@ -428,14 +438,12 @@ async function processImportBatch({
                 })
               }
 
-              // Update the document - don't specify draft to let Payload handle versions properly
-              // This will create a new draft version for collections with versions enabled
               savedDocument = await req.payload.update({
                 id: existingDoc.id as number | string,
                 collection: collectionSlug,
                 data: updateData,
                 depth: 0,
-                // Don't specify draft - this creates a new draft for versioned collections
+                draft: draftOption,
                 overrideAccess: false,
                 req,
                 user,

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -3298,6 +3298,13 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(draftPage.title).toBe(`Upsert Test ${timestamp} Updated`)
       expect(draftPage.excerpt).toBe('updated')
 
+      // Pages has no defaultVersionStatus override, so it falls back to 'published' -
+      // the update is expected to apply directly to the published version too.
+      expect(publishedPage).toBeDefined()
+      expect(publishedPage._status).toBe('published')
+      expect(publishedPage.title).toBe(`Upsert Test ${timestamp} Updated`)
+      expect(publishedPage.excerpt).toBe('updated')
+
       const newPages = await payload.find({
         collection: 'pages',
         where: {
@@ -6195,6 +6202,75 @@ describe('@payloadcms/plugin-import-export', () => {
               { title: { equals: 'Default Draft Config Override Test' } },
             ],
           },
+        })
+      })
+
+      it('should preserve the published version and create a draft when updating with defaultVersionStatus draft', async () => {
+        const timestamp = Date.now()
+        const existingDoc = await payload.create({
+          collection: 'posts-imports-only',
+          draft: false,
+          data: {
+            title: `Draft Status Update Test ${timestamp}`,
+            _status: 'published',
+          },
+        })
+
+        const csvContent =
+          'id,title\n' + `${existingDoc.id},"Draft Status Update Test ${timestamp} Updated"`
+        const csvBuffer = Buffer.from(csvContent)
+
+        let importDoc = await payload.create({
+          collection: 'imports',
+          user,
+          data: {
+            collectionSlug: 'posts-imports-only',
+            importMode: 'update',
+            matchField: 'id',
+          },
+          file: {
+            data: csvBuffer,
+            mimetype: 'text/csv',
+            name: 'draft-status-update-test.csv',
+            size: csvBuffer.length,
+          },
+        })
+
+        await payload.jobs.run()
+
+        importDoc = await payload.findByID({
+          collection: 'imports',
+          id: importDoc.id,
+        })
+
+        expect(importDoc.status).toBe('completed')
+        expect(importDoc.summary?.updated).toBe(1)
+        expect(importDoc.summary?.issues).toBe(0)
+
+        // The row omitted `_status`, so the plugin's `defaultVersionStatus: 'draft'`
+        // config for this collection should apply - the published version must stay
+        // untouched and the incoming data should land in a new draft version instead.
+        const publishedDoc = await payload.findByID({
+          collection: 'posts-imports-only',
+          id: existingDoc.id,
+          draft: false,
+        })
+
+        expect(publishedDoc._status).toBe('published')
+        expect(publishedDoc.title).toBe(`Draft Status Update Test ${timestamp}`)
+
+        const draftDoc = await payload.findByID({
+          collection: 'posts-imports-only',
+          id: existingDoc.id,
+          draft: true,
+        })
+
+        expect(draftDoc._status).toBe('draft')
+        expect(draftDoc.title).toBe(`Draft Status Update Test ${timestamp} Updated`)
+
+        await payload.delete({
+          collection: 'posts-imports-only',
+          id: existingDoc.id,
         })
       })
     })


### PR DESCRIPTION
## Problem

When importing into a collection with `versions.drafts` enabled using `importMode: 'update'` or `'upsert'` against an existing document, `processImportBatch` (in `packages/plugin-import-export/src/import/batchProcessor.ts`) never passed `draft` to `payload.update()`, and never applied the plugin's `defaultVersionStatus` fallback — that fallback only existed on the sibling create branch.

Effect: re-importing a document (e.g. one exported without its `_status` column) always overwrote the currently published version live, even when `defaultVersionStatus: 'draft'` was configured, because Payload core's `update` operation only saves a draft when the `draft` argument is explicitly passed (`isSavingDraft = Boolean(draftArg && ...)` in `packages/payload/src/collections/operations/utilities/update.ts`).

## Root cause

The `importMode === 'update' || importMode === 'upsert'` branch's "existing document found" case built `updateData` but skipped the `_status`/`draftOption` resolution that the `create` branch (and the upsert-creates-new branch) already do, and never forwarded `draft` to either of the two `req.payload.update()` calls that follow (the multi-locale branch and the non-multi-locale branch).

## Fix

Mirrors the existing create-mode logic: resolves `statusValue = updateData._status || options.defaultVersionStatus`, derives `draftOption`, sets `updateData._status`, and passes `draft: draftOption` to both `payload.update()` calls.

## Tests

- Added a regression test under the `posts-imports-only` describe block in `test/plugin-import-export/int.spec.ts` (that collection already configures `defaultVersionStatus: 'draft'` with `versions.drafts: true`). It creates a published doc, updates it via an `update`-mode import with a row that omits `_status`, and asserts the published version is untouched while a new draft version holds the updated data.
- Added published-version assertions to the existing `should handle upsert mode correctly` test to cover the published-default-status path (pages has no `defaultVersionStatus` override, so it should continue to publish directly — confirming no regression there).
- Full scoped suite (`pnpm run test:int plugin-import-export`) passes: 238 passed, 5 skipped, 0 failed.

## Test plan

- [x] `pnpm run test:int plugin-import-export` passes locally (MongoDB)
- [x] `tsc --noEmit` / build of `plugin-import-export` succeeds
- [x] No changes to unrelated create-mode or explicit-`_status`-in-row behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)