### PR TITLE
feat(ui): portal datepicker element

### DIFF
--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -95,6 +95,7 @@ const DatePicker: React.FC<Props> = (props) => {
     onChange,
     placeholderText,
     popperPlacement: 'bottom-start',
+    portalId: 'date-time-picker-portal',
     previousMonthButtonLabel: <ChevronIcon direction="left" />,
     previousYearButtonLabel: '‹',
     selected: value && new Date(value),

--- a/packages/ui/src/elements/DatePicker/index.css
+++ b/packages/ui/src/elements/DatePicker/index.css
@@ -40,7 +40,7 @@
   }
 
   .react-datepicker-popper {
-    z-index: 10;
+    z-index: var(--z-portal-element);
     line-height: 0;
   }
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1596,9 +1596,6 @@ describe('Versions', () => {
       const popper = page.locator('.react-datepicker-popper')
       await expect(popper).toBeVisible()
 
-      // The calendar is portaled to a dedicated container appended to the document body,
-      // escaping the drawer's `.drawer__content-children` (which caps its height with
-      // `overflow-y: auto`) so it isn't clipped when it renders near the bottom of the drawer.
       const portalInfo = await popper.evaluate((el) => ({
         isInsideDrawerScroll: el.closest('.drawer__content-children') !== null,
         isInsidePortal: el.closest('#date-time-picker-portal') !== null,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1581,6 +1581,34 @@ describe('Versions', () => {
       })
     })
 
+    test('should not clip the calendar popup inside the schedule publish drawer', async () => {
+      await page.goto(url.create)
+      await page.locator('#field-title').fill('scheduled publish positioning')
+      await page.locator('#field-description').fill('scheduled publish positioning description')
+
+      await saveDocAndAssert(page)
+      await page.locator('#schedule-publish-button').click()
+
+      await expect(page.locator('.drawer__header')).toBeVisible()
+
+      await page.locator('.date-time-picker input').click()
+
+      const popper = page.locator('.react-datepicker-popper')
+      await expect(popper).toBeVisible()
+
+      // The calendar is portaled to a dedicated container appended to the document body,
+      // escaping the drawer's `.drawer__content-children` (which caps its height with
+      // `overflow-y: auto`) so it isn't clipped when it renders near the bottom of the drawer.
+      const portalInfo = await popper.evaluate((el) => ({
+        isInsideDrawerScroll: el.closest('.drawer__content-children') !== null,
+        isInsidePortal: el.closest('#date-time-picker-portal') !== null,
+      }))
+      expect(portalInfo.isInsideDrawerScroll).toBe(false)
+      expect(portalInfo.isInsidePortal).toBe(true)
+
+      await expect(popper).toBeInViewport()
+    })
+
     test('can still schedule publish once autosave is triggered', async () => {
       await page.goto(autosaveURL.create)
       await page.locator('#field-title').fill('scheduled publish')


### PR DESCRIPTION
This PR portals the React Datepicker element so that it doesn't have any overflow issues within our UI and doesn't get clipped anymore, this mostly affected mobile devices where vertical space is limited.

## Before

https://github.com/user-attachments/assets/92a12b12-dc79-427f-b03d-8755a8d91b63

## After

https://github.com/user-attachments/assets/f91e6dfc-3ae3-46e2-b939-aca3961ad95c

