### PR TITLE
docs: fix field type guard imports

### DIFF
--- a/tools/claude-plugin/skills/payload/reference/FIELD-TYPE-GUARDS.md
+++ b/tools/claude-plugin/skills/payload/reference/FIELD-TYPE-GUARDS.md
@@ -10,7 +10,7 @@ Checks if field contains nested fields (group, array, row, or collapsible).
 
 ```ts
 import type { Field } from 'payload'
-import { fieldHasSubFields } from 'payload'
+import { fieldHasSubFields } from 'payload/shared'
 
 function traverseFields(fields: Field[]): void {
   fields.forEach((field) => {
@@ -43,7 +43,7 @@ if (fieldHasSubFields(field) && !fieldIsArrayType(field)) {
 Checks if field type is `'array'`.
 
 ```ts
-import { fieldIsArrayType } from 'payload'
+import { fieldIsArrayType } from 'payload/shared'
 
 if (fieldIsArrayType(field)) {
   // field.type === 'array'
@@ -65,7 +65,7 @@ fieldIsArrayType<TField extends ClientField | Field>(
 Checks if field type is `'blocks'`.
 
 ```ts
-import { fieldIsBlockType } from 'payload'
+import { fieldIsBlockType } from 'payload/shared'
 
 if (fieldIsBlockType(field)) {
   // field.type === 'blocks'
@@ -98,7 +98,7 @@ if (fieldIsArrayType(field)) {
 Checks if field type is `'group'`.
 
 ```ts
-import { fieldIsGroupType } from 'payload'
+import { fieldIsGroupType } from 'payload/shared'
 
 if (fieldIsGroupType(field)) {
   // field.type === 'group'
@@ -121,7 +121,7 @@ fieldIsGroupType<TField extends ClientField | Field>(
 Checks if field can have multiple values (select, relationship, or upload with `hasMany`).
 
 ```ts
-import { fieldSupportsMany } from 'payload'
+import { fieldSupportsMany } from 'payload/shared'
 
 if (fieldSupportsMany(field)) {
   // field.type is 'select' | 'relationship' | 'upload'
@@ -145,7 +145,7 @@ fieldSupportsMany<TField extends ClientField | Field>(
 Checks if field is relationship/upload/join with numeric `maxDepth` property.
 
 ```ts
-import { fieldHasMaxDepth } from 'payload'
+import { fieldHasMaxDepth } from 'payload/shared'
 
 if (fieldHasMaxDepth(field)) {
   // field.type is 'upload' | 'relationship' | 'join'
@@ -167,7 +167,7 @@ fieldHasMaxDepth<TField extends ClientField | Field>(
 Checks if field needs localization handling (accounts for parent localization).
 
 ```ts
-import { fieldShouldBeLocalized } from 'payload'
+import { fieldShouldBeLocalized } from 'payload/shared'
 
 function processField(field: Field, parentIsLocalized: boolean) {
   if (fieldShouldBeLocalized({ field, parentIsLocalized })) {
@@ -200,7 +200,7 @@ if (fieldShouldBeLocalized({ field, parentIsLocalized: false })) {
 Checks if field is virtual (computed or virtual relationship).
 
 ```ts
-import { fieldIsVirtual } from 'payload'
+import { fieldIsVirtual } from 'payload/shared'
 
 if (fieldIsVirtual(field)) {
   // field.virtual is truthy
@@ -226,7 +226,7 @@ fieldIsVirtual(field: Field | Tab): boolean
 **Most commonly used guard.** Checks if field stores data (has name and is not UI-only).
 
 ```ts
-import { fieldAffectsData } from 'payload'
+import { fieldAffectsData } from 'payload/shared'
 
 function generateSchema(fields: Field[]) {
   fields.forEach((field) => {
@@ -257,7 +257,7 @@ const dataFields = fields.filter(fieldAffectsData)
 Checks if field is UI-only (type `'ui'`).
 
 ```ts
-import { fieldIsPresentationalOnly } from 'payload'
+import { fieldIsPresentationalOnly } from 'payload/shared'
 
 if (fieldIsPresentationalOnly(field)) {
   // field.type === 'ui'
@@ -279,7 +279,7 @@ fieldIsPresentationalOnly<TField extends ClientField | Field | TabAsField | TabA
 Checks if field name is exactly `'id'`.
 
 ```ts
-import { fieldIsID } from 'payload'
+import { fieldIsID } from 'payload/shared'
 
 if (fieldIsID(field)) {
   // field.name === 'id'
@@ -300,7 +300,7 @@ fieldIsID<TField extends ClientField | Field>(
 Checks if field is hidden or admin-disabled.
 
 ```ts
-import { fieldIsHiddenOrDisabled } from 'payload'
+import { fieldIsHiddenOrDisabled } from 'payload/shared'
 
 const visibleFields = fields.filter((field) => !fieldIsHiddenOrDisabled(field))
 ```
@@ -320,7 +320,7 @@ fieldIsHiddenOrDisabled<TField extends ClientField | Field | TabAsField | TabAsF
 Checks if field is positioned in sidebar.
 
 ```ts
-import { fieldIsSidebar } from 'payload'
+import { fieldIsSidebar } from 'payload/shared'
 
 const [mainFields, sidebarFields] = fields.reduce(
   ([main, sidebar], field) => {
@@ -348,7 +348,7 @@ fieldIsSidebar<TField extends ClientField | Field | TabAsField | TabAsFieldClien
 Checks if tab is named (stores data under tab name).
 
 ```ts
-import { tabHasName } from 'payload'
+import { tabHasName } from 'payload/shared'
 
 tabs.forEach((tab) => {
   if (tabHasName(tab)) {
@@ -372,7 +372,7 @@ tabHasName<TField extends ClientTab | Tab>(
 Checks if group is named (stores data under group name).
 
 ```ts
-import { groupHasName } from 'payload'
+import { groupHasName } from 'payload/shared'
 
 if (groupHasName(group)) {
   // group.name exists
@@ -393,7 +393,7 @@ groupHasName(group: Partial<NamedGroupFieldClient>): group is NamedGroupFieldCli
 Checks if option is object format `{label, value}` vs string.
 
 ```ts
-import { optionIsObject } from 'payload'
+import { optionIsObject } from 'payload/shared'
 
 field.options.forEach((option) => {
   if (optionIsObject(option)) {
@@ -415,7 +415,7 @@ optionIsObject(option: Option): option is OptionObject
 Checks if entire options array contains objects.
 
 ```ts
-import { optionsAreObjects } from 'payload'
+import { optionsAreObjects } from 'payload/shared'
 
 if (optionsAreObjects(field.options)) {
   // All options are OptionObject[]
@@ -434,7 +434,7 @@ optionsAreObjects(options: Option[]): options is OptionObject[]
 Checks if option is string value (not object).
 
 ```ts
-import { optionIsValue } from 'payload'
+import { optionIsValue } from 'payload/shared'
 
 if (optionIsValue(option)) {
   // option is string
@@ -453,7 +453,7 @@ optionIsValue(option: Option): option is string
 Checks if relationship value is polymorphic format `{relationTo, value}`.
 
 ```ts
-import { valueIsValueWithRelation } from 'payload'
+import { valueIsValueWithRelation } from 'payload/shared'
 
 if (valueIsValueWithRelation(fieldValue)) {
   // fieldValue.relationTo exists
@@ -473,7 +473,7 @@ valueIsValueWithRelation(value: unknown): value is ValueWithRelation
 ### Recursive Field Traversal
 
 ```ts
-import { fieldAffectsData, fieldHasSubFields } from 'payload'
+import { fieldAffectsData, fieldHasSubFields } from 'payload/shared'
 
 function traverseFields(fields: Field[], callback: (field: Field) => void) {
   fields.forEach((field) => {
@@ -491,7 +491,7 @@ function traverseFields(fields: Field[], callback: (field: Field) => void) {
 ### Filter Data-Bearing Fields
 
 ```ts
-import { fieldAffectsData, fieldIsPresentationalOnly, fieldIsHiddenOrDisabled } from 'payload'
+import { fieldAffectsData, fieldIsPresentationalOnly, fieldIsHiddenOrDisabled } from 'payload/shared'
 
 const dataFields = fields.filter(
   (field) =>
@@ -502,7 +502,7 @@ const dataFields = fields.filter(
 ### Container Type Switching
 
 ```ts
-import { fieldIsArrayType, fieldIsBlockType, fieldHasSubFields } from 'payload'
+import { fieldIsArrayType, fieldIsBlockType, fieldHasSubFields } from 'payload/shared'
 
 if (fieldIsArrayType(field)) {
   // Handle array-specific logic
@@ -516,7 +516,7 @@ if (fieldIsArrayType(field)) {
 ### Safe Property Access
 
 ```ts
-import { fieldSupportsMany, fieldHasMaxDepth } from 'payload'
+import { fieldSupportsMany, fieldHasMaxDepth } from 'payload/shared'
 
 // Without guard - TypeScript error
 // if (field.hasMany) { /* ... */ }
@@ -537,7 +537,7 @@ All guards preserve the original type constraint:
 
 ```ts
 import type { ClientField, Field } from 'payload'
-import { fieldHasSubFields } from 'payload'
+import { fieldHasSubFields } from 'payload/shared'
 
 function processServerField(field: Field) {
   if (fieldHasSubFields(field)) {

--- a/tools/claude-plugin/skills/payload/reference/FIELDS.md
+++ b/tools/claude-plugin/skills/payload/reference/FIELDS.md
@@ -721,7 +721,7 @@ Type guards for runtime field type checking and safe type narrowing.
 | `valueIsValueWithRelation`  | Value is polymorphic relationship                           | Handle polymorphic relationships         |
 
 ```ts
-import { fieldAffectsData, fieldHasSubFields, fieldIsArrayType } from 'payload'
+import { fieldAffectsData, fieldHasSubFields, fieldIsArrayType } from 'payload/shared'
 
 function processField(field: Field) {
   if (fieldAffectsData(field)) {


### PR DESCRIPTION
### What?

Updates the Payload Claude plugin field type guard reference docs to import runtime guard helpers from `payload/shared` instead of the root `payload` package.

Changed files:

- `tools/claude-plugin/skills/payload/reference/FIELD-TYPE-GUARDS.md`
- `tools/claude-plugin/skills/payload/reference/FIELDS.md`

### Why?

The field type guard helpers are exported from `payload/shared` via `packages/payload/src/exports/shared.ts`, and the repository's own usage imports helpers such as `fieldAffectsData`, `fieldHasSubFields`, and `fieldIsArrayType` from `payload/shared`. The previous examples could lead to copy-paste import errors for users following the reference docs.

### How?

- Kept type imports such as `Field` and `ClientField` from `payload`.
- Updated value imports for field guard helpers, tab/group guards, and option/value guards to use `payload/shared`.
- Mirrored the same import path in the quick reference example in `FIELDS.md`.

Verification:

- `git diff --check`
- `git grep -n "^import { .* } from 'payload'$" -- tools/claude-plugin/skills/payload/reference/FIELD-TYPE-GUARDS.md tools/claude-plugin/skills/payload/reference/FIELDS.md || true` confirmed no remaining root `payload` value imports in the affected reference examples.
- Confirmed `packages/payload/src/exports/shared.ts` exports the updated guard helpers.

Fixes #16909
