### PR TITLE
fix(ui): change icon on copy to clipboard and update tooltip

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -480,6 +480,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'upload:addFile',
   'upload:addFiles',
   'upload:bulkUpload',
+  'upload:copyLinkToFile',
   'upload:crop',
   'upload:cropToolDescription',
   'upload:dragAndDrop',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -559,6 +559,7 @@ export const arTranslations: DefaultTranslationsObject = {
     addFile: 'إضافة ملف',
     addFiles: 'أضف ملفات',
     bulkUpload: 'تحميل بالجملة',
+    copyLinkToFile: 'نسخ الرابط إلى الملف',
     crop: 'محصول',
     cropToolDescription: 'اسحب الزوايا المحددة للمنطقة، رسم منطقة جديدة أو قم بضبط القيم أدناه.',
     download: 'تحميل',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -576,6 +576,7 @@ export const azTranslations: DefaultTranslationsObject = {
     addFile: 'Fayl əlavə et',
     addFiles: 'Faylları Əlavə Edin',
     bulkUpload: 'Kütləvi Yükləmə',
+    copyLinkToFile: 'Fayla keçidi kopyalayın',
     crop: 'Məhsul',
     cropToolDescription:
       'Seçilmiş sahənin köşələrini sürükləyin, yeni bir sahə çəkin və ya aşağıdakı dəyərləri düzəltin.',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -570,6 +570,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     addFile: 'Добавяне на файл',
     addFiles: 'Добави файлове',
     bulkUpload: 'Масово Качване',
+    copyLinkToFile: 'Копиране на връзка към файла',
     crop: 'Изрязване',
     cropToolDescription:
       'Плъзни ъглите на избраната област, избери нова област или коригирай стойностите по-долу.',

--- a/packages/translations/src/languages/bnBd.ts
+++ b/packages/translations/src/languages/bnBd.ts
@@ -579,6 +579,7 @@ export const bnBdTranslations: DefaultTranslationsObject = {
     addFile: 'ফাইল যোগ করুন',
     addFiles: 'ফাইলগুলি যোগ করুন',
     bulkUpload: 'বাল্ক আপলোড',
+    copyLinkToFile: 'ফাইলের লিঙ্ক কপি করুন',
     crop: 'ক্রপ করুন',
     cropToolDescription:
       'নির্বাচিত অঞ্চলের কোণগুলি টানুন, একটি নতুন অঞ্চল আঁকুন বা নিচের মানগুলি সামঞ্জস্য করুন।',

--- a/packages/translations/src/languages/bnIn.ts
+++ b/packages/translations/src/languages/bnIn.ts
@@ -578,6 +578,7 @@ export const bnInTranslations: DefaultTranslationsObject = {
     addFile: 'ফাইল যোগ করুন',
     addFiles: 'ফাইলগুলি যোগ করুন',
     bulkUpload: 'বাল্ক আপলোড',
+    copyLinkToFile: 'ফাইলের লিঙ্ক অনুলিপি করুন',
     crop: 'ক্রপ করুন',
     cropToolDescription:
       'নির্বাচিত অঞ্চলের কোণগুলি টানুন, একটি নতুন অঞ্চল আঁকুন বা নিচের মানগুলি সামঞ্জস্য করুন।',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -574,6 +574,7 @@ export const caTranslations: DefaultTranslationsObject = {
     addFile: 'Afegir fitxer',
     addFiles: 'Afegir fitxers',
     bulkUpload: 'Carregar arxius massius',
+    copyLinkToFile: "Copia l'enllaç al fitxer",
     crop: 'Retallar',
     cropToolDescription:
       'Arrossega les cantonades de l’àrea seleccionada, dibuixa una nova àrea o ajusta els valors a continuació.',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -566,6 +566,7 @@ export const csTranslations: DefaultTranslationsObject = {
     addFile: 'Přidat soubor',
     addFiles: 'Přidat soubory',
     bulkUpload: 'Hromadné nahrání',
+    copyLinkToFile: 'Zkopírovat odkaz na soubor',
     crop: 'Ořez',
     cropToolDescription:
       'Přetáhněte rohy vybrané oblasti, nakreslete novou oblast nebo upravte níže uvedené hodnoty.',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -570,6 +570,7 @@ export const daTranslations: DefaultTranslationsObject = {
     addFile: 'Tilføj fil',
     addFiles: 'Tilføj Filer',
     bulkUpload: 'Masseupload',
+    copyLinkToFile: 'Kopier link til fil',
     crop: 'Beskær',
     cropToolDescription:
       'Træk i hjørnerne af det valgte område, tegn et nyt område eller juster værdierne nedenfor.',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -583,6 +583,7 @@ export const deTranslations: DefaultTranslationsObject = {
     addFile: 'Datei hinzufügen',
     addFiles: 'Dateien hinzufügen',
     bulkUpload: 'Mehrere Dateien hochladen',
+    copyLinkToFile: 'Link zum Datei kopieren',
     crop: 'Zuschneiden',
     cropToolDescription:
       'Ziehe die Ecken des ausgewählten Bereichs, zeichne einen neuen Bereich oder passe die Werte unten an.',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -569,6 +569,7 @@ export const enTranslations = {
     addFile: 'Add file',
     addFiles: 'Add files',
     bulkUpload: 'Bulk Upload',
+    copyLinkToFile: 'Copy link to file',
     crop: 'Crop',
     cropToolDescription:
       'Drag the corners of the selected area, draw a new area or adjust the values below.',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -577,6 +577,7 @@ export const esTranslations: DefaultTranslationsObject = {
     addFile: 'Añadir archivo',
     addFiles: 'Añadir archivos',
     bulkUpload: 'Subida en lotes',
+    copyLinkToFile: 'Copiar enlace al archivo',
     crop: 'Recortar',
     cropToolDescription:
       'Arrastra las esquinas del área seleccionada, dibuja un nuevo área o ajusta los valores a continuación.',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -566,6 +566,7 @@ export const etTranslations: DefaultTranslationsObject = {
     addFile: 'Lisa fail',
     addFiles: 'Lisa failid',
     bulkUpload: 'Massiüleslaadimine',
+    copyLinkToFile: 'Kopeeri faili link',
     crop: 'Kärbi',
     cropToolDescription:
       'Lohista valitud ala nurki, joonista uus ala või kohanda väärtusi allpool.',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -562,6 +562,7 @@ export const faTranslations: DefaultTranslationsObject = {
     addFile: 'افزودن فایل',
     addFiles: 'افزودن فایل‌ها',
     bulkUpload: 'آپلود گروهی',
+    copyLinkToFile: 'کپی پیوند به فایل',
     crop: 'برش',
     cropToolDescription:
       'گوشه‌های ناحیه انتخاب شده را بکشید، یک ناحیه جدید رسم کنید یا مقادیر زیر را تنظیم نمایید.',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -583,6 +583,7 @@ export const frTranslations: DefaultTranslationsObject = {
     addFile: 'Ajouter un fichier',
     addFiles: 'Ajouter des fichiers',
     bulkUpload: 'Téléchargement en masse',
+    copyLinkToFile: 'Copier le lien vers le fichier',
     crop: 'Recadrer',
     cropToolDescription:
       'Faites glisser les coins de la zone sélectionnée, dessinez une nouvelle zone ou ajustez les valeurs ci-dessous.',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -553,6 +553,7 @@ export const heTranslations: DefaultTranslationsObject = {
     addFile: 'הוסף קובץ',
     addFiles: 'הוסף קבצים',
     bulkUpload: 'העלאה בתפוצה רחבה',
+    copyLinkToFile: 'העתק קישור לקובץ',
     crop: 'חתוך',
     cropToolDescription: 'גרור את הפינות של האזור שנבחר, צייר אזור חדש או התאם את הערכים למטה.',
     download: 'הורדה',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -569,6 +569,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     addFile: 'Dodaj datoteku',
     addFiles: 'Dodaj datoteke',
     bulkUpload: 'Masovno dodavanje',
+    copyLinkToFile: 'Kopirajte poveznicu na datoteku',
     crop: 'Izreži',
     cropToolDescription:
       'Povucite kutove odabranog područja, nacrtajte novo područje ili prilagodite vrijednosti ispod.',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -576,6 +576,7 @@ export const huTranslations: DefaultTranslationsObject = {
     addFile: 'Fájl hozzáadása',
     addFiles: 'Fájlok hozzáadása',
     bulkUpload: 'Tömeges feltöltés',
+    copyLinkToFile: 'Hivatkozás másolása a fájlhoz',
     crop: 'Termés',
     cropToolDescription:
       'Húzza a kijelölt terület sarkait, rajzoljon új területet, vagy igazítsa a lentebb található értékeket.',

--- a/packages/translations/src/languages/hy.ts
+++ b/packages/translations/src/languages/hy.ts
@@ -574,6 +574,7 @@ export const hyTranslations: DefaultTranslationsObject = {
     addFile: 'Ավելացնել ֆայլ',
     addFiles: 'Ավելացնել ֆայլեր',
     bulkUpload: 'Զանգվածային վերբեռնում',
+    copyLinkToFile: 'Պատճենել հղումը ֆայլին',
     crop: 'Կտրել',
     cropToolDescription:
       'Քաշեք ընտրված տարածքի անկյունները, նշեք նոր տարածք կամ կարգավորեք ստորև նշված արժեքները։',

--- a/packages/translations/src/languages/id.ts
+++ b/packages/translations/src/languages/id.ts
@@ -574,6 +574,7 @@ export const idTranslations: DefaultTranslationsObject = {
     addFile: 'Tambah file',
     addFiles: 'Tambah file',
     bulkUpload: 'Unggah Massal',
+    copyLinkToFile: 'Salin tautan ke file',
     crop: 'Pangkas',
     cropToolDescription:
       'Seret sudut area yang dipilih, gambar area baru atau sesuaikan nilai di bawah ini.',

--- a/packages/translations/src/languages/is.ts
+++ b/packages/translations/src/languages/is.ts
@@ -568,6 +568,7 @@ export const isTranslations: DefaultTranslationsObject = {
     addFile: 'Bæta við skrá',
     addFiles: 'Bæta við skrám',
     bulkUpload: 'Magn upphal',
+    copyLinkToFile: 'Afrita hlekk á skrá',
     crop: 'Skera',
     cropToolDescription:
       'Dragðu horn valda svæðisins, teiknaðu nýtt svæði eða stilltu gildin hér að neðan.',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -576,6 +576,7 @@ export const itTranslations: DefaultTranslationsObject = {
     addFile: 'Aggiungi file',
     addFiles: 'Aggiungi File',
     bulkUpload: 'Caricamento in Blocco',
+    copyLinkToFile: 'Copia link al file',
     crop: 'Raccolto',
     cropToolDescription:
       "Trascina gli angoli dell'area selezionata, disegna una nuova area o regola i valori qui sotto.",

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -570,6 +570,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     addFile: 'ファイルを追加',
     addFiles: 'ファイルを追加する',
     bulkUpload: '一括アップロード',
+    copyLinkToFile: 'ファイルへのリンクをコピー',
     crop: 'クロップ',
     cropToolDescription:
       '選択したエリアのコーナーをドラッグしたり、新たなエリアを描画したり、下記の値を調整してください。',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -567,6 +567,7 @@ export const koTranslations: DefaultTranslationsObject = {
     addFile: '파일 추가',
     addFiles: '파일 추가',
     bulkUpload: '일괄 업로드',
+    copyLinkToFile: '파일에 대한 링크 복사',
     crop: '자르기',
     cropToolDescription:
       '선택한 영역의 모퉁이를 드래그하거나 새로운 영역을 그리거나 아래의 값을 조정하세요.',

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -572,6 +572,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     addFile: 'Pridėti failą',
     addFiles: 'Pridėti failus',
     bulkUpload: 'Masinis įkėlimas',
+    copyLinkToFile: 'Kopijuoti nuorodą į failą',
     crop: 'Pasėlis',
     cropToolDescription:
       'Temkite pasirinktos srities kampus, nubrėžkite naują sritį arba koreguokite žemiau esančias reikšmes.',

--- a/packages/translations/src/languages/lv.ts
+++ b/packages/translations/src/languages/lv.ts
@@ -568,6 +568,7 @@ export const lvTranslations: DefaultTranslationsObject = {
     addFile: 'Pievienot failu',
     addFiles: 'Pievienot failus',
     bulkUpload: 'Masveida augšupielāde',
+    copyLinkToFile: 'Kopēt saiti uz failu',
     crop: 'Apgriezt',
     cropToolDescription:
       'Velciet atlasītā apgabala stūrus, uzzīmējiet jaunu apgabalu vai pielāgojiet vērtības zemāk.',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -578,6 +578,7 @@ export const myTranslations: DefaultTranslationsObject = {
     addFile: 'ဖိုင်ထည့်ပါ',
     addFiles: 'ဖိုင်များ ထည့်ပါ',
     bulkUpload: 'အစုလိုက် အပ်လုဒ်',
+    copyLinkToFile: 'ဖိုင်အတွက်လင့်ခ်ကို ကူးယူပါ',
     crop: 'သုန်း',
     cropToolDescription:
       'ရွေးထားသည့်ဧရိယာတွင်မွေးလျှက်မှုများကိုဆွဲပြီး, အသစ်တည်ပြီးသို့မဟုတ်အောက်ပါတ',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -573,6 +573,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     addFile: 'Legg til fil',
     addFiles: 'Legg til filer',
     bulkUpload: 'Bulk opplasting',
+    copyLinkToFile: 'Kopier lenke til fil',
     crop: 'Beskjær',
     cropToolDescription:
       'Dra hjørnene av det valgte området, tegn et nytt område eller juster verdiene nedenfor.',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -578,6 +578,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     addFile: 'Bestand toevoegen',
     addFiles: 'Bestanden toevoegen',
     bulkUpload: 'Bulk Upload',
+    copyLinkToFile: 'Kopieer link naar bestand',
     crop: 'Bijsnijden',
     cropToolDescription:
       'Sleep de hoeken van het geselecteerde gebied, teken een nieuw gebied of pas de waarden hieronder aan.',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -569,6 +569,7 @@ export const plTranslations: DefaultTranslationsObject = {
     addFile: 'Dodaj plik',
     addFiles: 'Dodaj pliki',
     bulkUpload: 'Załaduj masowo',
+    copyLinkToFile: 'Kopiuj link do pliku',
     crop: 'Przytnij',
     cropToolDescription:
       'Przeciągnij narożniki wybranego obszaru, narysuj nowy obszar lub dostosuj poniższe wartości.',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -573,6 +573,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     addFile: 'Adicionar arquivo',
     addFiles: 'Adicionar Arquivos',
     bulkUpload: 'Upload em Massa',
+    copyLinkToFile: 'Copiar link para o arquivo',
     crop: 'Cultura',
     cropToolDescription:
       'Arraste as bordas da área selecionada, desenhe uma nova área ou ajuste os valores abaixo.',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -576,6 +576,7 @@ export const roTranslations: DefaultTranslationsObject = {
     addFile: 'Adaugă fișier',
     addFiles: 'Adăugați fișiere',
     bulkUpload: 'Încărcare în masă',
+    copyLinkToFile: 'Copiați linkul către fișier',
     crop: 'Cultură',
     cropToolDescription:
       'Trageți colțurile zonei selectate, desenați o nouă zonă sau ajustați valorile de mai jos.',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -569,6 +569,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     addFile: 'Додај датотеку',
     addFiles: 'Dodaj datoteke',
     bulkUpload: 'Masovno otpremanje',
+    copyLinkToFile: 'Kopiraj vezu ka fajlu',
     crop: 'Исеците слику',
     cropToolDescription:
       'Превуците углове изабраног подручја, нацртајте ново подручје или прилагодите вредности испод.',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -570,6 +570,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     addFile: 'Dodaj datoteku',
     addFiles: 'Dodaj Datoteke',
     bulkUpload: 'Masovno otpremanje',
+    copyLinkToFile: 'Kopiraj link ka fajlu',
     crop: 'Isecite sliku',
     cropToolDescription:
       'Prevucite uglove izabranog područja, nacrtajte novo područje ili prilagodite vrednosti ispod.',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -575,6 +575,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     addFile: 'Добавить файл',
     addFiles: 'Добавить файлы',
     bulkUpload: 'Массовая загрузка',
+    copyLinkToFile: 'Скопировать ссылку на файл',
     crop: 'Обрезать',
     cropToolDescription:
       'Перетащите углы выбранной области, нарисуйте новую область или отрегулируйте значения ниже.',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -567,6 +567,7 @@ export const skTranslations: DefaultTranslationsObject = {
     addFile: 'Pridať súbor',
     addFiles: 'Pridať súbory',
     bulkUpload: 'Hromadné nahranie',
+    copyLinkToFile: 'Kopírovať odkaz na súbor',
     crop: 'Orezať',
     cropToolDescription:
       'Potiahnite rohy vybranej oblasti, nakreslite novú oblasť alebo upravte hodnoty nižšie.',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -568,6 +568,7 @@ export const slTranslations: DefaultTranslationsObject = {
     addFile: 'Dodaj datoteko',
     addFiles: 'Dodaj datoteke',
     bulkUpload: 'Množično nalaganje',
+    copyLinkToFile: 'Kopiraj povezavo do datoteke',
     crop: 'Obreži',
     cropToolDescription:
       'Povlecite kote izbranega območja, narišite novo območje ali prilagodite vrednosti spodaj.',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -572,6 +572,7 @@ export const svTranslations: DefaultTranslationsObject = {
     addFile: 'Lägg till fil',
     addFiles: 'Lägg till filer',
     bulkUpload: 'Massuppladdning',
+    copyLinkToFile: 'Kopiera länk till fil',
     crop: 'Beskär',
     cropToolDescription:
       'Dra i hörnen på det valda området, rita ett nytt område eller justera värdena nedan.',

--- a/packages/translations/src/languages/ta.ts
+++ b/packages/translations/src/languages/ta.ts
@@ -572,6 +572,7 @@ export const taTranslations: DefaultTranslationsObject = {
     addFile: 'கோப்பை சேர்க்கவும்',
     addFiles: 'கோப்புகளை சேர்க்கவும்',
     bulkUpload: 'மொத்தமாக பதிவேற்றம்',
+    copyLinkToFile: 'கோப்புக்கான இணைப்பை நகலெடுக்கவும்',
     crop: 'வெட்டுக',
     cropToolDescription:
       'தேர்ந்த பகுதியின் மூலைகளை இழுத்து, புதிய பகுதியை வரையுங்கள் அல்லது கீழே உள்ள மதிப்புகளைச் சரிசெய்யவும்.',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -561,6 +561,7 @@ export const thTranslations: DefaultTranslationsObject = {
     addFile: 'เพิ่มไฟล์',
     addFiles: 'เพิ่มไฟล์',
     bulkUpload: 'อัปโหลดจำนวนมาก',
+    copyLinkToFile: 'คัดลอกลิงก์ไปยังไฟล์',
     crop: 'พืชผล',
     cropToolDescription: 'ลากมุมของพื้นที่ที่เลือก, วาดพื้นที่ใหม่หรือปรับค่าด้านล่าง',
     download: 'ดาวน์โหลด',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -577,6 +577,7 @@ export const trTranslations: DefaultTranslationsObject = {
     addFile: 'Dosya ekle',
     addFiles: 'Dosya Ekle',
     bulkUpload: 'Toplu Yükleme',
+    copyLinkToFile: 'Dosyanın bağlantısını kopyala',
     crop: 'Mahsulat',
     cropToolDescription:
       'Seçilen alanın köşelerini sürükleyin, yeni bir alan çizin ya da aşağıdaki değerleri ayarlayın.',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -566,6 +566,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     addFile: 'Додати файл',
     addFiles: 'Додати файли',
     bulkUpload: 'Масове завантаження',
+    copyLinkToFile: 'Скопіювати посилання на файл',
     crop: 'Обрізати',
     cropToolDescription:
       'Перетягніть кути обраної області, намалюйте нову область або скоригуйте значення нижче.',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -571,6 +571,7 @@ export const viTranslations: DefaultTranslationsObject = {
     addFile: 'Thêm tập tin',
     addFiles: 'Thêm tệp',
     bulkUpload: 'Tải lên số lượng lớn',
+    copyLinkToFile: 'Sao chép liên kết đến tệp',
     crop: 'Cắt xén',
     cropToolDescription:
       'Kéo các góc của khu vực đã chọn, vẽ một khu vực mới hoặc điều chỉnh các giá trị dưới đây.',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -545,6 +545,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     addFile: '添加文件',
     addFiles: '添加文件',
     bulkUpload: '批量上传',
+    copyLinkToFile: '复制文件链接',
     crop: '裁剪',
     cropToolDescription: '拖动所选区域的角落，绘制一个新区域或调整以下的值。',
     download: '下载',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -543,6 +543,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     addFile: '新增檔案',
     addFiles: '新增多個檔案',
     bulkUpload: '大量上傳',
+    copyLinkToFile: '複製檔案連結',
     crop: '裁剪',
     cropToolDescription: '拖曳選取區域的角落、重新繪製區域或調整下方數值以進行裁剪。',
     download: '下載',

--- a/packages/ui/src/elements/CopyToClipboard/index.tsx
+++ b/packages/ui/src/elements/CopyToClipboard/index.tsx
@@ -10,11 +10,17 @@ const baseClass = 'copy-to-clipboard'
 
 export type Props = {
   defaultMessage?: string
+  icon?: React.ReactNode
   successMessage?: string
   value?: string
 }
 
-export const CopyToClipboard: React.FC<Props> = ({ defaultMessage, successMessage, value }) => {
+export const CopyToClipboard: React.FC<Props> = ({
+  defaultMessage,
+  icon,
+  successMessage,
+  value,
+}) => {
   const [copied, setCopied] = useState(false)
   const [hovered, setHovered] = useState(false)
   const { t } = useTranslation()
@@ -37,7 +43,7 @@ export const CopyToClipboard: React.FC<Props> = ({ defaultMessage, successMessag
         }}
         type="button"
       >
-        <CopyIcon />
+        {icon ?? <CopyIcon />}
         <Tooltip delay={copied ? 0 : undefined} show={hovered || copied}>
           {copied && (successMessage ?? t('general:copied'))}
           {!copied && (defaultMessage ?? t('general:copy'))}

--- a/packages/ui/src/elements/FileManager/FileToolbar/index.tsx
+++ b/packages/ui/src/elements/FileManager/FileToolbar/index.tsx
@@ -5,6 +5,7 @@ import { useElementHeightVariable } from '../../../hooks/useElementHeightVariabl
 import { ChevronIcon } from '../../../icons/Chevron/index.js'
 import { CropIcon } from '../../../icons/Crop/index.js'
 import { DownloadIcon } from '../../../icons/Download/index.js'
+import { LinkIcon } from '../../../icons/Link/index.js'
 import { NewTabIcon } from '../../../icons/NewTab/index.js'
 import { SwapIcon } from '../../../icons/Swap/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
@@ -70,7 +71,13 @@ export const FileToolbar: React.FC<Props> = ({
       </div>
 
       <div className={`${baseClass}__right`}>
-        {fileUrl && <CopyToClipboard value={fileUrl} />}
+        {fileUrl && (
+          <CopyToClipboard
+            defaultMessage={t('upload:copyLinkToFile')}
+            icon={<LinkIcon />}
+            value={fileUrl}
+          />
+        )}
         {isAdjustable && (
           <Button
             aria-label={t('upload:editImage')}

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -369,6 +369,27 @@ describe('Uploads', () => {
     expect(clipbaordContent).toBe(mediaDoc?.url)
   })
 
+  test('should show the link icon and "Copy link to file" tooltip on the copy link button', async () => {
+    const mediaDoc = (
+      await payload.find({
+        collection: mediaSlug,
+        depth: 0,
+        limit: 1,
+        pagination: false,
+      })
+    ).docs[0]
+
+    await page.goto(mediaURL.edit(mediaDoc!.id))
+
+    const copyLinkButton = page.locator('.file-toolbar .copy-to-clipboard')
+    await expect(copyLinkButton.locator('.icon--link')).toBeVisible()
+
+    await copyLinkButton.hover()
+    await expect(
+      page.locator('.tooltip--show', { hasText: exactText('Copy link to file') }),
+    ).toBeVisible()
+  })
+
   test('should show side-by-side layout for upload collection document with file', async () => {
     const mediaDoc = (
       await payload.find({


### PR DESCRIPTION
Updated the wording for the copy to clipboard tooltip and change the icon to be a link.

## Before

<img width="180" height="201" alt="image" src="https://github.com/user-attachments/assets/26f4dadf-ac1f-4ddb-a7d5-a33ae0db249a" />


## After

<img width="233" height="176" alt="image" src="https://github.com/user-attachments/assets/2a8c2477-1662-4b45-8de4-54184e106437" />
