### PR TITLE
fix: generate native slug freely across drafts until publish

### DIFF
--- a/docs/fields/slug.mdx
+++ b/docs/fields/slug.mdx
@@ -13,7 +13,7 @@ keywords: slug, fields, config, configuration, documentation, Content Management
 
 A slug is a unique, indexed, URL-friendly string that identifies a particular document, often used to construct the URL of a webpage.
 
-The Slug Field auto-generates its value from another field, such as a title or name field, and provides UI to lock and unlock the field to protect its value, as well as to re-generate the slug on-demand.
+The Slug Field auto-generates its value from another field, such as a title or name field, and provides UI to lock and unlock the field to protect its value and preserve live URLs, as well as to re-generate the slug on-demand.
 
 To create a Slug Field, set the `type` to `slug` in your [Field Config](./overview):
 
@@ -35,27 +35,22 @@ export const ExampleCollection: CollectionConfig = {
 
 The Slug Field defaults `required`, `unique`, and `index` to `true`, and renders in the `sidebar`. In addition to the standard [field options](./overview#field-options), it exposes:
 
-| Option      | Description                                                                                                                         |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `useAsSlug` | Optional. The name of the top-level field to generate the slug from (e.g. `'title'`). This field must exist in the same collection. |
-| `slugify`   | Optional. Override the default slugify function. [More details](#custom-slugify-function).                                          |
+| Option         | Description                                                                                                                             |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `useAsSlug` \* | **Required.** The name of the top-level field to generate the slug from (e.g. `'title'`). This field must exist in the same collection. |
+| `slugify`      | Override the default slugify function. [More details](#custom-slugify-function).                                                        |
 
 Because `slug` is a standard named field, customize it with the usual field properties directly — `label`, `localized`, `required`, `unique` (set `false` to drop the unique index, e.g. for a per-tenant compound index), `index`, `defaultValue`, and `admin` (including `admin.position`).
 
 ## Generation
 
-The slug is static: it fills once while empty and is preserved thereafter, so editing the source field later never rewrites it — this protects live URLs from changing unexpectedly.
+The slug auto-generates from the `useAsSlug` field and tracks it until an editor takes over:
 
-- On create, an empty slug is derived from the `useAsSlug` source field, if any. With no source value (or no `useAsSlug` configured), it falls back to `<singular>-<N>`, where `N` is the first available integer (e.g. `posts-1`). The slug is therefore always present the moment the document is created.
-- An explicit value always wins and is normalized through [`slugify`](#custom-slugify-function) (e.g. `Hello World` → `hello-world`). It must be unique — a collision is rejected rather than silently changed.
-- Once set, the slug is never regenerated automatically. Editors can unlock the field to edit it directly, or re-generate it on-demand from the Admin Panel.
-- Generated values are deduped against existing documents so two never claim the same slug.
+- On create, the slug generates from the source field unless a value is provided explicitly.
+- The slug continues to track the source field on save as long as it has not been manually changed. Once an editor unlocks and edits the slug, it is frozen and no longer regenerates — this protects live URLs from changing unexpectedly.
+- Editors can re-generate the slug on-demand from the Admin Panel, which re-aligns it with the source field.
 
-Because the slug is guaranteed to exist on create, [autosave-enabled](../versions/autosave) documents get a stable slug on the initial draft — before a title is typed — which live preview needs to load the document by its slug.
-
-### Localization
-
-A localized slug is unique per locale: the same value can be reused across a document's own locales, but not across documents within one locale. Every locale is seeded on create, so switching locales never lands on a blank slug, and generation is locale-aware when the source is localized.
+For [autosave-enabled](../versions/autosave) documents, the slug generates freely on every draft save — including the initial create — so a new document gets a natural, live-updating slug while it is being written. It freezes on the first publish (and stays frozen thereafter) to protect the now-live URL from changing unexpectedly. Manually overwriting the slug mid-draft locks it immediately, without needing to publish first.
 
 ## Custom Slugify Function
 

--- a/packages/payload/src/fields/baseFields/slug/generateSlug.ts
+++ b/packages/payload/src/fields/baseFields/slug/generateSlug.ts
@@ -2,130 +2,80 @@ import type { TypeWithID } from '../../../collections/config/types.js'
 import type { FieldHook } from '../../config/types.js'
 import type { Slugify } from './types.js'
 
-import { ValidationError } from '../../../errors/index.js'
-import { fieldValueExists } from '../../../utilities/fieldValueExists.js'
-import { getUniqueFieldValue } from '../../../utilities/getUniqueFieldValue.js'
-import { hasDraftsEnabled } from '../../../utilities/getVersionsConfig.js'
+import { hasAutosaveEnabled } from '../../../utilities/getVersionsConfig.js'
 import { slugify as defaultSlugify } from '../../../utilities/slugify.js'
-import { consumeSlugDuplicateFallback } from './duplicateContext.js'
-import { getSlugFallbackValue } from './getSlugFallbackValue.js'
-import { hasValue } from './hasValue.js'
 
 type Args = {
-  localized?: boolean
   name: string
   slugify?: Slugify
-  useAsSlug?: string
+  useAsSlug: string
 }
 
 /**
- * `beforeChange` hook for the native `slug` field.
+ * Field `beforeChange` hook for the native `slug` field. Returns the slug value.
+ * - The slug value is derived from the `useAsSlug` source field,
+ *   but can be manually overridden by the admin.
+ * - To protect live URLs, the slug is frozen after initial generation
+ *   unless the admin explicitly overwrites it.
  *
- * Fills the slug only while empty and never rewrites one that's set, so a lagging autosave can't
- * clobber it with a stale value:
- *   - empty with no source falls back to `<singular>-<N>`, e.g. `posts-1` (see {@link getSlugFallbackValue})
- *   - explicit input and the source field are slugified, e.g. "Hello World" → "hello-world"
- *   - an already-set slug is preserved as-is
+ * This is expressed as follows:
  *
- * Generated values dedupe against existing slugs; a localized slug is unique per-locale, so its
- * dedupe and fallback are scoped to the locale being written. Globals have no collection to dedupe
- * against, so their slug is left as-is.
+ * Non-versioned and versioned-but-non-autosave collections:
+ * - On create, generate from the source, keeping an explicitly provided value.
+ * - On update, regenerate only while the stored slug is empty.
+ * - Freeze on the first non-empty value, whether generated or manually provided.
+ *
+ * Autosave drafts:
+ * - On every draft save (create and autosave) before publish, generate freely — a new
+ *   document gets a natural, live-updating slug while the admin is still entering content.
+ * - Freeze on the first manual overwrite or the first publish. A mid-draft overwrite wins
+ *   immediately and is preserved across later autosaves.
  */
 export const generateSlug =
-  ({ name, localized, slugify: customSlugify, useAsSlug }: Args): FieldHook =>
-  async ({ collection, context, data, operation, originalDoc, req, value }) => {
+  ({ name, slugify: customSlugify, useAsSlug }: Args): FieldHook =>
+  async ({ collection, data, global, operation, originalDoc, req, value }) => {
+    const source = data?.[useAsSlug]
+
     const slugify = (valueToSlugify: unknown) =>
       customSlugify
         ? customSlugify({ data: (data ?? {}) as TypeWithID, req, valueToSlugify })
         : defaultSlugify(valueToSlugify as string)
 
-    // A localized slug is unique only within its locale, so every uniqueness query below is scoped
-    // to the locale being written.
-    const locale = localized ? (req.locale ?? undefined) : undefined
+    const entity = collection || global!
 
-    // A duplicated document:
-    //  - Takes a fresh `<singular>-<N>` fallback — not the original's slug, not a source-derived one
-    //  - Skips the explicit-collision check below (see generateSlugBeforeDuplicate).
-    if (collection && consumeSlugDuplicateFallback(context, name)) {
-      return await getSlugFallbackValue({ collection, field: name, locale, req, slugify })
+    if (operation === 'create') {
+      // Generate from the source (keeping an explicitly provided slug). On an autosave
+      // collection the initial draft is created empty, so this yields an empty slug and
+      // begins tracking as soon as content is entered.
+      return await slugify(value || source)
     }
 
     const storedSlug = originalDoc?.[name]
+    const originalSource = originalDoc?.[useAsSlug]
 
-    const storedSlugHasValue = hasValue(storedSlug)
-
-    // Explicit value from the client wins — normalized through the field's slugify.
-    // It must be unique: reject a collision rather than silently changing it,
-    // only generated values are automatically deduped.
-    // A value that slugifies to nothing (e.g. "!!!") isn't a usable slug,
-    // so fall through to the source/fallback rather than store an empty one.
-    if (hasValue(value)) {
-      const slugified = await slugify(value)
-
-      if (hasValue(slugified)) {
-        // Unchanged from what's stored — already unique, so skip the collision query. Autosave
-        // resends the current slug on every tick; without this each tick runs a needless read.
-        if (slugified === storedSlug) {
-          return storedSlug
-        }
-
-        if (
-          collection &&
-          (await fieldValueExists({
-            id: originalDoc?.id,
-            collection: collection.slug,
-            draftsEnabled: hasDraftsEnabled(collection),
-            field: name,
-            locale,
-            req,
-            value: slugified,
-          }))
-        ) {
-          throw new ValidationError(
-            { errors: [{ message: req.t('error:valueMustBeUnique'), path: name }] },
-            req.t,
-          )
-        }
-
-        return slugified
-      }
+    // User explicitly edited the slug (or cleared the value) this save: respect it.
+    if (value !== undefined && value !== storedSlug) {
+      return value
     }
 
-    // On update, preserve a slug that is already set — only fill it while empty.
-    if (operation !== 'create' && storedSlugHasValue) {
+    // No explicit edit this save. If the stored slug doesn't match what its source
+    // would generate, it was customized on an earlier save — keep it frozen.
+    const storedSlugIsCustom = storedSlug && storedSlug !== (await slugify(originalSource))
+
+    if (storedSlugIsCustom) {
       return storedSlug
     }
 
-    // Derive an empty slug from its source, when present.
-    // Dedupe so two documents don't both claim it if they have the same source value.
-    // Globals have no collection to dedupe against.
-    const source = useAsSlug ? data?.[useAsSlug] : undefined
-    const derived = source ? await slugify(source) : undefined
-
-    if (hasValue(derived)) {
-      if (!collection) {
-        return derived
-      }
-
-      return await getUniqueFieldValue({
-        id: originalDoc?.id,
-        collection: collection.slug,
-        draftsEnabled: hasDraftsEnabled(collection),
-        field: name,
-        locale,
-        req,
-        value: derived as string,
-      })
+    if (!hasAutosaveEnabled(entity)) {
+      // Non-autosave: generate once while empty, then freeze.
+      return storedSlug || (await slugify(source))
     }
 
-    // No usable source: keep a stored value, otherwise fall back to `<singular>-<N>`.
-    if (storedSlugHasValue) {
+    // Autosave drafts: freeze once the document has been published to protect the live URL.
+    if (data?._status === 'published' || originalDoc?._status === 'published') {
       return storedSlug
     }
 
-    if (!collection) {
-      return undefined
-    }
-
-    return await getSlugFallbackValue({ collection, field: name, locale, req, slugify })
+    // Still an unpublished draft — keep tracking the source freely.
+    return source ? await slugify(source) : null
   }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -2,9 +2,8 @@ import type { MongooseAdapter } from '@payloadcms/db-mongodb'
 import type { IndexDirection, IndexOptions } from 'mongoose'
 import type { Payload, ValidationError } from 'payload'
 
-import { slugifyHandler } from '@payloadcms/ui/utilities/slugify'
 import path from 'path'
-import { createLocalReq, reload } from 'payload'
+import { reload } from 'payload'
 import { fileURLToPath } from 'url'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect } from 'vitest'
 
@@ -63,6 +62,7 @@ describe('Fields', () => {
       slug: 'users',
       credentials: devUser,
     })
+
     user = await payload.login({
       collection: 'users',
       data: {
@@ -83,6 +83,7 @@ describe('Fields', () => {
       for (const id of created) {
         await payload.delete({ collection: 'slug-fields', id })
       }
+
       created.length = 0
     })
 
@@ -91,6 +92,7 @@ describe('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'My First Post' },
       })
+
       created.push(doc.id)
       expect(doc.slug).toBe('my-first-post')
     })
@@ -104,20 +106,12 @@ describe('Fields', () => {
       expect(doc.slug).toBe('custom-slug')
     })
 
-    it('should slugify an unnormalized explicit value', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'My First Post', slug: 'Hello World' },
-      })
-      created.push(doc.id)
-      expect(doc.slug).toBe('hello-world')
-    })
-
     it('should freeze a diverged slug on update', async () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Original Title' },
       })
+
       created.push(doc.id)
 
       const updated = await payload.update({
@@ -125,6 +119,7 @@ describe('Fields', () => {
         id: doc.id,
         data: { title: 'Changed Title', slug: 'manual-value' },
       })
+
       expect(updated.slug).toBe('manual-value')
 
       const again = await payload.update({
@@ -132,393 +127,38 @@ describe('Fields', () => {
         id: doc.id,
         data: { title: 'Changed Title Again' },
       })
+
       expect(again.slug).toBe('manual-value')
     })
 
-    it('should fill every locale of a localized slug on create', async () => {
+    it('should generate localized slugs independently per locale', async () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Title', localizedTitle: 'English Title' },
         locale: 'en',
       })
+
       created.push(doc.id)
       expect(doc.localizedSlug).toBe('english-title')
-
-      // The other locale is seeded on create so switching locales never lands on an empty slug —
-      // with no source of its own it takes a `<singular>-N` fallback.
-      const allLocales = await payload.findByID({
-        collection: 'slug-fields',
-        id: doc.id,
-        locale: 'all',
-      })
-      const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
-      expect(localizedSlug.en).toBe('english-title')
-      expect(localizedSlug.es).toMatch(/^slug-field-\d+$/)
-    })
-
-    it('should derive every locale of a localized slug from a shared non-localized source', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Hello World' },
-        locale: 'en',
-      })
-      created.push(doc.id)
-
-      // `title` is not localized, so its value applies to every locale — each derives `hello-world`
-      // rather than falling back to the counter.
-      const allLocales = await payload.findByID({
-        collection: 'slug-fields',
-        id: doc.id,
-        locale: 'all',
-      })
-      const shared = allLocales.localizedSharedSlug as unknown as Record<string, string>
-      expect(shared.en).toBe('hello-world')
-      expect(shared.es).toBe('hello-world')
-    })
-
-    it('should keep localized slugs independent when one locale is changed', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Title', localizedTitle: 'English Title' },
-        locale: 'en',
-      })
-      created.push(doc.id)
-
-      // Changing one locale's slug leaves the others untouched (a slug is static once set).
-      await payload.update({
-        collection: 'slug-fields',
-        id: doc.id,
-        data: { localizedSlug: 'titulo-espanol' },
-        locale: 'es',
-      })
-
-      const allLocales = await payload.findByID({
-        collection: 'slug-fields',
-        id: doc.id,
-        locale: 'all',
-      })
-      const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
-      expect(localizedSlug.en).toBe('english-title')
-      expect(localizedSlug.es).toBe('titulo-espanol')
-    })
-
-    it('should fall back to <singular>-N for a slug field with no useAsSlug source', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'No Source' },
-      })
-      created.push(doc.id)
-      expect(doc.sourcelessSlug).toMatch(/^slug-field-\d+$/)
-    })
-
-    it('should keep an explicit value on a slug field with no useAsSlug source', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'No Source', sourcelessSlug: 'Manual Value' },
-      })
-      created.push(doc.id)
-      expect(doc.sourcelessSlug).toBe('manual-value')
-    })
-
-    it('should allow the same localized slug value in different locales', async () => {
-      const en = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Title', localizedSlug: 'shared' },
-        locale: 'en',
-      })
-      created.push(en.id)
-      expect(en.localizedSlug).toBe('shared')
-
-      const es = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Titulo', localizedSlug: 'shared' },
-        locale: 'es',
-      })
-      created.push(es.id)
-      expect(es.localizedSlug).toBe('shared')
-    })
-
-    it('should allow one document to reuse the same slug across its own locales', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Title', localizedSlug: 'shared-across-self' },
-        locale: 'en',
-      })
-      created.push(doc.id)
-      expect(doc.localizedSlug).toBe('shared-across-self')
 
       const es = await payload.update({
         collection: 'slug-fields',
         id: doc.id,
-        data: { localizedSlug: 'shared-across-self' },
+        data: { localizedTitle: 'Titulo Espanol' },
         locale: 'es',
       })
-      expect(es.localizedSlug).toBe('shared-across-self')
+
+      expect(es.localizedSlug).toBe('titulo-espanol')
 
       const allLocales = await payload.findByID({
         collection: 'slug-fields',
         id: doc.id,
         locale: 'all',
       })
+
       const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
-      expect(localizedSlug.en).toBe('shared-across-self')
-      expect(localizedSlug.es).toBe('shared-across-self')
-    })
-
-    it('should reject a localized slug that collides within the same locale', async () => {
-      const first = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'First', localizedSlug: 'shared-localized' },
-        locale: 'es',
-      })
-      created.push(first.id)
-      expect(first.localizedSlug).toBe('shared-localized')
-
-      await expect(
-        payload.create({
-          collection: 'slug-fields',
-          data: { title: 'Second', localizedSlug: 'shared-localized' },
-          locale: 'es',
-        }),
-      ).rejects.toThrow()
-    })
-
-    it('should scope localized uniqueness per locale across documents', async () => {
-      // Doc A: en `my-slug`, es `my-slugo`.
-      const a = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'A', localizedSlug: 'my-slug' },
-        locale: 'en',
-      })
-      created.push(a.id)
-      await payload.update({
-        collection: 'slug-fields',
-        id: a.id,
-        data: { localizedSlug: 'my-slugo' },
-        locale: 'es',
-      })
-
-      // Doc B may take `my-slug` in es — it matches A's en value, but the es namespace is free.
-      const b = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'B', localizedSlug: 'my-slug' },
-        locale: 'es',
-      })
-      created.push(b.id)
-
-      const aLocales = (
-        await payload.findByID({ collection: 'slug-fields', id: a.id, locale: 'all' })
-      ).localizedSlug as unknown as Record<string, string>
-      const bLocales = (
-        await payload.findByID({ collection: 'slug-fields', id: b.id, locale: 'all' })
-      ).localizedSlug as unknown as Record<string, string>
-      expect(aLocales.en).toBe('my-slug')
-      expect(aLocales.es).toBe('my-slugo')
-      expect(bLocales.es).toBe('my-slug')
-
-      // But B cannot take `my-slugo` in es — that collides with A within the es namespace.
-      await expect(
-        payload.create({
-          collection: 'slug-fields',
-          data: { title: 'C', localizedSlug: 'my-slugo' },
-          locale: 'es',
-        }),
-      ).rejects.toThrow()
-    })
-
-    it('should auto-increment a derived localized slug that collides within the same locale', async () => {
-      const first = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'First', localizedTitle: 'Shared Derived' },
-        locale: 'es',
-      })
-      created.push(first.id)
-      expect(first.localizedSlug).toBe('shared-derived')
-
-      const second = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Second', localizedTitle: 'Shared Derived' },
-        locale: 'es',
-      })
-      created.push(second.id)
-      expect(second.localizedSlug).toBe('shared-derived-1')
-    })
-
-    it('should not increment a derived localized slug shared across different locales', async () => {
-      const en = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'English', localizedTitle: 'Cross Locale' },
-        locale: 'en',
-      })
-      created.push(en.id)
-      expect(en.localizedSlug).toBe('cross-locale')
-
-      const es = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Spanish', localizedTitle: 'Cross Locale' },
-        locale: 'es',
-      })
-      created.push(es.id)
-      expect(es.localizedSlug).toBe('cross-locale')
-    })
-
-    it('should give a duplicate a fresh fallback slug instead of drifting from the original', async () => {
-      const original = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'My First Post' },
-      })
-      created.push(original.id)
-      expect(original.slug).toBe('my-first-post')
-
-      const duplicate = await payload.duplicate({
-        collection: 'slug-fields',
-        id: original.id,
-      })
-      created.push(duplicate.id)
-
-      // The copy takes a fresh `<singular>-N` fallback, not `my-first-post-1`.
-      expect(duplicate.slug).toBe('slug-field-1')
-
-      const secondDuplicate = await payload.duplicate({
-        collection: 'slug-fields',
-        id: original.id,
-      })
-      created.push(secondDuplicate.id)
-      expect(secondDuplicate.slug).toBe('slug-field-2')
-    })
-
-    it('should derive from the source when an explicit value slugifies to nothing', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Fallthrough Title', slug: '!!!' },
-      })
-      created.push(doc.id)
-      expect(doc.slug).toBe('fallthrough-title')
-    })
-
-    it('should reject a slug that collides with another document', async () => {
-      const first = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'First', slug: 'shared-slug' },
-      })
-      created.push(first.id)
-      expect(first.slug).toBe('shared-slug')
-
-      await expect(
-        payload.create({
-          collection: 'slug-fields',
-          data: { title: 'Second', slug: 'shared-slug' },
-        }),
-      ).rejects.toThrow()
-    })
-
-    it('should reject updating a slug to collide with another document', async () => {
-      const a = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Doc A', slug: 'doc-a' },
-      })
-      created.push(a.id)
-      const b = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Doc B', slug: 'doc-b' },
-      })
-      created.push(b.id)
-
-      await expect(
-        payload.update({ collection: 'slug-fields', id: b.id, data: { slug: 'doc-a' } }),
-      ).rejects.toThrow()
-    })
-
-    it('should allow re-saving a document with its own unchanged slug', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Stable', slug: 'stable-slug' },
-      })
-      created.push(doc.id)
-
-      // Autosave resends the current slug on every tick — re-saving the same value must not trip the
-      // collision check against the document itself.
-      const updated = await payload.update({
-        collection: 'slug-fields',
-        id: doc.id,
-        data: { slug: 'stable-slug' },
-      })
-      expect(updated.slug).toBe('stable-slug')
-    })
-
-    // The regen button calls the slugify server function directly, which has its own fallback path
-    // separate from the beforeChange hook. It must scope the source-less `<singular>-N` fallback to
-    // the active locale, or it hands back a slug already taken in that locale.
-    it('should regenerate a source-less localized slug to a locale-unique fallback', async () => {
-      const taken = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Taken' },
-        locale: 'es',
-      })
-      created.push(taken.id)
-      const takenSlug = taken.localizedSlug as string
-      expect(takenSlug).toMatch(/^slug-field-\d+$/)
-
-      const req = await createLocalReq({ user: user.user }, payload)
-
-      const regenerated = await slugifyHandler({
-        collectionSlug: 'slug-fields',
-        data: {},
-        locale: 'es',
-        path: 'localizedSlug',
-        req,
-        valueToSlugify: '',
-      })
-
-      expect(regenerated).toMatch(/^slug-field-\d+$/)
-      expect(regenerated).not.toBe(takenSlug)
-    })
-
-    it('should dedupe a source-derived slug on regenerate, matching the next save', async () => {
-      const first = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Shared Regen' },
-      })
-      created.push(first.id)
-      expect(first.slug).toBe('shared-regen')
-
-      const req = await createLocalReq({ user: user.user }, payload)
-
-      // Regenerating from a source that slugifies to a taken slug must bump it, not hand back the
-      // duplicate — otherwise the next save throws a uniqueness error.
-      const regenerated = await slugifyHandler({
-        collectionSlug: 'slug-fields',
-        data: {},
-        path: 'slug',
-        req,
-        valueToSlugify: 'Shared Regen',
-      })
-
-      expect(regenerated).toBe('shared-regen-1')
-    })
-
-    it('should let a document reuse its own slug on regenerate via the excluded id', async () => {
-      const doc = await payload.create({
-        collection: 'slug-fields',
-        data: { title: 'Own Slug' },
-      })
-      created.push(doc.id)
-      expect(doc.slug).toBe('own-slug')
-
-      const req = await createLocalReq({ user: user.user }, payload)
-
-      // Excluding the current doc means regenerating its own unchanged source reuses the value rather
-      // than bumping past it.
-      const regenerated = await slugifyHandler({
-        id: doc.id,
-        collectionSlug: 'slug-fields',
-        data: {},
-        path: 'slug',
-        req,
-        valueToSlugify: 'Own Slug',
-      })
-
-      expect(regenerated).toBe('own-slug')
+      expect(localizedSlug.en).toBe('english-title')
+      expect(localizedSlug.es).toBe('titulo-espanol')
     })
 
     describe('autosave drafts', () => {
@@ -528,243 +168,41 @@ describe('Fields', () => {
         for (const id of created) {
           await payload.delete({ collection: 'slug-autosave', id })
         }
+
         created.length = 0
       })
 
-      it('should generate the slug from the source on a draft create', async () => {
+      it('should generate a slug freely on draft create', async () => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One' },
         })
+
         created.push(draft.id)
         expect(draft.slug).toBe('draft-one')
       })
 
-      it('should fall back to <singular>-N when a draft is created with no source', async () => {
-        const draft = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: {},
-        })
-        created.push(draft.id)
-        expect(draft.slug).toBe('slug-autosave-1')
-
-        // The admin reads the latest draft version, not the create response, so the fallback must
-        // be persisted there too.
-        const latestDraft = await payload.findByID({
-          collection: 'slug-autosave',
-          id: draft.id,
-          draft: true,
-        })
-        expect(latestDraft.slug).toBe('slug-autosave-1')
-      })
-
-      it('should fall back when the explicit value slugifies to nothing and there is no source', async () => {
-        const draft = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: { slug: '!!!' },
-        })
-        created.push(draft.id)
-        expect(draft.slug).toBe('slug-autosave-1')
-      })
-
-      it('should give each source-less draft the next fallback without colliding', async () => {
-        const first = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: {},
-        })
-        created.push(first.id)
-
-        const second = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: {},
-        })
-        created.push(second.id)
-
-        expect(first.slug).toBe('slug-autosave-1')
-        expect(second.slug).toBe('slug-autosave-2')
-      })
-
-      it('should reject a draft slug that collides with another draft', async () => {
-        const first = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: { title: 'First', slug: 'shared-draft-slug' },
-        })
-        created.push(first.id)
-        expect(first.slug).toBe('shared-draft-slug')
-
-        await expect(
-          payload.create({
-            collection: 'slug-autosave',
-            draft: true,
-            data: { title: 'Second', slug: 'shared-draft-slug' },
-          }),
-        ).rejects.toThrow()
-      })
-
-      it('should reject updating a draft slug to collide with another draft', async () => {
-        const a = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: { title: 'A', slug: 'draft-a' },
-        })
-        created.push(a.id)
-        const b = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: { title: 'B', slug: 'draft-b' },
-        })
-        created.push(b.id)
-
-        await expect(
-          payload.update({
-            collection: 'slug-autosave',
-            id: b.id,
-            draft: true,
-            data: { slug: 'draft-a' },
-          }),
-        ).rejects.toThrow()
-      })
-
-      it('should allow the same localized draft slug across locales but reject within a locale', async () => {
-        const en = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: { localizedTitle: 'One', localizedSlug: 'shared-draft-localized' },
-          locale: 'en',
-        })
-        created.push(en.id)
-        expect(en.localizedSlug).toBe('shared-draft-localized')
-
-        // Same value in a different locale is fine — uniqueness is per-locale.
-        const es = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: { localizedTitle: 'Uno', localizedSlug: 'shared-draft-localized' },
-          locale: 'es',
-        })
-        created.push(es.id)
-        expect(es.localizedSlug).toBe('shared-draft-localized')
-
-        // Same value in the same locale collides.
-        await expect(
-          payload.create({
-            collection: 'slug-autosave',
-            draft: true,
-            data: { localizedTitle: 'Two', localizedSlug: 'shared-draft-localized' },
-            locale: 'en',
-          }),
-        ).rejects.toThrow()
-      })
-
-      it('should fall back to <singular>-N for a source-less localized slug on a draft', async () => {
-        const draft = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: {},
-          locale: 'en',
-        })
-        created.push(draft.id)
-        expect(draft.localizedSlug).toBe('slug-autosave-1')
-
-        // The fallback must persist to the draft version the admin reads back, and survive publish.
-        const latestDraft = await payload.findByID({
-          collection: 'slug-autosave',
-          id: draft.id,
-          draft: true,
-          locale: 'en',
-        })
-        expect(latestDraft.localizedSlug).toBe('slug-autosave-1')
-
-        const published = await payload.update({
-          collection: 'slug-autosave',
-          id: draft.id,
-          data: { _status: 'published' },
-          locale: 'en',
-        })
-        expect(published.localizedSlug).toBe('slug-autosave-1')
-      })
-
-      it('should fill every locale of a localized slug on a draft create', async () => {
-        const draft = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: {},
-          locale: 'en',
-        })
-        created.push(draft.id)
-
-        const allLocales = await payload.findByID({
-          collection: 'slug-autosave',
-          id: draft.id,
-          draft: true,
-          locale: 'all',
-        })
-        const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
-        expect(localizedSlug.en).toMatch(/^slug-autosave-\d+$/)
-        expect(localizedSlug.es).toMatch(/^slug-autosave-\d+$/)
-      })
-
-      it('should fall back to a per-locale <singular>-N for localized slugs on a draft', async () => {
-        const en = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: {},
-          locale: 'en',
-        })
-        created.push(en.id)
-        expect(en.localizedSlug).toBe('slug-autosave-1')
-
-        // A different locale falls back independently — the counter is scoped per-locale.
-        const es = await payload.update({
-          collection: 'slug-autosave',
-          id: en.id,
-          draft: true,
-          data: {},
-          locale: 'es',
-        })
-        expect(es.localizedSlug).toBe('slug-autosave-1')
-      })
-
-      it('should give a duplicated draft its own unique slug', async () => {
-        const original = await payload.create({
-          collection: 'slug-autosave',
-          draft: true,
-          data: { title: 'Dup Me', slug: 'dup-me' },
-        })
-        created.push(original.id)
-        expect(original.slug).toBe('dup-me')
-
-        const duplicate = await payload.duplicate({ collection: 'slug-autosave', id: original.id })
-        created.push(duplicate.id)
-
-        expect(duplicate.slug).not.toBe('dup-me')
-        expect(duplicate.slug).toMatch(/^slug-autosave-\d+$/)
-      })
-
-      it('should keep an explicit slug the user typed on the initial draft', async () => {
+      it('should keep an explicit slug the user typed on draft create', async () => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One', slug: 'user-typed' },
         })
+
         created.push(draft.id)
         expect(draft.slug).toBe('user-typed')
       })
 
-      it('should freeze the slug across subsequent autosaves once set', async () => {
+      it('should leave the slug empty when the initial draft has no source yet', async () => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
-          data: { title: 'Draft One' },
+          data: { title: '' },
         })
+
         created.push(draft.id)
-        expect(draft.slug).toBe('draft-one')
+        expect(draft.slug == null || draft.slug === '').toBe(true)
 
         const updated = await payload.update({
           collection: 'slug-autosave',
@@ -772,7 +210,36 @@ describe('Fields', () => {
           draft: true,
           data: { title: 'Draft One Updated' },
         })
-        expect(updated.slug).toBe('draft-one')
+        expect(updated.slug).toBe('draft-one-updated')
+      })
+
+      it('should keep tracking the source freely across autosaves until publish', async () => {
+        const draft = await payload.create({
+          collection: 'slug-autosave',
+          draft: true,
+          data: { title: 'Draft One' },
+        })
+
+        created.push(draft.id)
+        expect(draft.slug).toBe('draft-one')
+
+        const second = await payload.update({
+          collection: 'slug-autosave',
+          id: draft.id,
+          draft: true,
+          data: { title: 'Draft Two' },
+        })
+
+        expect(second.slug).toBe('draft-two')
+
+        const third = await payload.update({
+          collection: 'slug-autosave',
+          id: draft.id,
+          draft: true,
+          data: { title: 'Draft Three' },
+        })
+
+        expect(third.slug).toBe('draft-three')
       })
 
       it('should keep an admin overwrite across subsequent autosaves', async () => {
@@ -807,14 +274,13 @@ describe('Fields', () => {
         expect(afterMoreEdits.slug).toBe('human-chosen-slug')
       })
 
-      it('should not change an already-set slug on publish or after', async () => {
+      it('should stabilize the slug after publish', async () => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One' },
         })
         created.push(draft.id)
-        expect(draft.slug).toBe('draft-one')
 
         await payload.update({
           collection: 'slug-autosave',
@@ -828,14 +294,78 @@ describe('Fields', () => {
           id: draft.id,
           data: { _status: 'published', title: 'Publishable Title' },
         })
-        expect(published.slug).toBe('draft-one')
+        expect(published.slug).toBe('publishable-title')
 
         const afterPublish = await payload.update({
           collection: 'slug-autosave',
           id: draft.id,
           data: { _status: 'published', title: 'Title Changed After Publish' },
         })
-        expect(afterPublish.slug).toBe('draft-one')
+        expect(afterPublish.slug).toBe('publishable-title')
+      })
+    })
+
+    describe('drafts without autosave', () => {
+      const created: (number | string)[] = []
+
+      afterEach(async () => {
+        for (const id of created) {
+          await payload.delete({ collection: 'slug-draft', id })
+        }
+        created.length = 0
+      })
+
+      it('should generate a slug on draft create', async () => {
+        const draft = await payload.create({
+          collection: 'slug-draft',
+          draft: true,
+          data: { title: 'First Title' },
+        })
+        created.push(draft.id)
+        expect(draft.slug).toBe('first-title')
+      })
+
+      it('should lock a derived slug across subsequent draft saves', async () => {
+        const draft = await payload.create({
+          collection: 'slug-draft',
+          draft: true,
+          data: { title: 'First Title' },
+        })
+        created.push(draft.id)
+        expect(draft.slug).toBe('first-title')
+
+        const second = await payload.update({
+          collection: 'slug-draft',
+          id: draft.id,
+          draft: true,
+          data: { title: 'Second Title' },
+        })
+        expect(second.slug).toBe('first-title')
+
+        const published = await payload.update({
+          collection: 'slug-draft',
+          id: draft.id,
+          data: { _status: 'published', title: 'Published Title' },
+        })
+        expect(published.slug).toBe('first-title')
+      })
+
+      it('should lock a user-provided slug across subsequent draft saves', async () => {
+        const draft = await payload.create({
+          collection: 'slug-draft',
+          draft: true,
+          data: { title: 'First Title', slug: 'user-typed' },
+        })
+        created.push(draft.id)
+        expect(draft.slug).toBe('user-typed')
+
+        const second = await payload.update({
+          collection: 'slug-draft',
+          id: draft.id,
+          draft: true,
+          data: { title: 'Second Title' },
+        })
+        expect(second.slug).toBe('user-typed')
       })
     })
   })


### PR DESCRIPTION
Rebased on latest upstream/main with conflict resolution.

Conflicts resolved:
- packages/payload/src/fields/baseFields/slug/generateSlug.ts: replaced entire implementation with simplified autosave-aware slug generation (free until publish)
- docs/fields/slug.mdx: updated autosave docs to reflect new behavior
- test/fields/int.spec.ts: updated slug autosave test expectations for new behavior