### PR TITLE
fix(templates): point cloudflare-d1 deploy link to 3.x branch

### DIFF
--- a/templates/with-cloudflare-d1/README.md
+++ b/templates/with-cloudflare-d1/README.md
@@ -1,6 +1,6 @@
 # Payload Cloudflare Template
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/payloadcms/payload/tree/main/templates/with-cloudflare-d1)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/payloadcms/payload/tree/3.x/templates/with-cloudflare-d1)
 
 **This can only be deployed on Paid Workers right now due to size limits.** This template comes configured with the bare minimum to get started on anything you need.
 


### PR DESCRIPTION
## Summary
- Update the one-click Deploy to Cloudflare link in the with-cloudflare-d1 template README to point to the 3.x branch instead of main.