### PR TITLE
fix: restore version fails validation on relationship filterOptions fields

### DIFF
--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -183,9 +183,33 @@ export const restoreVersionOperation = async <
 
     req.context.isRestoringVersion = true
 
+    // Validation runs against the default locale, so we need a request with an
+    // overridden `locale`/`fallbackLocale`. `req` is the incoming web `Request`,
+    // whose `headers` and `url` are getters backed by private class fields.
+    // Deriving an object via `Object.create(req)` leaves those getters on the
+    // prototype, so reading them later (e.g. in `createLocalReq` while validating
+    // a relationship field's `filterOptions`) invokes them with the wrong
+    // receiver and throws `Cannot read private member #... from an object whose
+    // class did not declare it`. Copy the resolved values as own data properties
+    // so they don't delegate to the private-field getters.
     const reqWithValidationLocale = Object.assign(Object.create(req), req, {
       fallbackLocale: null,
       locale: validationLocale,
+    })
+
+    Object.defineProperties(reqWithValidationLocale, {
+      headers: {
+        configurable: true,
+        enumerable: true,
+        value: req.headers,
+        writable: true,
+      },
+      url: {
+        configurable: true,
+        enumerable: true,
+        value: req.url,
+        writable: true,
+      },
     })
 
     let data = await beforeValidate({

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -17,6 +17,7 @@ import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { deepCopyObjectSimple } from '../../utilities/deepCopyObject.js'
 import { hasDraftValidationEnabled } from '../../utilities/getVersionsConfig.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
+import { isolateObjectProperty } from '../../utilities/isolateObjectProperty.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { resolveSelect } from '../../utilities/resolveSelect.js'
 import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
@@ -183,34 +184,9 @@ export const restoreVersionOperation = async <
 
     req.context.isRestoringVersion = true
 
-    // Validation runs against the default locale, so we need a request with an
-    // overridden `locale`/`fallbackLocale`. `req` is the incoming web `Request`,
-    // whose `headers` and `url` are getters backed by private class fields.
-    // Deriving an object via `Object.create(req)` leaves those getters on the
-    // prototype, so reading them later (e.g. in `createLocalReq` while validating
-    // a relationship field's `filterOptions`) invokes them with the wrong
-    // receiver and throws `Cannot read private member #... from an object whose
-    // class did not declare it`. Copy the resolved values as own data properties
-    // so they don't delegate to the private-field getters.
-    const reqWithValidationLocale = Object.assign(Object.create(req), req, {
-      fallbackLocale: null,
-      locale: validationLocale,
-    })
-
-    Object.defineProperties(reqWithValidationLocale, {
-      headers: {
-        configurable: true,
-        enumerable: true,
-        value: req.headers,
-        writable: true,
-      },
-      url: {
-        configurable: true,
-        enumerable: true,
-        value: req.url,
-        writable: true,
-      },
-    })
+    const reqWithValidationLocale = isolateObjectProperty(req, ['fallbackLocale', 'locale'])
+    reqWithValidationLocale.fallbackLocale = null
+    reqWithValidationLocale.locale = validationLocale
 
     let data = await beforeValidate({
       id: parentDocID,

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -124,6 +124,16 @@ const DraftPosts: CollectionConfig = {
       relationTo: draftCollectionSlug,
     },
     {
+      // `filterOptions` forces relationship validation to query the database
+      // (validateFilterOptions), which is the path that broke version restore
+      // when `req` is a real web Request. See versions int.spec restore tests.
+      name: 'relationWithFilterOptions',
+      type: 'relationship',
+      filterOptions: () => true,
+      hasMany: true,
+      relationTo: draftCollectionSlug,
+    },
+    {
       name: 'restrictedToUpdate',
       type: 'checkbox',
     },

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -124,12 +124,12 @@ const DraftPosts: CollectionConfig = {
       relationTo: draftCollectionSlug,
     },
     {
-      // `filterOptions` forces relationship validation to query the database
-      // (validateFilterOptions), which is the path that broke version restore
-      // when `req` is a real web Request. See versions int.spec restore tests.
       name: 'relationWithFilterOptions',
       type: 'relationship',
-      filterOptions: () => true,
+      filterOptions: ({ req }) => {
+        // Verify validation preserves access to native Request properties.
+        return req.payloadAPI === 'REST' ? req.method === 'POST' : true
+      },
       hasMany: true,
       relationTo: draftCollectionSlug,
     },

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -31,8 +31,8 @@ import {
   draftWithUploadCloudStorageCollectionSlug,
   draftWithUploadCollectionSlug,
   localizedCollectionSlug,
-  nestedArraySelectCollectionSlug,
   localizedGlobalSlug,
+  nestedArraySelectCollectionSlug,
   versionCollectionSlug,
 } from './slugs.js'
 
@@ -891,6 +891,69 @@ describe('Versions', () => {
           updatedAt: latestDraft.updatedAt,
         })
         expect(latestDraft.blocksField).toHaveLength(0)
+      })
+
+      it('should restore a version via REST when a relationship field with filterOptions is set', async () => {
+        // Regression: the REST API passes a real web Request whose `headers`/`url`
+        // are getters backed by private class fields. When restoring a version of
+        // a doc with a relationship field that defines `filterOptions`, relationship
+        // validation runs `validateFilterOptions` -> `createLocalReq`, which reads
+        // `req.headers`. A broken request clone invoked that getter with the wrong
+        // receiver and threw; the error was swallowed and every selection was
+        // reported as invalid, failing the restore with a 400 ValidationError.
+        const target = await payload.create({
+          collection: draftCollectionSlug,
+          data: { description: 'target', title: 'filter-options target' },
+          draft: true,
+        })
+
+        const doc = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            description: 'has relation',
+            relationWithFilterOptions: [target.id],
+            title: 'filter-options doc',
+          },
+          draft: true,
+        })
+
+        await payload.update({
+          id: doc.id,
+          collection: draftCollectionSlug,
+          data: {
+            relationWithFilterOptions: [target.id],
+            title: 'filter-options doc updated',
+          },
+          draft: true,
+        })
+
+        const versions = await payload.findVersions({
+          collection: draftCollectionSlug,
+          where: { parent: { equals: doc.id } },
+        })
+
+        const versionToRestore = versions.docs[versions.docs.length - 1]
+        expect(versionToRestore?.version.relationWithFilterOptions).toBeDefined()
+
+        // Mimics the admin UI restore button: POST /:collection/versions/:id
+        const response = await restClient.POST(
+          `/${draftCollectionSlug}/versions/${versionToRestore!.id}`,
+        )
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body.errors).toBeUndefined()
+
+        const restored = await payload.findByID({
+          id: doc.id,
+          collection: draftCollectionSlug,
+          depth: 0,
+          draft: true,
+        })
+        expect(restored.relationWithFilterOptions).toStrictEqual([target.id])
+
+        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: target.id })
       })
 
       it('should not copy current document fields into restored version', async () => {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -894,13 +894,6 @@ describe('Versions', () => {
       })
 
       it('should restore a version via REST when a relationship field with filterOptions is set', async () => {
-        // Regression: the REST API passes a real web Request whose `headers`/`url`
-        // are getters backed by private class fields. When restoring a version of
-        // a doc with a relationship field that defines `filterOptions`, relationship
-        // validation runs `validateFilterOptions` -> `createLocalReq`, which reads
-        // `req.headers`. A broken request clone invoked that getter with the wrong
-        // receiver and threw; the error was swallowed and every selection was
-        // reported as invalid, failing the restore with a 400 ValidationError.
         const target = await payload.create({
           collection: draftCollectionSlug,
           data: { description: 'target', title: 'filter-options target' },
@@ -952,8 +945,8 @@ describe('Versions', () => {
         })
         expect(restored.relationWithFilterOptions).toStrictEqual([target.id])
 
-        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: target.id })
+        await payload.delete({ id: doc.id, collection: draftCollectionSlug })
+        await payload.delete({ id: target.id, collection: draftCollectionSlug })
       })
 
       it('should not copy current document fields into restored version', async () => {

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -311,6 +311,7 @@ export interface DraftPost {
   select?: ('test1' | 'test2')[] | null;
   blocksField?: Block[] | null;
   relation?: (string | null) | DraftPost;
+  relationWithFilterOptions?: (string | DraftPost)[] | null;
   restrictedToUpdate?: boolean | null;
   updatedAt: string;
   createdAt: string;
@@ -1108,6 +1109,7 @@ export interface DraftPostsSelect<T extends boolean = true> {
             };
       };
   relation?: T;
+  relationWithFilterOptions?: T;
   restrictedToUpdate?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
Restoring a collection version through the REST API could report valid relationship selections as invalid when the field defines `filterOptions`.

1. Version restore validates data using the default locale, requiring an isolated `locale` and `fallbackLocale`.
2. The derived request inherited native `Request` getters backed by private fields.
3. Accessing properties such as `headers`, `url`, or `method` used the derived object as the receiver and threw. Relationship validation caught the error and reported the selection as invalid.

The fix is to isolate only `locale` and `fallbackLocale` with `isolateObjectProperty`, preserving access to the original request’s native properties.

Adds a REST regression test covering version restore with a `filterOptions` relationship field.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216597988811194