### PR TITLE
fix(ui): disable orderable drag handle when table is not sorted by order

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -402,6 +402,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'general:sorryNotFound',
   'general:sort',
   'general:sortByLabelDirection',
+  'general:sortByOrderToReorder',
   'general:stayOnThisPage',
   'general:submissionSuccessful',
   'general:submit',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -469,6 +469,7 @@ export const arTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'عذرًا - لا يوجد شيء يتوافق مع طلبك.',
     sort: 'ترتيب',
     sortByLabelDirection: 'رتّب حسب {{label}} {{direction}}',
+    sortByOrderToReorder: 'لإعادة ترتيب الصفوف، يجب أولاً فرزها وفقاً لعمود "Order".',
     stayOnThisPage: 'البقاء على هذه الصفحة',
     submissionSuccessful: 'تمت الإرسال بنجاح.',
     submit: 'إرسال',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -483,6 +483,8 @@ export const azTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Üzr istəyirik - sizin tələbinizə uyğun heç nə yoxdur.',
     sort: 'Sırala',
     sortByLabelDirection: '{{label}} {{direction}} ilə sırala',
+    sortByOrderToReorder:
+      'Sətirlərin sırasını dəyişdirmək üçün əvvəlcə onları "Order" sütununa görə çeşidləməlisiniz.',
     stayOnThisPage: 'Bu səhifədə qal',
     submissionSuccessful: 'Təqdimat uğurlu oldu.',
     submit: 'Təqdim et',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -479,6 +479,8 @@ export const bgTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Съжаляваме-няма нищо, което да отговаря на търсенето ти.',
     sort: 'Сортирай',
     sortByLabelDirection: 'Сортирай по {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'За да пренаредите редовете, първо трябва да ги сортирате по колоната "Order".',
     stayOnThisPage: 'Остани на тази страница',
     submissionSuccessful: 'Успешно подаване.',
     submit: 'Подай',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -486,6 +486,8 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'দুঃখিত—আপনার অনুরোধের সাথে মিলে এমন কিছুই নেই।',
     sort: 'সাজান',
     sortByLabelDirection: '{{label}} দ্বারা {{direction}} সাজান',
+    sortByOrderToReorder:
+      'সারিগুলিকে পুনরায় সাজানোর জন্য আপনাকে প্রথমে "Order" কলাম অনুযায়ী সেগুলোকে ছাঁটাই করতে হবে।',
     stayOnThisPage: 'এই পৃষ্ঠায় থাকুন',
     submissionSuccessful: 'জমা সফল হয়েছে।',
     submit: 'জমা দিন',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -485,6 +485,8 @@ export const bnInTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'দুঃখিত—আপনার অনুরোধের সাথে মিলে এমন কিছুই নেই।',
     sort: 'সাজান',
     sortByLabelDirection: '{{label}} দ্বারা {{direction}} সাজান',
+    sortByOrderToReorder:
+      'সারিগুলিকে পুনরায় সাজাতে হলে আপনাকে প্রথমে "Order" কলাম অনুযায়ী সেগুলি সাজাতে হবে।',
     stayOnThisPage: 'এই পৃষ্ঠায় থাকুন',
     submissionSuccessful: 'জমা সফল হয়েছে।',
     submit: 'জমা দিন',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -483,6 +483,8 @@ export const caTranslations: DefaultTranslationsObject = {
     sorryNotFound: "Ho sento, no s'ha trobat la pàgina que busques.",
     sort: 'Ordena',
     sortByLabelDirection: 'Ordena per {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Per reordenar les files, primer les heu d\'ordenar per la columna "Order".',
     stayOnThisPage: 'Permaneix en aquesta pàgina',
     submissionSuccessful: 'Enviament exitós',
     submit: 'Envia',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -475,6 +475,8 @@ export const csTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Je nám líto, ale neexistuje nic, co by odpovídalo vašemu požadavku.',
     sort: 'Třídit',
     sortByLabelDirection: 'Seřadit podle {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Pro přeuspořádání řádků je nejprve nutné je seřadit podle sloupce „Pořadí“.',
     stayOnThisPage: 'Zůstat na této stránce',
     submissionSuccessful: 'Odeslání úspěšné.',
     submit: 'Odeslat',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -479,6 +479,8 @@ export const daTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Beklager—der er intet, der svarer til din handling.',
     sort: 'Sorter',
     sortByLabelDirection: 'Sorter efter {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'For at omarrangere rækkerne skal du først sortere dem efter kolonnen "Order".',
     stayOnThisPage: 'Forbliv på siden',
     submissionSuccessful: 'Indsendt.',
     submit: 'Send',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -490,6 +490,8 @@ export const deTranslations: DefaultTranslationsObject = {
       'Es tut uns leid, aber wir haben nichts gefunden, was deiner Anfrage entspricht.',
     sort: 'Sortieren',
     sortByLabelDirection: 'Sortieren nach {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Um die Zeilen neu anzuordnen, müssen Sie sie zunächst nach der Spalte „Reihenfolge“ sortieren.',
     stayOnThisPage: 'Auf dieser Seite bleiben',
     submissionSuccessful: 'Übermittlung erfolgreich.',
     submit: 'Senden',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -479,6 +479,7 @@ export const enTranslations = {
     sorryNotFound: 'Sorry—there is nothing to correspond with your request.',
     sort: 'Sort',
     sortByLabelDirection: 'Sort by {{label}} {{direction}}',
+    sortByOrderToReorder: 'To reorder the rows you must first sort them by the "Order" column.',
     stayOnThisPage: 'Stay on this page',
     submissionSuccessful: 'Submission Successful.',
     submit: 'Submit',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -486,6 +486,8 @@ export const esTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Lo sentimos, no hay nada que coincida con tu solicitud.',
     sort: 'Ordenar',
     sortByLabelDirection: 'Ordenar por {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Para reorganizar las filas, primero debe ordenarlas por la columna "Orden".',
     stayOnThisPage: 'Permanecer en esta página',
     submissionSuccessful: 'Envío realizado con éxito.',
     submit: 'Enviar',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -475,6 +475,8 @@ export const etTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Vabandust - teie päringule vastavat sisu ei leitud.',
     sort: 'Sorteeri',
     sortByLabelDirection: 'Sorteeri {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Ridade ümberjärjestamiseks peate esmalt need sorteerima veeru "Order" järgi.',
     stayOnThisPage: 'Jää sellele lehele',
     submissionSuccessful: 'Esitamine õnnestus.',
     submit: 'Esita',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -470,6 +470,8 @@ export const faTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'متأسفانه، موردی مطابق با درخواست شما پیدا نشد.',
     sort: 'مرتب‌سازی',
     sortByLabelDirection: 'مرتب‌سازی بر اساس {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'برای تغییر ترتیب ردیف‌ها ابتدا باید آن‌ها را بر اساس ستون "Order" مرتب‌سازی کنید.',
     stayOnThisPage: 'در همین صفحه بمان',
     submissionSuccessful: 'با موفقیت ارسال شد.',
     submit: 'ارسال',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -490,6 +490,8 @@ export const frTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Désolé, rien ne correspond à votre demande.',
     sort: 'Trier',
     sortByLabelDirection: 'Trier par {{label}} {{direction}}',
+    sortByOrderToReorder:
+      "Pour réorganiser les lignes, vous devez d'abord les trier selon la colonne « Ordre ».",
     stayOnThisPage: 'Rester sur cette page',
     submissionSuccessful: 'Soumission réussie.',
     submit: 'Soumettre',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -464,6 +464,7 @@ export const heTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'מצטערים - אין תוצאות התואמות את הבקשה.',
     sort: 'מיין',
     sortByLabelDirection: 'מיין לפי {{label}} {{direction}}',
+    sortByOrderToReorder: 'כדי לשנות את סדר השורות, עליך תחילה למיין אותן לפי עמודת "Order".',
     stayOnThisPage: 'הישאר בדף זה',
     submissionSuccessful: 'נשלח בהצלחה.',
     submit: 'שלח',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -478,6 +478,8 @@ export const hrTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Nažalost, ne postoji ništa što odgovara vašem zahtjevu.',
     sort: 'Sortiraj',
     sortByLabelDirection: 'Sortiraj prema {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Da biste promijenili redoslijed redova, prvo ih morate sortirati prema stupcu "Order".',
     stayOnThisPage: 'Ostani na ovoj stranici',
     submissionSuccessful: 'Uspješno slanje',
     submit: 'Podnesi',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -485,6 +485,8 @@ export const huTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Sajnáljuk – nincs semmi, ami megfelelne a kérésének.',
     sort: 'Rendezés',
     sortByLabelDirection: 'Rendezés {{label}} {{direction}} szerint',
+    sortByOrderToReorder:
+      'A sorok átrendezéséhez először az "Order" oszlop szerint kell rendezni őket.',
     stayOnThisPage: 'Maradjon ezen az oldalon',
     submissionSuccessful: 'Beküldés sikeres.',
     submit: 'Beküldés',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -481,6 +481,8 @@ export const hyTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Ներողություն, Ձեր հարցմանը համապատասխան ոչինչ չկա։',
     sort: 'Տեսակավորել',
     sortByLabelDirection: 'Տեսակավորել ըստ {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Տողերը վերադասավորելու համար նախ անհրաժեշտ է դրանք դասավորել "Order" սյան միջոցով:',
     stayOnThisPage: 'Մնալ այս էջում',
     submissionSuccessful: 'Հայտը հաջողությամբ ուղարկվել է։',
     submit: 'Հաստատել',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -481,6 +481,8 @@ export const idTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Maaf—tidak ada yang sesuai dengan permintaan Anda.',
     sort: 'Urutkan',
     sortByLabelDirection: 'Urutkan berdasarkan {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Untuk mengubah urutan baris, Anda harus terlebih dahulu mengurutkannya berdasarkan kolom "Order".',
     stayOnThisPage: 'Tetap di halaman ini',
     submissionSuccessful: 'Pengiriman Berhasil.',
     submit: 'Kirim',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -476,6 +476,8 @@ export const isTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Því miður, það er ekkert sem samsvarar beiðninni þinni.',
     sort: 'Raða',
     sortByLabelDirection: 'Raða eftir {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Til að endurraða röðunum þarftu fyrst að raða þeim eftir dálkinum „Order“.',
     stayOnThisPage: 'Áfram á þessari síðu',
     submissionSuccessful: 'Sending tókst.',
     submit: 'Senda',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -485,6 +485,8 @@ export const itTranslations: DefaultTranslationsObject = {
     sorryNotFound: "Siamo spiacenti, non c'è nulla che corrisponda alla tua richiesta.",
     sort: 'Ordina',
     sortByLabelDirection: 'Ordina per {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Per riordinare le righe è necessario prima ordinarle in base alla colonna "Ordine".',
     stayOnThisPage: 'Rimani su questa pagina',
     submissionSuccessful: 'Invio riuscito.',
     submit: 'Invia',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -480,6 +480,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     sorryNotFound: '申し訳ありません。リクエストに対応する内容が見つかりませんでした。',
     sort: '並び替え',
     sortByLabelDirection: '{{label}}により並べ替え {{direction}}',
+    sortByOrderToReorder: '行を並べ替えるには、まず「Order」列でソートする必要があります。',
     stayOnThisPage: 'この画面にとどまる',
     submissionSuccessful: '送信が成功しました。',
     submit: '送信',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -477,6 +477,7 @@ export const koTranslations: DefaultTranslationsObject = {
     sorryNotFound: '죄송합니다. 요청과 일치하는 항목이 없습니다.',
     sort: '정렬',
     sortByLabelDirection: '{{label}} {{direction}}으로 정렬',
+    sortByOrderToReorder: '행의 순서를 변경하려면 먼저 "Order" 열을 기준으로 정렬해야 합니다.',
     stayOnThisPage: '이 페이지에 머무르기',
     submissionSuccessful: '제출이 완료되었습니다.',
     submit: '제출',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -481,6 +481,8 @@ export const ltTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Atsiprašau - nėra nieko, atitinkančio jūsų užklausą.',
     sort: 'Rūšiuoti',
     sortByLabelDirection: 'Rūšiuoti pagal {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Norėdami pertvarkyti eilutes, pirmiausia turite jas surikiuoti pagal „Order“ stulpelį.',
     stayOnThisPage: 'Likite šiame puslapyje',
     submissionSuccessful: 'Pateikimas sėkmingas.',
     submit: 'Pateikti',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -478,6 +478,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Atvainojiet — jūsu pieprasījumam neatbilst nekas.',
     sort: 'Kārtot',
     sortByLabelDirection: 'Kārtot pēc {{label}} {{direction}}',
+    sortByOrderToReorder: 'Lai pārkārtotu rindas, vispirms tās jāšķiro pēc kolonnas "Order".',
     stayOnThisPage: 'Palikt šajā lapā',
     submissionSuccessful: 'Iesniegšana veiksmīga.',
     submit: 'Iesniegt',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -485,6 +485,8 @@ export const myTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'ဝမ်းနည်းပါသည်။ သင်ရှာနေတဲ့ဟာ ဒီမှာမရှိပါ။',
     sort: 'အစဉ်လိုက်',
     sortByLabelDirection: 'အစဉ်အလိုက် စီမံခန့်ခွဲထားသည် {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'အတန်းတန်းများကို ပြန်စီရန်အတွက် မူရင်းအားဖြင့် "Order" column ကို အရင်ဆုံး စီတန်းရပါမည်။',
     stayOnThisPage: 'ဒီမှာပဲ ဆက်နေမည်။',
     submissionSuccessful: 'သိမ်းဆည်းမှု အောင်မြင်ပါသည်။',
     submit: 'သိမ်းဆည်းမည်။',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -482,6 +482,8 @@ export const nbTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Beklager, det er ingenting som samsvarer med forespørselen din.',
     sort: 'Sortér',
     sortByLabelDirection: 'Sorter etter {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'For å endre rekkefølgen på radene må du først sortere dem etter "Order"-kolonnen.',
     stayOnThisPage: 'Bli på denne siden',
     submissionSuccessful: 'Innsending vellykket.',
     submit: 'Send inn',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -487,6 +487,8 @@ export const nlTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Sorry, er is niets dat overeen komt met uw verzoek.',
     sort: 'Sorteer',
     sortByLabelDirection: 'Sorteer op {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Om de rijen opnieuw te rangschikken, moet u ze eerst sorteren op de kolom "Order".',
     stayOnThisPage: 'Blijf op deze pagina',
     submissionSuccessful: 'Indiening succesvol.',
     submit: 'Indienen',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -478,6 +478,8 @@ export const plTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Przepraszamy — nie ma nic, co odpowiadałoby twojemu zapytaniu.',
     sort: 'Sortuj',
     sortByLabelDirection: 'Sortuj według {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Aby zmienić kolejność wierszy, należy najpierw posortować je według kolumny "Order".',
     stayOnThisPage: 'Pozostań na stronie',
     submissionSuccessful: 'Zgłoszenie zakończone powodzeniem.',
     submit: 'Zatwierdź',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -482,6 +482,8 @@ export const ptTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Desculpe—não há nada que corresponda à sua requisição.',
     sort: 'Ordenar',
     sortByLabelDirection: 'Ordenar por {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Para reordenar as linhas, é necessário primeiro classificá-las pela coluna "Ordem".',
     stayOnThisPage: 'Permanecer nessa página',
     submissionSuccessful: 'Envio bem-sucedido.',
     submit: 'Enviar',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -485,6 +485,8 @@ export const roTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Ne pare rău - nu există nimic care să corespundă cu cererea dvs.',
     sort: 'Sortează',
     sortByLabelDirection: 'Sortează după {{etichetă}} {{direcţie}}',
+    sortByOrderToReorder:
+      'Pentru a reordona rândurile, trebuie mai întâi să le sortați după coloana „Order”.',
     stayOnThisPage: 'Rămâneți pe această pagină',
     submissionSuccessful: 'Trimitere cu succes.',
     submit: 'Trimite',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -478,6 +478,8 @@ export const rsTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Нажалост, не постоји ништа што одговара вашем захтеву.',
     sort: 'Сортирај',
     sortByLabelDirection: 'Сортирај према {{label}} {{дирецтион}}',
+    sortByOrderToReorder:
+      'Da biste preuredili redove, prvo ih morate sortirati prema koloni „Redosled”.',
     stayOnThisPage: 'Остани на овој страници',
     submissionSuccessful: 'Успешно слање',
     submit: 'Потврди',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -479,6 +479,8 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Nažalost, ne postoji ništa što odgovara vašem zahtevu.',
     sort: 'Sortiraj',
     sortByLabelDirection: 'Sortiraj prema {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Da biste promenili redosled redova, prvo ih morate sortirati prema koloni „Redosled“.',
     stayOnThisPage: 'Ostani na ovoj stranici',
     submissionSuccessful: 'Uspešno slanje',
     submit: 'Potvrdi',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -482,6 +482,8 @@ export const ruTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'К сожалению, ничего подходящего под ваш запрос нет.',
     sort: 'Сортировать',
     sortByLabelDirection: 'Сортировать по {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Чтобы изменить порядок строк, сначала отсортируйте их по столбцу «Порядок».',
     stayOnThisPage: 'Остаться на этой странице',
     submissionSuccessful: 'Успешно отправлено.',
     submit: 'Отправить',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -476,6 +476,8 @@ export const skTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Je nám ľúto, ale neexistuje nič, čo by zodpovedalo vášmu požiadavku.',
     sort: 'Zoradiť',
     sortByLabelDirection: 'Zoradiť podľa {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Ak chcete zmeniť poradie riadkov, musíte ich najprv zoradiť podľa stĺpca "Order".',
     stayOnThisPage: 'Zostať na tejto stránke',
     submissionSuccessful: 'Odoslanie úspešné.',
     submit: 'Odoslať',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -477,6 +477,8 @@ export const slTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Oprostite - ničesar ni mogoče najti, kar bi ustrezalo vaši zahtevi.',
     sort: 'Razvrsti',
     sortByLabelDirection: 'Razvrsti po {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Za ponovno razvrstitev vrstic jih morate najprej razvrstiti po stolpcu "Order".',
     stayOnThisPage: 'Ostani na tej strani',
     submissionSuccessful: 'Oddaja uspešna.',
     submit: 'Oddaj',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -481,6 +481,8 @@ export const svTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Tyvärr, det finns inget som motsvarar din begäran.',
     sort: 'Sortera',
     sortByLabelDirection: 'Sortera efter {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'För att omordna raderna måste du först sortera dem efter kolumnen "Order".',
     stayOnThisPage: 'Stanna på denna sida',
     submissionSuccessful: 'Skickat',
     submit: 'Skicka',

--- a/packages/translations/src/languages/ta.ts
+++ b/packages/translations/src/languages/ta.ts
@@ -480,6 +480,8 @@ export const taTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'மன்னிக்கவும் — உங்கள் கோரிக்கைக்கு பொருந்த எதுவும் இல்லை.',
     sort: 'வரிசைப்படுத்து',
     sortByLabelDirection: '{{label}}-ஐ {{direction}} வரிசைப்படுத்து',
+    sortByOrderToReorder:
+      'வரிசைகளை மறுநிரல் செய்ய, முதலில் அவற்றை "Order" நெடுவரிசையின் அடிப்படையில் வரிசைப்படுத்த வேண்டும்.',
     stayOnThisPage: 'இந்தப் பக்கத்தில் இரு',
     submissionSuccessful: 'சமர்ப்பிப்பு வெற்றிகரமாக முடிந்தது.',
     submit: 'சமர்ப்பி',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -471,6 +471,7 @@ export const thTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'ขออภัย ไม่สามารถทำตามคำขอของคุณได้',
     sort: 'เรียง',
     sortByLabelDirection: 'เรียงลำดับตาม {{label}} {{direction}}',
+    sortByOrderToReorder: 'ในการจัดลำดับแถวใหม่ คุณต้องจัดเรียงแถวเหล่านั้นตามคอลัมน์ "Order" ก่อน',
     stayOnThisPage: 'อยู่หน้านี้ต่อ',
     submissionSuccessful: 'ส่งสำเร็จ',
     submit: 'ส่ง',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -485,6 +485,8 @@ export const trTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Üzgünüz, isteğinizle eşleşen bir sonuç bulunamadı.',
     sort: 'Sırala',
     sortByLabelDirection: '{{label}} göre sırala {{direction}}',
+    sortByOrderToReorder:
+      'Satırları yeniden sıralamak için önce "Order" sütununa göre sıralama yapmalısınız.',
     stayOnThisPage: 'Bu sayfada kal',
     submissionSuccessful: 'Gönderme başarılı',
     submit: 'Gönder',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -475,6 +475,8 @@ export const ukTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Вибачте, немає нічого, що відповідало б Вашому запиту.',
     sort: 'Сортувати',
     sortByLabelDirection: 'Сортувати за {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Щоб змінити порядок рядків, спочатку потрібно відсортувати їх за стовпцем "Order".',
     stayOnThisPage: 'Залишитись на цій сторінці',
     submissionSuccessful: 'Успішно відправлено.',
     submit: 'Відправити',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -480,6 +480,8 @@ export const viTranslations: DefaultTranslationsObject = {
     sorryNotFound: 'Xin lỗi, không có kết quả nào tương ứng với yêu cầu của bạn.',
     sort: 'Sắp xếp',
     sortByLabelDirection: 'Sắp xếp theo {{label}} {{direction}}',
+    sortByOrderToReorder:
+      'Để sắp xếp lại các hàng, trước tiên bạn phải sắp xếp chúng theo cột "Order".',
     stayOnThisPage: 'Ở lại trang này',
     submissionSuccessful: 'Gửi thành công.',
     submit: 'Gửi',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -456,6 +456,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     sorryNotFound: '对不起，没有与您的请求相对应的东西。',
     sort: '排序',
     sortByLabelDirection: '按 {{label}} {{direction}} 排序',
+    sortByOrderToReorder: '要重新排序行，您必须首先按照“Order”列进行排序。',
     stayOnThisPage: '停留在此页面',
     submissionSuccessful: '提交成功。',
     submit: '提交',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -454,6 +454,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     sorryNotFound: '很抱歉，找不到符合條件的內容。',
     sort: '排序',
     sortByLabelDirection: '依 {{label}} {{direction}} 排序',
+    sortByOrderToReorder: '若要重新排序列，您必須先以「Order」欄位進行排序。',
     stayOnThisPage: '留在此頁面',
     submissionSuccessful: '送出成功。',
     submit: '送出',

--- a/packages/ui/src/elements/Table/OrderableRow.tsx
+++ b/packages/ui/src/elements/Table/OrderableRow.tsx
@@ -1,12 +1,14 @@
 import type { DraggableSyntheticListeners } from '@dnd-kit/core'
 import type { Column } from 'payload'
-import type { HTMLAttributes, Ref } from 'react'
+import type { HTMLAttributes, KeyboardEvent, Ref } from 'react'
 
 export type Props = {
   readonly cellMap: Record<string, number>
   readonly columns: Column[]
   readonly dragAttributes?: HTMLAttributes<unknown>
   readonly dragListeners?: DraggableSyntheticListeners
+  readonly isOrderable?: boolean
+  readonly onDisabledDragAttempt?: () => void
   readonly ref?: Ref<HTMLTableRowElement>
   readonly rowId: number | string
 } & HTMLAttributes<HTMLTableRowElement>
@@ -16,6 +18,8 @@ export const OrderableRow = ({
   columns,
   dragAttributes = {},
   dragListeners = {},
+  isOrderable = true,
+  onDisabledDragAttempt,
   rowId,
   ...rest
 }: Props) => (
@@ -28,9 +32,25 @@ export const OrderableRow = ({
 
       // For drag handles, wrap in div with drag attributes
       if (accessor === '_dragHandle') {
+        // When not orderable, dnd-kit's own drag listeners are disabled, so pressing the keys
+        // it would normally use to start a drag does nothing silently. Intercept them here to
+        // tell the user why instead.
+        const dragHandleListeners = {
+          ...dragListeners,
+          onKeyDown: (event: KeyboardEvent) => {
+            if (!isOrderable && (event.code === 'Space' || event.code === 'Enter')) {
+              event.preventDefault()
+              onDisabledDragAttempt?.()
+              return
+            }
+
+            dragListeners?.onKeyDown?.(event)
+          },
+        }
+
         return (
           <td className={`cell-${accessor}`} key={colIndex}>
-            <div {...dragAttributes} {...dragListeners}>
+            <div {...dragAttributes} {...dragHandleListeners}>
               {cell}
             </div>
           </td>

--- a/packages/ui/src/elements/Table/OrderableTable.tsx
+++ b/packages/ui/src/elements/Table/OrderableTable.tsx
@@ -19,6 +19,10 @@ import { OrderableRowDragPreview } from './OrderableRowDragPreview.js'
 
 const baseClass = 'table'
 
+const mustSortByOrderMessage = 'To reorder the rows you must first sort them by the "Order" column'
+// A stable id so repeated attempts (e.g. holding Space) update the same toast instead of stacking new ones
+const mustSortByOrderToastId = 'orderable-table-must-sort-by-order'
+
 export type Props = {
   readonly appearance?: 'condensed' | 'default'
   readonly BeforeTable?: React.ReactNode
@@ -40,6 +44,8 @@ export const OrderableTable: React.FC<Props> = ({
   const { code: localeCode } = useLocale()
   // Use the data from ListQueryProvider if available, otherwise use the props
   const serverData = listQueryData?.docs || initialData
+
+  const isOrderable = query.sort === orderableFieldName || query.sort === `-${orderableFieldName}`
 
   // Local state to track the current order of rows
   const [localData, setLocalData] = useState(serverData)
@@ -67,8 +73,8 @@ export const OrderableTable: React.FC<Props> = ({
   }
 
   const handleDragEnd = async ({ moveFromIndex, moveToIndex }) => {
-    if (query.sort !== orderableFieldName && query.sort !== `-${orderableFieldName}`) {
-      toast.warning('To reorder the rows you must first sort them by the "Order" column')
+    if (!isOrderable) {
+      toast.warning(mustSortByOrderMessage, { id: mustSortByOrderToastId })
       setDragActiveRowId(undefined)
       return
     }
@@ -168,6 +174,10 @@ export const OrderableTable: React.FC<Props> = ({
     setDragActiveRowId(id)
   }
 
+  const handleDisabledDragAttempt = () => {
+    toast.warning(mustSortByOrderMessage, { id: mustSortByOrderToastId })
+  }
+
   const rowIds = localData.map((row) => row.id ?? row._id)
 
   return (
@@ -190,7 +200,11 @@ export const OrderableTable: React.FC<Props> = ({
           </thead>
           <tbody>
             {localData.map((row, rowIndex) => (
-              <DraggableSortableItem id={rowIds[rowIndex]} key={rowIds[rowIndex]}>
+              <DraggableSortableItem
+                disabled={!isOrderable}
+                id={rowIds[rowIndex]}
+                key={rowIds[rowIndex]}
+              >
                 {({ attributes, isDragging, listeners, setNodeRef, transform, transition }) => (
                   <OrderableRow
                     cellMap={cellMap}
@@ -198,6 +212,8 @@ export const OrderableTable: React.FC<Props> = ({
                     columns={activeColumns}
                     dragAttributes={attributes}
                     dragListeners={listeners}
+                    isOrderable={isOrderable}
+                    onDisabledDragAttempt={handleDisabledDragAttempt}
                     ref={setNodeRef}
                     rowId={row.id ?? row._id}
                     style={{

--- a/packages/ui/src/elements/Table/OrderableTable.tsx
+++ b/packages/ui/src/elements/Table/OrderableTable.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 import { useConfig } from '../../providers/Config/index.js'
 import { useListQuery } from '../../providers/ListQuery/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
+import { useTranslation } from '../../providers/Translation/index.js'
 import { DraggableSortableItem } from '../DraggableSortable/DraggableSortableItem/index.js'
 import { DraggableSortable } from '../DraggableSortable/index.js'
 import { OrderableRow } from './OrderableRow.js'
@@ -19,7 +20,6 @@ import { OrderableRowDragPreview } from './OrderableRowDragPreview.js'
 
 const baseClass = 'table'
 
-const mustSortByOrderMessage = 'To reorder the rows you must first sort them by the "Order" column'
 // A stable id so repeated attempts (e.g. holding Space) update the same toast instead of stacking new ones
 const mustSortByOrderToastId = 'orderable-table-must-sort-by-order'
 
@@ -42,6 +42,7 @@ export const OrderableTable: React.FC<Props> = ({
   const { config } = useConfig()
   const { data: listQueryData, orderableFieldName, query } = useListQuery()
   const { code: localeCode } = useLocale()
+  const { t } = useTranslation()
   // Use the data from ListQueryProvider if available, otherwise use the props
   const serverData = listQueryData?.docs || initialData
 
@@ -74,7 +75,7 @@ export const OrderableTable: React.FC<Props> = ({
 
   const handleDragEnd = async ({ moveFromIndex, moveToIndex }) => {
     if (!isOrderable) {
-      toast.warning(mustSortByOrderMessage, { id: mustSortByOrderToastId })
+      toast.warning(t('general:sortByOrderToReorder'), { id: mustSortByOrderToastId })
       setDragActiveRowId(undefined)
       return
     }
@@ -175,7 +176,7 @@ export const OrderableTable: React.FC<Props> = ({
   }
 
   const handleDisabledDragAttempt = () => {
-    toast.warning(mustSortByOrderMessage, { id: mustSortByOrderToastId })
+    toast.warning(t('general:sortByOrderToReorder'), { id: mustSortByOrderToastId })
   }
 
   const rowIds = localData.map((row) => row.id ?? row._id)

--- a/test/__helpers/e2e/sort/moveRow.ts
+++ b/test/__helpers/e2e/sort/moveRow.ts
@@ -4,6 +4,8 @@ import { expect } from '@playwright/test'
 
 import { closeAllToasts } from '../helpers.js'
 
+const mustSortByOrderMessage = 'To reorder the rows you must first sort them by the "Order" column'
+
 export async function moveRow(
   page: Page,
   {
@@ -12,7 +14,11 @@ export async function moveRow(
     expected = 'success',
     scope,
   }: {
-    expected?: 'success' | 'warning'
+    /**
+     * `'disabled'` asserts that the drag handle does not start a drag at all, which is the
+     * case when the table is not currently sorted by the orderable field.
+     */
+    expected?: 'disabled' | 'success'
     fromIndex: number
     /**
      * Scope the sorting to a specific table in the DOM.
@@ -53,11 +59,43 @@ export async function moveRow(
 
   await page.waitForTimeout(400) // dndkit animation
 
-  if (expected === 'warning') {
-    const toast = page.locator('.payload-toast-item.toast-warning')
-    await expect(toast).toHaveText(
-      'To reorder the rows you must first sort them by the "Order" column',
-    )
-    await closeAllToasts(page)
+  if (expected === 'disabled') {
+    await expect(page.locator('.payload-toast-item')).toHaveCount(0)
   }
+}
+
+/**
+ * Focuses a row's drag handle and presses Space on it, the key dnd-kit's keyboard sensor
+ * uses to pick up a row for reordering. When the table is not sorted by the orderable field,
+ * this should warn instead of allowing the row to be picked up.
+ */
+export async function attemptKeyboardReorder(
+  page: Page,
+  {
+    index,
+    presses = 1,
+    scope,
+  }: {
+    index: number
+    /**
+     * Number of times to press Space in a row, to assert that repeated attempts collapse
+     * into a single toast instead of stacking a new one per press.
+     */
+    presses?: number
+    scope?: Locator
+  },
+) {
+  const table = (scope || page).locator(`tbody`)
+  await table.scrollIntoViewIfNeeded()
+
+  const dragHandle = table.locator(`.sort-row`).nth(index)
+
+  for (let i = 0; i < presses; i++) {
+    await dragHandle.press('Space')
+  }
+
+  const toast = page.locator('.payload-toast-item.toast-warning')
+  await expect(toast).toHaveText(mustSortByOrderMessage)
+  await expect(page.locator('.payload-toast-item')).toHaveCount(1)
+  await closeAllToasts(page)
 }

--- a/test/__helpers/e2e/sort/moveRow.ts
+++ b/test/__helpers/e2e/sort/moveRow.ts
@@ -4,7 +4,7 @@ import { expect } from '@playwright/test'
 
 import { closeAllToasts } from '../helpers.js'
 
-const mustSortByOrderMessage = 'To reorder the rows you must first sort them by the "Order" column'
+const mustSortByOrderMessage = 'To reorder the rows you must first sort them by the "Order" column.'
 
 export async function moveRow(
   page: Page,

--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -14,7 +14,7 @@ import {
   // throttleTest
 } from '../__helpers/e2e/helpers.js'
 import { scrollEntirePage } from '../__helpers/e2e/scrollEntirePage.js'
-import { moveRow } from '../__helpers/e2e/sort/moveRow.js'
+import { attemptKeyboardReorder, moveRow } from '../__helpers/e2e/sort/moveRow.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../__helpers/shared/rest.js'
@@ -120,13 +120,22 @@ describe('Sort functionality', () => {
 
     await page.getByLabel('Sort by Title Ascending').click()
     await page.waitForURL(/sort=title/, { timeout: 2000 })
+    await assertRows(['A', 'B', 'C', 'D'])
 
-    // Expect a warning because not sorted by order first
+    // Dragging the handle with the mouse should not start a drag when not sorted by order
     await moveRow(page, {
       fromIndex: 0,
       toIndex: 2,
-      expected: 'warning',
+      expected: 'disabled',
     })
+
+    await assertRows(['A', 'B', 'C', 'D'])
+
+    // Pressing Space on the handle should warn instead of letting the user reorder with arrow keys
+    // Pressing it repeatedly should not stack multiple toasts
+    await attemptKeyboardReorder(page, { index: 0, presses: 3 })
+
+    await assertRows(['A', 'B', 'C', 'D'])
   })
 
   test('Orderable join fields', async () => {


### PR DESCRIPTION
## Summary

The orderable table drag handle stayed active when the list was not sorted by the order field. A user could drag a row, or press Space to pick it up and move it with arrow keys, before the app rejected the reorder only at drop time. The handle now blocks the interaction as soon as the user tries it.

Previously this would let you sort it without saving, causing confusion for keyboard users.

https://github.com/user-attachments/assets/c483c07b-fad0-429c-99b7-d7148a1c9fd6


## How

- Disable dnd-kit's pointer and keyboard activation on the handle when the table is not sorted by the order field. Dragging and picking up a row with Space no longer start at all.
- Intercept Space and Enter on the disabled handle. Show the existing "sort by order" warning right away, instead of letting the keystroke do nothing.
- Give the warning toast a stable id. Repeated attempts, such as holding Space, update one toast instead of stacking a new toast per press.

The fix lives in the shared table component, so it covers both the collection list view and join field tables.
