### PR TITLE
fix(templates): restore depth 2 in templates and examples

### DIFF
--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -43,6 +43,21 @@ export default buildConfig({
 })
 ```
 
+Two places inherit `defaultDepth` without naming it, so they change too:
+
+- **The authenticated user on `req.user`.** Auth collections populate the user document using `auth.depth`, which falls back to `defaultDepth` when you have not set it. Access control functions and hooks that reach two relationships deep from the user, such as `user.tenant.owner`, now receive an ID instead of a document. Because access control reads this value, the failure is silent rather than an error. Set `auth.depth` explicitly on the collection if you depend on it:
+
+```diff
+export const Users: CollectionConfig = {
+  slug: 'users',
+  auth: {
++   depth: 2,
+  },
+}
+```
+
+- **`originalDoc` in the search plugin's `beforeSync`.** When localization is enabled, `@payloadcms/plugin-search` refetches the document without an explicit depth before handing it to your `beforeSync` hook. Read only first-level relationships there, or refetch yourself with the depth you need.
+
 ### Versions are now enabled by default for all collections and globals
 
 Collections and globals now have `versions: true` by default (`maxPerDoc`/`max: 100`, drafts disabled). In previous versions you had to opt in; you now opt out.

--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -43,20 +43,7 @@ export default buildConfig({
 })
 ```
 
-Two places inherit `defaultDepth` without naming it, so they change too:
-
-- **The authenticated user on `req.user`.** Auth collections populate the user document using `auth.depth`, which falls back to `defaultDepth` when you have not set it. Access control functions and hooks that reach two relationships deep from the user, such as `user.tenant.owner`, now receive an ID instead of a document. Because access control reads this value, the failure is silent rather than an error. Set `auth.depth` explicitly on the collection if you depend on it:
-
-```diff
-export const Users: CollectionConfig = {
-  slug: 'users',
-  auth: {
-+   depth: 2,
-  },
-}
-```
-
-- **`originalDoc` in the search plugin's `beforeSync`.** When localization is enabled, `@payloadcms/plugin-search` refetches the document without an explicit depth before handing it to your `beforeSync` hook. Read only first-level relationships there, or refetch yourself with the depth you need.
+One place inherits `defaultDepth` without naming it: when localization is enabled, `@payloadcms/plugin-search` refetches the document without an explicit depth before handing `originalDoc` to your `beforeSync` hook. Read only first-level relationships there, or refetch yourself with the depth you need.
 
 ### Versions are now enabled by default for all collections and globals
 

--- a/examples/localization/src/app/(frontend)/[locale]/[slug]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/[slug]/page.tsx
@@ -93,8 +93,6 @@ const queryPage = cache(async ({ slug, locale }: { slug: string; locale: TypedLo
 
   const result = await payload.find({
     collection: 'pages',
-    // Blocks such as Archive render cards for documents embedded in this page,
-    // whose own upload and relationship fields sit two levels deep.
     depth: 2,
     draft,
     limit: 1,

--- a/examples/localization/src/app/(frontend)/[locale]/[slug]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/[slug]/page.tsx
@@ -93,6 +93,9 @@ const queryPage = cache(async ({ slug, locale }: { slug: string; locale: TypedLo
 
   const result = await payload.find({
     collection: 'pages',
+    // Blocks such as Archive render cards for documents embedded in this page,
+    // whose own upload and relationship fields sit two levels deep.
+    depth: 2,
     draft,
     limit: 1,
     locale,

--- a/examples/localization/src/app/(frontend)/[locale]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/page.tsx
@@ -71,6 +71,9 @@ const queryPage = cache(async ({ locale, slug }: { locale: TypedLocale; slug: st
 
   const result = await payload.find({
     collection: 'pages',
+    // Blocks such as Archive render cards for documents embedded in this page,
+    // whose own upload and relationship fields sit two levels deep.
+    depth: 2,
     draft,
     limit: 1,
     overrideAccess: draft,

--- a/examples/localization/src/app/(frontend)/[locale]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/page.tsx
@@ -71,8 +71,6 @@ const queryPage = cache(async ({ locale, slug }: { locale: TypedLocale; slug: st
 
   const result = await payload.find({
     collection: 'pages',
-    // Blocks such as Archive render cards for documents embedded in this page,
-    // whose own upload and relationship fields sit two levels deep.
     depth: 2,
     draft,
     limit: 1,

--- a/examples/localization/src/app/(frontend)/[locale]/posts/[slug]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/posts/[slug]/page.tsx
@@ -88,8 +88,6 @@ const queryPost = cache(async ({ slug, locale }: { slug: string; locale: TypedLo
 
   const result = await payload.find({
     collection: 'posts',
-    // Related post cards read `meta.image` and `categories`, which sit two
-    // levels deep from this post.
     depth: 2,
     draft,
     limit: 1,

--- a/examples/localization/src/app/(frontend)/[locale]/posts/[slug]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/posts/[slug]/page.tsx
@@ -88,6 +88,9 @@ const queryPost = cache(async ({ slug, locale }: { slug: string; locale: TypedLo
 
   const result = await payload.find({
     collection: 'posts',
+    // Related post cards read `meta.image` and `categories`, which sit two
+    // levels deep from this post.
+    depth: 2,
     draft,
     limit: 1,
     overrideAccess: draft,

--- a/templates/ecommerce/src/app/(app)/[slug]/page.tsx
+++ b/templates/ecommerce/src/app/(app)/[slug]/page.tsx
@@ -86,8 +86,6 @@ const queryPageBySlug = async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'pages',
-    // Product blocks such as Carousel and ThreeItemGrid read `meta.image` on
-    // products embedded in this page, which sits two levels deep.
     depth: 2,
     draft,
     limit: 1,

--- a/templates/ecommerce/src/app/(app)/[slug]/page.tsx
+++ b/templates/ecommerce/src/app/(app)/[slug]/page.tsx
@@ -86,6 +86,9 @@ const queryPageBySlug = async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'pages',
+    // Product blocks such as Carousel and ThreeItemGrid read `meta.image` on
+    // products embedded in this page, which sits two levels deep.
+    depth: 2,
     draft,
     limit: 1,
     overrideAccess: draft,

--- a/templates/ecommerce/src/blocks/Carousel/Component.client.tsx
+++ b/templates/ecommerce/src/blocks/Carousel/Component.client.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { Media, Product } from '@/payload-types'
+import type { Product } from '@/payload-types'
 
 import { Carousel, CarouselContent, CarouselItem } from '@/components/ui/carousel'
 import AutoScroll from 'embla-carousel-auto-scroll'
@@ -38,7 +38,7 @@ export const CarouselClient: React.FC<{ products: Product[] }> = async ({ produc
                   amount: product.priceInUSD!,
                   title: product.title,
                 }}
-                media={product.meta?.image as Media}
+                media={product.meta?.image}
               />
             </Link>
           </CarouselItem>

--- a/templates/ecommerce/src/blocks/ThreeItemGrid/Component.tsx
+++ b/templates/ecommerce/src/blocks/ThreeItemGrid/Component.tsx
@@ -1,4 +1,4 @@
-import type { Media, Product, ThreeItemGridBlock as ThreeItemGridBlockProps } from '@/payload-types'
+import type { Product, ThreeItemGridBlock as ThreeItemGridBlockProps } from '@/payload-types'
 
 import { GridTileImage } from '@/components/Grid/tile'
 import Link from 'next/link'
@@ -29,7 +29,7 @@ export const ThreeItemGridItem: React.FC<Props> = ({ item, size }) => {
             position: size === 'full' ? 'center' : 'bottom',
             title: item.title,
           }}
-          media={item.meta?.image as Media}
+          media={item.meta?.image}
         />
       </Link>
     </div>

--- a/templates/ecommerce/src/components/Grid/tile.tsx
+++ b/templates/ecommerce/src/components/Grid/tile.tsx
@@ -13,7 +13,11 @@ type Props = {
     position?: 'bottom' | 'center'
     title: string
   }
-  media: MediaType
+  /**
+   * May arrive as an ID when the product was populated as a nested relationship
+   * and the query depth did not reach its `meta.image`.
+   */
+  media?: (string | null) | MediaType
 }
 
 export const GridTileImage: React.FC<Props> = ({
@@ -33,7 +37,7 @@ export const GridTileImage: React.FC<Props> = ({
         },
       )}
     >
-      {props.media ? (
+      {props.media && typeof props.media === 'object' ? (
         <Media
           className={clsx('relative h-full w-full object-cover', {
             'transition duration-300 ease-in-out group-hover:scale-105': isInteractive,

--- a/templates/ecommerce/src/components/Grid/tile.tsx
+++ b/templates/ecommerce/src/components/Grid/tile.tsx
@@ -13,10 +13,7 @@ type Props = {
     position?: 'bottom' | 'center'
     title: string
   }
-  /**
-   * May arrive as an ID when the product was populated as a nested relationship
-   * and the query depth did not reach its `meta.image`.
-   */
+  /** Arrives as an ID when the query depth did not reach the product's `meta.image`. */
   media?: (string | null) | MediaType
 }
 

--- a/templates/website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/[slug]/page.tsx
@@ -98,6 +98,9 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'pages',
+    // Blocks such as Archive render cards for documents embedded in this page,
+    // whose own upload and relationship fields sit two levels deep.
+    depth: 2,
     draft,
     limit: 1,
     pagination: false,

--- a/templates/website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/[slug]/page.tsx
@@ -98,8 +98,6 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'pages',
-    // Blocks such as Archive render cards for documents embedded in this page,
-    // whose own upload and relationship fields sit two levels deep.
     depth: 2,
     draft,
     limit: 1,

--- a/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -93,8 +93,6 @@ const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'posts',
-    // Related post cards read `meta.image` and `categories`, which sit two
-    // levels deep from this post.
     depth: 2,
     draft,
     limit: 1,

--- a/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -93,6 +93,9 @@ const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'posts',
+    // Related post cards read `meta.image` and `categories`, which sit two
+    // levels deep from this post.
+    depth: 2,
     draft,
     limit: 1,
     overrideAccess: draft,

--- a/templates/website/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/website/tests/e2e/frontend.e2e.spec.ts
@@ -29,7 +29,7 @@ test.describe('Frontend', () => {
       await cleanupRelatedPosts()
     })
 
-    test('should render the image and category of a related post', async ({ page }) => {
+    test('should render related post cards with their image and category', async ({ page }) => {
       await page.goto(`http://localhost:3000/posts/${relatedPostsFixture.postSlug}`)
 
       await expect(page.locator('h1')).toHaveText(relatedPostsFixture.postTitle)

--- a/templates/website/tests/e2e/frontend.e2e.spec.ts
+++ b/templates/website/tests/e2e/frontend.e2e.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect, Page } from '@playwright/test'
+import {
+  cleanupRelatedPosts,
+  relatedPostsFixture,
+  seedRelatedPosts,
+} from '../helpers/seedRelatedPosts'
 
 test.describe('Frontend', () => {
   let page: Page
@@ -13,5 +18,31 @@ test.describe('Frontend', () => {
     await expect(page).toHaveTitle(/Payload Website Template/)
     const heading = page.locator('h1').first()
     await expect(heading).toHaveText('Payload Website Template')
+  })
+
+  test.describe('post detail', () => {
+    test.beforeAll(async () => {
+      await seedRelatedPosts()
+    })
+
+    test.afterAll(async () => {
+      await cleanupRelatedPosts()
+    })
+
+    test('should render the image and category of a related post', async ({ page }) => {
+      await page.goto(`http://localhost:3000/posts/${relatedPostsFixture.postSlug}`)
+
+      await expect(page.locator('h1')).toHaveText(relatedPostsFixture.postTitle)
+
+      const postCards = page.locator('article article')
+
+      const relatedCard = postCards.filter({
+        has: page.getByRole('link', { name: relatedPostsFixture.relatedPostTitle }),
+      })
+
+      await expect(relatedCard).toHaveCount(1)
+      await expect(relatedCard.locator('img')).toBeAttached()
+      await expect(relatedCard).toContainText(relatedPostsFixture.categoryTitle)
+    })
   })
 })

--- a/templates/website/tests/helpers/seedRelatedPosts.ts
+++ b/templates/website/tests/helpers/seedRelatedPosts.ts
@@ -13,20 +13,19 @@ const dirname = path.dirname(filename)
 const disableRevalidate = { context: { disableRevalidate: true } }
 
 export const relatedPostsFixture = {
-  categorySlug: 'depth-test-category',
-  categoryTitle: 'Depth Test Category',
-  imageAlt: 'Depth test image',
-  postSlug: 'depth-test-post',
-  postTitle: 'Depth Test Post',
-  relatedPostSlug: 'depth-test-related-post',
-  relatedPostTitle: 'Depth Test Related Post',
+  categorySlug: 'test-category',
+  categoryTitle: 'Test Category',
+  imageAlt: 'Test image',
+  postSlug: 'test-post-with-related-posts',
+  postTitle: 'Test Post With Related Posts',
+  relatedPostSlug: 'test-related-post',
+  relatedPostTitle: 'Test Related Post',
 }
 
 /**
- * Creates a published post whose single `relatedPosts` entry carries both a
- * `meta.image` upload and a category. Rendering the post therefore requires two
- * levels of population: one to reach the related post, another to reach its
- * image and category.
+ * Creates a published post that links to one related post, where the related
+ * post has both an SEO image and a category. Gives the related-post cards on
+ * the post page something to render.
  */
 export async function seedRelatedPosts(): Promise<void> {
   const payload = await getPayload({ config })

--- a/templates/website/tests/helpers/seedRelatedPosts.ts
+++ b/templates/website/tests/helpers/seedRelatedPosts.ts
@@ -1,0 +1,144 @@
+import type { Payload, RequiredDataFromCollectionSlug } from 'payload'
+
+import path from 'path'
+import { getPayload } from 'payload'
+import { fileURLToPath } from 'url'
+
+import config from '../../src/payload.config.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+// Revalidation hooks call `revalidatePath`, which is unavailable outside a Next request.
+const disableRevalidate = { context: { disableRevalidate: true } }
+
+export const relatedPostsFixture = {
+  categorySlug: 'depth-test-category',
+  categoryTitle: 'Depth Test Category',
+  imageAlt: 'Depth test image',
+  postSlug: 'depth-test-post',
+  postTitle: 'Depth Test Post',
+  relatedPostSlug: 'depth-test-related-post',
+  relatedPostTitle: 'Depth Test Related Post',
+}
+
+/**
+ * Creates a published post whose single `relatedPosts` entry carries both a
+ * `meta.image` upload and a category. Rendering the post therefore requires two
+ * levels of population: one to reach the related post, another to reach its
+ * image and category.
+ */
+export async function seedRelatedPosts(): Promise<void> {
+  const payload = await getPayload({ config })
+
+  await deleteFixture({ payload })
+
+  const category = await payload.create({
+    collection: 'categories',
+    data: {
+      slug: relatedPostsFixture.categorySlug,
+      title: relatedPostsFixture.categoryTitle,
+    },
+    ...disableRevalidate,
+  })
+
+  const image = await payload.create({
+    collection: 'media',
+    data: { alt: relatedPostsFixture.imageAlt },
+    filePath: path.resolve(dirname, '../../src/endpoints/seed/image-post1.webp'),
+    ...disableRevalidate,
+  })
+
+  const relatedPost = await payload.create({
+    collection: 'posts',
+    data: {
+      _status: 'published',
+      categories: [category.id],
+      content: buildContent('Related post content.'),
+      meta: { image: image.id },
+      slug: relatedPostsFixture.relatedPostSlug,
+      title: relatedPostsFixture.relatedPostTitle,
+    },
+    ...disableRevalidate,
+  })
+
+  await payload.create({
+    collection: 'posts',
+    data: {
+      _status: 'published',
+      content: buildContent('Post content.'),
+      relatedPosts: [relatedPost.id],
+      slug: relatedPostsFixture.postSlug,
+      title: relatedPostsFixture.postTitle,
+    },
+    ...disableRevalidate,
+  })
+}
+
+export async function cleanupRelatedPosts(): Promise<void> {
+  const payload = await getPayload({ config })
+
+  await deleteFixture({ payload })
+}
+
+async function deleteFixture({ payload }: { payload: Payload }): Promise<void> {
+  await payload.delete({
+    collection: 'posts',
+    where: {
+      slug: {
+        in: [relatedPostsFixture.postSlug, relatedPostsFixture.relatedPostSlug],
+      },
+    },
+    ...disableRevalidate,
+  })
+
+  await payload.delete({
+    collection: 'categories',
+    where: {
+      slug: { equals: relatedPostsFixture.categorySlug },
+    },
+    ...disableRevalidate,
+  })
+
+  await payload.delete({
+    collection: 'media',
+    where: {
+      alt: { equals: relatedPostsFixture.imageAlt },
+    },
+    ...disableRevalidate,
+  })
+}
+
+function buildContent(text: string): RequiredDataFromCollectionSlug<'posts'>['content'] {
+  return {
+    root: {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              detail: 0,
+              format: 0,
+              mode: 'normal',
+              style: '',
+              text,
+              version: 1,
+            },
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          textFormat: 0,
+          textStyle: '',
+          version: 1,
+        },
+      ],
+      direction: 'ltr',
+      format: '',
+      indent: 0,
+      version: 1,
+    },
+  }
+}

--- a/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
@@ -98,6 +98,9 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'pages',
+    // Blocks such as Archive render cards for documents embedded in this page,
+    // whose own upload and relationship fields sit two levels deep.
+    depth: 2,
     draft,
     limit: 1,
     pagination: false,

--- a/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
@@ -98,8 +98,6 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'pages',
-    // Blocks such as Archive render cards for documents embedded in this page,
-    // whose own upload and relationship fields sit two levels deep.
     depth: 2,
     draft,
     limit: 1,

--- a/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -93,8 +93,6 @@ const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'posts',
-    // Related post cards read `meta.image` and `categories`, which sit two
-    // levels deep from this post.
     depth: 2,
     draft,
     limit: 1,

--- a/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -93,6 +93,9 @@ const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'posts',
+    // Related post cards read `meta.image` and `categories`, which sit two
+    // levels deep from this post.
+    depth: 2,
     draft,
     limit: 1,
     overrideAccess: draft,


### PR DESCRIPTION
Follow-up to #17510, now merged. Restores `depth: 2` where the app-layer code we ship needs it.

Reducing `defaultDepth` to 1 is safe for Payload's own source: every internal `find`/`findByID` in `packages/**` either passes an explicit depth or only reads IDs and scalars. The breakage is in the apps we ship as starting points. The website, with-vercel-website and ecommerce templates, plus the localization example, all render documents embedded in the document they queried (related posts, hand-picked archive selections, product blocks), which puts those embedded documents' own upload and relationship fields two levels from the query root. `Posts.defaultPopulate` already lists `categories` and `meta.image`, so the fields were meant to reach the cards, but `defaultPopulate` is a `select`: it controls which fields come back, not how deep they resolve.

In the website templates and the localization example the failure is silent. `Card` guards with `typeof metaImage !== 'string'`, so an unpopulated image renders neither the image nor the "No image" fallback, and category labels vanish the same way. The website seed sets `relatedPosts` on all three demo posts, so it shows up on every post page of a freshly seeded site. The ecommerce template is worse: `GridTileImage` only checked truthiness, and an ID string is truthy, so a bare ID reached `next/image` with an empty `src` and undefined dimensions.

What changed:

- `depth: 2` on the five page and post queries.
- `GridTileImage` narrows before rendering, and its `media` prop type is widened to `(string | null) | Media`, which is what `payload-types.ts` already declares for `meta.image`. The three `as Media` casts at the call sites were hiding that.
- Dropped the `auth.depth` note from the v4 migration guide, since #17540 fixes that fallback rather than leaving it as something users must work around.

CI stayed green because the template e2e spec seeded no content and only asserted the homepage title and `h1`, both of which come from the hardcoded `homeStatic` fallback. Added `tests/helpers/seedRelatedPosts.ts` plus a case that opens a post and asserts its related card renders an image and a category title, cleaning up in `afterAll`. It lives in the template because the regression is in the template's own query, so only something that runs the template can catch it, and the templates already ship their own test files and a `seedUser` helper. Scoped to `templates/website` since that is the only one in the CI matrix.

## Test plan

- `build-template-website-mongodb` passes, including the new related-post assertion
- Seed the ecommerce template, add a `ThreeItemGrid` or `Carousel` block to a page, confirm tiles render. Not covered by CI, since ecommerce is not in the template matrix
