### PR TITLE
fix!: apply the documented auth.depth default of 0

### DIFF
--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -121,6 +121,7 @@ export const addDefaultsToAuthConfig = (auth: IncomingAuthType): IncomingAuthTyp
     ...(auth.cookies || {}),
   }
 
+  auth.depth = auth.depth ?? 0
   auth.forgotPassword = auth.forgotPassword ?? {}
   auth.lockTime = auth.lockTime ?? 600000 // 10 minutes
   auth.loginWithUsername = auth.loginWithUsername ?? false

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -1086,6 +1086,12 @@ describe('Auth', () => {
     })
   })
 
+  describe('config defaults', () => {
+    it('should default auth.depth to 0 when the collection does not set it', () => {
+      expect(payload.collections[publicUsersSlug]?.config.auth.depth).toBe(0)
+    })
+  })
+
   describe('disableLocalStrategy', () => {
     it('should allow create of a user with disableLocalStrategy', async () => {
       const email = 'test@example.com'


### PR DESCRIPTION
`auth.depth` has been documented as defaulting to `0` since it was introduced, but that default was never applied. `addDefaultsToAuthConfig` has a line for every other auth default except `depth`, so it stayed `undefined`, the auth strategies passed that straight into `findByID`, and `afterRead` fell back to `defaultDepth`. The result is that `req.user` has been populated on every authenticated request rather than not at all: two levels deep before #17510, one level after.

The fix is the one missing line, `auth.depth = auth.depth ?? 0`.

Labelled breaking because relationship and upload fields on `req.user` become IDs, in access control, hooks and `/api/users/me`. Access control that reads something like `user.tenant.owner.id` now gets an ID and denies quietly, so the failure is silent rather than an error. Anyone who wants the old behaviour can set `auth.depth` on the collection, which is what the prop is for.

Added a test asserting the sanitized value on an auth collection that omits `depth`; without the fix it fails with `expected undefined to be +0`. The full int matrix, unit and type tests are green. I also checked the rest of the repo for code that would need updating alongside this: `test/auth/config.ts` is the only place that sets `auth.depth`, no template or example has a relationship or upload field on an auth collection (their `roles` fields are all `select`s, which depth does not touch), and the multi-tenant and ecommerce plugins already normalize both the ID and the document shape.
