### PR TITLE
ci: tag main with canary tags on prerelease publish

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -23,6 +23,7 @@ jobs:
     name: publish-prerelease-${{ github.ref_name }}-${{ github.sha }}
     permissions:
       id-token: write
+      contents: write
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -60,3 +61,15 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Tag canary release
+        if: steps.determine_release_type.outputs.release_type == 'canary' && inputs.dry_run != true
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists, skipping."
+            exit 0
+          fi
+          git tag -a "${TAG}" -m "${TAG}"
+          git push origin "${TAG}"


### PR DESCRIPTION
Adds a step to the `publish-prerelease` workflow that pushes a git tag to `main` after a successful canary publish. The step tags the published commit only; no version-bump commit is created.

## Key Changes

- **Canary tag push**
  - A new `Tag canary release` step runs after the publish step. It reads the resolved version from `package.json` and pushes an annotated tag `v<version>` (a tag that carries its own message and tagger).
  - The step runs only for canary releases from `main`. It skips on dry runs.
  - An existing tag counts as success. A re-run logs and exits 0 instead of failing.
- **Workflow permission**
  - The job now requests `contents: write`. The default workflow token needs it to push the tag.
