### PR TITLE
fix(ui): resolve named-tab field permissions in bulk edit field select (3.x backport of #17523)

### DIFF
--- a/packages/ui/src/elements/FieldSelect/reduceFieldOptions.spec.ts
+++ b/packages/ui/src/elements/FieldSelect/reduceFieldOptions.spec.ts
@@ -1,0 +1,151 @@
+import type { ClientField } from 'payload'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { FieldOption } from './reduceFieldOptions.js'
+
+// Mock the JSX label builder: irrelevant to permission logic and avoids needing a React runtime here.
+vi.mock('../../utilities/combineFieldLabel.js', () => ({
+  combineFieldLabel: () => null,
+}))
+
+import { reduceFieldOptions } from './reduceFieldOptions.js'
+
+const text = (name: string): ClientField => ({ name, type: 'text' }) as ClientField
+
+const namesOf = (options: FieldOption[]): (string | undefined)[] =>
+  options.map((option) => ('name' in option.value.field ? option.value.field.name : undefined))
+
+// A denied field omits the operation key at runtime, which `SanitizedFieldPermissions` can't express — cast at the boundary.
+type Permissions = Parameters<typeof reduceFieldOptions>[0]['permissions']
+const optionsFor = (fields: ClientField[], permissions: unknown): FieldOption[] =>
+  reduceFieldOptions({ fields, permissions: permissions as Permissions })
+
+// Granted sets the operation to `true`; denied omits the key, mirroring `populateFieldPermissions`.
+const granted = { create: true, read: true, update: true }
+const readOnly = { create: true, read: true }
+
+describe('reduceFieldOptions', () => {
+  it('excludes a restricted field inside a named tab while keeping its clean siblings', () => {
+    const fields: ClientField[] = [
+      {
+        type: 'tabs',
+        tabs: [{ name: 'namedTab', fields: [text('okInTab'), text('restrictedInTab')] }],
+      } as ClientField,
+    ]
+
+    const permissions = {
+      namedTab: {
+        ...granted,
+        fields: {
+          okInTab: granted,
+          restrictedInTab: readOnly,
+        },
+      },
+    }
+
+    const options = optionsFor(fields, permissions)
+    const names = namesOf(options)
+
+    expect(names).toContain('okInTab')
+    expect(names).not.toContain('restrictedInTab')
+  })
+
+  it('excludes a restricted field inside a nested named tab', () => {
+    const fields: ClientField[] = [
+      {
+        type: 'tabs',
+        tabs: [
+          {
+            name: 'outerTab',
+            fields: [
+              {
+                type: 'tabs',
+                tabs: [{ name: 'innerTab', fields: [text('deepOk'), text('deepRestricted')] }],
+              },
+            ],
+          },
+        ],
+      } as ClientField,
+    ]
+
+    const permissions = {
+      outerTab: {
+        ...granted,
+        fields: {
+          innerTab: {
+            ...granted,
+            fields: {
+              deepOk: granted,
+              deepRestricted: readOnly,
+            },
+          },
+        },
+      },
+    }
+
+    const options = optionsFor(fields, permissions)
+    const names = namesOf(options)
+
+    expect(names).toContain('deepOk')
+    expect(names).not.toContain('deepRestricted')
+  })
+
+  it('only affects the named tab that contains the restricted field', () => {
+    const fields: ClientField[] = [
+      {
+        type: 'tabs',
+        tabs: [
+          { name: 'cleanTab', fields: [text('cleanField')] },
+          { name: 'restrictedHostTab', fields: [text('restrictedField')] },
+        ],
+      } as ClientField,
+    ]
+
+    const permissions = {
+      cleanTab: { ...granted, fields: { cleanField: granted } },
+      restrictedHostTab: { ...granted, fields: { restrictedField: readOnly } },
+    }
+
+    const options = optionsFor(fields, permissions)
+    const names = namesOf(options)
+
+    expect(names).toContain('cleanField')
+    expect(names).not.toContain('restrictedField')
+  })
+
+  it('includes every named-tab field when permissions are fully granted', () => {
+    const fields: ClientField[] = [
+      {
+        type: 'tabs',
+        tabs: [{ name: 'namedTab', fields: [text('a'), text('b')] }],
+      } as ClientField,
+    ]
+
+    const options = optionsFor(fields, true)
+    const names = namesOf(options)
+
+    expect(names).toEqual(expect.arrayContaining(['a', 'b']))
+  })
+
+  it('applies parent permissions to an unnamed tab and excludes its restricted fields', () => {
+    const fields: ClientField[] = [
+      {
+        type: 'tabs',
+        tabs: [{ label: 'Unnamed', fields: [text('okAtRoot'), text('restrictedAtRoot')] }],
+      } as ClientField,
+    ]
+
+    // Unnamed tabs share the parent's permission map, so subfields resolve at the parent level.
+    const permissions = {
+      okAtRoot: granted,
+      restrictedAtRoot: readOnly,
+    }
+
+    const options = optionsFor(fields, permissions)
+    const names = namesOf(options)
+
+    expect(names).toContain('okAtRoot')
+    expect(names).not.toContain('restrictedAtRoot')
+  })
+})

--- a/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
+++ b/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
@@ -104,10 +104,17 @@ export const reduceFieldOptions = ({
         ...field.tabs.reduce((tabFields, tab) => {
           if ('fields' in tab) {
             const isNamedTab = 'name' in tab && tab.name
-            const tabPermissions =
+
+            const namedTabPermissions =
               isNamedTab && fieldPermissions && fieldPermissions !== true
-                ? (fieldPermissions[tab.name] ?? fieldPermissions)
-                : fieldPermissions
+                ? fieldPermissions[tab.name]
+                : undefined
+
+            const tabPermissions = isNamedTab
+              ? namedTabPermissions === true
+                ? true
+                : (namedTabPermissions?.fields ?? fieldPermissions)
+              : fieldPermissions
 
             return [
               ...tabFields,

--- a/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
+++ b/packages/ui/src/elements/FieldSelect/reduceFieldOptions.ts
@@ -104,6 +104,11 @@ export const reduceFieldOptions = ({
         ...field.tabs.reduce((tabFields, tab) => {
           if ('fields' in tab) {
             const isNamedTab = 'name' in tab && tab.name
+            const tabPermissions =
+              isNamedTab && fieldPermissions && fieldPermissions !== true
+                ? (fieldPermissions[tab.name] ?? fieldPermissions)
+                : fieldPermissions
+
             return [
               ...tabFields,
               ...reduceFieldOptions({
@@ -111,7 +116,7 @@ export const reduceFieldOptions = ({
                 labelPrefix,
                 parentPath: path,
                 path: isNamedTab ? createNestedClientFieldPath(path, tab as ClientField) : path,
-                permissions: fieldPermissions,
+                permissions: tabPermissions,
               }),
             ]
           }

--- a/test/bulk-edit/collections/RestrictedTabs/index.ts
+++ b/test/bulk-edit/collections/RestrictedTabs/index.ts
@@ -30,6 +30,14 @@ export const RestrictedTabsCollection: CollectionConfig = {
               type: 'text',
               label: 'Named Tab Field',
             },
+            {
+              name: 'namedTabNoUpdate',
+              type: 'text',
+              label: 'Named Tab No Update',
+              access: {
+                update: () => false,
+              },
+            },
           ],
         },
       ],

--- a/test/bulk-edit/collections/RestrictedTabs/index.ts
+++ b/test/bulk-edit/collections/RestrictedTabs/index.ts
@@ -1,0 +1,39 @@
+import type { CollectionConfig } from 'payload'
+
+import { restrictedTabsSlug } from '../../shared.js'
+
+export const RestrictedTabsCollection: CollectionConfig = {
+  slug: restrictedTabsSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    {
+      name: 'noUpdate',
+      type: 'text',
+      access: {
+        update: () => false,
+      },
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          name: 'namedTab',
+          fields: [
+            {
+              name: 'namedTabText',
+              type: 'text',
+              label: 'Named Tab Field',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  versions: false,
+}

--- a/test/bulk-edit/config.ts
+++ b/test/bulk-edit/config.ts
@@ -3,6 +3,7 @@ import path from 'path'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { PostsCollection } from './collections/Posts/index.js'
+import { RestrictedTabsCollection } from './collections/RestrictedTabs/index.js'
 import { TabsCollection } from './collections/Tabs/index.js'
 import { seed } from './seed.js'
 
@@ -10,7 +11,7 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  collections: [PostsCollection, TabsCollection],
+  collections: [PostsCollection, TabsCollection, RestrictedTabsCollection],
   admin: {
     importMap: {
       baseDir: path.resolve(dirname),

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -834,10 +834,15 @@ test.describe('Bulk Edit', () => {
 
     await bulkEditForm.locator('.field-select .rs__control').click()
 
-    const option = bulkEditForm.locator('.field-select .rs__option', {
+    const visibleOption = bulkEditForm.locator('.field-select .rs__option', {
       hasText: exactText('Named Tab Field'),
     })
-    await expect(option).toBeVisible()
+    await expect(visibleOption).toBeVisible()
+
+    const hiddenOption = bulkEditForm.locator('.field-select .rs__option', {
+      hasText: exactText('Named Tab No Update'),
+    })
+    await expect(hiddenOption).toBeHidden()
 
     await payload.delete({ collection: restrictedTabsSlug, id: doc.id })
   })

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -25,7 +25,7 @@ import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../__helpers/shared/clearAndSeed/reInitializeDB.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
-import { postsSlug, tabsSlug } from './shared.js'
+import { postsSlug, restrictedTabsSlug, tabsSlug } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -38,12 +38,14 @@ test.describe('Bulk Edit', () => {
   let page: Page
   let postsUrl: AdminUrlUtil
   let tabsUrl: AdminUrlUtil
+  let restrictedTabsUrl: AdminUrlUtil
 
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
     postsUrl = new AdminUrlUtil(serverURL, postsSlug)
     tabsUrl = new AdminUrlUtil(serverURL, tabsSlug)
+    restrictedTabsUrl = new AdminUrlUtil(serverURL, restrictedTabsSlug)
 
     context = await browser.newContext()
     page = await context.newPage()
@@ -802,6 +804,42 @@ test.describe('Bulk Edit', () => {
       .toEqual('updated value')
 
     await payload.delete({ collection: tabsSlug, id: originalDoc.id })
+  })
+
+  test('should include named-tab fields in bulk edit when a collection has a restricted field', async () => {
+    const doc = await payload.create({
+      collection: restrictedTabsSlug,
+      data: { title: 'Restricted Tabs Doc' },
+    })
+
+    await page.goto(restrictedTabsUrl.list)
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    await addListFilter({
+      page,
+      fieldLabel: 'ID',
+      operatorLabel: 'equals',
+      value: doc.id,
+    })
+
+    await page.locator('table tbody tr.row-1 input[type="checkbox"]').check()
+    await page
+      .locator('.list-selection__actions .btn', {
+        hasText: 'Edit',
+      })
+      .click()
+
+    const bulkEditForm = page.locator('form.edit-many__form')
+    await expect(bulkEditForm).toBeVisible()
+
+    await bulkEditForm.locator('.field-select .rs__control').click()
+
+    const option = bulkEditForm.locator('.field-select .rs__option', {
+      hasText: exactText('Named Tab Field'),
+    })
+    await expect(option).toBeVisible()
+
+    await payload.delete({ collection: restrictedTabsSlug, id: doc.id })
   })
 
   test('should show clean labels for fields inside label-false groups and rows', async () => {

--- a/test/bulk-edit/payload-types.ts
+++ b/test/bulk-edit/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     posts: Post;
     tabs: Tab;
+    'restricted-tabs': RestrictedTab;
     'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
@@ -79,6 +80,7 @@ export interface Config {
   collectionsSelect: {
     posts: PostsSelect<false> | PostsSelect<true>;
     tabs: TabsSelect<false> | TabsSelect<true>;
+    'restricted-tabs': RestrictedTabsSelect<false> | RestrictedTabsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -187,6 +189,20 @@ export interface Tab {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "restricted-tabs".
+ */
+export interface RestrictedTab {
+  id: string;
+  title?: string | null;
+  noUpdate?: string | null;
+  namedTab?: {
+    namedTabText?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -241,6 +257,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'tabs';
         value: string | Tab;
+      } | null)
+    | ({
+        relationTo: 'restricted-tabs';
+        value: string | RestrictedTab;
       } | null)
     | ({
         relationTo: 'users';
@@ -357,6 +377,21 @@ export interface TabsSelect<T extends boolean = true> {
     | T
     | {
         rowText?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "restricted-tabs_select".
+ */
+export interface RestrictedTabsSelect<T extends boolean = true> {
+  title?: T;
+  noUpdate?: T;
+  namedTab?:
+    | T
+    | {
+        namedTabText?: T;
       };
   updatedAt?: T;
   createdAt?: T;

--- a/test/bulk-edit/payload-types.ts
+++ b/test/bulk-edit/payload-types.ts
@@ -197,6 +197,7 @@ export interface RestrictedTab {
   noUpdate?: string | null;
   namedTab?: {
     namedTabText?: string | null;
+    namedTabNoUpdate?: string | null;
   };
   updatedAt: string;
   createdAt: string;
@@ -392,6 +393,7 @@ export interface RestrictedTabsSelect<T extends boolean = true> {
     | T
     | {
         namedTabText?: T;
+        namedTabNoUpdate?: T;
       };
   updatedAt?: T;
   createdAt?: T;

--- a/test/bulk-edit/shared.ts
+++ b/test/bulk-edit/shared.ts
@@ -1,3 +1,5 @@
 export const postsSlug = 'posts'
 
 export const tabsSlug = 'tabs'
+
+export const restrictedTabsSlug = 'restricted-tabs'


### PR DESCRIPTION
Backport to #17523 to `3.x`.

Resolves fields nested inside a named tab against the tab's own nested permission map in the bulk edit field select.

A named tab nests its subfields' permissions under `[tab.name].fields`, like a group. The tabs branch of `reduceFieldOptions` passed the parent-level permissions straight into a named tab's subfields instead of descending into that map. This surfaced once a collection's permissions resolved to a detailed object — which happens as soon as any field defines `access` (e.g. `update: () => false`); a plain `true` masked it — with two effects:

- Granted subfields were dropped from the field select, since their permissions couldn't be resolved at the parent level.
- Restricted subfields could leak in, since `getFieldPermissions` fell back to the tab's own blanket `update: true` inherited from the parent.

The fix descends into `fieldPermissions[tab.name].fields` (collapsing to `true` when the tab is fully granted), matching how `Group` and `Array` unwrap `.fields` before rendering their children.

Covered by an isolated `reduceFieldOptions` unit test (restricted field inside a named tab, nested named tabs, multiple named tabs) and a bulk-edit e2e assertion.
