### PR TITLE
fix(ui): prevent past schedule publish and unpublish

### DIFF
--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
@@ -263,7 +263,7 @@ export const ScheduleDrawer: React.FC<Props> = ({
   }, [upcoming, fetchUpcoming])
 
   const minTime = useMemo(() => {
-    if (date && isToday(date)) {
+    if (!date || isToday(date)) {
       return new Date()
     }
 
@@ -306,6 +306,11 @@ export const ScheduleDrawer: React.FC<Props> = ({
             minDate={new Date()}
             minTime={minTime}
             onChange={(e) => onChangeDate(e)}
+            overrides={{
+              onChangeRaw: (event) => {
+                event?.preventDefault()
+              },
+            }}
             pickerAppearance="dayAndTime"
             readOnly={processing}
             timeFormat={schedulePublishConfig?.timeFormat}

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
@@ -306,11 +306,6 @@ export const ScheduleDrawer: React.FC<Props> = ({
             minDate={new Date()}
             minTime={minTime}
             onChange={(e) => onChangeDate(e)}
-            overrides={{
-              onChangeRaw: (event) => {
-                event?.preventDefault()
-              },
-            }}
             pickerAppearance="dayAndTime"
             readOnly={processing}
             timeFormat={schedulePublishConfig?.timeFormat}

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1511,57 +1511,6 @@ describe('Versions', () => {
       timezoneId: londonTimezone,
     })
 
-    const selectScheduleDateTime = async ({
-      day,
-      month,
-      page,
-      timeOptions,
-      year,
-    }: {
-      day: number
-      month: string
-      page: Page
-      timeOptions?: string[]
-      year: string
-    }) => {
-      const dateInput = page.locator('.date-time-picker__input-wrapper input')
-      await dateInput.click()
-
-      const popper = page.locator('.react-datepicker-popper')
-      await expect(popper).toBeVisible()
-
-      await popper.locator('.react-datepicker__year-select').selectOption(year)
-      await popper.locator('.react-datepicker__month-select').selectOption(month)
-
-      const dayClass = String(day).padStart(3, '0')
-      await popper
-        .locator(
-          `.react-datepicker__day--${dayClass}:not(.react-datepicker__day--outside-month):not(.react-datepicker__day--disabled)`,
-        )
-        .first()
-        .click()
-
-      if (timeOptions?.length) {
-        let hasSelectedTime = false
-
-        for (const timeOption of timeOptions) {
-          const timeLocator = popper.locator('.react-datepicker__time-list-item', {
-            hasText: timeOption,
-          })
-
-          if ((await timeLocator.count()) > 0) {
-            await timeLocator.first().click()
-            hasSelectedTime = true
-            break
-          }
-        }
-
-        if (!hasSelectedTime) {
-          throw new Error('Could not find matching time option in schedule publish date picker')
-        }
-      }
-    }
-
     beforeAll(() => {
       url = new AdminUrlUtil(serverURL, draftCollectionSlug)
       autosaveURL = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
@@ -1584,13 +1533,8 @@ describe('Versions', () => {
       // nothing in scheduled
       await expect(page.locator('.drawer__content')).toContainText('No upcoming events scheduled.')
 
-      // set a future date using picker controls
-      await selectScheduleDateTime({
-        day: 21,
-        month: '1', // February
-        page,
-        year: '2050',
-      })
+      await page.locator('.date-time-picker input').fill('Feb 21, 2050 12:00 AM')
+      await page.keyboard.press('Enter')
 
       // save the scheduled publish
       await page.locator('#scheduled-publish-save').click()
@@ -1704,17 +1648,11 @@ describe('Versions', () => {
       await dropdownControlSelector.click()
       await getSelectMenu({ page: localPage }).locator('.rs__option', { hasText: 'Paris' }).click()
 
-      // Set Jan 1, 2049 at 6 PM in the selected timezone. Time format can be 24h or 12h.
-      await selectScheduleDateTime({
-        day: 1,
-        month: '0', // January
-        page: localPage,
-        timeOptions: ['18:00', '6:00 PM'],
-        year: '2049',
-      })
+      const dateInput = drawerContent.locator('.date-time-picker__input-wrapper input')
+      await dateInput.fill('Jan 1, 2049 6:00 PM')
+      await localPage.keyboard.press('Enter')
 
       const saveButton = drawerContent.locator('.schedule-publish__actions button')
-
       await saveButton.click()
 
       const upcomingContent = localPage.locator('.schedule-publish__upcoming')

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1649,7 +1649,9 @@ describe('Versions', () => {
       await getSelectMenu({ page: localPage }).locator('.rs__option', { hasText: 'Paris' }).click()
 
       const dateInput = drawerContent.locator('.date-time-picker__input-wrapper input')
-      await dateInput.fill('Jan 1, 2049 6:00 PM')
+      // Create a date for 2049-01-01 18:00:00 UTC, so it is timezone-invariant across CI environments
+      const date = new Date(Date.UTC(2049, 0, 1, 18, 0))
+      await dateInput.fill(date.toISOString())
       await localPage.keyboard.press('Enter')
 
       const saveButton = drawerContent.locator('.schedule-publish__actions button')
@@ -1678,6 +1680,36 @@ describe('Versions', () => {
 
       // eslint-disable-next-line payload/no-flaky-assertions
       expect(createdJob?.waitUntil).toEqual('2049-01-01T17:00:00.000Z')
+    })
+
+    test('greys out past times in the date picker', async () => {
+      await page.goto(url.create)
+      await page.locator('#field-title').fill('test past times')
+      await page.locator('#field-description').fill('test past times description')
+
+      await saveDocAndAssert(page)
+      await page.locator('#schedule-publish-button').click()
+      await expect(page.locator('.drawer__header')).toBeVisible()
+
+      await page.locator('.date-time-picker input').click()
+      const popper = page.locator('.react-datepicker-popper')
+      await expect(popper).toBeVisible()
+
+      // With no date selected, times before now should be disabled (minTime = now)
+      const firstTimeItem = popper.locator('.react-datepicker__time-list-item').first()
+      await expect(firstTimeItem).toHaveClass(/react-datepicker__time-list-item--disabled/)
+
+      // Select a far-future date — minTime becomes startOfDay, enabling all times
+      await popper.locator('.react-datepicker__year-select').selectOption('2050')
+      await popper.locator('.react-datepicker__month-select').selectOption('1') // February
+      await popper
+        .locator(
+          `.react-datepicker__day--021:not(.react-datepicker__day--outside-month):not(.react-datepicker__day--disabled)`,
+        )
+        .first()
+        .click()
+
+      await expect(firstTimeItem).not.toHaveClass(/react-datepicker__time-list-item--disabled/)
     })
   })
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1515,13 +1515,13 @@ describe('Versions', () => {
       day,
       month,
       page,
-      time,
+      timeOptions,
       year,
     }: {
       day: number
       month: string
       page: Page
-      time: string
+      timeOptions?: string[]
       year: string
     }) => {
       const dateInput = page.locator('.date-time-picker__input-wrapper input')
@@ -1541,12 +1541,25 @@ describe('Versions', () => {
         .first()
         .click()
 
-      await popper
-        .locator('.react-datepicker__time-list-item', {
-          hasText: time,
-        })
-        .first()
-        .click()
+      if (timeOptions?.length) {
+        let hasSelectedTime = false
+
+        for (const timeOption of timeOptions) {
+          const timeLocator = popper.locator('.react-datepicker__time-list-item', {
+            hasText: timeOption,
+          })
+
+          if ((await timeLocator.count()) > 0) {
+            await timeLocator.first().click()
+            hasSelectedTime = true
+            break
+          }
+        }
+
+        if (!hasSelectedTime) {
+          throw new Error('Could not find matching time option in schedule publish date picker')
+        }
+      }
     }
 
     beforeAll(() => {
@@ -1571,12 +1584,11 @@ describe('Versions', () => {
       // nothing in scheduled
       await expect(page.locator('.drawer__content')).toContainText('No upcoming events scheduled.')
 
-      // set date and time via picker controls
+      // set a future date using picker controls
       await selectScheduleDateTime({
         day: 21,
         month: '1', // February
         page,
-        time: '12:00 AM',
         year: '2050',
       })
 
@@ -1692,12 +1704,12 @@ describe('Versions', () => {
       await dropdownControlSelector.click()
       await getSelectMenu({ page: localPage }).locator('.rs__option', { hasText: 'Paris' }).click()
 
-      // Use picker controls to set Jan 1, 2049 at 6:00 PM in the selected timezone.
+      // Set Jan 1, 2049 at 6 PM in the selected timezone. Time format can be 24h or 12h.
       await selectScheduleDateTime({
         day: 1,
         month: '0', // January
         page: localPage,
-        time: '6:00 PM',
+        timeOptions: ['18:00', '6:00 PM'],
         year: '2049',
       })
 
@@ -1959,7 +1971,8 @@ describe('Versions', () => {
       await saveDocAndAssert(page, '#action-save-draft', 'error')
 
       const parentFieldType = page.locator('.field-type:has(#field-title)')
-      await expect(parentFieldType.locator('.tooltip--show')).toBeVisible()
+
+      await expect(page.locator('.tooltip--show')).toBeVisible()
       await expect(parentFieldType).toHaveClass(/error/)
 
       await titleField.fill('New title')

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1511,6 +1511,44 @@ describe('Versions', () => {
       timezoneId: londonTimezone,
     })
 
+    const selectScheduleDateTime = async ({
+      day,
+      month,
+      page,
+      time,
+      year,
+    }: {
+      day: number
+      month: string
+      page: Page
+      time: string
+      year: string
+    }) => {
+      const dateInput = page.locator('.date-time-picker__input-wrapper input')
+      await dateInput.click()
+
+      const popper = page.locator('.react-datepicker-popper')
+      await expect(popper).toBeVisible()
+
+      await popper.locator('.react-datepicker__year-select').selectOption(year)
+      await popper.locator('.react-datepicker__month-select').selectOption(month)
+
+      const dayClass = String(day).padStart(3, '0')
+      await popper
+        .locator(
+          `.react-datepicker__day--${dayClass}:not(.react-datepicker__day--outside-month):not(.react-datepicker__day--disabled)`,
+        )
+        .first()
+        .click()
+
+      await popper
+        .locator('.react-datepicker__time-list-item', {
+          hasText: time,
+        })
+        .first()
+        .click()
+    }
+
     beforeAll(() => {
       url = new AdminUrlUtil(serverURL, draftCollectionSlug)
       autosaveURL = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
@@ -1533,9 +1571,14 @@ describe('Versions', () => {
       // nothing in scheduled
       await expect(page.locator('.drawer__content')).toContainText('No upcoming events scheduled.')
 
-      // set date and time
-      await page.locator('.date-time-picker input').fill('Feb 21, 2050 12:00 AM')
-      await page.keyboard.press('Enter')
+      // set date and time via picker controls
+      await selectScheduleDateTime({
+        day: 21,
+        month: '1', // February
+        page,
+        time: '12:00 AM',
+        year: '2050',
+      })
 
       // save the scheduled publish
       await page.locator('#scheduled-publish-save').click()
@@ -1649,12 +1692,14 @@ describe('Versions', () => {
       await dropdownControlSelector.click()
       await getSelectMenu({ page: localPage }).locator('.rs__option', { hasText: 'Paris' }).click()
 
-      const dateInput = drawerContent.locator('.date-time-picker__input-wrapper input')
-      // Create a date for 2049-01-01 18:00:00 UTC, so it is timezone-invariant across CI environments
-      const date = new Date(Date.UTC(2049, 0, 1, 18, 0))
-
-      await dateInput.fill(date.toISOString())
-      await localPage.keyboard.press('Enter') // formats the date to the correct format
+      // Use picker controls to set Jan 1, 2049 at 6:00 PM in the selected timezone.
+      await selectScheduleDateTime({
+        day: 1,
+        month: '0', // January
+        page: localPage,
+        time: '6:00 PM',
+        year: '2049',
+      })
 
       const saveButton = drawerContent.locator('.schedule-publish__actions button')
 


### PR DESCRIPTION
This updates schedule publish/unpublish UX so users can only choose valid times (no past dates/times) through the picker.

Test added to versions > e2e.
