### PR TITLE
fix(drizzle): apply limitedBoundParameters workaround to parent path

### DIFF
--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -423,7 +423,7 @@ export function parseParams({
                 if (
                   adapter.limitedBoundParameters &&
                   (operator === 'in' || operator === 'not_in') &&
-                  relationOrPath === 'id' &&
+                  (relationOrPath === 'id' || relationOrPath === 'parent') &&
                   Array.isArray(queryValue)
                 ) {
                   let isInvalid = false

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1456,6 +1456,53 @@ describe('Versions', () => {
         expect(findDoc.title).toStrictEqual('updated title')
         expect(findDoc.description).toStrictEqual('updated description')
       })
+
+      it('should bulk publish more than 100 drafts without exceeding bound parameter limits', async () => {
+        // Create 120 draft documents — mirrors the D1 100-bound-parameter issue (#17493)
+        const docs = await Promise.all(
+          Array.from({ length: 120 }, (_, i) =>
+            payload.create({
+              collection: draftCollectionSlug,
+              data: {
+                description: `bulk publish description ${i}`,
+                title: `bulk publish title ${i}`,
+              },
+              draft: true,
+            }),
+          ),
+        )
+
+        const ids = docs.map((doc) => doc.id)
+
+        // Bulk publish all 120 at once using id IN (...) — this is the exact
+        // where-clause shape the admin's PublishMany sends
+        const updated = await payload.update({
+          collection: draftCollectionSlug,
+          data: {
+            _status: 'published',
+          },
+          draft: true,
+          where: {
+            id: {
+              in: ids,
+            },
+          },
+        })
+
+        expect(updated.docs).toHaveLength(120)
+        expect(updated.errors).toHaveLength(0)
+
+        // Verify they were actually published, not just returned
+        const findResult = await payload.find({
+          collection: draftCollectionSlug,
+          limit: 0,
+          where: {
+            and: [{ id: { in: ids } }, { _status: { equals: 'published' } }],
+          },
+        })
+
+        expect(findResult.totalDocs).toBe(120)
+      })
     })
 
     describe('Delete', () => {


### PR DESCRIPTION
## What?

Extend the `limitedBoundParameters` workaround in `parseParams` to also match the `parent` query path in addition to `id`.

## Why?

Cloudflare D1 limits the number of bound SQL parameters to 100. Payload already avoids this limitation by inlining values for `id IN (...)` queries when `limitedBoundParameters` is enabled.

However, drafts queries rewrite `id` to `parent` via `appendVersionToQueryKey()` before reaching `parseParams`. Because the workaround only matched `relationOrPath === 'id'`, it was skipped for drafts, causing large bulk publish operations to generate one bound parameter per ID and exceed D1's limit.

## How?

* Extend the D1 `limitedBoundParameters` condition to apply when `relationOrPath` is either `id` or `parent`.
* Add an integration test that creates 120 draft documents and bulk publishes them using `where: { id: { in: ids } }`.
* Verify that all documents are published successfully without errors, covering the code path that previously exceeded D1's bound parameter limit.

Fixes #17493
