### PR TITLE
fix(ui): translate Dialog close button aria-label (replacement of #16991)

### DIFF
--- a/packages/ui/src/elements/Dialog/DialogHeader/index.tsx
+++ b/packages/ui/src/elements/Dialog/DialogHeader/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react'
 
+import { useTranslation } from '../../../providers/Translation/index.js'
 import { XIcon } from '../../../icons/X/index.js'
 import { Button } from '../../Button/index.js'
 import { useModal } from '../../Modal/index.js'
@@ -26,6 +27,7 @@ export const DialogHeader: React.FC<DialogHeaderProps> = ({
 }) => {
   const { slug, isConfirming } = useDialogContext()
   const { closeModal } = useModal()
+  const { t } = useTranslation()
 
   if (!title && !children && !showClose) {
     return null
@@ -42,7 +44,7 @@ export const DialogHeader: React.FC<DialogHeaderProps> = ({
         {children ? <div className={`${baseClass}__header-extras`}>{children}</div> : null}
         {showClose ? (
           <Button
-            aria-label="Close"
+            aria-label={t('general:close')}
             buttonStyle="ghost"
             disabled={isConfirming}
             icon={<XIcon />}


### PR DESCRIPTION
Replacement of #16991 by @jhjh1214. Original was CONFLICTING — rebased onto main, conflict resolved in DialogHeader (kept HEAD structure with onClose support, applied PR's t('general:close')).