### PR TITLE
perf!: reduce default query depth from 2 to 1

### DIFF
--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -22,6 +22,27 @@ The codemod is idempotent and safe to run on a partially-migrated project.
 
 ## Breaking Changes
 
+### Default query depth reduced to `1`
+
+Queries that omit `depth` now populate one relationship level instead of two. This reduces database work and response size by default.
+
+If your application relies on two populated levels, prefer specifying `depth: 2` only on the queries that need it:
+
+```ts
+const posts = await payload.find({
+  collection: 'posts',
+  depth: 2,
+})
+```
+
+To preserve the Payload 3.x behavior application-wide, set `defaultDepth: 2`:
+
+```diff
+export default buildConfig({
++ defaultDepth: 2,
+})
+```
+
 ### Versions are now enabled by default for all collections and globals
 
 Collections and globals now have `versions: true` by default (`maxPerDoc`/`max: 100`, drafts disabled). In previous versions you had to opt in; you now opt out.

--- a/docs/queries/depth.mdx
+++ b/docs/queries/depth.mdx
@@ -81,7 +81,7 @@ fetch('https://localhost:3000/api/posts?depth=2')
 
 ## Default Depth
 
-If no depth is specified in the request, Payload will use its default depth for all requests. By default, this is set to `2`.
+If no depth is specified in the request, Payload will use its default depth for all requests. By default, this is set to `1`.
 
 To change the default depth on the application level, you can use the `defaultDepth` option in your root Payload config:
 
@@ -91,7 +91,7 @@ import { buildConfig } from 'payload/config'
 export default buildConfig({
   // ...
   // highlight-start
-  defaultDepth: 1,
+  defaultDepth: 2,
   // highlight-end
   // ...
 })

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -41,7 +41,7 @@ export const addDefaultsToConfig = (config: Config): Config => {
   config.cors = config.cors ?? []
   config.csrf = config.csrf ?? []
   config.custom = config.custom ?? {}
-  config.defaultDepth = config.defaultDepth ?? 2
+  config.defaultDepth = config.defaultDepth ?? 1
   config.defaultMaxTextLength = config.defaultMaxTextLength ?? 40000
   config.endpoints = config.endpoints ?? []
   config.globals = config.globals ?? []

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1268,7 +1268,7 @@ export type Config = {
    *
    * @see https://payloadcms.com/docs/getting-started/concepts#depth
    *
-   * @default 2
+   * @default 1
    */
   defaultDepth?: number
   /**

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -963,6 +963,14 @@ describe('Relationships', () => {
       })
 
       describe('depth', () => {
+        it('should populate one level by default', async () => {
+          const doc = await restClient.GET(`/${slug}/${post.id}`).then((res) => res.json())
+          const chainedRel = doc?.chainedRelation as EasierChained
+
+          expect(chainedRel.id).toEqual(chained.id)
+          expect(chainedRel.relation).toEqual(chained2.id)
+        })
+
         it('should populate to depth', async () => {
           const doc = await restClient
             .GET(`/${slug}/${post.id}`, {
@@ -1081,12 +1089,10 @@ describe('Relationships', () => {
 
             const doc = result.docs[0]
 
-            // Default depth should apply, not depth: 0 from req.query
-            // So relationships should be populated (not just IDs)
             const chainedRel = doc?.chainedRelation as EasierChained
 
-            expect(chainedRel).toHaveProperty('id')
             expect(chainedRel.id).toEqual(chained.id)
+            expect(chainedRel.relation).toEqual(chained2.id)
           })
         })
       })


### PR DESCRIPTION
Reduces Payload's default query depth from `2` to `1`, improving query performance out of the box for every application without requiring configuration changes. Queries now avoid second-level relationship population—and its associated database, transformation, and serialization work—unless explicitly requested.

Although a default of `0` would produce the fastest possible queries, `depth: 1` strikes a better balance between performance and DX. `2` is unnecessarily expensive as a default, while the tradeoff between `0` and `1` is less clear. Ultimately, `1` gives us the best of both worlds: substantially less relationship population by default without making the default response shape too limited.

Related discussion: https://github.com/payloadcms/payload/discussions/15351
Resolves PYLD-2395

## Breaking Changes

Applications that rely on implicit second-level relationship population are affected. Queries that omit `depth` now populate one relationship level instead of two.

Request the additional depth where needed:

```diff
const posts = await payload.find({
  collection: 'posts',
+ depth: 2,
})
```

To preserve the previous behavior application-wide:

```diff
export default buildConfig({
+ defaultDepth: 2,
})
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216910993520508
