### PR TITLE
fix(next): support HEAD requests in REST routes (replacement of #16761)

### DIFF
--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -51,6 +51,8 @@ export const OPTIONS = handlerBuilder
 
 export const GET = handlerBuilder
 
+export const HEAD = GET
+
 export const POST = handlerBuilder
 
 export const DELETE = handlerBuilder


### PR DESCRIPTION
Replacement of #16761 by @raunak3208. Original was CONFLICTING — rebased onto main, conflict resolved (dropped payload.db binary file).