### PR TITLE
fix: catch errors from filter options in list view WhereBuilder

### DIFF
--- a/packages/payload/src/admin/views/list.ts
+++ b/packages/payload/src/admin/views/list.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../collections/config/types.js'
 import type { ServerProps } from '../../config/types.js'
 import type { PaginatedDocs } from '../../database/types.js'
+import type { Option } from '../../fields/config/types.js'
 import type { CollectionPreferences } from '../../preferences/types.js'
 import type { QueryPreset } from '../../query-presets/types.js'
 import type { ResolvedFilterOptions, Where } from '../../types/index.js'
@@ -101,7 +102,7 @@ export type ListViewClientProps = {
   queryPreset?: QueryPreset
   queryPresetPermissions?: SanitizedCollectionPermission
   renderedFilters?: Map<string, React.ReactNode>
-  resolvedFilterOptions?: Map<string, ResolvedFilterOptions>
+  resolvedFilterOptions?: Map<string, Option[] | ResolvedFilterOptions>
   viewType: ViewTypes
 } & ListViewSlots
 

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -205,14 +205,24 @@ export const promise = async ({
         if (field.type === 'blocks' && field.filterOptions) {
           // Re-run filteroptions. If the validation error is due to filteroptions, we need to add error paths to all the blocks
           // that are no longer valid
-          const validationResult = await validateBlocksFilterOptions({
-            id,
-            data,
-            filterOptions: field.filterOptions,
-            req,
-            siblingData,
-            value: siblingData[field.name],
-          })
+          let validationResult: Awaited<ReturnType<typeof validateBlocksFilterOptions>> | undefined
+
+          try {
+            validationResult = await validateBlocksFilterOptions({
+              id,
+              data,
+              filterOptions: field.filterOptions,
+              req,
+              siblingData,
+              value: siblingData[field.name],
+            })
+          } catch (err) {
+            req.payload.logger.error({
+              err,
+              msg: `Failed to resolve filterOptions for field "${field.name}" during validation`,
+            })
+          }
+
           if (validationResult?.invalidBlockSlugs?.length) {
             filterOptionsError = true
             let rowIndex = -1

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -614,7 +614,7 @@ export async function validateBlocksFilterOptions({
 }
 export const blocks: BlocksFieldValidation = async (
   value,
-  { id, data, filterOptions, maxRows, minRows, req: { t }, req, required, siblingData },
+  { id, name, data, filterOptions, maxRows, minRows, req: { t }, req, required, siblingData },
 ) => {
   const lengthValidationResult = validateArrayLength(value, { maxRows, minRows, required, t })
   if (typeof lengthValidationResult === 'string') {
@@ -622,14 +622,26 @@ export const blocks: BlocksFieldValidation = async (
   }
 
   if (filterOptions) {
-    const { invalidBlockSlugs } = await validateBlocksFilterOptions({
-      id,
-      data,
-      filterOptions,
-      req,
-      siblingData,
-      value,
-    })
+    let invalidBlockSlugs: string[] | undefined
+
+    try {
+      ;({ invalidBlockSlugs } = await validateBlocksFilterOptions({
+        id,
+        data,
+        filterOptions,
+        req,
+        siblingData,
+        value,
+      }))
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to resolve filterOptions for field "${name}" during validation`,
+      })
+
+      return t('validation:invalidInput')
+    }
+
     if (invalidBlockSlugs?.length) {
       return t('validation:invalidBlocks', { blocks: invalidBlockSlugs.join(', ') })
     }
@@ -972,17 +984,27 @@ export type SelectFieldSingleValidation = Validate<string, unknown, unknown, Sel
 
 export const select: SelectFieldValidation = async (
   value,
-  { data, filterOptions, hasMany, options, req, req: { t }, required, siblingData },
+  { name, data, filterOptions, hasMany, options, req, req: { t }, required, siblingData },
 ) => {
-  const filteredOptions =
-    typeof filterOptions === 'function'
-      ? await filterOptions({
-          data,
-          options,
-          req,
-          siblingData,
-        })
-      : options
+  let filteredOptions = options
+
+  if (typeof filterOptions === 'function') {
+    try {
+      filteredOptions = await filterOptions({
+        data,
+        options,
+        req,
+        siblingData,
+      })
+    } catch (err) {
+      req.payload.logger.error({
+        err,
+        msg: `Failed to resolve filterOptions for field "${name}" during validation`,
+      })
+
+      return t('validation:invalidInput')
+    }
+  }
 
   if (
     Array.isArray(value) &&

--- a/packages/ui/src/elements/ListControls/types.ts
+++ b/packages/ui/src/elements/ListControls/types.ts
@@ -1,5 +1,6 @@
 import type {
   ClientCollectionConfig,
+  Option,
   QueryPreset,
   ResolvedFilterOptions,
   SanitizedCollectionPermission,
@@ -35,5 +36,5 @@ export type ListControlsProps = {
   readonly queryPreset?: QueryPreset
   readonly queryPresetPermissions?: SanitizedCollectionPermission
   readonly renderedFilters?: Map<string, React.ReactNode>
-  readonly resolvedFilterOptions?: Map<string, ResolvedFilterOptions>
+  readonly resolvedFilterOptions?: Map<string, Option[] | ResolvedFilterOptions>
 }

--- a/packages/ui/src/elements/ListWhereBuilder/index.tsx
+++ b/packages/ui/src/elements/ListWhereBuilder/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientField, ResolvedFilterOptions, SanitizedCollectionConfig } from 'payload'
+import type { ClientField, Option, ResolvedFilterOptions, SanitizedCollectionConfig } from 'payload'
 
 import React, { useCallback } from 'react'
 
@@ -12,7 +12,7 @@ export type ListWhereBuilderProps = {
   readonly fields: ClientField[]
   readonly onEmptyRemove?: () => void
   readonly renderedFilters?: Map<string, React.ReactNode>
-  readonly resolvedFilterOptions?: Map<string, ResolvedFilterOptions>
+  readonly resolvedFilterOptions?: Map<string, Option[] | ResolvedFilterOptions>
 }
 
 /**

--- a/packages/ui/src/elements/WhereBuilder/Condition/DefaultFilter/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/DefaultFilter/index.tsx
@@ -19,7 +19,7 @@ import { Text } from '../Text/index.js'
 type Props = {
   booleanSelect: boolean
   disabled: boolean
-  filterOptions?: ResolvedFilterOptions
+  filterOptions?: Option[] | ResolvedFilterOptions
   internalField: ReducedField
   onChange: React.Dispatch<React.SetStateAction<string>>
   operator: Operator
@@ -51,6 +51,8 @@ export const DefaultFilter: React.FC<Props> = ({
     )
   }
 
+  const whereFilterOptions = Array.isArray(filterOptions) ? {} : (filterOptions ?? {})
+
   switch (internalField?.field?.type) {
     case 'date': {
       return (
@@ -81,7 +83,7 @@ export const DefaultFilter: React.FC<Props> = ({
         <RelationshipFilter
           disabled={disabled}
           field={internalField.field}
-          filterOptions={filterOptions ?? {}}
+          filterOptions={whereFilterOptions}
           onChange={onChange}
           operator={operator}
           value={value}
@@ -94,7 +96,7 @@ export const DefaultFilter: React.FC<Props> = ({
         <RelationshipFilter
           disabled={disabled}
           field={internalField.field}
-          filterOptions={filterOptions ?? {}}
+          filterOptions={whereFilterOptions}
           onChange={onChange}
           operator={operator}
           value={value}

--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -15,7 +15,7 @@ export type Props = {
   readonly andIndex: number
   readonly disableRemoveButton: boolean
   readonly fieldPath: string
-  readonly filterOptions?: ResolvedFilterOptions
+  readonly filterOptions?: PayloadOption[] | ResolvedFilterOptions
   readonly isFirstCondition: boolean
   readonly join: 'and' | 'or'
   readonly operator: Operator
@@ -86,7 +86,7 @@ export const Condition: React.FC<Props> = (props) => {
       { label: t('general:false'), value: 'false' },
     ]
   } else if (reducedField?.field && 'options' in reducedField.field) {
-    valueOptions = reducedField.field.options
+    valueOptions = Array.isArray(filterOptions) ? filterOptions : reducedField.field.options
   }
 
   const updateValue = useEffectEvent(async (debouncedValue: Value) => {

--- a/packages/ui/src/elements/WhereBuilder/types.ts
+++ b/packages/ui/src/elements/WhereBuilder/types.ts
@@ -1,6 +1,7 @@
 import type {
   ClientField,
   Operator,
+  Option,
   ResolvedFilterOptions,
   SanitizedCollectionConfig,
   Where,
@@ -15,7 +16,7 @@ export type WhereBuilderProps = {
   /** Called when the last condition is removed, so the parent has empty state control. */
   readonly onEmptyRemove?: () => void
   readonly renderedFilters?: Map<string, React.ReactNode>
-  readonly resolvedFilterOptions?: Map<string, ResolvedFilterOptions>
+  readonly resolvedFilterOptions?: Map<string, Option[] | ResolvedFilterOptions>
   /** The current `where` value to render conditions from. */
   readonly value?: Where
 }

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -446,16 +446,23 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
           ReturnType<typeof validateBlocksFilterOptions>
         > | null = null
         if (field.filterOptions) {
-          filterOptionsValidationResult = await validateBlocksFilterOptions({
-            id,
-            data: fullData,
-            filterOptions: field.filterOptions,
-            req,
-            siblingData: data,
-            value: data[field.name],
-          })
+          try {
+            filterOptionsValidationResult = await validateBlocksFilterOptions({
+              id,
+              data: fullData,
+              filterOptions: field.filterOptions,
+              req,
+              siblingData: data,
+              value: data[field.name],
+            })
 
-          fieldState.blocksFilterOptions = filterOptionsValidationResult.allowedBlockSlugs
+            fieldState.blocksFilterOptions = filterOptionsValidationResult.allowedBlockSlugs
+          } catch (err) {
+            req.payload.logger.error({
+              err,
+              msg: `Failed to resolve filterOptions for field "${path}", falling back to unfiltered options`,
+            })
+          }
         }
 
         const { promises, rowMetadata } = blocksValue.reduce(
@@ -723,17 +730,24 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
           }
 
           if (typeof field.filterOptions === 'function') {
-            const query = await resolveFilterOptions(field.filterOptions, {
-              id,
-              blockData,
-              data: fullData,
-              relationTo: field.relationTo,
-              req,
-              siblingData: data,
-              user: req.user,
-            })
+            try {
+              const query = await resolveFilterOptions(field.filterOptions, {
+                id,
+                blockData,
+                data: fullData,
+                relationTo: field.relationTo,
+                req,
+                siblingData: data,
+                user: req.user,
+              })
 
-            fieldState.filterOptions = query
+              fieldState.filterOptions = query
+            } catch (err) {
+              req.payload.logger.error({
+                err,
+                msg: `Failed to resolve filterOptions for field "${path}", falling back to unfiltered options`,
+              })
+            }
           }
         }
 
@@ -796,12 +810,19 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
 
       case 'select': {
         if (typeof field.filterOptions === 'function') {
-          fieldState.selectFilterOptions = await field.filterOptions({
-            data: fullData,
-            options: field.options,
-            req,
-            siblingData: data,
-          })
+          try {
+            fieldState.selectFilterOptions = await field.filterOptions({
+              data: fullData,
+              options: field.options,
+              req,
+              siblingData: data,
+            })
+          } catch (err) {
+            req.payload.logger.error({
+              err,
+              msg: `Failed to resolve filterOptions for field "${path}", falling back to unfiltered options`,
+            })
+          }
         }
 
         if (data[field.name] !== undefined) {

--- a/packages/ui/src/views/List/resolveAllFilterOptions.spec.ts
+++ b/packages/ui/src/views/List/resolveAllFilterOptions.spec.ts
@@ -1,10 +1,19 @@
 import type { Field, PayloadRequest } from 'payload'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { resolveAllFilterOptions } from './resolveAllFilterOptions.js'
 
 const mockReq = {} as PayloadRequest
+
+const createMockReqWithLogger = () =>
+  ({
+    payload: {
+      logger: {
+        error: vi.fn(),
+      },
+    },
+  }) as unknown as PayloadRequest & { payload: { logger: { error: ReturnType<typeof vi.fn> } } }
 
 describe('resolveAllFilterOptions', () => {
   it('resolves relationship filterOptions into a Where query keyed by relationTo collection', async () => {
@@ -113,5 +122,105 @@ describe('resolveAllFilterOptions', () => {
     const result = await resolveAllFilterOptions({ fields, req: mockReq })
 
     expect(result.get('group.selectField')).toEqual([{ label: 'One', value: 'one' }])
+  })
+
+  it('logs and omits the map entry when a relationship filterOptions throws synchronously, without failing sibling fields', async () => {
+    const req = createMockReqWithLogger()
+
+    const fields = [
+      {
+        name: 'brokenRelationship',
+        type: 'relationship',
+        relationTo: 'posts',
+        filterOptions: () => {
+          throw new Error('boom')
+        },
+      },
+      {
+        name: 'healthySelect',
+        type: 'select',
+        options: [{ label: 'One', value: 'one' }],
+        filterOptions: ({ options }) => options,
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req })
+
+    expect(result.has('brokenRelationship')).toBe(false)
+    expect(result.get('healthySelect')).toEqual([{ label: 'One', value: 'one' }])
+    expect(req.payload.logger.error).toHaveBeenCalledTimes(1)
+    expect(req.payload.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ msg: expect.stringContaining('brokenRelationship') }),
+    )
+  })
+
+  it('logs and omits the map entry when a relationship filterOptions rejects asynchronously', async () => {
+    const req = createMockReqWithLogger()
+
+    const fields = [
+      {
+        name: 'brokenRelationship',
+        type: 'relationship',
+        relationTo: 'posts',
+        filterOptions: async () => {
+          throw new Error('boom')
+        },
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req })
+
+    expect(result.has('brokenRelationship')).toBe(false)
+    expect(req.payload.logger.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs and omits the map entry when a select filterOptions throws synchronously, without failing sibling fields', async () => {
+    const req = createMockReqWithLogger()
+
+    const fields = [
+      {
+        name: 'brokenSelect',
+        type: 'select',
+        options: [{ label: 'One', value: 'one' }],
+        filterOptions: () => {
+          throw new Error('boom')
+        },
+      },
+      {
+        name: 'healthySelect',
+        type: 'select',
+        options: [{ label: 'One', value: 'one' }],
+        filterOptions: ({ options }) => options,
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req })
+
+    expect(result.has('brokenSelect')).toBe(false)
+    expect(result.get('healthySelect')).toEqual([{ label: 'One', value: 'one' }])
+    expect(req.payload.logger.error).toHaveBeenCalledTimes(1)
+    expect(req.payload.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ msg: expect.stringContaining('brokenSelect') }),
+    )
+  })
+
+  it('logs and omits the map entry when a select filterOptions rejects asynchronously', async () => {
+    const req = createMockReqWithLogger()
+
+    const fields = [
+      {
+        name: 'brokenSelect',
+        type: 'select',
+        options: [{ label: 'One', value: 'one' }],
+        filterOptions: async () => {
+          throw new Error('boom')
+        },
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req })
+
+    expect(result.has('brokenSelect')).toBe(false)
+    expect(req.payload.logger.error).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/ui/src/views/List/resolveAllFilterOptions.spec.ts
+++ b/packages/ui/src/views/List/resolveAllFilterOptions.spec.ts
@@ -1,0 +1,117 @@
+import type { Field, PayloadRequest } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveAllFilterOptions } from './resolveAllFilterOptions.js'
+
+const mockReq = {} as PayloadRequest
+
+describe('resolveAllFilterOptions', () => {
+  it('resolves relationship filterOptions into a Where query keyed by relationTo collection', async () => {
+    const fields = [
+      {
+        name: 'relationshipField',
+        type: 'relationship',
+        relationTo: 'posts',
+        filterOptions: () => ({ status: { equals: 'published' } }),
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req: mockReq })
+
+    expect(result.get('relationshipField')).toEqual({
+      posts: { status: { equals: 'published' } },
+    })
+  })
+
+  it('resolves select filterOptions into a filtered Option array', async () => {
+    const fields = [
+      {
+        name: 'selectField',
+        type: 'select',
+        options: [
+          { label: 'One', value: 'one' },
+          { label: 'Two', value: 'two' },
+          { label: 'Three', value: 'three' },
+        ],
+        filterOptions: ({ options }) =>
+          options.filter(
+            (option) => (typeof option === 'string' ? option : option.value) !== 'three',
+          ),
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req: mockReq })
+
+    expect(result.get('selectField')).toEqual([
+      { label: 'One', value: 'one' },
+      { label: 'Two', value: 'two' },
+    ])
+  })
+
+  it('awaits an async select filterOptions function and resolves it to a plain Option array', async () => {
+    const fields = [
+      {
+        name: 'selectField',
+        type: 'select',
+        options: [
+          { label: 'One', value: 'one' },
+          { label: 'Two', value: 'two' },
+          { label: 'Three', value: 'three' },
+        ],
+        filterOptions: async ({ options }) =>
+          options.filter(
+            (option) => (typeof option === 'string' ? option : option.value) !== 'three',
+          ),
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req: mockReq })
+
+    expect(result.get('selectField')).toEqual([
+      { label: 'One', value: 'one' },
+      { label: 'Two', value: 'two' },
+    ])
+  })
+
+  it('does not add a map entry for select fields without a filterOptions function', async () => {
+    const fields = [
+      {
+        name: 'selectField',
+        type: 'select',
+        options: [{ label: 'One', value: 'one' }],
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req: mockReq })
+
+    expect(result.has('selectField')).toBe(false)
+  })
+
+  it('resolves select filterOptions nested under a group field using the dot-notation path', async () => {
+    const fields = [
+      {
+        name: 'group',
+        type: 'group',
+        fields: [
+          {
+            name: 'selectField',
+            type: 'select',
+            options: [
+              { label: 'One', value: 'one' },
+              { label: 'Two', value: 'two' },
+            ],
+            filterOptions: ({ options }) =>
+              options.filter(
+                (option) => (typeof option === 'string' ? option : option.value) !== 'two',
+              ),
+          },
+        ],
+      },
+    ] as Field[]
+
+    const result = await resolveAllFilterOptions({ fields, req: mockReq })
+
+    expect(result.get('group.selectField')).toEqual([{ label: 'One', value: 'one' }])
+  })
+})

--- a/packages/ui/src/views/List/resolveAllFilterOptions.ts
+++ b/packages/ui/src/views/List/resolveAllFilterOptions.ts
@@ -1,4 +1,4 @@
-import type { Field, PayloadRequest, ResolvedFilterOptions } from 'payload'
+import type { Field, Option, PayloadRequest, ResolvedFilterOptions } from 'payload'
 
 import {
   fieldAffectsData,
@@ -18,9 +18,11 @@ export const resolveAllFilterOptions = async ({
   fields: Field[]
   pathPrefix?: string
   req: PayloadRequest
-  result?: Map<string, ResolvedFilterOptions>
-}): Promise<Map<string, ResolvedFilterOptions>> => {
-  const resolvedFilterOptions = !result ? new Map<string, ResolvedFilterOptions>() : result
+  result?: Map<string, Option[] | ResolvedFilterOptions>
+}): Promise<Map<string, Option[] | ResolvedFilterOptions>> => {
+  const resolvedFilterOptions = !result
+    ? new Map<string, Option[] | ResolvedFilterOptions>()
+    : result
 
   await Promise.all(
     fields.map(async (field) => {
@@ -47,6 +49,17 @@ export const resolveAllFilterOptions = async ({
           req,
           siblingData: {}, // use empty object to prevent breaking queries when accessing properties of `siblingData`
           user: req.user,
+        })
+
+        resolvedFilterOptions.set(fieldPath, options)
+      }
+
+      if (field.type === 'select' && typeof field.filterOptions === 'function') {
+        const options = await field.filterOptions({
+          data: {}, // use empty object to prevent breaking queries when accessing properties of `data`
+          options: field.options,
+          req,
+          siblingData: {}, // use empty object to prevent breaking queries when accessing properties of `siblingData`
         })
 
         resolvedFilterOptions.set(fieldPath, options)

--- a/packages/ui/src/views/List/resolveAllFilterOptions.ts
+++ b/packages/ui/src/views/List/resolveAllFilterOptions.ts
@@ -41,28 +41,42 @@ export const resolveAllFilterOptions = async ({
         'filterOptions' in field &&
         field.filterOptions
       ) {
-        const options = await resolveFilterOptions(field.filterOptions, {
-          id: undefined,
-          blockData: undefined,
-          data: {}, // use empty object to prevent breaking queries when accessing properties of `data`
-          relationTo: field.relationTo,
-          req,
-          siblingData: {}, // use empty object to prevent breaking queries when accessing properties of `siblingData`
-          user: req.user,
-        })
+        try {
+          const options = await resolveFilterOptions(field.filterOptions, {
+            id: undefined,
+            blockData: undefined,
+            data: {}, // use empty object to prevent breaking queries when accessing properties of `data`
+            relationTo: field.relationTo,
+            req,
+            siblingData: {}, // use empty object to prevent breaking queries when accessing properties of `siblingData`
+            user: req.user,
+          })
 
-        resolvedFilterOptions.set(fieldPath, options)
+          resolvedFilterOptions.set(fieldPath, options)
+        } catch (err) {
+          req.payload.logger.error({
+            err,
+            msg: `Failed to resolve filterOptions for field "${fieldPath}" in the list view filter panel, falling back to unfiltered options`,
+          })
+        }
       }
 
       if (field.type === 'select' && typeof field.filterOptions === 'function') {
-        const options = await field.filterOptions({
-          data: {}, // use empty object to prevent breaking queries when accessing properties of `data`
-          options: field.options,
-          req,
-          siblingData: {}, // use empty object to prevent breaking queries when accessing properties of `siblingData`
-        })
+        try {
+          const options = await field.filterOptions({
+            data: {}, // use empty object to prevent breaking queries when accessing properties of `data`
+            options: field.options,
+            req,
+            siblingData: {}, // use empty object to prevent breaking queries when accessing properties of `siblingData`
+          })
 
-        resolvedFilterOptions.set(fieldPath, options)
+          resolvedFilterOptions.set(fieldPath, options)
+        } catch (err) {
+          req.payload.logger.error({
+            err,
+            msg: `Failed to resolve filterOptions for field "${fieldPath}" in the list view filter panel, falling back to unfiltered options`,
+          })
+        }
       }
 
       if (fieldHasSubFields(field)) {

--- a/test/fields-relationship/collections/FilterOptionsThrows/index.ts
+++ b/test/fields-relationship/collections/FilterOptionsThrows/index.ts
@@ -1,0 +1,25 @@
+import type { CollectionConfig } from 'payload'
+
+import { relationFilterOptionsThrowsSlug, relationOneSlug } from '../../slugs.js'
+
+export const RelationshipFilterOptionsThrows: CollectionConfig = {
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+    },
+    {
+      name: 'relationshipWithThrowingFilterOptions',
+      type: 'relationship',
+      filterOptions: () => {
+        throw new Error('Intentional error thrown by filterOptions for testing purposes')
+      },
+      relationTo: relationOneSlug,
+    },
+  ],
+  slug: relationFilterOptionsThrowsSlug,
+  versions: false,
+}

--- a/test/fields-relationship/config.ts
+++ b/test/fields-relationship/config.ts
@@ -7,6 +7,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Collection1 } from './collections/Collection1/index.js'
 import { Collection2 } from './collections/Collection2/index.js'
 import { RelationshipFilterFalse } from './collections/FilterFalse/index.js'
+import { RelationshipFilterOptionsThrows } from './collections/FilterOptionsThrows/index.js'
 import { RelationshipFilterTrue } from './collections/FilterTrue/index.js'
 import { MixedMedia } from './collections/MixedMedia/index.js'
 import { Podcast } from './collections/Podcast/index.js'
@@ -29,6 +30,7 @@ export default buildConfigWithDefaults({
   collections: [
     Relationship,
     RelationshipFilterFalse,
+    RelationshipFilterOptionsThrows,
     RelationshipFilterTrue,
     Relation1,
     Relation2,

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -40,6 +40,7 @@ import {
   collection1Slug,
   mixedMediaCollectionSlug,
   relationFalseFilterOptionSlug,
+  relationFilterOptionsThrowsSlug,
   relationOneSlug,
   relationRestrictedSlug,
   relationTrueFilterOptionSlug,
@@ -513,6 +514,28 @@ describe('Relationship Field', () => {
       await expect(valueOptions2).toHaveCount(2)
       await expect(valueOptions2.locator(`text=None`)).toBeVisible()
       await expect(valueOptions2.locator(`text=${idToInclude}`)).toBeVisible()
+    })
+
+    test('should fall back to unfiltered options in the list view filter panel when a relationship filterOptions function throws', async () => {
+      const filterOptionsThrowsUrl = new AdminUrlUtil(serverURL, relationFilterOptionsThrowsSlug)
+
+      await page.goto(filterOptionsThrowsUrl.list)
+      await wait(300)
+
+      const { condition } = await addListFilter({
+        page,
+        fieldLabel: 'Relationship With Throwing Filter Options',
+        operatorLabel: 'equals',
+      })
+
+      const valueInput = condition.locator('.condition__value input')
+      await valueInput.click()
+      const valueOptions = getSelectMenu({ page }).locator('.rs__option')
+
+      await expect(valueOptions).toHaveCount(3)
+      await expect(valueOptions.locator(`text=None`)).toBeVisible()
+      await expect(valueOptions.locator(`text=${relationOneDoc.id}`)).toBeVisible()
+      await expect(valueOptions.locator(`text=${anotherRelationOneDoc.id}`)).toBeVisible()
     })
 
     test('should allow usage of relationTo in `filterOptions`', async () => {

--- a/test/fields-relationship/payload-types.ts
+++ b/test/fields-relationship/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     'fields-relationship': FieldsRelationship;
     'relation-filter-false': RelationFilterFalse;
+    'relation-filter-options-throws': RelationFilterOptionsThrow;
     'relation-filter-true': RelationFilterTrue;
     'relation-one': RelationOne;
     'relation-two': RelationTwo;
@@ -91,6 +92,7 @@ export interface Config {
   collectionsSelect: {
     'fields-relationship': FieldsRelationshipSelect<false> | FieldsRelationshipSelect<true>;
     'relation-filter-false': RelationFilterFalseSelect<false> | RelationFilterFalseSelect<true>;
+    'relation-filter-options-throws': RelationFilterOptionsThrowsSelect<false> | RelationFilterOptionsThrowsSelect<true>;
     'relation-filter-true': RelationFilterTrueSelect<false> | RelationFilterTrueSelect<true>;
     'relation-one': RelationOneSelect<false> | RelationOneSelect<true>;
     'relation-two': RelationTwoSelect<false> | RelationTwoSelect<true>;
@@ -118,6 +120,8 @@ export interface Config {
   locale: 'en';
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -287,6 +291,17 @@ export interface RelationFilterTrue {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "relation-filter-options-throws".
+ */
+export interface RelationFilterOptionsThrow {
+  id: string;
+  name?: string | null;
+  relationshipWithThrowingFilterOptions?: (string | null) | RelationOne;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "relation-updated-externally".
  */
 export interface RelationUpdatedExternally {
@@ -445,6 +460,10 @@ export interface PayloadLockedDocument {
         value: string | RelationFilterFalse;
       } | null)
     | ({
+        relationTo: 'relation-filter-options-throws';
+        value: string | RelationFilterOptionsThrow;
+      } | null)
+    | ({
         relationTo: 'relation-filter-true';
         value: string | RelationFilterTrue;
       } | null)
@@ -572,6 +591,16 @@ export interface FieldsRelationshipSelect<T extends boolean = true> {
  */
 export interface RelationFilterFalseSelect<T extends boolean = true> {
   name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "relation-filter-options-throws_select".
+ */
+export interface RelationFilterOptionsThrowsSelect<T extends boolean = true> {
+  name?: T;
+  relationshipWithThrowingFilterOptions?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -766,6 +795,74 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection:
+      | 'fields-relationship'
+      | 'relation-filter-false'
+      | 'relation-filter-options-throws'
+      | 'relation-filter-true'
+      | 'relation-one'
+      | 'relation-two'
+      | 'relation-restricted'
+      | 'relation-with-title'
+      | 'relation-updated-externally'
+      | 'collection-1'
+      | 'collection-2'
+      | 'videos'
+      | 'podcasts'
+      | 'mixed-media'
+      | 'versioned-relationship-field'
+      | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?:
+      | (
+          | 'fields-relationship'
+          | 'relation-filter-false'
+          | 'relation-filter-options-throws'
+          | 'relation-filter-true'
+          | 'relation-one'
+          | 'relation-two'
+          | 'relation-restricted'
+          | 'relation-with-title'
+          | 'relation-updated-externally'
+          | 'collection-1'
+          | 'collection-2'
+          | 'videos'
+          | 'podcasts'
+          | 'mixed-media'
+          | 'versioned-relationship-field'
+          | 'users'
+        )[]
+      | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/fields-relationship/slugs.ts
+++ b/test/fields-relationship/slugs.ts
@@ -3,6 +3,7 @@ export const slug = 'fields-relationship'
 export const relationOneSlug = 'relation-one'
 export const relationTrueFilterOptionSlug = 'relation-filter-true'
 export const relationFalseFilterOptionSlug = 'relation-filter-false'
+export const relationFilterOptionsThrowsSlug = 'relation-filter-options-throws'
 export const relationTwoSlug = 'relation-two'
 export const relationRestrictedSlug = 'relation-restricted'
 export const relationWithTitleSlug = 'relation-with-title'
@@ -18,6 +19,7 @@ export const collectionSlugs = [
   relationOneSlug,
   relationTrueFilterOptionSlug,
   relationFalseFilterOptionSlug,
+  relationFilterOptionsThrowsSlug,
   relationTwoSlug,
   relationRestrictedSlug,
   relationWithTitleSlug,

--- a/test/fields/collections/Select/e2e.spec.ts
+++ b/test/fields/collections/Select/e2e.spec.ts
@@ -10,6 +10,7 @@ import type { Config } from '../../payload-types.js'
 
 import { checkFocusIndicators } from '../../../__helpers/e2e/checkFocusIndicators.js'
 import { clickColumnSelectorItem, openListColumns } from '../../../__helpers/e2e/columns/index.js'
+import { addListFilter } from '../../../__helpers/e2e/filters/addListFilter.js'
 import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
@@ -17,6 +18,7 @@ import {
   waitForFormReady,
 } from '../../../__helpers/e2e/helpers.js'
 import { runAxeScan } from '../../../__helpers/e2e/runAxeScan.js'
+import { getSelectMenu } from '../../../__helpers/e2e/selectInput.js'
 import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
 import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
@@ -136,6 +138,26 @@ describe('Select', () => {
     await field.click({ delay: 100 })
     await expect(options.locator('text=Value One')).toBeHidden()
     await expect(options.locator('text=Value Two')).toBeVisible()
+  })
+
+  test('should resolve an async, DB-backed `filterOptions` for the list view filter value options', async () => {
+    await page.goto(url.list)
+
+    const { condition } = await addListFilter({
+      fieldLabel: 'Select with async filtered options',
+      operatorLabel: 'equals',
+      page,
+    })
+
+    await condition.locator('.condition__value input').click()
+
+    // react-select portals its menu to the document body, so options must be queried page-wide
+    const valueOptions = getSelectMenu({ page }).locator('.rs__option')
+
+    await expect(valueOptions).toHaveCount(3)
+    await expect(valueOptions.locator('text=Value One')).toBeVisible()
+    await expect(valueOptions.locator('text=Value Two')).toBeVisible()
+    await expect(valueOptions.locator('text=Value Three')).toBeVisible()
   })
 
   test('should retain search when reducing options', async () => {

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -993,6 +993,7 @@ export interface CheckboxField {
   id: string;
   checkbox: boolean;
   checkboxNotRequired?: boolean | null;
+  checkboxRequiresTrue?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1274,7 +1275,7 @@ export interface EmailField {
  */
 export interface RadioField {
   id: string;
-  radio?: ('one' | 'two' | 'three') | null;
+  radio: 'one' | 'two' | 'three';
   radioWithJsxLabelOption?: ('one' | 'two' | 'three') | null;
   updatedAt: string;
   createdAt: string;
@@ -2871,6 +2872,7 @@ export interface LocalizedTabsBlockSelect<T extends boolean = true> {
 export interface CheckboxFieldsSelect<T extends boolean = true> {
   checkbox?: T;
   checkboxNotRequired?: T;
+  checkboxRequiresTrue?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/form-state/collections/FilterOptionsThrows/index.ts
+++ b/test/form-state/collections/FilterOptionsThrows/index.ts
@@ -1,0 +1,51 @@
+import type { CollectionConfig } from 'payload'
+
+export const filterOptionsThrowsSlug = 'filter-options-throws'
+
+export const FilterOptionsThrowsCollection: CollectionConfig = {
+  slug: filterOptionsThrowsSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    {
+      name: 'selectWithThrowingFilterOptions',
+      type: 'select',
+      filterOptions: () => {
+        throw new Error('Intentional error thrown by filterOptions for testing purposes')
+      },
+      options: ['allowed', 'excluded'],
+    },
+    {
+      name: 'relationshipWithThrowingFilterOptions',
+      type: 'relationship',
+      filterOptions: () => {
+        throw new Error('Intentional error thrown by filterOptions for testing purposes')
+      },
+      relationTo: filterOptionsThrowsSlug,
+    },
+    {
+      name: 'blocksWithThrowingFilterOptions',
+      type: 'blocks',
+      blocks: [
+        {
+          slug: 'textBlock',
+          fields: [
+            {
+              name: 'text',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+      filterOptions: () => {
+        throw new Error('Intentional error thrown by filterOptions for testing purposes')
+      },
+    },
+  ],
+  versions: false,
+}

--- a/test/form-state/config.ts
+++ b/test/form-state/config.ts
@@ -5,13 +5,19 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { AutosavePostsCollection } from './collections/Autosave/index.js'
 import { ConditionsCollection } from './collections/Conditions/index.js'
+import { FilterOptionsThrowsCollection } from './collections/FilterOptionsThrows/index.js'
 import { PostsCollection, postsSlug } from './collections/Posts/index.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  collections: [PostsCollection, AutosavePostsCollection, ConditionsCollection],
+  collections: [
+    PostsCollection,
+    AutosavePostsCollection,
+    ConditionsCollection,
+    FilterOptionsThrowsCollection,
+  ],
   admin: {
     importMap: {
       baseDir: path.resolve(dirname),

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -1,17 +1,18 @@
-import type { FieldState, FormState, Payload, User } from 'payload'
+import type { FieldState, FormState, Payload, User, ValidationError } from 'payload'
 import type React from 'react'
 
 import { buildFormState } from '@payloadcms/ui/utilities/buildFormState'
 import path from 'path'
 import { createLocalReq } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
 import { conditionsSlug } from './collections/Conditions/index.js'
+import { filterOptionsThrowsSlug } from './collections/FilterOptionsThrows/index.js'
 import { postsSlug } from './collections/Posts/index.js'
 
 // eslint-disable-next-line payload/no-relative-monorepo-imports
@@ -1371,5 +1372,144 @@ describe('Form State', () => {
     expect(state.selectWithAsyncFilterOptions?.selectFilterOptions).toStrictEqual(['allowed'])
 
     await payload.delete({ collection: postsSlug, id: postData.id })
+  })
+
+  describe('filterOptions throwing', () => {
+    it('should fall back to unfiltered options in form state when a relationship field filterOptions function throws', async () => {
+      const req = await createLocalReq({ user }, payload)
+      const loggerErrorSpy = vi.spyOn(req.payload.logger, 'error')
+
+      const { state } = await buildFormState({
+        mockRSCs: true,
+        collectionSlug: filterOptionsThrowsSlug,
+        data: {},
+        docPermissions: undefined,
+        docPreferences: {
+          fields: {},
+        },
+        documentFormState: undefined,
+        operation: 'create',
+        renderAllFields: false,
+        req,
+        schemaPath: filterOptionsThrowsSlug,
+      })
+
+      expect(state.relationshipWithThrowingFilterOptions?.filterOptions).toBeUndefined()
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: expect.stringContaining('relationshipWithThrowingFilterOptions'),
+        }),
+      )
+
+      loggerErrorSpy.mockRestore()
+    })
+
+    it('should fall back to unfiltered options in form state when a select field filterOptions function throws', async () => {
+      const req = await createLocalReq({ user }, payload)
+      const loggerErrorSpy = vi.spyOn(req.payload.logger, 'error')
+
+      const { state } = await buildFormState({
+        mockRSCs: true,
+        collectionSlug: filterOptionsThrowsSlug,
+        data: {},
+        docPermissions: undefined,
+        docPreferences: {
+          fields: {},
+        },
+        documentFormState: undefined,
+        operation: 'create',
+        renderAllFields: false,
+        req,
+        schemaPath: filterOptionsThrowsSlug,
+      })
+
+      expect(state.selectWithThrowingFilterOptions?.selectFilterOptions).toBeUndefined()
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: expect.stringContaining('selectWithThrowingFilterOptions'),
+        }),
+      )
+
+      loggerErrorSpy.mockRestore()
+    })
+
+    it('should fall back to unfiltered options in form state when a blocks field filterOptions function throws', async () => {
+      const req = await createLocalReq({ user }, payload)
+      const loggerErrorSpy = vi.spyOn(req.payload.logger, 'error')
+
+      const { state } = await buildFormState({
+        mockRSCs: true,
+        collectionSlug: filterOptionsThrowsSlug,
+        data: {},
+        docPermissions: undefined,
+        docPreferences: {
+          fields: {},
+        },
+        documentFormState: undefined,
+        operation: 'create',
+        renderAllFields: false,
+        req,
+        schemaPath: filterOptionsThrowsSlug,
+      })
+
+      expect(state.blocksWithThrowingFilterOptions?.blocksFilterOptions).toBeUndefined()
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: expect.stringContaining('blocksWithThrowingFilterOptions'),
+        }),
+      )
+
+      loggerErrorSpy.mockRestore()
+    })
+
+    it('should fail validation instead of crashing when a select field filterOptions function throws on create', async () => {
+      let error: undefined | ValidationError
+
+      try {
+        await payload.create({
+          collection: filterOptionsThrowsSlug,
+          data: {
+            title: 'Test',
+          },
+        })
+      } catch (e) {
+        error = e as ValidationError
+      }
+
+      expect(error?.data?.errors).toContainEqual(
+        expect.objectContaining({
+          path: 'selectWithThrowingFilterOptions',
+          message: 'This field has an invalid input.',
+        }),
+      )
+    })
+
+    it('should fail validation instead of crashing when a blocks field filterOptions function throws on create', async () => {
+      let error: undefined | ValidationError
+
+      try {
+        await payload.create({
+          collection: filterOptionsThrowsSlug,
+          data: {
+            title: 'Test',
+            blocksWithThrowingFilterOptions: [
+              {
+                blockType: 'textBlock',
+                text: 'hello',
+              },
+            ],
+          },
+        })
+      } catch (e) {
+        error = e as ValidationError
+      }
+
+      expect(error?.data?.errors).toContainEqual(
+        expect.objectContaining({
+          path: 'blocksWithThrowingFilterOptions',
+          message: 'This field has an invalid input.',
+        }),
+      )
+    })
   })
 })

--- a/test/form-state/payload-types.ts
+++ b/test/form-state/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     posts: Post;
     'autosave-posts': AutosavePost;
     conditions: Condition;
+    'filter-options-throws': FilterOptionsThrow;
     'payload-kv': PayloadKv;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
@@ -81,6 +82,7 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     'autosave-posts': AutosavePostsSelect<false> | AutosavePostsSelect<true>;
     conditions: ConditionsSelect<false> | ConditionsSelect<true>;
+    'filter-options-throws': FilterOptionsThrowsSelect<false> | FilterOptionsThrowsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -212,6 +214,29 @@ export interface Condition {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "filter-options-throws".
+ */
+export interface FilterOptionsThrow {
+  id: string;
+  title?: string | null;
+  selectWithThrowingFilterOptions?: ('allowed' | 'excluded') | null;
+  relationshipWithThrowingFilterOptions?: (string | null) | FilterOptionsThrow;
+  blocksWithThrowingFilterOptions?: TextBlock[] | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TextBlock".
+ */
+export interface TextBlock {
+  text?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'textBlock';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -270,6 +295,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'conditions';
         value: string | Condition;
+      } | null)
+    | ({
+        relationTo: 'filter-options-throws';
+        value: string | FilterOptionsThrow;
       } | null)
     | ({
         relationTo: 'users';
@@ -396,6 +425,28 @@ export interface ConditionsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "filter-options-throws_select".
+ */
+export interface FilterOptionsThrowsSelect<T extends boolean = true> {
+  title?: T;
+  selectWithThrowingFilterOptions?: T;
+  relationshipWithThrowingFilterOptions?: T;
+  blocksWithThrowingFilterOptions?:
+    | T
+    | {
+        textBlock?:
+          | T
+          | {
+              text?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -473,7 +524,7 @@ export interface CollectionsWidget {
 export interface CollectionQueryWidget {
   data?: {
     title?: string | null;
-    relatedCollection: 'posts' | 'autosave-posts' | 'conditions' | 'users';
+    relatedCollection: 'posts' | 'autosave-posts' | 'conditions' | 'filter-options-throws' | 'users';
     where?:
       | {
           [k: string]: unknown;
@@ -495,7 +546,7 @@ export interface CollectionQueryWidget {
  */
 export interface ActivityWidget {
   data?: {
-    excludedCollections?: ('posts' | 'autosave-posts' | 'conditions' | 'users')[] | null;
+    excludedCollections?: ('posts' | 'autosave-posts' | 'conditions' | 'filter-options-throws' | 'users')[] | null;
   };
   width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }


### PR DESCRIPTION
## Summary

A `filterOptions` function is user-authored code and can throw. Before this change, a throwing `filterOptions` crashed the list view, crashed the edit and create views, and could crash a document create or update with an unhandled error. This change catches those errors at every call site and applies a consistent, safe fallback.

## How

- Every place that resolves `filterOptions` for display (list view filter panel, edit/create view form state) now catches a thrown error, logs it, and falls back to the field's unfiltered options. This covers relationship, upload, select, and blocks fields.
- Every place that resolves `filterOptions` for validation (document create and update) now catches a thrown error, logs it, and fails validation for that field. A broken `filterOptions` blocks the write instead of silently accepting an unverified value.
- Relationship and upload field validation already failed closed on a thrown `filterOptions`. Select and blocks field validation did not; both now match. A second, unguarded `filterOptions` re-check used to build a per-block error message is also covered.
- Display and validation intentionally use different fallbacks: display degrades to unfiltered because it only affects what a user sees, while validation fails closed because it decides what gets written to the database.

## Alternatives considered

For validation, a throwing `filterOptions` could instead fall back to unfiltered, matching the display behavior. This was rejected because `filterOptions` can act as an access restriction on writes, and silently lifting that restriction on error would allow an unverified value through instead of surfacing the misconfiguration.

First merge this: https://github.com/payloadcms/payload/pull/17536