### PR TITLE
fix: preserve user data during session updates

### DIFF
--- a/packages/drizzle/src/transform/write/traverseFields.ts
+++ b/packages/drizzle/src/transform/write/traverseFields.ts
@@ -138,6 +138,11 @@ export const traverseFields = ({
     fieldName = `${fieldPrefix || ''}${field.name}`
     fieldData = data[field.name]
 
+    // Undefined fields are omitted from partial updates. updatedAt is derived when it is absent.
+    if (fieldData === undefined && !(field.type === 'date' && fieldName === 'updatedAt')) {
+      return
+    }
+
     const isLocalized = fieldShouldBeLocalized({ field, parentIsLocalized })
 
     if (field.type === 'array') {

--- a/packages/payload/src/auth/operations/logout.ts
+++ b/packages/payload/src/auth/operations/logout.ts
@@ -69,23 +69,18 @@ export const logoutOperation = async (incomingArgs: Arguments): Promise<boolean>
         throw new APIError('No User', httpStatus.BAD_REQUEST)
       }
 
-      if (allSessions) {
-        userWithSessions.sessions = []
-      } else {
-        const sessionsAfterLogout = (userWithSessions?.sessions || []).filter(
-          (s) => s.id !== req?.user?._sid,
-        )
-
-        userWithSessions.sessions = sessionsAfterLogout
-      }
-
-      // Prevent updatedAt from being updated when only removing a session
-      ;(userWithSessions as any).updatedAt = null
+      const sessions = allSessions
+        ? []
+        : (userWithSessions.sessions || []).filter((session) => session.id !== req.user?._sid)
 
       await req.payload.db.updateOne({
         id: user.id,
         collection: collectionConfig.slug,
-        data: userWithSessions,
+        data: {
+          sessions,
+          // Prevent updatedAt from being updated when only removing a session
+          updatedAt: null,
+        },
         req,
         returning: false,
       })

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -99,7 +99,6 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
         id: user.id,
         collection: collectionConfig.slug,
         data: {
-          ...user,
           // Prevent updatedAt from being updated when only refreshing a session
           sessions: removeExpiredSessions(user.sessions),
           updatedAt: null,

--- a/packages/payload/src/auth/sessions.ts
+++ b/packages/payload/src/auth/sessions.ts
@@ -52,7 +52,7 @@ export const addSessionToUser = async ({
       id: user.id,
       collection: collectionConfig.slug,
       data: {
-        ...user,
+        sessions: user.sessions,
         // Prevent updatedAt from being updated when only adding a session
         updatedAt: null,
       },
@@ -87,7 +87,11 @@ export const revokeSession = async ({
     await payload.db.updateOne({
       id: user.id,
       collection: collectionConfig.slug,
-      data: user,
+      data: {
+        sessions: user.sessions,
+        // Prevent updatedAt from being updated when only removing a session
+        updatedAt: null,
+      },
       req,
       returning: false,
     })

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -1668,6 +1668,62 @@ describe('Auth', () => {
   })
 
   describe('Sessions', () => {
+    const expectSessionOperationToPreserveConcurrentUpdate = async ({
+      operation,
+      userID,
+    }: {
+      operation: () => Promise<unknown>
+      userID: number | string
+    }): Promise<void> => {
+      const concurrentValue = `concurrent-update-${Date.now()}`
+      const updateOne = payload.db.updateOne.bind(payload.db)
+      let concurrentUpdateInjected = false
+
+      const updateOneSpy = vitest
+        .spyOn(payload.db, 'updateOne')
+        .mockImplementation(async (args) => {
+          const isTargetSessionWrite =
+            !concurrentUpdateInjected &&
+            args.collection === slug &&
+            args.id === userID &&
+            args.returning === false &&
+            Array.isArray(args.data.sessions)
+
+          if (isTargetSessionWrite) {
+            concurrentUpdateInjected = true
+
+            await updateOne({
+              id: userID,
+              collection: slug,
+              data: {
+                custom: concurrentValue,
+              },
+              req: args.req,
+            })
+          }
+
+          return updateOne(args)
+        })
+
+      try {
+        await operation()
+      } finally {
+        updateOneSpy.mockRestore()
+      }
+
+      const updatedUser = await payload.findByID({
+        id: userID,
+        collection: slug,
+      })
+
+      expect(concurrentUpdateInjected).toBe(true)
+      expect(updatedUser).toMatchObject({
+        custom: concurrentValue,
+        loginMetadata: [{ info: 'preserve-session-metadata' }],
+        roles: ['user'],
+      })
+    }
+
     it('should set a session on a user', async () => {
       const authenticated = await payload.login({
         collection: slug,
@@ -1699,6 +1755,43 @@ describe('Auth', () => {
       expect(matchedSession).toBeDefined()
       expect(matchedSession?.createdAt).toBeDefined()
       expect(matchedSession?.expiresAt).toBeDefined()
+    })
+
+    it('should preserve concurrent field updates when logging in', async () => {
+      expect.hasAssertions()
+
+      const testUser = await payload.create({
+        collection: slug,
+        data: {
+          custom: 'before-login',
+          email: `session-login-${Date.now()}@example.com`,
+          loginMetadata: [{ info: 'preserve-session-metadata' }],
+          password: 'test123',
+          roles: ['user'],
+        },
+      })
+
+      try {
+        await expectSessionOperationToPreserveConcurrentUpdate({
+          operation: async () => {
+            const result = await payload.login({
+              collection: slug,
+              data: {
+                email: testUser.email,
+                password: 'test123',
+              },
+            })
+
+            expect(result.token).toBeTruthy()
+          },
+          userID: testUser.id,
+        })
+      } finally {
+        await payload.delete({
+          id: testUser.id,
+          collection: slug,
+        })
+      }
     })
 
     it('should log out a user and delete only the session being logged out', async () => {
@@ -1746,6 +1839,48 @@ describe('Auth', () => {
 
       const existingSession = remainingSessions.find(({ id }) => id === decoded2.sid)
       expect(existingSession?.id).toStrictEqual(decoded2.sid)
+    })
+
+    it('should preserve concurrent field updates when logging out', async () => {
+      expect.hasAssertions()
+
+      const testUser = await payload.create({
+        collection: slug,
+        data: {
+          custom: 'before-logout',
+          email: `session-logout-${Date.now()}@example.com`,
+          loginMetadata: [{ info: 'preserve-session-metadata' }],
+          password: 'test123',
+          roles: ['user'],
+        },
+      })
+      const authenticated = await payload.login({
+        collection: slug,
+        data: {
+          email: testUser.email,
+          password: 'test123',
+        },
+      })
+
+      try {
+        await expectSessionOperationToPreserveConcurrentUpdate({
+          operation: async () => {
+            const response = await restClient.POST(`/${slug}/logout`, {
+              headers: {
+                Authorization: `JWT ${authenticated.token}`,
+              },
+            })
+
+            expect(response.status).toBe(200)
+          },
+          userID: testUser.id,
+        })
+      } finally {
+        await payload.delete({
+          id: testUser.id,
+          collection: slug,
+        })
+      }
     })
 
     it('should refresh an existing session', async () => {
@@ -1798,6 +1933,48 @@ describe('Auth', () => {
       expect(new Date(matchedSession?.expiresAt as unknown as string).getTime()).toBeLessThan(
         new Date(matchedRefreshedSession?.expiresAt as unknown as string).getTime(),
       )
+    })
+
+    it('should preserve concurrent field updates when refreshing a session', async () => {
+      expect.hasAssertions()
+
+      const testUser = await payload.create({
+        collection: slug,
+        data: {
+          custom: 'before-refresh',
+          email: `session-refresh-${Date.now()}@example.com`,
+          loginMetadata: [{ info: 'preserve-session-metadata' }],
+          password: 'test123',
+          roles: ['user'],
+        },
+      })
+      const authenticated = await payload.login({
+        collection: slug,
+        data: {
+          email: testUser.email,
+          password: 'test123',
+        },
+      })
+
+      try {
+        await expectSessionOperationToPreserveConcurrentUpdate({
+          operation: async () => {
+            const response = await restClient.POST(`/${slug}/refresh-token`, {
+              headers: {
+                Authorization: `JWT ${authenticated.token}`,
+              },
+            })
+
+            expect(response.status).toBe(200)
+          },
+          userID: testUser.id,
+        })
+      } finally {
+        await payload.delete({
+          id: testUser.id,
+          collection: slug,
+        })
+      }
     })
 
     it('should reject a refresh when its session is revoked after authentication', async () => {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -4548,6 +4548,52 @@ describe('database', () => {
     expect(res.arrayWithIDs?.[0]?.text).toBe('some text')
   })
 
+  it('should preserve omitted complex fields in a partial updateOne', async () => {
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        arrayWithIDs: [{ text: 'array value' }],
+        blocks: [
+          {
+            blockType: 'block-third',
+          },
+        ],
+        blocksWithIDs: [
+          {
+            blockType: 'block-first',
+            text: 'block value',
+          },
+        ],
+        title: 'before partial update',
+      },
+    })
+
+    const result = (await payload.db.updateOne({
+      id: post.id,
+      collection: 'posts',
+      data: {
+        blocksWithIDs: [
+          {
+            id: post.blocksWithIDs?.[0]?.id,
+            blockType: 'block-first',
+            text: 'updated block value',
+          },
+        ],
+        title: 'after partial update',
+      },
+    })) as unknown as DataFromCollectionSlug<'posts'>
+
+    expect(result.title).toBe('after partial update')
+    expect(result.arrayWithIDs).toMatchObject([{ text: 'array value' }])
+    expect(result.blocks).toMatchObject([{ blockType: 'block-third' }])
+    expect(result.blocksWithIDs).toMatchObject([
+      {
+        blockType: 'block-first',
+        text: 'updated block value',
+      },
+    ])
+  })
+
   it('should use optimized updateMany', async () => {
     const post1 = await payload.create({
       collection: 'posts',


### PR DESCRIPTION
## Summary

- make Drizzle partial writes treat `undefined` complex fields as omitted while preserving implicit `updatedAt` handling
- update session mutations to persist only `sessions` and `updatedAt` in login, rollback/revoke, logout, and refresh paths
- add deterministic regressions proving session writes do not overwrite an intervening scalar update or erase array / select-has-many data
- add a database regression covering omitted arrays and blocks during a partial `updateOne`

## Context

This addresses the full-document write reported in #17295 and builds on the narrow-write direction proposed in #17296.

While validating that approach across adapters, I found a SQL prerequisite: the Drizzle slow update path currently visits omitted arrays, blocks, and has-many selects as empty values. A session-only update could therefore delete unrelated rows such as auth roles or login metadata in PostgreSQL and SQLite. The first commit makes `undefined` mean “omit” while keeping `null` available for explicit clearing.

The auth commit then removes the stale user snapshot from all four session write paths. The regression injects an unrelated write immediately before each session update; current `main` overwrites it, while the narrow payload preserves it.

This PR intentionally does **not** claim to fix concurrent session-array mutations from #16027 / #17135. Those operations still use read-modify-write and need an atomic, cross-adapter design. I will keep that discussion separate.

I opened this as a draft because the add/revoke portion overlaps #17296 and I want to coordinate rather than obscure that contribution. Maintainer edits are enabled.

## Validation

- MongoDB replica set: full auth + database integration suites — 233 passed, 11 skipped
- MongoDB replica set: new targeted regressions after final assertions — 4 passed
- SQLite: full auth suite passed; new auth and database regressions passed
- PostgreSQL: full auth suite — 71 passed
- all 39 package builds completed successfully
- lint-staged passed for both commits
- Prettier check passed for all six changed files

The generic PostgreSQL database suite could not initialize locally because the available PostgreSQL installation does not include PostGIS; adapter behavior is still exercised by the passing auth suite.