### PR TITLE
fix(ui): keep form modified after any failed submit, not just drafts

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -459,15 +459,14 @@ export const Form: React.FC<FormProps> = (props) => {
           setProcessing(false)
           setSubmitted(true)
 
+          // The document was not persisted, so keep the form marked as modified
+          // to keep the save buttons enabled for retry.
+          setModified(true)
+
           // When there was an error submitting a draft,
           // set the form state to unsubmitted, to not trigger visible form validation on changes after the failed submit.
-          // Also keep the form as modified so the save button remains enabled for retry.
-          if (overridesFromArgs['_status'] === 'draft') {
-            setModified(true)
-
-            if (!validateDrafts) {
-              setSubmitted(false)
-            }
+          if (overridesFromArgs['_status'] === 'draft' && !validateDrafts) {
+            setSubmitted(false)
           }
 
           contextRef.current = { ...contextRef.current } // triggers rerender of all components that subscribe to form


### PR DESCRIPTION
### What?

When a save request fails, the form is left marked as unmodified. This disables the "Save draft" button even though the user's unsaved changes are still sitting in the form.

### Why?

`setModified(false)` runs after every submit request completes, regardless of whether it succeeded. The error branch then only restores the modified state when the submission was a draft (`_status === 'draft'`).

So a failed publish, or any failed save on a collection without drafts enabled, leaves the form looking clean when it isn't. To an editor this reads as "my changes were saved": the save buttons are greyed out, so they navigate away and the work is lost.

The intent is already documented in that branch's existing comment, "keep the form as modified so the save button remains enabled for retry". It was just scoped to drafts only.

**Steps to reproduce**

1. Collection with drafts enabled and a required `title`
2. Save a draft, then edit content and clear the title
3. Click "Publish changes" — the request fails validation
4. "Save draft" is now disabled, with unsaved changes still in the form

### How?

Moves `setModified(true)` out of the draft-only condition. If the request failed, the document was not persisted, so the form is still modified relative to what is stored and the save buttons should stay enabled for a retry.

Draft-specific behaviour is unchanged: `setSubmitted(false)` still only runs for drafts when `validateDrafts` is off, so failed draft saves continue not to trigger visible validation.

Fixes #17517