### PR TITLE
fix(ui): flip the sort icon when changing direction

### DIFF
--- a/packages/ui/src/elements/SortHeader/index.tsx
+++ b/packages/ui/src/elements/SortHeader/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import { SortDownIcon } from '../../icons/Sort/index.js'
+import { SortDownIcon, SortUpIcon } from '../../icons/Sort/index.js'
 import { useListQuery } from '../../providers/ListQuery/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import './index.css'
@@ -17,29 +17,26 @@ const baseClass = 'sort-header'
 function useSort() {
   const { handleSortChange, orderableFieldName, query } = useListQuery()
   const querySort = Array.isArray(query.sort) ? query.sort[0] : query.sort
-  const isActive = querySort === orderableFieldName
+  const isAscending = querySort === orderableFieldName
+  const isDescending = querySort === `-${orderableFieldName}`
+  const isActive = isAscending || isDescending
 
   const handleSortPress = () => {
-    // If it's already sorted by the "_order" field, do nothing
-    if (isActive) {
-      return
-    }
-    // If NOT sorted by the "_order" field, sort by that field.
-    void handleSortChange(orderableFieldName)
+    void handleSortChange(isAscending ? `-${orderableFieldName}` : orderableFieldName)
   }
 
-  return { handleSortPress, isActive }
+  return { handleSortPress, isActive, isAscending }
 }
 
 export const SortHeader: React.FC<SortHeaderProps> = (props) => {
   const { appearance } = props
-  const { handleSortPress, isActive } = useSort()
+  const { handleSortPress, isActive, isAscending } = useSort()
   const { t } = useTranslation()
 
   return (
     <button
       aria-label={t('general:sortByLabelDirection', {
-        direction: t('general:ascending'),
+        direction: isAscending ? t('general:descending') : t('general:ascending'),
         label: 'Order',
       })}
       className={[
@@ -52,7 +49,7 @@ export const SortHeader: React.FC<SortHeaderProps> = (props) => {
       onClick={handleSortPress}
       type="button"
     >
-      <SortDownIcon />
+      {isAscending ? <SortUpIcon /> : <SortDownIcon />}
     </button>
   )
 }

--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -112,8 +112,12 @@ describe('Sort functionality', () => {
 
     await assertRows(['A', 'C', 'D', 'B'])
 
-    // Note: Clicking the sort button again should not change the order
-    // In previous versions we allowed ascending and descending order.
+    // Clicking the sort button again should toggle to descending order
+    await page.locator('button.sort-header').nth(0).click()
+    await page.waitForURL(/sort=-_order/, { timeout: 2000 })
+    await assertRows(['B', 'D', 'C', 'A'])
+
+    // Clicking the sort button again should toggle back to ascending order
     await page.locator('button.sort-header').nth(0).click()
     await page.waitForURL(/sort=_order/, { timeout: 2000 })
     await assertRows(['A', 'C', 'D', 'B'])

--- a/test/sort/e2e.spec.ts
+++ b/test/sort/e2e.spec.ts
@@ -117,10 +117,33 @@ describe('Sort functionality', () => {
     await page.waitForURL(/sort=-_order/, { timeout: 2000 })
     await assertRows(['B', 'D', 'C', 'A'])
 
+    await moveRow(page, {
+      fromIndex: 0,
+      toIndex: 2,
+    })
+
+    await assertRows(['D', 'C', 'B', 'A'])
+
+    // Move to top
+    await moveRow(page, {
+      fromIndex: 2,
+      toIndex: 0,
+    })
+
+    await assertRows(['B', 'D', 'C', 'A'])
+
+    // Move to bottom
+    await moveRow(page, {
+      fromIndex: 0,
+      toIndex: 3,
+    })
+
+    await assertRows(['D', 'C', 'A', 'B'])
+
     // Clicking the sort button again should toggle back to ascending order
     await page.locator('button.sort-header').nth(0).click()
     await page.waitForURL(/sort=_order/, { timeout: 2000 })
-    await assertRows(['A', 'C', 'D', 'B'])
+    await assertRows(['B', 'A', 'C', 'D'])
 
     await page.getByLabel('Sort by Title Ascending').click()
     await page.waitForURL(/sort=title/, { timeout: 2000 })


### PR DESCRIPTION
## Summary

The orderable table header let users sort by the manual order field only in ascending direction. A previous change removed the ascending/descending toggle because the icon did not change, so users could not tell which direction was active. This change restores the toggle and flips the icon to show the current direction.

https://github.com/user-attachments/assets/e508fbd6-e716-4d1a-806e-68292ddf8fc5


