### PR TITLE
fix(templates): mark website button as client component for radix-slot context

### DIFF
--- a/templates/website/src/components/ui/button.tsx
+++ b/templates/website/src/components/ui/button.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { cn } from '@/utilities/ui'
 import { Slot } from '@radix-ui/react-slot'
 import { type VariantProps, cva } from 'class-variance-authority'


### PR DESCRIPTION
## What?

Adds a `'use client'` directive to the website template's `src/components/ui/button.tsx`.

## Why?

The website template build fails when `@radix-ui/react-slot@1.3.1` is resolved (published 2026-07-22, part of a coordinated Radix release), with:

```
TypeError: createContext only works in Client Components. Add the "use client"
directive at the top of the file to use it.
    at module evaluation (src/components/ui/button.tsx:2:1)   // import { Slot } from '@radix-ui/react-slot'
    at module evaluation (src/components/Link/index.tsx)
    at src/Footer/Component.tsx
    at src/app/(frontend)/layout.tsx
```

Root cause: `@radix-ui/react-slot@1.3.1` introduced a **module-level** `React.createContext` (`SlotContext`) that `1.3.0` did not have. The template pulls Radix via unpinned caret ranges (`^1.0.2`) with no committed lockfile, so a fresh install resolves `1.3.1`.

`ui/button.tsx` imports `Slot` but had no `'use client'` directive, and it is reachable from the Server Component graph (`layout.tsx` → `Footer` → `Link` → `button`). Evaluating that module on the server now runs `createContext`, which throws under React's server condition — so the build fails while collecting page data.

This is unrelated to any individual PR's diff; it affects every recent PR (e.g. one touching only `richtext-lexical` failed identically). Upstream regression is tracked in radix-ui/primitives#3542.

## How?

Mark `button.tsx` as a client component. It now legitimately depends on client-only context via `react-slot`, so this keeps its module body out of the server graph. The other Radix-importing template components (`label`, `checkbox`, `select`) already have the directive; `button` was the only one missing it.

## Alternatives considered — why `'use client'` over pinning a version

The other common fix is to **pin `@radix-ui/react-slot` to `1.3.0`** (e.g. a root `overrides`/`resolutions` entry, optionally guarded by a Renovate/Dependabot rule to stop the broken version from being re-introduced). We chose the directive instead:

- **Version-independent.** `'use client'` is the resolution Next.js's own error message prescribes and works with *any* Radix version — including the eventual fixed release. Pinning freezes Slot at an old version and only holds until the next transitive bump slips the bad version back in.
- **Nothing to unwind.** A pin is temporary debt: it needs a tracking note and a cleanup PR once a fixed Radix ships. The directive is a one-line, permanent correctness fix with no follow-up.
- **It reflects reality.** `Button` genuinely depends on client-only context now (via `react-slot`), so marking it a client component is accurate rather than a workaround. This template has no committed lockfile, so relying on version resolution to stay safe is inherently fragile here.
- **Trade-off we accept:** `Button` is now always a client component (a negligible bundle cost — it was already client-consumed through its interactive usages). Pinning would instead keep `Button` server-renderable, which matters more for a shared design system betting on an upstream fix than for a starter template.


Companion to the `main` fix in #17476.
