### PR TITLE
fix(ui): keep field identity stable across array row reorder

### DIFF
--- a/packages/ui/src/forms/RenderFields/index.tsx
+++ b/packages/ui/src/forms/RenderFields/index.tsx
@@ -93,7 +93,17 @@ export const RenderFields: React.FC<RenderFieldsProps> = (props) => {
           })
 
           return (
-            <FieldPathContext key={`${path}-${i}`} value={path}>
+            // The key must not contain `path`, which embeds the row indexes of
+            // every ancestor array or blocks field. Reordering or removing a
+            // row shifts those indexes, and a path-based key would then remount
+            // the field subtree of each sibling at or after it. Within one
+            // `RenderFields` call the schema fixes the length and order of
+            // `fields`, so name — or type, for presentational fields — plus
+            // index identifies a field without referring to its address.
+            <FieldPathContext
+              key={`${'name' in field ? field.name : field.type}-${i}`}
+              value={path}
+            >
               <RenderField
                 clientFieldConfig={field}
                 forceRender={forceRender}


### PR DESCRIPTION
### What?

Key `RenderFields` children by field name (or type) + index instead of by form `path`.

### Context / original problem

We hit this while editing documents that nest Lexical editors inside array / blocks rows (in our app: a Columns layout block). After reordering rows — especially under React Strict Mode — nested editors could remount as **empty or stale**, even when form / document state was still correct.

The full failure mode is a **stack of three** issues on the same remount path after row move → form update → nested editor remount:

1. **Companion PR (Form)** — re-applying an unchanged `initialState` via `REPLACE_STATE` discards in-flight edits / can revert order.
2. **This PR (RenderFields)** — path-based React keys force remounts of sibling field subtrees when ancestor row indexes shift.
3. **Outside Payload — `@lexical/react`** — decorator portals skipped if created before the root element exists, then never retried → empty Lexical block boxes. Fixed separately by recomputing portals when the root attaches. Not included in this PR.

A/B testing under Strict Mode: Form guard alone still left **empty nested content** on “add row, then move up”; RenderFields key fix alone does not stop stale `REPLACE_STATE`. **Both Payload PRs are required** for the admin UI to stay correct. The Lexical portal fix is additionally required so remounted block decorators do not stay blank.

### Why? (this change)

`path` embeds the row indexes of every ancestor array or blocks field. Moving or deleting a row shifts those indexes, so React treats sibling fields as new identities and remounts their subtrees.

Most controlled fields recover from form state. Uncontrolled editors such as Lexical rebuild from scratch and can show blank or stale nested content even when form state is still correct — and that remount is exactly when the Lexical portal race (item 3 above) can bite as well.

### How?

Within one `RenderFields` call the schema fixes the length and order of `fields`, so `name` — or `type` for presentational fields — plus index identifies a field without encoding its address:

```ts
key={`${'name' in field ? field.name : field.type}-${i}`}
```

### Reproduction (manual)

1. Next.js admin with `reactStrictMode: true`.
2. Array/blocks row containing nested Lexical blocks.
3. Add a row (or edit nested blocks), then move that row up/down.
4. Without this key change: nested editors remount empty/stale for siblings at/after the moved row. With it: nested content stays attached to the correct field instance (with the Form companion + Lexical portal fix for the full stack).

Verified together with the Form `initialState` guard under Strict Mode; both were necessary. Lexical empty boxes were verified separately via the `@lexical/react` portal patch.

### Related

- Companion PR (Form `initialState` guard): https://github.com/payloadcms/payload/pull/17622 — please treat as a pair under Strict Mode.
- Lexical empty-decorator remount: separate `@lexical/react` fix; not part of this repo.

Same RenderFields bug exists on `main` (v4). Happy to open a follow-up PR there, or fine if you’d rather cherry-pick / forward-port after merge.