### PR TITLE
fix(ui): use latest server response after unpublish + HEAD route (replacement of #16762)

### DIFF
--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -51,6 +51,8 @@ export const OPTIONS = handlerBuilder
 
 export const GET = handlerBuilder
 
+export const HEAD = GET
+
 export const POST = handlerBuilder
 
 export const DELETE = handlerBuilder

--- a/packages/ui/src/elements/UnpublishButton/index.tsx
+++ b/packages/ui/src/elements/UnpublishButton/index.tsx
@@ -102,11 +102,11 @@ export function UnpublishButton({
           })
 
           if (res.status === 200) {
-            void resetForm({
-              ...(dataFromProps || {}),
-              _status: 'draft',
-            })
+            const json = await res.json()
 
+            void resetForm({
+              ...(json?.doc || json),
+            })
             toast.success(t('version:unpublishedSuccessfully'))
             if (!unpublishAll) {
               incrementVersionCount()


### PR DESCRIPTION
Replacement of #16762 by @raunak3208. Original was CONFLICTING — rebased onto main, conflict resolved (dropped payload.db binary file).