### PR TITLE
fix(ui): use latest server response after unpublish

### DIFF
--- a/packages/ui/src/elements/UnpublishButton/index.tsx
+++ b/packages/ui/src/elements/UnpublishButton/index.tsx
@@ -104,11 +104,11 @@ export function UnpublishButton({
           })
 
           if (res.status === 200) {
-            void resetForm({
-              ...(dataFromProps || {}),
-              _status: 'draft',
-            })
+            const json = await res.json()
 
+            void resetForm({
+              ...(json?.doc || json),
+            })
             toast.success(t('version:unpublishedSuccessfully'))
             if (!unpublishAll) {
               incrementVersionCount()


### PR DESCRIPTION
Rebased on latest main — clean cherry-pick, no conflicts.