### PR TITLE
fix(ui): add accessible names to row-select checkboxes

### DIFF
--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -13,11 +13,12 @@ const baseClass = 'select-row'
 
 export const SelectRow: React.FC<{
   rowData: {
-    _isLocked: boolean
-    _userEditing: User
-    id: string
+    _isLocked?: boolean
+    _userEditing?: User
+    id: number | string
   }
-}> = ({ rowData }) => {
+  selectRowLabel?: string
+}> = ({ rowData, selectRowLabel }) => {
   const { user } = useAuth()
   const { selected, setSelection } = useSelection()
   const { _isLocked, _userEditing } = rowData || {}
@@ -30,6 +31,7 @@ export const SelectRow: React.FC<{
 
   return (
     <CheckboxInput
+      aria-label={selectRowLabel || `Select ${rowData.id}`}
       checked={Boolean(selected.get(rowData.id))}
       className={[baseClass, `${baseClass}__checkbox`].join(' ')}
       onToggle={() => setSelection(rowData.id)}

--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -17,7 +17,7 @@ export const SelectRow: React.FC<{
     _userEditing?: User
     id: number | string
   }
-  selectRowLabel?: string
+  selectRowLabel: string
 }> = ({ rowData, selectRowLabel }) => {
   const { user } = useAuth()
   const { selected, setSelection } = useSelection()
@@ -31,7 +31,7 @@ export const SelectRow: React.FC<{
 
   return (
     <CheckboxInput
-      aria-label={selectRowLabel || `Select ${rowData.id}`}
+      aria-label={selectRowLabel}
       checked={Boolean(selected.get(rowData.id))}
       className={[baseClass, `${baseClass}__checkbox`].join(' ')}
       onToggle={() => setSelection(rowData.id)}

--- a/packages/ui/src/fields/Checkbox/Input.tsx
+++ b/packages/ui/src/fields/Checkbox/Input.tsx
@@ -11,6 +11,8 @@ import { LineIcon } from '../../icons/Line/index.js'
 
 export type CheckboxInputProps = {
   readonly AfterInput?: React.ReactNode
+  readonly 'aria-label'?: string
+  readonly 'aria-labelledby'?: string
   readonly BeforeInput?: React.ReactNode
   readonly checked?: boolean
   readonly className?: string
@@ -40,6 +42,8 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
   id: idFromProps,
   name,
   AfterInput,
+  'aria-label': ariaLabelFromProps,
+  'aria-labelledby': ariaLabelledByFromProps,
   BeforeInput,
   checked,
   className,
@@ -59,6 +63,8 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
   const [showTooltip, setShowTooltip] = useState(false)
   const fallbackID = useId()
   const id = idFromProps || fallbackID
+  const ariaLabel = ariaLabelFromProps || undefined
+  const ariaLabelledBy = ariaLabel ? undefined : ariaLabelledByFromProps || name
 
   useEffect(() => {
     setIsHydrated(true)
@@ -85,8 +91,8 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
       <div className={`${inputBaseClass}__wrap`}>
         <div className={`${inputBaseClass}__input`}>
           <input
-            aria-label=""
-            aria-labelledby={name}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
             checked={Boolean(checked)}
             disabled={readOnly}
             id={id}

--- a/packages/ui/src/utilities/renderTable.tsx
+++ b/packages/ui/src/utilities/renderTable.tsx
@@ -252,8 +252,12 @@ export const renderTable = ({
         hidden: true,
       },
       Heading: <SelectAll />,
-      renderedCells: (data?.docs || []).map((_, i) => (
-        <SelectRow key={i} rowData={data?.docs[i]} />
+      renderedCells: (data?.docs || []).map((row, i) => (
+        <SelectRow
+          key={i}
+          rowData={row}
+          selectRowLabel={getSelectRowLabel({ i18n, rowData: row, useAsTitle })}
+        />
       )),
     } as Column)
   }
@@ -338,4 +342,22 @@ export const renderTable = ({
       </TableSectionRoot>
     ),
   }
+}
+
+const getSelectRowLabel = ({
+  i18n,
+  rowData,
+  useAsTitle,
+}: {
+  i18n: I18nClient
+  rowData: { id: number | string } & Record<string, unknown>
+  useAsTitle: CollectionConfig['admin']['useAsTitle']
+}) => {
+  const title = useAsTitle ? rowData[useAsTitle] : undefined
+  const label =
+    typeof title === 'number' || (typeof title === 'string' && title)
+      ? String(title)
+      : String(rowData.id)
+
+  return i18n.t('general:selectLabel', { label })
 }

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -262,6 +262,11 @@ export const renderListView = async (
   /** Automatically force select active columns. */
   const select = transformColumnsToSelect(columns)
 
+  /** Force select `useAsTitle` for accessible row-selection labels, even if its column is hidden. */
+  if (enableRowSelections && collectionConfig.admin.useAsTitle) {
+    select[collectionConfig.admin.useAsTitle] = true
+  }
+
   /** Force select image fields for list view thumbnails */
   appendUploadSelectFields({
     collectionConfig,

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -174,6 +174,14 @@ describe('List View', () => {
   })
 
   describe('list view table', () => {
+    test('should render row select checkboxes with accessible names', async () => {
+      const rowCheckboxes = page.locator(`${tableRowLocator} .select-row__checkbox input`)
+
+      await expect(rowCheckboxes).toHaveCount(2)
+      await expect(page.getByRole('checkbox', { name: 'Select post1' })).toBeVisible()
+      await expect(page.getByRole('checkbox', { name: 'Select post2' })).toBeVisible()
+    })
+
     test('should link second cell', async () => {
       const { id } = await createPost()
       await page.reload()

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -174,10 +174,49 @@ describe('List View', () => {
   })
 
   describe('list view table', () => {
+    const fallbackDocumentIDs: (number | string)[] = []
+
+    test.afterEach(async () => {
+      for (const id of fallbackDocumentIDs) {
+        await payload.delete({
+          id,
+          collection: listViewSelectAPISlug,
+        })
+      }
+      fallbackDocumentIDs.length = 0
+    })
+
     test('should render row select checkboxes with accessible names', async () => {
       const rowCheckboxes = page.locator(`${tableRowLocator} .select-row__checkbox input`)
 
       await expect(rowCheckboxes).toHaveCount(2)
+      await expect(page.getByRole('checkbox', { name: 'Select post1' })).toBeVisible()
+      await expect(page.getByRole('checkbox', { name: 'Select post2' })).toBeVisible()
+    })
+
+    test('should use the document ID in the accessible name when useAsTitle is not configured', async () => {
+      const doc = await payload.create({
+        collection: listViewSelectAPISlug,
+        data: {
+          title: 'Fallback test title',
+        },
+      })
+      fallbackDocumentIDs.push(doc.id)
+      const selectAPIUrl = new AdminUrlUtil(serverURL, listViewSelectAPISlug)
+
+      await page.goto(selectAPIUrl.list)
+      await expect(page.getByRole('checkbox', { name: `Select ${doc.id}` })).toBeVisible()
+    })
+
+    test('should use useAsTitle in the accessible name when its column is hidden', async () => {
+      await toggleColumn(page, {
+        columnLabel: 'Title',
+        columnName: 'title',
+        targetState: 'off',
+      })
+      await page.reload()
+
+      await expect(page.locator('#heading-title')).toBeHidden()
       await expect(page.getByRole('checkbox', { name: 'Select post1' })).toBeVisible()
       await expect(page.getByRole('checkbox', { name: 'Select post2' })).toBeVisible()
     })


### PR DESCRIPTION
Adds accessible names to admin list-view row-selection checkboxes.

1. `CheckboxInput` forced `aria-label=""` and fell back to `aria-labelledby={name}`, but row-select checkboxes do not provide a matching label target.
2. `SelectRow` did not pass a row-specific accessible name, so assistive technology exposed unlabeled controls in the list view.

This change lets `CheckboxInput` accept explicit `aria-label` and `aria-labelledby` props, generates localized row labels from `useAsTitle` with an `id` fallback, and adds an e2e regression that checks for `Select post1` and `Select post2`.

Fixes #17376
