### PR TITLE
fix(db-mongodb): bump mongoose to 8.24.1 for GHSA-664h-wqgq-64gw (3.x backport of #17609)

### DIFF
--- a/packages/db-mongodb/package.json
+++ b/packages/db-mongodb/package.json
@@ -52,7 +52,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "mongoose": "8.22.1",
+    "mongoose": "8.24.1",
     "mongoose-paginate-v2": "1.9.4",
     "prompts": "2.4.2",
     "uuid": "13.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,11 +342,11 @@ importers:
   packages/db-mongodb:
     dependencies:
       mongoose:
-        specifier: 8.22.1
-        version: 8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)
+        specifier: 8.24.1
+        version: 8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)
       mongoose-paginate-v2:
         specifier: 1.9.4
-        version: 1.9.4(mongoose@8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9))
+        version: 1.9.4(mongoose@8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9))
       prompts:
         specifier: 2.4.2
         version: 2.4.2
@@ -12180,6 +12180,10 @@ packages:
     resolution: {integrity: sha512-c0bzt7ElI1CwWiyFSgg9bfhlFcblAoPwr+gmDcLCryClyKaeixWhP9KDGnr13kRPE8KPAuUN3ZZ3jSDxSPvoTg==}
     engines: {node: '>=16.20.1'}
 
+  mongoose@8.24.1:
+    resolution: {integrity: sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==}
+    engines: {node: '>=16.20.1'}
+
   mpath@0.8.4:
     resolution: {integrity: sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==}
     engines: {node: '>=4.0.0'}
@@ -20959,7 +20963,7 @@ snapshots:
   '@types/mongoose-aggregate-paginate-v2@1.0.12(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)':
     dependencies:
       '@types/node': 22.19.9
-      mongoose: 8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)
+      mongoose: 8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -25827,18 +25831,37 @@ snapshots:
       '@aws-sdk/credential-providers': 3.1059.0
       socks: 2.8.9
 
-  mongoose-lean-virtuals@1.1.1(mongoose@8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)):
+  mongoose-lean-virtuals@1.1.1(mongoose@8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)):
     dependencies:
-      mongoose: 8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)
+      mongoose: 8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)
       mpath: 0.8.4
 
-  mongoose-paginate-v2@1.9.4(mongoose@8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)):
+  mongoose-paginate-v2@1.9.4(mongoose@8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)):
     dependencies:
-      mongoose-lean-virtuals: 1.1.1(mongoose@8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9))
+      mongoose-lean-virtuals: 1.1.1(mongoose@8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9))
     transitivePeerDependencies:
       - mongoose
 
   mongoose@8.22.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9):
+    dependencies:
+      bson: 6.10.4
+      kareem: 2.6.3
+      mongodb: 6.20.0(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9)
+      mpath: 0.9.0
+      mquery: 5.0.0
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+      - supports-color
+
+  mongoose@8.24.1(@aws-sdk/credential-providers@3.1059.0)(socks@2.8.9):
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3


### PR DESCRIPTION
Backport to https://github.com/payloadcms/payload/pull/17609 to 3.x.

Bumps `mongoose` from `8.22.1` to `8.24.1` to resolve [GHSA-664h-wqgq-64gw](https://github.com/advisories/GHSA-664h-wqgq-64gw), a prototype pollution in update casting affecting all `8.x` releases before `8.24.1`. Same pattern as #16672, which fixed the prior advisory.

`8.22.1` → `8.24.1` is a patch-level move within the same major with no breaking changes.

Fixes #17607 