### PR TITLE
feat: support async filterOptions on select fields

### DIFF
--- a/docs/fields/select.mdx
+++ b/docs/fields/select.mdx
@@ -82,6 +82,8 @@ The result of `filterOptions` will determine:
 - Which options are displayed in the Admin Panel
 - Which options can be saved to the database
 
+This function can be synchronous or asynchronous, i.e. it can return `Option[]` or `Promise<Option[]>`, allowing you to perform an async lookup (e.g. querying another collection) before resolving the filtered options.
+
 To do this, use the `filterOptions` property in your [Field Config](./overview):
 
 ```ts

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1171,7 +1171,7 @@ export type SelectField = {
     options: Option[]
     req: PayloadRequest
     siblingData: Data
-  }) => Option[]
+  }) => Option[] | Promise<Option[]>
   hasMany?: boolean
   /**
    * Customize generated GraphQL and Typescript schema names.

--- a/packages/payload/src/fields/validations.spec.ts
+++ b/packages/payload/src/fields/validations.spec.ts
@@ -399,103 +399,121 @@ describe('Field Validations', () => {
     }
     it('should allow valid input', async () => {
       const val = 'one'
-      const result = select(val, selectOptions)
+      const result = await select(val, selectOptions)
       expect(result).toStrictEqual(true)
     })
-    it('should prevent invalid input', () => {
+    it('should prevent invalid input', async () => {
       const val = 'bad'
-      const result = select(val, selectOptions)
+      const result = await select(val, selectOptions)
       expect(result).not.toStrictEqual(true)
     })
-    it('should allow null input', () => {
+    it('should allow null input', async () => {
       const val = null
-      const result = select(val, selectOptions)
+      const result = await select(val, selectOptions)
       expect(result).toStrictEqual(true)
     })
-    it('should allow undefined input', () => {
+    it('should allow undefined input', async () => {
       let val
-      const result = select(val, selectOptions)
+      const result = await select(val, selectOptions)
       expect(result).toStrictEqual(true)
     })
-    it('should prevent empty string input', () => {
+    it('should prevent empty string input', async () => {
       const val = ''
-      const result = select(val, selectOptions)
+      const result = await select(val, selectOptions)
       expect(result).not.toStrictEqual(true)
     })
-    it('should prevent undefined input with required', () => {
+    it('should prevent undefined input with required', async () => {
       let val
-      const result = select(val, optionsRequired)
+      const result = await select(val, optionsRequired)
       expect(result).not.toStrictEqual(true)
     })
-    it('should prevent empty string input with required', () => {
-      const result = select('', optionsRequired)
+    it('should prevent empty string input with required', async () => {
+      const result = await select('', optionsRequired)
       expect(result).not.toStrictEqual(true)
     })
-    it('should prevent undefined input with required and hasMany', () => {
+    it('should prevent undefined input with required and hasMany', async () => {
       let val
       options.hasMany = true
-      const result = select(val, optionsRequired)
+      const result = await select(val, optionsRequired)
       expect(result).not.toStrictEqual(true)
     })
-    it('should prevent empty array input with required and hasMany', () => {
+    it('should prevent empty array input with required and hasMany', async () => {
       optionsRequired.hasMany = true
-      const result = select([], optionsRequired)
+      const result = await select([], optionsRequired)
       expect(result).not.toStrictEqual(true)
     })
-    it('should prevent empty string array input with required and hasMany', () => {
+    it('should prevent empty string array input with required and hasMany', async () => {
       options.hasMany = true
-      const result = select([''], optionsRequired)
+      const result = await select([''], optionsRequired)
       expect(result).not.toStrictEqual(true)
     })
-    it('should prevent null input with required and hasMany', () => {
+    it('should prevent null input with required and hasMany', async () => {
       const val = null
       options.hasMany = true
-      const result = select(val, optionsRequired)
+      const result = await select(val, optionsRequired)
       expect(result).not.toStrictEqual(true)
     })
-    it('should allow valid input with option objects', () => {
+    it('should allow valid input with option objects', async () => {
       const val = 'one'
       options.hasMany = false
-      const result = select(val, optionsRequired)
+      const result = await select(val, optionsRequired)
       expect(result).toStrictEqual(true)
     })
-    it('should prevent invalid input with option objects', () => {
+    it('should prevent invalid input with option objects', async () => {
       const val = 'bad'
       options.hasMany = false
-      const result = select(val, optionsRequired)
+      const result = await select(val, optionsRequired)
       expect(result).not.toStrictEqual(true)
     })
-    it('should allow empty string input with option object', () => {
+    it('should allow empty string input with option object', async () => {
       const val = ''
-      const result = select(val, optionsWithEmptyString)
+      const result = await select(val, optionsWithEmptyString)
       expect(result).toStrictEqual(true)
     })
-    it('should allow empty string input with option object and required', () => {
+    it('should allow empty string input with option object and required', async () => {
       const val = ''
       optionsWithEmptyString.required = true
-      const result = select(val, optionsWithEmptyString)
+      const result = await select(val, optionsWithEmptyString)
       expect(result).toStrictEqual(true)
     })
-    it('should allow valid input with hasMany', () => {
+    it('should allow valid input with hasMany', async () => {
       const val = ['one', 'two']
-      const result = select(val, selectOptions)
+      const result = await select(val, selectOptions)
       expect(result).toStrictEqual(true)
     })
-    it('should prevent invalid input with hasMany', () => {
+    it('should prevent invalid input with hasMany', async () => {
       const val = ['one', 'bad']
-      const result = select(val, selectOptions)
+      const result = await select(val, selectOptions)
       expect(result).not.toStrictEqual(true)
     })
-    it('should allow valid input with hasMany option objects', () => {
+    it('should allow valid input with hasMany option objects', async () => {
       const val = ['one', 'three']
       optionsRequired.hasMany = true
-      const result = select(val, optionsRequired)
+      const result = await select(val, optionsRequired)
       expect(result).toStrictEqual(true)
     })
-    it('should prevent invalid input with hasMany option objects', () => {
+    it('should prevent invalid input with hasMany option objects', async () => {
       const val = ['three', 'bad']
       optionsRequired.hasMany = true
-      const result = select(val, optionsRequired)
+      const result = await select(val, optionsRequired)
+      expect(result).not.toStrictEqual(true)
+    })
+    it('should resolve a promise-returning filterOptions before validating', async () => {
+      const val = 'one'
+      const filterOptions: SelectField['filterOptions'] = async ({ options }) => {
+        await Promise.resolve()
+        return options
+      }
+      const result = await select(val, { ...selectOptions, filterOptions })
+      expect(result).toStrictEqual(true)
+    })
+    it('should reject a value excluded by a promise-returning filterOptions', async () => {
+      const val = 'one'
+      const filterOptions: SelectField['filterOptions'] = async ({ options }) => {
+        await Promise.resolve()
+        return (options as string[]).filter((option) => option !== 'one')
+      }
+      const result = await select(val, { ...selectOptions, filterOptions })
       expect(result).not.toStrictEqual(true)
     })
   })

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -970,13 +970,13 @@ export type SelectFieldManyValidation = Validate<string[], unknown, unknown, Sel
 
 export type SelectFieldSingleValidation = Validate<string, unknown, unknown, SelectField>
 
-export const select: SelectFieldValidation = (
+export const select: SelectFieldValidation = async (
   value,
   { data, filterOptions, hasMany, options, req, req: { t }, required, siblingData },
 ) => {
   const filteredOptions =
     typeof filterOptions === 'function'
-      ? filterOptions({
+      ? await filterOptions({
           data,
           options,
           req,

--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -48,9 +48,9 @@ export const getConstraints = (config: Config): Field => ({
             name: 'constraint',
             type: 'select',
             defaultValue: 'onlyMe',
-            filterOptions: (args) =>
+            filterOptions: async (args) =>
               typeof config?.queryPresets?.filterConstraints === 'function'
-                ? config.queryPresets.filterConstraints(args)
+                ? await config.queryPresets.filterConstraints(args)
                 : args.options,
             label: ({ i18n }) =>
               `Specify who can ${constraintOperation} this ${getTranslation(config.queryPresets?.labels?.singular || 'Preset', i18n)}`,

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -796,7 +796,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
 
       case 'select': {
         if (typeof field.filterOptions === 'function') {
-          fieldState.selectFilterOptions = field.filterOptions({
+          fieldState.selectFilterOptions = await field.filterOptions({
             data: fullData,
             options: field.options,
             req,

--- a/test/fields/collections/Select/e2e.spec.ts
+++ b/test/fields/collections/Select/e2e.spec.ts
@@ -120,6 +120,24 @@ describe('Select', () => {
     await expect(options.locator('text=One')).toBeHidden()
   })
 
+  test('should reduce options via an async, DB-backed `filterOptions`', async () => {
+    await page.goto(url.create)
+    await waitForFormReady(page)
+
+    const field = page.locator('#field-selectAsyncFilterOptions')
+    await field.click({ delay: 100 })
+    const options = page.locator('.rs__option')
+    await expect(options.locator('text=Value One')).toBeVisible()
+
+    // click the field again to close the options
+    await field.click({ delay: 100 })
+
+    await page.locator('#field-disallowOption2').click()
+    await field.click({ delay: 100 })
+    await expect(options.locator('text=Value One')).toBeHidden()
+    await expect(options.locator('text=Value Two')).toBeVisible()
+  })
+
   test('should retain search when reducing options', async () => {
     await page.goto(url.create)
     await waitForFormReady(page)

--- a/test/fields/collections/Select/index.ts
+++ b/test/fields/collections/Select/index.ts
@@ -272,6 +272,40 @@ const SelectFields: CollectionConfig = {
             )
           : options,
     },
+    {
+      name: 'disallowOption2',
+      type: 'checkbox',
+    },
+    {
+      name: 'selectAsyncFilterOptions',
+      label: 'Select with async filtered options',
+      type: 'select',
+      defaultValue: 'one',
+      options: [
+        {
+          label: 'Value One',
+          value: 'one',
+        },
+        {
+          label: 'Value Two',
+          value: 'two',
+        },
+        {
+          label: 'Value Three',
+          value: 'three',
+        },
+      ],
+      filterOptions: async ({ options, data }) => {
+        // fake async lookup
+        await Promise.resolve()
+
+        return data.disallowOption2
+          ? options.filter(
+              (option) => (typeof option === 'string' ? options : option.value) !== 'one',
+            )
+          : options
+      },
+    },
   ],
 }
 

--- a/test/fields/collections/Select/index.ts
+++ b/test/fields/collections/Select/index.ts
@@ -295,9 +295,13 @@ const SelectFields: CollectionConfig = {
           value: 'three',
         },
       ],
-      filterOptions: async ({ options, data }) => {
-        // fake async lookup
-        await Promise.resolve()
+      filterOptions: async ({ options, data, req }) => {
+        // real async lookup, e.g. checking another collection to decide which options are allowed
+        await req.payload.find({
+          collection: selectFieldsSlug,
+          limit: 0,
+          req,
+        })
 
         return data.disallowOption2
           ? options.filter(

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1899,6 +1899,28 @@ describe('Fields', () => {
       expect(result).toBeTruthy()
     })
 
+    it('should prevent against saving a value excluded by an async `filterOptions`', async () => {
+      await expect(
+        payload.create({
+          collection: 'select-fields',
+          data: {
+            disallowOption2: true,
+            selectAsyncFilterOptions: 'one',
+          },
+        }),
+      ).rejects.toThrow('The following field is invalid: Select with async filtered options')
+
+      const result = await payload.create({
+        collection: 'select-fields',
+        data: {
+          disallowOption2: true,
+          selectAsyncFilterOptions: 'two',
+        },
+      })
+
+      expect(result).toBeTruthy()
+    })
+
     it('should throw field error when duplicate values in hasMany select field', async () => {
       let error: undefined | ValidationError
 

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1730,6 +1730,8 @@ export interface SelectField {
   selectWithJsxLabelOption?: ('one' | 'two' | 'three') | null;
   disallowOption1?: boolean | null;
   selectWithFilteredOptions?: ('one' | 'two' | 'three') | null;
+  disallowOption2?: boolean | null;
+  selectAsyncFilterOptions?: ('one' | 'two' | 'three') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -3517,6 +3519,8 @@ export interface SelectFieldsSelect<T extends boolean = true> {
   selectWithJsxLabelOption?: T;
   disallowOption1?: T;
   selectWithFilteredOptions?: T;
+  disallowOption2?: T;
+  selectAsyncFilterOptions?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/form-state/collections/Posts/index.ts
+++ b/test/form-state/collections/Posts/index.ts
@@ -153,6 +153,16 @@ export const PostsCollection: CollectionConfig = {
         },
       ],
     },
+    {
+      name: 'selectWithAsyncFilterOptions',
+      type: 'select',
+      filterOptions: async ({ options }) => {
+        await Promise.resolve()
+
+        return (options as string[]).filter((option) => option !== 'excluded')
+      },
+      options: ['allowed', 'excluded'],
+    },
   ],
   versions: false,
 }

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -1341,4 +1341,35 @@ describe('Form State', () => {
     expect(state.array).toBeDefined()
     expect(state?.array?.rows).toEqual([]) // should be [] not undefined
   })
+
+  it('should resolve a promise-returning `filterOptions` on a select field into `selectFilterOptions`', async () => {
+    const req = await createLocalReq({ user }, payload)
+
+    const postData = await payload.create({
+      collection: postsSlug,
+      data: {
+        title: 'Test Post',
+      },
+    })
+
+    const { state } = await buildFormState({
+      mockRSCs: true,
+      id: postData.id,
+      collectionSlug: postsSlug,
+      data: postData,
+      docPermissions: undefined,
+      docPreferences: {
+        fields: {},
+      },
+      documentFormState: undefined,
+      operation: 'update',
+      renderAllFields: false,
+      req,
+      schemaPath: postsSlug,
+    })
+
+    expect(state.selectWithAsyncFilterOptions?.selectFilterOptions).toStrictEqual(['allowed'])
+
+    await payload.delete({ collection: postsSlug, id: postData.id })
+  })
 })

--- a/test/form-state/payload-types.ts
+++ b/test/form-state/payload-types.ts
@@ -161,6 +161,7 @@ export interface Post {
         }[]
       | null;
   };
+  selectWithAsyncFilterOptions?: ('allowed' | 'excluded') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -366,6 +367,7 @@ export interface PostsSelect<T extends boolean = true> {
               id?: T;
             };
       };
+  selectWithAsyncFilterOptions?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/query-presets/config.ts
+++ b/test/query-presets/config.ts
@@ -27,12 +27,15 @@ export default buildConfigWithDefaults({
       read: ({ req: { user } }) => Boolean(user?.roles?.length && !user?.roles?.includes('user')),
       update: ({ req: { user } }) => Boolean(user?.roles?.length && !user?.roles?.includes('user')),
     },
-    filterConstraints: ({ req, options }) =>
-      !req.user?.roles?.includes('admin')
+    filterConstraints: async ({ req, options }) => {
+      await Promise.resolve()
+
+      return !req.user?.roles?.includes('admin')
         ? options.filter(
             (option) => (typeof option === 'string' ? option : option.value) !== 'onlyAdmins',
           )
-        : options,
+        : options
+    },
     constraints: {
       read: [
         {


### PR DESCRIPTION
## Summary

`filterOptions` on `relationship`, `upload`, and `blocks` fields has always supported returning a `Promise`, and it's correctly `await`ed everywhere it's called. `select` fields (and `queryPresets.filterConstraints`, which is aliased to the same type) were the odd one out — the type only allowed a sync `Option[]` return, and the one place it's invoked (`validations.ts`) never awaited it. If you defined an async `filterOptions` on a `select` field anyway (nothing stopped you at runtime), the validator would call `.some()` on a `Promise` object and throw `TypeError: filteredOptions.some is not a function`, and the admin UI would assign a raw `Promise` to `selectFilterOptions` instead of the resolved array.

This PR brings `select.filterOptions` to parity with the other fields so `await` is the uniform calling convention everywhere.

Resolves PYLD-2032