### PR TITLE
docs(plugin-mcp): fix broken Claude Code link

### DIFF
--- a/docs/plugins/mcp.mdx
+++ b/docs/plugins/mcp.mdx
@@ -368,7 +368,7 @@ Most clients support the streamable-HTTP transport directly. If yours doesn't, t
 }
 ```
 
-#### [Claude Code](https://docs.claude.ai/en/docs/claude-code/mcp)
+#### [Claude Code](https://code.claude.com/docs/en/mcp)
 
 ```bash
 claude mcp add --transport http Payload http://127.0.0.1:3000/api/mcp \


### PR DESCRIPTION
Mirrors #17502 to `main`.

The Claude Code MCP docs link in `docs/plugins/mcp.mdx` points at docs.claude.ai/en/docs/claude-code/mcp, which no longer resolves. Updated to the current URL, https://code.claude.com/docs/en/mcp (returns 200).