### PR TITLE
fix(ui): add missing React keys in folder list views

### DIFF
--- a/packages/ui/src/elements/DefaultListViewTabs/index.tsx
+++ b/packages/ui/src/elements/DefaultListViewTabs/index.tsx
@@ -81,6 +81,7 @@ export const DefaultListViewTabs: React.FC<DefaultListViewTabsProps> = ({
         disabled={viewType === 'list'}
         el="button"
         id={allButtonId}
+        key="all-tab"
         onClick={() => handleViewChange('list')}
       >
         {t('general:all')} {getTranslation(collectionConfig?.labels?.plural, i18n)}
@@ -97,6 +98,7 @@ export const DefaultListViewTabs: React.FC<DefaultListViewTabsProps> = ({
             .join(' ')}
           disabled={viewType === 'folders'}
           el="button"
+          key="folders-tab"
           onClick={() => handleViewChange('folders')}
         >
           {t('folder:byFolder')}
@@ -115,6 +117,7 @@ export const DefaultListViewTabs: React.FC<DefaultListViewTabsProps> = ({
           disabled={viewType === 'trash'}
           el="button"
           id="trash-view-pill"
+          key="trash-tab"
           onClick={() => handleViewChange('trash')}
         >
           {t('general:trash')}

--- a/packages/ui/src/elements/FolderView/Drawers/MoveToFolder/index.tsx
+++ b/packages/ui/src/elements/FolderView/Drawers/MoveToFolder/index.tsx
@@ -263,7 +263,7 @@ function Content({
               id: null,
               name: (
                 <span className={`${baseClass}__folder-breadcrumbs-root`}>
-                  <ColoredFolderIcon />
+                  <ColoredFolderIcon key="folder-icon" />
                   {t('folder:folders')}
                 </span>
               ),

--- a/packages/ui/src/elements/FolderView/FolderFileTable/index.tsx
+++ b/packages/ui/src/elements/FolderView/FolderFileTable/index.tsx
@@ -118,7 +118,7 @@ export function FolderFileTable({ showRelationCell = true }: Props) {
                 if (index === 0) {
                   return (
                     <span className={`${baseClass}__cell-with-icon`} key={`${itemKey}-${name}`}>
-                      <ColoredFolderIcon />
+                      <ColoredFolderIcon key="folder-icon" />
                       {cellValue}
                     </span>
                   )

--- a/packages/ui/src/views/BrowseByFolder/index.tsx
+++ b/packages/ui/src/views/BrowseByFolder/index.tsx
@@ -174,7 +174,7 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
           ? {
               label: (
                 <div className={`${baseClass}__step-nav-icon-label`} key="root">
-                  <ColoredFolderIcon />
+                  <ColoredFolderIcon key="folder-icon" />
                   {t('folder:browseByFolder')}
                 </div>
               ),
@@ -196,7 +196,7 @@ function BrowseByFolderViewInContext(props: BrowseByFolderViewInContextProps) {
                     })
                   }}
                 >
-                  <ColoredFolderIcon />
+                  <ColoredFolderIcon key="folder-icon" />
                   {t('folder:browseByFolder')}
                 </DroppableBreadcrumb>
               ),

--- a/packages/ui/src/views/CollectionFolder/index.tsx
+++ b/packages/ui/src/views/CollectionFolder/index.tsx
@@ -174,7 +174,7 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
           ? {
               label: (
                 <div className={`${baseClass}__step-nav-icon-label`} key="root">
-                  <ColoredFolderIcon />
+                  <ColoredFolderIcon key="folder-icon" />
                   {getTranslation(labels?.plural, i18n)}
                 </div>
               ),
@@ -203,7 +203,7 @@ function CollectionFolderViewInContext(props: CollectionFolderViewInContextProps
                     })
                   }}
                 >
-                  <ColoredFolderIcon />
+                  <ColoredFolderIcon key="folder-icon" />
                   {getTranslation(labels?.plural, i18n)}
                 </DroppableBreadcrumb>
               ),


### PR DESCRIPTION
## Description

With folders enabled, published `@payloadcms/ui` (built with React Compiler) triggers React console warnings:

> Each child in a list should have a unique "key" prop.

Folder UI renders `ColoredFolderIcon` next to a label (and list-view tab buttons) as sibling children. In source TSX this is valid as normal JSX children. After `build:reactcompiler`, those siblings are emitted as an array of elements without keys, for example:

    children: [_jsx(ColoredFolderIcon, {}), getTranslation(...)]

React then warns about missing keys (often attributed to a minified parent from `CollectionFolderView`).

This PR adds stable `key` props in the source so they survive the React Compiler build:

- `key="folder-icon"` on `ColoredFolderIcon` in folder breadcrumbs / table / move drawer
- `key="all-tab" | "folders-tab" | "trash-tab"` on `DefaultListViewTabs` buttons

## Reproduction

1. Use a Payload app with folders enabled and the **published** `@payloadcms/ui` package (not monorepo source-alias `pnpm dev`, which points at TSX and does not surface this warning).
2. Open a collection with folders (e.g. Media) → **By Folder** view / folder breadcrumbs.
3. Observe the React key warning in the browser console.

Alternatively, after `pnpm turbo build --filter="@payloadcms/ui..."`, inspect compiled output:

    rg 'ColoredFolderIcon, \{\}' packages/ui/dist/views/CollectionFolder/index.js

Before this fix the pattern has no key; after rebuild it should include `key: "folder-icon"`.

## Notes

- Targets `3.x` (folder UI). On `main` this area is being replaced by hierarchy.
- No intentional behavior change — console warning fix only.
