### PR TITLE
fix: remove non-functional transition styles

### DIFF
--- a/packages/richtext-lexical/src/features/debug/testRecorder/client/plugin/index.css
+++ b/packages/richtext-lexical/src/features/debug/testRecorder/client/plugin/index.css
@@ -19,7 +19,6 @@
     box-shadow: 1px 2px 2px rgba(0, 0, 0, 0.4);
     background-color: #222;
     color: white;
-    transition: box-shadow 50ms ease-out;
   }
 
   .test-recorder-button:active {

--- a/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/index.css
+++ b/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/index.css
@@ -13,7 +13,6 @@
     inset-inline-start: 0;
     opacity: 0;
     border-radius: var(--radius-large);
-    transition: opacity 0.2s;
     will-change: transform;
     overflow: clip;
     box-shadow: var(--elevation-100-canvas);

--- a/packages/richtext-lexical/src/features/toolbars/inline/client/Toolbar/index.css
+++ b/packages/richtext-lexical/src/features/toolbars/inline/client/Toolbar/index.css
@@ -12,7 +12,6 @@
     z-index: 2;
     opacity: 0;
     border-radius: var(--radius-medium);
-    transition: opacity 0.2s;
     will-change: transform;
     box-shadow: var(--elevation-300-tooltip);
   }

--- a/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/index.css
+++ b/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/index.css
@@ -19,7 +19,6 @@
     border-radius: var(--radius-medium);
     cursor: pointer;
     position: relative;
-    transition: background-color 0.15s cubic-bezier(0, 0.2, 0.2, 1);
     min-width: calc(var(--spacer-4) + var(--spacer-2-5));
 
     &:disabled {
@@ -83,7 +82,6 @@
       all: unset;
       cursor: pointer;
       color: var(--color-text);
-      transition: background-color 0.15s cubic-bezier(0, 0.2, 0.2, 1);
       position: relative;
       font-family: var(--text-body-medium-font-family);
       font-size: var(--text-body-medium-font-size);

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.css
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.css
@@ -29,7 +29,6 @@
     width: 100%;
     height: 100%;
     background-color: transparent;
-    transition: background-color 0.1s ease-in-out;
     display: flex;
     justify-content: center;
     border-radius: var(--radius-medium);

--- a/packages/richtext-lexical/src/lexical/plugins/SlashMenu/index.css
+++ b/packages/richtext-lexical/src/lexical/plugins/SlashMenu/index.css
@@ -42,7 +42,6 @@
     border-radius: var(--radius-medium);
     cursor: pointer;
     gap: var(--spacer-1);
-    transition: background-color 0.15s cubic-bezier(0, 0.2, 0.2, 1);
 
     .icon {
       color: var(--color-icon-secondary);

--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.css
@@ -13,10 +13,6 @@
     &:focus-visible {
       outline: none !important;
     }
-
-    & > * {
-      transition: transform 0.2s ease-in-out;
-    }
   }
 
   @media (min-width: 768px) {

--- a/packages/ui/src/css/forms.css
+++ b/packages/ui/src/css/forms.css
@@ -13,9 +13,6 @@
     padding: 0 var(--field-padding-inline);
     appearance: none;
     -webkit-appearance: none;
-    transition-property: box-shadow, background-color;
-    transition-duration: 100ms;
-    transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
     outline: none;
 
     &[data-rtl='true'] {
@@ -70,9 +67,6 @@
     border: var(--stroke-width-small) solid var(--field-color-border);
     border-radius: var(--field-border-radius);
     min-height: var(--field-min-height-large);
-    transition-property: box-shadow, background-color;
-    transition-duration: 100ms;
-    transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
 
     &:where(:hover:not(:focus-within):not(:has(input:disabled)):not(:has(input:read-only))) {
       border-color: var(--field-color-border-hover);

--- a/packages/ui/src/elements/AddNewRelation/index.css
+++ b/packages/ui/src/elements/AddNewRelation/index.css
@@ -22,7 +22,6 @@
       border-radius: var(--button-radius);
       color: var(--color-icon);
       cursor: pointer;
-      transition: background-color 100ms;
 
       &:hover {
         background: var(--color-bg-secondary-hover);

--- a/packages/ui/src/elements/AppHeader/index.css
+++ b/packages/ui/src/elements/AppHeader/index.css
@@ -80,9 +80,6 @@
     border-radius: var(--button-radius);
     cursor: pointer;
     color: var(--color-icon);
-    transition:
-      background-color 0.15s ease,
-      border-color 0.15s ease;
 
     &:hover {
       background-color: var(--color-bg-transparent-hover);

--- a/packages/ui/src/elements/CodeEditor/index.css
+++ b/packages/ui/src/elements/CodeEditor/index.css
@@ -19,11 +19,6 @@
     font-size: var(--text-body);
     color: var(--color-text-default-primary);
 
-    /* Transitions */
-    transition-property: border, box-shadow, background-color;
-    transition-duration: 100ms, 100ms, 500ms;
-    transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
-
     &:focus-within {
       border-color: var(--field-color-border-focus);
     }

--- a/packages/ui/src/elements/CommandPalette/index.css
+++ b/packages/ui/src/elements/CommandPalette/index.css
@@ -191,11 +191,4 @@
     border: 0;
     border-radius: var(--radius-small);
   }
-
-  @media (prefers-reduced-motion: reduce) {
-    .cmd-palette,
-    .cmd-palette__inner {
-      transition: none;
-    }
-  }
 }

--- a/packages/ui/src/elements/FileDetails/StaticFileDetails/index.css
+++ b/packages/ui/src/elements/FileDetails/StaticFileDetails/index.css
@@ -28,7 +28,6 @@
     border: var(--stroke-width-small) solid var(--theme-border-color);
     background: var(--theme-input-bg);
     box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);
-    transition: border 100ms cubic-bezier(0, 0.2, 0.2, 1);
   }
 
   .file-details__remove .btn__icon:not(:disabled):hover {

--- a/packages/ui/src/elements/Hierarchy/ColumnBrowser/ColumnItem/index.css
+++ b/packages/ui/src/elements/Hierarchy/ColumnBrowser/ColumnItem/index.css
@@ -4,7 +4,6 @@
     align-items: center;
     padding: var(--spacer-1) var(--spacer-2);
     cursor: pointer;
-    transition: background-color 80ms ease;
     user-select: none;
     gap: var(--spacer-2-5);
     border-radius: var(--button-radius);

--- a/packages/ui/src/elements/Hierarchy/Tree/TreeNode/index.css
+++ b/packages/ui/src/elements/Hierarchy/Tree/TreeNode/index.css
@@ -29,7 +29,6 @@
   .tree-node__content {
     display: flex;
     align-items: center;
-    transition: background-color 100ms ease;
     font-size: var(--tree-font-size);
     line-height: var(--tree-node-content-height);
   }

--- a/packages/ui/src/elements/InputStepper/index.css
+++ b/packages/ui/src/elements/InputStepper/index.css
@@ -20,7 +20,6 @@
       background: transparent;
       color: var(--color-icon-secondary);
       cursor: pointer;
-      transition: color 100ms;
 
       &:hover:not(:disabled) {
         color: var(--color-icon);

--- a/packages/ui/src/elements/Nav/SidebarTabs/index.css
+++ b/packages/ui/src/elements/Nav/SidebarTabs/index.css
@@ -29,10 +29,6 @@
     border: var(--stroke-width-small) solid transparent;
     background-color: transparent;
     color: var(--color-icon-secondary);
-    transition:
-      background-color 0.15s ease,
-      border-color 0.15s ease,
-      color 0.15s ease;
     position: relative;
 
     &:hover {
@@ -56,7 +52,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: opacity 0.15s ease;
   }
 
   /* Visually hidden but still accessible for screen readers */

--- a/packages/ui/src/elements/NavGroup/index.css
+++ b/packages/ui/src/elements/NavGroup/index.css
@@ -57,7 +57,6 @@
     color: var(--color-icon-tertiary);
     left: calc(-1 * var(--spacer-1));
     opacity: 0;
-    transition: opacity 150ms ease;
   }
 
   .nav-group--collapsed .collapsible__toggle {

--- a/packages/ui/src/elements/PreviewSizes/index.css
+++ b/packages/ui/src/elements/PreviewSizes/index.css
@@ -79,7 +79,6 @@
     display: flex;
     gap: var(--spacer-3);
     cursor: pointer;
-    transition: background-color 0.2s ease-in-out;
   }
 
   .preview-sizes__sizeOption:hover {

--- a/packages/ui/src/elements/ReactSelect/ClearIndicator/index.css
+++ b/packages/ui/src/elements/ReactSelect/ClearIndicator/index.css
@@ -6,7 +6,6 @@
     justify-content: center;
     flex-shrink: 0;
     color: var(--color-icon-secondary);
-    transition: color 100ms;
 
     &:hover {
       color: var(--color-icon);

--- a/packages/ui/src/elements/ReactSelect/MultiValue/index.css
+++ b/packages/ui/src/elements/ReactSelect/MultiValue/index.css
@@ -8,7 +8,6 @@
       background: var(--color-bg);
       height: 1.25rem;
       margin: 0;
-      transition: border 0.2s cubic-bezier(0.2, 0, 0, 1);
 
       &:focus,
       &:focus-visible {

--- a/packages/ui/src/elements/ReactSelect/index.css
+++ b/packages/ui/src/elements/ReactSelect/index.css
@@ -18,9 +18,6 @@
       line-height: var(--text-body-medium-line-height);
       -webkit-appearance: none;
       appearance: none;
-      transition-property: box-shadow, background-color;
-      transition-duration: 100ms;
-      transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
       height: auto;
       padding-block: calc(var(--spacer-1) + 1px);
       padding-inline: var(--field-padding-inline) var(--spacer-5);

--- a/packages/ui/src/elements/SidebarToggle/index.css
+++ b/packages/ui/src/elements/SidebarToggle/index.css
@@ -11,7 +11,6 @@
     color: var(--color-icon);
     cursor: pointer;
     outline: none;
-    transition: background-color 100ms ease;
 
     &:hover {
       background: var(--color-bg-hover);

--- a/packages/ui/src/elements/Tooltip/index.css
+++ b/packages/ui/src/elements/Tooltip/index.css
@@ -76,7 +76,6 @@
   .tooltip--show {
     visibility: visible;
     opacity: 1;
-    transition: opacity 0.2s ease-in-out;
     cursor: default;
   }
 

--- a/packages/ui/src/fields/Slug/index.css
+++ b/packages/ui/src/fields/Slug/index.css
@@ -46,7 +46,6 @@
       background: transparent;
       color: var(--color-icon-secondary);
       cursor: pointer;
-      transition: color 100ms;
 
       &:hover {
         color: var(--color-icon);

--- a/packages/ui/src/scss/vars.scss
+++ b/packages/ui/src/scss/vars.scss
@@ -141,9 +141,6 @@ $focus-box-shadow: 0 0 0 $style-stroke-width-m var(--theme-success-500);
   line-height: base(1);
   padding: base(0.4) base(0.75);
   -webkit-appearance: none;
-  transition-property: border, box-shadow, background-color;
-  transition-duration: 100ms, 100ms, 500ms;
-  transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
 
   &[data-rtl='true'] {
     direction: rtl;

--- a/packages/ui/src/views/Dashboard/Default/ModularDashboard/index.css
+++ b/packages/ui/src/views/Dashboard/Default/ModularDashboard/index.css
@@ -66,7 +66,6 @@
 
   .widget-wrapper__controls {
     opacity: 0;
-    transition: opacity 0.2s ease;
   }
 
   .widget:focus-visible .widget-wrapper__controls,
@@ -94,10 +93,6 @@
     width: 100%;
   }
 
-  .widget-wrapper--editing .widget-wrapper__controls {
-    transition: opacity 0.2s ease;
-  }
-
   .widget-wrapper--editing:hover .widget-wrapper__controls {
     opacity: 1;
   }
@@ -123,7 +118,6 @@
     border-radius: var(--radius-small);
     cursor: pointer;
     color: var(--color-text-ondanger);
-    transition: all 0.2s ease;
 
     &:hover {
       background: var(--color-bg-danger-hover);
@@ -154,7 +148,6 @@
     border-radius: var(--radius-small);
     cursor: pointer;
     color: var(--color-bg);
-    transition: all 0.2s ease;
 
     & .icon {
       width: var(--spacer-3);
@@ -185,7 +178,6 @@
     border: none;
     border-radius: var(--radius-small);
     cursor: pointer;
-    transition: all 0.2s ease;
     font-family: var(--text-body-small-font-family);
     font-size: var(--text-body-small-font-size);
     font-weight: var(--text-body-small-font-weight);

--- a/templates/ecommerce/src/components/Header/index.css
+++ b/templates/ecommerce/src/components/Header/index.css
@@ -10,7 +10,6 @@
     width: 100%;
     height: 2px;
     background-color: var(--primary);
-    transition: transform 0.3s;
   }
 
   &:not(.active) {

--- a/test/a11y/components/styles.css
+++ b/test/a11y/components/styles.css
@@ -97,7 +97,6 @@
       inset: -4px;
       border-radius: 6px;
       outline: 0px solid transparent;
-      transition: outline 0.2s;
     }
 
     &:focus {
@@ -125,7 +124,6 @@
       inset: -4px;
       border-radius: 6px;
       border: 0px solid transparent;
-      transition: border 0.2s;
     }
 
     &:focus {
@@ -154,7 +152,6 @@
       inset: -4px;
       border-radius: 6px;
       box-shadow: 0 0 0 0 rgba(153, 0, 204, 0);
-      transition: box-shadow 0.2s;
     }
 
     &:focus {

--- a/test/evals/components/EvalDashboard/CompareTable.tsx
+++ b/test/evals/components/EvalDashboard/CompareTable.tsx
@@ -1408,7 +1408,6 @@ export function CompareTable({
                         gap: '0 12px',
                         gridTemplateColumns: '1fr 80px 60px 110px 130px 130px 90px 32px',
                         padding: '10px 12px',
-                        transition: 'background 0.1s',
                       }}
                       tabIndex={0}
                     >

--- a/test/evals/components/EvalDashboard/NavLink.tsx
+++ b/test/evals/components/EvalDashboard/NavLink.tsx
@@ -22,7 +22,6 @@ const navItemStyle = (hovered: boolean): React.CSSProperties => ({
   gap: '8px',
   padding: '6px 10px',
   textDecoration: 'none',
-  transition: 'background 0.15s',
 })
 
 function InternalNavItem({

--- a/test/evals/components/EvalDashboard/ResultsTable.tsx
+++ b/test/evals/components/EvalDashboard/ResultsTable.tsx
@@ -1152,7 +1152,6 @@ export function ResultsTable({ codegenHtml, entries }: Props) {
                         gap: '0 12px',
                         gridTemplateColumns: '1fr 100px 70px 80px 120px 100px 100px 32px',
                         padding: '10px 12px',
-                        transition: 'background 0.1s',
                       }}
                       tabIndex={0}
                     >

--- a/test/live-preview/app/live-preview/_components/Footer/index.module.scss
+++ b/test/live-preview/app/live-preview/_components/Footer/index.module.scss
@@ -27,7 +27,6 @@
   align-items: center;
   flex-wrap: wrap;
   opacity: 1;
-  transition: opacity 100ms linear;
   visibility: visible;
 
   > * {

--- a/test/live-preview/prod/app/live-preview/_components/Footer/index.module.scss
+++ b/test/live-preview/prod/app/live-preview/_components/Footer/index.module.scss
@@ -27,7 +27,6 @@
   align-items: center;
   flex-wrap: wrap;
   opacity: 1;
-  transition: opacity 100ms linear;
   visibility: visible;
 
   > * {

--- a/test/plugin-multi-tenant/components/BeforeLogin/index.css
+++ b/test/plugin-multi-tenant/components/BeforeLogin/index.css
@@ -36,7 +36,6 @@
     background-color: var(--color-bg);
     cursor: pointer;
     text-align: left;
-    transition: all 0.2s;
   }
 
   .before-login__button:hover:not(:disabled) {

--- a/test/v4/views/Components/Icons/index.css
+++ b/test/v4/views/Components/Icons/index.css
@@ -21,7 +21,6 @@
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.15s ease;
 }
 
 .icons-view__back:hover {

--- a/test/v4/views/Components/index.css
+++ b/test/v4/views/Components/index.css
@@ -21,7 +21,6 @@
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.15s ease;
 }
 
 .components-view__back:hover {
@@ -202,7 +201,6 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-medium);
   background: var(--color-bg);
-  transition: border-color 0.15s ease;
   min-width: 100px;
   overflow: hidden;
 }

--- a/test/v4/views/Dashboard/index.css
+++ b/test/v4/views/Dashboard/index.css
@@ -15,7 +15,6 @@
   font-size: 14px;
   font-weight: 500;
   color: var(--theme-elevation-700);
-  transition: all 0.15s ease;
 }
 
 .custom-dashboard__tab:hover {


### PR DESCRIPTION
Removes hover, focus, and color transition styles across the admin UI, the Lexical editor, and the test suites, as part of the v4 redesign.

Only transitions that drive a component's actual animation feature are kept, e.g. `Drawer`, `Loading`, route `ProgressBar`, `ToastContainer`, `AnimateHeight`, and drag-and-drop reordering.