### PR TITLE
fix: resolve validation and parsing bugs in core utilities

### DIFF
--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -544,15 +544,14 @@ export const promise = async ({
               (curBlock) => typeof curBlock !== 'string' && curBlock.slug === blockTypeToMatch,
             ) as Block | undefined)
 
-          const { blockSelect, blockSelectMode } = getBlockSelect({
-            block: block!,
-            // TODO: fix this
-            // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-            select: select?.[field.name]!,
-            selectMode: selectMode!,
-          })
-
           if (block) {
+            const { blockSelect, blockSelectMode } = getBlockSelect({
+              block,
+              // TODO: fix this
+              // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+              select: select?.[field.name]!,
+              selectMode: selectMode!,
+            })
             traverseFields({
               blockData: row,
               collection,

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -847,9 +847,7 @@ export const upload: UploadFieldValidation = async (value, options) => {
 
     if (invalidRelationships.length > 0) {
       return `This relationship field has the following invalid relationships: ${invalidRelationships
-        .map((err, invalid) => {
-          return `${err} ${JSON.stringify(invalid)}`
-        })
+        .map((value) => JSON.stringify(value))
         .join(', ')}`
     }
   }
@@ -950,9 +948,7 @@ export const relationship: RelationshipFieldValidation = async (value, options) 
 
     if (invalidRelationships.length > 0) {
       return `This relationship field has the following invalid relationships: ${invalidRelationships
-        .map((err, invalid) => {
-          return `${err} ${JSON.stringify(invalid)}`
-        })
+        .map((value) => JSON.stringify(value))
         .join(', ')}`
     }
   }
@@ -1075,15 +1071,12 @@ export const point: PointFieldValidation = (value = ['', ''], { req: { t }, requ
   const lat = parseFloat(String(value[1]))
   if (
     required &&
-    ((value[0] && value[1] && typeof lng !== 'number' && typeof lat !== 'number') ||
-      Number.isNaN(lng) ||
-      Number.isNaN(lat) ||
-      (Array.isArray(value) && value.length !== 2))
+    (Number.isNaN(lng) || Number.isNaN(lat) || (Array.isArray(value) && value.length !== 2))
   ) {
     return t('validation:requiresTwoNumbers')
   }
 
-  if ((value[1] && Number.isNaN(lng)) || (value[0] && Number.isNaN(lat))) {
+  if ((value[0] && Number.isNaN(lng)) || (value[1] && Number.isNaN(lat))) {
     return t('validation:invalidInput')
   }
 

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -56,7 +56,11 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
       }
 
       if (fields?._payload && typeof fields._payload === 'string') {
-        req.data = JSON.parse(fields._payload)
+        try {
+          req.data = JSON.parse(fields._payload)
+        } catch {
+          throw new APIError('Invalid JSON in _payload field', 400)
+        }
       }
 
       if (!req.file && fields?.file && typeof fields?.file === 'string') {

--- a/packages/payload/src/utilities/mergeListSearchAndWhere.ts
+++ b/packages/payload/src/utilities/mergeListSearchAndWhere.ts
@@ -15,10 +15,6 @@ export const hoistQueryParamsToAnd = (currentWhere: Where, incomingWhere: Where)
 
   if ('and' in currentWhere && currentWhere.and) {
     currentWhere.and.push(incomingWhere)
-  } else if ('or' in currentWhere) {
-    currentWhere = {
-      and: [currentWhere, incomingWhere],
-    }
   } else {
     currentWhere = {
       and: [currentWhere, incomingWhere],

--- a/packages/payload/src/utilities/parseParams/index.spec.ts
+++ b/packages/payload/src/utilities/parseParams/index.spec.ts
@@ -237,16 +237,14 @@ describe('parseParams', () => {
       expect(result).toEqual({})
     })
 
-    it('should throw error for null params (current implementation bug)', () => {
-      expect(() => {
-        parseParams(null as any)
-      }).toThrow(TypeError)
+    it('should return empty object for null params', () => {
+      const result = parseParams(null as any)
+      expect(result).toEqual({})
     })
 
-    it('should throw error for undefined params (current implementation bug)', () => {
-      expect(() => {
-        parseParams(undefined as any)
-      }).toThrow(TypeError)
+    it('should return empty object for undefined params', () => {
+      const result = parseParams(undefined as any)
+      expect(result).toEqual({})
     })
 
     it('should preserve unknown parameters', () => {

--- a/packages/payload/src/utilities/parseParams/index.ts
+++ b/packages/payload/src/utilities/parseParams/index.ts
@@ -72,7 +72,11 @@ export const numberParams = ['depth', 'limit', 'page']
  *   c. `sort` provided as a comma-separated string or array is converted to an array of strings
  */
 export const parseParams = (params: RawParams): ParsedParams => {
-  const parsedParams = (params || {}) as ParsedParams
+  if (!params || typeof params !== 'object') {
+    return {} as ParsedParams
+  }
+
+  const parsedParams = params as ParsedParams
 
   // iterate through known params to make this very fast
   for (const key of booleanParams) {


### PR DESCRIPTION
### What?

Fixed 7 bugs across payload core utilities:

- **`addDataAndFileToRequest.ts`** — `JSON.parse` on `_payload` field had no try/catch, throwing unhandled `SyntaxError` on invalid JSON
- **`validations.ts`** — point field validator had swapped lng/lat NaN checks (`value[1]` checked against `lng`, `value[0]` against `lat`)
- **`validations.ts`** — removed dead `typeof lng !== 'number'` branch in point validator (always false since `parseFloat` returns `number`)
- **`validations.ts`** — upload/relationship error messages appended a numeric index to each invalid value due to swapped `.map()` parameter names
- **`afterRead/promise.ts`** — `getBlockSelect()` called with `block!` before the `if (block)` guard, risking runtime error on undefined block
- **`parseParams/index.ts`** — `key in params` throws `TypeError` when params is null/undefined (documented as "current implementation bug" in tests)
- **`mergeListSearchAndWhere.ts`** — `else if` and `else` branches in `hoistQueryParamsToAnd` executed identical code

### Why?

These are runtime correctness bugs. The swapped lng/lat check causes valid point inputs to be rejected. The unguarded `JSON.parse` crashes the server on malformed multipart payloads. The non-null assertion can throw on documents with unknown block types.

### How?

- Wrapped `_payload` JSON.parse in try/catch matching the pattern used for `fields.file` on the next line
- Swapped `value[0]`/`value[1]` indices to match their correct coordinate variables
- Moved `getBlockSelect()` inside the existing `if (block)` guard
- Added early return in `parseParams` for null/undefined, updated tests from "throws TypeError" to "returns {}"
- Simplified `.map()` callback to remove misleading index
- Collapsed duplicate else branches