### PR TITLE
feat(ui): add retry to FormErrorHandler

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -513,7 +513,8 @@ export const Form: React.FC<FormProps> = (props) => {
             })
 
             nonFieldErrors.forEach((err) => {
-              if (onNonFieldError?.(err)) {
+              // Pass overridesFromArgs (not the computed overrides) so a retry re-evaluates any function overrides against current fields.
+              if (onNonFieldError?.(err, () => void submit({ overrides: overridesFromArgs }))) {
                 return
               }
               errorToast(<FieldErrorsToast errorMessage={err.message || t('error:unknown')} />)

--- a/packages/ui/src/providers/FormErrorHandler/index.tsx
+++ b/packages/ui/src/providers/FormErrorHandler/index.tsx
@@ -17,8 +17,12 @@ export type NonFieldError = {
  *
  * Multiple handlers can be chained by composing providers; the first one to
  * return `true` wins.
+ *
+ * `retry` re-submits the form that produced the error, allowing the user to
+ * retry after resolving the underlying issue (e.g. deleting documents to free
+ * up quota).
  */
-export type FormErrorHandler = (err: NonFieldError) => boolean
+export type FormErrorHandler = (err: NonFieldError, retry: () => void) => boolean
 
 export const FormErrorHandlerContext = createContext<FormErrorHandler | undefined>(undefined)
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1511,57 +1511,6 @@ describe('Versions', () => {
       timezoneId: londonTimezone,
     })
 
-    const selectScheduleDateTime = async ({
-      day,
-      month,
-      page,
-      timeOptions,
-      year,
-    }: {
-      day: number
-      month: string
-      page: Page
-      timeOptions?: string[]
-      year: string
-    }) => {
-      const dateInput = page.locator('.date-time-picker__input-wrapper input')
-      await dateInput.click()
-
-      const popper = page.locator('.react-datepicker-popper')
-      await expect(popper).toBeVisible()
-
-      await popper.locator('.react-datepicker__year-select').selectOption(year)
-      await popper.locator('.react-datepicker__month-select').selectOption(month)
-
-      const dayClass = String(day).padStart(3, '0')
-      await popper
-        .locator(
-          `.react-datepicker__day--${dayClass}:not(.react-datepicker__day--outside-month):not(.react-datepicker__day--disabled)`,
-        )
-        .first()
-        .click()
-
-      if (timeOptions?.length) {
-        let hasSelectedTime = false
-
-        for (const timeOption of timeOptions) {
-          const timeLocator = popper.locator('.react-datepicker__time-list-item', {
-            hasText: timeOption,
-          })
-
-          if ((await timeLocator.count()) > 0) {
-            await timeLocator.first().click()
-            hasSelectedTime = true
-            break
-          }
-        }
-
-        if (!hasSelectedTime) {
-          throw new Error('Could not find matching time option in schedule publish date picker')
-        }
-      }
-    }
-
     beforeAll(() => {
       url = new AdminUrlUtil(serverURL, draftCollectionSlug)
       autosaveURL = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
@@ -1584,13 +1533,9 @@ describe('Versions', () => {
       // nothing in scheduled
       await expect(page.locator('.drawer__content')).toContainText('No upcoming events scheduled.')
 
-      // set a future date using picker controls
-      await selectScheduleDateTime({
-        day: 21,
-        month: '1', // February
-        page,
-        year: '2050',
-      })
+      // set date and time
+      await page.locator('.date-time-picker input').fill('Feb 21, 2050 12:00 AM')
+      await page.keyboard.press('Enter')
 
       // save the scheduled publish
       await page.locator('#scheduled-publish-save').click()
@@ -1704,14 +1649,12 @@ describe('Versions', () => {
       await dropdownControlSelector.click()
       await getSelectMenu({ page: localPage }).locator('.rs__option', { hasText: 'Paris' }).click()
 
-      // Set Jan 1, 2049 at 6 PM in the selected timezone. Time format can be 24h or 12h.
-      await selectScheduleDateTime({
-        day: 1,
-        month: '0', // January
-        page: localPage,
-        timeOptions: ['18:00', '6:00 PM'],
-        year: '2049',
-      })
+      const dateInput = drawerContent.locator('.date-time-picker__input-wrapper input')
+      // Create a date for 2049-01-01 18:00:00 UTC, so it is timezone-invariant across CI environments
+      const date = new Date(Date.UTC(2049, 0, 1, 18, 0))
+
+      await dateInput.fill(date.toISOString())
+      await localPage.keyboard.press('Enter') // formats the date to the correct format
 
       const saveButton = drawerContent.locator('.schedule-publish__actions button')
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1511,6 +1511,57 @@ describe('Versions', () => {
       timezoneId: londonTimezone,
     })
 
+    const selectScheduleDateTime = async ({
+      day,
+      month,
+      page,
+      timeOptions,
+      year,
+    }: {
+      day: number
+      month: string
+      page: Page
+      timeOptions?: string[]
+      year: string
+    }) => {
+      const dateInput = page.locator('.date-time-picker__input-wrapper input')
+      await dateInput.click()
+
+      const popper = page.locator('.react-datepicker-popper')
+      await expect(popper).toBeVisible()
+
+      await popper.locator('.react-datepicker__year-select').selectOption(year)
+      await popper.locator('.react-datepicker__month-select').selectOption(month)
+
+      const dayClass = String(day).padStart(3, '0')
+      await popper
+        .locator(
+          `.react-datepicker__day--${dayClass}:not(.react-datepicker__day--outside-month):not(.react-datepicker__day--disabled)`,
+        )
+        .first()
+        .click()
+
+      if (timeOptions?.length) {
+        let hasSelectedTime = false
+
+        for (const timeOption of timeOptions) {
+          const timeLocator = popper.locator('.react-datepicker__time-list-item', {
+            hasText: timeOption,
+          })
+
+          if ((await timeLocator.count()) > 0) {
+            await timeLocator.first().click()
+            hasSelectedTime = true
+            break
+          }
+        }
+
+        if (!hasSelectedTime) {
+          throw new Error('Could not find matching time option in schedule publish date picker')
+        }
+      }
+    }
+
     beforeAll(() => {
       url = new AdminUrlUtil(serverURL, draftCollectionSlug)
       autosaveURL = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
@@ -1533,9 +1584,13 @@ describe('Versions', () => {
       // nothing in scheduled
       await expect(page.locator('.drawer__content')).toContainText('No upcoming events scheduled.')
 
-      // set date and time
-      await page.locator('.date-time-picker input').fill('Feb 21, 2050 12:00 AM')
-      await page.keyboard.press('Enter')
+      // set a future date using picker controls
+      await selectScheduleDateTime({
+        day: 21,
+        month: '1', // February
+        page,
+        year: '2050',
+      })
 
       // save the scheduled publish
       await page.locator('#scheduled-publish-save').click()
@@ -1649,12 +1704,14 @@ describe('Versions', () => {
       await dropdownControlSelector.click()
       await getSelectMenu({ page: localPage }).locator('.rs__option', { hasText: 'Paris' }).click()
 
-      const dateInput = drawerContent.locator('.date-time-picker__input-wrapper input')
-      // Create a date for 2049-01-01 18:00:00 UTC, so it is timezone-invariant across CI environments
-      const date = new Date(Date.UTC(2049, 0, 1, 18, 0))
-
-      await dateInput.fill(date.toISOString())
-      await localPage.keyboard.press('Enter') // formats the date to the correct format
+      // Set Jan 1, 2049 at 6 PM in the selected timezone. Time format can be 24h or 12h.
+      await selectScheduleDateTime({
+        day: 1,
+        month: '0', // January
+        page: localPage,
+        timeOptions: ['18:00', '6:00 PM'],
+        year: '2049',
+      })
 
       const saveButton = drawerContent.locator('.schedule-publish__actions button')
 


### PR DESCRIPTION
Extends `FormErrorHandler` with a second argument `retry: () => void` that re-submits the form that produced the error.

Needed for the Figma `payload-plugin`.