### PR TITLE
fix(ui): redirect authenticated users on inactivity route

### DIFF
--- a/packages/ui/src/views/Logout/index.tsx
+++ b/packages/ui/src/views/Logout/index.tsx
@@ -1,5 +1,6 @@
 import type { AdminViewServerProps } from 'payload'
 
+import { getSafeRedirect } from 'payload/shared'
 import React from 'react'
 
 // eslint-disable-next-line payload/no-imports-from-exports-dir -- Server component must reference exports/client bundle for proper client boundary in prod builds
@@ -14,6 +15,7 @@ export const LogoutView: React.FC<
   } & AdminViewServerProps
 > = ({ inactivity, initPageResult, searchParams }) => {
   const {
+    req,
     req: {
       payload: {
         config: {
@@ -23,6 +25,15 @@ export const LogoutView: React.FC<
       user,
     },
   } = initPageResult
+
+  // Reaching the inactivity route while still authenticated (e.g. auto-login has
+  // re-authenticated the user) means the inactivity screen doesn't apply. Redirect back
+  // to where they were headed instead of rendering the logout overlay indefinitely.
+  if (inactivity && user) {
+    req.server.redirect(
+      getSafeRedirect({ fallbackTo: adminRoute, redirectTo: searchParams.redirect as string }),
+    )
+  }
 
   return (
     <div className={`${baseClass}`}>

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -128,6 +128,29 @@ describe('General', () => {
     await ensureCompilationIsDone({ customAdminRoutes, page, serverURL })
   })
 
+  describe('inactivity route', () => {
+    test('should redirect to admin when reaching the inactivity route while still authenticated', async () => {
+      // With auto-login enabled, the AuthProvider re-authenticates the user, so a request
+      // to the inactivity route arrives already logged in. Previously this rendered the
+      // logout loading overlay indefinitely — the user should instead be sent back to the
+      // route they were headed to (via the `redirect` param) rather than getting stuck.
+      const redirectTo = formatAdminURL({ adminRoute, path: '/collections/posts' })
+
+      await page.goto(
+        formatAdminURL({
+          adminRoute,
+          path: `${customAdminRoutes.inactivity!}?redirect=${encodeURIComponent(redirectTo)}`,
+          serverURL,
+        }),
+      )
+
+      await expect(page).toHaveURL(new RegExp(`${redirectTo}$`))
+      await expect(page.locator('.collection-list')).toBeVisible()
+      await expect(page.locator('.loading-overlay')).toBeHidden()
+      await expect(page).not.toHaveURL(/custom-inactivity/)
+    })
+  })
+
   describe('metadata', () => {
     describe('root title and description', () => {
       test('should render custom page title suffix', async () => {


### PR DESCRIPTION
## What

Redirects users away from the logout-inactivity route when they're still authenticated, instead of rendering the logout loading overlay forever.

## Why

With auto-login enabled, reaching the inactivity route (e.g.`/admin/logout-inactivity?redirect=%2Fadmin%2Fcollections%2Fusers`) loadedindefinitely. The `AuthProvider` re-authenticates the user on mount, so the inactivity view always saw a logged-in user and fell through to a permanent `<LoadingOverlay>` with no navigation.

## How

`LogoutView` now redirects server-side when `inactivity && user` (same approach as the login page).

## Testing

Added to test/admin/e2e.