### PR TITLE
fix(ui): reset tab error badge after successful save

### DIFF
--- a/packages/ui/src/forms/WatchChildErrors/index.tsx
+++ b/packages/ui/src/forms/WatchChildErrors/index.tsx
@@ -29,8 +29,12 @@ export const WatchChildErrors: React.FC<TrackSubSchemaErrorCountProps> = ({
 
   useThrottledEffect(
     () => {
+      // Errors are only surfaced after a submit attempt. Once the form is no longer
+      // submitted (e.g. after a successful save resets the submitted flag), reset the
+      // count to 0 so stale error indicators don't linger on the tab.
+      let errorCount = 0
+
       if (hasSubmitted) {
-        let errorCount = 0
         Object.entries(formState).forEach(([key]) => {
           const matchingSegment = segmentsToMatch?.some((segment) => {
             const segmentToMatch = [...parentPath, segment].join('.')
@@ -52,8 +56,9 @@ export const WatchChildErrors: React.FC<TrackSubSchemaErrorCountProps> = ({
             }
           }
         })
-        setErrorCount(errorCount)
       }
+
+      setErrorCount(errorCount)
     },
     250,
     [formState, hasSubmitted, fields],

--- a/test/field-error-states/collections/TabErrorReset/index.ts
+++ b/test/field-error-states/collections/TabErrorReset/index.ts
@@ -1,0 +1,33 @@
+import type { CollectionConfig } from 'payload'
+
+import { collectionSlugs } from '../../shared.js'
+
+export const TabErrorReset: CollectionConfig = {
+  slug: collectionSlugs.tabErrorReset,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          name: 'errorTab',
+          fields: [
+            {
+              name: 'requiredInTab',
+              type: 'text',
+              required: true,
+            },
+          ],
+          label: 'Error Tab',
+        },
+      ],
+    },
+  ],
+  versions: false,
+}

--- a/test/field-error-states/config.ts
+++ b/test/field-error-states/config.ts
@@ -6,6 +6,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { ErrorFieldsCollection } from './collections/ErrorFields/index.js'
 import { PrevValue } from './collections/PrevValue/index.js'
 import { PrevValueRelation } from './collections/PrevValueRelation/index.js'
+import { TabErrorReset } from './collections/TabErrorReset/index.js'
 import Uploads from './collections/Upload/index.js'
 import { ValidateDraftsOff } from './collections/ValidateDraftsOff/index.js'
 import { ValidateDraftsOn } from './collections/ValidateDraftsOn/index.js'
@@ -27,6 +28,7 @@ export default buildConfigWithDefaults({
     ValidateDraftsOnAndAutosave,
     PrevValue,
     PrevValueRelation,
+    TabErrorReset,
   ],
   globals: [GlobalValidateDraftsOn],
   onInit: async (payload) => {

--- a/test/field-error-states/e2e.spec.ts
+++ b/test/field-error-states/e2e.spec.ts
@@ -34,6 +34,7 @@ describe('Field Error States', () => {
   let prevValue: AdminUrlUtil
   let prevValueRelation: AdminUrlUtil
   let errorFieldsURL: AdminUrlUtil
+  let tabErrorReset: AdminUrlUtil
   let adminRoute: string
 
   beforeAll(async ({ browser }, testInfo) => {
@@ -48,6 +49,7 @@ describe('Field Error States', () => {
     prevValue = new AdminUrlUtil(serverURL, collectionSlugs.prevValue!)
     prevValueRelation = new AdminUrlUtil(serverURL, collectionSlugs.prevValueRelation!)
     errorFieldsURL = new AdminUrlUtil(serverURL, collectionSlugs.errorFields!)
+    tabErrorReset = new AdminUrlUtil(serverURL, collectionSlugs.tabErrorReset!)
 
     const {
       routes: { admin: adminRouteFromConfig },
@@ -359,6 +361,46 @@ describe('Field Error States', () => {
         page.locator('#field-blocksWithMinRows .banner.banner--type-danger'),
       ).toBeVisible()
       await expect(page.locator('#field-blocksWithMinRows .field-error')).toHaveCount(0)
+    })
+  })
+
+  describe('tab error badge reset', () => {
+    test('should clear tab error badge after fixing a child field and re-saving', async ({
+      page,
+    }) => {
+      // Create a valid document so we land on the edit view (no redirect on subsequent saves).
+      await page.goto(tabErrorReset.create)
+      await waitForFormReady(page)
+      await page.locator('#field-title').fill('Reset badge')
+      await page.locator('#field-errorTab__requiredInTab').fill('valid')
+      await saveDocAndAssert(page, '#action-save')
+
+      // Clear the required child field and save -> the tab shows an error badge.
+      await page.locator('#field-errorTab__requiredInTab').fill('')
+      await saveDocAndAssert(page, '#action-save', 'error')
+
+      const tabErrorBadge = page.locator('.tabs-field__tab-button--active .error-pill')
+      await expect(tabErrorBadge).toBeVisible()
+      await expect(tabErrorBadge).toContainText('1')
+
+      // Fix the field and save in the same tick. This coalesces the throttled error
+      // recompute with the successful-save state transition (submitted -> false), which
+      // previously left the tab badge stranded because the recompute was gated on the
+      // submitted flag still being true.
+      await page.evaluate(() => {
+        const input = document.querySelector<HTMLInputElement>('#field-errorTab__requiredInTab')!
+        const nativeSetter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )!.set!
+        nativeSetter.call(input, 'fixed')
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+        document.querySelector<HTMLButtonElement>('#action-save')!.click()
+      })
+
+      // The save succeeds and the field-level error clears, so the tab badge must clear too.
+      await expect(page.locator('.payload-toast-container')).toContainText('successfully')
+      await expect(tabErrorBadge).toBeHidden()
     })
   })
 })

--- a/test/field-error-states/payload-types.ts
+++ b/test/field-error-states/payload-types.ts
@@ -62,21 +62,21 @@ export type SupportedTimezones =
   | 'Pacific/Fiji';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_1486C0E2".
+ * via the `definition` "LexicalNodes_DFDE7E69".
  */
-export type LexicalNodes_1486C0E2 =
+export type LexicalNodes_DFDE7E69 =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_1486C0E2>
+  | SerializedParagraphNode<LexicalNodes_DFDE7E69>
   | SerializedBlockNode<MyBlock>
-  | SerializedHeadingNode<LexicalNodes_1486C0E2>
+  | SerializedHeadingNode<LexicalNodes_DFDE7E69>
   | SerializedUploadNode<'uploads'>
-  | SerializedQuoteNode<LexicalNodes_1486C0E2>
-  | SerializedListNode<LexicalNodes_1486C0E2>
-  | SerializedListItemNode<LexicalNodes_1486C0E2>
-  | SerializedAutoLinkNode<LexicalNodes_1486C0E2, LexicalLinkFields_0A7E9EC0>
-  | SerializedLinkNode<LexicalNodes_1486C0E2, LexicalLinkFields_0A7E9EC0>
+  | SerializedQuoteNode<LexicalNodes_DFDE7E69>
+  | SerializedListNode<LexicalNodes_DFDE7E69>
+  | SerializedListItemNode<LexicalNodes_DFDE7E69>
+  | SerializedAutoLinkNode<LexicalNodes_DFDE7E69, LexicalLinkFields_0A7E9EC0>
+  | SerializedLinkNode<LexicalNodes_DFDE7E69, LexicalLinkFields_0A7E9EC0>
   | SerializedRelationshipNode<
       | 'error-fields'
       | 'validate-drafts-on'
@@ -84,6 +84,7 @@ export type LexicalNodes_1486C0E2 =
       | 'validate-drafts-on-autosave'
       | 'prev-value'
       | 'prev-value-relation'
+      | 'tab-error-reset'
       | 'payload-kv'
       | 'users'
       | 'payload-locked-documents'
@@ -104,6 +105,7 @@ export interface Config {
     'validate-drafts-on-autosave': ValidateDraftsOnAutosave;
     'prev-value': PrevValue;
     'prev-value-relation': PrevValueRelation;
+    'tab-error-reset': TabErrorReset;
     'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
@@ -119,6 +121,7 @@ export interface Config {
     'validate-drafts-on-autosave': ValidateDraftsOnAutosaveSelect<false> | ValidateDraftsOnAutosaveSelect<true>;
     'prev-value': PrevValueSelect<false> | PrevValueSelect<true>;
     'prev-value-relation': PrevValueRelationSelect<false> | PrevValueRelationSelect<true>;
+    'tab-error-reset': TabErrorResetSelect<false> | TabErrorResetSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -138,6 +141,8 @@ export interface Config {
   locale: null;
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -209,7 +214,7 @@ export interface ErrorField {
           point: [number, number];
           radio: 'mint' | 'dark_gray';
           relationship: string | User;
-          richtext: LexicalRichText<LexicalNodes_1486C0E2>;
+          richtext: LexicalRichText<LexicalNodes_DFDE7E69>;
           select: 'mint' | 'dark_gray';
           upload: string | Upload;
           text: string;
@@ -248,7 +253,7 @@ export interface ErrorField {
         point: [number, number];
         radio: 'mint' | 'dark_gray';
         relationship: string | User;
-        richtext: LexicalRichText<LexicalNodes_1486C0E2>;
+        richtext: LexicalRichText<LexicalNodes_DFDE7E69>;
         select: 'mint' | 'dark_gray';
         upload: string | Upload;
         text: string;
@@ -267,6 +272,13 @@ export interface ErrorField {
     id?: string | null;
   }[];
   layout?: Block1[] | null;
+  arrayWithMinRows?:
+    | {
+        name?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  blocksWithMinRows?: MinRowsBlock[] | null;
   group: {
     text: string;
   };
@@ -306,7 +318,7 @@ export interface Upload {
   id: string;
   text?: string | null;
   media?: (string | null) | Upload;
-  richText?: LexicalRichText<LexicalNodes_1486C0E2> | null;
+  richText?: LexicalRichText<LexicalNodes_DFDE7E69> | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -354,7 +366,7 @@ export interface Block1 {
         point: [number, number];
         radio: 'mint' | 'dark_gray';
         relationship: string | User;
-        richtext: LexicalRichText<LexicalNodes_1486C0E2>;
+        richtext: LexicalRichText<LexicalNodes_DFDE7E69>;
         select: 'mint' | 'dark_gray';
         upload: string | Upload;
         text: string;
@@ -365,6 +377,16 @@ export interface Block1 {
   id?: string | null;
   blockName?: string | null;
   blockType: 'block1';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "MinRowsBlock".
+ */
+export interface MinRowsBlock {
+  name?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'minRowsBlock';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -446,6 +468,19 @@ export interface PrevValueRelation {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tab-error-reset".
+ */
+export interface TabErrorReset {
+  id: string;
+  title?: string | null;
+  errorTab: {
+    requiredInTab: string;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -495,6 +530,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'prev-value-relation';
         value: string | PrevValueRelation;
+      } | null)
+    | ({
+        relationTo: 'tab-error-reset';
+        value: string | TabErrorReset;
       } | null)
     | ({
         relationTo: 'users';
@@ -672,6 +711,23 @@ export interface ErrorFieldsSelect<T extends boolean = true> {
               blockName?: T;
             };
       };
+  arrayWithMinRows?:
+    | T
+    | {
+        name?: T;
+        id?: T;
+      };
+  blocksWithMinRows?:
+    | T
+    | {
+        minRowsBlock?:
+          | T
+          | {
+              name?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
   group?:
     | T
     | {
@@ -752,6 +808,20 @@ export interface PrevValueSelect<T extends boolean = true> {
  */
 export interface PrevValueRelationSelect<T extends boolean = true> {
   previousValueRelation?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tab-error-reset_select".
+ */
+export interface TabErrorResetSelect<T extends boolean = true> {
+  title?: T;
+  errorTab?:
+    | T
+    | {
+        requiredInTab?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
 }
@@ -854,6 +924,60 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection:
+      | 'error-fields'
+      | 'uploads'
+      | 'validate-drafts-on'
+      | 'validate-drafts-off'
+      | 'validate-drafts-on-autosave'
+      | 'prev-value'
+      | 'prev-value-relation'
+      | 'tab-error-reset'
+      | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?:
+      | (
+          | 'error-fields'
+          | 'uploads'
+          | 'validate-drafts-on'
+          | 'validate-drafts-off'
+          | 'validate-drafts-on-autosave'
+          | 'prev-value'
+          | 'prev-value-relation'
+          | 'tab-error-reset'
+          | 'users'
+        )[]
+      | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/field-error-states/shared.ts
+++ b/test/field-error-states/shared.ts
@@ -9,6 +9,7 @@ export const collectionSlugs: {
   prevValue: 'prev-value',
   prevValueRelation: 'prev-value-relation',
   errorFields: 'error-fields',
+  tabErrorReset: 'tab-error-reset',
 }
 
 export const globalSlugs: {


### PR DESCRIPTION
## What

Fixes a Tabs field bug (with the Tanstack adapter) where the tab error pill (the count badge for invalid child fields) stays visible after you fix a validation error and save successfully — even though the field-level error correctly clears.

## Why

`WatchChildErrors` recomputed the tab's error count only while `hasSubmitted` was `true`:

```ts
if (hasSubmitted) { ...count...; setErrorCount(errorCount) }  // never reset otherwise
```

The recompute runs inside a 250ms `useThrottledEffect`. A successful save merges valid server state and flips `submitted` back to `false` in quick succession. The reactive "clear the badge" recompute (which needs `hasSubmitted === true`) gets coalesced by the throttle with the `submitted → false` transition, so the only effect run that materializes sees `hasSubmitted === false`, hits the guard, and never calls `setErrorCount(0)` — leaving a stale badge on the tab.

## How

Always call `setErrorCount`, computing `0` when the form is not submitted, so the badge clears on a successful save regardless of throttle timing.

## Reproduction

1. Give a collection a Tabs field with a `required` child field.
2. Save with the field empty → the tab shows an error badge.
3. Fill the field and save again → the field error clears but the tab badge stays.

## Tests

- Adds a `TabErrorReset` collection to `test/field-error-states`.
- Adds a `tab error badge reset` e2e test that triggers the error, then fixes and re-saves within the throttle window and asserts the badge is hidden after the successful save.
- Verified the test **fails on the pre-fix code** and **passes with the fix**.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216597988811182