### PR TITLE
fix(plugin-mcp): bump @modelcontextprotocol/sdk to 1.30.0 for GHSA-frvp-7c67-39w9 (3.x)

### DIFF
--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -48,7 +48,7 @@
     "pack:plugin": "pnpm build && pnpm pack"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.27.1",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@types/json-schema": "7.0.15",
     "json-schema-to-zod": "2.6.1",
     "mcp-handler": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1187,8 +1187,8 @@ importers:
   packages/plugin-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.27.1
-        version: 1.27.1(zod@3.25.76)
+        specifier: 1.30.0
+        version: 1.30.0(zod@3.25.76)
       '@types/json-schema':
         specifier: 7.0.15
         version: 7.0.15
@@ -1197,7 +1197,7 @@ importers:
         version: 2.6.1
       mcp-handler:
         specifier: ^1.0.7
-        version: 1.1.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))
+        version: 1.1.0(@modelcontextprotocol/sdk@1.30.0(zod@3.25.76))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))
       zod:
         specifier: ^3.25.50
         version: 3.25.76
@@ -5573,6 +5573,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -18291,6 +18301,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.23)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.23
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@monaco-editor/loader@1.7.0':
     dependencies:
       state-local: 1.0.7
@@ -25392,9 +25424,9 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
-  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)):
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.30.0(zod@3.25.76))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@hono/node-server@<2.0.5': '>=2.0.5'
   '@types/request>form-data': ^2.5.6
   amazon-cognito-identity-js>js-cookie: ^3.0.7
   copyfiles: 2.4.1
   cross-env: 7.0.3
   dotenv: 16.4.7
   graphql: 16.8.1
-  mcp-handler>@modelcontextprotocol/sdk: 1.27.1
+  mcp-handler>@modelcontextprotocol/sdk: 1.30.0
   react: 19.2.6
   react-dom: 19.2.6
   typescript: 5.7.3
@@ -2315,8 +2316,8 @@ importers:
         specifier: 2.14.4
         version: 2.14.4
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.1
-        version: 1.27.1(zod@3.25.76)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@3.25.76)
       '@next/env':
         specifier: 16.2.6
         version: 16.2.6
@@ -5040,9 +5041,9 @@ packages:
     resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
     engines: {node: '>=14'}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.12':
+    resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -5570,16 +5571,6 @@ packages:
     resolution: {integrity: sha512-PYn05ET2USfBAeXF6NZfWl0O32KVyE8ncQ/ngysrh3hoIV7l3qGGH7ubeFx+D8VWQ682qYhwGygUzQv2j1tGGg==}
     engines: {node: '>=16.13'}
     deprecated: Miniflare v2 is no longer supported. Please upgrade to Miniflare v4
-
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -11877,7 +11868,7 @@ packages:
     resolution: {integrity: sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==}
     hasBin: true
     peerDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1
+      '@modelcontextprotocol/sdk': 1.30.0
       next: '>=13.0.0'
     peerDependenciesMeta:
       next:
@@ -17756,7 +17747,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@2.0.12(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
 
@@ -18279,31 +18270,9 @@ snapshots:
     dependencies:
       '@miniflare/shared': 2.14.4
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 2.0.12(hono@4.12.23)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,13 +27,14 @@ savePrefix: ''
 verifyDepsBeforeRun: false
 
 overrides:
+  '@hono/node-server@<2.0.5': '>=2.0.5' # GHSA-frvp-7c67-39w9: no patched 1.x exists
   '@types/request>form-data': '^2.5.6'
   'amazon-cognito-identity-js>js-cookie': '^3.0.7'
   copyfiles: 'catalog:'
   cross-env: 'catalog:'
   dotenv: 'catalog:'
   graphql: '16.8.1'
-  'mcp-handler>@modelcontextprotocol/sdk': '1.27.1'
+  'mcp-handler>@modelcontextprotocol/sdk': '1.30.0'
   react: 'catalog:'
   react-dom: 'catalog:'
   typescript: 'catalog:'

--- a/test/package.json
+++ b/test/package.json
@@ -31,7 +31,7 @@
     "@date-fns/tz": "1.2.0",
     "@miniflare/d1": "2.14.4",
     "@miniflare/shared": "2.14.4",
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@next/env": "16.2.6",
     "@opennextjs/cloudflare": "1.16.1",
     "@payloadcms/admin-bar": "workspace:*",


### PR DESCRIPTION
Bumps `@modelcontextprotocol/sdk` from `1.27.1` to `1.30.0` to resolve [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9), a path traversal in `@hono/node-server` affecting every `1.x` release. `1.30.0` is the first SDK version whose `@hono/node-server` range (`^1.19.9 || ^2.0.5`) admits the patched `>= 2.0.5`, so downstream installs can reach it instead of being stuck on the exact pin.

The SDK bump alone fixes downstream consumers — a fresh `npm`/`pnpm install` of the published package resolves `@hono/node-server` to `2.0.12`. But this repo's own lockfile stayed on the vulnerable `1.19.14`: pnpm reuses any already-resolved version that still satisfies the union range and won't upgrade a transitive on its own. Clearing it required three supporting changes:

- Bumps the `mcp-handler>@modelcontextprotocol/sdk` override from `1.27.1` to `1.30.0`, dropping the duplicate `1.x`-range SDK that `mcp-handler` otherwise pulls in.
- Bumps the dev-only `@modelcontextprotocol/sdk` in `test/package.json` to `^1.30.0` for consistency.
- Adds a `'@hono/node-server@<2.0.5': '>=2.0.5'` override to force the transitive onto the patched line, since no patched `1.x` exists and pnpm won't move it otherwise. This affects only this repo's tree, not published resolution.

Net lockfile change: `@hono/node-server` `1.19.14` → `2.0.12`, single `@modelcontextprotocol/sdk@1.30.0`, no unrelated churn.

3.x only — `plugin-mcp@4.0` already migrated off the SDK.

Fixes #17610
