### PR TITLE
fix(tanstack-start): preserve admin view across route transitions

### DIFF
--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -118,6 +118,7 @@ const nextSuites: TestConfig[] = [
  */
 const tanstackSuites: TestConfig[] = [
   { file: '_community', framework: 'tanstack-start', optional: false, shards: 1 },
+  { file: 'admin-routing', framework: 'tanstack-start', optional: false, shards: 1 },
 ]
 
 export default createE2EConfig([...nextSuites, ...tanstackSuites])

--- a/packages/tanstack-start/src/routes/adminRoutes.tsx
+++ b/packages/tanstack-start/src/routes/adminRoutes.tsx
@@ -32,12 +32,9 @@ function AdminPage() {
   // The per-route view key is attached server-side to the view subtree instead, via `renderRoot`'s `key` in `loadAdminPage`.
   const data = useLoaderData({ strict: false })
 
-  // The loader resolves as soon as the RSC wire data lands, but rendering the payload then
-  // suspends while its client references are imported — code-split chunks in a production build.
-  // Router state lives in an external store, so the transition TanStack wraps the commit in
-  // de-opts to a synchronous render and that suspension hits the nearest fallback, which is
-  // `null` unless a `pendingComponent` is configured — blanking the page. Deferring the payload
-  // keeps the previous view painted until the new one is renderable, then swaps.
+  // Route state comes from an external store, so a new RSC payload that suspends
+  // on code-split client references can reveal the router's null fallback.
+  // Keep the current payload painted until the next one is renderable.
   const rscPayload = useDeferredValue(data?.rscPayload)
 
   return <Fragment>{rscPayload}</Fragment>
@@ -68,6 +65,9 @@ const adminRouteOptions = ({
 }) => ({
   component: AdminPage,
   head: ({ loaderData }: { loaderData?: any }) => getAdminMeta(loaderData?.metadata),
+  // Both admin routes must use the same boundary type so index ↔ splat
+  // navigation preserves the existing admin subtree.
+  notFoundComponent: AdminNotFound,
   // `staleReloadMode: 'blocking'` (a property of the loader *object*, not a
   // sibling route option — router-core only reads it off a non-function loader)
   // makes stale-match revalidation await the fresh loader before committing,
@@ -102,35 +102,21 @@ const adminRouteOptions = ({
  * client view.
  */
 export function payloadAdminSplatRoute({ load }: { load: AdminLoad }) {
-  return {
-    ...adminRouteOptions({
-      forwardNotFoundPayload: true,
-      load,
-      resolveSplat: (params) => params._splat ?? '',
-    }),
-    notFoundComponent: AdminNotFound,
-  }
+  return adminRouteOptions({
+    forwardNotFoundPayload: true,
+    load,
+    resolveSplat: (params) => params._splat ?? '',
+  })
 }
 
 /**
- * Route options for the admin index route (`/_payload/admin/`). Same loader as the
- * splat route but throws a bare `notFound()` (no rscPayload) on miss, so
- * `AdminNotFound` falls through to the bare client view.
- *
- * `notFoundComponent` must be set here even though the payload is never forwarded:
- * TanStack picks the boundary component from its presence (`routeNotFoundComponent ?
- * CatchNotFound : SafeFragment`), so leaving it off gives this route a different
- * component type than the splat route at the same position in the tree. Navigating
- * between the two would then unmount the whole admin subtree and remount it —
- * blanking the page for as long as the new view takes to render.
+ * Route options for the admin index route (`/_payload/admin/`). Not-found
+ * results omit the RSC payload and fall back to `NotFoundClient`.
  */
 export function payloadAdminIndexRoute({ load }: { load: AdminLoad }) {
-  return {
-    ...adminRouteOptions({
-      forwardNotFoundPayload: false,
-      load,
-      resolveSplat: () => '',
-    }),
-    notFoundComponent: AdminNotFound,
-  }
+  return adminRouteOptions({
+    forwardNotFoundPayload: false,
+    load,
+    resolveSplat: () => '',
+  })
 }

--- a/packages/tanstack-start/src/routes/adminRoutes.tsx
+++ b/packages/tanstack-start/src/routes/adminRoutes.tsx
@@ -2,7 +2,7 @@
 
 import { NotFoundClient } from '@payloadcms/ui'
 import { notFound, redirect, useLoaderData } from '@tanstack/react-router'
-import { Fragment, type ReactNode } from 'react'
+import { Fragment, type ReactNode, useDeferredValue } from 'react'
 
 import { getAdminMeta } from '../utilities/meta.js'
 
@@ -31,7 +31,16 @@ function AdminPage() {
   // Note: React key intentionally omitted here so the persistent template (nav, header) doesn't remount and flash on navigation.
   // The per-route view key is attached server-side to the view subtree instead, via `renderRoot`'s `key` in `loadAdminPage`.
   const data = useLoaderData({ strict: false })
-  return <Fragment>{data?.rscPayload}</Fragment>
+
+  // The loader resolves as soon as the RSC wire data lands, but rendering the payload then
+  // suspends while its client references are imported — code-split chunks in a production build.
+  // Router state lives in an external store, so the transition TanStack wraps the commit in
+  // de-opts to a synchronous render and that suspension hits the nearest fallback, which is
+  // `null` unless a `pendingComponent` is configured — blanking the page. Deferring the payload
+  // keeps the previous view painted until the new one is renderable, then swaps.
+  const rscPayload = useDeferredValue(data?.rscPayload)
+
+  return <Fragment>{rscPayload}</Fragment>
 }
 
 function AdminNotFound(props: { data?: { routeKey?: string; rscPayload?: ReactNode } }) {

--- a/packages/tanstack-start/src/routes/adminRoutes.tsx
+++ b/packages/tanstack-start/src/routes/adminRoutes.tsx
@@ -114,12 +114,23 @@ export function payloadAdminSplatRoute({ load }: { load: AdminLoad }) {
 
 /**
  * Route options for the admin index route (`/_payload/admin/`). Same loader as the
- * splat route but throws a bare `notFound()` (no rscPayload) on miss.
+ * splat route but throws a bare `notFound()` (no rscPayload) on miss, so
+ * `AdminNotFound` falls through to the bare client view.
+ *
+ * `notFoundComponent` must be set here even though the payload is never forwarded:
+ * TanStack picks the boundary component from its presence (`routeNotFoundComponent ?
+ * CatchNotFound : SafeFragment`), so leaving it off gives this route a different
+ * component type than the splat route at the same position in the tree. Navigating
+ * between the two would then unmount the whole admin subtree and remount it —
+ * blanking the page for as long as the new view takes to render.
  */
 export function payloadAdminIndexRoute({ load }: { load: AdminLoad }) {
-  return adminRouteOptions({
-    forwardNotFoundPayload: false,
-    load,
-    resolveSplat: () => '',
-  })
+  return {
+    ...adminRouteOptions({
+      forwardNotFoundPayload: false,
+      load,
+      resolveSplat: () => '',
+    }),
+    notFoundComponent: AdminNotFound,
+  }
 }

--- a/test/admin-routing/collections/Posts.ts
+++ b/test/admin-routing/collections/Posts.ts
@@ -1,0 +1,21 @@
+import type { CollectionConfig } from 'payload'
+
+export const postsSlug = 'posts'
+
+export const Posts: CollectionConfig = {
+  slug: postsSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      admin: {
+        components: {
+          Field: '/components/TitleField.js#TitleField',
+        },
+      },
+    },
+  ],
+}

--- a/test/admin-routing/components/TitleField.tsx
+++ b/test/admin-routing/components/TitleField.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import type { TextFieldClientComponent } from 'payload'
+
+import { TextField } from '@payloadcms/ui'
+import React from 'react'
+
+export const TitleField: TextFieldClientComponent = (props) => {
+  return <TextField {...props} />
+}

--- a/test/admin-routing/config.ts
+++ b/test/admin-routing/config.ts
@@ -1,0 +1,35 @@
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { devUser } from '../credentials.js'
+import { Posts } from './collections/Posts.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+export default buildConfigWithDefaults({
+  admin: {
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+  },
+  collections: [Posts],
+  onInit: async (payload) => {
+    const { totalDocs } = await payload.count({
+      collection: 'users',
+    })
+
+    if (totalDocs > 0) {
+      return
+    }
+
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
+  },
+})

--- a/test/admin-routing/e2e.spec.ts
+++ b/test/admin-routing/e2e.spec.ts
@@ -24,7 +24,7 @@ test.afterEach(async ({ page }) => {
 })
 
 test(
-  'should preserve the admin subtree during index-to-splat navigation',
+  'should keep the previous admin view painted during index-to-splat navigation',
   { framework: 'tanstack-start' },
   async ({ page }) => {
     test.skip(
@@ -38,7 +38,6 @@ test(
     await ensureCompilationIsDone({ page, serverURL })
     await page.goto(postsURL.admin)
 
-    const adminTemplate = await page.locator('.template-default').elementHandle()
     let isClientChunkBlocked = false
     const clientChunkGate = new Promise<void>((resolve) => {
       releaseClientChunk = resolve
@@ -60,8 +59,8 @@ test(
     await page.locator(`#card-${postsSlug} .card__actions a`).click()
     await expect.poll(() => isClientChunkBlocked).toBe(true)
 
-    expect(await adminTemplate?.evaluate((element) => element.isConnected)).toBe(true)
     await expect(page.locator('.template-default')).toBeVisible()
+    await expect(page.locator(`#card-${postsSlug}`)).toBeVisible()
 
     releaseClientChunk?.()
     releaseClientChunk = undefined

--- a/test/admin-routing/e2e.spec.ts
+++ b/test/admin-routing/e2e.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { ensureCompilationIsDone } from '../__helpers/e2e/helpers.js'
+import { test } from '../__helpers/e2e/playwright.js'
+import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
+import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
+import { postsSlug } from './collections/Posts.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+const clientChunkPattern = /\/assets\/[^/]+\.js(?:\?.*)?$/
+
+let releaseClientChunk: (() => void) | undefined
+let pendingClientChunk: Promise<void> | undefined
+
+test.afterEach(async ({ page }) => {
+  releaseClientChunk?.()
+  await pendingClientChunk
+  releaseClientChunk = undefined
+  pendingClientChunk = undefined
+  await page.unroute(clientChunkPattern)
+})
+
+test(
+  'should preserve the admin subtree during index-to-splat navigation',
+  { framework: 'tanstack-start' },
+  async ({ page }) => {
+    test.skip(
+      process.env.PAYLOAD_TEST_PROD !== 'true',
+      'Production client chunks are required to suspend the next RSC payload.',
+    )
+
+    const { serverURL } = await initPayloadE2ENoConfig({ dirname })
+    const postsURL = new AdminUrlUtil(serverURL, postsSlug)
+
+    await ensureCompilationIsDone({ page, serverURL })
+    await page.goto(postsURL.admin)
+
+    const adminTemplate = await page.locator('.template-default').elementHandle()
+    let isClientChunkBlocked = false
+    const clientChunkGate = new Promise<void>((resolve) => {
+      releaseClientChunk = resolve
+    })
+
+    await page.route(
+      clientChunkPattern,
+      async (route) => {
+        isClientChunkBlocked = true
+        pendingClientChunk = (async () => {
+          await clientChunkGate
+          await route.continue()
+        })()
+        await pendingClientChunk
+      },
+      { times: 1 },
+    )
+
+    await page.locator(`#card-${postsSlug} .card__actions a`).click()
+    await expect.poll(() => isClientChunkBlocked).toBe(true)
+
+    expect(await adminTemplate?.evaluate((element) => element.isConnected)).toBe(true)
+    await expect(page.locator('.template-default')).toBeVisible()
+
+    releaseClientChunk?.()
+    releaseClientChunk = undefined
+
+    await expect(page).toHaveURL(postsURL.create)
+    await expect(page.locator('#field-title')).toBeVisible()
+  },
+)

--- a/test/admin-routing/tsconfig.eslint.json
+++ b/test/admin-routing/tsconfig.eslint.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/test/admin-routing/tsconfig.json
+++ b/test/admin-routing/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@payload-config": ["./config.ts"]
+    }
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}


### PR DESCRIPTION
The admin panel momentarily renders blank screens during some client-side navigation events in TanStack Start.

Two things contribute to the blank state:

1. The route loader finishes as soon as it receives the next page's RSC response. In production, the browser may still need to download JavaScript chunks before it can render that page. The router has already switched routes during that gap, so its empty fallback replaces the current view.
2. The `/admin` dashboard and `/admin/*` pages were wrapped in different not-found boundaries. React therefore treated navigation between them as a change in the surrounding component tree and removed the current admin view instead of preserving it through the transition.

The fix preserves the current admin view until the next route can render by:

- Deferring `rscPayload` updates so the current view remains painted while the next view loads
- Giving both routes the same `notFoundComponent` so their boundary tree remains stable

### Test coverage

Adds a standalone `admin-routing` E2E suite for focused route-level admin coverage. The suite is required for TanStack Start in CI while the broader `admin` suite remains disabled there due to unrelated flakes.

The long-term vision here is to incrementally move routing, navigation, custom view, and route-derived metadata coverage out of the bloated `admin/e2e/general` as that suite is dissolved into more focused suites. `admin-routing` stays scoped to behavior selected or produced by an admin URL, while feature-specific admin behavior remains in its corresponding suite.

---

### Before

https://github.com/user-attachments/assets/8670d905-1105-4be1-8806-f3f1bd0fb5e2

### After

https://github.com/user-attachments/assets/f7172756-e35c-4548-b4f4-201b16be6dd1