### PR TITLE
fix(richtext-lexical): honor escaped pipes in markdown tables

### DIFF
--- a/packages/richtext-lexical/src/features/table/markdownTransformer.ts
+++ b/packages/richtext-lexical/src/features/table/markdownTransformer.ts
@@ -49,7 +49,10 @@ export const PAYLOAD_TABLE: (props: { allTransformers: Transformer[] }) => Eleme
         // It's TableCellNode, so it's just to make flow happy
         if ($isTableCellNode(cell)) {
           rowOutput.push(
-            $convertToMarkdownString(allTransformers, cell).replace(/\n/g, '\\n').trim(),
+            $convertToMarkdownString(allTransformers, cell)
+              .replace(/\n/g, '\\n')
+              .replace(/\|/g, '\\|')
+              .trim(),
           )
 
           if (cell.__headerState === TableCellHeaderStates.ROW) {
@@ -165,7 +168,7 @@ function getTableColumnsSize(table: TableNode) {
 }
 
 const $createTableCell = (textContent: string, allTransformers: Transformer[]): TableCellNode => {
-  textContent = textContent.replace(/\\n/g, '\n')
+  textContent = textContent.replace(/\\n/g, '\n').replace(/\\\|/g, '|')
   const cell = $createTableCellNode(TableCellHeaderStates.NO_STATUS)
   // shouldMergeAdjacentLines is true to preserve how cell content was parsed
   // before the exported $convertFromMarkdownString default changed to false.
@@ -181,5 +184,7 @@ const mapToTableCells = (
   if (!match || !match[1]) {
     return null
   }
-  return match[1].split('|').map((text) => $createTableCell(text, allTransformers))
+  return match[1]
+    .split(/(?<=(?<!\\)(?:\\\\)*)\|/)
+    .map((text) => $createTableCell(text, allTransformers))
 }

--- a/test/lexical-mdx/int.spec.ts
+++ b/test/lexical-mdx/int.spec.ts
@@ -262,6 +262,75 @@ describe('Lexical MDX', () => {
       expect(serialized).not.toContain('"type":"link"')
     })
   })
+
+  describe('table markdown: escaped pipes', () => {
+    const escapedPipeTable = [
+      '| Option | Type |',
+      '| --- | --- |',
+      '| relationTo | string \\| string[] |',
+    ].join('\n')
+
+    function tableCellTexts(table: { children?: unknown[] }): string[][] {
+      return (table.children as { children: unknown[] }[]).map((row) =>
+        (row.children as { children: unknown[] }[]).map((cell) =>
+          (cell.children as { children: { text: string }[] }[])
+            .map((paragraph) => paragraph.children.map((text) => text.text).join(''))
+            .join(''),
+        ),
+      )
+    }
+
+    it('should treat an escaped pipe as cell content rather than a column divider', () => {
+      const result = mdxToEditorJSON({ editorConfig, mdxWithFrontmatter: escapedPipeTable })
+      const rootChildren = result.editorState.root.children
+
+      expect(rootChildren).toHaveLength(1)
+      expect(tableCellTexts(rootChildren[0])).toStrictEqual([
+        [' Option ', ' Type '],
+        [' relationTo ', ' string | string[] '],
+      ])
+    })
+
+    it('should escape pipes in cell content on export so the table round-trips', () => {
+      const { editorState } = mdxToEditorJSON({
+        editorConfig,
+        mdxWithFrontmatter: escapedPipeTable,
+      })
+      const markdown = editorJSONToMDX({ editorConfig, editorState })
+
+      expect(markdown).toContain('| string \\| string[] |')
+
+      const reimported = mdxToEditorJSON({ editorConfig, mdxWithFrontmatter: markdown })
+      expect(reimported.editorState.root.children).toStrictEqual(editorState.root.children)
+    })
+
+    it('should treat a pipe preceded by an escaped backslash as a column divider', () => {
+      const result = mdxToEditorJSON({
+        editorConfig,
+        mdxWithFrontmatter: ['| H1 | H2 |', '| --- | --- |', '| path\\\\| b |'].join('\n'),
+      })
+      const rootChildren = result.editorState.root.children
+
+      expect(rootChildren).toHaveLength(1)
+      expect(tableCellTexts(rootChildren[0])).toStrictEqual([
+        [' H1 ', ' H2 '],
+        [' path\\', ' b '],
+      ])
+    })
+
+    it('should round-trip a cell holding a backslash next to an escaped pipe', () => {
+      const { editorState } = mdxToEditorJSON({
+        editorConfig,
+        mdxWithFrontmatter: ['| H1 | H2 |', '| --- | --- |', '| a\\\\\\|b | c |'].join('\n'),
+      })
+
+      expect(tableCellTexts(editorState.root.children[0])[1]).toStrictEqual([' a\\|b ', ' c '])
+
+      const markdown = editorJSONToMDX({ editorConfig, editorState })
+      const reimported = mdxToEditorJSON({ editorConfig, mdxWithFrontmatter: markdown })
+      expect(reimported.editorState.root.children).toStrictEqual(editorState.root.children)
+    })
+  })
 })
 
 function removeUndefinedAndIDRecursively(obj: object) {


### PR DESCRIPTION
### What?

GFM writes a literal pipe inside a table cell as `\|`. The markdown table transformer ignores the escape, so a table containing a union type imports as two tables.

Input (the shape used in `docs/hierarchy/overview.mdx:289`):

```
| Option | Type |
| --- | --- |
| relationTo | string \| string[] |
```

On `main` the data row splits into three cells, so its column count no longer matches the header and the row detaches into a second table node — one table for the header, another holding `relationTo` / `string \` / `string[]`.

Export is the mirror image: a cell whose text is `a|b` is written out as `| a|b | c |`, which this transformer's own import path then reads back as three cells.

### Why?

`mapToTableCells` splits the row on a bare `/\|/` and `$createTableCell` never unescapes `\|`; the export path escapes newlines but not pipes. Union types in an API-reference table are the ordinary case for this — the repo's own docs have 10 such rows across 4 files.

### How?

Split the row on a pipe only where the run of backslashes before it is even, unescape `\|` when building the cell, and escape `|` on export. Cell padding is left as-is.

The even-backslash rule is load-bearing, which is why the lookbehind is not just `(?<!\\)`: in `| path\\| b |` the `\\` is an escaped backslash and the pipe *is* a divider, so the simpler regex would break a row that parses correctly today. I checked cell count and cell content against `marked` 14 across eight rows, including that one and `` `string \| string[]` ``, and they agree on all of them.

Four tests in `test/lexical-mdx/int.spec.ts`. Three fail without the source change (`expected [ …(2) ] to have a length of 1`) and pass with it; the fourth pins `| path\\| b |`, which `main` already gets right. `test/lexical-mdx` and `test/lexical` are green.
