### PR TITLE
refactor(richtext-lexical): upgrade lexical to 0.48.0

### DIFF
--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -635,9 +635,9 @@ The deprecated `isHTMLElement` utility has been removed from `@payloadcms/richte
 
 `lexical`'s built-in `isHTMLElement` is the canonical implementation and narrows against the node's owning-document `HTMLElement`, so it is also safe across iframes and other realms.
 
-### Lexical: vendored `@lexical/markdown` fork removed and lexical upgraded to `0.45.0`
+### Lexical: vendored `@lexical/markdown` fork removed and lexical upgraded to `0.48.0`
 
-`@payloadcms/richtext-lexical` no longer ships a vendored copy of `@lexical/markdown`. The package is now a direct dependency, every `@lexical/*` package was upgraded from `0.41.0` to `0.45.0`, and `@payloadcms/richtext-lexical/lexical/markdown` is a pure passthrough of `@lexical/markdown`.
+`@payloadcms/richtext-lexical` no longer ships a vendored copy of `@lexical/markdown`. The package is now a direct dependency, every `@lexical/*` package was upgraded from `0.41.0` to `0.48.0`, and `@payloadcms/richtext-lexical/lexical/markdown` is a pure passthrough of `@lexical/markdown`.
 
 Most projects use markdown through the editor or through `convertMarkdownToLexical` / `convertLexicalToMarkdown` and need no changes. You are only affected if you import from `@payloadcms/richtext-lexical/lexical/markdown` directly.
 
@@ -659,9 +659,9 @@ Most projects use markdown through the editor or through `convertMarkdownToLexic
 
 If you keep calling `$convertFromMarkdownString` directly, pass `editorConfig.features.markdownTransformers` as the second argument. Enable `payload/no-conflicting-lexical-markdown-imports` (included in `@payloadcms/eslint-config`) to catch imports and calls that rely on these mismatching defaults.
 
-**Whitespace-only markdown table cells now import as an empty paragraph** instead of a text node of padding spaces. This comes from the lexical `0.45` upgrade, not Payload's own code. No action is required unless you assert on those padding spaces in stored content.
+**Whitespace-only markdown table cells now import as an empty paragraph** instead of a text node of padding spaces. This comes from the lexical upgrade, not Payload's own code. No action is required unless you assert on those padding spaces in stored content.
 
-If you import lexical APIs directly through `@payloadcms/richtext-lexical/lexical/*`, also review the [lexical breaking changes](https://github.com/facebook/lexical/releases) between `0.41.0` and `0.45.0`. None of them require action for typical Payload usage.
+If you import lexical APIs directly through `@payloadcms/richtext-lexical/lexical/*`, also review the [lexical breaking changes](https://github.com/facebook/lexical/releases) between `0.41.0` and `0.48.0`. None of them require action for typical Payload usage.
 
 ### Field `typescriptSchema` renamed to `jsonSchema`
 

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -112,6 +112,11 @@
       "types": "./src/lexical-proxy/@lexical-utils.ts",
       "default": "./src/lexical-proxy/@lexical-utils.ts"
     },
+    "./lexical/react/ExtensionComponent": {
+      "import": "./src/lexical-proxy/@lexical-react/ExtensionComponent.ts",
+      "types": "./src/lexical-proxy/@lexical-react/ExtensionComponent.ts",
+      "default": "./src/lexical-proxy/@lexical-react/ExtensionComponent.ts"
+    },
     "./lexical/react/LexicalAutoEmbedPlugin": {
       "import": "./src/lexical-proxy/@lexical-react/LexicalAutoEmbedPlugin.ts",
       "types": "./src/lexical-proxy/@lexical-react/LexicalAutoEmbedPlugin.ts",
@@ -176,6 +181,16 @@
       "import": "./src/lexical-proxy/@lexical-react/LexicalContentEditable.ts",
       "types": "./src/lexical-proxy/@lexical-react/LexicalContentEditable.ts",
       "default": "./src/lexical-proxy/@lexical-react/LexicalContentEditable.ts"
+    },
+    "./lexical/react/LexicalExtensionComposer": {
+      "import": "./src/lexical-proxy/@lexical-react/LexicalExtensionComposer.ts",
+      "types": "./src/lexical-proxy/@lexical-react/LexicalExtensionComposer.ts",
+      "default": "./src/lexical-proxy/@lexical-react/LexicalExtensionComposer.ts"
+    },
+    "./lexical/react/LexicalExtensionEditorComposer": {
+      "import": "./src/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.ts",
+      "types": "./src/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.ts",
+      "default": "./src/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.ts"
     },
     "./lexical/react/LexicalNodeContextMenuPlugin": {
       "import": "./src/lexical-proxy/@lexical-react/LexicalNodeContextMenuPlugin.ts",
@@ -267,6 +282,11 @@
       "types": "./src/lexical-proxy/@lexical-react/LexicalRichTextPlugin.ts",
       "default": "./src/lexical-proxy/@lexical-react/LexicalRichTextPlugin.ts"
     },
+    "./lexical/react/LexicalSelectionAlwaysOnDisplay": {
+      "import": "./src/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.ts",
+      "types": "./src/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.ts",
+      "default": "./src/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.ts"
+    },
     "./lexical/react/LexicalTabIndentationPlugin": {
       "import": "./src/lexical-proxy/@lexical-react/LexicalTabIndentationPlugin.ts",
       "types": "./src/lexical-proxy/@lexical-react/LexicalTabIndentationPlugin.ts",
@@ -292,10 +312,55 @@
       "types": "./src/lexical-proxy/@lexical-react/LexicalTypeaheadMenuPlugin.ts",
       "default": "./src/lexical-proxy/@lexical-react/LexicalTypeaheadMenuPlugin.ts"
     },
+    "./lexical/react/ReactExtension": {
+      "import": "./src/lexical-proxy/@lexical-react/ReactExtension.ts",
+      "types": "./src/lexical-proxy/@lexical-react/ReactExtension.ts",
+      "default": "./src/lexical-proxy/@lexical-react/ReactExtension.ts"
+    },
+    "./lexical/react/ReactPluginHostExtension": {
+      "import": "./src/lexical-proxy/@lexical-react/ReactPluginHostExtension.ts",
+      "types": "./src/lexical-proxy/@lexical-react/ReactPluginHostExtension.ts",
+      "default": "./src/lexical-proxy/@lexical-react/ReactPluginHostExtension.ts"
+    },
+    "./lexical/react/ReactProviderExtension": {
+      "import": "./src/lexical-proxy/@lexical-react/ReactProviderExtension.ts",
+      "types": "./src/lexical-proxy/@lexical-react/ReactProviderExtension.ts",
+      "default": "./src/lexical-proxy/@lexical-react/ReactProviderExtension.ts"
+    },
+    "./lexical/react/TreeViewExtension": {
+      "import": "./src/lexical-proxy/@lexical-react/TreeViewExtension.ts",
+      "types": "./src/lexical-proxy/@lexical-react/TreeViewExtension.ts",
+      "default": "./src/lexical-proxy/@lexical-react/TreeViewExtension.ts"
+    },
+    "./lexical/react/useExtensionComponent": {
+      "import": "./src/lexical-proxy/@lexical-react/useExtensionComponent.ts",
+      "types": "./src/lexical-proxy/@lexical-react/useExtensionComponent.ts",
+      "default": "./src/lexical-proxy/@lexical-react/useExtensionComponent.ts"
+    },
+    "./lexical/react/useExtensionSignalValue": {
+      "import": "./src/lexical-proxy/@lexical-react/useExtensionSignalValue.ts",
+      "types": "./src/lexical-proxy/@lexical-react/useExtensionSignalValue.ts",
+      "default": "./src/lexical-proxy/@lexical-react/useExtensionSignalValue.ts"
+    },
+    "./lexical/react/useLexicalAriaLiveRegion": {
+      "import": "./src/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.ts",
+      "types": "./src/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.ts",
+      "default": "./src/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.ts"
+    },
     "./lexical/react/useLexicalEditable": {
       "import": "./src/lexical-proxy/@lexical-react/useLexicalEditable.ts",
       "types": "./src/lexical-proxy/@lexical-react/useLexicalEditable.ts",
       "default": "./src/lexical-proxy/@lexical-react/useLexicalEditable.ts"
+    },
+    "./lexical/react/useLexicalFocusManagerRef": {
+      "import": "./src/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.ts",
+      "types": "./src/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.ts",
+      "default": "./src/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.ts"
+    },
+    "./lexical/react/useLexicalFocusTrapRef": {
+      "import": "./src/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.ts",
+      "types": "./src/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.ts",
+      "default": "./src/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.ts"
     },
     "./lexical/react/useLexicalIsTextContentEmpty": {
       "import": "./src/lexical-proxy/@lexical-react/useLexicalIsTextContentEmpty.ts",
@@ -306,6 +371,16 @@
       "import": "./src/lexical-proxy/@lexical-react/useLexicalNodeSelection.ts",
       "types": "./src/lexical-proxy/@lexical-react/useLexicalNodeSelection.ts",
       "default": "./src/lexical-proxy/@lexical-react/useLexicalNodeSelection.ts"
+    },
+    "./lexical/react/useLexicalRovingTabIndexRef": {
+      "import": "./src/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.ts",
+      "types": "./src/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.ts",
+      "default": "./src/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.ts"
+    },
+    "./lexical/react/useLexicalSlotRef": {
+      "import": "./src/lexical-proxy/@lexical-react/useLexicalSlotRef.ts",
+      "types": "./src/lexical-proxy/@lexical-react/useLexicalSlotRef.ts",
+      "default": "./src/lexical-proxy/@lexical-react/useLexicalSlotRef.ts"
     },
     "./lexical/react/useLexicalSubscription": {
       "import": "./src/lexical-proxy/@lexical-react/useLexicalSubscription.ts",
@@ -361,18 +436,18 @@
     ]
   },
   "dependencies": {
-    "@lexical/clipboard": "0.45.0",
-    "@lexical/headless": "0.45.0",
-    "@lexical/html": "0.45.0",
-    "@lexical/link": "0.45.0",
-    "@lexical/list": "0.45.0",
-    "@lexical/mark": "0.45.0",
-    "@lexical/markdown": "0.45.0",
-    "@lexical/react": "0.45.0",
-    "@lexical/rich-text": "0.45.0",
-    "@lexical/selection": "0.45.0",
-    "@lexical/table": "0.45.0",
-    "@lexical/utils": "0.45.0",
+    "@lexical/clipboard": "0.48.0",
+    "@lexical/headless": "0.48.0",
+    "@lexical/html": "0.48.0",
+    "@lexical/link": "0.48.0",
+    "@lexical/list": "0.48.0",
+    "@lexical/mark": "0.48.0",
+    "@lexical/markdown": "0.48.0",
+    "@lexical/react": "0.48.0",
+    "@lexical/rich-text": "0.48.0",
+    "@lexical/selection": "0.48.0",
+    "@lexical/table": "0.48.0",
+    "@lexical/utils": "0.48.0",
     "@payloadcms/translations": "workspace:*",
     "@payloadcms/ui": "workspace:*",
     "acorn": "8.16.0",
@@ -381,7 +456,7 @@
     "dequal": "2.0.3",
     "escape-html": "1.0.3",
     "jsox": "1.2.125",
-    "lexical": "0.45.0",
+    "lexical": "0.48.0",
     "mdast-util-from-markdown": "2.0.3",
     "mdast-util-mdx-jsx": "3.2.0",
     "micromark-extension-mdx-jsx": "3.0.2",
@@ -396,7 +471,7 @@
     "@babel/preset-env": "7.27.2",
     "@babel/preset-react": "7.27.1",
     "@babel/preset-typescript": "7.27.1",
-    "@lexical/eslint-plugin": "0.45.0",
+    "@lexical/eslint-plugin": "0.48.0",
     "@payloadcms/eslint-config": "workspace:*",
     "@types/escape-html": "1.0.4",
     "@types/json-schema": "7.0.15",
@@ -512,6 +587,11 @@
         "types": "./dist/lexical-proxy/@lexical-utils.d.ts",
         "default": "./dist/lexical-proxy/@lexical-utils.js"
       },
+      "./lexical/react/ExtensionComponent": {
+        "import": "./dist/lexical-proxy/@lexical-react/ExtensionComponent.js",
+        "types": "./dist/lexical-proxy/@lexical-react/ExtensionComponent.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/ExtensionComponent.js"
+      },
       "./lexical/react/LexicalAutoEmbedPlugin": {
         "import": "./dist/lexical-proxy/@lexical-react/LexicalAutoEmbedPlugin.js",
         "types": "./dist/lexical-proxy/@lexical-react/LexicalAutoEmbedPlugin.d.ts",
@@ -576,6 +656,16 @@
         "import": "./dist/lexical-proxy/@lexical-react/LexicalContentEditable.js",
         "types": "./dist/lexical-proxy/@lexical-react/LexicalContentEditable.d.ts",
         "default": "./dist/lexical-proxy/@lexical-react/LexicalContentEditable.js"
+      },
+      "./lexical/react/LexicalExtensionComposer": {
+        "import": "./dist/lexical-proxy/@lexical-react/LexicalExtensionComposer.js",
+        "types": "./dist/lexical-proxy/@lexical-react/LexicalExtensionComposer.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/LexicalExtensionComposer.js"
+      },
+      "./lexical/react/LexicalExtensionEditorComposer": {
+        "import": "./dist/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.js",
+        "types": "./dist/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.js"
       },
       "./lexical/react/LexicalNodeContextMenuPlugin": {
         "import": "./dist/lexical-proxy/@lexical-react/LexicalNodeContextMenuPlugin.js",
@@ -667,6 +757,11 @@
         "types": "./dist/lexical-proxy/@lexical-react/LexicalRichTextPlugin.d.ts",
         "default": "./dist/lexical-proxy/@lexical-react/LexicalRichTextPlugin.js"
       },
+      "./lexical/react/LexicalSelectionAlwaysOnDisplay": {
+        "import": "./dist/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.js",
+        "types": "./dist/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.js"
+      },
       "./lexical/react/LexicalTabIndentationPlugin": {
         "import": "./dist/lexical-proxy/@lexical-react/LexicalTabIndentationPlugin.js",
         "types": "./dist/lexical-proxy/@lexical-react/LexicalTabIndentationPlugin.d.ts",
@@ -692,10 +787,55 @@
         "types": "./dist/lexical-proxy/@lexical-react/LexicalTypeaheadMenuPlugin.d.ts",
         "default": "./dist/lexical-proxy/@lexical-react/LexicalTypeaheadMenuPlugin.js"
       },
+      "./lexical/react/ReactExtension": {
+        "import": "./dist/lexical-proxy/@lexical-react/ReactExtension.js",
+        "types": "./dist/lexical-proxy/@lexical-react/ReactExtension.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/ReactExtension.js"
+      },
+      "./lexical/react/ReactPluginHostExtension": {
+        "import": "./dist/lexical-proxy/@lexical-react/ReactPluginHostExtension.js",
+        "types": "./dist/lexical-proxy/@lexical-react/ReactPluginHostExtension.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/ReactPluginHostExtension.js"
+      },
+      "./lexical/react/ReactProviderExtension": {
+        "import": "./dist/lexical-proxy/@lexical-react/ReactProviderExtension.js",
+        "types": "./dist/lexical-proxy/@lexical-react/ReactProviderExtension.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/ReactProviderExtension.js"
+      },
+      "./lexical/react/TreeViewExtension": {
+        "import": "./dist/lexical-proxy/@lexical-react/TreeViewExtension.js",
+        "types": "./dist/lexical-proxy/@lexical-react/TreeViewExtension.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/TreeViewExtension.js"
+      },
+      "./lexical/react/useExtensionComponent": {
+        "import": "./dist/lexical-proxy/@lexical-react/useExtensionComponent.js",
+        "types": "./dist/lexical-proxy/@lexical-react/useExtensionComponent.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/useExtensionComponent.js"
+      },
+      "./lexical/react/useExtensionSignalValue": {
+        "import": "./dist/lexical-proxy/@lexical-react/useExtensionSignalValue.js",
+        "types": "./dist/lexical-proxy/@lexical-react/useExtensionSignalValue.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/useExtensionSignalValue.js"
+      },
+      "./lexical/react/useLexicalAriaLiveRegion": {
+        "import": "./dist/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.js",
+        "types": "./dist/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.js"
+      },
       "./lexical/react/useLexicalEditable": {
         "import": "./dist/lexical-proxy/@lexical-react/useLexicalEditable.js",
         "types": "./dist/lexical-proxy/@lexical-react/useLexicalEditable.d.ts",
         "default": "./dist/lexical-proxy/@lexical-react/useLexicalEditable.js"
+      },
+      "./lexical/react/useLexicalFocusManagerRef": {
+        "import": "./dist/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.js",
+        "types": "./dist/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.js"
+      },
+      "./lexical/react/useLexicalFocusTrapRef": {
+        "import": "./dist/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.js",
+        "types": "./dist/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.js"
       },
       "./lexical/react/useLexicalIsTextContentEmpty": {
         "import": "./dist/lexical-proxy/@lexical-react/useLexicalIsTextContentEmpty.js",
@@ -706,6 +846,16 @@
         "import": "./dist/lexical-proxy/@lexical-react/useLexicalNodeSelection.js",
         "types": "./dist/lexical-proxy/@lexical-react/useLexicalNodeSelection.d.ts",
         "default": "./dist/lexical-proxy/@lexical-react/useLexicalNodeSelection.js"
+      },
+      "./lexical/react/useLexicalRovingTabIndexRef": {
+        "import": "./dist/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.js",
+        "types": "./dist/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.js"
+      },
+      "./lexical/react/useLexicalSlotRef": {
+        "import": "./dist/lexical-proxy/@lexical-react/useLexicalSlotRef.js",
+        "types": "./dist/lexical-proxy/@lexical-react/useLexicalSlotRef.d.ts",
+        "default": "./dist/lexical-proxy/@lexical-react/useLexicalSlotRef.js"
       },
       "./lexical/react/useLexicalSubscription": {
         "import": "./dist/lexical-proxy/@lexical-react/useLexicalSubscription.js",

--- a/packages/richtext-lexical/src/features/horizontalRule/client/nodes/HorizontalRuleNode.tsx
+++ b/packages/richtext-lexical/src/features/horizontalRule/client/nodes/HorizontalRuleNode.tsx
@@ -20,7 +20,9 @@ export class HorizontalRuleNode extends HorizontalRuleServerNode {
   /**
    * The data for this node is stored serialized as JSON. This is the "load function" of that node: it takes the saved data and converts it into a node.
    */
-  static override importJSON(serializedNode: SerializedHorizontalRuleNode): HorizontalRuleNode {
+  static override importJSON(
+    _serializedNode: Record<string, unknown> & SerializedHorizontalRuleNode,
+  ): HorizontalRuleNode {
     return $createHorizontalRuleNode()
   }
 

--- a/packages/richtext-lexical/src/features/horizontalRule/server/nodes/HorizontalRuleNode.tsx
+++ b/packages/richtext-lexical/src/features/horizontalRule/server/nodes/HorizontalRuleNode.tsx
@@ -52,7 +52,7 @@ export class HorizontalRuleServerNode extends DecoratorNode<null | React.ReactEl
    * The data for this node is stored serialized as JSON. This is the "load function" of that node: it takes the saved data and converts it into a node.
    */
   static override importJSON(
-    serializedNode: SerializedHorizontalRuleNode,
+    _serializedNode: Record<string, unknown> & SerializedHorizontalRuleNode,
   ): HorizontalRuleServerNode {
     return $createHorizontalRuleServerNode()
   }

--- a/packages/richtext-lexical/src/features/link/nodes/AutoLinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/AutoLinkNode.ts
@@ -29,7 +29,9 @@ export class AutoLinkNode extends LinkNode {
     return null
   }
 
-  static override importJSON(serializedNode: SerializedAutoLinkNode): AutoLinkNode {
+  static override importJSON(
+    serializedNode: Record<string, unknown> & SerializedAutoLinkNode,
+  ): AutoLinkNode {
     const node = $createAutoLinkNode({}).updateFromJSON(serializedNode)
 
     /**

--- a/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
@@ -72,7 +72,9 @@ export class LinkNode extends ElementNode {
     }
   }
 
-  static override importJSON(serializedNode: SerializedLinkNode): LinkNode {
+  static override importJSON(
+    serializedNode: Record<string, unknown> & SerializedLinkNode,
+  ): LinkNode {
     const node = $createLinkNode({}).updateFromJSON(serializedNode)
 
     /**

--- a/packages/richtext-lexical/src/features/upload/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/component/index.tsx
@@ -27,13 +27,13 @@ import React, { useCallback, useEffect, useId, useReducer, useRef, useState } fr
 import type { BaseClientFeatureProps } from '../../../typesClient.js'
 import type { UploadData } from '../../server/schema.js'
 import type { UploadFeaturePropsClient } from '../index.js'
-import type { UploadNode } from '../nodes/UploadNode.js'
 
 import { useEditorConfigContext } from '../../../../lexical/config/client/EditorConfigProvider.js'
 import { FieldsDrawer } from '../../../../utilities/fieldsDrawer/Drawer.js'
 import { useLexicalDocumentDrawer } from '../../../../utilities/fieldsDrawer/useLexicalDocumentDrawer.js'
 import { useLexicalDrawer } from '../../../../utilities/fieldsDrawer/useLexicalDrawer.js'
 import { INSERT_UPLOAD_WITH_DRAWER_COMMAND } from '../drawer/commands.js'
+import { $isUploadNode } from '../nodes/UploadNode.js'
 import './index.css'
 
 const initialParams = {
@@ -161,8 +161,8 @@ export const UploadComponent: React.FC<ElementProps> = (props) => {
     (_: FormState, data: JsonObject) => {
       // Update lexical node (with key nodeKey) with new data
       editor.update(() => {
-        const uploadNode: null | UploadNode = $getNodeByKey(nodeKey)
-        if (uploadNode) {
+        const uploadNode = $getNodeByKey(nodeKey)
+        if ($isUploadNode(uploadNode)) {
           const newData: UploadData = {
             ...uploadNode.getData(),
             fields: data,

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -23,7 +23,7 @@ import { richTextValidateHOC } from './validate/index.js'
 
 let checkedDependencies = false
 
-export const lexicalTargetVersion = '0.45.0'
+export const lexicalTargetVersion = '0.48.0'
 
 export function lexicalEditor(args?: LexicalEditorProps): LexicalRichTextAdapterProvider {
   if (

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ExtensionComponent.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ExtensionComponent.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/ExtensionComponent'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/LexicalExtensionComposer.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/LexicalExtensionComposer.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/LexicalExtensionComposer'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/LexicalExtensionEditorComposer.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/LexicalExtensionEditorComposer'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/LexicalSelectionAlwaysOnDisplay.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/LexicalSelectionAlwaysOnDisplay'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ReactExtension.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ReactExtension.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/ReactExtension'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ReactPluginHostExtension.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ReactPluginHostExtension.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/ReactPluginHostExtension'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ReactProviderExtension.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/ReactProviderExtension.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/ReactProviderExtension'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/TreeViewExtension.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/TreeViewExtension.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/TreeViewExtension'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useExtensionComponent.tsx
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useExtensionComponent.tsx
@@ -1,0 +1,1 @@
+export * from '@lexical/react/useExtensionComponent'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useExtensionSignalValue.ts
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useExtensionSignalValue.ts
@@ -1,0 +1,1 @@
+export * from '@lexical/react/useExtensionSignalValue'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.ts
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalAriaLiveRegion.ts
@@ -1,0 +1,1 @@
+export * from '@lexical/react/useLexicalAriaLiveRegion'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.ts
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalFocusManagerRef.ts
@@ -1,0 +1,1 @@
+export * from '@lexical/react/useLexicalFocusManagerRef'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.ts
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalFocusTrapRef.ts
@@ -1,0 +1,1 @@
+export * from '@lexical/react/useLexicalFocusTrapRef'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.ts
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalRovingTabIndexRef.ts
@@ -1,0 +1,1 @@
+export * from '@lexical/react/useLexicalRovingTabIndexRef'

--- a/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalSlotRef.ts
+++ b/packages/richtext-lexical/src/lexical-proxy/@lexical-react/useLexicalSlotRef.ts
@@ -1,0 +1,1 @@
+export * from '@lexical/react/useLexicalSlotRef'

--- a/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
@@ -3,7 +3,7 @@ import type { BaseSelection, LexicalCommand, LexicalEditor, TextNode } from 'lex
 import type { JSX, ReactPortal, RefObject } from 'react'
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext.js'
-import { mergeRegister } from '@lexical/utils'
+import { getScrollParent, mergeRegister } from '@lexical/utils'
 import {
   $getSelection,
   $isRangeSelection,
@@ -112,29 +112,6 @@ function $splitNodeContainingQuery(match: MenuTextMatch): TextNode | undefined {
   }
 
   return newNode
-}
-
-// Got from https://stackoverflow.com/a/42543908/2013580
-export function getScrollParent(
-  element: HTMLElement,
-  includeHidden: boolean,
-): HTMLBodyElement | HTMLElement {
-  let style = getComputedStyle(element)
-  const excludeStaticParent = style.position === 'absolute'
-  const overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/
-  if (style.position === 'fixed') {
-    return document.body
-  }
-  for (let parent: HTMLElement | null = element; (parent = parent.parentElement); ) {
-    style = getComputedStyle(parent)
-    if (excludeStaticParent && style.position === 'static') {
-      continue
-    }
-    if (overflowRegex.test(style.overflow + style.overflowY + style.overflowX)) {
-      return parent
-    }
-  }
-  return document.body
 }
 
 function isTriggerVisibleInNearestScrollContainer(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1415,41 +1415,41 @@ importers:
         specifier: 2.0.0
         version: 2.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@lexical/clipboard':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/headless':
-        specifier: 0.45.0
-        version: 0.45.0(bufferutil@4.1.0)
+        specifier: 0.48.0
+        version: 0.48.0(bufferutil@4.1.0)(typescript@7.0.2)
       '@lexical/html':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/link':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/list':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/mark':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/markdown':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/react':
-        specifier: 0.45.0
-        version: 0.45.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.31)
+        specifier: 0.48.0
+        version: 0.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(yjs@13.6.31)
       '@lexical/rich-text':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/selection':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/table':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@lexical/utils':
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       '@payloadcms/translations':
         specifier: workspace:*
         version: link:../translations
@@ -1475,8 +1475,8 @@ importers:
         specifier: 1.2.125
         version: 1.2.125
       lexical:
-        specifier: 0.45.0
-        version: 0.45.0
+        specifier: 0.48.0
+        version: 0.48.0(typescript@7.0.2)
       mdast-util-from-markdown:
         specifier: 2.0.3
         version: 2.0.3
@@ -1521,8 +1521,8 @@ importers:
         specifier: 7.27.1
         version: 7.27.1(@babel/core@7.27.3)
       '@lexical/eslint-plugin':
-        specifier: 0.45.0
-        version: 0.45.0(eslint@9.39.2(jiti@2.7.0))
+        specifier: 0.48.0
+        version: 0.48.0(eslint@9.39.2(jiti@2.7.0))(typescript@7.0.2)
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -5427,91 +5427,214 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
-  '@lexical/clipboard@0.45.0':
-    resolution: {integrity: sha512-9oDu2SNj/EZGjpXJTruz74Ls3VzF2Q41v1QB7JnTq5lh24byvIOdgEpOFHtr/7WVHssfXCbMtgFb5tW8rMaZ2g==}
+  '@lexical/a11y@0.48.0':
+    resolution: {integrity: sha512-18W4ehyipkUim4YVoDZitoH63Om3j6iCN4c84zdqE9RgkWf/PE4rvI/8BHTm6Ni7NkVE14nimXgkpaP5ok15zA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/code-core@0.45.0':
-    resolution: {integrity: sha512-zU3noYmfluSK38r0eBz3gHKzsgOksf9eHqoPIwXH6HovKCDo848HoW0i/hCRzRo9oPqydKikx0LIKUvWSaSNIw==}
+  '@lexical/clipboard@0.48.0':
+    resolution: {integrity: sha512-xO2trk6+yBl8XXa/VNe20kXczmPxFoWtUHjidbBLEtlGBj+mo63pJj6H5o/WlZsoMKmIOJxwxsn2ejrS8G0/7A==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/devtools-core@0.45.0':
-    resolution: {integrity: sha512-XiVedKif5nWbNj2CeNy30kokfk/iYb7Db+B1Z18bnr/uzp6IzkxpX6I4GeZu4HVbQJhGMCAdq19tFpYwXOx4sw==}
+  '@lexical/code-core@0.48.0':
+    resolution: {integrity: sha512-+O1Ge06AuSo6+r8R2Xk6SkWG07H5/e4K/Scw9aqCM/BRjITxgvFTHTNvgQbaobCsP0uBJiwW1+ZGeWAWcBCY4w==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/devtools-core@0.48.0':
+    resolution: {integrity: sha512-4kvKWW6ebgQnJNLXPLmw7dqgSChvzYIBNYtfuR6c48Sw+V/QXQTWqfIUbCIe5X4uG8EEXd5O/udXaJx7GBuP+w==}
     peerDependencies:
       react: 19.2.6
       react-dom: 19.2.6
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/dragon@0.45.0':
-    resolution: {integrity: sha512-34k2/QuM8A9WVqVCtNGx1ySBWXxMVKejKH3VBWnXEb1NdrDa/N8jLpu0gOCLcrrDjMdUzs9uVgW0D4FRf1Lixg==}
+  '@lexical/dragon@0.48.0':
+    resolution: {integrity: sha512-uPuu7fVca9vmL/Oz30CRZ7FIPIodwMrTgNsRmV8jE6Qd6a7RNiTW7r3+EhbhIdkLb/sjcWsYyOMyUR1TJAB0wQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/eslint-plugin@0.45.0':
-    resolution: {integrity: sha512-mkMGetydI5H3jWs9DT4owkRpDuWLKqwLae72BwnTRZjr7kPo9gpd+uepG9HMcRniyytc0mPkl5CEjwC/e5TUOw==}
+  '@lexical/eslint-plugin@0.48.0':
+    resolution: {integrity: sha512-1iSr4mO4H6L7aK/Z8uJNKX9GIRxg87shJ5pQ0R9W36hDj5Em5mvaM86ViL5mhSY/KnLPBy8JRGI0BauZ/q/aiw==}
     peerDependencies:
       eslint: '>=7.31.0'
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/extension@0.45.0':
-    resolution: {integrity: sha512-oJs1Zvrsqh32zZmeCkTQi7R2WoVIvaQE265JFZ/VczWlsWRdkkWQbGZ6iOlBZ3AmtiNgHoBeB0gZSoRQtWEQyA==}
+  '@lexical/extension@0.48.0':
+    resolution: {integrity: sha512-4uBObgz84mVbQWiumndmIhkuJL0ojHiMwFSvSUM/FCo1YMVIZvpI56blI0y+2Vix/oLui9EgVQSJjjWV4NAszw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/hashtag@0.45.0':
-    resolution: {integrity: sha512-gFX4n+9RjOFVkNUkEcv3JeQT0LvZ8fiHWHrIkg1m3JbyloG6mKDlsSlO1qnIPUaAB4V62Tbnmfv3I0qp1UvNuw==}
+  '@lexical/hashtag@0.48.0':
+    resolution: {integrity: sha512-hPQtdnbVoNAFsmfnCGfgY7mDbvk6mIznlCRmIR7tLeQKXqz/0Tb6eH3W24EESk9hAF8wFUYNKWE1/Kb3Hl2vEQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/headless@0.45.0':
-    resolution: {integrity: sha512-nzVqV3ne3+6jZainCdYUtKNBRSOb1AOGXDDSypWEFuMGLINV/gYAvLRlsFjp7hauo1ZuAySpWYkQcw6ltKappQ==}
+  '@lexical/headless@0.48.0':
+    resolution: {integrity: sha512-GvSFcmsRU4whY/ctyAxFV2MuYKIDt5w951GDS4QtV9R0iZLnZcVmr/Fd7DV23BX+DJt4sdfuGAEbDIPBxWJPWA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/history@0.45.0':
-    resolution: {integrity: sha512-KihtI8485Wx7kyFCtKNKk/nO2jSibRa8iL0OiKPZsYWVAQF5vFG3J00epX8EkEpeCx8Zjmj+3eytY05HPNd2nA==}
+  '@lexical/history@0.48.0':
+    resolution: {integrity: sha512-NllvUfO+u3mfi5uC8k2CodwdzeeopFFVtMZ/NMifzFbZFysdWi9m9mqfO46NrEA1rSFOydyefv6oMzC8ULXInA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/html@0.45.0':
-    resolution: {integrity: sha512-eK215f25cnAcIzNB1iRltg8hbvkK5wyyXvKQUqhfG/9HaSSVBCPuCyXKZicjZllQNvbFINGHFhTIqSP56drFSw==}
+  '@lexical/html@0.48.0':
+    resolution: {integrity: sha512-uBxlgKl4YgSNEgHJSshdBqtGDzruWdx1ewop+u6faT67qHUdP3P0cUXIrG6NToDWvsL6fzCstAbN76PMER1Pnw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/internal@0.45.0':
-    resolution: {integrity: sha512-IhyzCdb1/xdpTtvK0xnqUXpaVRsD2KTZ6EMZpavm6dhKaglf1zorpdbH7r6Hjps6SRb4DCn/t7lac+GMdDFbXg==}
+  '@lexical/internal@0.48.0':
+    resolution: {integrity: sha512-sRwg53K7N0ZQ7KNAvcCY38LSwGizbXP1zlR1lIojZp0GoqHWNvR+vL49t1wYXu1nXx3Osf4ilHHm+aGcwq5hTw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/link@0.45.0':
-    resolution: {integrity: sha512-9xpsRQ06IA4eVnx4OtFV0+Tmp2Etvh0dh9FTFd/LJYaqo2A0ZIuNUggueDZ0i2dhi8wWW8J08O7U0HxLcDWHAg==}
+  '@lexical/link@0.48.0':
+    resolution: {integrity: sha512-E0UDmNLUXs/yMCnnE7hbFO0CvhWghmqa+qqPksFfzLkpMHdPpdS1yg59YEbYoNHLi/DXIu4cFRvpHIEuooxwNg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/list@0.45.0':
-    resolution: {integrity: sha512-Eyff9KVLu5mV4QSid2aw9uYmKDKgDYToAaagI9Sp3VgqTMmvRUQJ0w7sr4zq8/FRKSzrsf4V2FjvLAuQE7eBUQ==}
+  '@lexical/list@0.48.0':
+    resolution: {integrity: sha512-9Qe/Vur44v9F9enj55SUzf79FVsijcGOQug7SpiIU8ekLr7JNzcilKYBYcZ6etGEo7bqQHsYMHXeJcSBbCI2zA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/mark@0.45.0':
-    resolution: {integrity: sha512-PMyGmnF6koE5TKCDlGe1k1t1ZOefReyYaKtx6OY3Tf1AyyKII6zRGR+dANrgWzYliYO7j4mpKBK00ykOnuF3zA==}
+  '@lexical/mark@0.48.0':
+    resolution: {integrity: sha512-DTtypWvnYSXyNUxEmsUnh4y0xXkmdk8Y72EZl8WDHcCwjqaLJlUakH7p/TuSJczs3uVSaoJzu0yh7oGkP1Vsvw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/markdown@0.45.0':
-    resolution: {integrity: sha512-fl/UUwudBXGnz44kOS07ZRN0DMfOWNnVl7GSSNyz6zDo1cMD60URt7LjF51bAG2oL8i1eRDX4/GV+7vBcuoGzw==}
+  '@lexical/markdown@0.48.0':
+    resolution: {integrity: sha512-1WasBenW4bEsa5xtnycVo8G2hcxIqyYLn3/r98yD2Y+54ZyeFuIQfOeJYhIgCh4YkKpfqyrFwkMQwAOsQDqZjA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/overflow@0.45.0':
-    resolution: {integrity: sha512-iw6Gc85phIGEjAFRDLiGOrnxK/EjyRlEfQHI7BeU0m+qHDCc94cThbeuaPTC7nnxHytFbRdtJIhoQvvcUR+PKA==}
+  '@lexical/overflow@0.48.0':
+    resolution: {integrity: sha512-1YEvMz2tW3EbwrON9mjrkjMVl/vdTcPYSn9P1j6mf5gj0LOoLDNI4TbvSD4SViy+TDghxNdG8YdCISyU2b4YKA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/plain-text@0.45.0':
-    resolution: {integrity: sha512-453bsKVk3oY5/ktp3A2zO2nFdXniU/zfD87eIcN50aXrIwvNm082GkfmBaDeVujk7fLgC2hG980xdcEH4xcG3w==}
+  '@lexical/plain-text@0.48.0':
+    resolution: {integrity: sha512-q4f/4VZKVgCrIW2FhDFR2RII1BU0ljedPgEmJ8XQn1zc+JOFPom8Lp0lV5nyEvZaAJYwM/TfoJ9g2V7ESFKznA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@lexical/react@0.45.0':
-    resolution: {integrity: sha512-LAaceAtcQpVMDvldhkrQC1MSawpj7aAm1CfGg6RbyQgTDDp2fKnP1gDhjQIef3lH8W2fYeXRe66EdzaFkoGHKA==}
+  '@lexical/react@0.48.0':
+    resolution: {integrity: sha512-uVh9/QSrbtjLjVbxfJ+sfiMyhUq/rv7H6uBEVDDIw1rkZJSDY1fvf/CX+dyKgwcDFjKQZ8/9i5f9UCVPeQ01hA==}
     peerDependencies:
       react: 19.2.6
       react-dom: 19.2.6
+      typescript: '>=5.2'
       yjs: '>=13.5.22'
     peerDependenciesMeta:
+      typescript:
+        optional: true
       yjs:
         optional: true
 
-  '@lexical/rich-text@0.45.0':
-    resolution: {integrity: sha512-jd+jIsDirqILuUQiNUJAzZWynVZHuN1ekqYcydgDFaUXMFBQgVr3mBUieQzMw2IDAEk98txntu/mZQav4BryQQ==}
-
-  '@lexical/selection@0.45.0':
-    resolution: {integrity: sha512-V2DYMhl84F1aZ24YpWMMqy9ikO7cVfD3G+GjMwrZnMt0JVnIghjPiYIEBb/OtqqA+mCbBwNhfpdK1RtF9HTbJA==}
-
-  '@lexical/table@0.45.0':
-    resolution: {integrity: sha512-OXbwEg0DqkTdvqnu7z+/u8bgnDz2sjHHXCG3zGRhEzDgHcWoVQ18IciwMdse7dTTNfBIJMuGJcRoWPrHf9UlhQ==}
-
-  '@lexical/text@0.45.0':
-    resolution: {integrity: sha512-ozI8fDsLTYAzEWXaBrGYZ0GnRbbIHi4IL99w5q06UfTQzBMYmF7WaccDP1krOOwwioPYQbiqZM7dh/41jsFELQ==}
-
-  '@lexical/utils@0.45.0':
-    resolution: {integrity: sha512-Fo5MMErqoPlUyTw1qVMZ9kE33ZjJF957KU683tsCrrlaVisVxpboL7BbAnxWTwCcIpAsfc6AUndJJ70M9NDMGg==}
-
-  '@lexical/yjs@0.45.0':
-    resolution: {integrity: sha512-HYbOovvOavtF1S7C13l9g21s4MFLLd/o49qdn+/uGj23j4yjG556XBSrF0c3BREXDXSUr+RTbI6uiQ+L5Ofcmw==}
+  '@lexical/rich-text@0.48.0':
+    resolution: {integrity: sha512-QMXFnwCKAQ4yzxvx5FwmANcx3K+NaBkGTxAVD8s8pOKDD/U5rzDS1iIvhH6TLWaFp7VzvLmLB+Sl1Ie/RnkaDQ==}
     peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/selection@0.48.0':
+    resolution: {integrity: sha512-Uc0wTrEtHcYK6z/aHHjkgH3vX/R4Bf8mO+qH3VbxfSAKYzNYktM0j+ZGdq5kIEL4frnw/9SulNCXlH7xpjuDgA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/table@0.48.0':
+    resolution: {integrity: sha512-t9Mz7q6ODLUz0lG5Xn9EY/5YiVpTHCqlPQP4EtFXlnBQT3DuKeDS3cC0Cn8sGSZc11YY5OLDfWpB64Frs9BL3g==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/text@0.48.0':
+    resolution: {integrity: sha512-ktTMRbsX4wKxdG2OpZCkrqtt8k9Vg/ZpWdukOQ0r1xPRtCuL1T+q91l7cy2ywIuCfMGYS0aoZGB4LdpUMe/H1g==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/utils@0.48.0':
+    resolution: {integrity: sha512-W4k4P+y6jmRfna8+ad4X+iMd5h8es5PC3bUw5tbi7MRApxaaFG/0w+uJiZVSwbT2Q6JnA2xhBaqzPgt/Gn6djg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/yjs@0.48.0':
+    resolution: {integrity: sha512-fFsE8EnPM/2KK9rMJ0z6T+Da5UW5V4P+XiAA03LoHTY5YQ/Oy8Q0i7Wcmocv/B/SpsY2o8g07euZEfudl9MVKA==}
+    peerDependencies:
+      typescript: '>=5.2'
       yjs: '>=13.5.22'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@libsql/client@0.14.0':
     resolution: {integrity: sha512-/9HEKfn6fwXB5aTEEoMeFh4CtG0ZzbncBb1e++OCdVpgKZ/xyMsIVYXm0w7Pv4RUel803vE6LwniB3PqD72R0Q==}
@@ -12091,8 +12214,13 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lexical@0.45.0:
-    resolution: {integrity: sha512-z2M9C2ILPW7SopQE1aKbOFdZJbe3HvsrgWnJKveMDrSEvVjU9Hce4UpKVsAdkwY7TgY9RDuCV3+sfrGu0WkL+w==}
+  lexical@0.48.0:
+    resolution: {integrity: sha512-KK4Tyr/cPsleoZ7XvhGRiRmcrZidSmoFUdIXK9nPubIifoC+80Dc5THyc4xtGKtsW24S1TsHzk5gmfBU+TxmEg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
@@ -18455,196 +18583,252 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@lexical/clipboard@0.45.0':
+  '@lexical/a11y@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.45.0
-      '@lexical/html': 0.45.0
-      '@lexical/internal': 0.45.0
-      '@lexical/list': 0.45.0
-      '@lexical/selection': 0.45.0
-      '@lexical/utils': 0.45.0
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@lexical/clipboard@0.48.0(typescript@7.0.2)':
+    dependencies:
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/html': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/list': 0.48.0(typescript@7.0.2)
+      '@lexical/selection': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
       '@types/trusted-types': 2.0.7
-      lexical: 0.45.0
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/code-core@0.45.0':
+  '@lexical/code-core@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.45.0
-      '@lexical/html': 0.45.0
-      '@lexical/internal': 0.45.0
-      lexical: 0.45.0
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/html': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/devtools-core@0.45.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@lexical/devtools-core@0.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2)':
     dependencies:
-      '@lexical/html': 0.45.0
-      '@lexical/link': 0.45.0
-      '@lexical/mark': 0.45.0
-      '@lexical/table': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/html': 0.48.0(typescript@7.0.2)
+      '@lexical/link': 0.48.0(typescript@7.0.2)
+      '@lexical/mark': 0.48.0(typescript@7.0.2)
+      '@lexical/table': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/dragon@0.45.0':
+  '@lexical/dragon@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.45.0
-      lexical: 0.45.0
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/eslint-plugin@0.45.0(eslint@9.39.2(jiti@2.7.0))':
+  '@lexical/eslint-plugin@0.48.0(eslint@9.39.2(jiti@2.7.0))(typescript@7.0.2)':
     dependencies:
       eslint: 9.39.2(jiti@2.7.0)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/extension@0.45.0':
+  '@lexical/extension@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.45.0
-      '@lexical/utils': 0.45.0
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
       '@preact/signals-core': 1.14.4
-      lexical: 0.45.0
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/hashtag@0.45.0':
+  '@lexical/hashtag@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/text': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/text': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/headless@0.45.0(bufferutil@4.1.0)':
+  '@lexical/headless@0.48.0(bufferutil@4.1.0)(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.45.0
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
       happy-dom: 20.10.6(bufferutil@4.1.0)
-      lexical: 0.45.0
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@lexical/history@0.45.0':
+  '@lexical/history@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/html@0.45.0':
+  '@lexical/html@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.45.0
-      '@lexical/internal': 0.45.0
-      '@lexical/selection': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/selection': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/internal@0.45.0': {}
+  '@lexical/internal@0.48.0(typescript@7.0.2)':
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/link@0.45.0':
+  '@lexical/link@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.45.0
-      '@lexical/html': 0.45.0
-      '@lexical/internal': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/html': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/list@0.45.0':
+  '@lexical/list@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.45.0
-      '@lexical/html': 0.45.0
-      '@lexical/internal': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/html': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/mark@0.45.0':
+  '@lexical/mark@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/markdown@0.45.0':
+  '@lexical/markdown@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/code-core': 0.45.0
-      '@lexical/internal': 0.45.0
-      '@lexical/link': 0.45.0
-      '@lexical/list': 0.45.0
-      '@lexical/rich-text': 0.45.0
-      '@lexical/selection': 0.45.0
-      '@lexical/text': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/code-core': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/link': 0.48.0(typescript@7.0.2)
+      '@lexical/list': 0.48.0(typescript@7.0.2)
+      '@lexical/rich-text': 0.48.0(typescript@7.0.2)
+      '@lexical/selection': 0.48.0(typescript@7.0.2)
+      '@lexical/text': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/overflow@0.45.0':
+  '@lexical/overflow@0.48.0(typescript@7.0.2)':
     dependencies:
-      lexical: 0.45.0
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/plain-text@0.45.0':
+  '@lexical/plain-text@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.45.0
-      '@lexical/dragon': 0.45.0
-      '@lexical/extension': 0.45.0
-      '@lexical/selection': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/clipboard': 0.48.0(typescript@7.0.2)
+      '@lexical/dragon': 0.48.0(typescript@7.0.2)
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/selection': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/react@0.45.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.31)':
+  '@lexical/react@0.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(yjs@13.6.31)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@lexical/devtools-core': 0.45.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@lexical/dragon': 0.45.0
-      '@lexical/extension': 0.45.0
-      '@lexical/hashtag': 0.45.0
-      '@lexical/history': 0.45.0
-      '@lexical/internal': 0.45.0
-      '@lexical/link': 0.45.0
-      '@lexical/list': 0.45.0
-      '@lexical/mark': 0.45.0
-      '@lexical/markdown': 0.45.0
-      '@lexical/overflow': 0.45.0
-      '@lexical/plain-text': 0.45.0
-      '@lexical/rich-text': 0.45.0
-      '@lexical/table': 0.45.0
-      '@lexical/text': 0.45.0
-      '@lexical/utils': 0.45.0
-      '@lexical/yjs': 0.45.0(yjs@13.6.31)
-      lexical: 0.45.0
+      '@lexical/a11y': 0.48.0(typescript@7.0.2)
+      '@lexical/devtools-core': 0.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
+      '@lexical/dragon': 0.48.0(typescript@7.0.2)
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/hashtag': 0.48.0(typescript@7.0.2)
+      '@lexical/history': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/link': 0.48.0(typescript@7.0.2)
+      '@lexical/list': 0.48.0(typescript@7.0.2)
+      '@lexical/mark': 0.48.0(typescript@7.0.2)
+      '@lexical/markdown': 0.48.0(typescript@7.0.2)
+      '@lexical/overflow': 0.48.0(typescript@7.0.2)
+      '@lexical/plain-text': 0.48.0(typescript@7.0.2)
+      '@lexical/rich-text': 0.48.0(typescript@7.0.2)
+      '@lexical/table': 0.48.0(typescript@7.0.2)
+      '@lexical/text': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      '@lexical/yjs': 0.48.0(typescript@7.0.2)(yjs@13.6.31)
+      lexical: 0.48.0(typescript@7.0.2)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-error-boundary: 6.1.1(react@19.2.6)
     optionalDependencies:
+      typescript: 7.0.2
       yjs: 13.6.31
 
-  '@lexical/rich-text@0.45.0':
+  '@lexical/rich-text@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.45.0
-      '@lexical/dragon': 0.45.0
-      '@lexical/extension': 0.45.0
-      '@lexical/html': 0.45.0
-      '@lexical/selection': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/clipboard': 0.48.0(typescript@7.0.2)
+      '@lexical/dragon': 0.48.0(typescript@7.0.2)
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/html': 0.48.0(typescript@7.0.2)
+      '@lexical/selection': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/selection@0.45.0':
+  '@lexical/selection@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.45.0
-      lexical: 0.45.0
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/table@0.45.0':
+  '@lexical/table@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.45.0
-      '@lexical/extension': 0.45.0
-      '@lexical/html': 0.45.0
-      '@lexical/internal': 0.45.0
-      '@lexical/utils': 0.45.0
-      lexical: 0.45.0
+      '@lexical/clipboard': 0.48.0(typescript@7.0.2)
+      '@lexical/extension': 0.48.0(typescript@7.0.2)
+      '@lexical/html': 0.48.0(typescript@7.0.2)
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/utils': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/text@0.45.0':
+  '@lexical/text@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.45.0
-      lexical: 0.45.0
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/utils@0.45.0':
+  '@lexical/utils@0.48.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.45.0
-      '@lexical/selection': 0.45.0
-      lexical: 0.45.0
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/selection': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
-  '@lexical/yjs@0.45.0(yjs@13.6.31)':
+  '@lexical/yjs@0.48.0(typescript@7.0.2)(yjs@13.6.31)':
     dependencies:
-      '@lexical/internal': 0.45.0
-      '@lexical/selection': 0.45.0
-      lexical: 0.45.0
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+      '@lexical/selection': 0.48.0(typescript@7.0.2)
+      lexical: 0.48.0(typescript@7.0.2)
       yjs: 13.6.31
+    optionalDependencies:
+      typescript: 7.0.2
 
   '@libsql/client@0.14.0(bufferutil@4.1.0)':
     dependencies:
@@ -26216,9 +26400,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lexical@0.45.0:
+  lexical@0.48.0(typescript@7.0.2):
     dependencies:
-      '@lexical/internal': 0.45.0
+      '@lexical/internal': 0.48.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
 
   lib0@0.2.117:
     dependencies:


### PR DESCRIPTION
Upgrades `lexical` and every `@lexical/*` package from `0.45.0` to `0.48.0`.

## Changes required

Lexical widened the base `importJSON` parameter to include `Record<string, unknown>`, which a TypeScript `interface` cannot satisfy. Four nodes (link, autolink, and both horizontal rules) intersect their serialized type with it to compensate, which needs no casts and leaves the serialized types alone.

## Also included

Fifteen `@lexical/react` subpaths are re-exported to reach parity with lexical exports. Payload's local `getScrollParent` copy is deleted now that `@lexical/utils` exports it.

## Lexical Breaking Changes


- [v0.48.0](https://github.com/facebook/lexical/releases/tag/v0.48.0) - no breaking changes.
- [v0.47.0](https://github.com/facebook/lexical/releases/tag/v0.47.0)
  - Composing on the middle of a segmented `TextNode` now preserves the DOM element. **No action** - IME-only internal change.
- [v0.46.0](https://github.com/facebook/lexical/releases/tag/v0.46.0)
  - **`static importJSON` widened its parameter** to `SerializedLexicalNode & Record<string, unknown>`. Not labelled breaking upstream, but it is for any subclass that narrows the parameter: a TypeScript `interface` cannot satisfy `Record<string, unknown>`. **Action taken** - four of our nodes now intersect their serialized type with it.
  - **Node traversal type parameters deprecated.** `$getNodeByKey<T>(key)` and friends resolve to `LexicalNode | null` now that a non-generic overload wins inference. **Action taken** - one call site switched to a type guard.
  - Removed exports deprecated since v0.32.1: `toggleLink`, `insertList`, `removeList`, and `ContentEditable`'s `Props` alias. **No action** - Payload defines its own `$toggleLink` and never imported the others.
  - Named slots, which have two observable effects: a new `dirtyLeaves` parameter on `syncLexicalUpdateToYjsV2__EXPERIMENTAL`, and element `NodeSelection`s now including their children in copy and export. **No action** - we have no `@lexical/yjs` dependency and call neither `$getHtmlContent` nor `$generateJSONFromSelectedNodes`.
  - `insertNodes` preserves a leading linebreak, and reconciler-managed `<br>`s are tagged `data-lexical-managed-linebreak="true"`. **No action** - but expect the attribute if you assert on editor DOM.
  - `DOMImportExtension` rules now register implicitly via node extensions. **No action.**
  - Captured selection generalized via `setDOMUnmanaged(captureSelection)`. **No action** - API unused by Payload.