### PR TITLE
ci: adjust filter base ref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          base: ${{ github.ref }}
           filters: |
             needs_build:
               - '.github/workflows/main.yml'
@@ -650,8 +651,12 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       [
+        changes,
         lint,
         build,
+        int-matrix,
+        e2e-matrix,
+        e2e-prep,
         build-and-test-templates,
         tests-unit,
         tests-int,


### PR DESCRIPTION
Fixes two CI gaps on the 3.x branch: path filtering compared against the wrong base ref, and the All Green gate ignored several upstream jobs.

`dorny/paths-filter` defaults its base to the repository default branch (main) on push events. Pushes to 3.x therefore diffed against an unrelated branch and produced meaningless filter output.

Separately, `all-green` did not list changes, int-matrix, e2e-matrix, or e2e-prep in needs. A failure in any of those left the dependent test jobs skipped, and a skipped result is neither failure nor cancelled, so the gate reported green.