### PR TITLE
fix: set loading state when refreshing Lexical upload drawer

### DIFF
--- a/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
@@ -87,6 +87,7 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
   const refresh = useCallback(
     async ({ slug, query }: { query?: ListQuery; slug: string }) => {
       try {
+        setIsLoading(true)
         const newQuery: ListQuery = { ...(query || {}), where: { ...(query?.where || {}) } }
 
         const filterOption = filterOptions?.[slug]


### PR DESCRIPTION
The ListDrawerContent component's refresh function was not resetting isLoading to true before starting a new server fetch. This caused the drawer content to briefly disappear and reappear when users searched for uploads in the Lexical editor's media drawer.

Fixes #17544