### PR TITLE
fix(drizzle): dedupe reused localized block tables

### DIFF
--- a/packages/drizzle/src/schema/buildRawSchema.spec.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.spec.ts
@@ -1,0 +1,110 @@
+import type { Block, Config, SanitizedConfig } from 'payload'
+import { sanitizeConfig } from 'payload'
+import { describe, expect, it } from 'vitest'
+
+import { setColumnID } from '../postgres/schema/setColumnID.js'
+import type { DrizzleAdapter } from '../types.js'
+import { buildRawSchema } from './buildRawSchema.js'
+
+const headlineBlock: Block = {
+  slug: 'headline',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}
+
+const createContainerBlock = (slug: string): Block => ({
+  slug,
+  fields: [
+    {
+      name: 'content',
+      type: 'blocks',
+      blockReferences: ['headline'],
+      blocks: [],
+    },
+  ],
+})
+
+const createAdapter = (config: SanitizedConfig): DrizzleAdapter =>
+  ({
+    blocksAsJSON: false,
+    fieldConstraints: {},
+    idType: 'serial',
+    localesSuffix: '_locales',
+    payload: {
+      blocks: Object.fromEntries(config.blocks.map((block) => [block.slug, block])),
+      collections: Object.fromEntries(
+        config.collections.map((collection) => [
+          collection.slug,
+          {
+            config: collection,
+            customIDType: undefined,
+          },
+        ]),
+      ),
+      config,
+    },
+    rawRelations: {},
+    rawTables: {},
+    tableNameMap: new Map(),
+    versionsSuffix: '_versions',
+  }) as unknown as DrizzleAdapter
+
+describe('buildRawSchema', () => {
+  it('should not create duplicate suffixed block tables for identical reused blocks under localized ancestors', async () => {
+    const layoutBlocks = [createContainerBlock('container'), createContainerBlock('container50')]
+
+    const config = await sanitizeConfig({
+      blocks: [headlineBlock],
+      collections: [
+        {
+          slug: 'pages',
+          fields: [
+            {
+              name: 'layout',
+              type: 'blocks',
+              localized: true,
+              blocks: layoutBlocks,
+            },
+          ],
+          timestamps: false,
+        },
+        {
+          slug: 'posts',
+          fields: [
+            {
+              name: 'layout',
+              type: 'blocks',
+              localized: true,
+              blocks: layoutBlocks,
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+      localization: {
+        defaultLocale: 'en',
+        locales: ['en', 'de'],
+      },
+    } as Config)
+
+    const adapter = createAdapter(config)
+
+    buildRawSchema({
+      adapter,
+      setColumnID,
+    })
+
+    expect(adapter.rawTables.pages_blocks_headline).toBeDefined()
+    expect(adapter.rawTables.pages_blocks_headline.columns._locale).toBeDefined()
+    expect(adapter.rawTables.pages_blocks_headline_2).toBeUndefined()
+    expect(adapter.rawTables.pages_blocks_headline_2_locales).toBeUndefined()
+    expect(adapter.rawTables.posts_blocks_headline).toBeDefined()
+    expect(adapter.rawTables.posts_blocks_headline.columns._locale).toBeDefined()
+    expect(adapter.rawTables.posts_blocks_headline_2).toBeUndefined()
+    expect(adapter.rawTables.posts_blocks_headline_2_locales).toBeUndefined()
+  })
+})

--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -395,15 +395,18 @@ export const traverseFields = ({
             throwValidationError,
             versionsCustomName: versions,
           })
-
+          const isLocalizedBlockTable =
+            Boolean(isFieldLocalized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock ||
+            forceLocalized
           if (typeof blocksTableNameMap[blockTableName] === 'undefined') {
             blocksTableNameMap[blockTableName] = 1
           } else if (
             !adapter.rawTables[blockTableName] ||
             !validateExistingBlockIsIdentical({
               block,
-              localized: field.localized,
-              rootTableName,
+              localized: isLocalizedBlockTable,
+              parentIsLocalized,
               table: adapter.rawTables[blockTableName],
               tableLocales: adapter.rawTables[`${blockTableName}${adapter.localesSuffix}`],
             })
@@ -465,12 +468,7 @@ export const traverseFields = ({
               },
             }
 
-            const isLocalized =
-              Boolean(isFieldLocalized && adapter.payload.config.localization) ||
-              withinLocalizedArrayOrBlock ||
-              forceLocalized
-
-            if (isLocalized) {
+            if (isLocalizedBlockTable) {
               baseColumns._locale = {
                 name: '_locale',
                 type: 'enum',
@@ -510,7 +508,7 @@ export const traverseFields = ({
               setColumnID,
               tableName: blockTableName,
               versions,
-              withinLocalizedArrayOrBlock: isLocalized,
+              withinLocalizedArrayOrBlock: isLocalizedBlockTable,
             })
 
             if (subHasLocalizedManyNumberField) {

--- a/packages/drizzle/src/utilities/validateExistingBlockIsIdentical.ts
+++ b/packages/drizzle/src/utilities/validateExistingBlockIsIdentical.ts
@@ -16,7 +16,6 @@ type Args = {
    * @todo make required in v4.0. Usually you'd wanna pass this in
    */
   parentIsLocalized?: boolean
-  rootTableName: string
   table: RawTable
   tableLocales?: RawTable
 }


### PR DESCRIPTION
Fixes duplicate `_N` block tables when identical `blockReferences` are reused under localized block paths.

Fixes #17424.

1. `traverseFields` validated existing block tables with the immediate `field.localized` flag, which dropped localization inherited from ancestor blocks and arrays.
2. `validateExistingBlockIsIdentical` never received `parentIsLocalized` from this call site, so nested block fields were flattened with incomplete localization context.

The fix passes the accumulated localization context into `validateExistingBlockIsIdentical` and reuses the same localized-table calculation that schema construction already uses when deciding whether an existing block table matches.

Adds a regression spec that builds two localized collections reusing the same nested `headline` block reference and asserts Payload does not create suffixed duplicate tables like `pages_blocks_headline_2` or `posts_blocks_headline_2`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216743516361216