### PR TITLE
test(richtext-lexical): assert pasted heading text instead of child index

### DIFF
--- a/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
@@ -129,9 +129,16 @@ describe('Lexical Fully Featured - database', () => {
       })
       const richText = lexicalFullyFeatured?.docs?.[0]?.richText
 
-      const headingNode = richText?.root?.children[0]
+      const headingNode = richText?.root?.children[0] as
+        | { children?: { text?: string }[]; type?: string }
+        | undefined
       expect(headingNode).toBeDefined()
-      expect(headingNode?.children?.[1]?.text).toBe('This is an image:')
+      expect(headingNode?.type).toBe('heading')
+      // Browsers serialize a copied selection differently per platform, so the heading's text can
+      // arrive split across several text nodes. Assert on the combined text, not a fixed child index.
+      expect(headingNode?.children?.map((child) => child.text ?? '').join('')).toBe(
+        'This is an image:',
+      )
 
       const uploadNode = richText?.root?.children?.[1]?.children?.[0]
       // @ts-expect-error unsafe access is fine in tests

--- a/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildEditorState,
   type DefaultNodeTypes,
+  type RichTextNodes,
   type SerializedInlineBlockNode,
 } from '@payloadcms/richtext-lexical'
 import { expect, type Page, test } from '@playwright/test'
@@ -22,6 +23,9 @@ import { LexicalHelpers, type PasteMode } from '../../utils.js'
 const filename = fileURLToPath(import.meta.url)
 const currentFolder = path.dirname(filename)
 const dirname = path.resolve(currentFolder, '../../../')
+
+type FullyFeaturedNode = RichTextNodes<Config['collections']['lexical-fully-featured']['richText']>
+type PastedTextBlockNode = Extract<FullyFeaturedNode, { type: 'heading' | 'paragraph' }>
 
 let payload: PayloadTestSDK<Config>
 let serverURL: string
@@ -129,16 +133,16 @@ describe('Lexical Fully Featured - database', () => {
       })
       const richText = lexicalFullyFeatured?.docs?.[0]?.richText
 
-      const headingNode = richText?.root?.children[0] as
-        | { children?: { text?: string }[] }
-        | undefined
-      expect(headingNode).toBeDefined()
-      // Where the browser places the interchange `<br>` it appends to a copied selection varies, and a
-      // leading one imports as a linebreak node that shifts every sibling. Assert on the block's combined
-      // text rather than a fixed child index.
-      expect(headingNode?.children?.map((child) => child.text ?? '').join('')).toBe(
-        'This is an image:',
-      )
+      const pastedTextBlock = richText?.root.children[0] as PastedTextBlockNode | undefined
+      expect(pastedTextBlock).toBeDefined()
+
+      // Browser clipboard serialization can insert a leading linebreak node.
+      // Assert the combined text instead of a fixed child index.
+      const combinedText = pastedTextBlock?.children
+        .map((child) => ('text' in child ? child.text : ''))
+        .join('')
+
+      expect(combinedText).toBe('This is an image:')
 
       const uploadNode = richText?.root?.children?.[1]?.children?.[0]
       // @ts-expect-error unsafe access is fine in tests

--- a/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
@@ -130,12 +130,12 @@ describe('Lexical Fully Featured - database', () => {
       const richText = lexicalFullyFeatured?.docs?.[0]?.richText
 
       const headingNode = richText?.root?.children[0] as
-        | { children?: { text?: string }[]; type?: string }
+        | { children?: { text?: string }[] }
         | undefined
       expect(headingNode).toBeDefined()
-      expect(headingNode?.type).toBe('heading')
-      // Browsers serialize a copied selection differently per platform, so the heading's text can
-      // arrive split across several text nodes. Assert on the combined text, not a fixed child index.
+      // Where the browser places the interchange `<br>` it appends to a copied selection varies, and a
+      // leading one imports as a linebreak node that shifts every sibling. Assert on the block's combined
+      // text rather than a fixed child index.
       expect(headingNode?.children?.map((child) => child.text ?? '').join('')).toBe(
         'This is an image:',
       )


### PR DESCRIPTION
Deflakes `ensure auto upload by copy & pasting image works when pasting from website`, which started flaking after #17579 moved `RouteTransitionProvider` outside `RouterAdapter` and `ServerFunctionsProvider`.

That context-order change altered admin rendering timing enough to expose an invalid assumption in the test’s browser clipboard round trip. The test copies the `/admin/custom-image` view through the clipboard, then reads the pasted block’s second child:

```ts
expect(headingNode?.children?.[1]?.text).toBe('This is an image:')
```

Chromium does not put the original source markup on the clipboard. It serializes the current selection with computed styles inlined and may append an interchange `<br class="Apple-interchange-newline">` marker (linebreak).

Where that marker lands depends on where the select-all range starts relative to the block boundary. The same copied text can therefore produce different Lexical node layouts:

| Copied fragment | Imported block |
| --- | --- |
| `<h2>This is an image:</h2>` | `heading [text]` |
| `<br class="Apple-interchange-newline">This is an image:` | `paragraph [linebreak, text]` |
| `<h2><br>This is an image:</h2>` | `heading [linebreak, text]` |

The previous assertion only passes when a leading `linebreak` shifts the text to child index `1`. When the block imports as `heading [text]`, the text is at index `0` and index `1` is `undefined`, even though the clipboard round trip and image upload both succeeded.

The test now asserts the block’s combined text, which holds for each equivalent node layout, while retaining the existing assertions for the auto-uploaded image.