### PR TITLE
docs: add SuperSend TX email adapter example

### DIFF
--- a/docs/email/overview.mdx
+++ b/docs/email/overview.mdx
@@ -31,7 +31,7 @@ An email adapter will require at least the following fields:
 
 | Name       | Package                                                                                    | Description                                                                                                                                                                                     |
 | ---------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nodemailer | [@payloadcms/email-nodemailer](https://www.npmjs.com/package/@payloadcms/email-nodemailer) | Use any [Nodemailer transport](https://nodemailer.com/transports), including SMTP, Resend, SendGrid, and more. This was provided by default in Payload 2.x. This is the easiest migration path. |
+| Nodemailer | [@payloadcms/email-nodemailer](https://www.npmjs.com/package/@payloadcms/email-nodemailer) | Use any [Nodemailer transport](https://nodemailer.com/transports), including SMTP, Resend, SendGrid, SuperSend TX, and more. This was provided by default in Payload 2.x. This is the easiest migration path. |
 | Resend     | [@payloadcms/email-resend](https://www.npmjs.com/package/@payloadcms/email-resend)         | Resend email via their REST API. This is preferred for serverless platforms such as Vercel because it is much more lightweight than the nodemailer adapter.                                     |
 
 ## Nodemailer Configuration
@@ -108,6 +108,29 @@ export default buildConfig({
     transportOptions: nodemailerSendgrid({
       apiKey: process.env.SENDGRID_API_KEY,
     }),
+  }),
+})
+```
+
+**Custom Transport with SuperSend TX:**
+
+You can also use a custom Nodemailer transport such as [SuperSend TX](https://docs.supersendtx.com/guides/payload) for transactional email over their HTTP API:
+
+```ts
+import { buildConfig } from 'payload'
+import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
+import nodemailer from 'nodemailer'
+import { createSuperSendTXTransport } from 'supersendtx-nodemailer'
+
+export default buildConfig({
+  email: nodemailerAdapter({
+    defaultFromAddress: 'info@payloadcms.com',
+    defaultFromName: 'Payload',
+    transport: nodemailer.createTransport(
+      createSuperSendTXTransport({
+        apiKey: process.env.SUPERSENDTX_API_KEY,
+      }),
+    ),
   }),
 })
 ```

--- a/docs/email/overview.mdx
+++ b/docs/email/overview.mdx
@@ -31,7 +31,7 @@ An email adapter will require at least the following fields:
 
 | Name       | Package                                                                                    | Description                                                                                                                                                                                     |
 | ---------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nodemailer | [@payloadcms/email-nodemailer](https://www.npmjs.com/package/@payloadcms/email-nodemailer) | Use any [Nodemailer transport](https://nodemailer.com/transports), including SMTP, Resend, SendGrid, SuperSend TX, and more. This was provided by default in Payload 2.x. This is the easiest migration path. |
+| Nodemailer | [@payloadcms/email-nodemailer](https://www.npmjs.com/package/@payloadcms/email-nodemailer) | Use any [Nodemailer transport](https://nodemailer.com/transports), including SMTP, Resend, SendGrid, and more. This was provided by default in Payload 2.x. This is the easiest migration path. |
 | Resend     | [@payloadcms/email-resend](https://www.npmjs.com/package/@payloadcms/email-resend)         | Resend email via their REST API. This is preferred for serverless platforms such as Vercel because it is much more lightweight than the nodemailer adapter.                                     |
 
 ## Nodemailer Configuration
@@ -112,25 +112,19 @@ export default buildConfig({
 })
 ```
 
-**Custom Transport with SuperSend TX:**
+**SuperSend TX adapter:**
 
-You can also use a custom Nodemailer transport such as [SuperSend TX](https://docs.supersendtx.com/guides/payload) for transactional email over their HTTP API:
+You can also use the first-party [SuperSend TX](https://docs.supersendtx.com/guides/payload) email adapter ([`supersendtx-payload`](https://www.npmjs.com/package/supersendtx-payload)) for transactional email over their HTTP API:
 
 ```ts
 import { buildConfig } from 'payload'
-import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
-import nodemailer from 'nodemailer'
-import { createSuperSendTXTransport } from 'supersendtx-nodemailer'
+import { supersendtxAdapter } from 'supersendtx-payload'
 
 export default buildConfig({
-  email: nodemailerAdapter({
+  email: supersendtxAdapter({
     defaultFromAddress: 'info@payloadcms.com',
     defaultFromName: 'Payload',
-    transport: nodemailer.createTransport(
-      createSuperSendTXTransport({
-        apiKey: process.env.SUPERSENDTX_API_KEY,
-      }),
-    ),
+    // apiKey: process.env.SUPERSENDTX_API_KEY,
   }),
 })
 ```


### PR DESCRIPTION
## Description

Adds a **SuperSend TX adapter** example to the email overview docs, next to the existing SendGrid / Nodemailer examples.

[`supersendtx-payload`](https://www.npmjs.com/package/supersendtx-payload) exposes `supersendtxAdapter()` — a Payload 3-shaped email adapter over the SuperSend TX HTTP API (no Nodemailer required).

Guide: https://docs.supersendtx.com/guides/payload

## Type of change

- [x] Documentation update

## Checklist

- [x] Example matches Payload `email:` adapter shape
- [x] Links to public npm package + docs