### PR TITLE
chore(plugin-mcp): add telemetry

### DIFF
--- a/packages/plugin-mcp/src/exports/internal.ts
+++ b/packages/plugin-mcp/src/exports/internal.ts
@@ -1,1 +1,2 @@
 export { filterMCPItems, getAuthorizedMCP } from '../endpoint/access.js'
+export { MCP_TOOL_TELEMETRY_MARKER } from '../types.js'

--- a/packages/plugin-mcp/src/mcp/buildMcpServer.ts
+++ b/packages/plugin-mcp/src/mcp/buildMcpServer.ts
@@ -13,6 +13,8 @@ import type {
   ToolInputSchema,
 } from '../types.js'
 
+import { withMcpErrorType } from '../telemetry/errorType.js'
+import { createMcpServerTelemetry } from '../telemetry/index.js'
 import { getLogger } from '../utils/getLogger.js'
 import { toStandardSchema } from '../utils/toStandardSchema.js'
 
@@ -66,6 +68,8 @@ export const buildMcpServer = ({
     return rest
   }
 
+  const wrapToolHandler = createMcpServerTelemetry({ req, server })
+
   /**
    * Runs a collection/global tool call:
    * - reads `collectionSlug` / `globalSlug` from the input
@@ -87,15 +91,18 @@ export const buildMcpServer = ({
     const slug = toolInput[slugKey] as string | undefined
 
     if (!slug) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error: "${item.mcpName}" requires ${slugKey}. Use getConfigInfo to inspect ${entity} slugs.`,
-          },
-        ],
-        isError: true,
-      }
+      return withMcpErrorType({
+        errorType: 'bad-request',
+        response: {
+          content: [
+            {
+              type: 'text',
+              text: `Error: "${item.mcpName}" requires ${slugKey}. Use getConfigInfo to inspect ${entity} slugs.`,
+            },
+          ],
+          isError: true,
+        },
+      })
     }
 
     const match = authorizedMCP.items.find(
@@ -108,15 +115,18 @@ export const buildMcpServer = ({
     )
 
     if (!match) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error: MCP access to "${item.mcpName}" is not enabled for ${entity} "${slug}"`,
-          },
-        ],
-        isError: true,
-      }
+      return withMcpErrorType({
+        errorType: 'access',
+        response: {
+          content: [
+            {
+              type: 'text',
+              text: `Error: MCP access to "${item.mcpName}" is not enabled for ${entity} "${slug}"`,
+            },
+          ],
+          isError: true,
+        },
+      })
     }
 
     const handlerArgs = {
@@ -161,8 +171,9 @@ export const buildMcpServer = ({
               description: item.tool.description,
               inputSchema: toStandardSchema(inputSchema),
             },
-            async (input: unknown, ctx: ServerContext) =>
+            wrapToolHandler(item, async (input, ctx) =>
               callEntityTool({ input, item, serverContext: ctx }),
+            ),
           )
           logger.info(`✅ Tool: ${item.mcpName} Registered.`)
           break
@@ -218,7 +229,7 @@ export const buildMcpServer = ({
               description: tool.description,
               inputSchema: tool.input ? toStandardSchema(tool.input) : undefined,
             },
-            async (input: unknown, ctx: ServerContext) => {
+            wrapToolHandler(item, async (input, ctx) => {
               const toolInput = (input ?? {}) as Record<string, unknown>
               const response = await tool.handler({
                 authorizedMCP,
@@ -232,7 +243,7 @@ export const buildMcpServer = ({
                 response,
                 toolName: item.mcpName,
               })
-            },
+            }),
           )
           logger.info(`✅ Tool: ${item.mcpName} Registered.`)
           break

--- a/packages/plugin-mcp/src/mcp/buildMcpServer.ts
+++ b/packages/plugin-mcp/src/mcp/buildMcpServer.ts
@@ -68,7 +68,7 @@ export const buildMcpServer = ({
     return rest
   }
 
-  const wrapToolHandler = createMcpServerTelemetry({ req, server })
+  const wrapToolHandler = createMcpServerTelemetry({ req })
 
   /**
    * Runs a collection/global tool call:

--- a/packages/plugin-mcp/src/mcp/builtin/collections/createTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/createTool.ts
@@ -1,9 +1,13 @@
 import type { SelectType } from 'payload'
 
+import { ValidationError } from 'payload'
 import { z } from 'zod'
+
+import type { MCPToolResponse } from '../../../types.js'
 
 import { defaultAccess } from '../../../defaultAccess.js'
 import { defineCollectionTool } from '../../../defineTool.js'
+import { withMcpErrorType } from '../../../telemetry/errorType.js'
 import { getLogger } from '../../../utils/getLogger.js'
 import {
   getCollectionVirtualFieldNames,
@@ -85,6 +89,8 @@ export const createDocumentsTool = defineCollectionTool({
     const virtualFieldNames = getCollectionVirtualFieldNames(payload.config, collectionSlug)
     const docs: Array<{ doc: Record<string, unknown>; index: number }> = []
     const errors: Array<{ index: number; message: string }> = []
+    let hasNonValidationError = false
+    let hasValidationError = false
     let validationSchema: Record<string, unknown> | undefined
 
     for (const [index, document] of documents.entries()) {
@@ -93,6 +99,7 @@ export const createDocumentsTool = defineCollectionTool({
         const validationError = validateCollectionData({ collectionSlug, data: inputData, req })
 
         if (validationError) {
+          hasValidationError = true
           const firstContent = validationError.content[0]
           const validationContent = validationError.structuredContent as
             | Record<string, unknown>
@@ -132,6 +139,11 @@ export const createDocumentsTool = defineCollectionTool({
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
 
+        if (error instanceof ValidationError) {
+          hasValidationError = true
+        } else {
+          hasNonValidationError = true
+        }
         logger.error(`Error creating document at index ${index} in ${collectionSlug}: ${message}`)
         errors.push({ index, message })
       }
@@ -148,7 +160,7 @@ export const createDocumentsTool = defineCollectionTool({
 
     logger.info(`Created ${docs.length} of ${documents.length} documents in ${collectionSlug}`)
 
-    return {
+    const response: MCPToolResponse = {
       content: [
         {
           type: 'text',
@@ -159,6 +171,10 @@ export const createDocumentsTool = defineCollectionTool({
       isError: docs.length === 0 && errors.length > 0,
       structuredContent,
     }
+
+    return response.isError && hasValidationError && !hasNonValidationError
+      ? withMcpErrorType({ errorType: 'validation', response })
+      : response
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error'
 

--- a/packages/plugin-mcp/src/mcp/builtin/collections/formatCollectionError.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/formatCollectionError.ts
@@ -1,7 +1,10 @@
 import type { CollectionSlug, PayloadRequest } from 'payload'
 
+import { ValidationError } from 'payload'
+
 import type { MCPToolResponse } from '../../../types.js'
 
+import { withMcpErrorType } from '../../../telemetry/errorType.js'
 import { getCollectionInputSchema } from '../../../utils/schemaConversion/getEntityInputSchema.js'
 
 const getValidationErrors = (error: unknown): undefined | unknown[] => {
@@ -63,7 +66,7 @@ export const formatCollectionError = ({
     ? `\n\nUse this schema for data:\n\`\`\`json\n${JSON.stringify(schema)}\n\`\`\``
     : ''
 
-  return {
+  const response: MCPToolResponse = {
     content: [
       {
         type: 'text',
@@ -81,4 +84,8 @@ export const formatCollectionError = ({
         }
       : {}),
   }
+
+  return error instanceof ValidationError
+    ? withMcpErrorType({ errorType: 'validation', response })
+    : response
 }

--- a/packages/plugin-mcp/src/mcp/builtin/collections/getCollectionSchemaTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/getCollectionSchemaTool.ts
@@ -2,6 +2,7 @@ import { getAccessResults } from 'payload'
 
 import { defaultAccess } from '../../../defaultAccess.js'
 import { defineCollectionTool } from '../../../defineTool.js'
+import { withMcpErrorType } from '../../../telemetry/errorType.js'
 import { getCollectionInputSchema } from '../../../utils/schemaConversion/getEntityInputSchema.js'
 
 export const getCollectionSchemaTool = defineCollectionTool({
@@ -24,15 +25,18 @@ export const getCollectionSchemaTool = defineCollectionTool({
     : (await getAccessResults({ req })).collections?.[collectionSlug]
 
   if (!authorizedMCP.overrideAccess && !permissions?.create && !permissions?.update) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Error: MCP access to "getCollectionSchema" is not enabled for collection "${collectionSlug}"`,
-        },
-      ],
-      isError: true,
-    }
+    return withMcpErrorType({
+      errorType: 'access',
+      response: {
+        content: [
+          {
+            type: 'text',
+            text: `Error: MCP access to "getCollectionSchema" is not enabled for collection "${collectionSlug}"`,
+          },
+        ],
+        isError: true,
+      },
+    })
   }
 
   const inputSchema = getCollectionInputSchema({
@@ -42,10 +46,13 @@ export const getCollectionSchemaTool = defineCollectionTool({
   })
 
   if (!inputSchema) {
-    return {
-      content: [{ type: 'text', text: `Error: Collection "${collectionSlug}" not found` }],
-      isError: true,
-    }
+    return withMcpErrorType({
+      errorType: 'bad-request',
+      response: {
+        content: [{ type: 'text', text: `Error: Collection "${collectionSlug}" not found` }],
+        isError: true,
+      },
+    })
   }
 
   const uploadConfig = req.payload.collections[collectionSlug]?.config.upload

--- a/packages/plugin-mcp/src/mcp/builtin/globals/getGlobalSchemaTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/globals/getGlobalSchemaTool.ts
@@ -2,6 +2,7 @@ import { getAccessResults } from 'payload'
 
 import { defaultAccess } from '../../../defaultAccess.js'
 import { defineGlobalTool } from '../../../defineTool.js'
+import { withMcpErrorType } from '../../../telemetry/errorType.js'
 import { getGlobalInputSchema } from '../../../utils/schemaConversion/getEntityInputSchema.js'
 
 export const getGlobalSchemaTool = defineGlobalTool({
@@ -24,15 +25,18 @@ export const getGlobalSchemaTool = defineGlobalTool({
     : (await getAccessResults({ req })).globals?.[globalSlug]
 
   if (!authorizedMCP.overrideAccess && !permissions?.update) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Error: MCP access to "getGlobalSchema" is not enabled for global "${globalSlug}"`,
-        },
-      ],
-      isError: true,
-    }
+    return withMcpErrorType({
+      errorType: 'access',
+      response: {
+        content: [
+          {
+            type: 'text',
+            text: `Error: MCP access to "getGlobalSchema" is not enabled for global "${globalSlug}"`,
+          },
+        ],
+        isError: true,
+      },
+    })
   }
 
   const inputSchema = getGlobalInputSchema({
@@ -42,10 +46,13 @@ export const getGlobalSchemaTool = defineGlobalTool({
   })
 
   if (!inputSchema) {
-    return {
-      content: [{ type: 'text', text: `Error: Global "${globalSlug}" not found` }],
-      isError: true,
-    }
+    return withMcpErrorType({
+      errorType: 'bad-request',
+      response: {
+        content: [{ type: 'text', text: `Error: Global "${globalSlug}" not found` }],
+        isError: true,
+      },
+    })
   }
 
   return {

--- a/packages/plugin-mcp/src/mcp/builtin/validateEntityData.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/validateEntityData.ts
@@ -4,6 +4,7 @@ import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/valida
 
 import type { JsonSchemaType, MCPToolResponse } from '../../types.js'
 
+import { withMcpErrorType } from '../../telemetry/errorType.js'
 import {
   getCollectionInputSchema,
   getGlobalInputSchema,
@@ -109,20 +110,23 @@ const validateData = ({
 
   const { schema } = entityValidator
 
-  return {
-    content: [
-      {
-        type: 'text',
-        text: `Invalid data for ${entity} "${slug}": ${result.errorMessage}\n\nUse this schema for data:\n\`\`\`json\n${JSON.stringify(schema)}\n\`\`\``,
+  return withMcpErrorType({
+    errorType: 'validation',
+    response: {
+      content: [
+        {
+          type: 'text',
+          text: `Invalid data for ${entity} "${slug}": ${result.errorMessage}\n\nUse this schema for data:\n\`\`\`json\n${JSON.stringify(schema)}\n\`\`\``,
+        },
+      ],
+      isError: true,
+      structuredContent: {
+        [`${entity}Slug`]: slug,
+        errors: [{ message: result.errorMessage }],
+        schema,
       },
-    ],
-    isError: true,
-    structuredContent: {
-      [`${entity}Slug`]: slug,
-      errors: [{ message: result.errorMessage }],
-      schema,
     },
-  }
+  })
 }
 
 /** Updates are partial — drop the schema's top-level `required` before validating. */

--- a/packages/plugin-mcp/src/mcp/sanitizeMCPConfig.ts
+++ b/packages/plugin-mcp/src/mcp/sanitizeMCPConfig.ts
@@ -18,6 +18,7 @@ import type {
 } from '../types.js'
 
 import { defaultAccess } from '../defaultAccess.js'
+import { MCP_TOOL_TELEMETRY_MARKER } from '../types.js'
 import {
   COLLECTION_AUTH_BUILTIN_ENTRIES,
   COLLECTION_AUTH_BUILTINS,
@@ -61,7 +62,11 @@ export const sanitizeMCPConfig = ({
       configKey,
       label: tool.annotations?.title ?? configKey,
       mcpName,
-      tool: { ...tool, access: tool.access ?? defaultAccess },
+      tool: {
+        ...tool,
+        access: tool.access ?? defaultAccess,
+        [MCP_TOOL_TELEMETRY_MARKER]: true,
+      },
     })
   }
 
@@ -155,6 +160,7 @@ const sanitizeCollectionConfig = ({
         access: override?.access ?? tool.access ?? defaultAccess,
         annotations,
         description: override?.description ?? tool.description,
+        [MCP_TOOL_TELEMETRY_MARKER]: true,
         overrideResponse:
           override?.overrideResponse ??
           collectionPluginConfig?.overrideResponse ??
@@ -183,6 +189,7 @@ const sanitizeCollectionConfig = ({
           access: override?.access ?? tool.access ?? defaultAccess,
           annotations,
           description: override?.description ?? tool.description,
+          [MCP_TOOL_TELEMETRY_MARKER]: true,
           overrideResponse:
             override?.overrideResponse ??
             collectionPluginConfig?.overrideResponse ??
@@ -249,6 +256,7 @@ const sanitizeGlobalConfig = ({
         access: override?.access ?? tool.access ?? defaultAccess,
         annotations,
         description: override?.description ?? tool.description,
+        [MCP_TOOL_TELEMETRY_MARKER]: true,
         overrideResponse:
           override?.overrideResponse ??
           globalPluginConfig?.overrideResponse ??

--- a/packages/plugin-mcp/src/telemetry/errorType.ts
+++ b/packages/plugin-mcp/src/telemetry/errorType.ts
@@ -1,0 +1,26 @@
+import type { MCPToolResponse } from '../types.js'
+
+export type MCPErrorType = 'access' | 'bad-request' | 'internal' | 'unknown' | 'validation'
+
+const mcpErrorType = Symbol('mcpErrorType')
+
+type TaggedMCPToolResponse = {
+  [mcpErrorType]?: MCPErrorType
+} & MCPToolResponse
+
+export const getMcpErrorType = ({ response }: { response: MCPToolResponse }): MCPErrorType =>
+  (response as TaggedMCPToolResponse)[mcpErrorType] ?? 'unknown'
+
+/**
+ * Symbols are preserved by response spreads but omitted from the serialized MCP response.
+ */
+export const withMcpErrorType = ({
+  errorType,
+  response,
+}: {
+  errorType: MCPErrorType
+  response: MCPToolResponse
+}): TaggedMCPToolResponse => ({
+  ...response,
+  [mcpErrorType]: errorType,
+})

--- a/packages/plugin-mcp/src/telemetry/index.ts
+++ b/packages/plugin-mcp/src/telemetry/index.ts
@@ -1,7 +1,6 @@
-import type { Implementation, McpServer, ServerContext } from '@modelcontextprotocol/server'
+import type { ServerContext } from '@modelcontextprotocol/server'
 import type { PayloadRequest } from 'payload'
 
-import { CLIENT_INFO_META_KEY, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/server'
 import { sendTelemetryEvent } from 'payload/internal'
 
 import type { MCPItem, MCPToolResponse } from '../types.js'
@@ -9,18 +8,7 @@ import type { MCPItem, MCPToolResponse } from '../types.js'
 import { MCP_TOOL_TELEMETRY_MARKER } from '../types.js'
 import { getMcpErrorType, type MCPErrorType } from './errorType.js'
 
-type ModernRequestEnvelope = {
-  [CLIENT_INFO_META_KEY]?: Implementation
-  [PROTOCOL_VERSION_META_KEY]?: string
-}
-
-export const createMcpServerTelemetry = ({
-  req,
-  server,
-}: {
-  req: PayloadRequest
-  server: McpServer
-}) => {
+export const createMcpServerTelemetry = ({ req }: { req: PayloadRequest }) => {
   const reportToolCall = ({
     ctx,
     errorType,
@@ -30,22 +18,13 @@ export const createMcpServerTelemetry = ({
     errorType: MCPErrorType | null
     tool: string
   }): void => {
-    const envelope = ctx.mcpReq.envelope as ModernRequestEnvelope | undefined
-    const clientInfo = envelope?.[CLIENT_INFO_META_KEY] ?? server.server.getClientVersion()
-
     void sendTelemetryEvent({
       event: {
         type: 'mcp-tool-call',
         authenticated: Boolean(req.user),
-        clientName: clientInfo?.name ?? null,
-        clientVersion: clientInfo?.version ?? null,
         errorType,
         isError: errorType !== null,
-        protocolPath: envelope ? 'modern' : 'legacy',
-        protocolVersion:
-          envelope?.[PROTOCOL_VERSION_META_KEY] ??
-          server.server.getNegotiatedProtocolVersion() ??
-          null,
+        protocolPath: ctx.mcpReq.envelope ? 'modern' : 'legacy',
         tool,
         transport: ctx.http?.req ? 'http' : 'stdio',
       },

--- a/packages/plugin-mcp/src/telemetry/index.ts
+++ b/packages/plugin-mcp/src/telemetry/index.ts
@@ -6,12 +6,7 @@ import { sendTelemetryEvent } from 'payload/internal'
 
 import type { MCPItem, MCPToolResponse } from '../types.js'
 
-import {
-  COLLECTION_AUTH_BUILTINS,
-  COLLECTION_BUILTINS,
-  GLOBAL_BUILTINS,
-  TOOL_BUILTINS,
-} from '../mcp/builtinTools.js'
+import { MCP_TOOL_TELEMETRY_MARKER } from '../types.js'
 import { getMcpErrorType, type MCPErrorType } from './errorType.js'
 
 type ModernRequestEnvelope = {
@@ -86,13 +81,5 @@ export const createMcpServerTelemetry = ({
 }
 
 // Do not send user-defined tool names to telemetry.
-const getTelemetryToolName = (item: MCPItem): string => {
-  const isBuiltin =
-    item.type === 'tool'
-      ? item.configKey in TOOL_BUILTINS
-      : item.type === 'collectionTool'
-        ? item.configKey in COLLECTION_BUILTINS || item.configKey in COLLECTION_AUTH_BUILTINS
-        : item.configKey in GLOBAL_BUILTINS
-
-  return isBuiltin ? item.mcpName : 'custom'
-}
+export const getTelemetryToolName = (item: MCPItem): string =>
+  'tool' in item && item.tool[MCP_TOOL_TELEMETRY_MARKER] === true ? item.mcpName : 'custom'

--- a/packages/plugin-mcp/src/telemetry/index.ts
+++ b/packages/plugin-mcp/src/telemetry/index.ts
@@ -1,0 +1,98 @@
+import type { Implementation, McpServer, ServerContext } from '@modelcontextprotocol/server'
+import type { PayloadRequest } from 'payload'
+
+import { CLIENT_INFO_META_KEY, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/server'
+import { sendTelemetryEvent } from 'payload/internal'
+
+import type { MCPItem, MCPToolResponse } from '../types.js'
+
+import {
+  COLLECTION_AUTH_BUILTINS,
+  COLLECTION_BUILTINS,
+  GLOBAL_BUILTINS,
+  TOOL_BUILTINS,
+} from '../mcp/builtinTools.js'
+import { getMcpErrorType, type MCPErrorType } from './errorType.js'
+
+type ModernRequestEnvelope = {
+  [CLIENT_INFO_META_KEY]?: Implementation
+  [PROTOCOL_VERSION_META_KEY]?: string
+}
+
+export const createMcpServerTelemetry = ({
+  req,
+  server,
+}: {
+  req: PayloadRequest
+  server: McpServer
+}) => {
+  const reportToolCall = ({
+    ctx,
+    errorType,
+    tool,
+  }: {
+    ctx: ServerContext
+    errorType: MCPErrorType | null
+    tool: string
+  }): void => {
+    const envelope = ctx.mcpReq.envelope as ModernRequestEnvelope | undefined
+    const clientInfo = envelope?.[CLIENT_INFO_META_KEY] ?? server.server.getClientVersion()
+
+    void sendTelemetryEvent({
+      event: {
+        type: 'mcp-tool-call',
+        authenticated: Boolean(req.user),
+        clientName: clientInfo?.name ?? null,
+        clientVersion: clientInfo?.version ?? null,
+        errorType,
+        isError: errorType !== null,
+        protocolPath: envelope ? 'modern' : 'legacy',
+        protocolVersion:
+          envelope?.[PROTOCOL_VERSION_META_KEY] ??
+          server.server.getNegotiatedProtocolVersion() ??
+          null,
+        tool,
+        transport: ctx.http?.req ? 'http' : 'stdio',
+      },
+      payload: req.payload,
+    })
+  }
+
+  return (
+    item: MCPItem,
+    handler: (input: unknown, ctx: ServerContext) => Promise<MCPToolResponse>,
+  ) => {
+    const tool = getTelemetryToolName(item)
+    // Tools with an input schema are invoked as `(input, ctx)`, tools without one
+    // as `(ctx)` - so the server context is always the final argument.
+    return async (...args: unknown[]): Promise<MCPToolResponse> => {
+      const ctx = args[args.length - 1] as ServerContext
+      const input = args.length > 1 ? args[0] : undefined
+
+      try {
+        const response = await handler(input, ctx)
+        reportToolCall({
+          ctx,
+          errorType: response.isError ? getMcpErrorType({ response }) : null,
+          tool,
+        })
+        return response
+      } catch (err) {
+        reportToolCall({ ctx, errorType: 'internal', tool })
+        throw err
+      }
+    }
+  }
+}
+
+// Do not send user-defined tool names to telemetry.
+const getTelemetryToolName = (item: MCPItem): string => {
+  const isBuiltin =
+    item.type === 'tool'
+      ? item.configKey in TOOL_BUILTINS
+      : item.type === 'collectionTool'
+        ? item.configKey in COLLECTION_BUILTINS || item.configKey in COLLECTION_AUTH_BUILTINS
+        : item.configKey in GLOBAL_BUILTINS
+
+  return isBuiltin ? item.mcpName : 'custom'
+}

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -30,6 +30,13 @@ export type { MCPCollectionAuthToolName, MCPCollectionBuiltinName, MCPGlobalBuil
 export type { JsonSchemaType, StandardSchemaWithJSON, ToolAnnotations }
 
 /**
+ * Marks first-party tools whose names may be included in telemetry.
+ *
+ * @internal
+ */
+export const MCP_TOOL_TELEMETRY_MARKER = Symbol('mcpToolTelemetry')
+
+/**
  * What a tool's `input` (or a prompt's `argsSchema`) can be — either a raw
  * JSON Schema 2020-12 literal, or a Standard Schema instance (Zod, Valibot, …).
  * Raw schemas may omit `$schema`; when present it must declare the 2020-12 dialect.
@@ -108,6 +115,7 @@ export type Tool<TSchema extends ToolInputSchema | undefined = ToolInputSchema |
   description: string
   handler: (args: ToolHandlerArgs<TSchema>) => MaybePromise<MCPToolResponse>
   input?: TSchema
+  [MCP_TOOL_TELEMETRY_MARKER]?: true
   /**
    * Override the return value of the tool handler
    */
@@ -126,7 +134,10 @@ export type CollectionTool<
   access?: (args: CollectionMCPAccessArgs) => MaybePromise<boolean>
   handler: (args: CollectionToolHandlerArgs<TSchema>) => MaybePromise<MCPToolResponse>
   input?: TSchema
-} & Pick<Tool, 'annotations' | 'description' | 'overrideResponse'>
+} & Pick<
+  Tool,
+  'annotations' | 'description' | 'overrideResponse' | typeof MCP_TOOL_TELEMETRY_MARKER
+>
 
 export type GlobalTool<TSchema extends ToolInputSchema | undefined = ToolInputSchema | undefined> =
   {
@@ -139,7 +150,10 @@ export type GlobalTool<TSchema extends ToolInputSchema | undefined = ToolInputSc
     access?: (args: GlobalMCPAccessArgs) => MaybePromise<boolean>
     handler: (args: GlobalToolHandlerArgs<TSchema>) => MaybePromise<MCPToolResponse>
     input?: TSchema
-  } & Pick<Tool, 'annotations' | 'description' | 'overrideResponse'>
+  } & Pick<
+    Tool,
+    'annotations' | 'description' | 'overrideResponse' | typeof MCP_TOOL_TELEMETRY_MARKER
+  >
 
 /**
  * Configures (or disables) a built-in tool without replacing it.


### PR DESCRIPTION
This adds an `mcp-tool-call` telemetry event so we can understand how the MCP plugin is used in real projects. Each event records the first-party tool name, transport, protocol path and version, client name and version, whether the request was authenticated, and whether the call failed. Only first-party tools are logged by name. Non-first-party tools are logged as `custom`.

There is no connection event because legacy and modern MCP transports do not share a reliable connection lifecycle. Tool calls are the common event that every transport can measure consistently.

## Error reporting

Failed calls include an error category of `validation`, `access`, `bad-request`, `internal`, or `unknown`. Known handled errors are tagged where they are created. An unclassified handled error stays `unknown`, while an error that escapes the tool handler is `internal`.

## Privacy

The events does not include tool inputs, outputs, document data, error messages, user identities, or custom tool names. User-defined tools are grouped under `custom`, authentication is only a boolean.