### PR TITLE
fix(ui): do not re-apply an initialState the form already applied

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -165,6 +165,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const contextRef = useRef({} as FormContextType)
   const abortResetFormRef = useRef<AbortController>(null)
   const isFirstRenderRef = useRef(true)
+  const lastAppliedInitialStateRef = useRef<FormState>(null)
 
   const fieldsReducer = useReducer(fieldReducer, {}, () => initialState)
 
@@ -799,15 +800,29 @@ export const Form: React.FC<FormProps> = (props) => {
   }, [submittedFromProps])
 
   useEffect(() => {
-    if (initialState) {
-      contextRef.current = { ...initContextState } as FormContextType
-      dispatchFields({
-        type: 'REPLACE_STATE',
-        optimize: false,
-        sanitize: true,
-        state: initialState,
-      })
+    if (!initialState) {
+      return
     }
+
+    // Applying the very same object a second time would discard every change
+    // made since it was first applied, so only react to a state we have not
+    // seen yet. The ref lives on this instance, so a genuine remount — where
+    // the reducer is re-initialized from `initialState` anyway — still applies
+    // it. Guarding on identity rather than deep equality keeps a caller free to
+    // hand over a structurally equal but newly built state to force a reset.
+    if (lastAppliedInitialStateRef.current === initialState) {
+      return
+    }
+
+    lastAppliedInitialStateRef.current = initialState
+
+    contextRef.current = { ...initContextState } as FormContextType
+    dispatchFields({
+      type: 'REPLACE_STATE',
+      optimize: false,
+      sanitize: true,
+      state: initialState,
+    })
   }, [initialState, dispatchFields])
 
   useThrottledEffect(


### PR DESCRIPTION
### What?

Prevent the Form from dispatching `REPLACE_STATE` again when the `initialState` prop has not actually changed (same object identity).

### Context / original problem

We hit this while editing documents that nest Lexical editors inside array / blocks rows (in our app: a Columns layout block). After reordering rows — especially under React Strict Mode — the admin UI could:

- snap back to a previous row order,
- show stale nested content, or
- look briefly consistent and then revert once delayed form / node sync finished.

The data path was usually still correct (Live Preview / saved document); the broken surface was the **admin form UI** after remounts and effect re-runs.

That user-facing failure is **not one bug**. It is a stack of three independent failures on the same remount path:

1. **This PR (Form)** — stale `REPLACE_STATE` from re-applying an unchanged `initialState`.
2. **Companion PR (RenderFields)** — React remounts the wrong field subtree because keys embed array `path` indexes.
3. **Outside Payload — `@lexical/react`** — after a remount, decorator portals can be skipped forever if `useDecorators` runs while `getElementByKey` is still `null` (empty Lexical block boxes). We fixed that with a small upstream-oriented patch that recomputes portals when the editor root attaches (`registerRootListener` / portal revision). That is **not** included here; Payload alone cannot fix empty decorator portals.

Under Strict Mode we needed **(1) + (2)** together for reliable reorder. **(3)** is required whenever nested Lexical blocks remount, with or without Strict Mode. Landing only this Form guard helps the “stale / reverted state” class of failures, but does not by itself fix path-key remounts or empty Lexical decorators.

### Why? (this change)

The `useEffect` that mirrors `initialState` into the field reducer re-runs whenever its dependency list fires, even if `initialState` is still the same object. That reapplies a snapshot the form has already moved past and discards in-flight edits (row reorder, nested lexical edits, etc.).

Strict Mode makes this much easier to hit (stricter effect / remount timing). With draft autosave enabled, the reverted UI state can also be written back to the document on the next save.

### How?

Track the last applied `initialState` on a per-instance ref (`lastAppliedInitialStateRef`) and return early when the prop is identical by reference.

- First apply after mount still runs (including sanitize), which initializing the reducer from `initialState` alone does not cover.
- Comparison is by identity, not deep equality, so callers can still force a reset by passing a newly built object (same pattern as `reset` / `replaceState`).
- The ref is per instance, so a genuine remount re-applies as before.

### Reproduction (manual)

1. Next.js admin with `reactStrictMode: true`.
2. Document with an array/blocks field that nests Lexical (blocks inside the editor are the clearest signal).
3. Edit nested content, then reorder / move a row (add-then-move-up is a strong case when combined with the RenderFields bug).
4. Without this guard: order or nested content can snap back after the effect re-fires. With it: those edits stick (assuming the companion RenderFields fix is also present for remount identity).

Verified in a production admin under Strict Mode together with the RenderFields companion and the Lexical portal patch.

### Related

- Companion PR (RenderFields remount identity): https://github.com/payloadcms/payload/pull/17623 — please review/merge alongside; A/B isolation showed both Payload fixes are required under Strict Mode.
- Lexical empty-decorator remount: separate `@lexical/react` fix (portal recompute on root attach); not part of this repo.

Same Form bug exists on `main` (v4). Happy to open a follow-up PR there, or fine if you’d rather cherry-pick / forward-port after merge.