### PR TITLE
test(richtext-lexical): create dev user first in seed to fix flaky e2e (3.x backport of #17507)

### DIFF
--- a/test/lexical/seed.ts
+++ b/test/lexical/seed.ts
@@ -95,6 +95,17 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export const seed = async (_payload: Payload) => {
+  // Create the admin user first so auto-login still works if a later seed step
+  // fails. Otherwise the empty users collection redirects to "Create first user".
+  await _payload.create({
+    collection: usersSlug,
+    data: {
+      email: devUser.email,
+      password: devUser.password,
+    },
+    depth: 0,
+  })
+
   const jpgPath = path.resolve(dirname, './collections/Upload/payload.jpg')
   const pngPath = path.resolve(dirname, './uploads/payload.png')
 
@@ -197,15 +208,6 @@ export const seed = async (_payload: Payload) => {
       .replace(/"\{\{TEXT_DOC_ID\}\}"/g, `${formattedTextID}`)
       .replace(/"\{\{RICH_TEXT_DOC_ID\}\}"/g, `${formattedRichTextDocID}`),
   )
-
-  await _payload.create({
-    collection: usersSlug,
-    data: {
-      email: devUser.email,
-      password: devUser.password,
-    },
-    depth: 0,
-  })
 
   await _payload.create({
     collection: lexicalFieldsSlug,


### PR DESCRIPTION
Backport of #17507 to 3.x.

Moves admin user creation to the top of the lexical seed so auto-login survives a failing seed step.

The user was created near the end of `seed`, after several uploads. If an earlier step failed, the seed aborted before the user existed, leaving the `users` collection empty. The admin then redirects to `/admin/create-first-user`, so the editor never renders and the "pure" suites (which rely only on `onInit` seeding, no `reInitializeDB`) time out.

Note: the original PR also included an import-ordering cleanup in two e2e spec files and a `test.skip` for the `tanstack-start` framework in a third spec file. Those changes are not included here because 3.x does not have the `tanstack-start` framework adapter and its import path conventions already differ from main, so those parts of the original diff don't apply.