### PR TITLE
feat(storage-azure): add support for Entra managed identity authentication

### DIFF
--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -314,18 +314,46 @@ export default buildConfig({
 })
 ```
 
+### Authentication#azure-authentication
+
+The adapter supports two mutually exclusive authentication methods: a `connectionString` (shown above), or an Entra ID `credential` for identity-based authentication without stored secrets — for example a managed identity on Azure App Service or a workload identity on AKS. Pass any [`TokenCredential`](https://learn.microsoft.com/en-us/javascript/api/@azure/core-auth/tokencredential) from `@azure/identity`:
+
+```ts
+import { DefaultAzureCredential } from '@azure/identity'
+
+azureStorage({
+  // ...
+  baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL, // https://<account>.blob.core.windows.net
+  credential: new DefaultAzureCredential(),
+  containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
+})
+```
+
+When using `credential`:
+
+- `baseURL` must be the storage account's blob endpoint (`https://<account>.blob.core.windows.net`), not a CDN URL, since it is also used to connect to the account.
+- The identity needs the **Storage Blob Data Contributor** role on the storage account or container. Client uploads (`clientUploads`) sign upload URLs with a [user delegation SAS](https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas), whose `generateUserDelegationKey` action is included in that role.
+- For a user-assigned managed identity with `DefaultAzureCredential`, set the `AZURE_CLIENT_ID` environment variable to the identity's client ID (or use `ManagedIdentityCredential` with an explicit client ID).
+
+<Banner type="warning">
+  SAS-based connection strings (containing `SharedAccessSignature=`) work for
+  server uploads but cannot sign upload URLs, so they are not supported with
+  `clientUploads`.
+</Banner>
+
 ### Configuration Options#azure-configuration
 
-| Option                 | Description                                                                              | Default |
-| ---------------------- | ---------------------------------------------------------------------------------------- | ------- |
-| `enabled`              | Whether or not to enable the plugin                                                      | `true`  |
-| `collections`          | Collections to apply the Azure Blob adapter to                                           |         |
-| `allowContainerCreate` | Whether or not to allow the container to be created if it does not exist                 | `false` |
-| `baseURL`              | Base URL for the Azure Blob storage account                                              |         |
-| `connectionString`     | Azure Blob storage connection string                                                     |         |
-| `containerName`        | Azure Blob storage container name                                                        |         |
-| `clientUploads`        | Upload directly to Azure instead of through Payload.                                     |         |
-| `useCompositePrefixes` | Combine collection prefix with document prefix instead of document prefix overriding it. | `false` |
+| Option                 | Description                                                                                            | Default |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
+| `enabled`              | Whether or not to enable the plugin                                                                    | `true`  |
+| `collections`          | Collections to apply the Azure Blob adapter to                                                         |         |
+| `allowContainerCreate` | Whether or not to allow the container to be created if it does not exist                               | `false` |
+| `baseURL`              | Base URL for the Azure Blob storage account (the blob endpoint when using `credential`)                |         |
+| `connectionString`     | Azure Blob storage connection string (mutually exclusive with `credential`)                            |         |
+| `credential`           | Entra ID `TokenCredential` (e.g. `DefaultAzureCredential`), mutually exclusive with `connectionString` |         |
+| `containerName`        | Azure Blob storage container name                                                                      |         |
+| `clientUploads`        | Upload directly to Azure instead of through Payload.                                                   |         |
+| `useCompositePrefixes` | Combine collection prefix with document prefix instead of document prefix overriding it.               | `false` |
 
 ## Google Cloud Storage
 

--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -16,6 +16,44 @@ pnpm add @payloadcms/storage-azure
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
 - When deploying to Vercel, server uploads are limited to 4.5MB. Set `clientUploads` to `true` to use upload instructions and send files directly to Azure.
 
+### Authentication
+
+The adapter supports two mutually exclusive authentication methods.
+
+#### Connection string
+
+```ts
+azureStorage({
+  // ...
+  baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL,
+  connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+  containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
+})
+```
+
+#### Entra ID / managed identity
+
+Pass any [`TokenCredential`](https://learn.microsoft.com/en-us/javascript/api/@azure/core-auth/tokencredential) from `@azure/identity` as `credential` to authenticate without storing secrets — for example with a managed identity on Azure App Service or a workload identity on AKS:
+
+```ts
+import { DefaultAzureCredential } from '@azure/identity'
+
+azureStorage({
+  // ...
+  baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL, // https://<account>.blob.core.windows.net
+  credential: new DefaultAzureCredential(),
+  containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
+})
+```
+
+Requirements when using `credential`:
+
+- `baseURL` must be the storage account's blob endpoint (`https://<account>.blob.core.windows.net`), not a CDN URL, since it is also used to connect to the account.
+- The identity needs the **Storage Blob Data Contributor** role on the storage account or container. Client uploads (`clientUploads`) sign upload URLs with a [user delegation SAS](https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas), whose `generateUserDelegationKey` action is included in that role.
+- For a user-assigned managed identity with `DefaultAzureCredential`, set the `AZURE_CLIENT_ID` environment variable to the identity's client ID (or use `ManagedIdentityCredential` with an explicit client ID).
+
+> **Note:** SAS-based connection strings (containing `SharedAccessSignature=`) work for server uploads but cannot sign upload URLs, so they are not supported with `clientUploads`.
+
 ### Client uploads and CORS
 
 Client uploads (`clientUploads: true`) use the Azure Blob SDK, which splits large files into blocks and therefore avoids the ~5GB limit of a single upload request. Because the SDK sends `x-ms-*` headers, the browser issues a CORS preflight, so your storage account's CORS rules must allow the `OPTIONS` and `PUT` methods **and** the required headers.
@@ -58,12 +96,13 @@ export default buildConfig({
 
 ### Configuration Options
 
-| Option                 | Description                                                              | Default |
-| ---------------------- | ------------------------------------------------------------------------ | ------- |
-| `enabled`              | Whether or not to enable the plugin                                      | `true`  |
-| `collections`          | Collections to apply the Azure Blob adapter to                           |         |
-| `allowContainerCreate` | Whether or not to allow the container to be created if it does not exist | `false` |
-| `baseURL`              | Base URL for the Azure Blob storage account                              |         |
-| `connectionString`     | Azure Blob storage connection string                                     |         |
-| `containerName`        | Azure Blob storage container name                                        |         |
-| `clientUploads`        | Upload directly to Azure instead of through Payload.                     |         |
+| Option                 | Description                                                                                            | Default |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
+| `enabled`              | Whether or not to enable the plugin                                                                    | `true`  |
+| `collections`          | Collections to apply the Azure Blob adapter to                                                         |         |
+| `allowContainerCreate` | Whether or not to allow the container to be created if it does not exist                               | `false` |
+| `baseURL`              | Base URL for the Azure Blob storage account (the blob endpoint when using `credential`)                |         |
+| `connectionString`     | Azure Blob storage connection string (mutually exclusive with `credential`)                            |         |
+| `credential`           | Entra ID `TokenCredential` (e.g. `DefaultAzureCredential`), mutually exclusive with `connectionString` |         |
+| `containerName`        | Azure Blob storage container name                                                                      |         |
+| `clientUploads`        | Upload directly to Azure instead of through Payload.                                                   |         |

--- a/packages/storage-azure/package.json
+++ b/packages/storage-azure/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
+    "@azure/core-auth": "^1.9.0",
     "@azure/storage-blob": "^12.11.0",
     "@payloadcms/plugin-cloud-storage": "workspace:*"
   },

--- a/packages/storage-azure/src/adapter.ts
+++ b/packages/storage-azure/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { ContainerClient } from '@azure/storage-blob'
+import type { BlobServiceClient, ContainerClient } from '@azure/storage-blob'
 import type {
   Adapter,
   ClientUploadsConfig,
@@ -17,6 +17,7 @@ interface CreateAzureAdapterArgs {
   clientUploads?: ClientUploadsConfig
   containerName: string
   createContainerIfNotExists: () => void
+  getBlobServiceClient: () => BlobServiceClient
   getStorageClient: () => ContainerClient
   useCompositePrefixes?: boolean
 }
@@ -27,6 +28,7 @@ export function createAzureAdapter({
   clientUploads,
   containerName,
   createContainerIfNotExists,
+  getBlobServiceClient,
   getStorageClient,
   useCompositePrefixes = false,
 }: CreateAzureAdapterArgs): Adapter {
@@ -52,6 +54,7 @@ export function createAzureAdapter({
         access: typeof clientUploads === 'object' ? clientUploads.access : undefined,
         collectionPrefix: prefix,
         containerName,
+        getBlobServiceClient,
         getStorageClient,
         useCompositePrefixes,
       }),

--- a/packages/storage-azure/src/generateUploadInstructions.spec.ts
+++ b/packages/storage-azure/src/generateUploadInstructions.spec.ts
@@ -1,0 +1,152 @@
+import type { TokenCredential } from '@azure/core-auth'
+import type { BlobServiceClient, UserDelegationKey } from '@azure/storage-blob'
+import type { PayloadRequest, UploadInstructions } from 'payload'
+
+import {
+  AnonymousCredential,
+  ContainerClient,
+  StorageSharedKeyCredential,
+} from '@azure/storage-blob'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@payloadcms/plugin-cloud-storage/utilities', () => ({
+  resolveSignedURLKey: vi.fn(({ docPrefix, filename }: { docPrefix?: string; filename: string }) =>
+    Promise.resolve({
+      fileKey: docPrefix ? `${docPrefix}/${filename}` : filename,
+      sanitizedDocPrefix: docPrefix ?? '',
+      sanitizedFilename: filename,
+    }),
+  ),
+}))
+
+import { generateUploadInstructions } from './generateUploadInstructions.js'
+
+const accountName = 'myaccount'
+const containerName = 'mycontainer'
+const containerURL = `https://${accountName}.blob.core.windows.net/${containerName}`
+
+const sharedKeyCredential = new StorageSharedKeyCredential(
+  accountName,
+  Buffer.from('account-key').toString('base64'),
+)
+
+const tokenCredential: TokenCredential = {
+  getToken: () =>
+    Promise.resolve({ expiresOnTimestamp: Date.now() + 60 * 60 * 1000, token: 'fake-token' }),
+}
+
+const createUserDelegationKey = (): UserDelegationKey => ({
+  signedExpiresOn: new Date(Date.now() + 6 * 60 * 60 * 1000),
+  signedObjectId: 'object-id',
+  signedService: 'b',
+  signedStartsOn: new Date(),
+  signedTenantId: 'tenant-id',
+  signedVersion: '2020-02-10',
+  value: Buffer.from('user-delegation-key').toString('base64'),
+})
+
+const createServiceClientMock = () => {
+  const getUserDelegationKey = vi.fn(() => Promise.resolve(createUserDelegationKey()))
+
+  return {
+    getUserDelegationKey,
+    serviceClient: { getUserDelegationKey } as unknown as BlobServiceClient,
+  }
+}
+
+const req = { t: (key: string) => key, user: { id: 1 } } as unknown as PayloadRequest
+
+const generateArgs = {
+  collectionSlug: 'media',
+  filename: 'file.png',
+  filesize: 3,
+  mimeType: 'image/png',
+  req,
+}
+
+const getSignedUploadURL = (instructions: UploadInstructions): URL => {
+  expect(instructions.type).toBe('dispatch')
+
+  const { data } = instructions as Extract<UploadInstructions, { type: 'dispatch' }>
+
+  return new URL((data as { url: string }).url)
+}
+
+const createGenerate = ({
+  credential,
+  serviceClient,
+}: {
+  credential: AnonymousCredential | StorageSharedKeyCredential | TokenCredential
+  serviceClient: BlobServiceClient
+}) =>
+  generateUploadInstructions({
+    collectionPrefix: '',
+    containerName,
+    getBlobServiceClient: () => serviceClient,
+    getStorageClient: () => new ContainerClient(containerURL, credential),
+  })
+
+describe('generateUploadInstructions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should sign a service SAS with a shared key credential', async () => {
+    const { getUserDelegationKey, serviceClient } = createServiceClientMock()
+    const generate = createGenerate({ credential: sharedKeyCredential, serviceClient })
+
+    const instructions = await generate(generateArgs)
+
+    const url = getSignedUploadURL(instructions)
+
+    expect(url.href).toContain(`${containerURL}/file.png?`)
+    expect(url.searchParams.get('sig')).toBeTruthy()
+    expect(url.searchParams.get('sp')).toBe('w')
+    // No user delegation SAS markers and no key requested
+    expect(url.searchParams.get('skoid')).toBeNull()
+    expect(getUserDelegationKey).not.toHaveBeenCalled()
+  })
+
+  it('should sign a user delegation SAS with a token credential', async () => {
+    const { getUserDelegationKey, serviceClient } = createServiceClientMock()
+    const generate = createGenerate({ credential: tokenCredential, serviceClient })
+
+    const instructions = await generate(generateArgs)
+
+    const url = getSignedUploadURL(instructions)
+
+    expect(url.href).toContain(`${containerURL}/file.png?`)
+    expect(url.searchParams.get('sig')).toBeTruthy()
+    expect(url.searchParams.get('sp')).toBe('w')
+    // User delegation SAS markers
+    expect(url.searchParams.get('skoid')).toBe('object-id')
+    expect(url.searchParams.get('sktid')).toBe('tenant-id')
+    expect(getUserDelegationKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('should reuse the cached user delegation key across requests', async () => {
+    const { getUserDelegationKey, serviceClient } = createServiceClientMock()
+    const generate = createGenerate({ credential: tokenCredential, serviceClient })
+
+    await generate(generateArgs)
+    await generate(generateArgs)
+
+    expect(getUserDelegationKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw for credentials that cannot sign SAS tokens', async () => {
+    const { serviceClient } = createServiceClientMock()
+    const generate = createGenerate({ credential: new AnonymousCredential(), serviceClient })
+
+    await expect(generate(generateArgs)).rejects.toThrow(/cannot sign upload URLs/)
+  })
+
+  it('should throw Forbidden when there is no user and no access override', async () => {
+    const { serviceClient } = createServiceClientMock()
+    const generate = createGenerate({ credential: sharedKeyCredential, serviceClient })
+
+    await expect(
+      generate({ ...generateArgs, req: { ...req, user: null } as unknown as PayloadRequest }),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/storage-azure/src/generateUploadInstructions.ts
+++ b/packages/storage-azure/src/generateUploadInstructions.ts
@@ -1,14 +1,40 @@
-import type { ContainerClient, StorageSharedKeyCredential } from '@azure/storage-blob'
+import type {
+  BlobServiceClient,
+  ContainerClient,
+  SASQueryParameters,
+  UserDelegationKey,
+} from '@azure/storage-blob'
 import type { GenerateUploadInstructions, UploadInstructionsAccess } from 'payload'
 
-import { BlobSASPermissions, generateBlobSASQueryParameters } from '@azure/storage-blob'
+import { isTokenCredential } from '@azure/core-auth'
+import {
+  BlobSASPermissions,
+  generateBlobSASQueryParameters,
+  StorageSharedKeyCredential,
+} from '@azure/storage-blob'
 import { resolveSignedURLKey } from '@payloadcms/plugin-cloud-storage/utilities'
-import { Forbidden } from 'payload'
+import { APIError, Forbidden } from 'payload'
+
+const SAS_EXPIRY_MS = 3 * 60 * 60 * 1000
+
+// User delegation keys are requested with twice the SAS lifetime and reused
+// while their remaining validity still covers a full SAS window (a user
+// delegation SAS becomes invalid once the key it was signed with expires).
+const USER_DELEGATION_KEY_LIFETIME_MS = 2 * SAS_EXPIRY_MS
+const USER_DELEGATION_KEY_REFRESH_MARGIN_MS = 5 * 60 * 1000
+
+type CachedUserDelegationKey = {
+  expiresOn: Date
+  key: UserDelegationKey
+}
+
+const userDelegationKeys = new WeakMap<BlobServiceClient, CachedUserDelegationKey>()
 
 interface Args {
   access?: UploadInstructionsAccess
   collectionPrefix: string
   containerName: string
+  getBlobServiceClient: () => BlobServiceClient
   getStorageClient: () => ContainerClient
   useCompositePrefixes?: boolean
 }
@@ -17,6 +43,7 @@ export const generateUploadInstructions = ({
   access,
   collectionPrefix,
   containerName,
+  getBlobServiceClient,
   getStorageClient,
   useCompositePrefixes = false,
 }: Args): GenerateUploadInstructions => {
@@ -42,19 +69,39 @@ export const generateUploadInstructions = ({
       useCompositePrefixes,
     })
 
-    const blobClient = getStorageClient().getBlobClient(fileKey)
+    const containerClient = getStorageClient()
+    const blobClient = containerClient.getBlobClient(fileKey)
 
-    const sasToken = generateBlobSASQueryParameters(
-      {
-        blobName: fileKey,
-        containerName,
-        contentType: mimeType,
-        expiresOn: new Date(Date.now() + 3 * 60 * 60 * 1000),
-        permissions: BlobSASPermissions.parse('w'),
-        startsOn: new Date(),
-      },
-      getStorageClient().credential as StorageSharedKeyCredential,
-    )
+    const sasOptions = {
+      blobName: fileKey,
+      containerName,
+      contentType: mimeType,
+      expiresOn: new Date(Date.now() + SAS_EXPIRY_MS),
+      permissions: BlobSASPermissions.parse('w'),
+      startsOn: new Date(),
+    }
+
+    const { credential } = containerClient
+
+    let sasToken: SASQueryParameters
+
+    if (credential instanceof StorageSharedKeyCredential) {
+      sasToken = generateBlobSASQueryParameters(sasOptions, credential)
+    } else if (isTokenCredential(credential)) {
+      const userDelegationKey = await getUserDelegationKey({
+        serviceClient: getBlobServiceClient(),
+      })
+
+      sasToken = generateBlobSASQueryParameters(
+        sasOptions,
+        userDelegationKey,
+        containerClient.accountName,
+      )
+    } else {
+      throw new APIError(
+        'Azure Blob storage: client uploads require an account-key connection string or an Entra `credential` — the configured credential cannot sign upload URLs (SAS-based connection strings are not supported for client uploads)',
+      )
+    }
 
     return {
       name: 'uploadToAzure',
@@ -70,4 +117,27 @@ export const generateUploadInstructions = ({
       },
     }
   }
+}
+
+async function getUserDelegationKey({
+  serviceClient,
+}: {
+  serviceClient: BlobServiceClient
+}): Promise<UserDelegationKey> {
+  const cached = userDelegationKeys.get(serviceClient)
+
+  const remainingValidityMs = cached ? cached.expiresOn.getTime() - Date.now() : 0
+
+  if (cached && remainingValidityMs > SAS_EXPIRY_MS + USER_DELEGATION_KEY_REFRESH_MARGIN_MS) {
+    return cached.key
+  }
+
+  const startsOn = new Date()
+  const expiresOn = new Date(Date.now() + USER_DELEGATION_KEY_LIFETIME_MS)
+
+  const key = await serviceClient.getUserDelegationKey(startsOn, expiresOn)
+
+  userDelegationKeys.set(serviceClient, { expiresOn, key })
+
+  return key
 }

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -1,3 +1,4 @@
+import type { TokenCredential } from '@azure/core-auth'
 import type {
   ClientUploadsConfig,
   PluginOptions as CloudStoragePluginOptions,
@@ -8,7 +9,44 @@ import type { Config, StorageAdapter, UploadCollectionSlug } from 'payload'
 import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 
 import { createAzureAdapter } from './adapter.js'
-import { getStorageClient as getStorageClientFunc } from './utils/getStorageClient.js'
+import {
+  getBlobServiceClient as getBlobServiceClientFunc,
+  getStorageClient as getStorageClientFunc,
+} from './utils/getStorageClient.js'
+
+/**
+ * Authentication for the Azure Blob storage account. Exactly one of the
+ * following must be provided:
+ *
+ * - `connectionString` — account-key or SAS-based connection string
+ * - `credential` — an Entra ID `TokenCredential` (e.g. `DefaultAzureCredential`
+ *   from `@azure/identity`) for managed identity / workload identity auth
+ */
+type AzureStorageAuth =
+  | {
+      /**
+       * Azure Blob storage connection string
+       */
+      connectionString: string
+      credential?: never
+    }
+  | {
+      connectionString?: never
+      /**
+       * Entra ID credential used to authenticate against the storage account,
+       * e.g. `DefaultAzureCredential` or `ManagedIdentityCredential` from
+       * `@azure/identity`.
+       *
+       * When set, `baseURL` must be the storage account's blob endpoint
+       * (`https://<account>.blob.core.windows.net`), not a CDN URL.
+       *
+       * The identity requires the `Storage Blob Data Contributor` role on the
+       * account or container. Client uploads (`clientUploads`) additionally rely
+       * on user delegation SAS, whose `generateUserDelegationKey` action is
+       * included in that role.
+       */
+      credential: TokenCredential
+    }
 
 export type AzureStorageOptions = {
   /**
@@ -59,11 +97,6 @@ export type AzureStorageOptions = {
   collections: Partial<Record<UploadCollectionSlug, Omit<CollectionOptions, 'adapter'> | true>>
 
   /**
-   * Azure Blob storage connection string
-   */
-  connectionString: string
-
-  /**
    * Azure Blob storage container name
    */
   containerName: string
@@ -88,7 +121,7 @@ export type AzureStorageOptions = {
    * @default false
    */
   useCompositePrefixes?: boolean
-}
+} & AzureStorageAuth
 
 type AzureStorageFactory = (azureStorageArgs: AzureStorageOptions) => StorageAdapter
 
@@ -98,11 +131,16 @@ export const azureStorage: AzureStorageFactory = (
   name: 'azure',
   collections: Object.keys(azureStorageOptions.collections),
   init: (incomingConfig: Config): Config => {
-    const getStorageClient = () =>
-      getStorageClientFunc({
-        connectionString: azureStorageOptions.connectionString,
-        containerName: azureStorageOptions.containerName,
-      })
+    const storageClientArgs = {
+      baseURL: azureStorageOptions.baseURL,
+      clientCacheKey: azureStorageOptions.clientCacheKey,
+      connectionString: azureStorageOptions.connectionString,
+      containerName: azureStorageOptions.containerName,
+      credential: azureStorageOptions.credential,
+    }
+
+    const getStorageClient = () => getStorageClientFunc(storageClientArgs)
+    const getBlobServiceClient = () => getBlobServiceClientFunc(storageClientArgs)
 
     const isPluginDisabled = azureStorageOptions.enabled === false
 
@@ -111,10 +149,7 @@ export const azureStorage: AzureStorageFactory = (
     }
 
     const createContainerIfNotExists = () => {
-      void getStorageClientFunc({
-        connectionString: azureStorageOptions.connectionString,
-        containerName: azureStorageOptions.containerName,
-      }).createIfNotExists({
+      void getStorageClient().createIfNotExists({
         access: 'blob',
       })
     }
@@ -125,6 +160,7 @@ export const azureStorage: AzureStorageFactory = (
       clientUploads: azureStorageOptions.clientUploads,
       containerName: azureStorageOptions.containerName,
       createContainerIfNotExists,
+      getBlobServiceClient,
       getStorageClient,
       useCompositePrefixes: azureStorageOptions.useCompositePrefixes,
     })

--- a/packages/storage-azure/src/utils/getStorageClient.spec.ts
+++ b/packages/storage-azure/src/utils/getStorageClient.spec.ts
@@ -1,0 +1,83 @@
+import type { TokenCredential } from '@azure/core-auth'
+
+import { describe, expect, it } from 'vitest'
+
+import { getBlobServiceClient, getStorageClient } from './getStorageClient.js'
+
+// Well-known Azurite development storage credentials
+const connectionString =
+  'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+
+const baseURL = 'https://myaccount.blob.core.windows.net'
+
+const createTokenCredential = (): TokenCredential => ({
+  getToken: () =>
+    Promise.resolve({ expiresOnTimestamp: Date.now() + 60 * 60 * 1000, token: 'fake-token' }),
+})
+
+describe('getStorageClient', () => {
+  it('should create a container client from a connection string', () => {
+    const client = getStorageClient({
+      connectionString,
+      containerName: 'connection-string-container',
+    })
+
+    expect(client.containerName).toBe('connection-string-container')
+    expect(client.accountName).toBe('devstoreaccount1')
+  })
+
+  it('should create a container client from a token credential and baseURL', () => {
+    const credential = createTokenCredential()
+
+    const client = getStorageClient({
+      baseURL,
+      containerName: 'credential-container',
+      credential,
+    })
+
+    expect(client.containerName).toBe('credential-container')
+    expect(client.accountName).toBe('myaccount')
+    expect(client.credential).toBe(credential)
+  })
+
+  it('should cache clients per cache key', () => {
+    const options = {
+      connectionString,
+      containerName: 'cached-container',
+    }
+
+    expect(getStorageClient(options)).toBe(getStorageClient(options))
+  })
+
+  it('should return the service client backing the container client', () => {
+    const credential = createTokenCredential()
+    const options = {
+      baseURL,
+      containerName: 'service-client-container',
+      credential,
+    }
+
+    const serviceClient = getBlobServiceClient(options)
+
+    expect(serviceClient.accountName).toBe('myaccount')
+    expect(serviceClient.credential).toBe(credential)
+    expect(getBlobServiceClient(options)).toBe(serviceClient)
+  })
+
+  it('should throw when neither connectionString nor credential is provided', () => {
+    expect(() =>
+      getStorageClient({
+        containerName: 'no-auth-container',
+      }),
+    ).toThrow(/connectionString.*credential/)
+  })
+
+  it('should throw when credential is provided without baseURL', () => {
+    expect(() =>
+      getStorageClient({
+        containerName: 'no-base-url-container',
+        credential: createTokenCredential(),
+      }),
+    ).toThrow(/baseURL/)
+  })
+})

--- a/packages/storage-azure/src/utils/getStorageClient.ts
+++ b/packages/storage-azure/src/utils/getStorageClient.ts
@@ -1,26 +1,70 @@
+import type { TokenCredential } from '@azure/core-auth'
 import type { ContainerClient } from '@azure/storage-blob'
 
 import { BlobServiceClient } from '@azure/storage-blob'
 
-import type { AzureStorageOptions } from '../index.js'
+export type GetStorageClientOptions = {
+  /**
+   * Storage account blob endpoint, required when authenticating with `credential`
+   */
+  baseURL?: string
+  clientCacheKey?: string
+  connectionString?: string
+  containerName: string
+  credential?: TokenCredential
+}
+
+type AzureClients = {
+  containerClient: ContainerClient
+  serviceClient: BlobServiceClient
+}
 
 // Cache the Azure Blob storage clients in a map so that multiple instances are not overriding each other in the case of different configurations used per collection
-const azureClients = new Map<string, ContainerClient>()
+const azureClients = new Map<string, AzureClients>()
 
-export function getStorageClient(
-  options: Pick<AzureStorageOptions, 'clientCacheKey' | 'connectionString' | 'containerName'>,
-): ContainerClient {
+export function getStorageClient(options: GetStorageClientOptions): ContainerClient {
+  return resolveAzureClients(options).containerClient
+}
+
+export function getBlobServiceClient(options: GetStorageClientOptions): BlobServiceClient {
+  return resolveAzureClients(options).serviceClient
+}
+
+function resolveAzureClients(options: GetStorageClientOptions): AzureClients {
   const cacheKey = options.clientCacheKey || `azure:${options.containerName}`
 
-  if (azureClients.has(cacheKey)) {
-    return azureClients.get(cacheKey)!
+  const cachedClients = azureClients.get(cacheKey)
+
+  if (cachedClients) {
+    return cachedClients
   }
 
-  const { connectionString, containerName } = options
+  const { baseURL, connectionString, containerName, credential } = options
 
-  const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
+  let serviceClient: BlobServiceClient
 
-  azureClients.set(cacheKey, blobServiceClient.getContainerClient(containerName))
+  if (connectionString) {
+    serviceClient = BlobServiceClient.fromConnectionString(connectionString)
+  } else if (credential) {
+    if (!baseURL) {
+      throw new Error(
+        'Azure Blob storage: `baseURL` must be set to the storage account blob endpoint when authenticating with `credential`',
+      )
+    }
 
-  return azureClients.get(cacheKey)!
+    serviceClient = new BlobServiceClient(baseURL, credential)
+  } else {
+    throw new Error(
+      'Azure Blob storage: provide either `connectionString` or `credential` to authenticate',
+    )
+  }
+
+  const clients: AzureClients = {
+    containerClient: serviceClient.getContainerClient(containerName),
+    serviceClient,
+  }
+
+  azureClients.set(cacheKey, clients)
+
+  return clients
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1581,6 +1581,9 @@ importers:
       '@azure/abort-controller':
         specifier: ^1.1.0
         version: 1.1.0
+      '@azure/core-auth':
+        specifier: ^1.9.0
+        version: 1.10.1
       '@azure/storage-blob':
         specifier: ^12.11.0
         version: 12.33.0


### PR DESCRIPTION
## What?

Adds Entra ID (managed identity) authentication to `@payloadcms/storage-azure`.

`AzureStorageOptions` now accepts either a `connectionString` (existing behaviour) or a `credential`, which can be any `TokenCredential` from `@azure/identity` such as `DefaultAzureCredential`. The two options are mutually exclusive at the type level, so misconfiguration is caught at compile time.

## Why?

Connection strings require storing the storage account key as a secret. On Azure App Service, Container Apps or AKS, identity-based authentication is Microsoft's recommended approach. There are no long-lived secrets to store, rotate or leak, and access is controlled through RBAC and can be revoked at any time. It also makes it possible to harden security further by disabling storage account key access entirely.

This has been requested before in #13627 (and #12004 prior to it), which proposed the same `credential` option. However, #13627 doesn't address `clientUploads`: the SAS signing code in `generateUploadInstructions` unconditionally casts the container client's credential to `StorageSharedKeyCredential`. With a `TokenCredential` configured, that cast is wrong at runtime and client uploads fail.

## How?

- `getStorageClient` now builds the `BlobServiceClient` from either auth method and caches both the service and container clients per cache key. The service client is needed to request user delegation keys when signing client upload URLs.
- `generateUploadInstructions` branches on the actual credential type instead of casting:
  - `StorageSharedKeyCredential` signs a service SAS, exactly as before, so there is no behaviour change for existing users.
  - `TokenCredential` fetches a user delegation key via `getUserDelegationKey` and signs a user delegation SAS. Keys are requested with twice the SAS lifetime and cached in a `WeakMap`, and only reused while their remaining validity still covers a full SAS window plus a clock-skew margin. In practice this means roughly one key fetch every three hours rather than one per upload.
- Docs and README updated with an Authentication section covering both methods, the `baseURL` requirement, the `Storage Blob Data Contributor` role requirement, and a note on the SAS connection string limitation.
- Unit tests added covering client construction and caching, both signing paths (asserting the `sig`/`sp` and `skoid`/`sktid` SAS parameters), delegation key caching, and the error cases.

Verified manually against a real storage account with a `DefaultAzureCredential`: server uploads, client uploads (delegation SAS) and downloads all work, and misconfigurations produce the intended errors.