### PR TITLE
test: include queues in content API summary

### DIFF
--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -1634,10 +1634,15 @@ describe('Queues - Payload', () => {
       })
     }
 
-    await payload.jobs.run({
-      silent: true,
-      limit: numberOfTasks,
-    })
+    // Content API caps bulk updates at 100 documents, and jobs.run claims the batch with updateJobs.
+    const maxTasksPerRun = payload.db.name === 'content-api' ? 100 : numberOfTasks
+
+    for (let offset = 0; offset < numberOfTasks; offset += maxTasksPerRun) {
+      await payload.jobs.run({
+        limit: Math.min(maxTasksPerRun, numberOfTasks - offset),
+        silent: true,
+      })
+    }
 
     const allSimples = await payload.find({
       collection: 'simple',

--- a/test/runTestsWithSummary.ts
+++ b/test/runTestsWithSummary.ts
@@ -54,7 +54,7 @@ const TEST_SUITES = [
   'plugin-stripe',
   'plugins',
   'query-presets',
-  // 'queues', Not supported yet in content api
+  'queues',
   'relationships',
   'sdk',
   'select',


### PR DESCRIPTION
## What changed

- Add the queues integration suite to the Content API summary test runner.
- Preserve the 150-job bulk-processing test while splitting Content API job runs into batches of 100 and 50.

## Why

The queues suite was originally excluded because queues were not supported by the Content API adapter. That compatibility gap is now closed, except that Content API bulk updates are capped at 100 documents. `jobs.run` claims jobs through a bulk `updateJobs` operation, so the existing test's 150-job run exceeded that cap.

Batching only when `payload.db.name === 'content-api'` keeps the existing coverage and behavior for every other database adapter while allowing the queues suite to run in the summary suite.

## Validation

- Formatting passes.
- `git diff --check` passes.
- The full Content API summary suite requires Payload's Content API/Figma adapter CI environment and is expected to run in CI.
