### PR TITLE
fix: pass id to delete access control on trash attempts in updateByID

### DIFF
--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -138,7 +138,10 @@ export const updateByIDOperation = async <
 
     if (isTrashAttempt && !overrideAccess) {
       // Pass data so access function can check data.deletedAt to know it's a trash attempt
-      const deleteAccessResult = await executeAccess({ data, req }, collectionConfig.access.delete)
+      const deleteAccessResult = await executeAccess(
+        { id, data, req },
+        collectionConfig.access.delete,
+      )
       fullWhere = combineQueries(fullWhere, deleteAccessResult)
     }
 

--- a/test/trash/collections/DifferentiatedTrashCollection/index.ts
+++ b/test/trash/collections/DifferentiatedTrashCollection/index.ts
@@ -2,6 +2,13 @@ import type { CollectionConfig } from 'payload'
 
 export const differentiatedTrashCollectionSlug = 'differentiated-trash-collection'
 
+/**
+ * Captures the `id` argument received by the `delete` access control function
+ * on the most recent invocation, so tests can assert it was passed through
+ * for soft-delete (trash) attempts.
+ */
+export let lastDeleteAccessID: number | string | undefined
+
 export const DifferentiatedTrashCollection: CollectionConfig = {
   slug: differentiatedTrashCollectionSlug,
   admin: {
@@ -19,7 +26,9 @@ export const DifferentiatedTrashCollection: CollectionConfig = {
    * - Admins: Can both trash and permanently delete
    */
   access: {
-    delete: ({ req: { user }, data }) => {
+    delete: ({ id, req: { user }, data }) => {
+      lastDeleteAccessID = id
+
       // Not logged in - no access
       if (!user) {
         return false

--- a/test/trash/int.spec.ts
+++ b/test/trash/int.spec.ts
@@ -10,7 +10,10 @@ import type { DifferentiatedTrashCollection, Post, RestrictedCollection } from '
 import { idToString } from '../__helpers/shared/idToString.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser, regularUser } from '../credentials.js'
-import { differentiatedTrashCollectionSlug } from './collections/DifferentiatedTrashCollection/index.js'
+import {
+  differentiatedTrashCollectionSlug,
+  lastDeleteAccessID,
+} from './collections/DifferentiatedTrashCollection/index.js'
 import { pagesSlug } from './collections/Pages/index.js'
 import { postsSlug } from './collections/Posts/index.js'
 import { restrictedCollectionSlug } from './collections/RestrictedCollection/index.js'
@@ -195,6 +198,7 @@ describe('trash', () => {
         })
 
         expect(trashedDoc.deletedAt).toBeDefined()
+        expect(lastDeleteAccessID).toBe(doc.id)
       })
 
       it('should allow admin to trash (soft-delete) a document', async () => {


### PR DESCRIPTION
The delete access control callback did not receive the document id when checking permissions for a soft-delete (trash) attempt inside updateByID, making it impossible to rely on id in access functions and forcing developers to inspect data.deletedAt instead.

Fixes #17452 