### PR TITLE
fix(tanstack-start): suppress dangling dependency sourcemap warnings

### DIFF
--- a/packages/tanstack-start/src/withPayload/index.ts
+++ b/packages/tanstack-start/src/withPayload/index.ts
@@ -31,8 +31,18 @@ import { wrapCjsForClient } from './workarounds/wrapCjsForClient.js'
  * Vite dependency warnings Payload consumers can't act on: third-party packages
  * ship sourcemaps whose original sources aren't published, so Vite warns on
  * every one. Suppressed by default (see `silenceDependencyWarnings`).
+ *
+ * `Failed to load source map` covers deps that ship a `sourceMappingURL` comment
+ * without the `.map` file it points at (e.g. `undici`'s `lib/llhttp/*.js`, pulled
+ * in via `@vercel/blob`). Vite appends the underlying `ENOENT` stack to that one,
+ * so each occurrence is a ~10-line block that buries real log output.
  */
-const suppressibleWarningPatterns = ['points to missing source files', 'Sourcemap for']
+const suppressibleWarningPatterns = [
+  'points to missing source files',
+  'Sourcemap for',
+  'Failed to load source map',
+  'references a map file outside its package',
+]
 
 /**
  * Wraps a Vite logger so warnings matching {@link suppressibleWarningPatterns}


### PR DESCRIPTION
Deps that ship a `sourceMappingURL` comment without the `.map` file it points at (e.g. `undici`'s `lib/llhttp/*.js`, reached via `@vercel/blob`) make Vite log `Failed to load source map` with the underlying ENOENT stack appended — a ~10 line block per occurrence, repeated on every dev server route, long enough to bury real log lines.

`withPayload` already suppressed this class of unactionable dependency warning, but its pattern list didn't match this message. Add it, plus the `references a map file outside its package` variant — the two remaining sourcemap warnings Vite emits that weren't covered.
