### PR TITLE
fix(ui): render field name for label:false fields in bulk-edit select

### DIFF
--- a/packages/ui/src/utilities/combineFieldLabel.tsx
+++ b/packages/ui/src/utilities/combineFieldLabel.tsx
@@ -1,5 +1,6 @@
 import type { ClientField } from 'payload'
 
+import { toWords } from 'payload/shared'
 import { Fragment } from 'react'
 
 import { RenderCustomComponent } from '../elements/RenderCustomComponent/index.js'
@@ -14,6 +15,15 @@ export const combineFieldLabel = ({
   field?: ClientField
   prefix?: React.ReactNode
 }): React.ReactNode => {
+  // Fall back to the humanized field name when a field has no label (e.g. `label: false`)
+  // so option lists like the bulk-edit field select never render an empty entry.
+  const label =
+    'label' in field && field.label
+      ? field.label
+      : 'name' in field && field.name
+        ? toWords(field.name)
+        : undefined
+
   return (
     <Fragment>
       {prefix ? (
@@ -25,7 +35,7 @@ export const combineFieldLabel = ({
       <span style={{ display: 'inline-block' }}>
         <RenderCustomComponent
           CustomComponent={CustomLabel}
-          Fallback={<FieldLabel label={'label' in field && field.label} />}
+          Fallback={<FieldLabel label={label} />}
         />
       </span>
     </Fragment>

--- a/test/bulk-edit/collections/Tabs/index.ts
+++ b/test/bulk-edit/collections/Tabs/index.ts
@@ -13,6 +13,11 @@ export const TabsCollection: CollectionConfig = {
       name: 'title',
     },
     {
+      name: 'noLabelText',
+      type: 'text',
+      label: false,
+    },
+    {
       type: 'tabs',
       tabs: [
         {

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -844,6 +844,46 @@ test.describe('Bulk Edit', () => {
     await payload.delete({ collection: tabsSlug, id: doc.id })
   })
 
+  test('should fall back to the field name for fields with label: false', async () => {
+    const doc = await payload.create({
+      collection: tabsSlug,
+      data: { title: 'No Label Doc' },
+    })
+
+    await page.goto(tabsUrl.list)
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    await addListFilter({
+      page,
+      fieldLabel: 'ID',
+      operatorLabel: 'equals',
+      value: doc.id,
+    })
+
+    await page.locator('table tbody tr.row-1 input[type="checkbox"]').check()
+    await page
+      .locator('.list-selection__actions .btn', {
+        hasText: 'Edit',
+      })
+      .click()
+
+    const bulkEditForm = page.locator('form.edit-many__form')
+    await expect(bulkEditForm).toBeVisible()
+
+    await bulkEditForm.locator('.field-select .rs__control').click()
+
+    const menu = getSelectMenu({ page })
+
+    // The `label: false` field must render its humanized name, not an empty option
+    await expect(menu.locator('.rs__option', { hasText: exactText('No Label Text') })).toBeVisible()
+
+    // No option should render without text
+    const optionTexts = await menu.locator('.rs__option').allInnerTexts()
+    expect(optionTexts.every((text) => text.trim().length > 0)).toBe(true)
+
+    await payload.delete({ collection: tabsSlug, id: doc.id })
+  })
+
   test('should preserve beforeInput components when selecting multiple fields', async () => {
     await deleteAllPosts()
     await createPost({ title: 'Post 1' })

--- a/test/bulk-edit/payload-types.ts
+++ b/test/bulk-edit/payload-types.ts
@@ -173,6 +173,7 @@ export interface TextBlock {
 export interface Tab {
   id: string;
   title?: string | null;
+  noLabelText?: string | null;
   tabTab?: {
     tabText?: string | null;
     tabTabArray?:
@@ -345,6 +346,7 @@ export interface PostsSelect<T extends boolean = true> {
  */
 export interface TabsSelect<T extends boolean = true> {
   title?: T;
+  noLabelText?: T;
   tabTab?:
     | T
     | {


### PR DESCRIPTION
The bulk-edit "Select fields to edit" dropdown showed a blank option for any leaf field with a falsy label (e.g. `label: false`), because `combineFieldLabel` passed the falsy label straight to `FieldLabel`, which rendered nothing. Reproduces on both Next.js and TanStack Start (shared UI code); the website template's `hero.richText` is one trigger.

Fix: fall back to the humanized field name when a field has no label. Adds a `label: false` field to the bulk-edit test collection and an e2e regression test.

<img width="696" height="986" alt="image" src="https://github.com/user-attachments/assets/39585df7-2cbd-4bea-b390-c4a1f7419d87" />


<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216782008624997