### PR TITLE
fix(richtext-lexical): resolve infinite transform loop in AutoLinkPlugin

### DIFF
--- a/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.spec.ts
+++ b/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.spec.ts
@@ -1,0 +1,45 @@
+import { createHeadlessEditor } from '@lexical/headless'
+import { $createParagraphNode, $createTextNode, $getRoot, TextNode } from 'lexical'
+import { describe, expect, it } from 'vitest'
+
+import { AutoLinkNode } from '../../../nodes/AutoLinkNode.js'
+import { LinkNode } from '../../../nodes/LinkNode.js'
+import { MATCHERS, registerAutoLinkTransform } from './index.js'
+
+function createEditor() {
+  return createHeadlessEditor({ nodes: [TextNode, LinkNode, AutoLinkNode] })
+}
+
+describe('registerAutoLinkTransform', () => {
+  it('does not hang when a formatted auto-linkable node follows a text node ending in non-ASCII punctuation', () => {
+    // Regression test for an infinite transform loop: a paragraph made of two text nodes
+    // where (a) the first ends in punctuation the separator check does not recognise (e.g.
+    // full-width "：" used in CJK text) and (b) the second looks like an email/URL and carries
+    // a non-zero text format (bold, italic, etc). Before the fix, `$createAutoLinkNode_`'s
+    // multi-node branch re-walked `nodes` (including the already-handled first node) with an
+    // offset that assumed it had been skipped, corrupting the tree (the first node ended up
+    // appended into the very AutoLinkNode that was about to replace it) and leaving the editor
+    // stuck forever inside Lexical's transform-then-reconcile loop.
+    const editor = createEditor()
+    const unregister = registerAutoLinkTransform(editor, MATCHERS)
+
+    const update = () => {
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode()
+          const leadingText = $createTextNode('有意者请将简历发送至：')
+          const emailText = $createTextNode('someone@example.com')
+          emailText.setFormat('bold')
+          emailText.toggleFormat('italic')
+          paragraph.append(leadingText, emailText)
+          $getRoot().append(paragraph)
+        },
+        { discrete: true },
+      )
+    }
+
+    expect(update).not.toThrow()
+
+    unregister()
+  }, 5_000)
+})

--- a/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
@@ -214,7 +214,13 @@ function $createAutoLinkNode_(
     }
     const linkNodes: LexicalNode[] = []
     let remainingTextNode
-    nodes.forEach((currentNode) => {
+    // `firstTextNode` (nodes[0]) is already accounted for via `firstLinkTextNode` above and
+    // `offset` is pre-seeded with its length, so only the remaining nodes need to be walked here.
+    // Iterating over the full `nodes` array double-processes `firstTextNode` at the wrong offset,
+    // which can push it into `linkNodes` a second time and later get appended into `linkNode`
+    // right as it's replaced by that same `linkNode` — corrupting the tree into a cycle that makes
+    // later traversals (e.g. `isAttached`) loop forever, freezing the editor.
+    nodes.slice(1).forEach((currentNode) => {
       const currentNodeText = currentNode.getTextContent()
       const currentNodeLength = currentNodeText.length
       const currentNodeStart = offset
@@ -405,42 +411,56 @@ function getTextNodesToMatch(textNode: TextNode): TextNode[] {
   return textNodesToMatch
 }
 
+/**
+ * Registers the auto-link text node transform on `editor`. Extracted as a plain function
+ * (rather than inlined in the `useEffect` below) so it can be exercised directly in unit
+ * tests via `@lexical/headless`, without needing to mount a React tree.
+ */
+export function registerAutoLinkTransform(
+  editor: LexicalEditor,
+  matchers: LinkMatcher[],
+  onChange?: ChangeHandler,
+): () => void {
+  if (!editor.hasNodes([AutoLinkNode])) {
+    throw new Error('LexicalAutoLinkPlugin: AutoLinkNode not registered on editor')
+  }
+
+  const onChangeWrapped = (url: null | string, prevUrl: null | string): void => {
+    if (onChange != null) {
+      onChange(url, prevUrl)
+    }
+  }
+
+  return mergeRegister(
+    editor.registerNodeTransform(TextNodeValue, (textNode: TextNode) => {
+      const parent = textNode.getParentOrThrow()
+      const previous = textNode.getPreviousSibling()
+      if ($isAutoLinkNode(parent)) {
+        handleLinkEdit(parent, matchers, onChangeWrapped)
+      } else if (!$isLinkNode(parent)) {
+        if (
+          textNode.isSimpleText() &&
+          (startsWithSeparator(textNode.getTextContent()) || !$isAutoLinkNode(previous))
+        ) {
+          const textNodesToMatch = getTextNodesToMatch(textNode)
+          $handleLinkCreation(textNodesToMatch, matchers, onChangeWrapped)
+        }
+
+        handleBadNeighbors(textNode, matchers, onChangeWrapped)
+      }
+    }),
+  )
+}
+
 function useAutoLink(
   editor: LexicalEditor,
   matchers: LinkMatcher[],
   onChange?: ChangeHandler,
 ): void {
-  useEffect(() => {
-    if (!editor.hasNodes([AutoLinkNode])) {
-      throw new Error('LexicalAutoLinkPlugin: AutoLinkNode not registered on editor')
-    }
-
-    const onChangeWrapped = (url: null | string, prevUrl: null | string): void => {
-      if (onChange != null) {
-        onChange(url, prevUrl)
-      }
-    }
-
-    return mergeRegister(
-      editor.registerNodeTransform(TextNodeValue, (textNode: TextNode) => {
-        const parent = textNode.getParentOrThrow()
-        const previous = textNode.getPreviousSibling()
-        if ($isAutoLinkNode(parent)) {
-          handleLinkEdit(parent, matchers, onChangeWrapped)
-        } else if (!$isLinkNode(parent)) {
-          if (
-            textNode.isSimpleText() &&
-            (startsWithSeparator(textNode.getTextContent()) || !$isAutoLinkNode(previous))
-          ) {
-            const textNodesToMatch = getTextNodesToMatch(textNode)
-            $handleLinkCreation(textNodesToMatch, matchers, onChangeWrapped)
-          }
-
-          handleBadNeighbors(textNode, matchers, onChangeWrapped)
-        }
-      }),
-    )
-  }, [editor, matchers, onChange])
+  useEffect(
+    () => registerAutoLinkTransform(editor, matchers, onChange),
+    [editor, matchers, onChange],
+  )
 }
 
 const URL_REGEX =
@@ -449,7 +469,7 @@ const URL_REGEX =
 const EMAIL_REGEX =
   /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\])|(([a-z\-\d]+\.)+[a-z]{2,}))/i
 
-const MATCHERS = [
+export const MATCHERS = [
   createLinkMatcherWithRegExp(URL_REGEX, (text) => {
     return text.startsWith('http') ? text : `https://${text}`
   }),


### PR DESCRIPTION
## What?

Fixes a bug in `AutoLinkPlugin` (`@payloadcms/richtext-lexical`) where the editor can hang forever — pegging the main thread and making the whole admin panel unresponsive — when it encounters a specific (and not particularly exotic) combination of content.

## Repro

A paragraph made of two text nodes:
1. Text ending in punctuation that `isSeparator`'s `PUNCTUATION_OR_SPACE = /[.,;\s]/` doesn't recognise — e.g. full-width CJK punctuation such as `：` (U+FF1A), which is very common in real-world Chinese content.
2. Immediately followed by a differently-formatted (bold/italic/etc) text node whose content looks like an email address or URL.

Opening the document's edit view in the admin panel freezes solid. Confirmed via CDP (`Debugger.pause` on the hung tab) that the JS main thread is stuck at ~100%+ CPU inside:

```
isAttached
$applyAllTransforms
$beginUpdate
updateEditor
update
markNodesWithTypesAsDirty
registerNodeTransform
```

## Root cause

Because the two runs have different formatting, Lexical keeps them as separate sibling `TextNode`s. The `EMAIL_REGEX` matcher's local-part character class doesn't exclude non-ASCII punctuation, so it happily matches across both nodes as one combined "email", landing in `$createAutoLinkNode_`'s `nodes.length > 1` branch:

```ts
} else if (nodes.length > 1) {
  const firstTextNode = nodes[0]!
  let offset = firstTextNode.getTextContent().length
  let firstLinkTextNode
  if (startIndex === 0) {
    firstLinkTextNode = firstTextNode
  } else {
    ;[, firstLinkTextNode] = firstTextNode.splitText(startIndex)
  }
  const linkNodes: LexicalNode[] = []
  let remainingTextNode
  nodes.forEach((currentNode) => { // <-- iterates the FULL nodes array
    ...
  })
```

`offset` is pre-seeded with `firstTextNode`'s length specifically because `firstTextNode` is already handled via `firstLinkTextNode` and is meant to be skipped in the loop below. But `nodes.forEach(...)` iterates the *full* `nodes` array (including index 0 again), so `firstTextNode` gets evaluated a second time at the wrong offset, gets pushed into `linkNodes`, and then gets `append`ed into the very `linkNode` that `firstLinkTextNode.replace(linkNode)` is about to use to replace it in the tree.

That leaves the Lexical node tree in an inconsistent state, and later traversals that walk up the parent chain (`isAttached`, invoked repeatedly from `$applyAllTransforms`'s dirty-node loop) never terminate — the editor is stuck forever.

## Fix

One-line fix: iterate `nodes.slice(1)` instead of `nodes`, since `nodes[0]` (`firstTextNode`) is already accounted for.

I also pulled the transform-registration logic out of `useAutoLink`'s `useEffect` into a standalone exported `registerAutoLinkTransform` function (and exported `MATCHERS`), purely so the regression test can exercise the real transform via `@lexical/headless` without needing to mount a React tree. No behavior change there — `useAutoLink` just calls it inside the same `useEffect`.

## Testing

- Added `index.spec.ts` next to the plugin, using the same `createHeadlessEditor` pattern as the existing `markdownTransformer.spec.ts` in this feature folder. It reproduces the exact paragraph structure above and asserts the update settles (with a 5s test timeout, so a regression fails fast instead of hanging CI forever).
- Bisected and confirmed against a real running admin panel: same paragraph, reproducibly hangs on `main`, works fine with this fix applied.
- I wasn't able to get the full monorepo's `pnpm install` to complete in my sandbox (native build failure in an unrelated package, `better-sqlite3`, plus a slow registry mirror), so I additionally verified the before/after behavior in an isolated minimal harness built directly against the `lexical` / `@lexical/headless` versions this package depends on, copying the exact transform logic — happy to re-verify against the real test runner if a maintainer can confirm CI passes, or if there's a lighter way to run just this package's vitest suite.

## Real-world impact

This isn't a contrived edge case — it's a plain paragraph like "请将简历发送至：someone@example.com" with the email in bold, which is an entirely ordinary thing to write in a "Contact us" section. I ran into it migrating ~530 real articles into Payload; 2 of them hit this exact pattern and their edit pages became completely unusable (had to fix the source content to work around it before finding and fixing the actual bug).