### PR TITLE
fix(ui): add accessible name to row select checkboxes

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -400,6 +400,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'general:selectAllRows',
   'general:selectedCount',
   'general:selectLabel',
+  'general:selectRow',
   'general:selectValue',
   'general:settings',
   'general:showAllLabel',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -467,6 +467,7 @@ export const arTranslations: DefaultTranslationsObject = {
     selectAllRows: 'حدد جميع الصفوف',
     selectedCount: 'تم تحديد {{count}} {{label}}',
     selectLabel: 'حدد {{label}}',
+    selectRow: undefined,
     selectValue: 'اختيار قيمة',
     settings: 'الإعدادات',
     showAllLabel: 'عرض كل {{label}}',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -481,6 +481,7 @@ export const azTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Bütün sıraları seçin',
     selectedCount: '{{count}} {{label}} seçildi',
     selectLabel: '{{label}} seçin',
+    selectRow: undefined,
     selectValue: 'Dəyər seçin',
     settings: 'Ayarlar',
     showAllLabel: 'Bütün {{label}}-ı göstər',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -477,6 +477,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Избери всички редове',
     selectedCount: '{{count}} {{label}} избрани',
     selectLabel: 'Изберете {{label}}',
+    selectRow: undefined,
     selectValue: 'Избери стойност',
     settings: 'Настройки',
     showAllLabel: 'Покажи всички {{label}}',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -484,6 +484,7 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     selectAllRows: 'সমস্ত সারি নির্বাচন করুন',
     selectedCount: '{{count}} {{label}} নির্বাচিত হয়েছে',
     selectLabel: '{{label}} নির্বাচন করুন',
+    selectRow: undefined,
     selectValue: 'একটি মান নির্বাচন করুন',
     settings: 'সেটিংস',
     showAllLabel: 'সমস্ত {{label}} দেখান',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -483,6 +483,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
     selectAllRows: 'সমস্ত সারি নির্বাচন করুন',
     selectedCount: '{{count}} {{label}} নির্বাচিত হয়েছে',
     selectLabel: '{{label}} নির্বাচন করুন',
+    selectRow: undefined,
     selectValue: 'একটি মান নির্বাচন করুন',
     settings: 'সেটিংস',
     showAllLabel: 'সমস্ত {{label}} দেখান',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -481,6 +481,7 @@ export const caTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Selecciona totes les files',
     selectedCount: '{{count}} {{label}} seleccionats',
     selectLabel: 'Selecciona {{label}}',
+    selectRow: undefined,
     selectValue: 'Selecciona un valor',
     settings: 'Configuració',
     showAllLabel: 'Mostra totes {{label}}',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -473,6 +473,7 @@ export const csTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Vyberte všechny řádky',
     selectedCount: 'Vybráno {{count}} {{label}}',
     selectLabel: 'Vyberte {{label}}',
+    selectRow: undefined,
     selectValue: 'Vyberte hodnotu',
     settings: 'Nastavení',
     showAllLabel: 'Zobrazit všechny {{label}}',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -477,6 +477,7 @@ export const daTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Vælg alle rækker',
     selectedCount: '{{count}} {{label}} valgt',
     selectLabel: 'Vælg {{label}}',
+    selectRow: undefined,
     selectValue: 'Vælg en værdi',
     settings: 'Indstillinger',
     showAllLabel: 'Vis alle {{label}}',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -487,6 +487,7 @@ export const deTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Alle Zeilen auswählen',
     selectedCount: '{{count}} {{label}} ausgewählt',
     selectLabel: '{{label}} auswählen',
+    selectRow: undefined,
     selectValue: 'Wert auswählen',
     settings: 'Einstellungen',
     showAllLabel: 'Alle {{label}} anzeigen',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -477,6 +477,7 @@ export const enTranslations = {
     selectAllRows: 'Select all rows',
     selectedCount: '{{count}} {{label}} selected',
     selectLabel: 'Select {{label}}',
+    selectRow: 'Select row: {{title}}',
     selectValue: 'Select a value',
     settings: 'Settings',
     showAllLabel: 'Show all {{label}}',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -484,6 +484,7 @@ export const esTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Seleccionar todas las filas',
     selectedCount: '{{count}} {{label}} seleccionados',
     selectLabel: 'Seleccionar {{label}}',
+    selectRow: undefined,
     selectValue: 'Seleccionar un valor',
     settings: 'Configuraciones',
     showAllLabel: 'Mostrar todos los elementos de {{label}}',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -473,6 +473,7 @@ export const etTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Vali kõik read',
     selectedCount: '{{count}} {{label}} valitud',
     selectLabel: 'Valige {{label}}',
+    selectRow: undefined,
     selectValue: 'Vali väärtus',
     settings: 'Seaded',
     showAllLabel: 'Näita kõiki {{label}}',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -468,6 +468,7 @@ export const faTranslations: DefaultTranslationsObject = {
     selectAllRows: 'انتخاب همه ردیف‌ها',
     selectedCount: '{{count}} {{label}} انتخاب شد',
     selectLabel: 'انتخاب {{label}}',
+    selectRow: undefined,
     selectValue: 'یک مقدار انتخاب کنید',
     settings: 'تنظیمات',
     showAllLabel: 'نمایش همه {{label}}',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -488,6 +488,7 @@ export const frTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Sélectionnez toutes les lignes',
     selectedCount: '{{count}} {{label}} sélectionné',
     selectLabel: 'Sélectionnez {{label}}',
+    selectRow: undefined,
     selectValue: 'Sélectionnez une valeur',
     settings: 'Paramètres',
     showAllLabel: 'Afficher tous les {{label}}',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -462,6 +462,7 @@ export const heTranslations: DefaultTranslationsObject = {
     selectAllRows: 'בחר את כל השורות',
     selectedCount: '{{count}} {{label}} נבחרו',
     selectLabel: '{{label}} בחר',
+    selectRow: undefined,
     selectValue: 'בחר ערך',
     settings: 'הגדרות',
     showAllLabel: 'הצג את כל ה{{label}}',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -476,6 +476,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Odaberite sve redove',
     selectedCount: '{{count}} {{label}} odabrano',
     selectLabel: 'Odaberite {{label}}',
+    selectRow: undefined,
     selectValue: 'Odaberi vrijednost',
     settings: 'Postavke',
     showAllLabel: 'Prikaži sve {{label}}',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -483,6 +483,7 @@ export const huTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Válassza ki az összes sort',
     selectedCount: '{{count}} {{label}} kiválasztva',
     selectLabel: 'Válassza ki a(z) {{label}} opciót',
+    selectRow: undefined,
     selectValue: 'Válasszon ki egy értéket',
     settings: 'Beállítások',
     showAllLabel: 'Mutasd az összes {{címke}}',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -479,6 +479,7 @@ export const hyTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Ընտրել բոլոր տողերը',
     selectedCount: '{{count}} {{label}} ընտրված է',
     selectLabel: 'ընտրել {{label}}',
+    selectRow: undefined,
     selectValue: 'Ընտրեք արժեք',
     settings: 'Կարգավորումներ',
     showAllLabel: 'Ցուցադրել բոլոր {{label}}-ները',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -479,6 +479,7 @@ export const idTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Pilih semua baris',
     selectedCount: '{{count}} {{label}} dipilih',
     selectLabel: 'Pilih {{label}}',
+    selectRow: undefined,
     selectValue: 'Pilih nilai',
     settings: 'Pengaturan',
     showAllLabel: 'Tampilkan semua {{label}}',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -474,6 +474,7 @@ export const isTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Velja allar raðir',
     selectedCount: '{{count}} {{label}} valið',
     selectLabel: 'Velja {{label}}',
+    selectRow: undefined,
     selectValue: 'Veldu gildi',
     settings: 'Stillingar',
     showAllLabel: 'Sýna allar {{label}}',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -483,6 +483,7 @@ export const itTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Seleziona tutte le righe',
     selectedCount: '{{count}} {{label}} selezionato',
     selectLabel: 'Seleziona {{label}}',
+    selectRow: undefined,
     selectValue: 'Seleziona un valore',
     settings: 'Impostazioni',
     showAllLabel: 'Mostra tutti {{label}}',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -478,6 +478,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     selectAllRows: 'すべての行を選択します',
     selectedCount: '{{count}}つの{{label}}を選択中',
     selectLabel: '{{label}}を選択してください',
+    selectRow: undefined,
     selectValue: '値を選択',
     settings: '設定',
     showAllLabel: 'すべての{{label}}を表示する',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -475,6 +475,7 @@ export const koTranslations: DefaultTranslationsObject = {
     selectAllRows: '모든 행 선택',
     selectedCount: '{{count}}개의 {{label}} 선택됨',
     selectLabel: '{{label}}을 선택하십시오.',
+    selectRow: undefined,
     selectValue: '값 선택',
     settings: '설정',
     showAllLabel: '{{label}} 모두 표시',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -479,6 +479,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Pasirinkite visas eilutes',
     selectedCount: '{{count}} {{label}} pasirinkta',
     selectLabel: 'Pasirinkite {{label}}',
+    selectRow: undefined,
     selectValue: 'Pasirinkite reikšmę',
     settings: 'Nustatymai',
     showAllLabel: 'Rodyti visus {{label}}',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -476,6 +476,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Atlasīt visas rindas',
     selectedCount: 'Atlasīti {{count}} {{label}}',
     selectLabel: 'Atlasīt {{label}}',
+    selectRow: undefined,
     selectValue: 'Atlasīt vērtību',
     settings: 'Iestatījumi',
     showAllLabel: 'Rādīt visus {{label}}',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -483,6 +483,7 @@ export const myTranslations: DefaultTranslationsObject = {
     selectAllRows: 'အားလုံးကိုရွေးချယ်ပါ',
     selectedCount: '{{count}} {{label}} ကို ရွေးထားသည်။',
     selectLabel: '{{label}} ရွေးချယ်ပါ',
+    selectRow: undefined,
     selectValue: 'တစ်ခုခုကို ရွေးချယ်ပါ။',
     settings: 'ဆက်တင်များ',
     showAllLabel: '{{label}} အားလုံး ပြပါ',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -480,6 +480,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Velg alle rader',
     selectedCount: '{{count}} {{label}} valgt',
     selectLabel: 'Velg {{label}}',
+    selectRow: undefined,
     selectValue: 'Velg en verdi',
     settings: 'Innstillinger',
     showAllLabel: 'Vis alle {{label}}',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -485,6 +485,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Selecteer alle rijen',
     selectedCount: '{{count}} {{label}} geselecteerd',
     selectLabel: 'Selecteer {{label}}',
+    selectRow: undefined,
     selectValue: 'Selecteer een waarde',
     settings: 'Instellingen',
     showAllLabel: 'Toon alle {{label}}',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -476,6 +476,7 @@ export const plTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Wybierz wszystkie wiersze',
     selectedCount: 'Wybrano {{count}} {{label}}',
     selectLabel: 'Wybierz {{label}}',
+    selectRow: undefined,
     selectValue: 'Wybierz wartość',
     settings: 'Ustawienia',
     showAllLabel: 'Pokaż wszystkie {{label}}',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -480,6 +480,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Selecione todas as linhas',
     selectedCount: '{{count}} {{label}} selecionado',
     selectLabel: 'Selecione {{label}}',
+    selectRow: undefined,
     selectValue: 'Selecione um valor',
     settings: 'Configurações',
     showAllLabel: 'Mostre todos {{label}}',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -483,6 +483,7 @@ export const roTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Selectează toate rândurile',
     selectedCount: '{{count}} {{label}} selectate',
     selectLabel: 'Selectați {{label}}',
+    selectRow: undefined,
     selectValue: 'Selectați o valoare',
     settings: 'Setări',
     showAllLabel: 'Afișează toate {{eticheta}}',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -476,6 +476,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Одаберите све редове',
     selectedCount: '{{count}} {{label}} одабрано',
     selectLabel: 'Izaberite {{label}}',
+    selectRow: undefined,
     selectValue: 'Одабери вредност',
     settings: 'Podešavanja',
     showAllLabel: 'Прикажи све {{label}}',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -477,6 +477,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Odaberite sve redove',
     selectedCount: '{{count}} {{label}} odabrano',
     selectLabel: 'Izaberite {{label}}',
+    selectRow: undefined,
     selectValue: 'Odaberi vrednost',
     settings: 'Podešavanja',
     showAllLabel: 'Prikaži sve {{label}}',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -480,6 +480,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Выбрать все строки',
     selectedCount: '{{count}} {{label}} выбрано',
     selectLabel: 'Выберите {{label}}',
+    selectRow: undefined,
     selectValue: 'Выбрать значение',
     settings: 'Настройки',
     showAllLabel: 'Показать все {{label}}',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -474,6 +474,7 @@ export const skTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Vybrať všetky riadky',
     selectedCount: 'Vybrané {{count}} {{label}}',
     selectLabel: 'Vyberte {{label}}',
+    selectRow: undefined,
     selectValue: 'Vybrať hodnotu',
     settings: 'Nastavenia',
     showAllLabel: 'Zobraziť všetky {{label}}',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -475,6 +475,7 @@ export const slTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Izberi vse vrstice',
     selectedCount: '{{count}} {{label}} izbranih',
     selectLabel: 'Izberite {{label}}',
+    selectRow: undefined,
     selectValue: 'Izberi vrednost',
     settings: 'Nastavitve',
     showAllLabel: 'Pokaži vse {{label}}',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -479,6 +479,7 @@ export const svTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Välj alla rader',
     selectedCount: '{{count}} {{label}} har valts',
     selectLabel: 'Välj {{label}}',
+    selectRow: undefined,
     selectValue: 'Välj ett värde',
     settings: 'Inställningar',
     showAllLabel: 'Visa alla {{label}}',

--- a/packages/translations/src/languages/ta.ts
+++ b/packages/translations/src/languages/ta.ts
@@ -478,6 +478,7 @@ export const taTranslations: DefaultTranslationsObject = {
     selectAllRows: 'அனைத்து வரிசைகளையும் தேர்ந்தெடு',
     selectedCount: '{{count}} {{label}} தேர்ந்தெடுக்கப்பட்டது',
     selectLabel: '{{label}}-ஐத் தேர்ந்தெடு',
+    selectRow: undefined,
     selectValue: 'ஒரு மதிப்பைத் தேர்ந்தெடு',
     settings: 'அமைப்புகள்',
     showAllLabel: 'அனைத்து {{label}}-ஐக் காட்டு',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -469,6 +469,7 @@ export const thTranslations: DefaultTranslationsObject = {
     selectAllRows: 'เลือกทุกแถว',
     selectedCount: 'เลือก {{count}} {{label}} แล้ว',
     selectLabel: 'เลือก {{label}}',
+    selectRow: undefined,
     selectValue: 'เลือกค่า',
     settings: 'การตั้งค่า',
     showAllLabel: 'แสดง {{label}} ทั้งหมด',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -483,6 +483,7 @@ export const trTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Tüm satırları seçin',
     selectedCount: '{{count}} {{label}} seçildi',
     selectLabel: '{{label}} seçin',
+    selectRow: undefined,
     selectValue: 'Bir değer seçin',
     settings: 'Ayarlar',
     showAllLabel: 'Tüm {{label}} göster',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -473,6 +473,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Обрати всі рядки',
     selectedCount: 'Обрано {{count}} {{label}}',
     selectLabel: 'Виберіть {{label}}',
+    selectRow: undefined,
     selectValue: 'Обрати значення',
     settings: 'Налаштування',
     showAllLabel: 'Показати всі {{label}}',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -478,6 +478,7 @@ export const viTranslations: DefaultTranslationsObject = {
     selectAllRows: 'Chọn tất cả các hàng',
     selectedCount: 'Đã chọn {{count}} {{label}}',
     selectLabel: 'Chọn {{label}}',
+    selectRow: undefined,
     selectValue: 'Chọn một giá trị',
     settings: 'Cài đặt',
     showAllLabel: 'Hiển thị tất cả {{label}}',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -454,6 +454,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     selectAllRows: '选择所有行',
     selectedCount: '已选择 {{count}} 个 {{label}}',
     selectLabel: '选择 {{label}}',
+    selectRow: undefined,
     selectValue: '选择一个值',
     settings: '设置',
     showAllLabel: '显示所有 {{label}}',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -452,6 +452,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     selectAllRows: '選取所有列',
     selectedCount: '已選取 {{count}} 個 {{label}}',
     selectLabel: '選取 {{label}}',
+    selectRow: undefined,
     selectValue: '請選取一個值',
     settings: '設定',
     showAllLabel: '顯示所有 {{label}}',

--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -17,8 +17,8 @@ export const SelectRow: React.FC<{
     _userEditing?: User
     id: number | string
   }
-  selectRowLabel: string
-}> = ({ rowData, selectRowLabel }) => {
+  rowLabel?: string
+}> = ({ rowData, rowLabel }) => {
   const { user } = useAuth()
   const { selected, setSelection } = useSelection()
   const { _isLocked, _userEditing } = rowData || {}
@@ -31,7 +31,7 @@ export const SelectRow: React.FC<{
 
   return (
     <CheckboxInput
-      aria-label={selectRowLabel}
+      aria-label={rowLabel}
       checked={Boolean(selected.get(rowData.id))}
       className={[baseClass, `${baseClass}__checkbox`].join(' ')}
       onToggle={() => setSelection(rowData.id)}

--- a/packages/ui/src/fields/Checkbox/Input.tsx
+++ b/packages/ui/src/fields/Checkbox/Input.tsx
@@ -11,6 +11,7 @@ import { LineIcon } from '../../icons/Line/index.js'
 
 export type CheckboxInputProps = {
   readonly AfterInput?: React.ReactNode
+  /** Accessible label for the checkbox input. Takes precedence over `aria-labelledby`. */
   readonly 'aria-label'?: string
   readonly 'aria-labelledby'?: string
   readonly BeforeInput?: React.ReactNode
@@ -42,8 +43,8 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
   id: idFromProps,
   name,
   AfterInput,
-  'aria-label': ariaLabelFromProps,
-  'aria-labelledby': ariaLabelledByFromProps,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
   BeforeInput,
   checked,
   className,
@@ -63,8 +64,6 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
   const [showTooltip, setShowTooltip] = useState(false)
   const fallbackID = useId()
   const id = idFromProps || fallbackID
-  const ariaLabel = ariaLabelFromProps || undefined
-  const ariaLabelledBy = ariaLabel ? undefined : ariaLabelledByFromProps || name
 
   useEffect(() => {
     setIsHydrated(true)
@@ -91,8 +90,8 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
       <div className={`${inputBaseClass}__wrap`}>
         <div className={`${inputBaseClass}__input`}>
           <input
-            aria-label={ariaLabel}
-            aria-labelledby={ariaLabelledBy}
+            aria-label={ariaLabel || undefined}
+            aria-labelledby={!ariaLabel && name ? name : undefined}
             checked={Boolean(checked)}
             disabled={readOnly}
             id={id}

--- a/packages/ui/src/utilities/renderTable.tsx
+++ b/packages/ui/src/utilities/renderTable.tsx
@@ -252,13 +252,11 @@ export const renderTable = ({
         hidden: true,
       },
       Heading: <SelectAll />,
-      renderedCells: (data?.docs || []).map((row, i) => (
-        <SelectRow
-          key={i}
-          rowData={row}
-          selectRowLabel={getSelectRowLabel({ i18n, rowData: row, useAsTitle })}
-        />
-      )),
+      renderedCells: (data?.docs || []).map((doc, i) => {
+        const titleValue = useAsTitle ? (doc[useAsTitle] ?? doc.id) : doc.id
+        const rowLabel = i18n.t('general:selectRow', { title: String(titleValue) })
+        return <SelectRow key={i} rowData={doc} rowLabel={rowLabel} />
+      }),
     } as Column)
   }
 


### PR DESCRIPTION
Rebased on latest upstream/main with conflict resolution.

Conflicts resolved:
- packages/ui/src/elements/SelectRow/index.tsx: renamed selectRowLabel prop to rowLabel
- packages/ui/src/fields/Checkbox/Input.tsx: merged PR's accessible label logic with upstream's aria-labelledby prop
- packages/ui/src/utilities/renderTable.tsx: replaced getSelectRowLabel helper with inline computed rowLabel using i18n

Original author: @kumarshobhit-1