### PR TITLE
fix(drizzle): validate companion table name length against 63-char limit

### DIFF
--- a/packages/drizzle/src/createTableName.ts
+++ b/packages/drizzle/src/createTableName.ts
@@ -1,9 +1,10 @@
 import type { DBIdentifierName } from 'payload'
 
-import { APIError } from 'payload'
 import toSnakeCase from 'to-snake-case'
 
 import type { DrizzleAdapter } from './types.js'
+
+import { validateIdentifierLength } from './utilities/validateIdentifierLength.js'
 
 type Args = {
   adapter: Pick<DrizzleAdapter, 'tableNameMap' | 'versionsSuffix'>
@@ -76,13 +77,5 @@ export const createTableName = ({
     return result
   }
 
-  if (result.length > 63) {
-    throw new APIError(
-      `Exceeded max identifier length for table or enum name of 63 characters. Invalid name: ${result}.
-Tip: You can use the dbName property to reduce the table name length.
-      `,
-    )
-  }
-
-  return result
+  return validateIdentifierLength(result)
 }

--- a/packages/drizzle/src/schema/build.ts
+++ b/packages/drizzle/src/schema/build.ts
@@ -19,6 +19,7 @@ import { createTableName } from '../createTableName.js'
 import { buildForeignKeyName } from '../utilities/buildForeignKeyName.js'
 import { buildIndexName } from '../utilities/buildIndexName.js'
 import { isUUIDType } from '../utilities/isUUIDType.js'
+import { validateIdentifierLength } from '../utilities/validateIdentifierLength.js'
 import { traverseFields } from './traverseFields.js'
 
 type Args = {
@@ -188,7 +189,7 @@ export const buildTable = ({
   adapter.rawTables[tableName] = table
 
   if (hasLocalizedField || localizedRelations.size) {
-    const localeTableName = `${tableName}${adapter.localesSuffix}`
+    const localeTableName = validateIdentifierLength(`${tableName}${adapter.localesSuffix}`)
     adapter.rawTables[localeTableName] = localesTable
 
     localesColumns.id = {
@@ -339,7 +340,7 @@ export const buildTable = ({
 
   if (isRoot) {
     if (hasManyTextField) {
-      const textsTableName = `${rootTableName}_texts`
+      const textsTableName = validateIdentifierLength(`${rootTableName}_texts`)
       adapter.rawTables[textsTableName] = textsTable
 
       const columns: Record<string, RawColumn> = {
@@ -445,7 +446,7 @@ export const buildTable = ({
     }
 
     if (hasManyNumberField) {
-      const numbersTableName = `${rootTableName}_numbers`
+      const numbersTableName = validateIdentifierLength(`${rootTableName}_numbers`)
       adapter.rawTables[numbersTableName] = numbersTable
       const columns: Record<string, RawColumn> = {
         id: {
@@ -575,7 +576,9 @@ export const buildTable = ({
         }
       }
 
-      const relationshipsTableName = `${tableName}${adapter.relationshipsSuffix}`
+      const relationshipsTableName = validateIdentifierLength(
+        `${tableName}${adapter.relationshipsSuffix}`,
+      )
 
       const relationshipIndexes: Record<string, RawIndex> = {
         order: {

--- a/packages/drizzle/src/schema/buildRawSchema.spec.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.spec.ts
@@ -164,4 +164,69 @@ describe('buildRawSchema', () => {
     expect(adapter.rawTables.posts_blocks_headline_2).toBeUndefined()
     expect(adapter.rawTables.posts_blocks_headline_2_locales).toBeUndefined()
   })
+
+  it('should throw when a localized field pushes the _locales companion table past 63 chars', async () => {
+    // Base table name (61 chars) is under the limit, but `${base}_locales` (69) overflows it.
+    const longSlug = `localized_collection_${'x'.repeat(40)}`
+
+    const config = await sanitizeConfig({
+      collections: [
+        {
+          slug: longSlug,
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              localized: true,
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+      localization: {
+        defaultLocale: 'en',
+        locales: ['en', 'de'],
+      },
+    } as Config)
+
+    const adapter = createAdapter(config)
+
+    expect(() =>
+      buildRawSchema({
+        adapter,
+        setColumnID,
+      }),
+    ).toThrow('Exceeded max identifier length')
+  })
+
+  it('should not throw for a localized field whose _locales companion table fits within 63 chars', async () => {
+    const config = await sanitizeConfig({
+      collections: [
+        {
+          slug: 'short_localized',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              localized: true,
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+      localization: {
+        defaultLocale: 'en',
+        locales: ['en', 'de'],
+      },
+    } as Config)
+
+    const adapter = createAdapter(config)
+
+    buildRawSchema({
+      adapter,
+      setColumnID,
+    })
+
+    expect(adapter.rawTables.short_localized_locales).toBeDefined()
+  })
 })

--- a/packages/drizzle/src/schema/buildRawSchema.spec.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.spec.ts
@@ -181,6 +181,7 @@ describe('buildRawSchema', () => {
             },
           ],
           timestamps: false,
+          versions: false,
         },
       ],
       localization: {
@@ -212,6 +213,7 @@ describe('buildRawSchema', () => {
             },
           ],
           timestamps: false,
+          versions: false,
         },
       ],
       localization: {

--- a/packages/drizzle/src/utilities/validateIdentifierLength.spec.ts
+++ b/packages/drizzle/src/utilities/validateIdentifierLength.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { maxIdentifierLength, validateIdentifierLength } from './validateIdentifierLength.js'
+
+describe('validateIdentifierLength', () => {
+  it('should return the name unchanged when at or under the 63-char limit', () => {
+    const name = 'a'.repeat(maxIdentifierLength)
+
+    expect(validateIdentifierLength(name)).toBe(name)
+  })
+
+  it('should throw when the name exceeds the 63-char limit', () => {
+    const name = 'a'.repeat(maxIdentifierLength + 1)
+
+    expect(() => validateIdentifierLength(name)).toThrow('Exceeded max identifier length')
+  })
+
+  it('should include the invalid name and the dbName tip in the error', () => {
+    const name = `some_long_table_name${'x'.repeat(maxIdentifierLength)}_locales`
+
+    expect(() => validateIdentifierLength(name)).toThrow(name)
+    expect(() => validateIdentifierLength(name)).toThrow(
+      'You can use the dbName property to reduce the table name length',
+    )
+  })
+})

--- a/packages/drizzle/src/utilities/validateIdentifierLength.ts
+++ b/packages/drizzle/src/utilities/validateIdentifierLength.ts
@@ -5,8 +5,6 @@ export const maxIdentifierLength = 63
 
 /**
  * Throws if a table or enum identifier exceeds the Postgres 63-char limit.
- * Covers companion table names (_locales, _rels, _texts, _numbers) that are built by
- * concatenation outside createTableName and would otherwise be silently truncated by Postgres.
  */
 export const validateIdentifierLength = (name: string): string => {
   if (name.length > maxIdentifierLength) {

--- a/packages/drizzle/src/utilities/validateIdentifierLength.ts
+++ b/packages/drizzle/src/utilities/validateIdentifierLength.ts
@@ -1,0 +1,21 @@
+import { APIError } from 'payload'
+
+/** Postgres max identifier length (NAMEDATALEN - 1). */
+export const maxIdentifierLength = 63
+
+/**
+ * Throws if a table or enum identifier exceeds the Postgres 63-char limit.
+ * Covers companion table names (_locales, _rels, _texts, _numbers) that are built by
+ * concatenation outside createTableName and would otherwise be silently truncated by Postgres.
+ */
+export const validateIdentifierLength = (name: string): string => {
+  if (name.length > maxIdentifierLength) {
+    throw new APIError(
+      `Exceeded max identifier length for table or enum name of ${maxIdentifierLength} characters. Invalid name: ${name}.
+Tip: You can use the dbName property to reduce the table name length.
+      `,
+    )
+  }
+
+  return name
+}


### PR DESCRIPTION
Mirror of #17563 which targets `3.x`

## The bug

Payload validates base table names against Postgres's 63-char limit, but the companion tables (`_locales`, `_rels`, `_texts`, `_numbers`) are built by concatenation afterward and never checked. A base name in the 56-63 char window passes, while its companion silently overflows and Postgres truncates it - leaving the DB schema out of sync with what Payload thinks it created (in dev, `push` then prompts `Is <table> created or renamed?` on every boot).

```ts
{ slug: 'a_fairly_long_collection_slug_that_is_still_under_63_chars', // base ≤ 63 → OK
  fields: [{ name: 'title', type: 'text', localized: true }] }        // ..._locales (+8) → silently truncated
```

## The fix

Extract the 63-char check out of `createTableName` into a reusable `validateIdentifierLength`, and apply it at the 4 companion-table definition sites in `schema/build.ts`. Over-long companions now fail fast with the existing error + `dbName` tip.

## Tests

- Unit - `validateIdentifierLength.spec.ts`: throws over 63, passes at/under.
- Regression - `buildRawSchema.spec.ts`: an overflowing `_locales` now throws in-memory.
- Cherry-picked the two new `buildRawSchema.spec.ts` fixtures now explicitly set `versions: false` since main defaults collections to `versions: true` as of #16871 (landed after this PR's original base), which otherwise requires `timestamps` and fails these fixtures for unrelated reasons.