### PR TITLE
fix(ui): re-scope bulkUpload onSuccess by field path to fix hasMany upload collision

### DIFF
--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -78,10 +78,10 @@ export function BulkUploadModal() {
   const {
     modalSlug,
     onCancel,
+    setCurrentActivePath,
     setInitialFiles,
     setInitialForms,
     setOnCancel,
-    setOnSuccess,
     setParentID,
     setSelectableCollections,
     setSuccessfullyUploaded,
@@ -116,7 +116,7 @@ export function BulkUploadModal() {
         setInitialFiles(undefined)
         setInitialForms(undefined)
         setOnCancel(() => () => null)
-        setOnSuccess(() => () => null)
+        setCurrentActivePath(undefined)
         setSelectableCollections(null)
         setSuccessfullyUploaded(false)
       }
@@ -147,6 +147,14 @@ export function BulkUploadModal() {
 
 export type BulkUploadContext = {
   collectionSlug: CollectionSlug
+  /**
+   * The field path (or collection slug, for the list view's bulk upload) that currently owns the
+   * open bulk upload modal. Used to look up the correct entry in the onSuccess map below, so that
+   * when multiple hasMany upload fields are mounted on the same page (e.g. a top-level gallery
+   * plus per-row galleries inside an array field), an upload always resolves against the field
+   * whose "Create New" button was actually clicked — not whichever field's effect last ran.
+   */
+  currentActivePath: string
   initialFiles: FileList
   /**
    * Like initialFiles, but allows manually providing initial form state or the form ID for each file
@@ -173,13 +181,14 @@ export type BulkUploadContext = {
    */
   selectableCollections?: null | string[]
   setCollectionSlug: (slug: string) => void
+  setCurrentActivePath: (path: string) => void
   setInitialFiles: (files: FileList) => void
   setInitialForms: (
     forms: ((forms: InitialForms | undefined) => InitialForms | undefined) | InitialForms,
   ) => void
   setMaxFiles: (maxFiles: number) => void
   setOnCancel: (onCancel: BulkUploadContext['onCancel']) => void
-  setOnSuccess: (onSuccess: BulkUploadContext['onSuccess']) => void
+  setOnSuccess: (path: string, onSuccess: BulkUploadContext['onSuccess']) => void
   setParentID: (parentID: number | string | undefined) => void
   /**
    * Set the collections that can be selected in the collection dropdown (if applicable)
@@ -193,6 +202,7 @@ export type BulkUploadContext = {
 
 const Context = React.createContext<BulkUploadContext>({
   collectionSlug: '',
+  currentActivePath: undefined,
   initialFiles: undefined,
   initialForms: [],
   maxFiles: undefined,
@@ -202,6 +212,7 @@ const Context = React.createContext<BulkUploadContext>({
   parentID: undefined,
   selectableCollections: null,
   setCollectionSlug: () => null,
+  setCurrentActivePath: () => null,
   setInitialFiles: () => null,
   setInitialForms: () => null,
   setMaxFiles: () => null,
@@ -222,7 +233,9 @@ export function BulkUploadProvider({
   const [selectableCollections, setSelectableCollections] = React.useState<null | string[]>(null)
   const [collection, setCollection] = React.useState<string>()
   const [parentID, setParentID] = React.useState<number | string | undefined>(undefined)
-  const [onSuccessFunction, setOnSuccessFunction] = React.useState<BulkUploadContext['onSuccess']>()
+  const [currentActivePath, setCurrentActivePath] = React.useState<string>(undefined)
+  const [onSuccessFunctionMap, setOnSuccessFunctionMap] =
+    React.useState<Record<string, BulkUploadContext['onSuccess']>>()
   const [onCancelFunction, setOnCancelFunction] = React.useState<BulkUploadContext['onCancel']>()
   const [initialFiles, setInitialFiles] = React.useState<FileList>(undefined)
   const [initialForms, setInitialForms] = React.useState<InitialForms>(undefined)
@@ -231,9 +244,12 @@ export function BulkUploadProvider({
 
   const modalSlug = `${modalSlugPrefix ? `${modalSlugPrefix}-` : ''}${useBulkUploadModalSlug()}`
 
-  const setOnSuccess: BulkUploadContext['setOnSuccess'] = (onSuccess) => {
-    setOnSuccessFunction(() => onSuccess)
-  }
+  const setOnSuccess: BulkUploadContext['setOnSuccess'] = React.useCallback((path, onSuccess) => {
+    setOnSuccessFunctionMap((prev) => ({
+      ...prev,
+      [path]: onSuccess,
+    }))
+  }, [])
   const setOnCancel: BulkUploadContext['setOnCancel'] = (onCancel) => {
     setOnCancelFunction(() => onCancel)
   }
@@ -242,6 +258,7 @@ export function BulkUploadProvider({
     <Context
       value={{
         collectionSlug: collection,
+        currentActivePath,
         initialFiles,
         initialForms,
         maxFiles,
@@ -252,6 +269,8 @@ export function BulkUploadProvider({
           }
         },
         onSuccess: (newDocs, errorCount) => {
+          const onSuccessFunction =
+            currentActivePath !== undefined ? onSuccessFunctionMap?.[currentActivePath] : undefined
           if (typeof onSuccessFunction === 'function') {
             onSuccessFunction(newDocs, errorCount)
           }
@@ -259,6 +278,7 @@ export function BulkUploadProvider({
         parentID,
         selectableCollections,
         setCollectionSlug: setCollection,
+        setCurrentActivePath,
         setInitialFiles,
         setInitialForms,
         setMaxFiles,

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -123,6 +123,7 @@ export function UploadInput(props: UploadInputProps) {
   const {
     modalSlug: drawerSlug,
     setCollectionSlug,
+    setCurrentActivePath,
     setInitialFiles,
     setMaxFiles,
     setOnSuccess,
@@ -394,6 +395,7 @@ export function UploadInput(props: UploadInputProps) {
         setMaxFiles(maxRows)
       }
 
+      setCurrentActivePath(path)
       openModal(drawerSlug)
     },
     [
@@ -408,6 +410,8 @@ export function UploadInput(props: UploadInputProps) {
       setInitialFiles,
       setSelectableCollections,
       setMaxFiles,
+      path,
+      setCurrentActivePath,
     ],
   )
 
@@ -637,7 +641,7 @@ export function UploadInput(props: UploadInputProps) {
   }, [populateDocs, value, relationTo])
 
   useEffect(() => {
-    setOnSuccess(onUploadSuccess)
+    setOnSuccess(path, onUploadSuccess)
   }, [value, path, onUploadSuccess, setOnSuccess])
 
   const showDropzone =

--- a/packages/ui/src/views/List/index.client.tsx
+++ b/packages/ui/src/views/List/index.client.tsx
@@ -98,7 +98,12 @@ export function DefaultListView(props: ListViewClientProps) {
   }, [query?.where])
 
   const { openModal } = useModal()
-  const { modalSlug: bulkUploadModalSlug, setCollectionSlug, setOnSuccess } = useBulkUpload()
+  const {
+    modalSlug: bulkUploadModalSlug,
+    setCollectionSlug,
+    setCurrentActivePath,
+    setOnSuccess,
+  } = useBulkUpload()
 
   const collectionConfig = getEntityConfig({ collectionSlug })
 
@@ -135,9 +140,18 @@ export function DefaultListView(props: ListViewClientProps) {
 
   const openBulkUpload = React.useCallback(() => {
     setCollectionSlug(collectionSlug)
+    setCurrentActivePath(collectionSlug)
     openModal(bulkUploadModalSlug)
-    setOnSuccess(() => router.refresh())
-  }, [router, collectionSlug, bulkUploadModalSlug, openModal, setCollectionSlug, setOnSuccess])
+    setOnSuccess(collectionSlug, () => router.refresh())
+  }, [
+    router,
+    collectionSlug,
+    bulkUploadModalSlug,
+    openModal,
+    setCollectionSlug,
+    setCurrentActivePath,
+    setOnSuccess,
+  ])
 
   useEffect(() => {
     if (!isInDrawer) {


### PR DESCRIPTION
## What

`BulkUploadProvider` (packages/ui/src/elements/BulkUpload/index.tsx) currently holds a single `onSuccess` callback shared across every mounted upload field. Each `UploadInput` reactively re-registers it via `setOnSuccess(onUploadSuccess)` in a `useEffect` keyed on its own `value`/`path` — so whichever field's effect last ran "wins" ownership of the next upload's success handler, regardless of which field's "Create New" button the user actually clicked.

On any page with more than one `hasMany` upload field mounted at once — e.g. a top-level gallery field plus a nested array field whose rows each have their own gallery field — using "Create New" on one field can silently resolve against a *different* field's closure. The new Media doc gets created successfully, but it's merged into the wrong field's local `value`, so from the field you actually clicked, the upload appears to just vanish.

## Why this looks like a regression

This is the same defect class as #10177, which #10189 fixed for exactly this reason — introducing a path-keyed `onSuccess` map plus an explicit "current active path" set at click time, rather than relying on effect mount/render order. That fix landed in v3.12.0.

A later refactor of this provider (the Drawer → Modal rename, plus the `parentID`/`initialForms` additions visible in the current `main`) reverted the shape of `onSuccess`/`setOnSuccess` back down to a single shared callback, with no per-path map and no `currentActivePath`. This PR reintroduces that pattern against the current provider shape.

## Fix

- `BulkUploadContext.setOnSuccess` takes `(path, onSuccess)` and stores callbacks in a `Record<string, onSuccess>` map instead of a single value.
- Added `currentActivePath` / `setCurrentActivePath` to the context, set imperatively the moment a field opens the bulk upload modal (`UploadInput.onLocalFileSelection`, and the list view's `openBulkUpload`) — so the field that was actually clicked owns the next success callback, independent of any sibling field's render timing.
- `BulkUploadProvider`'s `onSuccess` dispatcher looks up the map by `currentActivePath` instead of calling a single stored function.
- `currentActivePath` is cleared on modal close alongside the other per-session state.

## Repro

1. A collection/global with a top-level `hasMany` upload field, and a nested `array` field whose rows each contain their own `hasMany` upload field (mirrors this repo's own `packages/ui/src/fields/Upload` reuse pattern — any schema with two `hasMany` upload fields mounted on the same edit view reproduces this).
2. Add at least one row to the array field so its upload field mounts alongside the top-level one.
3. Use "Create New" on the top-level field's dropzone and upload a file.
4. The Media doc is created, but the new file does not appear in the top-level field — it merges into the array row's field state instead (or is dropped if that field's effect hasn't captured a stale `value` closure).

## Notes for reviewers

- I wasn't able to run the full monorepo test suite in this environment (sandboxed, no ability to install/build the whole repo) — the diff is a straightforward reapplication of the pattern from #10189 onto the current provider shape, but please have CI/e2e confirm.
- Happy to add a specific e2e/int test under `test/fields` covering two sibling `hasMany` upload fields if that's wanted — didn't want to guess at the preferred test harness placement without more context.