### PR TITLE
fix: head requests to /api/media/file/:filename return 404 instead of 200 (RFC 9110 §9.3.2)

### DIFF
--- a/packages/next/src/exports/routes.ts
+++ b/packages/next/src/exports/routes.ts
@@ -3,6 +3,7 @@ export { GRAPHQL_PLAYGROUND_GET, GRAPHQL_POST } from '../routes/graphql/index.js
 export {
   DELETE as REST_DELETE,
   GET as REST_GET,
+  HEAD as REST_HEAD,
   OPTIONS as REST_OPTIONS,
   PATCH as REST_PATCH,
   POST as REST_POST,

--- a/packages/next/src/routes/index.ts
+++ b/packages/next/src/routes/index.ts
@@ -3,7 +3,9 @@ export { GRAPHQL_PLAYGROUND_GET, GRAPHQL_POST } from './graphql/index.js'
 export {
   DELETE as REST_DELETE,
   GET as REST_GET,
+  HEAD as REST_HEAD,
   OPTIONS as REST_OPTIONS,
   PATCH as REST_PATCH,
   POST as REST_POST,
+  PUT as REST_PUT,
 } from './rest/index.js'

--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -51,6 +51,8 @@ export const OPTIONS = handlerBuilder
 
 export const GET = handlerBuilder
 
+export const HEAD = handlerBuilder
+
 export const POST = handlerBuilder
 
 export const DELETE = handlerBuilder

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -216,31 +216,45 @@ export const handleEndpoints = async ({
       )
     }
 
+    const reqMethod = req.method?.toLowerCase()
+
+    const findEndpoint = (targetMethod: string) =>
+      endpoints?.find((endpoint) => {
+        if (endpoint.method !== targetMethod) {
+          return false
+        }
+
+        const pathMatchFn = match(endpoint.path, { decode: decodeURIComponent })
+
+        const matchResult = pathMatchFn(adjustedPathname)
+
+        if (!matchResult) {
+          return false
+        }
+
+        req.routeParams = matchResult.params as Record<string, unknown>
+
+        // Inject to routeParams the slug as well so it can be used later
+        if (collection) {
+          req.routeParams.collection = collection.config.slug
+        } else if (globalConfig) {
+          req.routeParams.global = globalConfig.slug
+        }
+
+        return true
+      })
+
     // Find the relevant endpoint configuration
-    const endpoint = endpoints?.find((endpoint) => {
-      if (endpoint.method !== req.method?.toLowerCase()) {
-        return false
-      }
+    let endpoint = findEndpoint(reqMethod!)
 
-      const pathMatchFn = match(endpoint.path, { decode: decodeURIComponent })
-
-      const matchResult = pathMatchFn(adjustedPathname)
-
-      if (!matchResult) {
-        return false
-      }
-
-      req.routeParams = matchResult.params as Record<string, unknown>
-
-      // Inject to routeParams the slug as well so it can be used later
-      if (collection) {
-        req.routeParams.collection = collection.config.slug
-      } else if (globalConfig) {
-        req.routeParams.global = globalConfig.slug
-      }
-
-      return true
-    })
+    // Per RFC 9110 §9.3.2, HEAD must behave identically to GET except that the
+    // server must not send a response body. Fall back to the GET endpoint so that
+    // HEAD /file/:filename returns the same status and headers as GET.
+    let isHeadViaGetFallback = false
+    if (!endpoint && reqMethod === 'head') {
+      endpoint = findEndpoint('get')
+      isHeadViaGetFallback = Boolean(endpoint)
+    }
 
     if (endpoint) {
       handler = endpoint.handler
@@ -267,7 +281,15 @@ export const handleEndpoints = async ({
 
     const response = await handler(req)
 
-    return new Response(response.body, {
+    // For HEAD requests resolved via the GET fallback, cancel the body stream
+    // (e.g. an open fs.ReadStream) so the file handle is released immediately,
+    // then return an empty body — headers and status are preserved as required
+    // by RFC 9110 §9.3.2.
+    if (isHeadViaGetFallback && response.body) {
+      await response.body.cancel()
+    }
+
+    return new Response(isHeadViaGetFallback ? null : response.body, {
       headers: headersWithCors({
         headers: mergeHeaders(req.responseHeaders ?? new Headers(), response.headers),
         req,

--- a/test/__helpers/shared/NextRESTClient.ts
+++ b/test/__helpers/shared/NextRESTClient.ts
@@ -5,6 +5,7 @@ import {
   REST_DELETE as createDELETE,
   REST_GET as createGET,
   GRAPHQL_POST as createGraphqlPOST,
+  REST_HEAD as createHEAD,
   REST_PATCH as createPATCH,
   REST_POST as createPOST,
   REST_PUT as createPUT,
@@ -59,6 +60,11 @@ export class NextRESTClient {
 
   private _GRAPHQL_POST: (request: Request) => Promise<Response>
 
+  private _HEAD: (
+    request: Request,
+    args: { params: Promise<{ slug: string[] }> },
+  ) => Promise<Response>
+
   private _PATCH: (
     request: Request,
     args: { params: Promise<{ slug: string[] }> },
@@ -86,6 +92,7 @@ export class NextRESTClient {
       this.serverURL = config.serverURL
     }
     this._GET = createGET(config)
+    this._HEAD = createHEAD(config)
     this._POST = createPOST(config)
     this._DELETE = createDELETE(config)
     this._PATCH = createPATCH(config)
@@ -163,6 +170,22 @@ export class NextRESTClient {
       method: 'GET',
     })
     return this._GET(request, { params: Promise.resolve({ slug }) })
+  }
+
+  async HEAD(
+    path: ValidPath,
+    options: Omit<RequestInit, 'body'> & RequestOptions = {},
+  ): Promise<Response> {
+    const { slug, params, url } = this.generateRequestParts(path)
+    const { query, ...rest } = options || {}
+    const queryParams = generateQueryString(query, params)
+
+    const request = new Request(`${url}${queryParams}`, {
+      ...rest,
+      headers: this.buildHeaders(options),
+      method: 'HEAD',
+    })
+    return this._HEAD(request, { params: Promise.resolve({ slug }) })
   }
 
   async GRAPHQL_POST(options: RequestInit & RequestOptions): Promise<Response> {

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -715,6 +715,25 @@ describe('Collections - Uploads', () => {
 
         await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
       })
+
+      it('should handle HEAD request for media file returning identical status and content-type', async () => {
+        const filePath = path.resolve(dirname, './image.png')
+        const file = await getFileByPath(filePath)
+        file.name = 'head-test.png'
+
+        const mediaDoc = (await payload.create({
+          collection: mediaSlug,
+          data: {},
+          file,
+        })) as unknown as Media
+
+        const response = await restClient.HEAD(`/${mediaSlug}/file/${mediaDoc.filename}`)
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toContain('image/png')
+
+        await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
+      })
     })
   })
 


### PR DESCRIPTION
**Problem**

Per RFC 9110 §9.3.2, a HEAD response must be identical to GET except for
the absence of a response body. However, `HEAD /api/media/file/:filename`
returned `404` while `GET` returned `200` for the exact same URL.
```bash
URL='https://your-site.example.com/api/media/file/portrait.jpg'
curl -sI "$URL" | head -n1
# Observed: HTTP/2 404
# Expected: HTTP/2 200
curl -s -o /dev/null -w '%{http_code}\n' "$URL"
# Observed: 200 (GET works fine)
This causes operator scripts and upstream proxies that use HEAD as a cheap existence probe to report false 404s.

**Root Cause**
Two compounding issues:

HEAD was not exported from @payloadcms/next/routes — so Next.js App Router had no explicit HEAD handler, falling back to its auto-synthesis which failed to reach the media file route.

handleEndpoints passed the full body back for HEAD — the HEAD→GET routing fallback correctly found the getFileHandler, but the handler opened an fs.createReadStream and returned a Response with a full body stream. The body was passed through unchanged, leaking an open file handle and producing a non-RFC-compliant response.

**Fix**
packages/next/src/routes/rest/index.ts
Export HEAD = handlerBuilder so Next.js App Router registers an explicit HEAD handler at the route level.

packages/next/src/routes/index.ts + packages/next/src/exports/routes.ts
Re-export HEAD as REST_HEAD so consumers can import it explicitly in their app/(payload)/api/[...slug]/route.ts.

packages/payload/src/utilities/handleEndpoints.ts
When HEAD is resolved via the GET fallback:

Cancel the body stream immediately — releases the fs.createReadStream file handle, prevents resource leaks.
Return new Response(null, ...) — body-less, but with identical Content-Type, Content-Length, Accept-Ranges, and status code, fully compliant with RFC 9110 §9.3.2.
test/__helpers/shared/NextRESTClient.ts
Add a HEAD() method wired to REST_HEAD so integration tests can issue HEAD requests end-to-end.

test/uploads/int.spec.ts
Add regression test verifying:

HEAD /media/file/:filename → 200
content-type header matches (image/png)
Uploaded document is cleaned up after the test