### PR TITLE
chore: resolve local @payloadcms/figma from the figma monorepo

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payloadcms/figma": ["../enterprise-plugins/packages/figma/src/index.ts"],
+      "@payloadcms/figma": ["../figma/payload/payload-plugin/src/index.ts"],
       "@payload-config": ["./test/_community/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,9 @@ import { defineConfig } from 'vitest/config'
 
 // Use process.cwd() to be safe in both CJS and ESM contexts within Vitest
 const ROOT_DIR = process.cwd()
-const figmaPath = path.resolve(ROOT_DIR, '../enterprise-plugins/packages/figma/src/index.ts')
+const figmaPath =
+  process.env.PAYLOAD_FIGMA_PLUGIN_PATH ??
+  path.resolve(ROOT_DIR, '../figma/payload/payload-plugin/src/index.ts')
 const hasFigma = fs.existsSync(figmaPath)
 const evalFixturesDir = path.resolve(ROOT_DIR, 'test/evals/fixtures')
 


### PR DESCRIPTION
## Why

The dev-only alias for `@payloadcms/figma` points at `../enterprise-plugins/packages/figma`, where the adapter used to live. It has since moved into the figma monorepo, so on a current checkout that path does not resolve, `hasFigma` is false, and the alias quietly falls back to `node_modules`. Local edits to the adapter are then ignored by tests, which is the opposite of what the alias exists for.

## What

- Point the alias at the new location.
- Add `PAYLOAD_FIGMA_PLUGIN_PATH` to override it. A relative path can only ever name one checkout, so the env var covers a clone under a different directory name, or several worktrees where you want to choose which one a run resolves against.

## Test plan

With the monorepo checked out next to this repo and nothing configured:

```
pnpm exec vitest list test/access-control/int.spec.ts
[Dev Setup] Using local @payloadcms/figma source
```

Setting `PAYLOAD_FIGMA_PLUGIN_PATH` makes the log show that path instead. A checkout where neither path exists is unaffected: `hasFigma` stays false and the alias is not applied.