### PR TITLE
fix: pass id to delete access control on soft delete in updateByID

### DIFF
--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -133,7 +133,7 @@ export const updateByIDOperation = async <
 
     if (isTrashAttempt && !overrideAccess) {
       // Pass data so access function can check data.deletedAt to know it's a trash attempt
-      const deleteAccessResult = await executeAccess({ data, req }, collectionConfig.access.delete)
+      const deleteAccessResult = await executeAccess({ id, data, req }, collectionConfig.access.delete)
       fullWhere = combineQueries(fullWhere, deleteAccessResult)
     }
 


### PR DESCRIPTION
### What?
Fixes a missing `id` in the `access.delete` control callback when a document is soft-deleted (trashed) via the `updateByID` operation.

### Why?
When a collection has `trash: true`, soft-deleting a document goes through the `updateByID` operation. The `access.update` callback correctly receives `{ id, data, req }`, but the `access.delete` callback (called right below it for the trash check) only received `{ data, req }` — `id` was missing. This makes it impossible for a `delete` access control function to reliably identify which document is being trashed, forcing developers to rely on `data.deletedAt` alone, which is poor DX and was already flagged as confusing in the linked issue.

### How?
One-line fix in `packages/payload/src/collections/operations/updateByID.ts` — `id` was already destructured and in scope at that point in the function, so it just needed to be passed through:

```diff
- const deleteAccessResult = await executeAccess({ data, req }, collectionConfig.access.delete)
+ const deleteAccessResult = await executeAccess({ id, data, req }, collectionConfig.access.delete)
```

Fixes #17452
