### PR TITLE
fix(drizzle): dedupe reused localized block tables

### DIFF
--- a/packages/drizzle/src/schema/buildRawSchema.spec.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.spec.ts
@@ -1,0 +1,167 @@
+import type { Block, Config, SanitizedConfig } from 'payload'
+import { sanitizeConfig } from 'payload'
+import { describe, expect, it } from 'vitest'
+
+import { setColumnID } from '../postgres/schema/setColumnID.js'
+import type { DrizzleAdapter } from '../types.js'
+import { buildRawSchema } from './buildRawSchema.js'
+
+const headlineBlock: Block = {
+  slug: 'headline',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}
+
+const createContainerBlock = (slug: string): Block => ({
+  slug,
+  fields: [
+    {
+      name: 'content',
+      type: 'blocks',
+      blocks: ['headline'],
+    },
+  ],
+})
+
+const createAdapter = (config: SanitizedConfig): DrizzleAdapter =>
+  ({
+    blocksAsJSON: false,
+    fieldConstraints: {},
+    idType: 'serial',
+    localesSuffix: '_locales',
+    payload: {
+      blocks: Object.fromEntries(config.blocks.map((block) => [block.slug, block])),
+      collections: Object.fromEntries(
+        config.collections.map((collection) => [
+          collection.slug,
+          {
+            config: collection,
+            customIDType: undefined,
+          },
+        ]),
+      ),
+      config,
+    },
+    rawRelations: {},
+    rawTables: {},
+    tableNameMap: new Map(),
+    versionsSuffix: '_versions',
+  }) as unknown as DrizzleAdapter
+
+describe('buildRawSchema', () => {
+  it('should create suffixed block tables for different schemas with the same slug', async () => {
+    const config = await sanitizeConfig({
+      collections: [
+        {
+          slug: 'pages',
+          fields: [
+            {
+              name: 'primaryContent',
+              type: 'blocks',
+              localized: true,
+              blocks: [
+                {
+                  slug: 'content',
+                  fields: [
+                    {
+                      name: 'title',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'secondaryContent',
+              type: 'blocks',
+              localized: true,
+              blocks: [
+                {
+                  slug: 'content',
+                  fields: [
+                    {
+                      name: 'description',
+                      type: 'textarea',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      localization: {
+        defaultLocale: 'en',
+        locales: ['en', 'de'],
+      },
+    } as Config)
+
+    const adapter = createAdapter(config)
+
+    buildRawSchema({
+      adapter,
+      setColumnID,
+    })
+
+    expect(adapter.rawTables.pages_blocks_content.columns.title).toBeDefined()
+    expect(adapter.rawTables.pages_blocks_content.columns._locale).toBeDefined()
+    expect(adapter.rawTables.pages_blocks_content_2.columns.description).toBeDefined()
+    expect(adapter.rawTables.pages_blocks_content_2.columns._locale).toBeDefined()
+  })
+
+  it('should not create duplicate suffixed block tables for identical reused blocks under localized ancestors', async () => {
+    const layoutBlocks = [createContainerBlock('container'), createContainerBlock('container50')]
+
+    const config = await sanitizeConfig({
+      blocks: [headlineBlock],
+      collections: [
+        {
+          slug: 'pages',
+          fields: [
+            {
+              name: 'layout',
+              type: 'blocks',
+              localized: true,
+              blocks: layoutBlocks,
+            },
+          ],
+        },
+        {
+          slug: 'posts',
+          fields: [
+            {
+              name: 'layout',
+              type: 'blocks',
+              localized: true,
+              blocks: layoutBlocks,
+            },
+          ],
+        },
+      ],
+      localization: {
+        defaultLocale: 'en',
+        locales: ['en', 'de'],
+      },
+    } as Config)
+
+    const adapter = createAdapter(config)
+
+    buildRawSchema({
+      adapter,
+      setColumnID,
+    })
+
+    expect(adapter.rawTables.pages_blocks_headline).toBeDefined()
+    expect(adapter.rawTables.pages_blocks_headline.columns._locale).toBeDefined()
+    expect(adapter.rawTables.pages_blocks_headline_2).toBeUndefined()
+    expect(adapter.rawTables.pages_blocks_headline_2_locales).toBeUndefined()
+    expect(adapter.rawTables.posts_blocks_headline).toBeDefined()
+    expect(adapter.rawTables.posts_blocks_headline.columns._locale).toBeDefined()
+    expect(adapter.rawTables.posts_blocks_headline_2).toBeUndefined()
+    expect(adapter.rawTables.posts_blocks_headline_2_locales).toBeUndefined()
+  })
+})

--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -396,14 +396,19 @@ export const traverseFields = ({
             versionsCustomName: versions,
           })
 
+          const isLocalizedBlockTable =
+            Boolean(isFieldLocalized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock ||
+            forceLocalized
+
           if (typeof blocksTableNameMap[blockTableName] === 'undefined') {
             blocksTableNameMap[blockTableName] = 1
           } else if (
             !adapter.rawTables[blockTableName] ||
             !validateExistingBlockIsIdentical({
               block,
-              localized: field.localized,
-              rootTableName,
+              localized: isLocalizedBlockTable,
+              parentIsLocalized,
               table: adapter.rawTables[blockTableName],
               tableLocales: adapter.rawTables[`${blockTableName}${adapter.localesSuffix}`],
             })
@@ -465,12 +470,7 @@ export const traverseFields = ({
               },
             }
 
-            const isLocalized =
-              Boolean(isFieldLocalized && adapter.payload.config.localization) ||
-              withinLocalizedArrayOrBlock ||
-              forceLocalized
-
-            if (isLocalized) {
+            if (isLocalizedBlockTable) {
               baseColumns._locale = {
                 name: '_locale',
                 type: 'enum',
@@ -510,7 +510,7 @@ export const traverseFields = ({
               setColumnID,
               tableName: blockTableName,
               versions,
-              withinLocalizedArrayOrBlock: isLocalized,
+              withinLocalizedArrayOrBlock: isLocalizedBlockTable,
             })
 
             if (subHasLocalizedManyNumberField) {

--- a/packages/drizzle/src/utilities/validateExistingBlockIsIdentical.ts
+++ b/packages/drizzle/src/utilities/validateExistingBlockIsIdentical.ts
@@ -12,11 +12,7 @@ import type { RawTable } from '../types.js'
 type Args = {
   block: Block
   localized: boolean
-  /**
-   * @todo make required in v4.0. Usually you'd wanna pass this in
-   */
-  parentIsLocalized?: boolean
-  rootTableName: string
+  parentIsLocalized: boolean
   table: RawTable
   tableLocales?: RawTable
 }


### PR DESCRIPTION
Reuses localized block tables when identical block references appear beneath localized ancestors, preventing duplicate `_N` tables in 4.x. Ports #17430 while preserving suffixed tables for genuinely different same-slug schemas.

Fixes #17424.