### PR TITLE
fix(graphql): preserve hasMany relationship order in populated results (replacement of #17004)

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -718,15 +718,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
 
               if (result) {
                 if (isRelatedToManyCollections) {
-                  results.push({
+                  results[i] = {
                     relationTo: collectionSlug,
                     value: {
                       ...result,
                       collection: collectionSlug,
                     },
-                  })
+                  }
                 } else {
-                  results.push(result)
+                  results[i] = result
                 }
               }
             }
@@ -739,7 +739,10 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           }
 
           await Promise.all(resultPromises)
-          return results
+          // Assigned by index above so the populated order matches the stored
+          // order regardless of which dataloader promise settles first. Filter
+          // out holes left by skipped (invalid collection / missing) entries.
+          return results.filter((result) => result !== undefined)
         }
 
         let id = value
@@ -1137,15 +1140,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
 
               if (result) {
                 if (isRelatedToManyCollections) {
-                  results.push({
+                  results[i] = {
                     relationTo: collectionSlug,
                     value: {
                       ...result,
                       collection: collectionSlug,
                     },
-                  })
+                  }
                 } else {
-                  results.push(result)
+                  results[i] = result
                 }
               }
             }
@@ -1158,7 +1161,10 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           }
 
           await Promise.all(resultPromises)
-          return results
+          // Assigned by index above so the populated order matches the stored
+          // order regardless of which dataloader promise settles first. Filter
+          // out holes left by skipped (invalid collection / missing) entries.
+          return results.filter((result) => result !== undefined)
         }
 
         let id = value

--- a/test/graphql/config.ts
+++ b/test/graphql/config.ts
@@ -33,6 +33,17 @@ export default buildConfigWithDefaults({
           },
         },
         {
+          type: 'relationship',
+          name: 'singleRelation',
+          relationTo: 'posts',
+        },
+        {
+          type: 'relationship',
+          name: 'manyRelations',
+          hasMany: true,
+          relationTo: 'posts',
+        },
+        {
           name: 'contentBlockField',
           type: 'blocks',
           blocks: [ContentBlock],

--- a/test/graphql/int.spec.ts
+++ b/test/graphql/int.spec.ts
@@ -306,6 +306,43 @@ query {
         expect(fields.virtualComputed!.type instanceof GraphQLNonNull).toBe(false)
         expect(fields.virtualFromRelation!.type instanceof GraphQLNonNull).toBe(false)
       })
-    })
+
+      it('should preserve hasMany relationship order when a single relationship to the same collection is queried first', async () => {
+        const postA = await payload.create({ collection: 'posts', data: { title: 'A' } })
+        const postB = await payload.create({ collection: 'posts', data: { title: 'B' } })
+        const postC = await payload.create({ collection: 'posts', data: { title: 'C' } })
+
+        const parent = await payload.create({
+          collection: 'posts',
+          data: {
+            title: 'parent',
+            manyRelations: [postA.id, postB.id, postC.id],
+            singleRelation: postA.id,
+          },
+        })
+
+        const query = `query {
+        Post(id: ${idToString(parent.id, payload)}) {
+          singleRelation {
+            title
+          }
+          manyRelations {
+            title
+          }
+        }
+      }`
+
+        const response = await restClient
+          .GRAPHQL_POST({ body: JSON.stringify({ query }) })
+          .then((res) => res.json())
+
+        expect(response.errors).toBeUndefined()
+        expect(response.data.Post.manyRelations.map((doc) => doc.title)).toStrictEqual(['A', 'B', 'C'])
+
+        await payload.delete({
+          collection: 'posts',
+          where: { id: { in: [parent.id, postA.id, postB.id, postC.id] } },
+        })
+      })
   })
 })


### PR DESCRIPTION
Replacement of #17004 by @yashs33244. Original was CONFLICTING — rebased onto main, conflict resolved in test/graphql/int.spec.ts (merged with new nullable schema types test).