### PR TITLE
feat(ui): add paste from clipboard button

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -490,6 +490,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'upload:height',
   'upload:fromURL',
   'upload:linkToFile',
+  'upload:pasteFromClipboard',
   'upload:pasteURL',
   'upload:renameFile',
   'upload:replaceFile',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -576,6 +576,7 @@ export const arTranslations: DefaultTranslationsObject = {
     linkToFile: 'رابط إلى الملف',
     moreInfo: 'معلومات أكثر',
     noFile: 'لا يوجد ملف',
+    pasteFromClipboard: 'لصق من الحافظة',
     pasteURL: 'لصق الرابط',
     previewSizes: 'أحجام المعاينة',
     renameFile: 'إعادة تسمية الملف',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -594,6 +594,7 @@ export const azTranslations: DefaultTranslationsObject = {
     linkToFile: 'Fayla keçid',
     moreInfo: 'Daha çox məlumat',
     noFile: 'Heç bir fayl',
+    pasteFromClipboard: 'Mübadilə buferindən yapışdır',
     pasteURL: 'URL yapışdır',
     previewSizes: 'Öncədən baxış ölçüləri',
     renameFile: 'Fayl adını dəyişdirin',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -588,6 +588,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     linkToFile: 'Връзка към файл',
     moreInfo: 'Повече информация',
     noFile: 'Няма файл',
+    pasteFromClipboard: 'Поставяне от клипборда',
     pasteURL: 'Поставяне на URL',
     previewSizes: 'Преглед на размери',
     renameFile: 'Преименувайте файл',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -596,6 +596,7 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     linkToFile: 'ফাইলের লিঙ্ক',
     moreInfo: 'আরও তথ্য',
     noFile: 'কোনো ফাইল নেই',
+    pasteFromClipboard: 'ক্লিপবোর্ড থেকে পেস্ট করুন',
     pasteURL: 'URL পেস্ট করুন',
     previewSizes: 'প্রিভিউ আকারগুলি',
     renameFile: 'ফাইলের নাম পরিবর্তন করুন',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -595,6 +595,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
     linkToFile: 'ফাইলের লিঙ্ক',
     moreInfo: 'আরও তথ্য',
     noFile: 'কোনো ফাইল নেই',
+    pasteFromClipboard: 'ক্লিপবোর্ড থেকে পেস্ট করুন',
     pasteURL: 'URL পেস্ট করুন',
     previewSizes: 'প্রিভিউ আকারগুলি',
     renameFile: 'ফাইলের নাম পরিবর্তন করুন',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -592,6 +592,7 @@ export const caTranslations: DefaultTranslationsObject = {
     linkToFile: "Enllaç a l'arxiu",
     moreInfo: 'Més informació',
     noFile: 'No hi ha cap fitxer',
+    pasteFromClipboard: 'Enganxa des del porta-retalls',
     pasteURL: "Enganxa l'URL",
     previewSizes: 'Mides de la vista prèvia',
     renameFile: 'Canviar el nom del fitxer',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -584,6 +584,7 @@ export const csTranslations: DefaultTranslationsObject = {
     linkToFile: 'Odkaz na soubor',
     moreInfo: 'Více informací',
     noFile: 'Žádný soubor',
+    pasteFromClipboard: 'Vložit ze schránky',
     pasteURL: 'Vložit URL',
     previewSizes: 'Náhled velikostí',
     renameFile: 'Přejmenovat soubor',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -588,6 +588,7 @@ export const daTranslations: DefaultTranslationsObject = {
     linkToFile: 'Link til fil',
     moreInfo: 'Mere info',
     noFile: 'Ingen fil',
+    pasteFromClipboard: 'Indsæt fra udklipsholder',
     pasteURL: 'Indsæt URL',
     previewSizes: 'Forhåndsvisningsstørrelser',
     renameFile: 'Omdøb fil',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -601,6 +601,7 @@ export const deTranslations: DefaultTranslationsObject = {
     linkToFile: 'Link zur Datei',
     moreInfo: 'Mehr Info',
     noFile: 'Keine Datei',
+    pasteFromClipboard: 'Aus der Zwischenablage einfügen',
     pasteURL: 'URL einfügen',
     previewSizes: 'Bildgrößen anzeigen',
     renameFile: 'Datei umbenennen',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -588,6 +588,7 @@ export const enTranslations = {
     linkToFile: 'Link to file',
     moreInfo: 'More info',
     noFile: 'No file',
+    pasteFromClipboard: 'Paste from clipboard',
     pasteURL: 'Paste URL',
     previewSizes: 'Preview Sizes',
     renameFile: 'Rename file',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -595,6 +595,7 @@ export const esTranslations: DefaultTranslationsObject = {
     linkToFile: 'Enlace al archivo',
     moreInfo: 'Más info',
     noFile: 'Ningún archivo',
+    pasteFromClipboard: 'Pegar desde el portapapeles',
     pasteURL: 'Pegar URL',
     previewSizes: 'Tamaños de Vista Previa',
     renameFile: 'Renombrar archivo',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -583,6 +583,7 @@ export const etTranslations: DefaultTranslationsObject = {
     linkToFile: 'Lingid failile',
     moreInfo: 'Rohkem infot',
     noFile: 'Pole faili',
+    pasteFromClipboard: 'Kleebi lõikelaualt',
     pasteURL: 'Kleebi URL',
     previewSizes: 'Eelvaate suurused',
     renameFile: 'Faili ümbernimetamine',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -579,6 +579,7 @@ export const faTranslations: DefaultTranslationsObject = {
     linkToFile: 'پیوند به فایل',
     moreInfo: 'اطلاعات بیشتر',
     noFile: 'فایلی وجود ندارد',
+    pasteFromClipboard: 'جای‌گذاری از کلیپ‌بورد',
     pasteURL: 'جای‌گذاری URL',
     previewSizes: 'اندازه‌های پیش‌نمایش',
     renameFile: 'تغییر نام فایل',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -601,6 +601,7 @@ export const frTranslations: DefaultTranslationsObject = {
     linkToFile: 'Lien vers le fichier',
     moreInfo: 'Plus d’infos',
     noFile: 'Aucun fichier',
+    pasteFromClipboard: 'Coller depuis le presse-papiers',
     pasteURL: "Coller l'URL",
     previewSizes: 'Tailles d’aperçu',
     renameFile: 'Renommer le fichier',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -570,6 +570,7 @@ export const heTranslations: DefaultTranslationsObject = {
     linkToFile: 'קישור לקובץ',
     moreInfo: 'מידע נוסף',
     noFile: 'אין קובץ',
+    pasteFromClipboard: 'הדבק מלוח הגזירים',
     pasteURL: 'הדבק כתובת אתר',
     previewSizes: 'גדלי תצוגה מקדימה',
     renameFile: 'שנה את שם הקובץ',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -587,6 +587,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     linkToFile: 'Poveznica na datoteku',
     moreInfo: 'Više informacija',
     noFile: 'Nema datoteke',
+    pasteFromClipboard: 'Zalijepi iz međuspremnika',
     pasteURL: 'Zalijepi URL',
     previewSizes: 'Veličine pregleda',
     renameFile: 'Preimenujte datoteku',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -594,6 +594,7 @@ export const huTranslations: DefaultTranslationsObject = {
     linkToFile: 'Hivatkozás a fájlra',
     moreInfo: 'További információ',
     noFile: 'Nincs fájl',
+    pasteFromClipboard: 'Beillesztés a vágólapról',
     pasteURL: 'URL beillesztése',
     previewSizes: 'Előnézeti méretek',
     renameFile: 'Fájl átnevezése',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -592,6 +592,7 @@ export const hyTranslations: DefaultTranslationsObject = {
     linkToFile: 'Հղում դեպի ֆայլ',
     moreInfo: 'Ավելի շատ տեղեկություն',
     noFile: 'Ֆայլ չկա',
+    pasteFromClipboard: 'Տեղադրել սեղմատախտակից',
     pasteURL: 'Տեղադրել URL',
     previewSizes: 'Նախադիտման չափեր',
     renameFile: 'Վերանվանել ֆայլը',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -592,6 +592,7 @@ export const idTranslations: DefaultTranslationsObject = {
     linkToFile: 'Tautan ke berkas',
     moreInfo: 'Info lebih lanjut',
     noFile: 'Tidak ada file',
+    pasteFromClipboard: 'Tempel dari papan klip',
     pasteURL: 'Tempel URL',
     previewSizes: 'Ukuran Pratinjau',
     renameFile: 'Ganti nama file',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -586,6 +586,7 @@ export const isTranslations: DefaultTranslationsObject = {
     linkToFile: 'Tengill á skrá',
     moreInfo: 'Fleiri upplýsingar',
     noFile: 'Engin skrá',
+    pasteFromClipboard: 'Líma af klippispjaldi',
     pasteURL: 'Líma vefslóð',
     previewSizes: 'Forskoðunarstærðir',
     renameFile: 'Endurnefna skrá',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -594,6 +594,7 @@ export const itTranslations: DefaultTranslationsObject = {
     linkToFile: 'Collega al file',
     moreInfo: 'Più info',
     noFile: 'Nessun file',
+    pasteFromClipboard: 'Incolla dagli appunti',
     pasteURL: 'Incolla URL',
     previewSizes: 'Anteprime Dimensioni',
     renameFile: 'Rinomina file',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -588,6 +588,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     linkToFile: 'ファイルへのリンク',
     moreInfo: '詳細を表示',
     noFile: 'ファイルなし',
+    pasteFromClipboard: 'クリップボードから貼り付け',
     pasteURL: 'URLを貼り付け',
     previewSizes: 'プレビューサイズ',
     renameFile: 'ファイル名を変更',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -585,6 +585,7 @@ export const koTranslations: DefaultTranslationsObject = {
     linkToFile: '파일로 연결',
     moreInfo: '정보 더보기',
     noFile: '파일 없음',
+    pasteFromClipboard: '클립보드에서 붙여넣기',
     pasteURL: 'URL 붙여넣기',
     previewSizes: '미리보기 크기',
     renameFile: '파일 이름 변경',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -590,6 +590,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     linkToFile: 'Nuoroda į failą',
     moreInfo: 'Daugiau informacijos',
     noFile: 'Nėra failo',
+    pasteFromClipboard: 'Įklijuokite iš iškarpinės',
     pasteURL: 'Įklijuokite URL',
     previewSizes: 'Peržiūros dydžiai',
     renameFile: 'Pervadinti failą',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -587,6 +587,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     linkToFile: 'Saite uz failu',
     moreInfo: 'Vairāk informācijas',
     noFile: 'Nav faila',
+    pasteFromClipboard: 'Ielīmēt no starpliktuves',
     pasteURL: 'Ielīmēt URL',
     previewSizes: 'Priekšskatījuma izmēri',
     renameFile: 'Pārsaukt failu',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -596,6 +596,7 @@ export const myTranslations: DefaultTranslationsObject = {
     linkToFile: 'ဖိုင်သို့ ချိတ်ဆက်မှု',
     moreInfo: 'အချက်အလက်',
     noFile: 'ဖိုင် မရှိပါ',
+    pasteFromClipboard: 'ကလစ်ဘုတ်မှ ကူးထည့်ပါ',
     pasteURL: 'URL ကို ကူးထည့်ပါ',
     previewSizes: 'အစမ်းကြည့်အရွယ်အစားများ',
     renameFile: 'ဖိုင်အမည်ပြောင်းရန်',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -591,6 +591,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     linkToFile: 'Lenke til fil',
     moreInfo: 'Mer info',
     noFile: 'Ingen fil',
+    pasteFromClipboard: 'Lim inn fra utklippstavle',
     pasteURL: 'Lim inn URL',
     previewSizes: 'Forhåndsvisningsstørrelser',
     renameFile: 'Gi nytt navn til fil',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -596,6 +596,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     linkToFile: 'Koppeling naar bestand',
     moreInfo: 'Meer info',
     noFile: 'Geen bestand',
+    pasteFromClipboard: 'Plakken vanuit klembord',
     pasteURL: 'URL plakken',
     previewSizes: 'Voorbeeldgroottes',
     renameFile: 'Bestand hernoemen',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -587,6 +587,7 @@ export const plTranslations: DefaultTranslationsObject = {
     linkToFile: 'Link do pliku',
     moreInfo: 'Więcej informacji',
     noFile: 'Brak pliku',
+    pasteFromClipboard: 'Wklej ze schowka',
     pasteURL: 'Wklej URL',
     previewSizes: 'Rozmiary podglądu',
     renameFile: 'Zmień nazwę pliku',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -591,6 +591,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     linkToFile: 'Link para arquivo',
     moreInfo: 'Ver mais',
     noFile: 'Sem arquivo',
+    pasteFromClipboard: 'Colar da área de transferência',
     pasteURL: 'Colar URL',
     previewSizes: 'Tamanhos de Pré-visualização',
     renameFile: 'Renomear arquivo',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -594,6 +594,7 @@ export const roTranslations: DefaultTranslationsObject = {
     linkToFile: 'Link către fișier',
     moreInfo: 'Mai multe informații',
     noFile: 'Niciun fișier',
+    pasteFromClipboard: 'Lipește din clipboard',
     pasteURL: 'Lipește URL',
     previewSizes: 'Dimensiuni Previzualizare',
     renameFile: 'Redenumiți fișierul',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -587,6 +587,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     linkToFile: 'Веза до фајла',
     moreInfo: 'Више информација',
     noFile: 'Nema fajla',
+    pasteFromClipboard: 'Налепи из клипборда',
     pasteURL: 'Налепи URL',
     previewSizes: 'Величине прегледа',
     renameFile: 'Преименујте фајл',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -588,6 +588,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     linkToFile: 'Link ka fajlu',
     moreInfo: 'Više informacija',
     noFile: 'Nema datoteke',
+    pasteFromClipboard: 'Nalepi iz klipborda',
     pasteURL: 'Nalepi URL',
     previewSizes: 'Veličine pregleda',
     renameFile: 'Preimenujte fajl',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -593,6 +593,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     linkToFile: 'Ссылка на файл',
     moreInfo: 'Больше информации',
     noFile: 'Нет файла',
+    pasteFromClipboard: 'Вставить из буфера обмена',
     pasteURL: 'Вставить URL',
     previewSizes: 'Предварительный просмотр размеров',
     renameFile: 'Переименовать файл',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -585,6 +585,7 @@ export const skTranslations: DefaultTranslationsObject = {
     linkToFile: 'Odkaz na súbor',
     moreInfo: 'Viac informácií',
     noFile: 'Žiadny súbor',
+    pasteFromClipboard: 'Vložiť zo schránky',
     pasteURL: 'Vložiť URL',
     previewSizes: 'Náhľady veľkostí',
     renameFile: 'Premenovať súbor',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -586,6 +586,7 @@ export const slTranslations: DefaultTranslationsObject = {
     linkToFile: 'Povezava do datoteke',
     moreInfo: 'Več informacij',
     noFile: 'Ni datoteke.',
+    pasteFromClipboard: 'Prilepi iz odložišča',
     pasteURL: 'Prilepi URL',
     previewSizes: 'Velikosti predogleda',
     renameFile: 'Preimenuj datoteko',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -590,6 +590,7 @@ export const svTranslations: DefaultTranslationsObject = {
     linkToFile: 'Länk till fil',
     moreInfo: 'Mer info',
     noFile: 'Ingen fil',
+    pasteFromClipboard: 'Klistra in från urklipp',
     pasteURL: 'Klistra in URL',
     previewSizes: 'Förhandsgranska storlekar',
     renameFile: 'Byt namn på fil',

--- a/packages/translations/src/languages/ta.ts
+++ b/packages/translations/src/languages/ta.ts
@@ -590,6 +590,7 @@ export const taTranslations: DefaultTranslationsObject = {
     linkToFile: 'கோப்பிற்கான இணைப்பு',
     moreInfo: 'மேலும் தகவல்',
     noFile: 'கோப்பு இல்லை',
+    pasteFromClipboard: 'பிடிப்புப் பலகையிலிருந்து ஒட்டுக',
     pasteURL: 'URL ஒட்டுக',
     previewSizes: 'முன்னோட்ட அளவுகள்',
     renameFile: 'கோப்பை மறுபெயரிடு',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -578,6 +578,7 @@ export const thTranslations: DefaultTranslationsObject = {
     linkToFile: 'ลิงก์ไปยังไฟล์',
     moreInfo: 'แสดงข้อมูล',
     noFile: 'ไม่มีไฟล์',
+    pasteFromClipboard: 'วางจากคลิปบอร์ด',
     pasteURL: 'วาง URL',
     previewSizes: 'ขนาดตัวอย่าง',
     renameFile: 'เปลี่ยนชื่อไฟล์',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -595,6 +595,7 @@ export const trTranslations: DefaultTranslationsObject = {
     linkToFile: 'Dosyaya bağlantı',
     moreInfo: 'Daha fazla bilgi',
     noFile: 'Dosya yok',
+    pasteFromClipboard: 'Panodan yapıştır',
     pasteURL: 'URL yapıştır',
     previewSizes: 'Önizleme Boyutları',
     renameFile: 'Dosyayı yeniden adlandır',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -584,6 +584,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     linkToFile: 'Посилання на файл',
     moreInfo: 'Більше інформації',
     noFile: 'Немає файлу',
+    pasteFromClipboard: 'Вставити з буфера обміну',
     pasteURL: 'Вставити URL',
     previewSizes: 'Попередній перегляд розмірів',
     renameFile: 'Перейменувати файл',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -589,6 +589,7 @@ export const viTranslations: DefaultTranslationsObject = {
     linkToFile: 'Liên kết tới tệp',
     moreInfo: 'Xem thêm',
     noFile: 'Không có tệp',
+    pasteFromClipboard: 'Dán từ khay nhớ tạm',
     pasteURL: 'Dán URL',
     previewSizes: 'Kích cỡ xem trước',
     renameFile: 'Đổi tên tệp',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -562,6 +562,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     linkToFile: '链接到文件',
     moreInfo: '更多信息',
     noFile: '没有文件',
+    pasteFromClipboard: '从剪贴板粘贴',
     pasteURL: '粘贴网址',
     previewSizes: '预览尺寸',
     renameFile: '重命名文件',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -560,6 +560,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     linkToFile: '連結至檔案',
     moreInfo: '顯示更多資訊',
     noFile: '無檔案',
+    pasteFromClipboard: '從剪貼簿貼上',
     pasteURL: '貼上網址',
     previewSizes: '預覽尺寸',
     renameFile: '重新命名檔案',

--- a/packages/ui/src/elements/BulkUpload/AddFilesView/index.css
+++ b/packages/ui/src/elements/BulkUpload/AddFilesView/index.css
@@ -31,8 +31,20 @@
   }
 
   .bulk-upload--add-files__dragAndDropText {
+    display: none;
     margin: 0;
     text-transform: lowercase;
     align-self: center;
+  }
+
+  .bulk-upload--add-files__orText {
+    color: var(--color-text-tertiary);
+    text-transform: lowercase;
+  }
+
+  @media (min-width: 769px) {
+    .bulk-upload--add-files__dragAndDropText {
+      display: block;
+    }
   }
 }

--- a/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
@@ -56,6 +56,7 @@ export function AddFilesView({ acceptMimeTypes, modalSlug: modalSlug, onDrop }: 
             <span className={`${baseClass}__orText`}>{t('general:or')}</span>
             <Button
               buttonStyle="secondary"
+              className={`${baseClass}__pasteFromClipboard`}
               icon="clipboard"
               onClick={handlePasteFromClipboard}
               size="medium"

--- a/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import React from 'react'
+import { toast } from 'sonner'
 
 import { useTranslation } from '../../../providers/Translation/index.js'
+import { getFilesFromClipboard } from '../../../utilities/getFilesFromClipboard.js'
 import { Button } from '../../Button/index.js'
 import { DialogHeader, DialogModal } from '../../Dialog/index.js'
 import { Dropzone } from '../../Dropzone/index.js'
@@ -19,6 +21,19 @@ export function AddFilesView({ acceptMimeTypes, modalSlug: modalSlug, onDrop }: 
   const { t } = useTranslation()
 
   const inputRef = React.useRef<HTMLInputElement>(null)
+
+  const handlePasteFromClipboard = React.useCallback(async () => {
+    try {
+      const files = await getFilesFromClipboard()
+      if (!files) {
+        toast.error('No file found in clipboard.')
+        return
+      }
+      onDrop(files)
+    } catch (_err) {
+      toast.error('Unable to read from clipboard.')
+    }
+  }, [onDrop])
 
   return (
     <DialogModal className={baseClass} size="large" slug={modalSlug}>
@@ -38,6 +53,14 @@ export function AddFilesView({ acceptMimeTypes, modalSlug: modalSlug, onDrop }: 
             >
               {t('upload:selectFile')}
             </Button>
+            <span className={`${baseClass}__orText`}>{t('general:or')}</span>
+            <Button
+              buttonStyle="secondary"
+              icon="clipboard"
+              onClick={handlePasteFromClipboard}
+              size="medium"
+              tooltip={t('upload:pasteFromClipboard')}
+            />
             <input
               accept={acceptMimeTypes}
               aria-hidden="true"

--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -4,6 +4,7 @@ import React, { Fragment } from 'react'
 import type { Props } from './types.js'
 
 import { ChevronIcon } from '../../icons/Chevron/index.js'
+import { ClipboardIcon } from '../../icons/Clipboard/index.js'
 import { EditIcon } from '../../icons/Edit/index.js'
 import { LinkIcon } from '../../icons/Link/index.js'
 import { PlusIcon } from '../../icons/Plus/index.js'
@@ -19,6 +20,7 @@ import { Tooltip } from '../Tooltip/index.js'
 
 const icons = {
   chevron: ChevronIcon,
+  clipboard: ClipboardIcon,
   edit: EditIcon,
   link: LinkIcon,
   plus: PlusIcon,

--- a/packages/ui/src/elements/Dropzone/index.css
+++ b/packages/ui/src/elements/Dropzone/index.css
@@ -8,8 +8,7 @@
     background-color: var(--color-bg-secondary);
     border: var(--stroke-width-small) dashed var(--special-border-translucent);
     border-radius: var(--field-border-radius);
-    /* visible, not clip/hidden, so Button tooltips (not portaled) inside the dropzone aren't cut off */
-    overflow: visible;
+    overflow: clip;
     width: 100%;
 
     .btn {

--- a/packages/ui/src/elements/Dropzone/index.css
+++ b/packages/ui/src/elements/Dropzone/index.css
@@ -1,12 +1,15 @@
 @layer payload-default {
   .dropzone {
+    --accessibility-outline-offset: -2px;
+
     position: relative;
     display: flex;
     align-items: flex-start;
     background-color: var(--color-bg-secondary);
     border: var(--stroke-width-small) dashed var(--special-border-translucent);
     border-radius: var(--field-border-radius);
-    overflow: clip;
+    /* visible, not clip/hidden, so Button tooltips (not portaled) inside the dropzone aren't cut off */
+    overflow: visible;
     width: 100%;
 
     .btn {
@@ -15,6 +18,11 @@
 
     &:hover {
       background: var(--color-bg-hover);
+    }
+
+    &:focus {
+      outline: var(--accessibility-outline);
+      outline-offset: var(--accessibility-outline-offset);
     }
 
     &.dragging {

--- a/packages/ui/src/elements/FileManager/index.css
+++ b/packages/ui/src/elements/FileManager/index.css
@@ -135,7 +135,13 @@
     color: var(--color-text-tertiary);
   }
 
-  @container edit-main (min-width: 1024px) {
+  @media (max-width: 768px) {
+    .file-manager__drag-text {
+      display: none;
+    }
+  }
+
+  @container edit-main (max-width: 1024px) {
     .file-manager {
       min-height: 100px;
       border-bottom: none;

--- a/packages/ui/src/elements/FileManager/index.tsx
+++ b/packages/ui/src/elements/FileManager/index.tsx
@@ -17,6 +17,7 @@ import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { useUploadControls } from '../../providers/UploadControls/index.js'
 import { useUploadEdits } from '../../providers/UploadEdits/index.js'
+import { getFilesFromClipboard } from '../../utilities/getFilesFromClipboard.js'
 import { Button } from '../Button/index.js'
 import { Drawer } from '../Drawer/index.js'
 import { Dropzone } from '../Dropzone/index.js'
@@ -180,6 +181,19 @@ export const FileManager: React.FC<FileManagerProps> = ({
     (files: FileList) => handleFileChange({ file: files?.[0] }),
     [handleFileChange],
   )
+
+  const handlePasteFromClipboard = useCallback(async () => {
+    try {
+      const files = await getFilesFromClipboard()
+      if (!files) {
+        toast.error('No file found in clipboard.')
+        return
+      }
+      handleFileSelection(files)
+    } catch (_err) {
+      toast.error('Unable to read from clipboard.')
+    }
+  }, [handleFileSelection])
 
   const isValidUrl = Boolean(fileUrl && URL.canParse(fileUrl))
 
@@ -448,6 +462,14 @@ export const FileManager: React.FC<FileManagerProps> = ({
                           </Button>
                         </Fragment>
                       )}
+                      <span className={`${baseClass}__or-text`}>{t('general:or')}</span>
+                      <Button
+                        buttonStyle="secondary"
+                        icon="clipboard"
+                        onClick={handlePasteFromClipboard}
+                        size="medium"
+                        tooltip={t('upload:pasteFromClipboard')}
+                      />
                       {UploadControls ?? null}
                     </div>
                     <p className={`${baseClass}__drag-text`}>

--- a/packages/ui/src/elements/FileManager/index.tsx
+++ b/packages/ui/src/elements/FileManager/index.tsx
@@ -465,6 +465,7 @@ export const FileManager: React.FC<FileManagerProps> = ({
                       <span className={`${baseClass}__or-text`}>{t('general:or')}</span>
                       <Button
                         buttonStyle="secondary"
+                        className={`${baseClass}__pasteFromClipboard`}
                         icon="clipboard"
                         onClick={handlePasteFromClipboard}
                         size="medium"

--- a/packages/ui/src/elements/Upload/index.css
+++ b/packages/ui/src/elements/Upload/index.css
@@ -252,5 +252,9 @@
     .file-field__edit {
       display: none;
     }
+
+    .file-field__dragAndDropText {
+      display: none;
+    }
   }
 }

--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -17,11 +17,12 @@ import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { UploadControlsProvider, useUploadControls } from '../../providers/UploadControls/index.js'
 import { useUploadEdits } from '../../providers/UploadEdits/index.js'
+import { getFilesFromClipboard } from '../../utilities/getFilesFromClipboard.js'
 import { Button } from '../Button/index.js'
 import { Drawer } from '../Drawer/index.js'
 import { Dropzone } from '../Dropzone/index.js'
-import { EditUpload } from '../EditUpload/index.js'
 import './index.css'
+import { EditUpload } from '../EditUpload/index.js'
 import { FileDetails } from '../FileDetails/index.js'
 import { PreviewSizes } from '../PreviewSizes/index.js'
 import { Thumbnail } from '../Thumbnail/index.js'
@@ -232,6 +233,19 @@ const UploadComponent: React.FC<UploadComponentProps> = (props) => {
     },
     [handleFileChange],
   )
+
+  const handlePasteFromClipboard = useCallback(async () => {
+    try {
+      const files = await getFilesFromClipboard()
+      if (!files) {
+        toast.error('No file found in clipboard.')
+        return
+      }
+      handleFileSelection(files)
+    } catch (_err) {
+      toast.error('Unable to read from clipboard.')
+    }
+  }, [handleFileSelection])
 
   const handleFileRemoval = useCallback(() => {
     setRemovedFile(true)
@@ -493,6 +507,15 @@ const UploadComponent: React.FC<UploadComponentProps> = (props) => {
                       </Button>
                     </Fragment>
                   )}
+
+                  <span className={`${baseClass}__orText`}>{t('general:or')}</span>
+                  <Button
+                    buttonStyle="pill"
+                    icon="clipboard"
+                    onClick={handlePasteFromClipboard}
+                    size="medium"
+                    tooltip={t('upload:pasteFromClipboard')}
+                  />
 
                   {UploadControls ? UploadControls : null}
                 </div>

--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -511,6 +511,7 @@ const UploadComponent: React.FC<UploadComponentProps> = (props) => {
                   <span className={`${baseClass}__orText`}>{t('general:or')}</span>
                   <Button
                     buttonStyle="pill"
+                    className={`${baseClass}__pasteFromClipboard`}
                     icon="clipboard"
                     onClick={handlePasteFromClipboard}
                     size="medium"

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -779,6 +779,7 @@ export function UploadInput(props: UploadInputProps) {
                       </span>
                       <Button
                         buttonStyle="secondary"
+                        className={`${baseClass}__pasteFromClipboard`}
                         icon="clipboard"
                         onClick={handlePasteFromClipboard}
                         size="medium"

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -17,6 +17,7 @@ import { useModal } from '@faceless-ui/modal'
 import { formatAdminURL } from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { useCallback, useEffect, useMemo } from 'react'
+import { toast } from 'sonner'
 
 import type { ListDrawerProps } from '../../elements/ListDrawer/types.js'
 import type { ReloadDoc, ValueAsDataWithRelation } from './types.js'
@@ -34,6 +35,7 @@ import { FieldLabel } from '../../fields/FieldLabel/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { getFilesFromClipboard } from '../../utilities/getFilesFromClipboard.js'
 import { normalizeRelationshipValue } from '../../utilities/normalizeRelationshipValue.js'
 import { fieldBaseClass } from '../shared/index.js'
 import { UploadComponentHasMany } from './HasMany/index.js'
@@ -411,6 +413,19 @@ export function UploadInput(props: UploadInputProps) {
     ],
   )
 
+  const handlePasteFromClipboard = useCallback(async () => {
+    try {
+      const files = await getFilesFromClipboard()
+      if (!files) {
+        toast.error('No file found in clipboard.')
+        return
+      }
+      onLocalFileSelection(files)
+    } catch (_err) {
+      toast.error('Unable to read from clipboard.')
+    }
+  }, [onLocalFileSelection])
+
   // only hasMany can bulk select
   const onListBulkSelect = React.useCallback<NonNullable<ListDrawerProps['onBulkSelect']>>(
     async (docs, collectionSlug) => {
@@ -757,6 +772,20 @@ export function UploadInput(props: UploadInputProps) {
                   >
                     {t('fields:chooseFromExisting')}
                   </Button>
+                  {canCreate && !readOnly && (
+                    <>
+                      <span className={`${baseClass}__dropzoneContent__orText`}>
+                        {t('general:or')}
+                      </span>
+                      <Button
+                        buttonStyle="secondary"
+                        icon="clipboard"
+                        onClick={handlePasteFromClipboard}
+                        size="medium"
+                        tooltip={t('upload:pasteFromClipboard')}
+                      />
+                    </>
+                  )}
                   <CreateDocDrawer onSave={onDocCreate} />
                   <ListDrawer
                     allowCreate={canCreate}

--- a/packages/ui/src/utilities/getFilesFromClipboard.ts
+++ b/packages/ui/src/utilities/getFilesFromClipboard.ts
@@ -1,0 +1,24 @@
+export const getFilesFromClipboard = async (): Promise<FileList | null> => {
+  if (!navigator.clipboard?.read) {
+    return null
+  }
+
+  const clipboardItems = await navigator.clipboard.read()
+  const dataTransfer = new DataTransfer()
+
+  for (const clipboardItem of clipboardItems) {
+    for (const type of clipboardItem.types) {
+      if (type.startsWith('text/')) {
+        continue
+      }
+
+      const blob = await clipboardItem.getType(type)
+      const extension = type.split('/')[1] ?? 'bin'
+      const filename = `clipboard-${dataTransfer.items.length + 1}.${extension}`
+
+      dataTransfer.items.add(new File([blob], filename, { type }))
+    }
+  }
+
+  return dataTransfer.files.length > 0 ? dataTransfer.files : null
+}

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -87,7 +87,7 @@ const adminThumbnailFunctionSrcPattern = new RegExp(
     '$',
 )
 
-const { afterAll, beforeAll, beforeEach, describe } = test
+const { afterAll, afterEach, beforeAll, beforeEach, describe } = test
 
 let payload: PayloadTestSDK<Config>
 let client: RESTClient
@@ -527,6 +527,59 @@ describe('Uploads', () => {
       hasText: 'Paste URL',
     })
     await expect(pasteURLButton).toBeHidden()
+  })
+
+  describe('paste from clipboard', () => {
+    afterEach(async () => {
+      // Restore clipboard permissions in case a test revoked them, since later tests in this
+      // file share the same browser context and assume clipboard-read/write is granted.
+      await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    })
+
+    test('should paste an image file from the clipboard', async () => {
+      await gotoAndWaitForForm(page, mediaURL.create)
+
+      const imageBytes = Array.from(readFileSync(path.resolve(dirname, './image.png')))
+
+      await page.evaluate(async (bytes) => {
+        const blob = new Blob([new Uint8Array(bytes)], { type: 'image/png' })
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+      }, imageBytes)
+
+      await page.locator('.file-manager__pasteFromClipboard').click()
+
+      await expect(page.locator('#field-filemanager-filename')).toHaveValue('clipboard-1.png')
+
+      await saveDocAndAssert(page)
+    })
+
+    test('should show an error when the clipboard has no file', async () => {
+      await gotoAndWaitForForm(page, mediaURL.create)
+
+      await page.evaluate(async () => {
+        await navigator.clipboard.writeText('no files here')
+      })
+
+      await page.locator('.file-manager__pasteFromClipboard').click()
+
+      await expect(page.locator('.payload-toast-container .toast-error')).toContainText(
+        'No file found in clipboard.',
+      )
+      await closeAllToasts(page)
+    })
+
+    test('should show an error when clipboard access is blocked', async () => {
+      await gotoAndWaitForForm(page, mediaURL.create)
+
+      await page.context().clearPermissions()
+
+      await page.locator('.file-manager__pasteFromClipboard').click()
+
+      await expect(page.locator('.payload-toast-container .toast-error')).toContainText(
+        'Unable to read from clipboard.',
+      )
+      await closeAllToasts(page)
+    })
   })
 
   test('should properly create IOS file upload', async () => {

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -306,6 +306,8 @@ export interface Config {
   locale: 'en' | 'es' | 'fr';
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -4693,6 +4695,174 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection:
+      | 'relation'
+      | 'audio'
+      | 'gif-resize'
+      | 'filename-compound-index'
+      | 'no-image-sizes'
+      | 'object-fit'
+      | 'with-meta-data'
+      | 'without-meta-data'
+      | 'with-only-jpeg-meta-data'
+      | 'crop-only'
+      | 'focal-only'
+      | 'image-sizes-only'
+      | 'focal-no-sizes'
+      | 'media'
+      | 'allow-list-media'
+      | 'skip-safe-fetch-media'
+      | 'skip-safe-fetch-header-filter'
+      | 'skip-allow-list-safe-fetch-media'
+      | 'restrict-file-types'
+      | 'no-restrict-file-types'
+      | 'no-restrict-file-mime-types'
+      | 'pdf-only'
+      | 'restricted-mime-types'
+      | 'animated-type-media'
+      | 'enlarge'
+      | 'without-enlarge'
+      | 'reduce'
+      | 'media-trim'
+      | 'custom-file-name-media'
+      | 'unstored-media'
+      | 'externally-served-media'
+      | 'uploads-1'
+      | 'uploads-2'
+      | 'any-images'
+      | 'admin-thumbnail-function'
+      | 'admin-thumbnail-with-search-queries'
+      | 'admin-thumbnail-size'
+      | 'admin-upload-control'
+      | 'admin-upload-file-preview-single'
+      | 'admin-upload-file-preview-map'
+      | 'file-preview'
+      | 'no-files-required'
+      | 'relation-to-no-files-required'
+      | 'optional-file'
+      | 'required-file'
+      | 'versions'
+      | 'custom-upload-field'
+      | 'media-with-relation-preview'
+      | 'media-without-cache-tags'
+      | 'media-without-relation-preview'
+      | 'relation-preview'
+      | 'hide-file-input-on-create'
+      | 'best-fit'
+      | 'list-view-preview'
+      | 'three-dimensional'
+      | 'constructor-options'
+      | 'bulk-uploads'
+      | 'bulk-uploads-hook-error'
+      | 'simple-relationship'
+      | 'file-mime-type'
+      | 'svg-only'
+      | 'media-without-delete-access'
+      | 'media-with-image-size-admin-props'
+      | 'prefix-media'
+      | 'media-with-fields'
+      | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?:
+      | (
+          | 'relation'
+          | 'audio'
+          | 'gif-resize'
+          | 'filename-compound-index'
+          | 'no-image-sizes'
+          | 'object-fit'
+          | 'with-meta-data'
+          | 'without-meta-data'
+          | 'with-only-jpeg-meta-data'
+          | 'crop-only'
+          | 'focal-only'
+          | 'image-sizes-only'
+          | 'focal-no-sizes'
+          | 'media'
+          | 'allow-list-media'
+          | 'skip-safe-fetch-media'
+          | 'skip-safe-fetch-header-filter'
+          | 'skip-allow-list-safe-fetch-media'
+          | 'restrict-file-types'
+          | 'no-restrict-file-types'
+          | 'no-restrict-file-mime-types'
+          | 'pdf-only'
+          | 'restricted-mime-types'
+          | 'animated-type-media'
+          | 'enlarge'
+          | 'without-enlarge'
+          | 'reduce'
+          | 'media-trim'
+          | 'custom-file-name-media'
+          | 'unstored-media'
+          | 'externally-served-media'
+          | 'uploads-1'
+          | 'uploads-2'
+          | 'any-images'
+          | 'admin-thumbnail-function'
+          | 'admin-thumbnail-with-search-queries'
+          | 'admin-thumbnail-size'
+          | 'admin-upload-control'
+          | 'admin-upload-file-preview-single'
+          | 'admin-upload-file-preview-map'
+          | 'file-preview'
+          | 'no-files-required'
+          | 'relation-to-no-files-required'
+          | 'optional-file'
+          | 'required-file'
+          | 'versions'
+          | 'custom-upload-field'
+          | 'media-with-relation-preview'
+          | 'media-without-cache-tags'
+          | 'media-without-relation-preview'
+          | 'relation-preview'
+          | 'hide-file-input-on-create'
+          | 'best-fit'
+          | 'list-view-preview'
+          | 'three-dimensional'
+          | 'constructor-options'
+          | 'bulk-uploads'
+          | 'bulk-uploads-hook-error'
+          | 'simple-relationship'
+          | 'file-mime-type'
+          | 'svg-only'
+          | 'media-without-delete-access'
+          | 'media-with-image-size-admin-props'
+          | 'prefix-media'
+          | 'media-with-fields'
+          | 'users'
+        )[]
+      | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Rebased on latest upstream/main with conflict resolution.

Conflicts resolved:
- packages/ui/src/elements/FileManager/index.css: merged PR's mobile media query and container query max-width change with upstream's refactored container query content
- packages/ui/src/elements/FileManager/index.tsx: auto-merged cleanly