### PR TITLE
fix(ui): hide add button on read-only blocks field

### DIFF
--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -528,16 +528,16 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
           )}
         </DraggableSortable>
       )}
-      {!hasMaxRows && (
+      {!hasMaxRows && !readOnly && (
         <Fragment>
           <DrawerToggler
             className={`${baseClass}__drawer-toggler`}
-            disabled={readOnly || disabled}
+            disabled={disabled}
             slug={drawerSlug}
           >
             <Button
               buttonStyle="ghost"
-              disabled={readOnly || disabled}
+              disabled={disabled}
               el="span"
               icon={<CirclePlusIcon />}
               iconPosition="left"

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -1733,7 +1733,7 @@ describe('Access Control', () => {
 
       // Read-only blocks field should not allow adding blocks
       const readOnlyBlocksField = page.locator('#field-readOnlyBlocks')
-      await expect(readOnlyBlocksField.locator('.blocks-field__drawer-toggler')).toBeDisabled()
+      await expect(readOnlyBlocksField.locator('.blocks-field__drawer-toggler')).toBeHidden()
 
       // Editable block references field should allow adding blocks
       const editableBlockRefsField = page.locator('#field-editableBlockRefs')
@@ -1741,21 +1741,19 @@ describe('Access Control', () => {
 
       // Read-only block references field should not allow adding blocks
       const readOnlyBlockRefsField = page.locator('#field-readOnlyBlockRefs')
-      await expect(readOnlyBlockRefsField.locator('.blocks-field__drawer-toggler')).toBeDisabled()
+      await expect(readOnlyBlockRefsField.locator('.blocks-field__drawer-toggler')).toBeHidden()
 
       // Tab read-only blocks field should not allow adding blocks
       const tabReadOnlyBlocksField = page.locator(
         '.field-type.tabs-field #field-tabReadOnlyTest__tabReadOnlyBlocks',
       )
-      await expect(tabReadOnlyBlocksField.locator('.blocks-field__drawer-toggler')).toBeDisabled()
+      await expect(tabReadOnlyBlocksField.locator('.blocks-field__drawer-toggler')).toBeHidden()
 
       // Tab read-only block references field should not allow adding blocks
       const tabReadOnlyBlockRefsField = page.locator(
         '.field-type.tabs-field #field-tabReadOnlyTest__tabReadOnlyBlockRefs',
       )
-      await expect(
-        tabReadOnlyBlockRefsField.locator('.blocks-field__drawer-toggler'),
-      ).toBeDisabled()
+      await expect(tabReadOnlyBlockRefsField.locator('.blocks-field__drawer-toggler')).toBeHidden()
     })
 
     test('should respect field-level access control for individual fields within blocks', async () => {

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -104,6 +104,12 @@ describe('Block fields', () => {
     )
   })
 
+  test('should hide add button on readOnly blocks field', async () => {
+    await page.goto(url.create)
+
+    await expect(page.locator('#field-readOnly .blocks-field__drawer-toggler')).toBeHidden()
+  })
+
   test('should reset search state in blocks drawer on re-open', async () => {
     await page.goto(url.create)
 


### PR DESCRIPTION
Hides the block add button when a `blocks` field is `readOnly`, matching the existing `array` field behavior.

Previously the read-only `blocks` field kept rendering the add-block toggler in a disabled state, while the `array` field hid it entirely. Now both hide the add button when `readOnly`, and `disabled` only toggles the disabled state.

### Before
<img width="1407" height="221" alt="Screenshot 2026-07-21 at 2 53 08 PM" src="https://github.com/user-attachments/assets/13af44bc-c3f3-4572-adde-0d2258b50dfc" />

### After
<img width="1407" height="201" alt="Screenshot 2026-07-21 at 2 52 52 PM" src="https://github.com/user-attachments/assets/b93eb308-d951-44aa-821d-bf78e062740b" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216537669158392