### PR TITLE
chore(ui): export formErrorHandler

### DIFF
--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -437,6 +437,10 @@ export {
 } from '../../providers/RouteTransition/index.js'
 export { ConfigProvider, PageConfigProvider, useConfig } from '../../providers/Config/index.js'
 export { DocumentEventsProvider, useDocumentEvents } from '../../providers/DocumentEvents/index.js'
+export {
+  FormErrorHandlerContext,
+  useFormErrorHandler,
+} from '../../providers/FormErrorHandler/index.js'
 export { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 export { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
 export type { DocumentTitleContext } from '../../providers/DocumentTitle/index.js'

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -30,6 +30,7 @@ import { useThrottledEffect } from '../../hooks/useThrottledEffect.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
+import { useFormErrorHandler } from '../../providers/FormErrorHandler/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useOperation } from '../../providers/Operation/index.js'
 import { useRouter } from '../../providers/RouterAdapter/index.js'
@@ -95,6 +96,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const { code: locale } = useLocale()
   const { i18n, t } = useTranslation()
   const { refreshCookie, user } = useAuth()
+  const onNonFieldError = useFormErrorHandler()
   const operation = useOperation()
   const { queueTask } = useQueue()
 
@@ -278,11 +280,11 @@ export const Form: React.FC<FormProps> = (props) => {
       const hasFormSubmitAction =
         actionArg || typeof action === 'string' || typeof action === 'function'
 
-      if (redirect || disableToast || !hasFormSubmitAction) {
+      if (redirect || disableToast || !hasFormSubmitAction || Boolean(onNonFieldError)) {
         // Do not show submitting toast, as the promise toast may never disappear under these conditions.
         // Instead, make successToast() or errorToast() throw toast.success / toast.error
         successToast = (data) => toast.success(data)
-        errorToast = (data) => toast.error(data)
+        errorToast = (data) => { if (data) toast.error(data) }
       } else {
         toast.promise(promise, {
           error: (data) => {
@@ -511,6 +513,9 @@ export const Form: React.FC<FormProps> = (props) => {
             })
 
             nonFieldErrors.forEach((err) => {
+              if (onNonFieldError?.(err)) {
+                return
+              }
               errorToast(<FieldErrorsToast errorMessage={err.message || t('error:unknown')} />)
             })
 
@@ -551,6 +556,7 @@ export const Form: React.FC<FormProps> = (props) => {
       waitForAutocomplete,
       setModified,
       setSubmitted,
+      onNonFieldError,
     ],
   )
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -280,11 +280,11 @@ export const Form: React.FC<FormProps> = (props) => {
       const hasFormSubmitAction =
         actionArg || typeof action === 'string' || typeof action === 'function'
 
-      if (redirect || disableToast || !hasFormSubmitAction || Boolean(onNonFieldError)) {
+      if (redirect || disableToast || !hasFormSubmitAction) {
         // Do not show submitting toast, as the promise toast may never disappear under these conditions.
         // Instead, make successToast() or errorToast() throw toast.success / toast.error
         successToast = (data) => toast.success(data)
-        errorToast = (data) => { if (data) toast.error(data) }
+        errorToast = (data) => toast.error(data)
       } else {
         toast.promise(promise, {
           error: (data) => {

--- a/packages/ui/src/providers/FormErrorHandler/index.tsx
+++ b/packages/ui/src/providers/FormErrorHandler/index.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { createContext, use } from 'react'
+
+export type NonFieldError = {
+  data?: unknown
+  message: string
+}
+
+/**
+ * A callback that a plugin can provide to intercept non-field form errors before
+ * Payload shows its default error toast. Return `true` to claim the error (the
+ * default toast is suppressed). Return `false` to let Payload handle it normally.
+ *
+ * Set via `<FormErrorHandlerContext value={handler}>` inside an
+ * `admin.components.providers` entry. The Form reads this automatically — no
+ * changes to collection config or the edit view are required.
+ *
+ * Multiple handlers can be chained by composing providers; the first one to
+ * return `true` wins.
+ */
+export type FormErrorHandler = (err: NonFieldError) => boolean
+
+export const FormErrorHandlerContext = createContext<FormErrorHandler | undefined>(undefined)
+
+export const useFormErrorHandler = (): FormErrorHandler | undefined => use(FormErrorHandlerContext)


### PR DESCRIPTION
Adds a small seam in the Form component that allows plugins to intercept non-field save errors before Payload shows its default error toast.