### PR TITLE
fix(tanstack-start): exclude plugin client components from dep optimizer

### DIFF
--- a/packages/tanstack-start/src/withPayload/config/optimizeDeps.ts
+++ b/packages/tanstack-start/src/withPayload/config/optimizeDeps.ts
@@ -31,6 +31,21 @@ export const optimizeDepsExcludeDefaults: string[] = [
   '@aws-sdk/client-s3',
   '@aws-sdk/s3-request-presigner',
   '@google-cloud/storage',
+  // Plugins that ship `'use client'` components. Pre-bundling one puts its client
+  // components in the optimized dep chunk *and* in the `rsc` environment as client
+  // references, which `@vitejs/plugin-rsc` warns about ("client component
+  // dependency is inconsistently optimized") once per component. Only shows up in
+  // published installs; workspace source is never pre-bundled.
+  '@payloadcms/plugin-cloud-storage',
+  '@payloadcms/plugin-ecommerce',
+  '@payloadcms/plugin-form-builder',
+  '@payloadcms/plugin-import-export',
+  '@payloadcms/plugin-mcp',
+  '@payloadcms/plugin-multi-tenant',
+  '@payloadcms/plugin-search',
+  '@payloadcms/plugin-sentry',
+  '@payloadcms/plugin-seo',
+  '@payloadcms/plugin-stripe',
 ]
 
 /**


### PR DESCRIPTION
Pre-bundling a plugin that ships `'use client'` components puts those components in the optimized dep chunk *and* in the `rsc` environment as client references, so `@vitejs/plugin-rsc` warns "client component dependency is inconsistently optimized" once per component — seven on a first `/admin` load with plugin-seo and plugin-search installed.

Add the first-party plugins that ship client components to `optimizeDeps.exclude`, the same treatment `@payloadcms/ui` already gets. Only reproducible against published installs, since workspace source is never pre-bundled.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
