### PR TITLE
docs: remove deprecated root endpoint property

### DIFF
--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -667,6 +667,19 @@ export const Orders: CollectionConfig = {
   [Hooks](../hooks/overview).
 </Banner>
 
+#### Root-level routes
+
+Custom endpoints defined in your Payload Config are always mounted under your configured `routes.api` subpath (default: `/api`). If you need a route that is not behind this subpath, add a Next.js [Route Handler](https://nextjs.org/docs/app/api-reference/file-conventions/route) directly in your app folder, outside of the `(payload)` route group. You can still use the Local API inside it:
+
+```ts
+// src/app/my-route/route.ts
+export const GET = async (request: Request) => {
+  return Response.json({
+    message: 'This is an example of a custom route.',
+  })
+}
+```
+
 #### Helpful tips
 
 `req.data`

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -669,11 +669,12 @@ export const Orders: CollectionConfig = {
 
 #### Root-level routes
 
-Custom endpoints defined in your Payload Config are always mounted under your configured `routes.api` subpath (default: `/api`). If you need a route that is not behind this subpath, add a Next.js [Route Handler](https://nextjs.org/docs/app/api-reference/file-conventions/route) directly in your app folder, outside of the `(payload)` route group. You can still use the Local API inside it:
+Custom endpoints defined in your Payload Config are always mounted under your configured `routes.api` path (default: `/api`). To define a route that is not prefixed by this path, add a Next.js [Route Handler](https://nextjs.org/docs/app/api-reference/file-conventions/route) at the desired location in your app directory:
 
 ```ts
 // src/app/my-route/route.ts
-export const GET = async (request: Request) => {
+
+export const GET = async () => {
   return Response.json({
     message: 'This is an example of a custom route.',
   })

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -585,13 +585,12 @@ Additional REST API endpoints can be added to your application by providing an a
 
 Each endpoint object needs to have:
 
-| Property      | Description                                                                                                                                                                                                                                                |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`path`**    | A string for the endpoint route after the collection or globals slug                                                                                                                                                                                       |
-| **`method`**  | The lowercase HTTP verb to use: 'get', 'head', 'post', 'put', 'delete', 'connect' or 'options'                                                                                                                                                             |
-| **`handler`** | A function that accepts **req** - `PayloadRequest` object which contains [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) properties, currently authenticated `user` and the Local API instance `payload`.                          |
-| **`root`**    | When `true`, defines the endpoint on the root Next.js app, bypassing Payload handlers and the `routes.api` subpath. Note: this only applies to top-level endpoints of your Payload Config, endpoints defined on `collections` or `globals` cannot be root. |
-| **`custom`**  | Extension point for adding custom data (e.g. for plugins)                                                                                                                                                                                                  |
+| Property      | Description                                                                                                                                                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`path`**    | A string for the endpoint route after the collection or globals slug                                                                                                                                                              |
+| **`method`**  | The lowercase HTTP verb to use: 'get', 'head', 'post', 'put', 'delete', 'connect' or 'options'                                                                                                                                    |
+| **`handler`** | A function that accepts **req** - `PayloadRequest` object which contains [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) properties, currently authenticated `user` and the Local API instance `payload`. |
+| **`custom`**  | Extension point for adding custom data (e.g. for plugins)                                                                                                                                                                         |
 
 Example:
 


### PR DESCRIPTION
## What

Removes the `root` property from the custom endpoints table in the REST API docs.

## Why

The `root` property on `Endpoint` is deprecated in 3.0 and typed as `never` in `packages/payload/src/config/types.ts`, so it no longer has any effect. The docs still described it as a usable option.

Fixes #17553