### PR TITLE
fix: respect locale when counting global versions

### DIFF
--- a/packages/payload/src/globals/operations/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/countGlobalVersions.ts
@@ -77,6 +77,7 @@ export const countGlobalVersionsOperation = async <TSlug extends GlobalSlug>(
 
     const result = await payload.db.countGlobalVersions({
       global: global.slug,
+      locale: req?.locale || undefined,
       req,
       where: fullWhere,
     })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -4558,6 +4558,37 @@ describe('Localization', () => {
       })
       expect(result2.totalDocs).toBe(1)
     })
+
+    it('should count global versions with query on localized field respecting locale', async () => {
+      await payload.updateGlobal({
+        slug: globalWithDraftsSlug,
+        data: { text: 'global count en', _status: 'published' },
+        locale: defaultLocale,
+      })
+
+      await payload.updateGlobal({
+        slug: globalWithDraftsSlug,
+        data: { text: 'global count es', _status: 'published' },
+        locale: spanishLocale,
+      })
+
+      const englishWhere = { 'version.text': { equals: 'global count en' } }
+
+      const inEnglish = await payload.countGlobalVersions({
+        global: globalWithDraftsSlug,
+        locale: defaultLocale,
+        where: englishWhere,
+      })
+
+      const inSpanish = await payload.countGlobalVersions({
+        global: globalWithDraftsSlug,
+        locale: spanishLocale,
+        where: englishWhere,
+      })
+
+      expect(inEnglish.totalDocs).toBeGreaterThan(0)
+      expect(inSpanish.totalDocs).toBe(0)
+    })
   })
 })
 


### PR DESCRIPTION
Passes `req.locale` to `payload.db.countGlobalVersions` in the `countGlobalVersions` operation so queries on localized fields resolve against the correct locale.

Previously the operation omitted `locale`, so a `where` clause targeting a localized field (e.g. `version.text`) was matched against the wrong locale's data, returning incorrect counts.

Before:

```ts
const result = await payload.db.countGlobalVersions({
  global: global.slug,
  req,
  where: fullWhere,
})
```

After:

```ts
const result = await payload.db.countGlobalVersions({
  global: global.slug,
  locale: req?.locale || undefined,
  req,
  where: fullWhere,
})
```
