### PR TITLE
fix(templates): prevent unauthenticated draft-mode access in website preview route

### DIFF
--- a/templates/website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/website/src/app/(frontend)/next/preview/route.ts
@@ -35,10 +35,11 @@ export async function GET(req: NextRequest): Promise<Response> {
   let user
 
   try {
-    user = await payload.auth({
+    const authResult = await payload.auth({
       req: req as unknown as PayloadRequest,
       headers: req.headers,
     })
+    user = authResult.user
   } catch (error) {
     payload.logger.error({ err: error }, 'Error verifying token for live preview')
     return new Response('You are not allowed to preview this page', { status: 403 })


### PR DESCRIPTION
## What?

Fixes the auth bypass in the website template's preview route (`templates/website/src/app/(frontend)/next/preview/route.ts`).

Backport of #17205 (bf2d96e) from `main` to `3.x`. Closes #17204

## Why?

`payload.auth()` always resolves to a truthy object — `{ user, permissions, responseHeaders }` — even when the request is unauthenticated (in which case `user` is `null`). The route assigned that whole object to `user`, so the `if (!user)` guard was dead code and never returned 403.

The practical impact: anyone who knows `PREVIEW_SECRET` (which is only meant to block crawlers, not authorize users) could enable Next.js draft mode and read unpublished content without logging in.

## How?

Destructure `user` off the auth result so the guard checks the actual user rather than the always-truthy wrapper object.