### PR TITLE
fix(plugin-import-export): export relationship fields natively for JSON format

### DIFF
--- a/packages/plugin-import-export/src/components/ImportPreview/index.tsx
+++ b/packages/plugin-import-export/src/components/ImportPreview/index.tsx
@@ -14,7 +14,6 @@ import {
   useFormFields,
   useTranslation,
 } from '@payloadcms/ui'
-import { formatDocTitle } from '@payloadcms/ui/shared'
 import { fieldAffectsData, getObjectDotNotation } from 'payload/shared'
 import React, { useState, useTransition } from 'react'
 
@@ -25,6 +24,7 @@ import type {
 import type { ImportPreviewResponse } from '../../types.js'
 
 import { DEFAULT_PREVIEW_LIMIT, PREVIEW_LIMIT_OPTIONS } from '../../constants.js'
+import { RelationshipCell } from '../RelationshipCell/index.js'
 import './index.scss'
 
 const baseClass = 'import-preview'
@@ -223,7 +223,7 @@ export const ImportPreview: React.FC = () => {
                 active: true,
                 field,
                 Heading: label,
-                renderedCells: docs.map((doc) => {
+                renderedCells: docs.map((doc, rowIndex) => {
                   const value = getObjectDotNotation(doc, fieldPath)
 
                   if (value === undefined || value === null) {
@@ -232,62 +232,13 @@ export const ImportPreview: React.FC = () => {
 
                   // Format based on field type
                   if (field.type === 'relationship' || field.type === 'upload') {
-                    // Handle relationships
-                    if (typeof value === 'object' && !Array.isArray(value)) {
-                      // Single relationship
-                      const relationTo = Array.isArray(field.relationTo)
-                        ? (value as any).relationTo
-                        : field.relationTo
-
-                      const relatedConfig = config.collections.find((c) => c.slug === relationTo)
-                      if (relatedConfig && relatedConfig.admin?.useAsTitle) {
-                        const titleValue = (value as any)[relatedConfig.admin.useAsTitle]
-                        if (titleValue) {
-                          return formatDocTitle({
-                            collectionConfig: relatedConfig,
-                            data: value as any,
-                            dateFormat: config.admin.dateFormat,
-                            i18n,
-                          })
-                        }
-                      }
-
-                      // Fallback to ID
-                      const id = (value as any).id || value
-                      return `${getTranslation(relatedConfig?.labels?.singular || relationTo, i18n)}: ${id}`
-                    } else if (Array.isArray(value)) {
-                      // Multiple relationships
-                      return value
-                        .map((item) => {
-                          if (typeof item === 'object') {
-                            const relationTo = Array.isArray(field.relationTo)
-                              ? item.relationTo
-                              : field.relationTo
-                            const relatedConfig = config.collections.find(
-                              (c) => c.slug === relationTo,
-                            )
-
-                            if (relatedConfig && relatedConfig.admin?.useAsTitle) {
-                              const titleValue = item[relatedConfig.admin.useAsTitle]
-                              if (titleValue) {
-                                return formatDocTitle({
-                                  collectionConfig: relatedConfig,
-                                  data: item,
-                                  dateFormat: config.admin.dateFormat,
-                                  i18n,
-                                })
-                              }
-                            }
-
-                            return item.id || item
-                          }
-                          return item
-                        })
-                        .join(', ')
-                    }
-
-                    // Just an ID
-                    return String(value)
+                    return (
+                      <RelationshipCell
+                        key={`${fieldPath}-${rowIndex}`}
+                        relationTo={field.relationTo}
+                        value={value}
+                      />
+                    )
                   } else if (field.type === 'date') {
                     // Display date as string to avoid wrong locale/timezone conversion
                     return String(value)

--- a/packages/plugin-import-export/src/components/RelationshipCell/getRelationshipGroups.spec.ts
+++ b/packages/plugin-import-export/src/components/RelationshipCell/getRelationshipGroups.spec.ts
@@ -1,0 +1,203 @@
+import type { ClientCollectionConfig } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { getRelationshipGroups } from './getRelationshipGroups.js'
+
+const collections = [
+  {
+    slug: 'posts',
+    admin: { useAsTitle: 'title' },
+    fields: [{ name: 'title', type: 'text' }],
+    labels: { plural: 'Posts', singular: 'Post' },
+  },
+  {
+    slug: 'users',
+    admin: { useAsTitle: 'email' },
+    fields: [{ name: 'email', type: 'email' }],
+    labels: { plural: 'Users', singular: 'User' },
+  },
+] as unknown as ClientCollectionConfig[]
+
+const i18n = { t: (key: string) => key } as any
+
+const group = ({ relationTo, value }: { relationTo: string | string[]; value: unknown }) =>
+  getRelationshipGroups({ collections, dateFormat: 'MMMM do yyyy', i18n, relationTo, value })
+
+/** Collapses each group to `Label: value, value (+N)` so assertions stay readable. */
+const summarize = (groups: ReturnType<typeof group>) =>
+  groups.map(({ label, options, remaining }) => {
+    const values = options.join(', ')
+
+    return remaining ? `${label}: ${values} (+${remaining})` : `${label}: ${values}`
+  })
+
+describe('getRelationshipGroups', () => {
+  describe('monomorphic', () => {
+    it('should build a single group labeled with the plural collection label', () => {
+      expect(group({ relationTo: 'posts', value: 3 })).toEqual([
+        {
+          label: 'Posts',
+          options: ['3'],
+          remaining: 0,
+        },
+      ])
+    })
+
+    it('should collect a list of bare IDs into one group', () => {
+      expect(summarize(group({ relationTo: 'posts', value: [1, 2] }))).toEqual(['Posts: 1, 2'])
+    })
+
+    it('should title a populated document using useAsTitle', () => {
+      expect(
+        summarize(group({ relationTo: 'posts', value: { id: 3, title: 'The Wall' } })),
+      ).toEqual(['Posts: The Wall'])
+    })
+
+    it('should fall back to untitled and ID for a document with no useAsTitle value', () => {
+      expect(summarize(group({ relationTo: 'posts', value: { id: 3 } }))).toEqual([
+        'Posts: general:untitled - ID: 3',
+      ])
+    })
+  })
+
+  describe('polymorphic', () => {
+    it('should label a wrapped ID with its collection', () => {
+      expect(
+        summarize(
+          group({ relationTo: ['posts', 'users'], value: { relationTo: 'posts', value: 3 } }),
+        ),
+      ).toEqual(['Posts: 3'])
+    })
+
+    it('should title a wrapped populated document using useAsTitle', () => {
+      expect(
+        summarize(
+          group({
+            relationTo: ['posts', 'users'],
+            value: { relationTo: 'posts', value: { id: 3, title: 'The Wall' } },
+          }),
+        ),
+      ).toEqual(['Posts: The Wall'])
+    })
+
+    it('should group entries that share a collection', () => {
+      expect(
+        summarize(
+          group({
+            relationTo: ['posts', 'users'],
+            value: [
+              { relationTo: 'users', value: 7 },
+              { relationTo: 'posts', value: 3 },
+              { relationTo: 'users', value: 9 },
+            ],
+          }),
+        ),
+      ).toEqual(['Users: 7, 9', 'Posts: 3'])
+    })
+
+    it('should order groups by where their collection first appears', () => {
+      expect(
+        group({
+          relationTo: ['posts', 'users'],
+          value: [
+            { relationTo: 'posts', value: 3 },
+            { relationTo: 'users', value: 7 },
+          ],
+        }).map(({ label }) => label),
+      ).toEqual(['Posts', 'Users'])
+    })
+
+    it('should fall back to the collection slug when the collection has no labels', () => {
+      expect(
+        summarize(group({ relationTo: ['pages'], value: { relationTo: 'pages', value: 4 } })),
+      ).toEqual(['pages: 4'])
+    })
+
+    it('should keep entries whose collection is unknown in their own unlabeled group', () => {
+      expect(
+        summarize(
+          group({
+            relationTo: ['posts', 'users'],
+            value: [{ relationTo: 'posts', value: 3 }, 4],
+          }),
+        ),
+      ).toEqual(['Posts: 3', ': 4'])
+    })
+  })
+
+  describe('capping', () => {
+    it('should not report remaining options when the group fits', () => {
+      expect(summarize(group({ relationTo: 'posts', value: [1, 2, 3] }))).toEqual([
+        'Posts: 1, 2, 3',
+      ])
+    })
+
+    it('should cap a group at three options and count the rest', () => {
+      expect(summarize(group({ relationTo: 'posts', value: [1, 2, 3, 4, 5] }))).toEqual([
+        'Posts: 1, 2, 3 (+2)',
+      ])
+    })
+
+    it('should cap each collection independently rather than across the cell', () => {
+      expect(
+        summarize(
+          group({
+            relationTo: ['posts', 'users'],
+            value: [
+              { relationTo: 'users', value: 7 },
+              { relationTo: 'posts', value: 3 },
+              { relationTo: 'users', value: 9 },
+              { relationTo: 'posts', value: 4 },
+            ],
+          }),
+        ),
+      ).toEqual(['Users: 7, 9', 'Posts: 3, 4'])
+    })
+
+    it('should count overflow per collection', () => {
+      expect(
+        summarize(
+          group({
+            relationTo: ['posts', 'users'],
+            value: [
+              ...[1, 2, 3, 4, 5].map((value) => ({ relationTo: 'posts', value })),
+              ...[7, 8].map((value) => ({ relationTo: 'users', value })),
+            ],
+          }),
+        ),
+      ).toEqual(['Posts: 1, 2, 3 (+2)', 'Users: 7, 8'])
+    })
+
+    it('should not let a leading collection crowd out a later one', () => {
+      expect(
+        summarize(
+          group({
+            relationTo: ['posts', 'users'],
+            value: [
+              ...[1, 2, 3, 4].map((value) => ({ relationTo: 'posts', value })),
+              { relationTo: 'users', value: 7 },
+            ],
+          }),
+        ),
+      ).toEqual(['Posts: 1, 2, 3 (+1)', 'Users: 7'])
+    })
+  })
+
+  describe('unresolvable values', () => {
+    it('should render an object carrying no ID as JSON rather than [object Object]', () => {
+      expect(summarize(group({ relationTo: 'posts', value: { slug: 'no-id-here' } }))).toEqual([
+        'Posts: {"slug":"no-id-here"}',
+      ])
+    })
+
+    it('should never render [object Object] for a wrapped value', () => {
+      const groups = group({
+        relationTo: ['posts', 'users'],
+        value: { relationTo: 'posts', value: { title: 'No ID' } },
+      })
+
+      expect(groups[0]?.options[0]).not.toContain('[object Object]')
+    })
+  })
+})

--- a/packages/plugin-import-export/src/components/RelationshipCell/getRelationshipGroups.ts
+++ b/packages/plugin-import-export/src/components/RelationshipCell/getRelationshipGroups.ts
@@ -1,0 +1,153 @@
+import type { I18n } from '@payloadcms/translations'
+import type { ClientCollectionConfig, SanitizedConfig } from 'payload'
+
+import { getTranslation } from '@payloadcms/translations'
+import { formatDocTitle } from '@payloadcms/ui/shared'
+
+/**
+ * Labels rendered per collection before the rest collapse into `and N more`,
+ * matching `totalToShow` in the list view's relationship cell.
+ */
+export const TOTAL_TO_SHOW = 3
+
+type Args = {
+  collections: ClientCollectionConfig[]
+  dateFormat: SanitizedConfig['admin']['dateFormat']
+  i18n: I18n<any, any>
+  /** `field.relationTo` — an array when the field is polymorphic. */
+  relationTo: string | string[]
+  value: unknown
+}
+
+export type RelationshipGroup = {
+  /** Plural label of the target collection, empty when it cannot be determined. */
+  label: string
+  /** One rendered label per document, capped at `TOTAL_TO_SHOW`. */
+  options: string[]
+  /** Options past `TOTAL_TO_SHOW` dropped from this group, to render as `and N more`. */
+  remaining: number
+}
+
+/**
+ * Groups a relationship or upload value by target collection — one group per
+ * collection, labeled with its plural label, holding one label per document.
+ *
+ * Import files carry relationships in whichever shape produced them, so every
+ * entry is one of: a bare ID, a populated document, or the polymorphic
+ * `{ relationTo, value }` pair — whose `value` is itself an ID or a document.
+ *
+ * Each group caps at `TOTAL_TO_SHOW` options and counts the rest into `remaining`,
+ * so a polymorphic field shows the same depth per collection rather than spending
+ * one cell's worth of rows on whichever collection happens to come first. Groups are
+ * returned in the order their collection first appears, and entries whose collection
+ * cannot be determined collect into a single unlabeled group. Options keep their order
+ * in the file rather than being sorted, so the preview reflects what will be imported.
+ */
+export const getRelationshipGroups = ({
+  collections,
+  dateFormat,
+  i18n,
+  relationTo,
+  value,
+}: Args): RelationshipGroup[] => {
+  const entries = Array.isArray(value) ? value : [value]
+  const configsBySlug = new Map(collections.map((collection) => [collection.slug, collection]))
+
+  // Insertion order is the order each collection first appears, which is the order to render.
+  const groupsBySlug = new Map<string, RelationshipGroup>()
+
+  entries.forEach((entry) => {
+    const { slug, target } = resolveEntry({ entry, relationTo })
+
+    const key = slug ?? ''
+    let group = groupsBySlug.get(key)
+
+    if (!group) {
+      group = {
+        label: slug ? getTranslation(configsBySlug.get(slug)?.labels?.plural || slug, i18n) : '',
+        options: [],
+        remaining: 0,
+      }
+
+      groupsBySlug.set(key, group)
+    }
+
+    // Past the cap only the count matters, so skip the cost of titling the document.
+    if (group.options.length < TOTAL_TO_SHOW) {
+      group.options.push(
+        getOptionLabel({
+          collectionConfig: slug ? configsBySlug.get(slug) : undefined,
+          dateFormat,
+          entry,
+          i18n,
+          target,
+        }),
+      )
+    } else {
+      group.remaining++
+    }
+  })
+
+  return [...groupsBySlug.values()]
+}
+
+/**
+ * Splits an entry into the collection it targets — `undefined` when that cannot be
+ * determined — and the ID or document it points at.
+ */
+const resolveEntry = ({
+  entry,
+  relationTo,
+}: { entry: unknown } & Pick<Args, 'relationTo'>): { slug?: string; target: unknown } => {
+  if (isPolymorphicRelationship(entry)) {
+    return { slug: entry.relationTo, target: entry.value }
+  }
+
+  return { slug: Array.isArray(relationTo) ? undefined : relationTo, target: entry }
+}
+
+type GetOptionLabelArgs = {
+  collectionConfig?: ClientCollectionConfig
+  /** The original entry, kept for the JSON fallback when `target` holds no usable ID. */
+  entry: unknown
+  target: unknown
+} & Pick<Args, 'dateFormat' | 'i18n'>
+
+const getOptionLabel = ({
+  collectionConfig,
+  dateFormat,
+  entry,
+  i18n,
+  target,
+}: GetOptionLabelArgs): string => {
+  const doc = isRecord(target) ? target : undefined
+  const id = doc ? doc.id : target
+
+  // Fall back to JSON for anything that did not resolve to a usable ID. Interpolating an
+  // object into a template is the `[object Object]` this function exists to avoid.
+  if (typeof id !== 'string' && typeof id !== 'number') {
+    return JSON.stringify(entry) ?? ''
+  }
+
+  if (!doc) {
+    // A bare ID carries no document to title. Showing the ID alone is more honest than
+    // the field's `Untitled` fallback, which would assert the document has no title.
+    return `${id}`
+  }
+
+  return formatDocTitle({
+    collectionConfig,
+    data: doc as Parameters<typeof formatDocTitle>[0]['data'],
+    dateFormat,
+    fallback: `${i18n.t('general:untitled')} - ID: ${id}`,
+    i18n,
+  })
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isPolymorphicRelationship = (
+  value: unknown,
+): value is { relationTo: string; value: unknown } =>
+  isRecord(value) && typeof value.relationTo === 'string' && 'value' in value

--- a/packages/plugin-import-export/src/components/RelationshipCell/index.scss
+++ b/packages/plugin-import-export/src/components/RelationshipCell/index.scss
@@ -1,0 +1,26 @@
+@layer payload-default {
+  .import-preview-relationship {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    &__group {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    &__collection {
+      font-size: var(--font-size-small);
+      font-weight: 600;
+      color: var(--theme-elevation-500);
+      white-space: nowrap;
+    }
+
+    &__more {
+      display: block;
+      font-size: var(--font-size-small);
+      color: var(--theme-elevation-500);
+    }
+  }
+}

--- a/packages/plugin-import-export/src/components/RelationshipCell/index.tsx
+++ b/packages/plugin-import-export/src/components/RelationshipCell/index.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useConfig, useTranslation } from '@payloadcms/ui'
+import React from 'react'
+
+import { getRelationshipGroups } from './getRelationshipGroups.js'
+import './index.scss'
+
+const baseClass = 'import-preview-relationship'
+
+type Props = {
+  /** `field.relationTo` — an array when the field is polymorphic. */
+  relationTo: string | string[]
+  value: unknown
+}
+
+/**
+ * Renders a relationship or upload value for the import preview table, stacking
+ * one row per target collection.
+ */
+export const RelationshipCell: React.FC<Props> = ({ relationTo, value }) => {
+  const { config } = useConfig()
+  const { i18n } = useTranslation()
+
+  const groups = getRelationshipGroups({
+    collections: config.collections,
+    dateFormat: config.admin.dateFormat,
+    i18n,
+    relationTo,
+    value,
+  })
+
+  // The column heading already names a monomorphic field, whose collection never varies.
+  const showCollectionLabels = Array.isArray(relationTo)
+
+  if (!groups.length) {
+    return null
+  }
+
+  return (
+    <div className={baseClass}>
+      {groups.map(({ label, options, remaining }, index) => (
+        <div className={`${baseClass}__group`} key={label || index}>
+          {/* A `label` element would be unassociated here — the cell holds no control */}
+          {showCollectionLabels && label && (
+            <span className={`${baseClass}__collection`}>{label}</span>
+          )}
+          <div className={`${baseClass}__values`}>
+            {options.join(', ')}
+            {remaining > 0 && (
+              <span className={`${baseClass}__more`}>
+                {i18n.t('fields:itemsAndMore', { count: remaining, items: '' }).trim()}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
+++ b/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
@@ -1,8 +1,17 @@
-import { FlattenedField } from 'payload'
+import type { FlattenedField, PayloadRequest } from 'payload'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+import { applyFieldHooks } from './applyFieldHooks.js'
 import { getExportFieldFunctions } from './getExportFieldFunctions.js'
+
+const mockReq = {
+  payload: {
+    logger: {
+      error: vi.fn(),
+    },
+  },
+} as unknown as PayloadRequest
 
 describe('getExportFieldFunctions registration', () => {
   it('should not collide bare-key entries when two same-named fields with built-in handlers exist in different positions', () => {
@@ -38,77 +47,40 @@ describe('getExportFieldFunctions registration', () => {
   })
 })
 
-describe('relationship export handlers', () => {
-  const buildField = (overrides: Record<string, unknown>): FlattenedField[] => [
-    { name: 'rel', type: 'relationship', ...overrides } as unknown as FlattenedField,
-  ]
-
-  /**
-   * Invokes the registered handler the way the export pipelines do and returns both
-   * the hook's return value and whatever it wrote into the flat row.
-   */
-  const invoke = ({
-    fields,
-    format,
-    value,
-  }: {
-    fields: FlattenedField[]
-    format: 'csv' | 'json'
-    value: unknown
-  }) => {
-    const entry = getExportFieldFunctions({ fields })['rel']
-    const siblingData: Record<string, unknown> = {}
-
-    const returned = (entry as { fn: (args: Record<string, unknown>) => unknown }).fn({
-      columnName: 'rel',
-      data: {},
-      format,
-      siblingData,
-      siblingDoc: {},
-      value,
-    })
-
-    return { returned, siblingData }
-  }
-
-  it('should leave an unresolvable single polymorphic value untouched for json but suppress it for csv', () => {
-    const fields = buildField({ relationTo: ['posts', 'users'] })
-    const value = { relationTo: 'posts', value: null }
-
-    expect(invoke({ fields, format: 'json', value }).returned).toBeUndefined()
-    expect(invoke({ fields, format: 'csv', value }).returned).toBeNull()
-  })
-
-  it('should drop unresolvable ids from a hasMany monomorphic json export', () => {
-    const { returned } = invoke({
-      fields: buildField({ hasMany: true, relationTo: 'posts' }),
-      format: 'json',
-      value: [{ id: 'p1' }, {}, 'p2'],
-    })
-
-    expect(returned).toEqual(['p1', 'p2'])
-  })
-
-  describe('hasMany polymorphic with an unresolvable entry', () => {
-    const fields = buildField({ hasMany: true, relationTo: ['posts', 'users'] })
-    const value = [
-      { relationTo: 'users', value: null },
-      { relationTo: 'posts', value: 'p1' },
+describe('hasMany polymorphic CSV columns', () => {
+  it('should pin columns to the source index when an earlier relationship is orphaned', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'rel',
+        type: 'relationship',
+        hasMany: true,
+        relationTo: ['posts', 'users'],
+      } as unknown as FlattenedField,
     ]
 
-    it('should keep csv columns pinned to the source index', () => {
-      // The surviving entry stays at index 1 — shifting it to 0 would silently
-      // rewrite column names for every consumer of the CSV.
-      expect(invoke({ fields, format: 'csv', value }).siblingData).toEqual({
-        rel_1_id: 'p1',
-        rel_1_relationTo: 'posts',
-      })
+    const result = applyFieldHooks({
+      type: 'beforeExport',
+      // Exports populate at depth 1, so `value: null` is an orphaned reference —
+      // the target doc was deleted out from under it.
+      data: {
+        rel: [
+          { relationTo: 'users', value: null },
+          { relationTo: 'posts', value: 'p1' },
+        ],
+      },
+      fieldHooks: getExportFieldFunctions({ fields }),
+      fields,
+      format: 'csv',
+      operation: 'export',
+      req: mockReq,
     })
 
-    it('should drop the entry for json rather than leaving a hole', () => {
-      expect(invoke({ fields, format: 'json', value }).returned).toEqual([
-        { relationTo: 'posts', value: 'p1' },
-      ])
+    // The surviving entry stays at index 1 — shifting it to 0 would silently
+    // rewrite column names for every consumer of the CSV.
+    expect(result).toEqual({
+      rel: null,
+      rel_1_id: 'p1',
+      rel_1_relationTo: 'posts',
     })
   })
 })

--- a/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
+++ b/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
@@ -37,3 +37,78 @@ describe('getExportFieldFunctions registration', () => {
     expect(result['topLevelData']).toBeDefined()
   })
 })
+
+describe('relationship export handlers', () => {
+  const buildField = (overrides: Record<string, unknown>): FlattenedField[] => [
+    { name: 'rel', type: 'relationship', ...overrides } as unknown as FlattenedField,
+  ]
+
+  /**
+   * Invokes the registered handler the way the export pipelines do and returns both
+   * the hook's return value and whatever it wrote into the flat row.
+   */
+  const invoke = ({
+    fields,
+    format,
+    value,
+  }: {
+    fields: FlattenedField[]
+    format: 'csv' | 'json'
+    value: unknown
+  }) => {
+    const entry = getExportFieldFunctions({ fields })['rel']
+    const siblingData: Record<string, unknown> = {}
+
+    const returned = (entry as { fn: (args: Record<string, unknown>) => unknown }).fn({
+      columnName: 'rel',
+      data: {},
+      format,
+      siblingData,
+      siblingDoc: {},
+      value,
+    })
+
+    return { returned, siblingData }
+  }
+
+  it('should leave an unresolvable single polymorphic value untouched for json but suppress it for csv', () => {
+    const fields = buildField({ relationTo: ['posts', 'users'] })
+    const value = { relationTo: 'posts', value: null }
+
+    expect(invoke({ fields, format: 'json', value }).returned).toBeUndefined()
+    expect(invoke({ fields, format: 'csv', value }).returned).toBeNull()
+  })
+
+  it('should drop unresolvable ids from a hasMany monomorphic json export', () => {
+    const { returned } = invoke({
+      fields: buildField({ hasMany: true, relationTo: 'posts' }),
+      format: 'json',
+      value: [{ id: 'p1' }, {}, 'p2'],
+    })
+
+    expect(returned).toEqual(['p1', 'p2'])
+  })
+
+  describe('hasMany polymorphic with an unresolvable entry', () => {
+    const fields = buildField({ hasMany: true, relationTo: ['posts', 'users'] })
+    const value = [
+      { relationTo: 'users', value: null },
+      { relationTo: 'posts', value: 'p1' },
+    ]
+
+    it('should keep csv columns pinned to the source index', () => {
+      // The surviving entry stays at index 1 — shifting it to 0 would silently
+      // rewrite column names for every consumer of the CSV.
+      expect(invoke({ fields, format: 'csv', value }).siblingData).toEqual({
+        rel_1_id: 'p1',
+        rel_1_relationTo: 'posts',
+      })
+    })
+
+    it('should drop the entry for json rather than leaving a hole', () => {
+      expect(invoke({ fields, format: 'json', value }).returned).toEqual([
+        { relationTo: 'posts', value: 'p1' },
+      ])
+    })
+  })
+})

--- a/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
+++ b/packages/plugin-import-export/src/utilities/getExportFieldFunctions.spec.ts
@@ -84,3 +84,76 @@ describe('hasMany polymorphic CSV columns', () => {
     })
   })
 })
+
+describe('dangling references in JSON exports', () => {
+  it('should drop an orphaned entry from a hasMany array rather than exporting a null', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'rel',
+        type: 'relationship',
+        hasMany: true,
+        relationTo: 'posts',
+      } as unknown as FlattenedField,
+    ]
+
+    const result = applyFieldHooks({
+      type: 'beforeExport',
+      // Population resolves a soft-deleted target to null, which import rejects as an
+      // invalid relationship — failing the whole row rather than the one dead reference.
+      data: { rel: [null, 'p1'] },
+      fieldHooks: getExportFieldFunctions({ fields }),
+      fields,
+      format: 'json',
+      operation: 'export',
+      req: mockReq,
+    })
+
+    expect(result).toEqual({ rel: ['p1'] })
+  })
+
+  it('should clear an orphaned single polymorphic reference', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'rel',
+        type: 'relationship',
+        relationTo: ['posts', 'users'],
+      } as unknown as FlattenedField,
+    ]
+
+    const result = applyFieldHooks({
+      type: 'beforeExport',
+      data: { rel: { relationTo: 'posts', value: null } },
+      fieldHooks: getExportFieldFunctions({ fields }),
+      fields,
+      format: 'json',
+      operation: 'export',
+      req: mockReq,
+    })
+
+    expect(result).toEqual({ rel: null })
+  })
+
+  it('should leave a shape it does not recognize untouched', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'rel',
+        type: 'relationship',
+        relationTo: ['posts', 'users'],
+      } as unknown as FlattenedField,
+    ]
+
+    const result = applyFieldHooks({
+      type: 'beforeExport',
+      // Destroying a value this handler cannot interpret would lose data that a
+      // custom beforeExport hook or a hand-edited file may depend on.
+      data: { rel: { slug: 'not-a-relationship' } },
+      fieldHooks: getExportFieldFunctions({ fields }),
+      fields,
+      format: 'json',
+      operation: 'export',
+      req: mockReq,
+    })
+
+    expect(result).toEqual({ rel: { slug: 'not-a-relationship' } })
+  })
+})

--- a/packages/plugin-import-export/src/utilities/getExportFieldFunctions.ts
+++ b/packages/plugin-import-export/src/utilities/getExportFieldFunctions.ts
@@ -76,17 +76,18 @@ const registerExportHandler = (
     }
 
     registerHandler(({ format, siblingData, value }) => {
-      // An unresolvable relationship is suppressed for CSV, whose id/relationTo would
-      // otherwise land in sibling columns, but left untouched for JSON, which holds the
-      // source value verbatim.
-      const unresolved = format === 'json' ? undefined : null
-
+      // A shape this handler does not recognize is left untouched for JSON, which holds the
+      // source value verbatim. CSV still clears it, since its id/relationTo would otherwise
+      // land in sibling columns.
       if (!isPolymorphicRelValue(value)) {
-        return unresolved
+        return format === 'json' ? undefined : null
       }
+
+      // A recognized reference that resolves to no id is dangling, and a dangling reference
+      // cannot be imported back — clear it for both formats.
       const id = getPolymorphicRelId(value)
       if (id === undefined) {
-        return unresolved
+        return null
       }
 
       if (format === 'json') {
@@ -107,8 +108,10 @@ const registerExportHandler = (
       const ids = value.map((val) =>
         typeof val === 'object' && val ? (val as { id: unknown }).id : val,
       )
+      // A dangling reference cannot be imported back, so it is dropped rather than
+      // exported as a null the import would reject as an invalid relationship.
       if (format === 'json') {
-        return ids.filter((id) => id !== undefined)
+        return ids.filter((id) => id !== undefined && id !== null)
       }
       ids.forEach((id, i) => {
         siblingData[`${fullKey}_${i}_id`] = id

--- a/packages/plugin-import-export/src/utilities/getExportFieldFunctions.ts
+++ b/packages/plugin-import-export/src/utilities/getExportFieldFunctions.ts
@@ -75,46 +75,70 @@ const registerExportHandler = (
       return
     }
 
-    registerHandler(({ siblingData, value }) => {
-      if (isPolymorphicRelValue(value)) {
-        const id = getPolymorphicRelId(value)
-        if (id !== undefined) {
-          siblingData[`${fullKey}_id`] = id
-          siblingData[`${fullKey}_relationTo`] = value.relationTo
-        }
+    registerHandler(({ format, siblingData, value }) => {
+      // An unresolvable relationship is suppressed for CSV, whose id/relationTo would
+      // otherwise land in sibling columns, but left untouched for JSON, which holds the
+      // source value verbatim.
+      const unresolved = format === 'json' ? undefined : null
+
+      if (!isPolymorphicRelValue(value)) {
+        return unresolved
       }
+      const id = getPolymorphicRelId(value)
+      if (id === undefined) {
+        return unresolved
+      }
+
+      if (format === 'json') {
+        return { relationTo: value.relationTo, value: id }
+      }
+      siblingData[`${fullKey}_id`] = id
+      siblingData[`${fullKey}_relationTo`] = value.relationTo
       return null
     })
     return
   }
 
   if (!Array.isArray(field.relationTo)) {
-    registerHandler(({ siblingData, value }) => {
-      if (Array.isArray(value)) {
-        value.forEach((val, i) => {
-          const id = typeof val === 'object' && val ? (val as { id: unknown }).id : val
-          siblingData[`${fullKey}_${i}_id`] = id
-        })
-        return null
+    registerHandler(({ format, siblingData, value }) => {
+      if (!Array.isArray(value)) {
+        return undefined
       }
-      return undefined
+      const ids = value.map((val) =>
+        typeof val === 'object' && val ? (val as { id: unknown }).id : val,
+      )
+      if (format === 'json') {
+        return ids.filter((id) => id !== undefined)
+      }
+      ids.forEach((id, i) => {
+        siblingData[`${fullKey}_${i}_id`] = id
+      })
+      return null
     })
     return
   }
 
-  registerHandler(({ siblingData, value }) => {
-    if (Array.isArray(value)) {
-      value.forEach((val, i) => {
-        if (isPolymorphicRelValue(val)) {
-          const id = getPolymorphicRelId(val)
-          if (id !== undefined) {
-            siblingData[`${fullKey}_${i}_id`] = id
-            siblingData[`${fullKey}_${i}_relationTo`] = val.relationTo
-          }
-        }
-      })
-      return null
+  registerHandler(({ format, siblingData, value }) => {
+    if (!Array.isArray(value)) {
+      return undefined
     }
-    return undefined
+    // `index` is carried so CSV columns stay pinned to the source position: an entry
+    // that cannot be resolved to an id leaves a gap rather than shifting its siblings.
+    const rels = value.flatMap((val, index) => {
+      if (!isPolymorphicRelValue(val)) {
+        return []
+      }
+      const id = getPolymorphicRelId(val)
+      return id === undefined ? [] : [{ id, index, relationTo: val.relationTo }]
+    })
+
+    if (format === 'json') {
+      return rels.map((rel) => ({ relationTo: rel.relationTo, value: rel.id }))
+    }
+    rels.forEach(({ id, index, relationTo }) => {
+      siblingData[`${fullKey}_${index}_id`] = id
+      siblingData[`${fullKey}_${index}_relationTo`] = relationTo
+    })
+    return null
   })
 }

--- a/packages/plugin-import-export/src/utilities/unflattenObject.spec.ts
+++ b/packages/plugin-import-export/src/utilities/unflattenObject.spec.ts
@@ -405,6 +405,44 @@ describe('unflattenObject', () => {
       })
     })
 
+    describe('hasMany with gaps in the column indices', () => {
+      // Export pins each column to its source index, so an entry that could not be
+      // resolved to an id leaves a gap. Import must absorb the gap rather than
+      // emitting a null array entry.
+      const hasManyFields: FlattenedField[] = [
+        {
+          name: 'rels',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['posts', 'pages'],
+        } as FlattenedField,
+      ]
+
+      const expected = {
+        rels: [{ relationTo: 'posts', value: 'p1' }],
+      }
+
+      it('should absorb a leading gap left by an unresolvable entry', () => {
+        const data = {
+          rels_1_id: 'p1',
+          rels_1_relationTo: 'posts',
+        }
+
+        expect(unflattenObject({ data, fields: hasManyFields, req: mockReq })).toEqual(expected)
+      })
+
+      it('should absorb a gap padded with empty strings by schema columns', () => {
+        const data = {
+          rels_0_id: '',
+          rels_0_relationTo: '',
+          rels_1_id: 'p1',
+          rels_1_relationTo: 'posts',
+        }
+
+        expect(unflattenObject({ data, fields: hasManyFields, req: mockReq })).toEqual(expected)
+      })
+    })
+
     it('should skip polymorphic relationships with undefined values', () => {
       const data = {
         polymorphic_id: undefined,

--- a/test/plugin-import-export/e2e.spec.ts
+++ b/test/plugin-import-export/e2e.spec.ts
@@ -1066,6 +1066,147 @@ test.describe('Import Export Plugin', () => {
         }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
       })
     })
+
+    test.describe('Relationship Preview', () => {
+      const relationshipBaseClass = 'import-preview-relationship'
+
+      // The preview renders the file as-is without populating relationships, so these
+      // IDs never need to exist — nothing here reaches the database.
+      const uploadPreviewFile = async ({
+        docs,
+        name,
+      }: {
+        docs: Record<string, unknown>[]
+        name: string
+      }) => {
+        await page.goto(importsURL.create)
+        await expect(page.locator('.collection-edit')).toBeVisible()
+
+        const collectionField = page.locator('#field-collectionSlug')
+        await collectionField.locator('.rs__control').click()
+        await expect(page.locator('.rs__menu')).toBeVisible()
+        await page.locator('.rs__option:text-is("Pages")').click()
+
+        await page.locator('input[type="file"]').setInputFiles({
+          name,
+          buffer: Buffer.from(JSON.stringify(docs)),
+          mimeType: 'application/json',
+        })
+
+        await expect(async () => {
+          await expect(page.locator('.import-preview table')).toBeVisible()
+        }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
+      }
+
+      /** The first row's cell under the given column heading. */
+      const getPreviewCell = async ({ heading }: { heading: string }) => {
+        const previewTable = page.locator('.import-preview table')
+        const headings = await previewTable.locator('thead th').allTextContents()
+        const columnIndex = headings.findIndex((text) => text.trim() === heading)
+
+        expect(columnIndex).toBeGreaterThan(-1)
+
+        return previewTable.locator('tbody tr').first().locator('td').nth(columnIndex)
+      }
+
+      test('should group polymorphic relationship values by collection', async () => {
+        await uploadPreviewFile({
+          docs: [
+            {
+              title: 'Polymorphic Preview',
+              hasManyPolymorphic: [
+                { relationTo: 'users', value: 'preview-user-1' },
+                { relationTo: 'posts', value: 'preview-post-1' },
+              ],
+            },
+          ],
+          name: 'polymorphic-preview.json',
+        })
+
+        const cell = await getPreviewCell({ heading: 'Has Many Polymorphic' })
+        const groups = cell.locator(`.${relationshipBaseClass}__group`)
+
+        await expect(groups).toHaveCount(2)
+        await expect(groups.nth(0).locator(`.${relationshipBaseClass}__collection`)).toHaveText(
+          'Users',
+        )
+        await expect(groups.nth(0).locator(`.${relationshipBaseClass}__values`)).toHaveText(
+          'preview-user-1',
+        )
+        await expect(groups.nth(1).locator(`.${relationshipBaseClass}__collection`)).toHaveText(
+          'Posts',
+        )
+        await expect(groups.nth(1).locator(`.${relationshipBaseClass}__values`)).toHaveText(
+          'preview-post-1',
+        )
+      })
+
+      test('should not label the collection for monomorphic relationship values', async () => {
+        await uploadPreviewFile({
+          docs: [
+            {
+              title: 'Monomorphic Preview',
+              hasManyMonomorphic: ['preview-post-1', 'preview-post-2'],
+            },
+          ],
+          name: 'monomorphic-preview.json',
+        })
+
+        const cell = await getPreviewCell({ heading: 'Has Many Monomorphic' })
+
+        // The column heading already names the only collection this field can target
+        await expect(cell.locator(`.${relationshipBaseClass}__collection`)).toHaveCount(0)
+        await expect(cell.locator(`.${relationshipBaseClass}__values`)).toHaveText(
+          'preview-post-1, preview-post-2',
+        )
+      })
+
+      test('should show the document title for populated relationship values', async () => {
+        await uploadPreviewFile({
+          docs: [
+            {
+              title: 'Populated Preview',
+              hasManyMonomorphic: [{ id: 'preview-post-1', title: 'Populated Post Title' }],
+            },
+          ],
+          name: 'populated-relationship-preview.json',
+        })
+
+        const cell = await getPreviewCell({ heading: 'Has Many Monomorphic' })
+
+        await expect(cell.locator(`.${relationshipBaseClass}__values`)).toHaveText(
+          'Populated Post Title',
+        )
+      })
+
+      test('should collapse relationship values past the third into a count', async () => {
+        await uploadPreviewFile({
+          docs: [
+            {
+              title: 'Overflow Preview',
+              hasManyMonomorphic: [
+                'preview-post-1',
+                'preview-post-2',
+                'preview-post-3',
+                'preview-post-4',
+                'preview-post-5',
+              ],
+            },
+          ],
+          name: 'overflow-relationship-preview.json',
+        })
+
+        const cell = await getPreviewCell({ heading: 'Has Many Monomorphic' })
+
+        await expect(cell.locator(`.${relationshipBaseClass}__values`)).toContainText(
+          'preview-post-1, preview-post-2, preview-post-3',
+        )
+        await expect(cell.locator(`.${relationshipBaseClass}__values`)).not.toContainText(
+          'preview-post-4',
+        )
+        await expect(cell.locator(`.${relationshipBaseClass}__more`)).toHaveText('and 2 more')
+      })
+    })
   })
 
   test.describe('S3 Storage', () => {

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -4677,386 +4677,435 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should roundtrip a hasMany monomorphic relationship through CSV export/import', async () => {
-      const post1 = await payload.create({
-        collection: 'posts',
-        data: {
-          title: 'hasMany Monomorphic Post 1',
-        },
-      })
-      const post2 = await payload.create({
-        collection: 'posts',
-        data: {
-          title: 'hasMany Monomorphic Post 2',
-        },
+    describe('relationship roundtrips', () => {
+      const createdPostIDs: (number | string)[] = []
+
+      afterEach(async () => {
+        for (const id of createdPostIDs) {
+          try {
+            await payload.delete({
+              collection: 'posts',
+              id,
+            })
+          } catch {
+            // Ignore cleanup errors
+          }
+        }
+        createdPostIDs.length = 0
       })
 
-      const testPage = await payload.create({
-        collection: 'pages',
-        data: {
-          title: 'hasMany Monomorphic Roundtrip',
-          hasManyMonomorphic: [post1.id, post2.id],
-          _status: 'published',
-        },
-      })
+      it('should roundtrip a hasMany monomorphic relationship through CSV export/import', async () => {
+        const post1 = await payload.create({
+          collection: 'posts',
+          data: {
+            title: 'hasMany Monomorphic Post 1',
+          },
+        })
+        const post2 = await payload.create({
+          collection: 'posts',
+          data: {
+            title: 'hasMany Monomorphic Post 2',
+          },
+        })
 
-      const exportDoc = await payload.create({
-        collection: 'exports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          fields: ['id', 'title', 'hasManyMonomorphic'],
-          format: 'csv',
+        createdPostIDs.push(post1.id, post2.id)
+
+        const testPage = await payload.create({
+          collection: 'pages',
+          data: {
+            title: 'hasMany Monomorphic Roundtrip',
+            hasManyMonomorphic: [post1.id, post2.id],
+            _status: 'published',
+          },
+        })
+
+        const exportDoc = await payload.create({
+          collection: 'exports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            fields: ['id', 'title', 'hasManyMonomorphic'],
+            format: 'csv',
+            where: {
+              id: { equals: testPage.id },
+            },
+          },
+        })
+
+        await payload.jobs.run()
+
+        const exportedDoc = await payload.findByID({
+          collection: 'exports',
+          id: exportDoc.id,
+        })
+
+        const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+        const exportedRows = await readCSV(csvPath)
+
+        // CSV keeps each relationship flattened into indexed sibling columns
+        expect(exportedRows).toEqual([
+          {
+            id: String(testPage.id),
+            title: 'hasMany Monomorphic Roundtrip',
+            hasManyMonomorphic_0_id: String(post1.id),
+            hasManyMonomorphic_1_id: String(post2.id),
+          },
+        ])
+
+        await payload.delete({
+          collection: 'pages',
+          id: testPage.id,
+        })
+
+        let importDoc = await payload.create({
+          collection: 'imports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            importMode: 'create',
+          },
+          file: {
+            data: fs.readFileSync(csvPath),
+            mimetype: 'text/csv',
+            name: 'hasmany-monomorphic-roundtrip.csv',
+            size: fs.statSync(csvPath).size,
+          },
+        })
+
+        await payload.jobs.run()
+
+        importDoc = await payload.findByID({
+          collection: 'imports',
+          id: importDoc.id,
+        })
+
+        const importedPages = await payload.find({
+          collection: 'pages',
           where: {
-            id: { equals: testPage.id },
+            title: { equals: 'hasMany Monomorphic Roundtrip' },
           },
-        },
+          depth: 0,
+        })
+        const imported = importedPages.docs[0]
+
+        expect(importDoc.status).toBe('completed')
+        expect(importDoc.summary?.imported).toBe(1)
+        expect(importDoc.summary?.issues).toBe(0)
+        expect(importedPages.docs).toHaveLength(1)
+        expect(imported?.title).toBe('hasMany Monomorphic Roundtrip')
+        expect(imported?.hasManyMonomorphic).toHaveLength(2)
+        expect((imported?.hasManyMonomorphic ?? []).map(extractID)).toEqual([post1.id, post2.id])
+        // The flattened columns are consumed by the import, not carried onto the document
+        expect(imported).not.toHaveProperty('hasManyMonomorphic_0_id')
+        expect(imported).not.toHaveProperty('hasManyMonomorphic_1_id')
       })
 
-      await payload.jobs.run()
+      it('should roundtrip a hasMany monomorphic relationship through JSON export/import', async () => {
+        const post1 = await payload.create({
+          collection: 'posts',
+          data: { title: 'hasMany JSON Post 1' },
+        })
+        const post2 = await payload.create({
+          collection: 'posts',
+          data: { title: 'hasMany JSON Post 2' },
+        })
 
-      const exportedDoc = await payload.findByID({
-        collection: 'exports',
-        id: exportDoc.id,
-      })
+        createdPostIDs.push(post1.id, post2.id)
 
-      const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+        const testPage = await payload.create({
+          collection: 'pages',
+          data: {
+            title: 'hasMany JSON Roundtrip',
+            hasManyMonomorphic: [post1.id, post2.id],
+            _status: 'published',
+          },
+        })
 
-      await payload.delete({
-        collection: 'pages',
-        id: testPage.id,
-      })
+        const exportDoc = await payload.create({
+          collection: 'exports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            fields: ['id', 'title', 'hasManyMonomorphic'],
+            format: 'json',
+            where: {
+              id: { equals: testPage.id },
+            },
+          },
+        })
 
-      let importDoc = await payload.create({
-        collection: 'imports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          importMode: 'create',
-        },
-        file: {
-          data: fs.readFileSync(csvPath),
-          mimetype: 'text/csv',
-          name: 'hasmany-monomorphic-roundtrip.csv',
-          size: fs.statSync(csvPath).size,
-        },
-      })
+        await payload.jobs.run()
 
-      await payload.jobs.run()
+        const exportedDoc = await payload.findByID({
+          collection: 'exports',
+          id: exportDoc.id,
+        })
 
-      importDoc = await payload.findByID({
-        collection: 'imports',
-        id: importDoc.id,
-      })
+        const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+        const exportedDocs = await readJSON(jsonPath)
 
-      const importedPages = await payload.find({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasMany Monomorphic Roundtrip' },
-        },
-        depth: 0,
-      })
-      const imported = importedPages.docs[0]
+        // JSON holds the relationship natively — an array of IDs, with no flattened siblings
+        expect(exportedDocs).toEqual([
+          {
+            id: testPage.id,
+            title: 'hasMany JSON Roundtrip',
+            hasManyMonomorphic: [post1.id, post2.id],
+          },
+        ])
 
-      await payload.delete({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasMany Monomorphic Roundtrip' },
-        },
-      })
-      await payload.delete({ collection: 'posts', id: post1.id })
-      await payload.delete({ collection: 'posts', id: post2.id })
+        await payload.delete({
+          collection: 'pages',
+          id: testPage.id,
+        })
 
-      expect(importDoc.status).toBe('completed')
-      expect(importDoc.summary?.imported).toBe(1)
-      expect(importDoc.summary?.issues).toBe(0)
-      expect(importedPages.docs).toHaveLength(1)
-      expect(imported?.hasManyMonomorphic).toHaveLength(2)
-      expect((imported?.hasManyMonomorphic ?? []).map(extractID)).toEqual([post1.id, post2.id])
-    })
+        let importDoc = await payload.create({
+          collection: 'imports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            importMode: 'create',
+          },
+          file: {
+            data: fs.readFileSync(jsonPath),
+            mimetype: 'application/json',
+            name: 'hasmany-json-roundtrip.json',
+            size: fs.statSync(jsonPath).size,
+          },
+        })
 
-    it('should roundtrip a hasMany monomorphic relationship through JSON export/import', async () => {
-      const post1 = await payload.create({
-        collection: 'posts',
-        data: { title: 'hasMany JSON Post 1' },
-      })
-      const post2 = await payload.create({
-        collection: 'posts',
-        data: { title: 'hasMany JSON Post 2' },
-      })
+        await payload.jobs.run()
 
-      const testPage = await payload.create({
-        collection: 'pages',
-        data: {
-          title: 'hasMany JSON Roundtrip',
-          hasManyMonomorphic: [post1.id, post2.id],
-          _status: 'published',
-        },
-      })
+        importDoc = await payload.findByID({
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
-      const exportDoc = await payload.create({
-        collection: 'exports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          fields: ['id', 'title', 'hasManyMonomorphic'],
-          format: 'json',
+        const importedPages = await payload.find({
+          collection: 'pages',
           where: {
-            id: { equals: testPage.id },
+            title: { equals: 'hasMany JSON Roundtrip' },
           },
-        },
+          depth: 0,
+        })
+        const imported = importedPages.docs[0]
+
+        expect(importDoc.status).toBe('completed')
+        expect(importDoc.summary?.imported).toBe(1)
+        expect(importDoc.summary?.issues).toBe(0)
+        expect(importedPages.docs).toHaveLength(1)
+        expect(imported?.title).toBe('hasMany JSON Roundtrip')
+        expect(imported?.hasManyMonomorphic).toHaveLength(2)
+        expect((imported?.hasManyMonomorphic ?? []).map(extractID)).toEqual([post1.id, post2.id])
       })
 
-      await payload.jobs.run()
+      it('should roundtrip a single polymorphic relationship through JSON export/import', async () => {
+        const post1 = await payload.create({
+          collection: 'posts',
+          data: { title: 'hasOnePolymorphic JSON Post' },
+        })
 
-      const exportedDoc = await payload.findByID({
-        collection: 'exports',
-        id: exportDoc.id,
-      })
+        createdPostIDs.push(post1.id)
 
-      const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
-
-      await payload.delete({
-        collection: 'pages',
-        id: testPage.id,
-      })
-
-      let importDoc = await payload.create({
-        collection: 'imports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          importMode: 'create',
-        },
-        file: {
-          data: fs.readFileSync(jsonPath),
-          mimetype: 'application/json',
-          name: 'hasmany-json-roundtrip.json',
-          size: fs.statSync(jsonPath).size,
-        },
-      })
-
-      await payload.jobs.run()
-
-      importDoc = await payload.findByID({
-        collection: 'imports',
-        id: importDoc.id,
-      })
-
-      const importedPages = await payload.find({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasMany JSON Roundtrip' },
-        },
-        depth: 0,
-      })
-      const imported = importedPages.docs[0]
-
-      await payload.delete({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasMany JSON Roundtrip' },
-        },
-      })
-      await payload.delete({ collection: 'posts', id: post1.id })
-      await payload.delete({ collection: 'posts', id: post2.id })
-
-      expect(importDoc.status).toBe('completed')
-      expect(importedPages.docs).toHaveLength(1)
-      expect(imported?.hasManyMonomorphic).toHaveLength(2)
-      expect((imported?.hasManyMonomorphic ?? []).map(extractID)).toEqual([post1.id, post2.id])
-    })
-
-    it('should roundtrip a single polymorphic relationship through JSON export/import', async () => {
-      const post1 = await payload.create({
-        collection: 'posts',
-        data: { title: 'hasOnePolymorphic JSON Post' },
-      })
-
-      const testPage = await payload.create({
-        collection: 'pages',
-        data: {
-          title: 'hasOnePolymorphic JSON Roundtrip',
-          hasOnePolymorphic: {
-            relationTo: 'posts',
-            value: post1.id,
+        const testPage = await payload.create({
+          collection: 'pages',
+          data: {
+            title: 'hasOnePolymorphic JSON Roundtrip',
+            hasOnePolymorphic: {
+              relationTo: 'posts',
+              value: post1.id,
+            },
+            _status: 'published',
           },
-          _status: 'published',
-        },
-      })
+        })
 
-      const exportDoc = await payload.create({
-        collection: 'exports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          fields: ['id', 'title', 'hasOnePolymorphic'],
-          format: 'json',
+        const exportDoc = await payload.create({
+          collection: 'exports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            fields: ['id', 'title', 'hasOnePolymorphic'],
+            format: 'json',
+            where: {
+              id: { equals: testPage.id },
+            },
+          },
+        })
+
+        await payload.jobs.run()
+
+        const exportedDoc = await payload.findByID({
+          collection: 'exports',
+          id: exportDoc.id,
+        })
+
+        const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+        const exportedDocs = await readJSON(jsonPath)
+
+        // The `relationTo`/`value` pair survives intact rather than splitting into siblings
+        expect(exportedDocs).toEqual([
+          {
+            id: testPage.id,
+            title: 'hasOnePolymorphic JSON Roundtrip',
+            hasOnePolymorphic: { relationTo: 'posts', value: post1.id },
+          },
+        ])
+
+        await payload.delete({
+          collection: 'pages',
+          id: testPage.id,
+        })
+
+        let importDoc = await payload.create({
+          collection: 'imports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            importMode: 'create',
+          },
+          file: {
+            data: fs.readFileSync(jsonPath),
+            mimetype: 'application/json',
+            name: 'hasone-polymorphic-json-roundtrip.json',
+            size: fs.statSync(jsonPath).size,
+          },
+        })
+
+        await payload.jobs.run()
+
+        importDoc = await payload.findByID({
+          collection: 'imports',
+          id: importDoc.id,
+        })
+
+        const importedPages = await payload.find({
+          collection: 'pages',
           where: {
-            id: { equals: testPage.id },
+            title: { equals: 'hasOnePolymorphic JSON Roundtrip' },
           },
-        },
+          depth: 0,
+        })
+        const imported = importedPages.docs[0]
+
+        expect(importDoc.status).toBe('completed')
+        expect(importDoc.summary?.imported).toBe(1)
+        expect(importDoc.summary?.issues).toBe(0)
+        expect(importedPages.docs).toHaveLength(1)
+        expect(imported?.title).toBe('hasOnePolymorphic JSON Roundtrip')
+        expect(imported?.hasOnePolymorphic).toEqual({
+          relationTo: 'posts',
+          value: post1.id,
+        })
       })
 
-      await payload.jobs.run()
+      it('should roundtrip a hasMany polymorphic relationship through JSON export/import', async () => {
+        const testUser = await payload.find({
+          collection: 'users',
+          limit: 1,
+        })
+        const post1 = await payload.create({
+          collection: 'posts',
+          data: { title: 'hasManyPolymorphic JSON Post' },
+        })
 
-      const exportedDoc = await payload.findByID({
-        collection: 'exports',
-        id: exportDoc.id,
-      })
+        createdPostIDs.push(post1.id)
 
-      const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+        const testPage = await payload.create({
+          collection: 'pages',
+          data: {
+            title: 'hasManyPolymorphic JSON Roundtrip',
+            hasManyPolymorphic: [
+              { relationTo: 'users', value: testUser.docs[0]?.id },
+              { relationTo: 'posts', value: post1.id },
+            ],
+            _status: 'published',
+          },
+        })
 
-      await payload.delete({
-        collection: 'pages',
-        id: testPage.id,
-      })
+        const exportDoc = await payload.create({
+          collection: 'exports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            fields: ['id', 'title', 'hasManyPolymorphic'],
+            format: 'json',
+            where: {
+              id: { equals: testPage.id },
+            },
+          },
+        })
 
-      let importDoc = await payload.create({
-        collection: 'imports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          importMode: 'create',
-        },
-        file: {
-          data: fs.readFileSync(jsonPath),
-          mimetype: 'application/json',
-          name: 'hasone-polymorphic-json-roundtrip.json',
-          size: fs.statSync(jsonPath).size,
-        },
-      })
+        await payload.jobs.run()
 
-      await payload.jobs.run()
+        const exportedDoc = await payload.findByID({
+          collection: 'exports',
+          id: exportDoc.id,
+        })
 
-      importDoc = await payload.findByID({
-        collection: 'imports',
-        id: importDoc.id,
-      })
+        const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+        const exportedDocs = await readJSON(jsonPath)
 
-      const importedPages = await payload.find({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasOnePolymorphic JSON Roundtrip' },
-        },
-        depth: 0,
-      })
-      const imported = importedPages.docs[0]
+        // Each entry keeps its own `relationTo`, so a mixed list stays unambiguous
+        expect(exportedDocs).toEqual([
+          {
+            id: testPage.id,
+            title: 'hasManyPolymorphic JSON Roundtrip',
+            hasManyPolymorphic: [
+              { relationTo: 'users', value: testUser.docs[0]?.id },
+              { relationTo: 'posts', value: post1.id },
+            ],
+          },
+        ])
 
-      await payload.delete({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasOnePolymorphic JSON Roundtrip' },
-        },
-      })
-      await payload.delete({ collection: 'posts', id: post1.id })
+        await payload.delete({
+          collection: 'pages',
+          id: testPage.id,
+        })
 
-      expect(importDoc.status).toBe('completed')
-      expect(importedPages.docs).toHaveLength(1)
-      expect(imported?.hasOnePolymorphic).toEqual({
-        relationTo: 'posts',
-        value: post1.id,
-      })
-    })
+        let importDoc = await payload.create({
+          collection: 'imports',
+          user,
+          data: {
+            collectionSlug: 'pages',
+            importMode: 'create',
+          },
+          file: {
+            data: fs.readFileSync(jsonPath),
+            mimetype: 'application/json',
+            name: 'hasmany-polymorphic-json-roundtrip.json',
+            size: fs.statSync(jsonPath).size,
+          },
+        })
 
-    it('should roundtrip a hasMany polymorphic relationship through JSON export/import', async () => {
-      const testUser = await payload.find({
-        collection: 'users',
-        limit: 1,
-      })
-      const post1 = await payload.create({
-        collection: 'posts',
-        data: { title: 'hasManyPolymorphic JSON Post' },
-      })
+        await payload.jobs.run()
 
-      const testPage = await payload.create({
-        collection: 'pages',
-        data: {
-          title: 'hasManyPolymorphic JSON Roundtrip',
-          hasManyPolymorphic: [
-            { relationTo: 'users', value: testUser.docs[0]?.id },
-            { relationTo: 'posts', value: post1.id },
-          ],
-          _status: 'published',
-        },
-      })
+        importDoc = await payload.findByID({
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
-      const exportDoc = await payload.create({
-        collection: 'exports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          fields: ['id', 'title', 'hasManyPolymorphic'],
-          format: 'json',
+        const importedPages = await payload.find({
+          collection: 'pages',
           where: {
-            id: { equals: testPage.id },
+            title: { equals: 'hasManyPolymorphic JSON Roundtrip' },
           },
-        },
-      })
+          depth: 0,
+        })
+        const imported = importedPages.docs[0]
 
-      await payload.jobs.run()
-
-      const exportedDoc = await payload.findByID({
-        collection: 'exports',
-        id: exportDoc.id,
-      })
-
-      const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
-
-      await payload.delete({
-        collection: 'pages',
-        id: testPage.id,
-      })
-
-      let importDoc = await payload.create({
-        collection: 'imports',
-        user,
-        data: {
-          collectionSlug: 'pages',
-          importMode: 'create',
-        },
-        file: {
-          data: fs.readFileSync(jsonPath),
-          mimetype: 'application/json',
-          name: 'hasmany-polymorphic-json-roundtrip.json',
-          size: fs.statSync(jsonPath).size,
-        },
-      })
-
-      await payload.jobs.run()
-
-      importDoc = await payload.findByID({
-        collection: 'imports',
-        id: importDoc.id,
-      })
-
-      const importedPages = await payload.find({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasManyPolymorphic JSON Roundtrip' },
-        },
-        depth: 0,
-      })
-      const imported = importedPages.docs[0]
-
-      await payload.delete({
-        collection: 'pages',
-        where: {
-          title: { equals: 'hasManyPolymorphic JSON Roundtrip' },
-        },
-      })
-      await payload.delete({ collection: 'posts', id: post1.id })
-
-      expect(importDoc.status).toBe('completed')
-      expect(importedPages.docs).toHaveLength(1)
-      expect(imported?.hasManyPolymorphic).toHaveLength(2)
-      expect(imported?.hasManyPolymorphic?.[0]).toEqual({
-        relationTo: 'users',
-        value: testUser.docs[0]?.id,
-      })
-      expect(imported?.hasManyPolymorphic?.[1]).toEqual({
-        relationTo: 'posts',
-        value: post1.id,
+        expect(importDoc.status).toBe('completed')
+        expect(importDoc.summary?.imported).toBe(1)
+        expect(importDoc.summary?.issues).toBe(0)
+        expect(importedPages.docs).toHaveLength(1)
+        expect(imported?.title).toBe('hasManyPolymorphic JSON Roundtrip')
+        expect(imported?.hasManyPolymorphic).toHaveLength(2)
+        expect(imported?.hasManyPolymorphic?.[0]).toEqual({
+          relationTo: 'users',
+          value: testUser.docs[0]?.id,
+        })
+        expect(imported?.hasManyPolymorphic?.[1]).toEqual({
+          relationTo: 'posts',
+          value: post1.id,
+        })
       })
     })
 

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -4677,6 +4677,389 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
+    it('should roundtrip a hasMany monomorphic relationship through CSV export/import', async () => {
+      const post1 = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'hasMany Monomorphic Post 1',
+        },
+      })
+      const post2 = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'hasMany Monomorphic Post 2',
+        },
+      })
+
+      const testPage = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'hasMany Monomorphic Roundtrip',
+          hasManyMonomorphic: [post1.id, post2.id],
+          _status: 'published',
+        },
+      })
+
+      const exportDoc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          fields: ['id', 'title', 'hasManyMonomorphic'],
+          format: 'csv',
+          where: {
+            id: { equals: testPage.id },
+          },
+        },
+      })
+
+      await payload.jobs.run()
+
+      const exportedDoc = await payload.findByID({
+        collection: 'exports',
+        id: exportDoc.id,
+      })
+
+      const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+
+      await payload.delete({
+        collection: 'pages',
+        id: testPage.id,
+      })
+
+      let importDoc = await payload.create({
+        collection: 'imports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          importMode: 'create',
+        },
+        file: {
+          data: fs.readFileSync(csvPath),
+          mimetype: 'text/csv',
+          name: 'hasmany-monomorphic-roundtrip.csv',
+          size: fs.statSync(csvPath).size,
+        },
+      })
+
+      await payload.jobs.run()
+
+      importDoc = await payload.findByID({
+        collection: 'imports',
+        id: importDoc.id,
+      })
+
+      const importedPages = await payload.find({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasMany Monomorphic Roundtrip' },
+        },
+        depth: 0,
+      })
+      const imported = importedPages.docs[0]
+
+      await payload.delete({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasMany Monomorphic Roundtrip' },
+        },
+      })
+      await payload.delete({ collection: 'posts', id: post1.id })
+      await payload.delete({ collection: 'posts', id: post2.id })
+
+      expect(importDoc.status).toBe('completed')
+      expect(importDoc.summary?.imported).toBe(1)
+      expect(importDoc.summary?.issues).toBe(0)
+      expect(importedPages.docs).toHaveLength(1)
+      expect(imported?.hasManyMonomorphic).toHaveLength(2)
+      expect((imported?.hasManyMonomorphic ?? []).map(extractID)).toEqual([post1.id, post2.id])
+    })
+
+    it('should roundtrip a hasMany monomorphic relationship through JSON export/import', async () => {
+      const post1 = await payload.create({
+        collection: 'posts',
+        data: { title: 'hasMany JSON Post 1' },
+      })
+      const post2 = await payload.create({
+        collection: 'posts',
+        data: { title: 'hasMany JSON Post 2' },
+      })
+
+      const testPage = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'hasMany JSON Roundtrip',
+          hasManyMonomorphic: [post1.id, post2.id],
+          _status: 'published',
+        },
+      })
+
+      const exportDoc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          fields: ['id', 'title', 'hasManyMonomorphic'],
+          format: 'json',
+          where: {
+            id: { equals: testPage.id },
+          },
+        },
+      })
+
+      await payload.jobs.run()
+
+      const exportedDoc = await payload.findByID({
+        collection: 'exports',
+        id: exportDoc.id,
+      })
+
+      const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+
+      await payload.delete({
+        collection: 'pages',
+        id: testPage.id,
+      })
+
+      let importDoc = await payload.create({
+        collection: 'imports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          importMode: 'create',
+        },
+        file: {
+          data: fs.readFileSync(jsonPath),
+          mimetype: 'application/json',
+          name: 'hasmany-json-roundtrip.json',
+          size: fs.statSync(jsonPath).size,
+        },
+      })
+
+      await payload.jobs.run()
+
+      importDoc = await payload.findByID({
+        collection: 'imports',
+        id: importDoc.id,
+      })
+
+      const importedPages = await payload.find({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasMany JSON Roundtrip' },
+        },
+        depth: 0,
+      })
+      const imported = importedPages.docs[0]
+
+      await payload.delete({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasMany JSON Roundtrip' },
+        },
+      })
+      await payload.delete({ collection: 'posts', id: post1.id })
+      await payload.delete({ collection: 'posts', id: post2.id })
+
+      expect(importDoc.status).toBe('completed')
+      expect(importedPages.docs).toHaveLength(1)
+      expect(imported?.hasManyMonomorphic).toHaveLength(2)
+      expect((imported?.hasManyMonomorphic ?? []).map(extractID)).toEqual([post1.id, post2.id])
+    })
+
+    it('should roundtrip a single polymorphic relationship through JSON export/import', async () => {
+      const post1 = await payload.create({
+        collection: 'posts',
+        data: { title: 'hasOnePolymorphic JSON Post' },
+      })
+
+      const testPage = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'hasOnePolymorphic JSON Roundtrip',
+          hasOnePolymorphic: {
+            relationTo: 'posts',
+            value: post1.id,
+          },
+          _status: 'published',
+        },
+      })
+
+      const exportDoc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          fields: ['id', 'title', 'hasOnePolymorphic'],
+          format: 'json',
+          where: {
+            id: { equals: testPage.id },
+          },
+        },
+      })
+
+      await payload.jobs.run()
+
+      const exportedDoc = await payload.findByID({
+        collection: 'exports',
+        id: exportDoc.id,
+      })
+
+      const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+
+      await payload.delete({
+        collection: 'pages',
+        id: testPage.id,
+      })
+
+      let importDoc = await payload.create({
+        collection: 'imports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          importMode: 'create',
+        },
+        file: {
+          data: fs.readFileSync(jsonPath),
+          mimetype: 'application/json',
+          name: 'hasone-polymorphic-json-roundtrip.json',
+          size: fs.statSync(jsonPath).size,
+        },
+      })
+
+      await payload.jobs.run()
+
+      importDoc = await payload.findByID({
+        collection: 'imports',
+        id: importDoc.id,
+      })
+
+      const importedPages = await payload.find({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasOnePolymorphic JSON Roundtrip' },
+        },
+        depth: 0,
+      })
+      const imported = importedPages.docs[0]
+
+      await payload.delete({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasOnePolymorphic JSON Roundtrip' },
+        },
+      })
+      await payload.delete({ collection: 'posts', id: post1.id })
+
+      expect(importDoc.status).toBe('completed')
+      expect(importedPages.docs).toHaveLength(1)
+      expect(imported?.hasOnePolymorphic).toEqual({
+        relationTo: 'posts',
+        value: post1.id,
+      })
+    })
+
+    it('should roundtrip a hasMany polymorphic relationship through JSON export/import', async () => {
+      const testUser = await payload.find({
+        collection: 'users',
+        limit: 1,
+      })
+      const post1 = await payload.create({
+        collection: 'posts',
+        data: { title: 'hasManyPolymorphic JSON Post' },
+      })
+
+      const testPage = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'hasManyPolymorphic JSON Roundtrip',
+          hasManyPolymorphic: [
+            { relationTo: 'users', value: testUser.docs[0]?.id },
+            { relationTo: 'posts', value: post1.id },
+          ],
+          _status: 'published',
+        },
+      })
+
+      const exportDoc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          fields: ['id', 'title', 'hasManyPolymorphic'],
+          format: 'json',
+          where: {
+            id: { equals: testPage.id },
+          },
+        },
+      })
+
+      await payload.jobs.run()
+
+      const exportedDoc = await payload.findByID({
+        collection: 'exports',
+        id: exportDoc.id,
+      })
+
+      const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
+
+      await payload.delete({
+        collection: 'pages',
+        id: testPage.id,
+      })
+
+      let importDoc = await payload.create({
+        collection: 'imports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          importMode: 'create',
+        },
+        file: {
+          data: fs.readFileSync(jsonPath),
+          mimetype: 'application/json',
+          name: 'hasmany-polymorphic-json-roundtrip.json',
+          size: fs.statSync(jsonPath).size,
+        },
+      })
+
+      await payload.jobs.run()
+
+      importDoc = await payload.findByID({
+        collection: 'imports',
+        id: importDoc.id,
+      })
+
+      const importedPages = await payload.find({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasManyPolymorphic JSON Roundtrip' },
+        },
+        depth: 0,
+      })
+      const imported = importedPages.docs[0]
+
+      await payload.delete({
+        collection: 'pages',
+        where: {
+          title: { equals: 'hasManyPolymorphic JSON Roundtrip' },
+        },
+      })
+      await payload.delete({ collection: 'posts', id: post1.id })
+
+      expect(importDoc.status).toBe('completed')
+      expect(importedPages.docs).toHaveLength(1)
+      expect(imported?.hasManyPolymorphic).toHaveLength(2)
+      expect(imported?.hasManyPolymorphic?.[0]).toEqual({
+        relationTo: 'users',
+        value: testUser.docs[0]?.id,
+      })
+      expect(imported?.hasManyPolymorphic?.[1]).toEqual({
+        relationTo: 'posts',
+        value: post1.id,
+      })
+    })
+
     describe('batch processing', () => {
       it('should process large imports in batches', async () => {
         const rows = ['title,excerpt']


### PR DESCRIPTION
JSON exports of hasMany and polymorphic relationship fields now return their native value (an id, array of ids, or `{ relationTo, value }`) instead of being flattened into `field_N_id` columns with the field nulled out.

JSON Export Before Change:

```json
[
  {
    "id": 2,
    "name": "the wall",
    "description": "the north remembers",
    "events": null,
    "updatedAt": "2026-07-24T18:03:33.856Z",
    "createdAt": "2026-07-24T18:03:33.856Z",
    "events_0_id": 1,
    "events_1_id": 2
  }
]

```

JSON Export After Change:

```json
[
  {
    "id": 2,
    "name": "the wall",
    "description": "the north remembers",
    "events": [1,2],
    "updatedAt": "2026-07-24T18:03:33.856Z",
    "createdAt": "2026-07-24T18:03:33.856Z",
  }
]
```


That flattening only makes sense for CSV, but ran unconditionally for JSON too (#17110). JSON import never reversed it, so re-importing a collection's own JSON export silently dropped every hasMany/polymorphic relationship.

Testing

- Added JSON roundtrip tests for `monomorphic`, `single-polymorphic`, and `hasMany-polymorphic` relationships