### PR TITLE
fix: preserve nested arrays in cloneDataFromOriginalDoc

### DIFF
--- a/packages/payload/src/fields/hooks/beforeChange/cloneDataFromOriginalDoc.spec.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/cloneDataFromOriginalDoc.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { cloneDataFromOriginalDoc } from './cloneDataFromOriginalDoc.js'
+
+describe('cloneDataFromOriginalDoc', () => {
+  it('preserves nested arrays instead of converting them to index-keyed objects', () => {
+    const original = [
+      [1, 2],
+      [3, 4],
+    ]
+
+    const cloned = cloneDataFromOriginalDoc(original)
+
+    expect(cloned).toEqual([
+      [1, 2],
+      [3, 4],
+    ])
+    expect(Array.isArray((cloned as unknown[])[0])).toBe(true)
+  })
+
+  it('does not mutate the original array when cloning nested arrays', () => {
+    const original = [[1, 2]]
+
+    const cloned = cloneDataFromOriginalDoc(original) as unknown[][]
+    cloned[0]!.push(999)
+
+    expect(original[0]).toEqual([1, 2])
+  })
+
+  it('shallow clones object rows as before', () => {
+    const original = [{ id: '1', text: 'hello' }]
+
+    const cloned = cloneDataFromOriginalDoc(original)
+
+    expect(cloned).toEqual(original)
+    expect(cloned[0]).not.toBe(original[0])
+  })
+
+  it('shallow clones a plain object', () => {
+    const original = { foo: 'bar' }
+
+    const cloned = cloneDataFromOriginalDoc(original)
+
+    expect(cloned).toEqual(original)
+    expect(cloned).not.toBe(original)
+  })
+
+  it('returns primitives and null rows untouched', () => {
+    expect(cloneDataFromOriginalDoc(null as any)).toBe(null)
+    expect(cloneDataFromOriginalDoc(['a', 1, null] as any)).toEqual(['a', 1, null])
+  })
+})

--- a/packages/payload/src/fields/hooks/beforeChange/cloneDataFromOriginalDoc.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/cloneDataFromOriginalDoc.ts
@@ -5,6 +5,10 @@ export const cloneDataFromOriginalDoc = (
 ): JsonArray | JsonObject => {
   if (Array.isArray(originalDocData)) {
     return originalDocData.map((row) => {
+      if (Array.isArray(row)) {
+        return [...row]
+      }
+
       if (typeof row === 'object' && row != null) {
         return {
           ...row,

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -3515,6 +3515,38 @@ describe('Fields', () => {
       expect(updatedJsonFieldsDoc.json.state).toEqual({})
     })
 
+    it('should preserve nested arrays when the field is omitted from a partial update', async () => {
+      // customJSON has no jsonSchema restriction, so it can hold an arbitrary
+      // array-of-arrays shape (e.g. coordinate tuples) like the `json` field can.
+      const jsonFieldsDoc = await payload.create({
+        collection: 'json-fields',
+        data: {
+          customJSON: [
+            [1, 2],
+            [3, 4],
+          ],
+        },
+      })
+
+      expect(jsonFieldsDoc.customJSON).toEqual([
+        [1, 2],
+        [3, 4],
+      ])
+
+      const updatedJsonFieldsDoc = await payload.update({
+        id: jsonFieldsDoc.id,
+        collection: 'json-fields',
+        data: {
+          json: { foo: 'bar' },
+        },
+      })
+
+      expect(updatedJsonFieldsDoc.customJSON).toEqual([
+        [1, 2],
+        [3, 4],
+      ])
+    })
+
     describe('querying', () => {
       let fooBar
       let bazBar


### PR DESCRIPTION
### What?

`cloneDataFromOriginalDoc` mangles a `json` field's array-of-arrays value (e.g. `[[1, 2], [3, 4]]`) into an array of index-keyed objects (`[{"0": 1, "1": 2}, {"0": 3, "1": 4}]`) whenever the field is omitted from a partial `update`/`PATCH` and its value is carried forward from the original document.

### Why?

`cloneDataFromOriginalDoc` shallow-clones each row of an array value with `{...row}`. `typeof row === 'object'` is also `true` for arrays, so when a row is itself an array (nested arrays, as opposed to the usual array/blocks-field row objects), the object-spread branch runs instead and turns it into an index-keyed object. On a publish operation this trips field `validate` and is caught, but draft saves skip validation, so the corrupted shape silently persists to the database. Downstream consumers that iterate the tuples then crash with `TypeError: object is not iterable`.

### How?

Check `Array.isArray(row)` before the generic object check, and clone array rows with `[...row]` instead of `{...row}`, preserving their shape. This keeps the same one-level-deep shallow-clone semantics the function already uses for object rows — only the branching changes.

### Testing performed

- Added a unit test (`cloneDataFromOriginalDoc.spec.ts`) covering nested-array cloning, non-mutation of the original, and the existing object/primitive clone behavior. Verified it fails without the fix and passes with it.
- Added an integration regression test in `test/fields/int.spec.ts` reproducing the exact reported flow: create a doc with a `json` field holding an array-of-arrays, then partially update the doc without touching that field, and assert the stored value is unchanged. Verified it fails without the fix (reproducing the reported corruption exactly) and passes with it.
- Ran the full `test/fields` and `test/fields-relationship` integration suites (sqlite) — all passing, no regressions.
- `tsc --noEmit` on `packages/payload` — no errors.
- `prettier --check` and `eslint` on all changed files — clean.

Fixes #17475