### PR TITLE
fix: preserve parent localization through tabs 3.x

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -2152,11 +2152,11 @@ export function fieldShouldBeLocalized({
   field: ClientField | ClientTab | Field | Tab
   parentIsLocalized: boolean
 }): boolean {
-  return (
+  return Boolean(
     'localized' in field &&
-    field.localized! &&
-    (!parentIsLocalized ||
-      process.env.NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized === 'true')
+      field.localized &&
+      (!parentIsLocalized ||
+        process.env.NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized === 'true'),
   )
 }
 

--- a/packages/payload/src/fields/hooks/beforeValidate/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/traverseFields.ts
@@ -4,6 +4,7 @@ import type { RequestContext } from '../../../index.js'
 import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
+import { unflattenData } from '../../../utilities/unflattenData.js'
 import { promise } from './promise.js'
 
 type Args<T> = {
@@ -57,6 +58,7 @@ export const traverseFields = async <T>({
   siblingData,
   siblingDoc,
 }: Args<T>): Promise<void> => {
+  unflattenData(siblingData)
   const promises: Promise<void>[] = []
 
   fields.forEach((field, fieldIndex) => {

--- a/packages/payload/src/utilities/traverseFields.spec.ts
+++ b/packages/payload/src/utilities/traverseFields.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { traverseFields } from './traverseFields.js'
-import { Field } from '../fields/config/types.js'
+import type { Field } from '../fields/config/types.js'
 
 describe('traverseFields', () => {
   const tabsField: Field = {
@@ -47,6 +47,127 @@ describe('traverseFields', () => {
           }
         },
       })
+    })
+  })
+
+  describe('parent localization', () => {
+    it('should preserve parent localization through tabs', () => {
+      const fields: Field[] = [
+        {
+          name: 'group',
+          type: 'group',
+          localized: true,
+          fields: [
+            {
+              type: 'tabs',
+              tabs: [
+                {
+                  label: 'Tab',
+                  fields: [
+                    {
+                      name: 'text',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      let textParentIsLocalized: boolean | undefined
+
+      traverseFields({
+        fields,
+        callback: ({ field, parentIsLocalized }) => {
+          if (field.type === 'text') {
+            textParentIsLocalized = parentIsLocalized
+          }
+        },
+      })
+
+      expect(textParentIsLocalized).toBe(true)
+    })
+
+    it('should traverse localized tabs within localized parents', () => {
+      let textParentIsLocalized: boolean | undefined
+
+      traverseFields({
+        callback: ({ field, parentIsLocalized }) => {
+          if (field.type === 'text') {
+            textParentIsLocalized = parentIsLocalized
+          }
+        },
+        fields: [
+          {
+            name: 'group',
+            type: 'group',
+            localized: true,
+            fields: [
+              {
+                type: 'tabs',
+                tabs: [
+                  {
+                    name: 'tab',
+                    localized: true,
+                    fields: [
+                      {
+                        name: 'text',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        ref: {
+          group: {
+            en: {
+              tab: {
+                text: 'value',
+              },
+            },
+          },
+        },
+      })
+
+      expect(textParentIsLocalized).toBe(true)
+    })
+
+    it('should preserve parent localization through collapsibles', () => {
+      const fields: Field[] = [
+        {
+          name: 'group',
+          type: 'group',
+          localized: true,
+          fields: [
+            {
+              type: 'collapsible',
+              label: 'Collapsible',
+              fields: [
+                {
+                  name: 'text',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      let textParentIsLocalized: boolean | undefined
+
+      traverseFields({
+        fields,
+        callback: ({ field, parentIsLocalized }) => {
+          if (field.type === 'text') {
+            textParentIsLocalized = parentIsLocalized
+          }
+        },
+      })
+
+      expect(textParentIsLocalized).toBe(true)
     })
   })
 })

--- a/packages/payload/src/utilities/traverseFields.ts
+++ b/packages/payload/src/utilities/traverseFields.ts
@@ -159,7 +159,7 @@ export const traverseFields = ({
   fillEmpty = true,
   isTopLevel = true,
   leavesFirst = false,
-  parentIsLocalized,
+  parentIsLocalized = false,
   parentPath = '',
   parentRef = {},
   ref = {},
@@ -181,7 +181,7 @@ export const traverseFields = ({
     if (
       !leavesFirst &&
       callback &&
-      callback({ field, next, parentIsLocalized: parentIsLocalized!, parentPath, parentRef, ref })
+      callback({ field, next, parentIsLocalized, parentPath, parentRef, ref })
     ) {
       return true
     } else if (leavesFirst) {
@@ -189,7 +189,7 @@ export const traverseFields = ({
         callback({
           field,
           next,
-          parentIsLocalized: parentIsLocalized!,
+          parentIsLocalized,
           parentPath,
           parentRef,
           ref,
@@ -207,6 +207,7 @@ export const traverseFields = ({
 
     if (field.type === 'tabs' && 'tabs' in field) {
       for (const tab of field.tabs) {
+        const tabIsLocalized = fieldShouldBeLocalized({ field: tab, parentIsLocalized })
         let tabRef = ref
 
         if (skip) {
@@ -219,7 +220,7 @@ export const traverseFields = ({
             typeof ref[tab.name as keyof typeof ref] !== 'object'
           ) {
             if (fillEmpty) {
-              if (tab.localized) {
+              if (tabIsLocalized) {
                 ;(ref as Record<string, any>)[tab.name] = { en: {} }
               } else {
                 ;(ref as Record<string, any>)[tab.name] = {}
@@ -235,7 +236,7 @@ export const traverseFields = ({
             callback({
               field: { ...tab, type: 'tab' },
               next,
-              parentIsLocalized: parentIsLocalized!,
+              parentIsLocalized,
               parentPath,
               parentRef: currentParentRef,
               ref: tabRef,
@@ -247,7 +248,7 @@ export const traverseFields = ({
               callback({
                 field: { ...tab, type: 'tab' },
                 next,
-                parentIsLocalized: parentIsLocalized!,
+                parentIsLocalized,
                 parentPath,
                 parentRef: currentParentRef,
                 ref: tabRef,
@@ -257,7 +258,7 @@ export const traverseFields = ({
 
           tabRef = tabRef[tab.name as keyof typeof tabRef]
 
-          if (tab.localized) {
+          if (tabIsLocalized) {
             for (const key in tabRef as Record<string, unknown>) {
               if (
                 tabRef[key as keyof typeof tabRef] &&
@@ -286,7 +287,7 @@ export const traverseFields = ({
             callback({
               field: { ...tab, type: 'tab' },
               next,
-              parentIsLocalized: parentIsLocalized!,
+              parentIsLocalized,
               parentPath,
               parentRef: currentParentRef,
               ref: tabRef,
@@ -298,7 +299,7 @@ export const traverseFields = ({
               callback({
                 field: { ...tab, type: 'tab' },
                 next,
-                parentIsLocalized: parentIsLocalized!,
+                parentIsLocalized,
                 parentPath,
                 parentRef: currentParentRef,
                 ref: tabRef,
@@ -307,7 +308,7 @@ export const traverseFields = ({
           }
         }
 
-        if (!tab.localized) {
+        if (!tabIsLocalized) {
           traverseFields({
             callback,
             callbackStack,
@@ -316,7 +317,7 @@ export const traverseFields = ({
             fillEmpty,
             isTopLevel: false,
             leavesFirst,
-            parentIsLocalized: false,
+            parentIsLocalized,
             parentPath: tabHasName(tab) ? `${parentPath}${tab.name}.` : parentPath,
             parentRef: currentParentRef,
             ref: tabRef,
@@ -337,13 +338,13 @@ export const traverseFields = ({
         if (!ref[field.name as keyof typeof ref]) {
           if (fillEmpty) {
             if (field.type === 'group' || field.type === 'tab') {
-              if (fieldShouldBeLocalized({ field, parentIsLocalized: parentIsLocalized! })) {
+              if (fieldShouldBeLocalized({ field, parentIsLocalized })) {
                 ;(ref as Record<string, any>)[field.name] = { en: {} }
               } else {
                 ;(ref as Record<string, any>)[field.name] = {}
               }
             } else if (field.type === 'array' || field.type === 'blocks') {
-              if (fieldShouldBeLocalized({ field, parentIsLocalized: parentIsLocalized! })) {
+              if (fieldShouldBeLocalized({ field, parentIsLocalized })) {
                 ;(ref as Record<string, any>)[field.name] = { en: [] }
               } else {
                 ;(ref as Record<string, any>)[field.name] = []
@@ -358,7 +359,7 @@ export const traverseFields = ({
 
       if (
         (field.type === 'tab' || field.type === 'group') &&
-        fieldShouldBeLocalized({ field, parentIsLocalized: parentIsLocalized! }) &&
+        fieldShouldBeLocalized({ field, parentIsLocalized }) &&
         currentRef &&
         typeof currentRef === 'object'
       ) {
@@ -403,18 +404,7 @@ export const traverseFields = ({
         currentRef &&
         typeof currentRef === 'object'
       ) {
-        // TODO: `?? field.localized ?? false` shouldn't be necessary, but right now it
-        // is so that all fields are correctly traversed in copyToLocale and
-        // therefore pass the localization integration tests.
-        // I tried replacing the `!parentIsLocalized` condition with `parentIsLocalized === false`
-        // in `fieldShouldBeLocalized`, but several tests failed. We must be calling it with incorrect
-        // parameters somewhere.
-        if (
-          fieldShouldBeLocalized({
-            field,
-            parentIsLocalized: parentIsLocalized ?? false,
-          })
-        ) {
+        if (fieldShouldBeLocalized({ field, parentIsLocalized })) {
           if (Array.isArray(currentRef)) {
             traverseArrayOrBlocksField({
               callback,
@@ -458,7 +448,7 @@ export const traverseFields = ({
             field,
             fillEmpty,
             leavesFirst,
-            parentIsLocalized: parentIsLocalized!,
+            parentIsLocalized,
             parentPath,
             parentRef: currentParentRef,
           })

--- a/packages/payload/src/utilities/unflattenData.ts
+++ b/packages/payload/src/utilities/unflattenData.ts
@@ -1,0 +1,19 @@
+import type { JsonObject } from '../types/index.js'
+
+import { unflatten } from './unflatten.js'
+
+export const unflattenData = <T extends JsonObject>(data: T): T => {
+  if (!data || typeof data !== 'object' || !Object.keys(data).some((key) => key.includes('.'))) {
+    return data
+  }
+
+  const unflattened = unflatten(data) as JsonObject
+
+  for (const key of Object.keys(data)) {
+    delete data[key]
+  }
+
+  Object.assign(data, unflattened)
+
+  return data
+}

--- a/test/localization/collections/Array/index.ts
+++ b/test/localization/collections/Array/index.ts
@@ -8,13 +8,33 @@ export const ArrayCollection: CollectionConfig = {
     {
       name: 'items',
       type: 'array',
-      localized: true,
       fields: [
         {
           name: 'text',
           type: 'text',
         },
+        {
+          type: 'tabs',
+          tabs: [
+            {
+              fields: [
+                {
+                  name: 'nestedItems',
+                  type: 'array',
+                  fields: [
+                    {
+                      name: 'text',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+              label: 'Nested',
+            },
+          ],
+        },
       ],
+      localized: true,
     },
   ],
 }

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -7,6 +7,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type {
+  ArrayField,
   BlocksField,
   LocalizedPost,
   LocalizedSort,
@@ -3245,6 +3246,43 @@ describe('Localization', () => {
 
         // The source data should remain unchanged
         expect(refreshedDoc.topLevelArrayLocalized?.[0]?.text).toBe('some-text')
+      })
+
+      it('should copy nested arrays through tabs within localized arrays', async () => {
+        const doc = await payload.create({
+          collection: arrayCollectionSlug,
+          data: {
+            items: [
+              {
+                nestedItems: [
+                  {
+                    text: 'nested text',
+                  },
+                ],
+              },
+            ],
+          },
+          locale: 'en',
+        })
+
+        try {
+          const req = await createLocalReq({ user }, payload)
+
+          const res = (await copyDataFromLocaleHandler({
+            collectionSlug: arrayCollectionSlug,
+            docID: doc.id,
+            fromLocale: 'en',
+            req,
+            toLocale: 'es',
+          })) as ArrayField
+
+          expect(res.items?.[0]?.nestedItems?.[0]?.text).toBe('nested text')
+        } finally {
+          await payload.delete({
+            id: doc.id,
+            collection: arrayCollectionSlug,
+          })
+        }
       })
 
       it('should copy to locale without losing data when autosave and drafts are enabled', async () => {

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -3067,6 +3067,7 @@ describe('Localization', () => {
 
     describe('Copying To Locale', () => {
       let user: User
+      const createdDocs: { collection: string; id: number | string }[] = []
 
       beforeAll(async () => {
         user = (
@@ -3081,6 +3082,13 @@ describe('Localization', () => {
         ).docs[0] as unknown as User
 
         user['collection'] = 'users'
+      })
+
+      afterEach(async () => {
+        for (const { collection, id } of createdDocs) {
+          await payload.delete({ id, collection })
+        }
+        createdDocs.length = 0
       })
 
       it('should copy to locale', async () => {
@@ -3264,25 +3272,19 @@ describe('Localization', () => {
           },
           locale: 'en',
         })
+        createdDocs.push({ collection: arrayCollectionSlug, id: doc.id })
 
-        try {
-          const req = await createLocalReq({ user }, payload)
+        const req = await createLocalReq({ user }, payload)
 
-          const res = (await copyDataFromLocaleHandler({
-            collectionSlug: arrayCollectionSlug,
-            docID: doc.id,
-            fromLocale: 'en',
-            req,
-            toLocale: 'es',
-          })) as ArrayField
+        const res = (await copyDataFromLocaleHandler({
+          collectionSlug: arrayCollectionSlug,
+          docID: doc.id,
+          fromLocale: 'en',
+          req,
+          toLocale: 'es',
+        })) as ArrayField
 
-          expect(res.items?.[0]?.nestedItems?.[0]?.text).toBe('nested text')
-        } finally {
-          await payload.delete({
-            id: doc.id,
-            collection: arrayCollectionSlug,
-          })
-        }
+        expect(res.items?.[0]?.nestedItems?.[0]?.text).toBe('nested text')
       })
 
       it('should copy to locale without losing data when autosave and drafts are enabled', async () => {

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -521,6 +521,12 @@ export interface ArrayField {
   items?:
     | {
         text?: string | null;
+        nestedItems?:
+          | {
+              text?: string | null;
+              id?: string | null;
+            }[]
+          | null;
         id?: string | null;
       }[]
     | null;
@@ -1370,6 +1376,12 @@ export interface ArrayFieldsSelect<T extends boolean = true> {
     | T
     | {
         text?: T;
+        nestedItems?:
+          | T
+          | {
+              text?: T;
+              id?: T;
+            };
         id?: T;
       };
   updatedAt?: T;


### PR DESCRIPTION
Backport of #17578 to `3.x`.

This fixes two related localization bugs in `traverseFields`.

First, entering a non-localized tab always reset `parentIsLocalized` to `false`. Fields after the tab no longer knew that an earlier parent was localized. During Copy to Locale, this could reuse nested array or block row IDs and cause a database unique-constraint error.

Second, traversal checked `tab.localized` directly. A tab with `localized: true` inside an already-localized parent was incorrectly treated as another locale layer. This could make traversal interpret field names as locale names and skip nested fields.

Tabs now preserve inherited localization and only create a new locale layer when `fieldShouldBeLocalized` says they should. This matches localization handling behavior we have in other parts of Payload, like our hooks.

## Notes on the backport
- `3.x`'s `fieldShouldBeLocalized` keeps its `NEXT_PUBLIC_PAYLOAD_COMPATIBILITY_allowLocalizedWithinLocalized` compatibility clause; the `Boolean(...)` wrap was applied around it rather than replacing it.
- Regenerated `test/localization/payload-types.ts` via `pnpm dev:generate-types localization`.
- Dropped a stray `console.log('res', res)` that was present in the original test.

## Verification
- `traverseFields.spec.ts` unit tests: 4/4 pass
- New int test `should copy nested arrays through tabs within localized arrays`: passes
- Full `localization` int suite: 124 passed, 5 skipped, 0 failed
- eslint: 0 errors on changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)