### PR TITLE
fix: incorrect cron example seconds, fixes #17589

### DIFF
--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -27,11 +27,11 @@ export type AutorunCronConfig = {
    *     │ │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
    *     │ │ │ │ │ │
    *     │ │ │ │ │ │
-   *  - '* 0 * * * *' every hour at minute 0
-   *  - '* 0 0 * * *' daily at midnight
-   *  - '* 0 0 * * 0' weekly at midnight on Sundays
-   *  - '* 0 0 1 * *' monthly at midnight on the 1st day of the month
-   *  - '* 0/5 * * * *' every 5 minutes
+   *  - '0 0 * * * *' every hour at minute 0
+   *  - '0 0 0 * * *' daily at midnight
+   *  - '0 0 0 * * 0' weekly at midnight on Sundays
+   *  - '0 0 0 1 * *' monthly at midnight on the 1st day of the month
+   *  - '0 0/5 * * * *' every 5 minutes
    *  - '* * * * * *' every second
    */
   cron?: string
@@ -258,11 +258,11 @@ export type ScheduleConfig = {
    *     │ │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
    *     │ │ │ │ │ │
    *     │ │ │ │ │ │
-   *  - '* 0 * * * *' every hour at minute 0
-   *  - '* 0 0 * * *' daily at midnight
-   *  - '* 0 0 * * 0' weekly at midnight on Sundays
-   *  - '* 0 0 1 * *' monthly at midnight on the 1st day of the month
-   *  - '* 0/5 * * * *' every 5 minutes
+   *  - '0 0 * * * *' every hour at minute 0
+   *  - '0 0 0 * * *' daily at midnight
+   *  - '0 0 0 * * 0' weekly at midnight on Sundays
+   *  - '0 0 0 1 * *' monthly at midnight on the 1st day of the month
+   *  - '0 0/5 * * * *' every 5 minutes
    *  - '* * * * * *' every second
    */
   cron: string


### PR DESCRIPTION

The CRON expression examples were incorrect, details are described in the issue:
Fixes #17589

I'm not sure whether to also commit to a v3 branch, or whether somebody from the maintainters will backport this.

