### PR TITLE
fix(ui): match spacing on list view and doc view title and description

### DIFF
--- a/packages/ui/src/views/HierarchyList/index.css
+++ b/packages/ui/src/views/HierarchyList/index.css
@@ -45,7 +45,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: var(--spacer-3);
+    gap: var(--spacer-2-5);
   }
 
   .hierarchy-list__no-results > * {

--- a/packages/ui/src/views/List/index.css
+++ b/packages/ui/src/views/List/index.css
@@ -12,7 +12,7 @@
 
   .collection-list__sub-header {
     flex-basis: 100%;
-    padding-top: var(--spacer-3);
+    padding-top: var(--spacer-2-5);
   }
 
   .collection-list .table table {


### PR DESCRIPTION
Aligns spacing with doc view title and description. 