### PR TITLE
fix(plugin-search): reindex documents published in non-default locales

### DIFF
--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -205,7 +205,17 @@ export const generateReindexHandler =
                 continue
               }
 
-              docToSync = { ...doc, _status: localeStatus }
+              // The batch was fetched with `locale: 'all'`, so localized fields are locale maps.
+              // Re-fetch scoped to this locale so `syncDocAsSearchIndex` receives per-locale scalars.
+              docToSync =
+                (await payload.findByID({
+                  id: doc.id,
+                  collection,
+                  depth: 0,
+                  disableErrors: true,
+                  locale: localeToSync,
+                  ...defaultLocalApiProps,
+                })) ?? doc
             }
 
             // Sync this locale (create first index, then update with other locales accordingly)

--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -1,4 +1,4 @@
-import type { PayloadHandler, Where } from 'payload'
+import type { JsonObject, PayloadHandler, TypeWithID, Where } from 'payload'
 
 import {
   addLocalesToRequestFromData,
@@ -155,9 +155,12 @@ export const generateReindexHandler =
           collection,
           depth: 0,
           limit: batchSize,
-          // Fetch all locales so each locale's `_status` is available for gating below
+          // Fetch all locales so each locale's `_status` is available for gating below.
           locale: localizeStatusEnabled ? 'all' : defaultLocale,
           page: i + 1,
+          // Only `_status` is needed here; per-locale content is loaded scoped inside the loop.
+          // If that per-locale re-fetch is ever removed, widen this select to the indexed fields.
+          select: localizeStatusEnabled ? { _status: true } : undefined,
           where: syncDrafts || !draftsEnabled ? undefined : buildPublishedWhere(collection),
           ...defaultLocalApiProps,
         })
@@ -172,13 +175,37 @@ export const generateReindexHandler =
           // Loop through all locales and check each one
           let firstAllowedLocale = true
           for (const localeToSync of allLocales) {
+            // For localized status, skip locales that aren't published (unless syncing drafts),
+            // then load the doc scoped to this locale so downstream sees per-locale scalars
+            // (the batch only selected `_status`).
+            let docToSync: JsonObject & TypeWithID = doc
+            if (localizeStatusEnabled) {
+              const localeStatus = (doc as { _status?: Record<string, string> })._status?.[
+                localeToSync as string
+              ]
+
+              if (!syncDrafts && localeStatus !== 'published') {
+                continue
+              }
+
+              docToSync =
+                (await payload.findByID({
+                  id: doc.id,
+                  collection,
+                  depth: 0,
+                  disableErrors: true,
+                  locale: localeToSync,
+                  ...defaultLocalApiProps,
+                })) ?? doc
+            }
+
             // Check if we should skip this locale for this document
             let shouldSkip = false
             if (typeof pluginConfig.skipSync === 'function') {
               try {
                 shouldSkip = await pluginConfig.skipSync({
                   collectionSlug: collection,
-                  doc,
+                  doc: docToSync,
                   locale: localeToSync,
                   req,
                 })
@@ -192,30 +219,6 @@ export const generateReindexHandler =
 
             if (shouldSkip) {
               continue // Skip this locale
-            }
-
-            // Skip locales that aren't published (unless syncing drafts)
-            let docToSync = doc
-            if (localizeStatusEnabled) {
-              const localeStatus = (doc as { _status?: Record<string, string> })._status?.[
-                localeToSync as string
-              ]
-
-              if (!syncDrafts && localeStatus !== 'published') {
-                continue
-              }
-
-              // The batch was fetched with `locale: 'all'`, so localized fields are locale maps.
-              // Re-fetch scoped to this locale so `syncDocAsSearchIndex` receives per-locale scalars.
-              docToSync =
-                (await payload.findByID({
-                  id: doc.id,
-                  collection,
-                  depth: 0,
-                  disableErrors: true,
-                  locale: localeToSync,
-                  ...defaultLocalApiProps,
-                })) ?? doc
             }
 
             // Sync this locale (create first index, then update with other locales accordingly)

--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -8,6 +8,7 @@ import {
   initTransaction,
   killTransaction,
 } from 'payload'
+import { hasLocalizeStatusEnabled } from 'payload/shared'
 
 import type { SanitizedSearchPluginConfig } from '../types.js'
 
@@ -93,13 +94,29 @@ export const generateReindexHandler =
         equals: 'published',
       },
     }
+    // Localized `_status` tracks published state per-locale; match docs published in any locale.
+    function buildPublishedWhere(collection: string): Where {
+      const collectionConfig = payload.collections[collection]?.config
+      const localeCodes = payload.config.localization ? payload.config.localization.localeCodes : []
+
+      if (collectionConfig && hasLocalizeStatusEnabled(collectionConfig) && localeCodes.length) {
+        return {
+          or: localeCodes.map((localeCode) => ({
+            [`_status.${localeCode}`]: {
+              equals: 'published',
+            },
+          })),
+        }
+      }
+
+      return whereStatusPublished
+    }
     async function countDocuments(collection: string, drafts?: boolean): Promise<number> {
       const { totalDocs } = await payload.count({
         collection,
         ...defaultLocalApiProps,
-        locale: defaultLocale,
         req: undefined,
-        where: drafts ? undefined : whereStatusPublished,
+        where: drafts ? undefined : buildPublishedWhere(collection),
       })
       return totalDocs
     }
@@ -117,7 +134,11 @@ export const generateReindexHandler =
     async function reindexCollection(
       collection: string,
     ): Promise<{ docs: number; docsWithDrafts: number; errors: number }> {
-      const draftsEnabled = Boolean(payload.collections[collection]?.config.versions?.drafts)
+      const collectionConfig = payload.collections[collection]?.config
+      const draftsEnabled = Boolean(collectionConfig?.versions?.drafts)
+      const localizeStatusEnabled = collectionConfig
+        ? hasLocalizeStatusEnabled(collectionConfig)
+        : false
 
       const totalDocsWithDrafts = await countDocuments(collection, true)
       const totalDocs =
@@ -134,9 +155,10 @@ export const generateReindexHandler =
           collection,
           depth: 0,
           limit: batchSize,
-          locale: defaultLocale,
+          // Fetch all locales so each locale's `_status` is available for gating below
+          locale: localizeStatusEnabled ? 'all' : defaultLocale,
           page: i + 1,
-          where: syncDrafts || !draftsEnabled ? undefined : whereStatusPublished,
+          where: syncDrafts || !draftsEnabled ? undefined : buildPublishedWhere(collection),
           ...defaultLocalApiProps,
         })
 
@@ -172,14 +194,28 @@ export const generateReindexHandler =
               continue // Skip this locale
             }
 
+            // Skip locales that aren't published (unless syncing drafts)
+            let docToSync = doc
+            if (localizeStatusEnabled) {
+              const localeStatus = (doc as { _status?: Record<string, string> })._status?.[
+                localeToSync as string
+              ]
+
+              if (!syncDrafts && localeStatus !== 'published') {
+                continue
+              }
+
+              docToSync = { ...doc, _status: localeStatus }
+            }
+
             // Sync this locale (create first index, then update with other locales accordingly)
             const operation = firstAllowedLocale ? 'create' : 'update'
             firstAllowedLocale = false
 
             await syncDocAsSearchIndex({
               collection,
-              data: doc,
-              doc,
+              data: docToSync,
+              doc: docToSync,
               locale: localeToSync,
               onSyncError: () => operation === 'create' && localErrors++,
               operation,

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -580,13 +580,13 @@ describe('@payloadcms/plugin-search', () => {
     await payload.update({
       collection: postsSlug,
       id: postId,
-      data: { slug: 'post-slug-es' },
+      data: { _status: 'published', slug: 'post-slug-es' },
       locale: 'es',
     })
     await payload.update({
       collection: postsSlug,
       id: postId,
-      data: { slug: 'post-slug-de' },
+      data: { _status: 'published', slug: 'post-slug-de' },
       locale: 'de',
     })
 
@@ -760,6 +760,58 @@ describe('@payloadcms/plugin-search', () => {
 
     expect(postAfterReindex?.slug).not.toBeFalsy()
     expect(postAfterReindex?.slug).toStrictEqual(postBeforeReindex?.slug)
+  })
+
+  it('should reindex documents published only in a non-default locale when status is localized', async () => {
+    // Draft in the default locale ('en'), published only in a non-default locale ('de')
+    const post = await payload.create({
+      collection: postsSlug,
+      locale: 'en',
+      data: {
+        title: 'Published in DE only',
+        _status: 'draft',
+        slug: 'de-only-en',
+      },
+    })
+
+    await payload.update({
+      collection: postsSlug,
+      id: post.id,
+      locale: 'de',
+      data: {
+        _status: 'published',
+        slug: 'de-only-de',
+      },
+    })
+
+    const endpointRes = await restClient.POST(`/search/reindex`, {
+      body: JSON.stringify({
+        collections: [postsSlug],
+      }),
+      headers: {
+        Authorization: `JWT ${token}`,
+      },
+    })
+
+    expect(endpointRes.status).toBe(200)
+
+    const { docs } = await payload.find({
+      collection: 'search',
+      depth: 0,
+      pagination: false,
+      locale: 'all',
+      where: {
+        doc: {
+          equals: {
+            relationTo: postsSlug,
+            value: post.id,
+          },
+        },
+      },
+    })
+
+    // The document is published in 'de', so it must be indexed even though 'en' is a draft
+    expect(docs).toHaveLength(1)
   })
 
   it('should sync trashed documents correctly with search plugin', async () => {

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -812,6 +812,16 @@ describe('@payloadcms/plugin-search', () => {
 
     // The document is published in 'de', so it must be indexed even though 'en' is a draft
     expect(docs).toHaveLength(1)
+
+    // The indexed 'de' locale must hold that locale's scalar value, not the whole `locale: 'all'` map
+    const deSearchDoc = await payload.findByID({
+      collection: 'search',
+      id: docs[0]!.id,
+      depth: 0,
+      locale: 'de',
+    })
+
+    expect(deSearchDoc.slug).toBe('de-only-de')
   })
 
   it('should sync trashed documents correctly with search plugin', async () => {


### PR DESCRIPTION
Reindex now selects and indexes documents based on per-locale publish status, so a document published only in a non-default locale is included.

Since `_status` is localized whenever a collection has localized fields under localization, a document can be `published` in `de` while still `draft` in `en`. The reindex handler had three gaps under that model:

1. Candidate selection filtered on `_status: { equals: 'published' }` at the default locale, so a document published only in a non-default locale was never selected.
2. Documents were fetched at the default locale, so each locale's `_status` was unavailable for per-locale gating.
3. Every locale of a selected document was synced, so `draft` locale content could be indexed alongside `published` content.

The handler now builds the published filter as an `or` across `_status.<locale>` for every configured locale, fetches candidates with `locale: 'all'`, and only syncs the locales where the document is actually published.
