### PR TITLE
feat: support registered image size options

### DIFF
--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -60,7 +60,7 @@ export type GenerateImageName = (args: {
   width: number
 }) => string
 
-export type ImageSize = {
+type ImageSizeBase = {
   /**
    * Admin UI options that control how this image size appears in list views.
    */
@@ -80,15 +80,21 @@ export type ImageSize = {
     }
   }
   /**
-   * @deprecated prefer position
-   */
-  crop?: string // comes from sharp package
-  formatOptions?: ImageUploadFormatOptions
-  /**
    * Generate a custom name for the file of this image size.
    */
   generateImageName?: GenerateImageName
   name: string
+}
+
+/**
+ * Image size options implemented by Payload's default Sharp image processor.
+ */
+export type SharpImageSizeOptions = {
+  /**
+   * @deprecated prefer position
+   */
+  crop?: string // comes from sharp package
+  formatOptions?: ImageUploadFormatOptions
   trimOptions?: ImageUploadTrimOptions
   /**
    * When an uploaded image is smaller than the defined image size, we have 3 options:
@@ -101,6 +107,28 @@ export type ImageSize = {
    */
   withoutEnlargement?: ResizeOptions['withoutEnlargement']
 } & Omit<ResizeOptions, 'withoutEnlargement'>
+
+/**
+ * Interface to be module-augmented by image processing providers.
+ *
+ * When no provider is registered, ImageSize uses SharpImageSizeOptions.
+ * When providers are registered, ImageSize uses their registered options instead.
+ *
+ * @example
+ * declare module 'payload' {
+ *   interface RegisteredImageSizeOptions {
+ *     myProvider: MyProviderImageSizeOptions
+ *   }
+ * }
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Intentionally empty so image processing providers can augment it.
+export interface RegisteredImageSizeOptions {}
+
+type ImageSizeOptions = keyof RegisteredImageSizeOptions extends never
+  ? SharpImageSizeOptions
+  : RegisteredImageSizeOptions[keyof RegisteredImageSizeOptions]
+
+export type ImageSize = ImageSizeBase & ImageSizeOptions
 
 export type GetAdminThumbnail = (args: { doc: Record<string, unknown> }) => false | null | string
 

--- a/test/image-size-options/default/tsconfig.json
+++ b/test/image-size-options/default/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/test/image-size-options/default/types.spec.ts
+++ b/test/image-size-options/default/types.spec.ts
@@ -1,0 +1,24 @@
+import type { CollectionConfig, ImageSize } from 'payload'
+
+import { describe, expect, test } from 'tstyche'
+
+type CollectionUploadConfig = Exclude<NonNullable<CollectionConfig['upload']>, boolean>
+type CollectionImageSize = NonNullable<CollectionUploadConfig['imageSizes']>[number]
+
+describe('default image size options', () => {
+  test('should use Sharp options when no provider is registered', () => {
+    expect<'kernel' extends keyof ImageSize ? true : false>().type.toBe<true>()
+    expect<'withoutEnlargement' extends keyof ImageSize ? true : false>().type.toBe<true>()
+    expect<{
+      height: number
+      kernel: 'lanczos3'
+      name: string
+      width: number
+      withoutEnlargement: true
+    }>().type.toBeAssignableTo<ImageSize>()
+  })
+
+  test('should apply Sharp options to collection upload configuration', () => {
+    expect<CollectionImageSize>().type.toBe<ImageSize>()
+  })
+})

--- a/test/image-size-options/registered/tsconfig.json
+++ b/test/image-size-options/registered/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/test/image-size-options/registered/types.spec.ts
+++ b/test/image-size-options/registered/types.spec.ts
@@ -1,0 +1,36 @@
+import type { CollectionConfig, ImageSize } from 'payload'
+
+import { describe, expect, test } from 'tstyche'
+
+type TestImageSizeOptions = {
+  fit?: 'provider-fit'
+  providerOption?: boolean
+  width?: number
+}
+
+declare module 'payload' {
+  interface RegisteredImageSizeOptions {
+    testProvider: TestImageSizeOptions
+  }
+}
+
+type CollectionUploadConfig = Exclude<NonNullable<CollectionConfig['upload']>, boolean>
+type CollectionImageSize = NonNullable<CollectionUploadConfig['imageSizes']>[number]
+
+describe('registered image size options', () => {
+  test('should use registered provider options in ImageSize', () => {
+    expect<ImageSize['name']>().type.toBe<string>()
+    expect<ImageSize['fit']>().type.toBe<'provider-fit' | undefined>()
+    expect<ImageSize['providerOption']>().type.toBe<boolean | undefined>()
+    expect<ImageSize['width']>().type.toBe<number | undefined>()
+  })
+
+  test('should replace Sharp-specific options', () => {
+    expect<'kernel' extends keyof ImageSize ? true : false>().type.toBe<false>()
+    expect<'withoutEnlargement' extends keyof ImageSize ? true : false>().type.toBe<false>()
+  })
+
+  test('should apply registered options to collection upload configuration', () => {
+    expect<CollectionImageSize>().type.toBe<ImageSize>()
+  })
+})


### PR DESCRIPTION
## Description
Adds a module-augmentable image-size options registry so integrations can replace Payload’s default Sharp options with provider-specific configuration while preserving Sharp as the default.

## Changes
- Split shared image-size fields from Sharp-specific resize options.
- Add `RegisteredImageSizeOptions` as a module augmentation point for image-processing providers.
- Fall back to Sharp options when no provider is registered.
- Add isolated type tests for default Sharp behavior and registered provider behavior.

## Test Plan
- `pnpm test:types` — 6 files, 194 tests, and 274 assertions passed.