### PR TITLE
fix(db-mongodb): apply date coercion per element for in/not_in/all queries

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -194,10 +194,22 @@ export const sanitizeQueryValue = ({
     }
   }
 
-  if (field.type === 'date' && typeof val === 'string' && operator !== 'exists') {
-    formattedValue = new Date(val)
-    if (Number.isNaN(Date.parse(formattedValue))) {
-      return undefined
+  if (field.type === 'date' && operator !== 'exists') {
+    if (Array.isArray(formattedValue)) {
+      formattedValue = formattedValue.reduce<Date[]>((dates, item) => {
+        const date = item instanceof Date ? item : new Date(item as number | string)
+
+        if (!Number.isNaN(date.getTime())) {
+          dates.push(date)
+        }
+
+        return dates
+      }, [])
+    } else if (typeof val === 'string') {
+      formattedValue = new Date(val)
+      if (Number.isNaN(Date.parse(formattedValue))) {
+        return undefined
+      }
     }
   }
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1621,6 +1621,36 @@ describe('Fields', () => {
       expect(result.totalDocs).toBe(0)
     })
 
+    it('should query createdAt (in with a comma-delimited string)', async () => {
+      const result = await payload.find({
+        collection: 'date-fields',
+        depth: 0,
+        where: {
+          createdAt: {
+            in: `${doc.createdAt},${tenMinutesAgo.toISOString()}`,
+          },
+        },
+      })
+
+      expect(result.docs[0].id).toBe(doc.id)
+      expect(result.totalDocs).toBe(1)
+    })
+
+    it('should query createdAt (in ignoring unparseable values)', async () => {
+      const result = await payload.find({
+        collection: 'date-fields',
+        depth: 0,
+        where: {
+          createdAt: {
+            in: `${doc.createdAt},not-a-date`,
+          },
+        },
+      })
+
+      expect(result.docs[0].id).toBe(doc.id)
+      expect(result.totalDocs).toBe(1)
+    })
+
     // Function to generate random date between start and end dates
     function getRandomDate(start: Date, end: Date): string {
       const date = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()))


### PR DESCRIPTION
### What?

`where[createdAt][in]=<isoA>,<isoB>` on MongoDB returns **every** document instead of only the matching ones — the constraint is dropped silently. Same for `not_in` and `all`.

Repro over the REST API against `test/_community` with 3 posts, where `<isoA>` is the `createdAt` of the first:

| `where` on `createdAt` | expected | `main` | this PR |
|---|---|---|---|
| `in: "<isoA>,2020-01-01T00:00:00.000Z"` | 1 | 3 | 1 |
| `not_in: "<isoA>,2020-01-01T00:00:00.000Z"` | 2 | 3 | 2 |
| `all: "<isoA>,2020-01-01T00:00:00.000Z"` | 0 | 3 | 0 |

### Why?

Comma-delimited lists are the documented syntax for `in`/`not_in`/`all` (`docs/queries/overview.mdx`), so a hand-written REST query string carries them as one unsplit string — the table above is over REST, and the tests below reach the same code through the Local API.

`sanitizeQueryValue` splits that string into an array for those operators, but the date branch below it re-reads the raw `val`, which is still the unsplit string. `new Date('<isoA>,<isoB>')` is an Invalid Date, so it returns `undefined`, and `buildSearchParam` treats `undefined` as "no constraint".

### How?

Coerce per element when the value is already an array, dropping elements that don't parse.

Mapping without that filter is shorter, but it leaves an Invalid Date in the array and mongoose then throws `Cast to date failed for value "Invalid Date"` — turning a dropped filter into a 500 for `in=<isoA>,not-a-date`. Dropping unparseable elements is what `packages/drizzle/src/queries/sanitizeQueryValue.ts` already does. Happy to switch if you'd rather it throw.

Two tests in `test/fields/int.spec.ts`, next to the existing `in` date tests. I verified both fail without the source change (`expected 2 to be 1`, `expected 3 to be 1`) and pass with it; both also pass unmodified on SQLite. Full `test/fields` int suite is green on Mongo.
