### PR TITLE
fix: allow multiple autosave drafts with empty slugs

### DIFF
--- a/packages/payload/src/fields/baseFields/slug/generateSlug.ts
+++ b/packages/payload/src/fields/baseFields/slug/generateSlug.ts
@@ -37,7 +37,10 @@ export const generateSlug =
       // Autosave drafts: do not auto-generate on the initial draft — the user is still entering content.
       // Keep the explicit non-slugified value (if any); generation begins on a later autosave.
       if (hasAutosaveEnabled(entity) && data?._status === 'draft') {
-        return value || null
+        // Leave an empty slug absent rather than `null`: the field's unique index is sparse, which
+        // skips missing values but not `null`, so multiple empty autosave drafts would otherwise
+        // collide on the unique constraint.
+        return value || undefined
       }
 
       // Keep an explicitly provided slug; otherwise generate from the source.
@@ -75,7 +78,7 @@ export const generateSlug =
 
     // Do not generate on the very first draft (no prior version yet).
     if (priorVersions === 0) {
-      return storedSlug ?? null
+      return storedSlug ?? undefined
     }
 
     // Stabilize after publish to protect live URLs.
@@ -84,5 +87,5 @@ export const generateSlug =
     }
 
     // Still auto-tracking an unpublished draft with content.
-    return source ? await slugify(source) : null
+    return source ? await slugify(source) : undefined
   }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -172,6 +172,25 @@ describe('Fields', () => {
         expect(draft.slug == null || draft.slug === '').toBe(true)
       })
 
+      it('should allow multiple empty-slug drafts without a unique collision', async () => {
+        const first = await payload.create({
+          collection: 'slug-autosave',
+          draft: true,
+          data: { title: 'Draft One' },
+        })
+        created.push(first.id)
+
+        const second = await payload.create({
+          collection: 'slug-autosave',
+          draft: true,
+          data: { title: 'Draft Two' },
+        })
+        created.push(second.id)
+
+        expect(first.slug == null || first.slug === '').toBe(true)
+        expect(second.slug == null || second.slug === '').toBe(true)
+      })
+
       it('should keep an explicit slug the user typed on the initial draft', async () => {
         const draft = await payload.create({
           collection: 'slug-autosave',


### PR DESCRIPTION
Slug fields are unique, but a new autosave draft starts out without a slug. Empty slugs were being saved as `null`, and Mongo's unique index treats two `null`s as a duplicate — so creating a second draft failed with a "value must be unique" error, which also left the create view blank.

Empty slugs are now left unset instead of `null`. The unique index is sparse, so it skips documents that have no slug yet, letting multiple drafts coexist.

Adds a test that creates two empty-slug drafts and confirms they no longer collide.
