### PR TITLE
fix(drizzle): preserve both top-level and/or clauses in where queries

### DIFF
--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -75,7 +75,11 @@ export function parseParams({
             where: condition,
           })
           if (builtConditions.length > 0) {
-            result = conditionOperator(...builtConditions)
+            // AND sibling top-level `and`/`or` groups together instead of
+            // overwriting, so a where with both an `and` and an `or` key at the
+            // same level keeps both clauses (a bare assignment dropped the first).
+            const builtCondition = conditionOperator(...builtConditions)
+            result = result ? and(result, builtCondition) : builtCondition
           }
         } else {
           // It's a path - and there can be multiple comparisons on a single path.


### PR DESCRIPTION
### What?

In the SQL adapters (`@payloadcms/drizzle`), a `where` query that has **both** a top-level `and` key and a top-level `or` key silently drops one of them. Only the clause that happens to be iterated last is applied.

```
GET /api/posts?where[or][0][status][equals]=published
              &where[or][1][status][equals]=featured
              &where[and][0][views][greater_than]=100
```

- Expected: `(status = 'published' OR status = 'featured') AND views > 100`
- Actual: `views > 100` only — the entire `OR (status …)` restriction is dropped (reverse the key order and the `AND` clause is dropped instead), so the query returns rows that should have been filtered out.

### Why?

In `packages/drizzle/src/queries/parseParams.ts`, each top-level `and`/`or` key did a bare assignment:

```ts
if (builtConditions.length > 0) {
  result = conditionOperator(...builtConditions) // overwrites any previous and/or
}
```

Field-path constraints accumulate into `constraints[]` and are ANDed at the end, but the two array-keys overwrite the single `result`, so the first is lost. The MongoDB adapter (`packages/db-mongodb/src/queries/parseParams.ts`) stores them under separate `$and` / `$or` keys and keeps both — so the same valid query returns different result sets on Postgres/SQLite vs MongoDB.

### How?

AND the built groups together instead of overwriting:

```ts
const builtCondition = conditionOperator(...builtConditions)
result = result ? and(result, builtCondition) : builtCondition
```

Single-`and` and single-`or` queries produce byte-identical output; only the both-keys case changes (from dropping a clause to keeping both). Nested forms (`and: [{ or: [...] }]`) were already fine.

Verified with a standalone repro of the loop + end-combine (sibling `or`+`and` now keeps both; single-key output unchanged). I did not add an integration test because the where-query suite (`test/database/int.spec.ts`) runs against live DB adapters and I couldn't run it locally — happy to add one there if you'd like.

Fixes #
