### PR TITLE
fix(ui): add title tooltip to list view sort controls

### DIFF
--- a/packages/ui/src/elements/SortColumn/index.tsx
+++ b/packages/ui/src/elements/SortColumn/index.tsx
@@ -63,6 +63,10 @@ export const SortColumn: React.FC<SortColumnProps> = (props) => {
             })}
             className={[...descClasses, `${baseClass}__button`].filter(Boolean).join(' ')}
             onClick={() => void handleSortChange(desc)}
+            title={t('general:sortByLabelDirection', {
+              direction: t('general:descending'),
+              label,
+            })}
             type="button"
           >
             <ChevronIcon size={16} />
@@ -74,6 +78,10 @@ export const SortColumn: React.FC<SortColumnProps> = (props) => {
             })}
             className={[...ascClasses, `${baseClass}__button`].filter(Boolean).join(' ')}
             onClick={() => void handleSortChange(asc)}
+            title={t('general:sortByLabelDirection', {
+              direction: t('general:ascending'),
+              label,
+            })}
             type="button"
           >
             <ChevronIcon direction="up" size={16} />

--- a/packages/ui/src/elements/SortColumn/index.tsx
+++ b/packages/ui/src/elements/SortColumn/index.tsx
@@ -41,6 +41,15 @@ export const SortColumn: React.FC<SortColumnProps> = (props) => {
 
   const isSorted = sort === asc || sort === desc
 
+  const descLabel = t('general:sortByLabelDirection', {
+    direction: t('general:descending'),
+    label,
+  })
+  const ascLabel = t('general:sortByLabelDirection', {
+    direction: t('general:ascending'),
+    label,
+  })
+
   return (
     <div
       className={[
@@ -57,31 +66,19 @@ export const SortColumn: React.FC<SortColumnProps> = (props) => {
       {!disable && (
         <div className={`${baseClass}__buttons`}>
           <button
-            aria-label={t('general:sortByLabelDirection', {
-              direction: t('general:descending'),
-              label,
-            })}
+            aria-label={descLabel}
             className={[...descClasses, `${baseClass}__button`].filter(Boolean).join(' ')}
             onClick={() => void handleSortChange(desc)}
-            title={t('general:sortByLabelDirection', {
-              direction: t('general:descending'),
-              label,
-            })}
+            title={descLabel}
             type="button"
           >
             <ChevronIcon size={16} />
           </button>
           <button
-            aria-label={t('general:sortByLabelDirection', {
-              direction: t('general:ascending'),
-              label,
-            })}
+            aria-label={ascLabel}
             className={[...ascClasses, `${baseClass}__button`].filter(Boolean).join(' ')}
             onClick={() => void handleSortChange(asc)}
-            title={t('general:sortByLabelDirection', {
-              direction: t('general:ascending'),
-              label,
-            })}
+            title={ascLabel}
             type="button"
           >
             <ChevronIcon direction="up" size={16} />


### PR DESCRIPTION
Adds a `title` attribute to the ascending and descending sort buttons in `SortColumn` so hovering a chevron reveals which column and direction it sorts.

The buttons already exposed an `aria-label` for screen readers but had no visible tooltip on hover. The `title` reuses the existing `general:sortByLabelDirection` translation, e.g. "Sort by Title ascending".

<img width="274" height="89" alt="Screenshot 2026-07-22 at 11 46 06 AM" src="https://github.com/user-attachments/assets/74e0b0b9-7cf9-4e35-a963-5c19f351a9b1" />

<img width="279" height="87" alt="Screenshot 2026-07-22 at 11 46 13 AM" src="https://github.com/user-attachments/assets/3cdec802-1608-4b04-8bbc-a14b362d1e30" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216784036896444