### PR TITLE
ci: seed canary id on all versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-monorepo",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/admin-bar/package.json
+++ b/packages/admin-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/admin-bar",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "An admin bar for React apps using Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/codemod",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Codemods for migrating Payload projects across versions.",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/create-payload-app/package.json
+++ b/packages/create-payload-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-payload-app",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "homepage": "https://payloadcms.com",
   "repository": {
     "type": "git",

--- a/packages/db-d1-sqlite/package.json
+++ b/packages/db-d1-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/db-d1-sqlite",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The officially supported D1 SQLite database adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/db-mongodb/package.json
+++ b/packages/db-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/db-mongodb",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The officially supported MongoDB database adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/db-postgres",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The officially supported Postgres database adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/db-sqlite",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The officially supported SQLite database adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/db-vercel-postgres/package.json
+++ b/packages/db-vercel-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/db-vercel-postgres",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Vercel Postgres adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/drizzle",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "A library of shared functions used by different payload database adapters",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/email-nodemailer/package.json
+++ b/packages/email-nodemailer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/email-nodemailer",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Payload Nodemailer Email Adapter",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/email-resend/package.json
+++ b/packages/email-resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/email-resend",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Payload Resend Email Adapter",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/graphql",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "homepage": "https://payloadcms.com",
   "repository": {
     "type": "git",

--- a/packages/kv-redis/package.json
+++ b/packages/kv-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/kv-redis",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Redis KV adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/live-preview-react/package.json
+++ b/packages/live-preview-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/live-preview-react",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The official React SDK for Payload Live Preview",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/live-preview-vue/package.json
+++ b/packages/live-preview-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/live-preview-vue",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The official Vue SDK for Payload Live Preview",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/live-preview",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The official live preview JavaScript SDK for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/next",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "homepage": "https://payloadcms.com",
   "repository": {
     "type": "git",

--- a/packages/payload-cloud/package.json
+++ b/packages/payload-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/payload-cloud",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The official Payload Cloud plugin",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Node, React, Headless CMS and Application Framework built on Next.js",
   "keywords": [
     "admin panel",

--- a/packages/plugin-cloud-storage/package.json
+++ b/packages/plugin-cloud-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-cloud-storage",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The official cloud storage plugin for Payload CMS",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/plugin-ecommerce/package.json
+++ b/packages/plugin-ecommerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-ecommerce",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Ecommerce plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/plugin-form-builder/package.json
+++ b/packages/plugin-form-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-form-builder",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Form builder plugin for Payload CMS",
   "keywords": [
     "payload",

--- a/packages/plugin-import-export/package.json
+++ b/packages/plugin-import-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-import-export",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Import-Export plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-mcp",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "MCP (Model Context Protocol) capabilities with Payload",
   "keywords": [
     "plugin",

--- a/packages/plugin-multi-tenant/package.json
+++ b/packages/plugin-multi-tenant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-multi-tenant",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Multi Tenant plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/plugin-nested-docs/package.json
+++ b/packages/plugin-nested-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-nested-docs",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The official Nested Docs plugin for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/plugin-redirects/package.json
+++ b/packages/plugin-redirects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-redirects",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Redirects plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/plugin-search/package.json
+++ b/packages/plugin-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-search",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Search plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/plugin-sentry/package.json
+++ b/packages/plugin-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-sentry",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Sentry plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/plugin-seo/package.json
+++ b/packages/plugin-seo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-seo",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "SEO plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/plugin-stripe/package.json
+++ b/packages/plugin-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/plugin-stripe",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Stripe plugin for Payload",
   "keywords": [
     "payload",

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/richtext-lexical",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The officially supported Lexical richtext adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/sdk",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "The official Payload REST API SDK",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/storage-azure/package.json
+++ b/packages/storage-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/storage-azure",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Payload storage adapter for Azure Blob Storage",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/storage-gcs/package.json
+++ b/packages/storage-gcs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/storage-gcs",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Payload storage adapter for Google Cloud Storage",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/storage-r2/package.json
+++ b/packages/storage-r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/storage-r2",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Payload storage adapter for Cloudflare R2",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/storage-s3/package.json
+++ b/packages/storage-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/storage-s3",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Payload storage adapter for Amazon S3",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/storage-vercel-blob/package.json
+++ b/packages/storage-vercel-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/storage-vercel-blob",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "Payload storage adapter for Vercel Blob Storage",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/tanstack-start",
-  "version": "4.0.0-internal.183b315",
+  "version": "4.0.0-canary.14",
   "description": "TanStack Start framework adapter for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/translations",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "homepage": "https://payloadcms.com",
   "repository": {
     "type": "git",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/typescript-plugin",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "description": "TypeScript Language Service Plugin for Payload CMS - validates PayloadComponent import paths and provides autocomplete",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/ui",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-canary.14",
   "homepage": "https://payloadcms.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The beta version was a placeholder for a future version and has not had a published version. This seeds the canary preid for all packages. Future CI will reference this when determining version bumps.

NOTE: This _will not_ stay in sync until the new CI work is done, which will push version bumps to main.