### PR TITLE
fix(plugin-cloud-storage): prevent skipCloudStorage leaking onto shared request context

### DIFF
--- a/packages/plugin-cloud-storage/src/hooks/afterChange.spec.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.spec.ts
@@ -1,0 +1,132 @@
+import type { CollectionConfig, FileData, PayloadRequest, RequestContext, TypeWithID } from 'payload'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GeneratedAdapter } from '../types.js'
+
+import { getAfterChangeHook } from './afterChange.js'
+
+const collection = { slug: 'media' } as CollectionConfig
+
+const doc = {
+  id: 1,
+  filename: 'test.png',
+  mimeType: 'image/png',
+} as unknown as FileData & TypeWithID
+
+const createAdapter = () =>
+  ({
+    name: 'mock',
+    handleDelete: vi.fn(),
+    handleUpload: vi.fn().mockResolvedValue({ url: 'https://example.com/test.png' }),
+    staticHandler: vi.fn(),
+  }) as unknown as GeneratedAdapter
+
+/**
+ * Builds a req whose `payload.update` mimics the Local API: when a nested
+ * operation receives a req that already has a non-empty context,
+ * `createLocalReq` re-binds `req.context` to a shallow copy of it
+ * (see `getRequestContext` in `packages/payload/src/utilities/createLocalReq.ts`).
+ */
+const createReq = (
+  context: RequestContext,
+  options?: { onUpdate?: (req: PayloadRequest) => Promise<void> | void },
+): PayloadRequest => {
+  const req = {
+    context,
+    file: {
+      name: 'test.png',
+      data: Buffer.from('test'),
+      mimetype: 'image/png',
+      size: 4,
+    },
+    payload: {
+      logger: { error: vi.fn() },
+      update: vi.fn().mockImplementation(async () => {
+        await options?.onUpdate?.(req as unknown as PayloadRequest)
+        req.context = { ...req.context }
+        return doc
+      }),
+    },
+  }
+
+  return req as unknown as PayloadRequest
+}
+
+describe('getAfterChangeHook', () => {
+  it('does not leak skipCloudStorage onto a caller-provided context object', async () => {
+    const sharedContext: RequestContext = {}
+    const hook = getAfterChangeHook({ adapter: createAdapter(), collection })
+
+    await hook({
+      doc,
+      operation: 'create',
+      previousDoc: undefined,
+      req: createReq(sharedContext),
+    } as Parameters<typeof hook>[0])
+
+    expect('skipCloudStorage' in sharedContext).toBe(false)
+  })
+
+  it('uploads files on subsequent operations that reuse the same context object', async () => {
+    const sharedContext: RequestContext = {}
+    const adapter = createAdapter()
+    const hook = getAfterChangeHook({ adapter, collection })
+
+    // Sequential Local API calls sharing one context object, each with its
+    // own req - the seed/import-script pattern from #17546.
+    for (let i = 0; i < 3; i++) {
+      await hook({
+        doc,
+        operation: 'create',
+        previousDoc: undefined,
+        req: createReq(sharedContext),
+      } as Parameters<typeof hook>[0])
+    }
+
+    expect(adapter.handleUpload).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps the flag set during the nested metadata update to prevent recursion', async () => {
+    let flagDuringUpdate: unknown
+    const req = createReq(
+      {},
+      {
+        onUpdate: (updateReq) => {
+          flagDuringUpdate = updateReq.context.skipCloudStorage
+        },
+      },
+    )
+    const hook = getAfterChangeHook({ adapter: createAdapter(), collection })
+
+    await hook({
+      doc,
+      operation: 'create',
+      previousDoc: undefined,
+      req,
+    } as Parameters<typeof hook>[0])
+
+    expect(flagDuringUpdate).toBe(true)
+    // Cleaned up from the re-bound req.context as well, so later writes
+    // reusing this req are not skipped.
+    expect(req.context.skipCloudStorage).toBeUndefined()
+  })
+
+  it('removes the flag from the shared context even when the nested update rejects', async () => {
+    const sharedContext: RequestContext = {}
+    const req = createReq(sharedContext)
+    ;(req.payload.update as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('update failed'))
+    const hook = getAfterChangeHook({ adapter: createAdapter(), collection })
+
+    await expect(
+      hook({
+        doc,
+        operation: 'create',
+        previousDoc: undefined,
+        req,
+      } as Parameters<typeof hook>[0]),
+    ).rejects.toThrow('update failed')
+
+    expect('skipCloudStorage' in sharedContext).toBe(false)
+  })
+})

--- a/packages/plugin-cloud-storage/src/hooks/afterChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.ts
@@ -54,7 +54,14 @@ export const getAfterChangeHook =
           if (!req.context) {
             req.context = {}
           }
-          req.context.skipCloudStorage = true
+
+          // Capture the context object before the nested update. The Local API
+          // may re-bind req.context to a shallow copy, so the flag must be
+          // removed from this same reference afterwards - otherwise it would
+          // leak onto a caller-provided context object shared across Local API
+          // calls, silently skipping every subsequent upload.
+          const hookContext = req.context
+          hookContext.skipCloudStorage = true
 
           // Clear to prevent re-processing
           req.file = undefined
@@ -70,7 +77,14 @@ export const getAfterChangeHook =
               req,
             })
           } finally {
-            delete req.context.skipCloudStorage
+            delete hookContext.skipCloudStorage
+
+            // The nested update may have re-bound req.context to a copy that
+            // also carries the flag - clean it up so later writes reusing this
+            // req are not skipped.
+            if (req.context !== hookContext) {
+              delete req.context.skipCloudStorage
+            }
           }
 
           docWithMetadata = { ...doc, ...uploadMetadata }


### PR DESCRIPTION
Fixes #17546, reported by @edrpls, following the reporter's suggested approach.

Verified the exact mechanism traced in the issue: the plugin-cloud-storage `afterChange` hook sets `skipCloudStorage` on `req.context`, but the nested `req.payload.update({..., req})` runs `createLocalReq` -> `getRequestContext`, which re-binds `req.context` to a shallow copy. The `finally` cleanup then deletes the flag from that copy while the caller's shared context object keeps it forever, so every later `payload.create` sharing that object hits the early return and silently skips the upload.

The fix captures the context reference into a local before the nested update and deletes the flag from that same reference, plus cleans it from the re-bound copy so later writes reusing the same `req` are not skipped either. No new deps, no refactors.

Four unit tests cover the leak, the multi-create reuse pattern, recursion prevention during the nested update, and cleanup on rejection; exactly the two leak-regression tests fail on unfixed code. Plugin suite: 23 passed, zero new failures; eslint clean on the impl.
